### PR TITLE
Add dev k3s deployment and testing ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ K3S_KUBECONFIG ?= /home/jonathanoliver/.kube/config
 GO_SERVER_IMAGE ?= ghcr.io/jonathaneoliver/infinite-streaming:latest
 GO_PROXY_IMAGE ?= ghcr.io/jonathaneoliver/go-proxy:latest
 K8S_MANIFESTS ?= k8s-infinite-streaming.yaml
+K8S_DEPLOYMENT ?= infinite-streaming
 
 run:
 	./boss.sh 1 run
@@ -83,12 +84,12 @@ deploy-lenovo-k3s-local:
 		ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl apply -f -" < $$manifest; \
 	done; \
 	echo "Updating deployment images"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/infinite-streaming go-server=$(LENOVO_SERVER_IMAGE)"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/infinite-streaming go-proxy=$(LENOVO_PROXY_IMAGE)"; \
+	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-server=$(LENOVO_SERVER_IMAGE)"; \
+	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-proxy=$(LENOVO_PROXY_IMAGE)"; \
 	echo "Restarting deployments explicitly"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout restart deployment/infinite-streaming"; \
+	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout restart deployment/$(K8S_DEPLOYMENT)"; \
 	echo "Waiting for rollout"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout status deployment/infinite-streaming --timeout=180s"; \
+	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout status deployment/$(K8S_DEPLOYMENT) --timeout=180s"; \
 	echo "Deployment status"; \
 	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get pods -n default -o wide; echo; kubectl get svc -n default"
 
@@ -98,6 +99,11 @@ status-lenovo-k3s:
 	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get nodes; echo; kubectl get pods -A"
 
 deploy:
+	docker buildx build --platform linux/amd64 -t $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):dev --push .
+	docker buildx build --platform linux/amd64 -t $(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):dev --push ./go-proxy
+	$(MAKE) deploy-lenovo-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K8S_MANIFESTS=k8s-infinite-streaming-dev.yaml K8S_DEPLOYMENT=infinite-streaming-dev LENOVO_SERVER_IMAGE=$(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):dev LENOVO_PROXY_IMAGE=$(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):dev
+
+deploy-release:
 	docker buildx build --platform linux/amd64 -t $(LENOVO_SERVER_IMAGE) --push .
 	docker buildx build --platform linux/amd64 -t $(LENOVO_PROXY_IMAGE) --push ./go-proxy
 	$(MAKE) deploy-lenovo-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) LENOVO_SERVER_IMAGE=$(LENOVO_SERVER_IMAGE) LENOVO_PROXY_IMAGE=$(LENOVO_PROXY_IMAGE)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,41 @@ Open the UI:
 - Docker Compose: http://localhost:21081/
 - k3s (Lenovo): http://lenovo.local:30000/
 
+## Lenovo k3s: release vs dev
+
+Run release and dev side-by-side by using separate NodePort ranges and image tags.
+
+Release (stable):
+- UI: http://lenovo.local:30000/
+- Ports: 30000 (UI), 30081 (initial proxy), 30181-30881 (session ports)
+- Images: `:latest` (or your pinned release tag)
+- Deploy: `make deploy-release`
+
+Dev (active development):
+- UI: http://lenovo.local:40000/
+- Ports: 40000 (UI), 40081 (initial proxy), 40181-40881 (session ports)
+- Images: `:dev`
+- Deploy: `make deploy`
+
+The dev stack is defined in `k8s-infinite-streaming-dev.yaml`, while release uses `k8s-infinite-streaming.yaml`.
+
+## Release tagging notes
+
+Use an immutable tag for releases (for example, `v1.2.3` or a commit SHA) and keep `:latest` as a moving pointer.
+
+Suggested flow:
+1) Create a tag and push it (example: `git tag v1.2.3 && git push origin v1.2.3`).
+2) Build/push images with that tag (example: `:v1.2.3`).
+3) Deploy release using the pinned tag (set `LENOVO_SERVER_IMAGE` and `LENOVO_PROXY_IMAGE` to the release tag).
+
+Example deploy (release tag `v1.2.3`):
+
+```bash
+make deploy-release \
+  LENOVO_SERVER_IMAGE=100.111.190.54:5000/infinite-streaming:v1.2.3 \
+  LENOVO_PROXY_IMAGE=100.111.190.54:5000/go-proxy:v1.2.3
+```
+
 ## GitHub Container Registry (GHCR)
 
 This repo ships a GitHub Actions workflow that builds and publishes images to GHCR on pushes to `main`.

--- a/content/shared-nav.js
+++ b/content/shared-nav.js
@@ -85,16 +85,21 @@
     function isTestingPort(port) {
         const parsed = Number(port);
         if (!Number.isInteger(parsed)) return false;
-        return (parsed >= 30081 && parsed <= 30881) || (parsed >= 20081 && parsed <= 20881);
+        return (parsed >= 20081 && parsed <= 20881)
+            || (parsed >= 30081 && parsed <= 30881)
+            || (parsed >= 40081 && parsed <= 40881);
     }
 
     function resolveTestingPort(sourcePort) {
         const currentPort = window.location.port || (window.location.protocol === 'https:' ? '443' : '80');
-        if (isTestingPort(sourcePort)) {
-            return String(sourcePort);
+        if (currentPort === '40000') {
+            return '40081';
         }
         if (isTestingPort(currentPort)) {
             return String(currentPort);
+        }
+        if (isTestingPort(sourcePort)) {
+            return String(sourcePort);
         }
         if (currentPort === '30000') {
             return '30081';

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infinite-streaming-dev
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: infinite-streaming-dev
+  template:
+    metadata:
+      labels:
+        app: infinite-streaming-dev
+    spec:
+      containers:
+      - name: go-server
+        image: 100.111.190.54:5000/infinite-streaming:dev
+        imagePullPolicy: Always
+        command: ["/sbin/launch.sh", "1"]
+        ports:
+        - containerPort: 30000
+        env:
+        - name: INFINITE_STREAM_ROOT
+          value: "/boss"
+        - name: INFINITE_STREAM_UPLOADS_DIR
+          value: "/boss/boss-uploads"
+        - name: INFINITE_STREAM_SOURCES_DIR
+          value: "/boss/originals"
+        - name: INFINITE_STREAM_OUTPUT_DIR
+          value: "/boss/dynamic_content"
+        - name: INFINITE_STREAM_DATABASE_DIR
+          value: "/boss/boss-data"
+        - name: INFINITE_STREAM_TEMP_DIR
+          value: "/boss/boss-tmp"
+        - name: INFINITE_STREAM_CONTENT_DIR
+          value: "/content"
+        - name: TMPDIR
+          value: "/boss/boss-tmp"
+        - name: GO_LIVE_OUTPUT_DIR
+          value: "/go-live"
+        - name: GO_UPLOAD_ADDR
+          value: ":8003"
+        - name: INFINITE_STREAM_LISTEN_PORT
+          value: "30000"
+        - name: INFINITE_STREAM_PROXY_HOST
+          value: "127.0.0.1"
+        volumeMounts:
+        - name: boss-vol
+          mountPath: /boss
+        - name: certs-vol
+          mountPath: /etc/nginx/certs
+          readOnly: true
+        - name: go-live-tmpfs
+          mountPath: /go-live
+        - name: nginx-tmpfs
+          mountPath: /var/cache/nginx/live_playlists
+
+      - name: go-proxy
+        image: 100.111.190.54:5000/go-proxy:dev
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 30081
+        - containerPort: 30181
+        - containerPort: 30281
+        - containerPort: 30381
+        - containerPort: 30481
+        - containerPort: 30581
+        - containerPort: 30681
+        - containerPort: 30781
+        - containerPort: 30881
+        env:
+        - name: MEMCACHED_ADDR
+          value: "127.0.0.1:11211"
+        - name: INFINITE_STREAM_UPSTREAM_HOST
+          value: "127.0.0.1"
+        - name: INFINITE_STREAM_UPSTREAM_PORT
+          value: "30000"
+        - name: INFINITE_STREAM_MAX_SESSIONS
+          value: "8"
+        - name: INFINITE_STREAM_TC_INTERFACE
+          value: "eth0"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+
+      - name: memcached
+        image: memcached:latest
+        ports:
+        - containerPort: 11211
+
+      volumes:
+      - name: boss-vol
+        hostPath:
+          path: /home/jonathanoliver/boss
+          type: Directory
+      - name: certs-vol
+        hostPath:
+          path: /home/jonathanoliver/smashing/certs
+          type: Directory
+      - name: go-live-tmpfs
+        emptyDir:
+          medium: Memory
+          sizeLimit: 4Gi
+      - name: nginx-tmpfs
+        emptyDir:
+          medium: Memory
+          sizeLimit: 100Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infinite-streaming-dev
+spec:
+  selector:
+    app: infinite-streaming-dev
+  ports:
+    - name: p40000
+      port: 40000
+      targetPort: 30000
+      nodePort: 40000
+    - name: p40081
+      port: 40081
+      targetPort: 30081
+      nodePort: 40081
+    - name: p40181
+      port: 40181
+      targetPort: 30181
+      nodePort: 40181
+    - name: p40281
+      port: 40281
+      targetPort: 30281
+      nodePort: 40281
+    - name: p40381
+      port: 40381
+      targetPort: 30381
+      nodePort: 40381
+    - name: p40481
+      port: 40481
+      targetPort: 30481
+      nodePort: 40481
+    - name: p40581
+      port: 40581
+      targetPort: 30581
+      nodePort: 40581
+    - name: p40681
+      port: 40681
+      targetPort: 30681
+      nodePort: 40681
+    - name: p40781
+      port: 40781
+      targetPort: 30781
+      nodePort: 40781
+    - name: p40881
+      port: 40881
+      targetPort: 30881
+      nodePort: 40881
+  type: NodePort


### PR DESCRIPTION

This pull request introduces support for running both release and development ("dev") versions of the Lenovo k3s deployment side-by-side. It adds a new Kubernetes manifest and Makefile targets for the dev stack, updates deployment scripts to be more configurable, and improves documentation and UI logic to reflect these changes.

The most important changes are:

**Kubernetes & Deployment Configuration:**

* Added a new manifest `k8s-infinite-streaming-dev.yaml` to define the dev deployment and service, using separate ports (40000–40881) and image tags (`:dev`).
* Updated the `Makefile` to add `deploy` and `deploy-release` targets, allowing easy deployment of dev and release stacks with appropriate images, manifests, and deployment names.
* Made the deployment name configurable via the `K8S_DEPLOYMENT` variable, and updated deployment scripts to use this variable instead of hardcoding `infinite-streaming`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R8) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L86-R92)

**Documentation:**

* Expanded the `README.md` with a detailed section explaining how to run release and dev deployments side-by-side, including port assignments, image tags, deployment commands, and release tagging best practices.

**UI/Frontend Logic:**

* Updated `content/shared-nav.js` to recognize the new dev session port range (40081–40881) and to properly resolve the dev UI and proxy ports.