### PR TITLE
Codex/grouping sync fixes

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -100,6 +100,8 @@ The system is intended for:
 - Per‑port transport fault injection (DROP/REJECT) via nftables.
 - Transport faults support consecutive units in seconds or packets, with frequency in seconds.
 - Transport fault packet counters (drop/reject) are surfaced in API/UI for observability.
+- Server‑authoritative control updates with per‑field PATCH + control‑revision conflict handling.
+- Session grouping controls (group/ungroup/merge) with group badges and group‑aware control propagation.
 - Player selector: HLS.js, Shaka, Video.js, Native.
 - Logs player errors and HTTP failure details in the testing UI.
 
@@ -152,6 +154,7 @@ Many platforms already expose their own failure tools (player debug features, br
 ## 11) Configuration
 - Idle timeout for workers (configurable, visible in Go‑Monitor).
 - Output directories for generated manifests (tmpfs).
+- External/internal port mapping for NodePort deployments (go‑proxy uses `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, `PORT_RANGE_COUNT`; external `4xxxx` ports map to internal `3xxxx` ports).
 
 ## 12) Known Limitations & Expected‑but‑Missing Features
 These are features commonly expected in LL streaming origins but **not currently implemented** (or incomplete):
@@ -167,7 +170,7 @@ These are features commonly expected in LL streaming origins but **not currently
 - Full DASH‑IF conformance checks.
 
 ### Player/Origin
-- Simulated network throttling / fault injection at the origin.
+- Network shaping is Linux‑only (tc/netem); non‑Linux environments will report shaping as disabled.
 - CDN cache behavior simulation and stale‑while‑revalidate flows.
 - DRM signaling or encryption.
 

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ http://lenovo.local:30000/dashboard/testing-session.html?player_id=<uuid>&url=<e
 The `player_id` is required. The proxy uses it to bind the playback session to a dedicated port, so requests to the original port are redirected to a session‑specific port. This allows per‑session failure injection and traffic shaping without affecting other sessions.
 
 k3s NodePort mapping used by the testing flow:
-- Dashboard/UI: `30000`
-- Initial proxy stream port: `30081`
-- Session-assigned ports: `30181`, `30281`, `30381`, ... up to `30881`
+- External NodePorts (browser): `40000` (UI) and `40081` + `40181`..`40881` (sessions)
+- Internal container ports: `30000` (UI) and `30081` + `30181`..`30881` (sessions)
+- go‑proxy maps external → internal using `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, and `PORT_RANGE_COUNT`
 
 Controls:
 - **Retry Fetch**: re‑issues the current stream request without resetting the player.
@@ -257,6 +257,8 @@ See `PRD.md` for the full list.
 - Testing session player selector (HLS.js, Shaka, Video.js, Native) with error + HTTP failure logging.
 - Developer context menu option in Mosaic (developer=1) to open the HLS.js demo with the test URL.
 - Platform‑aware network shaping capabilities endpoint (Linux‑only support).
+- Server‑authoritative session updates with control‑revision conflict handling and SSE session stream.
+- Session grouping controls (group/ungroup/merge) that propagate failure settings and network shaping.
 
 ## Why unified error injection?
 Many environments already provide failure simulation (player debug tools, OS/Browser dev tools, routers, or lab network appliances). InfiniteStream still ships a unified error injection layer because it:

--- a/SESSION-GROUPING-IMPLEMENTATION.md
+++ b/SESSION-GROUPING-IMPLEMENTATION.md
@@ -1,0 +1,152 @@
+# Session Grouping Implementation - Summary
+
+## What Was Implemented
+
+This PR implements **hybrid session grouping** for InfiniteStream, enabling synchronized control of multiple streaming sessions for comparative player testing.
+
+## Key Features
+
+### 1. Automatic Grouping via Player ID Suffix
+- Sessions automatically group when `player_id` contains `_G###` pattern
+- Example: `hlsjs_G001` and `safari_G001` automatically form a group
+- Zero configuration required - just add the suffix to your URL
+- Group ID parsed and stored when session is created
+
+### 2. Manual Grouping via UI
+- Select multiple sessions using checkboxes in the Testing UI
+- Click "Link Selected Sessions" button
+- Sessions grouped with auto-generated or custom group ID
+- Unlink button available for easy separation
+
+### 3. Visual Indicators
+- **Green left border** on grouped session tabs
+- **Group badge** showing group ID (e.g., "G001")
+- **Linked info banner** showing other group members
+- **Unlink button** for breaking group association
+- **Active state** highlighted in blue
+
+### 4. Full Synchronization
+All control changes propagate to all sessions in a group:
+- Segment failure type, frequency, and timing
+- Manifest failure type, frequency, and timing
+- Master manifest failure settings
+- Transport fault type (DROP/REJECT) and timing
+- Network bandwidth limits (rate_mbps)
+- Network delay (delay_ms)
+- Packet loss percentage (loss_pct)
+- Complex network shaping patterns (multi-step bandwidth profiles)
+
+## Files Modified
+
+### Backend (Go)
+- `go-proxy/cmd/server/main.go` (+282 lines)
+  - Added `extractGroupId()` function for parsing `_G###` suffix
+  - Added `getSessionsByGroupId()`, `getGroupIdByPort()`, `getPortsForGroup()` helpers
+  - Modified `handleUpdateFailureSettings()` to propagate to group members
+  - Modified `handleNftShape()` and `handleNftPattern()` to propagate network settings
+  - Added 3 new API endpoints for UI-based grouping
+  - Formatted with gofmt
+
+### Frontend (HTML/JavaScript)
+- `content/dashboard/testing.html` (+148 lines)
+  - Added CSS for visual indicators (green borders, badges, info banner)
+  - Modified `renderSessionTabs()` to show group badges and checkboxes
+  - Added `renderGroupInfo()` to display linked session info
+  - Added event handlers for link/unlink operations
+  - Integrated group controls into existing UI
+
+### Documentation
+- `hls-player-error-testing-guide.md` (+130 lines)
+  - New section: "Session Grouping for Comparative Testing"
+  - Complete usage guide for both grouping methods
+  - API reference with examples
+  - Test scenario examples
+  
+- `SESSION-GROUPING.md` (new file, 2115 chars)
+  - Quick start guide
+  - Use cases and examples
+  - API reference
+  - Implementation details
+
+- `screenshots/session-grouping-mockup.html` (new file)
+  - Interactive HTML mockup showing UI in 4 scenarios
+  - Visual demonstration of all features
+
+## API Endpoints Added
+
+```
+POST /api/session-group/link
+POST /api/session-group/unlink
+GET  /api/session-group/{groupId}
+```
+
+## Use Cases
+
+1. **Compare Player Implementations**: Test HLS.js vs Safari native under identical conditions
+2. **Cross-Device Testing**: Compare desktop vs mobile player behavior
+3. **Multi-Player Validation**: Test multiple libraries (HLS.js, Shaka, Video.js) simultaneously
+4. **A/B Testing**: Compare different player configurations side-by-side
+
+## Example Usage
+
+### Automatic Grouping
+```bash
+# Tab 1
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=hlsjs_G001
+
+# Tab 2
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=safari_G001
+
+# Both sessions now synchronized - any control change applies to both
+```
+
+### Manual Grouping
+1. Open `/dashboard/testing.html`
+2. Check boxes next to Session 1 and Session 2
+3. Click "Link Selected Sessions"
+4. Sessions are grouped and show green borders
+
+## Technical Details
+
+- **Storage**: Session data stored in memcache (ephemeral, session-lifetime)
+- **Propagation**: Real-time - no page refresh needed
+- **Limits**: Up to 10 sessions can be grouped together
+- **Protocols**: Works with both LL-HLS and LL-DASH
+- **Independence**: Each session maintains its own metrics and measurements
+
+## Testing Status
+
+✅ Code complete and formatted
+✅ Documentation complete
+⏳ Docker build pending (environment network issues)
+⏳ Manual testing pending (requires running system)
+
+## Next Steps for Testing
+
+1. Build Docker container: `make build`
+2. Run system: `make run` or `docker compose up -d`
+3. Open two browser tabs with grouped player_ids
+4. Navigate to `/dashboard/testing.html`
+5. Apply failure injection to one session
+6. Verify settings propagate to other session
+7. Test UI-based grouping with checkboxes
+8. Test unlinking functionality
+9. Verify visual indicators display correctly
+
+## Code Quality
+
+- ✅ Follows existing code patterns
+- ✅ Minimal changes (only added functionality, no refactoring)
+- ✅ Formatted with gofmt
+- ✅ No breaking changes (backward compatible)
+- ✅ Sessions without groups work as before
+
+## Screenshots
+
+See `screenshots/session-grouping-mockup.html` for interactive visual demonstration of:
+- Scenario 1: Ungrouped sessions ready to link
+- Scenario 2: Auto-grouped sessions via player_id suffix
+- Scenario 3: Multiple independent groups
+- Scenario 4: Large group with three players
+
+Open the file in a browser to see the full UI mockup with all visual indicators.

--- a/SESSION-GROUPING.md
+++ b/SESSION-GROUPING.md
@@ -1,0 +1,83 @@
+# Session Grouping Feature
+
+## Quick Start
+
+Synchronize failure injection and network shaping across multiple streaming sessions for comparative player testing.
+
+### Automatic Grouping via Player ID
+
+Add `_G###` suffix to your player_id parameter:
+
+```bash
+# HLS.js
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=hlsjs_G001
+
+# Safari Native
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=safari_G001
+```
+
+Sessions with matching group IDs will automatically synchronize all control settings.
+
+### Manual Grouping via UI
+
+1. Open `/dashboard/testing.html`
+2. Select 2+ sessions using checkboxes
+3. Click "Link Selected Sessions"
+4. All selected sessions are now grouped
+
+## What Gets Synchronized
+
+- **Failure Injection**: Segment, manifest, and transport failures
+- **Network Shaping**: Bandwidth limits, packet loss, delay, and patterns
+- **Transport Faults**: DROP/REJECT timing and frequency
+
+## Visual Indicators
+
+- Green left border on session tabs
+- Group badge showing group ID
+- "Linked with" banner showing other group members
+- Unlink button for easy separation
+
+## Use Cases
+
+### Compare Player Implementations
+Test how HLS.js vs Safari native handle identical network conditions.
+
+### Cross-Device Testing
+Compare desktop vs mobile player behavior under same constraints.
+
+### Multi-Player Validation
+Test multiple player libraries (HLS.js, Shaka, Video.js) simultaneously.
+
+### A/B Testing
+Compare different player configurations or versions side-by-side.
+
+## API Reference
+
+### Link Sessions
+```bash
+POST /api/session-group/link
+{"session_ids": ["1", "2"], "group_id": "G001"}
+```
+
+### Unlink Session
+```bash
+POST /api/session-group/unlink
+{"session_id": "1"}
+```
+
+### Get Group Info
+```bash
+GET /api/session-group/G001
+```
+
+## Implementation Details
+
+- Backend: Go (go-proxy/cmd/server/main.go)
+- Frontend: JavaScript (content/dashboard/testing.html)
+- Storage: Memcache (ephemeral, session-lifetime)
+- Limits: Up to 10 sessions per group
+
+## For More Information
+
+See the full documentation in `hls-player-error-testing-guide.md` under "Session Grouping for Comparative Testing".

--- a/boss-content.conf.template
+++ b/boss-content.conf.template
@@ -156,6 +156,18 @@ server {
         add_header Expires "0" always;
     }
 
+    location = /api/sessions/stream {
+        proxy_pass http://go_proxy;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        add_header X-Accel-Buffering "no" always;
+    }
+
     location = /api/clear-sessions {
         proxy_pass http://go_proxy;
         add_header Access-Control-Allow-Origin * always;
@@ -173,6 +185,14 @@ server {
     }
 
     location ~ ^/api/failure-settings/ {
+        proxy_pass http://go_proxy;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+
+    location ~ ^/api/session-group/ {
         proxy_pass http://go_proxy;
         add_header Access-Control-Allow-Origin * always;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;

--- a/content/dashboard/testing-session-ui-refactored.js
+++ b/content/dashboard/testing-session-ui-refactored.js
@@ -153,7 +153,7 @@
     function renderManifestOptions(sessionId, variants, selected) {
         const selectedSet = new Set(selected || []);
         const list = sortedPlaylists(variants);
-        const allChecked = selectedSet.has('All');
+        const allChecked = selectedSet.size === 0 || selectedSet.has('All');
         const checkbox = (value, label) => {
             const checked = allChecked || selectedSet.has(value) ? 'checked' : '';
             return `<label><input type="checkbox" data-field="manifest_failure_urls" value="${value}" ${checked}>${label}</label>`;
@@ -448,6 +448,7 @@
         const transportActive = !!session.transport_fault_active;
         const transportDropPackets = Number(session.transport_fault_drop_packets || 0);
         const transportRejectPackets = Number(session.transport_fault_reject_packets || 0);
+        const portDisplay = session.x_forwarded_port_external || session.x_forwarded_port || '—';
 
         // Calculate summary counts for badge
         const masterCount = session.master_manifest_requests_count || 0;
@@ -463,7 +464,7 @@
             <div class="session-card" data-session-id="${sessionId}" data-session-port="${session.x_forwarded_port || ''}" data-shaping-presets="${encodedPresets}" data-shaping-video-presets="${encodedVideoPresets}" data-shaping-overhead-mbps="${overheadMbps}">
                 <div class="session-header">
                     ${hideTitle ? '' : `<div class="session-title">Session ${sessionId}</div>`}
-                    <div class="session-meta" title="Port">${session.x_forwarded_port || '—'}</div>
+                    <div class="session-meta" title="Port">${portDisplay}</div>
                 </div>
                 ${inlineHost ? `<div class="session-inline-player" data-inline-host="${sessionId}"></div>` : ''}
 
@@ -478,7 +479,7 @@
                         <div class="session-grid">
                             <div class="session-item"><span class="label">User Agent</span><span class="value">${session.user_agent || '—'}</span></div>
                             <div class="session-item"><span class="label">Player IP</span><span class="value">${session.player_ip || '—'}</span></div>
-                            ${showPortItem ? `<div class="session-item"><span class="label">Port</span><span class="value">${session.x_forwarded_port || '—'}</span></div>` : ''}
+                            ${showPortItem ? `<div class="session-item"><span class="label">Port</span><span class="value">${portDisplay}</span></div>` : ''}
                             <div class="session-item"><span class="label">Last Request</span><span class="value">${formatDate(session.last_request)}</span></div>
                             <div class="session-item"><span class="label">First Request</span><span class="value">${formatDate(session.first_request_time)}</span></div>
                             <div class="session-item"><span class="label">Session Duration</span><span class="value">${formatDuration(session.session_duration)}</span></div>
@@ -524,13 +525,13 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Consecutive</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="segment_consecutive_failures" value="${session.segment_consecutive_failures > 0 ? session.segment_consecutive_failures : 1}">
-                                            <span class="range-value">${session.segment_consecutive_failures > 0 ? session.segment_consecutive_failures : 1}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="segment_consecutive_failures" value="${Number.isFinite(Number(session.segment_consecutive_failures)) && Number(session.segment_consecutive_failures) >= 0 ? Number(session.segment_consecutive_failures) : 1}">
+                                            <span class="range-value">${Number.isFinite(Number(session.segment_consecutive_failures)) && Number(session.segment_consecutive_failures) >= 0 ? Number(session.segment_consecutive_failures) : 1}</span>
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="segment_failure_frequency" value="${session.segment_failure_frequency > 0 ? session.segment_failure_frequency : 6}">
-                                            <span class="range-value">${session.segment_failure_frequency > 0 ? session.segment_failure_frequency : 6}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="segment_failure_frequency" value="${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}">
+                                            <span class="range-value">${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
 
@@ -552,13 +553,13 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Consecutive</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="manifest_consecutive_failures" value="${session.manifest_consecutive_failures > 0 ? session.manifest_consecutive_failures : 1}">
-                                            <span class="range-value">${session.manifest_consecutive_failures > 0 ? session.manifest_consecutive_failures : 1}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="manifest_consecutive_failures" value="${Number.isFinite(Number(session.manifest_consecutive_failures)) && Number(session.manifest_consecutive_failures) >= 0 ? Number(session.manifest_consecutive_failures) : 1}">
+                                            <span class="range-value">${Number.isFinite(Number(session.manifest_consecutive_failures)) && Number(session.manifest_consecutive_failures) >= 0 ? Number(session.manifest_consecutive_failures) : 1}</span>
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="manifest_failure_frequency" value="${session.manifest_failure_frequency > 0 ? session.manifest_failure_frequency : 6}">
-                                            <span class="range-value">${session.manifest_failure_frequency > 0 ? session.manifest_failure_frequency : 6}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="manifest_failure_frequency" value="${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}">
+                                            <span class="range-value">${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
 
@@ -576,13 +577,13 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Consecutive</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_consecutive_failures" value="${session.master_manifest_consecutive_failures > 0 ? session.master_manifest_consecutive_failures : 1}">
-                                            <span class="range-value">${session.master_manifest_consecutive_failures > 0 ? session.master_manifest_consecutive_failures : 1}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_consecutive_failures" value="${Number.isFinite(Number(session.master_manifest_consecutive_failures)) && Number(session.master_manifest_consecutive_failures) >= 0 ? Number(session.master_manifest_consecutive_failures) : 1}">
+                                            <span class="range-value">${Number.isFinite(Number(session.master_manifest_consecutive_failures)) && Number(session.master_manifest_consecutive_failures) >= 0 ? Number(session.master_manifest_consecutive_failures) : 1}</span>
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_failure_frequency" value="${session.master_manifest_failure_frequency > 0 ? session.master_manifest_failure_frequency : 6}">
-                                            <span class="range-value">${session.master_manifest_failure_frequency > 0 ? session.master_manifest_failure_frequency : 6}</span>
+                                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_failure_frequency" value="${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}">
+                                            <span class="range-value">${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
 

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -155,7 +155,7 @@
     function renderManifestOptions(sessionId, variants, selected) {
         const selectedSet = new Set(selected || []);
         const list = sortedPlaylists(variants);
-        const allChecked = selectedSet.has('All');
+        const allChecked = selectedSet.size === 0 || selectedSet.has('All');
         const checkbox = (value, label) => {
             const checked = allChecked || selectedSet.has(value) ? 'checked' : '';
             return `<label><input type="checkbox" data-field="manifest_failure_urls" value="${value}" ${checked}>${label}</label>`;
@@ -444,17 +444,18 @@
         const transportActive = !!session.transport_fault_active;
         const transportDropPackets = Number(session.transport_fault_drop_packets || 0);
         const transportRejectPackets = Number(session.transport_fault_reject_packets || 0);
+        const portDisplay = session.x_forwarded_port_external || session.x_forwarded_port || '—';
         return `
             <div class="session-card" data-session-id="${sessionId}" data-session-port="${session.x_forwarded_port || ''}" data-shaping-presets="${encodedPresets}" data-shaping-video-presets="${encodedVideoPresets}" data-shaping-overhead-mbps="${overheadMbps}">
                 <div class="session-header">
                     ${hideTitle ? '' : `<div class="session-title">Session ${sessionId}</div>`}
-                    <div class="session-meta" title="Port">${session.x_forwarded_port || '—'}</div>
+                    <div class="session-meta" title="Port">${portDisplay}</div>
                 </div>
                 ${inlineHost ? `<div class="session-inline-player" data-inline-host="${sessionId}"></div>` : ''}
                 <div class="session-grid">
                     <div class="session-item"><span class="label">User Agent</span><span class="value">${session.user_agent || '—'}</span></div>
                     <div class="session-item"><span class="label">Player IP</span><span class="value">${session.player_ip || '—'}</span></div>
-                    ${showPortItem ? `<div class="session-item"><span class="label">Port</span><span class="value">${session.x_forwarded_port || '—'}</span></div>` : ''}
+                    ${showPortItem ? `<div class="session-item"><span class="label">Port</span><span class="value">${portDisplay}</span></div>` : ''}
                     <div class="session-item"><span class="label">Last Request</span><span class="value">${formatDate(session.last_request)}</span></div>
                     <div class="session-item"><span class="label">First Request</span><span class="value">${formatDate(session.first_request_time)}</span></div>
                     <div class="session-item"><span class="label">Session Duration</span><span class="value">${formatDuration(session.session_duration)}</span></div>
@@ -475,13 +476,13 @@
                         </div>
                         <div class="range-row">
                             <label>Consecutive</label>
-                            <input type="range" min="0" max="10" step="1" data-field="segment_consecutive_failures" value="${session.segment_consecutive_failures > 0 ? session.segment_consecutive_failures : 1}">
-                            <span class="range-value">${session.segment_consecutive_failures > 0 ? session.segment_consecutive_failures : 1}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="segment_consecutive_failures" value="${Number.isFinite(Number(session.segment_consecutive_failures)) && Number(session.segment_consecutive_failures) >= 0 ? Number(session.segment_consecutive_failures) : 1}">
+                            <span class="range-value">${Number.isFinite(Number(session.segment_consecutive_failures)) && Number(session.segment_consecutive_failures) >= 0 ? Number(session.segment_consecutive_failures) : 1}</span>
                         </div>
                         <div class="range-row">
                             <label>Frequency</label>
-                            <input type="range" min="0" max="10" step="1" data-field="segment_failure_frequency" value="${session.segment_failure_frequency > 0 ? session.segment_failure_frequency : 6}">
-                            <span class="range-value">${session.segment_failure_frequency > 0 ? session.segment_failure_frequency : 6}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="segment_failure_frequency" value="${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}">
+                            <span class="range-value">${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}</span>
                         </div>
                     </div>
                     <div class="failure-group">
@@ -494,13 +495,13 @@
                         </div>
                         <div class="range-row">
                             <label>Consecutive</label>
-                            <input type="range" min="0" max="10" step="1" data-field="manifest_consecutive_failures" value="${session.manifest_consecutive_failures > 0 ? session.manifest_consecutive_failures : 1}">
-                            <span class="range-value">${session.manifest_consecutive_failures > 0 ? session.manifest_consecutive_failures : 1}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="manifest_consecutive_failures" value="${Number.isFinite(Number(session.manifest_consecutive_failures)) && Number(session.manifest_consecutive_failures) >= 0 ? Number(session.manifest_consecutive_failures) : 1}">
+                            <span class="range-value">${Number.isFinite(Number(session.manifest_consecutive_failures)) && Number(session.manifest_consecutive_failures) >= 0 ? Number(session.manifest_consecutive_failures) : 1}</span>
                         </div>
                         <div class="range-row">
                             <label>Frequency</label>
-                            <input type="range" min="0" max="10" step="1" data-field="manifest_failure_frequency" value="${session.manifest_failure_frequency > 0 ? session.manifest_failure_frequency : 6}">
-                            <span class="range-value">${session.manifest_failure_frequency > 0 ? session.manifest_failure_frequency : 6}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="manifest_failure_frequency" value="${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}">
+                            <span class="range-value">${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}</span>
                         </div>
                     </div>
                     <div class="failure-group">
@@ -512,13 +513,13 @@
                         </div>
                         <div class="range-row">
                             <label>Consecutive</label>
-                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_consecutive_failures" value="${session.master_manifest_consecutive_failures > 0 ? session.master_manifest_consecutive_failures : 1}">
-                            <span class="range-value">${session.master_manifest_consecutive_failures > 0 ? session.master_manifest_consecutive_failures : 1}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_consecutive_failures" value="${Number.isFinite(Number(session.master_manifest_consecutive_failures)) && Number(session.master_manifest_consecutive_failures) >= 0 ? Number(session.master_manifest_consecutive_failures) : 1}">
+                            <span class="range-value">${Number.isFinite(Number(session.master_manifest_consecutive_failures)) && Number(session.master_manifest_consecutive_failures) >= 0 ? Number(session.master_manifest_consecutive_failures) : 1}</span>
                         </div>
                         <div class="range-row">
                             <label>Frequency</label>
-                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_failure_frequency" value="${session.master_manifest_failure_frequency > 0 ? session.master_manifest_failure_frequency : 6}">
-                            <span class="range-value">${session.master_manifest_failure_frequency > 0 ? session.master_manifest_failure_frequency : 6}</span>
+                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_failure_frequency" value="${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}">
+                            <span class="range-value">${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}</span>
                         </div>
                     </div>
                     <div class="failure-group">

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -60,6 +60,49 @@
 
         .panel-badge.videojs { background: #fce7f3; color: #9d174d; }
         .panel-badge.native { background: #e0f2fe; color: #0369a1; }
+        .panel-badge.group { background: #fde68a; color: #92400e; }
+        .group-controls-row {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            margin-bottom: 12px;
+            border: 1px solid #e5e7eb;
+            border-radius: 12px;
+            padding: 12px;
+            background: #f8fafc;
+        }
+        .group-banner {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 8px 10px;
+            border-radius: 10px;
+            border: 1px solid #bbf7d0;
+            background: #ecfdf3;
+            color: #166534;
+            font-weight: 600;
+        }
+        .group-banner .group-meta {
+            font-weight: 500;
+        }
+        .group-banner .group-actions {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+        .group-controls-row .group-select-row {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        .group-controls-row select {
+            min-width: 220px;
+        }
+        .group-controls-row .group-hint {
+            color: #6b7280;
+        }
 
         .player-frame {
             width: 100%;
@@ -490,6 +533,7 @@
         <div class="session-panel">
             <h3>Session Controls</h3>
             <div id="networkShapingBanner" class="status-message" style="display:none; margin-bottom: 10px;"></div>
+            <div id="sessionGroupControls" class="group-controls-row"></div>
             <div id="sessionControls">Loading session…</div>
         </div>
     </div>
@@ -510,15 +554,25 @@
         let autoRetryCount = 0;
         let autoRetryTimer = null;
         const pendingShaping = new Map();
+        const pendingFailureEdits = new Map();
+        const controlRevisionBySession = new Map();
         const bandwidthHistory = new Map();
         const bandwidthCharts = new Map();
         const bufferDepthCharts = new Map();
         const bandwidthVisibility = new Map();
         const bitrateAxisMaxBySession = new Map();
+        let lastSessionsList = [];
+        let groupSessionsFetchInFlight = false;
+        let groupSelectValue = '';
+        let groupSelectSessionId = '';
         let sessionPollController = null;
         let sessionPollInFlight = false;
         let sessionPollRequestSeq = 0;
         let sessionPollLastAppliedSeq = 0;
+        let sessionsStream = null;
+        let sessionPollTimer = null;
+        const failureSaveTimers = new Map();
+        const failureSaveFields = new Map();
         let playerEstimatedMbps = null;
         let currentRenditionMbps = null;
         const collapseState = new Map();
@@ -529,6 +583,7 @@
             'bitrate-chart': false
         };
         const collapseStoragePrefix = 'testing_session_collapse_';
+        let lastServerSession = null;
 
         function getStoredCollapseState(key) {
             try {
@@ -639,7 +694,7 @@
             };
         }
 
-        function setBadges(isDash, playerType) {
+        function setBadges(isDash, playerType, groupId) {
             const badges = document.getElementById('playerBadges');
             badges.innerHTML = '';
             const protocol = document.createElement('span');
@@ -660,6 +715,12 @@
             player.textContent = label;
             badges.appendChild(protocol);
             badges.appendChild(player);
+            if (groupId) {
+                const group = document.createElement('span');
+                group.className = 'panel-badge group';
+                group.textContent = groupId;
+                badges.appendChild(group);
+            }
         }
 
         function attachVideoEvents() {
@@ -845,7 +906,7 @@
             const choice = getPlayerChoice();
             const playerType = resolvePlayerChoice(url, choice);
             document.getElementById('playerUrl').textContent = url;
-            setBadges(isDash, playerType);
+            setBadges(isDash, playerType, lastServerSession?.group_id || '');
             if (playerType === 'shaka') {
                 shaka.polyfill.installAll();
                 if (!shaka.Player.isBrowserSupported()) {
@@ -956,6 +1017,187 @@
             TestingSessionUI.applyCollapsibleState(container);
         }
 
+        function formatSessionLabel(session) {
+            if (!session) return '';
+            const portValue = session.x_forwarded_port_external || session.x_forwarded_port || '';
+            const portSuffix = portValue ? ` (Port ${portValue})` : '';
+            const playerLabel = session.player_id ? ` · ${session.player_id}` : '';
+            return `Session ${session.session_id}${portSuffix}${playerLabel}`;
+        }
+
+        function renderGroupControls(session, sessions) {
+            if (!session || !session.session_id) return '';
+            const currentId = String(session.session_id);
+            const groupId = session.group_id || '';
+            const allSessions = Array.isArray(sessions) ? sessions : [];
+            const hasOtherSessions = allSessions.some(s => String(s.session_id) !== currentId);
+            const groupMembers = groupId
+                ? allSessions.filter(s => String(s.session_id) !== currentId && s.group_id === groupId)
+                : [];
+            const memberLabels = groupMembers.map(formatSessionLabel).join(', ');
+            const groupSummary = memberLabels || 'No other sessions yet';
+            const available = allSessions.filter(s => {
+                if (String(s.session_id) === currentId) return false;
+                if (!groupId) return true;
+                return s.group_id !== groupId;
+            });
+            const options = available.map(s => {
+                const groupSuffix = s.group_id ? ` · ${s.group_id}` : '';
+                const label = `${formatSessionLabel(s)}${groupSuffix}`;
+                return `<option value="${s.session_id}">${label}</option>`;
+            }).join('');
+            const selectDisabled = available.length === 0;
+            const selectLabel = groupId ? 'Add to group' : 'Group with';
+            const banner = groupId ? `
+                <div class="group-banner">
+                    <div class="group-meta">🔗 Grouped with: ${groupSummary} <span class="panel-badge group">${groupId}</span></div>
+                    <div class="group-actions">
+                        <button class="btn btn-secondary" data-action="ungroup">Ungroup</button>
+                    </div>
+                </div>
+            ` : '';
+            const hint = selectDisabled
+                ? (hasOtherSessions ? 'No available sessions to add.' : 'Waiting for other sessions...')
+                : '';
+            return `
+                ${banner}
+                <div class="group-select-row">
+                    <label>
+                        ${selectLabel}
+                        <select id="groupWithSelect" ${selectDisabled ? 'disabled' : ''}>
+                            <option value="">Select session…</option>
+                            ${options}
+                        </select>
+                    </label>
+                    <button class="btn btn-secondary" data-action="group-with" ${selectDisabled ? 'disabled' : ''}>Group</button>
+                    ${hint ? `<span class="group-hint">${hint}</span>` : ''}
+                </div>
+            `;
+        }
+
+        function updateGroupControls(session, sessions) {
+            const container = document.getElementById('sessionGroupControls');
+            if (!container) return;
+            container.innerHTML = renderGroupControls(session, sessions);
+            const select = container.querySelector('#groupWithSelect');
+            if (select) {
+                const currentId = session ? String(session.session_id || '') : '';
+                if (groupSelectSessionId && currentId === groupSelectSessionId && groupSelectValue) {
+                    select.value = groupSelectValue;
+                }
+            }
+            if (session && session.session_id && (!Array.isArray(sessions) || sessions.length <= 1) && !groupSessionsFetchInFlight) {
+                groupSessionsFetchInFlight = true;
+                fetch('/api/sessions', { cache: 'no-store' })
+                    .then(res => res.json())
+                    .then(all => {
+                        lastSessionsList = Array.isArray(all) ? all : [];
+                        container.innerHTML = renderGroupControls(session, lastSessionsList);
+                        const retrySelect = container.querySelector('#groupWithSelect');
+                        if (retrySelect) {
+                            const currentId = String(session.session_id || '');
+                            if (groupSelectSessionId && currentId === groupSelectSessionId && groupSelectValue) {
+                                retrySelect.value = groupSelectValue;
+                            }
+                        }
+                    })
+                    .catch(err => console.error('Error fetching sessions for grouping', err))
+                    .finally(() => {
+                        groupSessionsFetchInFlight = false;
+                    });
+            }
+        }
+
+        function bindGroupControls() {
+            const container = document.getElementById('sessionGroupControls');
+            if (!container) return;
+            container.addEventListener('change', (event) => {
+                const select = event.target.closest('#groupWithSelect');
+                if (!select) return;
+                groupSelectValue = String(select.value || '');
+                const session = lastServerSession;
+                groupSelectSessionId = session && session.session_id ? String(session.session_id) : '';
+            });
+            const requestGroupWith = (session, targetId, sessions) => {
+                if (!session || !session.session_id || !targetId) return;
+                const list = Array.isArray(sessions) ? sessions : [];
+                const targetSession = list.find(item => String(item.session_id) === targetId);
+                let groupId = session.group_id || '';
+                if (!groupId && targetSession && targetSession.group_id) {
+                    groupId = targetSession.group_id;
+                }
+                const ids = new Set([String(session.session_id), targetId]);
+                if (targetSession && targetSession.group_id && targetSession.group_id !== session.group_id) {
+                    list
+                        .filter(item => item.group_id === targetSession.group_id)
+                        .forEach(item => ids.add(String(item.session_id)));
+                }
+                if (ids.size < 2) {
+                    alert('Select a session to group with.');
+                    return;
+                }
+                const payload = {
+                    session_ids: Array.from(ids)
+                };
+                if (groupId) {
+                    payload.group_id = groupId;
+                }
+                fetch('/api/session-group/link', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                })
+                    .then(() => {
+                        groupSelectValue = '';
+                        groupSelectSessionId = '';
+                        refreshSession(session.player_id);
+                    })
+                    .catch(err => console.error('Error grouping sessions', err));
+            };
+            container.addEventListener('click', (event) => {
+                const button = event.target.closest('button');
+                if (!button) return;
+                const session = lastServerSession;
+                if (!session || !session.session_id) return;
+                if (button.dataset.action === 'group-with') {
+                    const select = container.querySelector('#groupWithSelect');
+                    const targetId = select ? String(select.value || '') : '';
+                    if (!targetId) return;
+                    const targetSession = lastSessionsList.find(item => String(item.session_id) === targetId);
+                    if (!targetSession) {
+                        fetch('/api/sessions', { cache: 'no-store' })
+                            .then(res => res.json())
+                            .then(all => {
+                                lastSessionsList = Array.isArray(all) ? all : [];
+                                requestGroupWith(session, targetId, lastSessionsList);
+                            })
+                            .catch(err => console.error('Error fetching sessions for grouping', err));
+                        return;
+                    }
+                    requestGroupWith(session, targetId, lastSessionsList);
+                    return;
+                }
+                if (button.dataset.action === 'ungroup') {
+                    if (!session.group_id) return;
+                    fetch('/api/session-group/unlink', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            session_id: String(session.session_id),
+                            group_id: session.group_id,
+                            unlink_group: true
+                        })
+                    })
+                        .then(() => {
+                            groupSelectValue = '';
+                            groupSelectSessionId = '';
+                            refreshSession(session.player_id);
+                        })
+                        .catch(err => console.error('Error ungrouping sessions', err));
+                }
+            });
+        }
+
         function normalizeTransportFaultType(session) {
             const raw = String(session.transport_failure_type || session.transport_fault_type || 'none').toLowerCase();
             if (raw === 'drop' || raw === 'reject') return raw;
@@ -974,10 +1216,66 @@
             return 'failures_per_seconds';
         }
 
+        function getControlRevision(session) {
+            const revision = session ? session.control_revision : null;
+            if (revision === undefined || revision === null || revision === '') {
+                return null;
+            }
+            return String(revision);
+        }
+
+        function shouldSyncControls(sessionId, session) {
+            const key = String(sessionId || session?.session_id || '');
+            if (!key) return true;
+            const revision = getControlRevision(session);
+            const lastRevision = controlRevisionBySession.get(key);
+            if (revision === null) {
+                if (lastRevision === undefined) {
+                    controlRevisionBySession.set(key, null);
+                    return true;
+                }
+                return false;
+            }
+            if (lastRevision !== revision) {
+                controlRevisionBySession.set(key, revision);
+                return true;
+            }
+            return false;
+        }
+
         function syncServerFaultControls(card, session) {
             if (!card || !session) return;
             const sessionId = String(card.dataset.sessionId || session.session_id || '');
             if (!sessionId) return;
+            const syncSelect = (namePrefix, value) => {
+                const select = card.querySelector(`select[name="${namePrefix}_${sessionId}"]`);
+                if (select && value) {
+                    select.value = value;
+                }
+            };
+            const syncRange = (field, value, fallback) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (!input) return;
+                const numeric = Number(value);
+                const resolved = Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+                input.value = String(resolved);
+                const valueEl = input.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = input.value;
+            };
+            const syncFailureScope = (field, values, allWhenEmpty) => {
+                const selected = Array.isArray(values) ? values.map(String) : [];
+                const selectedSet = new Set(selected);
+                const allChecked = allWhenEmpty
+                    ? (selected.length === 0 || selectedSet.has('All'))
+                    : selectedSet.has('All');
+                card.querySelectorAll(`input[data-field="${field}"]`).forEach(input => {
+                    if (input.value === 'All') {
+                        input.checked = allChecked;
+                        return;
+                    }
+                    input.checked = allChecked || selectedSet.has(input.value);
+                });
+            };
             const syncRadio = (namePrefix, value) => {
                 const radios = card.querySelectorAll(`input[name="${namePrefix}_${sessionId}"]`);
                 radios.forEach((radio) => {
@@ -989,6 +1287,17 @@
             syncRadio('master_manifest_failure_type', String(session.master_manifest_failure_type || 'none'));
             syncRadio('transport_failure_type', normalizeTransportFaultType(session));
             syncRadio('transport_failure_mode', normalizeTransportFailureMode(session));
+            syncSelect('segment_failure_mode', String(session.segment_failure_mode || 'failures_per_seconds'));
+            syncSelect('manifest_failure_mode', String(session.manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('master_manifest_failure_mode', String(session.master_manifest_failure_mode || 'failures_per_seconds'));
+            syncRange('segment_consecutive_failures', session.segment_consecutive_failures, 1);
+            syncRange('segment_failure_frequency', session.segment_failure_frequency, 6);
+            syncRange('manifest_consecutive_failures', session.manifest_consecutive_failures, 1);
+            syncRange('manifest_failure_frequency', session.manifest_failure_frequency, 6);
+            syncRange('master_manifest_consecutive_failures', session.master_manifest_consecutive_failures, 1);
+            syncRange('master_manifest_failure_frequency', session.master_manifest_failure_frequency, 6);
+            syncFailureScope('segment_failure_urls', session.segment_failure_urls, true);
+            syncFailureScope('manifest_failure_urls', session.manifest_failure_urls, false);
             TestingSessionUI.updateTransportModeUi(card);
             const transportConsecutiveInput = card.querySelector('input[data-field="transport_consecutive_failures"]');
             const transportFrequencyInput = card.querySelector('input[data-field="transport_failure_frequency"]');
@@ -1014,6 +1323,10 @@
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
+        }
+
+        function syncServerFaultData(card, session) {
+            if (!card || !session) return;
             const stateEl = card.querySelector('[data-field="transport_fault_state"]');
             if (stateEl) {
                 stateEl.textContent = session.transport_fault_active ? 'Active' : 'Idle';
@@ -1024,6 +1337,256 @@
                 const rejectPackets = Number(session.transport_fault_reject_packets || 0);
                 countersEl.textContent = `Drop ${dropPackets} pkts · Reject ${rejectPackets} pkts`;
             }
+        }
+
+        function closestStepDuration(seconds) {
+            const options = [6, 12, 18, 24];
+            const numeric = Number(seconds);
+            if (!Number.isFinite(numeric) || numeric <= 0) return 12;
+            let best = options[0];
+            let bestDiff = Math.abs(numeric - best);
+            options.forEach((value) => {
+                const diff = Math.abs(numeric - value);
+                if (diff < bestDiff) {
+                    best = value;
+                    bestDiff = diff;
+                }
+            });
+            return best;
+        }
+
+        function inferSegmentDurationSeconds(session) {
+            const explicit = Number(session?.nftables_pattern_segment_duration_seconds || 0);
+            if (Number.isFinite(explicit) && explicit > 0) {
+                return explicit;
+            }
+            const candidates = [
+                session?.manifest_url || '',
+                session?.master_manifest_url || '',
+                session?.last_request_url || ''
+            ];
+            for (const value of candidates) {
+                const match = value.match(/(?:_|\/)(\d+)s(?:[._/?]|$)/i);
+                if (match) {
+                    const parsed = Number(match[1]);
+                    if (Number.isFinite(parsed) && parsed > 0) {
+                        return parsed;
+                    }
+                }
+            }
+            return 1;
+        }
+
+        function resolvePatternDefaults(session) {
+            const segmentDurationSeconds = inferSegmentDurationSeconds(session);
+            const defaultSegments = Number(session?.nftables_pattern_default_segments || 2);
+            const storedDefaultStepSeconds = Number(session?.nftables_pattern_default_step_seconds || 0);
+            const defaultStepSeconds = Number.isFinite(storedDefaultStepSeconds) && storedDefaultStepSeconds > 0
+                ? storedDefaultStepSeconds
+                : segmentDurationSeconds * defaultSegments;
+            return {
+                segmentDurationSeconds,
+                selectedStepSeconds: closestStepDuration(defaultStepSeconds)
+            };
+        }
+
+        function syncNetworkShapingControls(card, session) {
+            if (!card || !session) return;
+            const sessionId = String(card.dataset.sessionId || session.session_id || '');
+            if (!sessionId) return;
+            const templateModeRaw = String(session.nftables_pattern_template_mode || '').toLowerCase();
+            const templateMode = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid'].includes(templateModeRaw)
+                ? templateModeRaw
+                : 'sliders';
+            card.querySelectorAll(`input[name="shaping_template_mode_${sessionId}"]`).forEach((radio) => {
+                radio.checked = radio.value === templateMode;
+            });
+            const marginRaw = Number(session.nftables_pattern_margin_pct);
+            const marginPct = [0, 10, 25, 50].includes(marginRaw) ? marginRaw : 0;
+            card.querySelectorAll(`input[name="shaping_template_margin_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === marginPct;
+            });
+            const defaults = resolvePatternDefaults(session);
+            card.querySelectorAll(`input[name="shaping_default_step_seconds_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === defaults.selectedStepSeconds;
+            });
+            const label = card.querySelector('[data-field="shaping_default_seconds_label"]');
+            if (label) {
+                label.textContent = `segment ${defaults.segmentDurationSeconds}s`;
+            }
+            updateTemplateModeUi(card);
+        }
+
+        function isFailureRangeField(field) {
+            return [
+                'segment_consecutive_failures',
+                'segment_failure_frequency',
+                'manifest_consecutive_failures',
+                'manifest_failure_frequency',
+                'master_manifest_consecutive_failures',
+                'master_manifest_failure_frequency',
+                'transport_consecutive_failures',
+                'transport_failure_frequency'
+            ].includes(field);
+        }
+
+        function getSessionBaseRevision() {
+            const revision = lastServerSession ? lastServerSession.control_revision : null;
+            if (revision === undefined || revision === null) {
+                return '';
+            }
+            return String(revision);
+        }
+
+        function queuePendingFailureEdits(sessionId, values) {
+            if (!sessionId || !values) return;
+            const key = String(sessionId);
+            const existing = pendingFailureEdits.get(key);
+            const merged = {
+                ...(existing ? existing.values : {}),
+                ...values
+            };
+            pendingFailureEdits.set(key, {
+                timestamp: Date.now(),
+                values: merged
+            });
+            setTimeout(() => {
+                const pending = pendingFailureEdits.get(key);
+                if (pending && Date.now() - pending.timestamp > 4500) {
+                    pendingFailureEdits.delete(key);
+                }
+            }, 5000);
+        }
+
+        function resolvePendingFailureEdits(sessionId, fields) {
+            const key = String(sessionId || '');
+            const pending = pendingFailureEdits.get(key);
+            if (!pending) return;
+            const values = { ...pending.values };
+            (fields || []).forEach(field => {
+                delete values[field];
+            });
+            if (Object.keys(values).length === 0) {
+                pendingFailureEdits.delete(key);
+            } else {
+                pendingFailureEdits.set(key, {
+                    timestamp: pending.timestamp,
+                    values
+                });
+            }
+        }
+
+        function buildSessionPatch(card, fields) {
+            const data = TestingSessionUI.readSessionSettings(card);
+            const set = {};
+            (fields || []).forEach(field => {
+                if (Object.prototype.hasOwnProperty.call(data, field)) {
+                    set[field] = data[field];
+                }
+            });
+            return {
+                sessionId: data.session_id,
+                set,
+                fields: fields || []
+            };
+        }
+
+        function applySessionPatchResponse(session) {
+            if (!session) return;
+            applySessionUpdate(session);
+        }
+
+        function sendSessionPatch(card, fields) {
+            const patch = buildSessionPatch(card, fields);
+            if (!patch.sessionId || Object.keys(patch.set).length === 0) {
+                return Promise.resolve();
+            }
+            queuePendingFailureEdits(patch.sessionId, patch.set);
+            return fetch(`/api/session/${patch.sessionId}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    set: patch.set,
+                    fields: patch.fields,
+                    base_revision: getSessionBaseRevision()
+                })
+            }).then(async response => {
+                const body = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    if (response.status === 409 && body.session) {
+                        resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                        pendingFailureEdits.delete(String(patch.sessionId));
+                        applySessionPatchResponse(body.session);
+                        return;
+                    }
+                    throw new Error(body.error || `HTTP ${response.status}`);
+                }
+                if (body.session) {
+                    resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                    applySessionPatchResponse(body.session);
+                }
+            }).catch(error => {
+                console.error('Error saving settings:', error);
+            });
+        }
+
+        function scheduleFailureSave(card, field) {
+            const sessionId = card?.dataset?.sessionId;
+            if (!sessionId || !field) return;
+            const key = String(sessionId);
+            if (!failureSaveFields.has(key)) {
+                failureSaveFields.set(key, new Set());
+            }
+            failureSaveFields.get(key).add(field);
+            if (failureSaveTimers.has(key)) {
+                clearTimeout(failureSaveTimers.get(key));
+            }
+            failureSaveTimers.set(key, setTimeout(() => {
+                const fields = Array.from(failureSaveFields.get(key) || []);
+                failureSaveFields.delete(key);
+                failureSaveTimers.delete(key);
+                if (fields.length) {
+                    sendSessionPatch(card, fields);
+                }
+            }, 200));
+        }
+
+        function parseSessionControlName(name, sessionId) {
+            if (!name || !sessionId) return '';
+            const suffix = `_${sessionId}`;
+            if (!name.endsWith(suffix)) return '';
+            return name.slice(0, -suffix.length);
+        }
+
+        function resolveSessionPatchFields(target, sessionId, field) {
+            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls') {
+                return [field];
+            }
+            const prefix = parseSessionControlName(target.name, sessionId);
+            if (!prefix) return [];
+            if (prefix.endsWith('_failure_type')) {
+                return [prefix];
+            }
+            if (prefix.endsWith('_failure_mode')) {
+                const base = prefix.replace('_failure_mode', '');
+                if (base === 'transport') {
+                    return [
+                        'transport_failure_mode',
+                        'transport_failure_units',
+                        'transport_consecutive_units',
+                        'transport_frequency_units',
+                        'transport_consecutive_failures',
+                        'transport_failure_frequency'
+                    ];
+                }
+                return [
+                    `${base}_failure_mode`,
+                    `${base}_failure_units`,
+                    `${base}_consecutive_units`,
+                    `${base}_frequency_units`
+                ];
+            }
+            return [];
         }
 
         function bindSessionControls() {
@@ -1237,6 +1800,9 @@
                 if (event.target.matches('input[type="range"]')) {
                     const valueEl = event.target.parentElement.querySelector('.range-value');
                     if (valueEl) valueEl.textContent = event.target.value;
+                    if (card && isFailureRangeField(event.target.dataset.field)) {
+                        scheduleFailureSave(card, event.target.dataset.field);
+                    }
                 }
                 if (event.target.dataset.field === 'shaping_step_mbps') {
                     const row = event.target.closest('.shape-step-row');
@@ -1292,17 +1858,48 @@
                         input.checked = event.target.checked;
                     });
                 }
+                if (event.target.dataset.field === 'manifest_failure_urls' && event.target.value !== 'All') {
+                    const checks = Array.from(card.querySelectorAll('input[data-field="manifest_failure_urls"]'));
+                    const allBox = checks.find(input => input.value === 'All');
+                    const scopedChecks = checks.filter(input => input.value !== 'All');
+                    if (allBox && allBox.checked) {
+                        allBox.checked = false;
+                    }
+                    if (!scopedChecks.some(input => input.checked) && allBox) {
+                        allBox.checked = true;
+                    }
+                }
                 if (event.target.dataset.field === 'segment_failure_urls' && event.target.value === 'All') {
                     const checks = card.querySelectorAll('input[data-field="segment_failure_urls"]');
                     checks.forEach(input => {
                         input.checked = event.target.checked;
                     });
                 }
+                if (event.target.dataset.field === 'segment_failure_urls' && event.target.value !== 'All') {
+                    const checks = Array.from(card.querySelectorAll('input[data-field="segment_failure_urls"]'));
+                    const allBox = checks.find(input => input.value === 'All');
+                    const scopedChecks = checks.filter(input => input.value !== 'All');
+                    if (allBox && allBox.checked) {
+                        allBox.checked = false;
+                    }
+                    if (!scopedChecks.some(input => input.checked) && allBox) {
+                        allBox.checked = true;
+                    }
+                }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_')) {
                     scheduleShapingApply(card);
                     return;
                 }
-                saveSession(card);
+                if (isFailureRangeField(event.target.dataset.field)) {
+                    scheduleFailureSave(card, event.target.dataset.field);
+                    return;
+                }
+                const sessionId = String(card.dataset.sessionId || '');
+                const field = event.target.dataset.field || '';
+                const fields = resolveSessionPatchFields(event.target, sessionId, field);
+                if (fields.length) {
+                    sendSessionPatch(card, fields);
+                }
             });
             container.addEventListener('click', (event) => {
                 const button = event.target.closest('button');
@@ -1365,11 +1962,8 @@
 
         function saveSession(card) {
             const data = TestingSessionUI.readSessionSettings(card);
-            fetch(`/api/failure-settings/${data.session_id}`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            }).catch(err => console.error('Error saving settings', err));
+            const fields = Object.keys(data || {}).filter(field => field !== 'session_id');
+            sendSessionPatch(card, fields);
         }
 
         function applyNetworkShaping(card) {
@@ -1448,7 +2042,10 @@
                     }
                     return response.json();
                 })
-                .then(sessions => sessions.find(session => session.player_id === playerId));
+                .then(sessions => {
+                    lastSessionsList = Array.isArray(sessions) ? sessions : [];
+                    return sessions.find(session => session.player_id === playerId);
+                });
         }
 
         function pushBandwidthSample(session) {
@@ -1764,6 +2361,71 @@
             }
         }
 
+        function applySessionUpdate(session) {
+            if (!session) return;
+            const container = document.getElementById('sessionControls');
+            const existingCard = container ? container.querySelector('.session-card') : null;
+            const serverSession = session;
+            lastServerSession = serverSession;
+            const sessionKey = String(serverSession.session_id || '');
+            const pending = pendingShaping.get(String(serverSession.session_id));
+            if (pending && Date.now() - pending.timestamp < 5000) {
+                session = {
+                    ...serverSession,
+                    ...pending.values
+                };
+            }
+            const pendingFailure = pendingFailureEdits.get(String(serverSession.session_id));
+            if (pendingFailure && Date.now() - pendingFailure.timestamp < 5000) {
+                session = {
+                    ...(session || serverSession),
+                    ...pendingFailure.values
+                };
+            }
+            if (!session) {
+                session = serverSession;
+            }
+            session = {
+                ...session,
+                ui_bitrate_axis_max: normalizeBitrateAxisMaxMode(
+                    bitrateAxisMaxBySession.get(String(session.session_id)) || session.ui_bitrate_axis_max || 'auto'
+                )
+            };
+            if (session.session_id) {
+                const portValue = session.x_forwarded_port_external || session.x_forwarded_port || '';
+                const portSuffix = portValue ? ` (Port ${portValue})` : '';
+                const titleParts = ['Testing Player', `Session ${session.session_id}${portSuffix}`];
+                if (session.player_id) {
+                    titleParts.push(session.player_id);
+                }
+                const titleText = titleParts.join(' · ');
+                document.title = titleText;
+                const titleEl = document.getElementById('pageTitle');
+                if (titleEl) {
+                    titleEl.textContent = titleText;
+                }
+            }
+            currentSessionId = session.session_id;
+            if (currentUrl) {
+                const isDash = currentUrl.includes('.mpd');
+                setBadges(isDash, resolvePlayerChoice(currentUrl, getPlayerChoice()), session.group_id || '');
+            }
+            updateGroupControls(session, lastSessionsList);
+            if (container && existingCard && container.contains(document.activeElement) &&
+                String(existingCard.dataset.sessionId || '') === sessionKey) {
+                const shouldSync = shouldSyncControls(sessionKey, session);
+                if (shouldSync) {
+                    syncServerFaultControls(existingCard, session);
+                    syncNetworkShapingControls(existingCard, session);
+                }
+                syncServerFaultData(existingCard, session);
+                pushBandwidthSample(session);
+                return;
+            }
+            renderSessionControls(session);
+            pushBandwidthSample(session);
+        }
+
         function refreshSession(playerId) {
             if (!playerId) return;
             if (sessionPollInFlight) {
@@ -1779,46 +2441,7 @@
                         return;
                     }
                     sessionPollLastAppliedSeq = requestSeq;
-                    if (session) {
-                        const container = document.getElementById('sessionControls');
-                        const existingCard = container ? container.querySelector('.session-card') : null;
-                        const sessionKey = String(session.session_id || '');
-                        const pending = pendingShaping.get(session.session_id);
-                        if (pending && Date.now() - pending.timestamp < 5000) {
-                            session = {
-                                ...session,
-                                ...pending.values
-                            };
-                        }
-                        session = {
-                            ...session,
-                            ui_bitrate_axis_max: normalizeBitrateAxisMaxMode(
-                                bitrateAxisMaxBySession.get(String(session.session_id)) || session.ui_bitrate_axis_max || 'auto'
-                            )
-                        };
-                        if (session.session_id) {
-                            const portSuffix = session.x_forwarded_port ? ` (Port ${session.x_forwarded_port})` : '';
-                            const titleParts = ['Testing Player', `Session ${session.session_id}${portSuffix}`];
-                            if (session.player_id) {
-                                titleParts.push(session.player_id);
-                            }
-                            const titleText = titleParts.join(' · ');
-                            document.title = titleText;
-                            const titleEl = document.getElementById('pageTitle');
-                            if (titleEl) {
-                                titleEl.textContent = titleText;
-                            }
-                        }
-                        currentSessionId = session.session_id;
-                        if (container && existingCard && container.contains(document.activeElement) &&
-                            String(existingCard.dataset.sessionId || '') === sessionKey) {
-                            syncServerFaultControls(existingCard, session);
-                            pushBandwidthSample(session);
-                            return;
-                        }
-                        renderSessionControls(session);
-                        pushBandwidthSample(session);
-                    }
+                    applySessionUpdate(session);
                 })
                 .catch(err => {
                     if (err && err.name === 'AbortError') return;
@@ -1830,6 +2453,36 @@
                     }
                     sessionPollInFlight = false;
                 });
+        }
+
+        function startSessionPolling(playerId) {
+            if (sessionPollTimer) return;
+            sessionPollTimer = setInterval(() => refreshSession(playerId), 1000);
+        }
+
+        function startSessionStream(playerId) {
+            if (!window.EventSource) return false;
+            if (!playerId) return false;
+            const source = new EventSource('/api/sessions/stream');
+            sessionsStream = source;
+            source.addEventListener('sessions', (event) => {
+                try {
+                    const sessions = JSON.parse(event.data);
+                    lastSessionsList = Array.isArray(sessions) ? sessions : [];
+                    const session = sessions.find(item => item.player_id === playerId);
+                    applySessionUpdate(session);
+                } catch (err) {
+                    console.error('Error parsing sessions stream payload', err);
+                }
+            });
+            source.addEventListener('error', () => {
+                if (source.readyState === EventSource.CLOSED) {
+                    source.close();
+                    sessionsStream = null;
+                    startSessionPolling(playerId);
+                }
+            });
+            return true;
         }
 
         function bootstrap() {
@@ -1851,8 +2504,11 @@
             attachVideoEvents();
             loadStream(params.url);
             bindSessionControls();
+            bindGroupControls();
             refreshSession(params.playerId);
-            setInterval(() => refreshSession(params.playerId), 1000);
+            if (!startSessionStream(params.playerId)) {
+                startSessionPolling(params.playerId);
+            }
             setInterval(updateStats, 500);
             const setNetworkShapingVisibility = (enabled) => {
                 document.querySelectorAll('[data-net-shaping]').forEach(el => {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -87,6 +87,72 @@
             border-color: #1e40af;
             box-shadow: 0 8px 18px rgba(30, 64, 175, 0.35);
         }
+
+        .session-tab.grouped {
+            border-left: 4px solid #10b981;
+            padding-left: 10px;
+        }
+
+        .session-tab.grouped.active {
+            border-left-color: #34d399;
+        }
+
+        .group-badge {
+            display: inline-block;
+            background: #10b981;
+            color: white;
+            font-size: 10px;
+            font-weight: 700;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 6px;
+            vertical-align: middle;
+        }
+
+        .session-tab.active .group-badge {
+            background: #34d399;
+        }
+
+        .group-controls {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+
+        .session-checkbox {
+            margin-right: 8px;
+            cursor: pointer;
+            width: 18px;
+            height: 18px;
+        }
+
+        .group-info {
+            font-size: 12px;
+            color: #10b981;
+            font-weight: 600;
+            margin-top: 8px;
+            padding: 6px 10px;
+            background: #d1fae5;
+            border-radius: 6px;
+            display: inline-block;
+        }
+
+        .unlink-btn {
+            font-size: 11px;
+            padding: 4px 10px;
+            margin-left: 8px;
+            background: #ef4444;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .unlink-btn:hover {
+            background: #dc2626;
+        }
     </style>
 </head>
 <body>
@@ -383,14 +449,30 @@
 
         function renderSessionTabs(sessions) {
             if (!sessions.length) return '';
+            const hasMultipleSessions = sessions.length > 1;
+            const hasUngroupedSessions = sessions.some(s => !s.group_id);
+            const showGroupControls = hasMultipleSessions && hasUngroupedSessions;
+            
             return `
+                ${showGroupControls ? `
+                <div class="group-controls">
+                    <button class="btn btn-sm btn-secondary" id="linkSelectedSessions">Link Selected Sessions</button>
+                    <span class="status-message">Select 2+ sessions to link</span>
+                </div>
+                ` : ''}
                 <div class="session-tabs">
                     ${sessions.map(session => {
                         const id = session.session_id;
                         const isActive = id === activeSessionId ? 'active' : '';
+                        const isGrouped = session.group_id ? 'grouped' : '';
                         const portSuffix = session.x_forwarded_port ? ` (Port ${session.x_forwarded_port})` : '';
                         const label = `Session ${id}${portSuffix} · ${session.player_id || 'Unknown Player'}`;
-                        return `<button class="session-tab ${isActive}" data-session-tab="${id}">${label}</button>`;
+                        const groupBadge = session.group_id ? `<span class="group-badge">${session.group_id}</span>` : '';
+                        const checkbox = showGroupControls && !session.group_id ? 
+                            `<input type="checkbox" class="session-checkbox" data-session-id="${id}">` : '';
+                        return `<button class="session-tab ${isActive} ${isGrouped}" data-session-tab="${id}">
+                            ${checkbox}${label}${groupBadge}
+                        </button>`;
                     }).join('')}
                 </div>
             `;
@@ -503,11 +585,13 @@
                 pushBandwidthSample(activeSession);
                 return;
             }
-            container.innerHTML = renderSessionTabs(sessions) + (activeSession ? TestingSessionUI.renderSessionCard(activeSession, {
-                hideTitle: true,
-                showPortItem: true,
-                sectionDefaults: collapseDefaults
-            }) : '');
+            container.innerHTML = renderSessionTabs(sessions) + (activeSession ? 
+                renderGroupInfo(activeSession, sessions) + 
+                TestingSessionUI.renderSessionCard(activeSession, {
+                    hideTitle: true,
+                    showPortItem: true,
+                    sectionDefaults: collapseDefaults
+                }) : '');
             if (activeSession) {
                 const restoredCard = container.querySelector('.session-card');
                 if (restoredCard) {
@@ -518,6 +602,22 @@
                 }
                 pushBandwidthSample(activeSession);
             }
+        }
+
+        function renderGroupInfo(session, allSessions) {
+            if (!session.group_id) return '';
+            const groupMembers = allSessions.filter(s => s.group_id === session.group_id && s.session_id !== session.session_id);
+            if (groupMembers.length === 0) return '';
+            const memberLabels = groupMembers.map(s => {
+                const portSuffix = s.x_forwarded_port ? ` (Port ${s.x_forwarded_port})` : '';
+                return `Session ${s.session_id}${portSuffix}`;
+            }).join(', ');
+            return `
+                <div class="group-info">
+                    🔗 Linked with: ${memberLabels}
+                    <button class="unlink-btn" data-session-id="${session.session_id}">Unlink</button>
+                </div>
+            `;
         }
 
         function pushBandwidthSample(session) {
@@ -903,6 +1003,48 @@
         document.getElementById('sessionsContainer').addEventListener('click', (event) => {
             const button = event.target.closest('button');
             if (!button) return;
+            
+            // Handle link selected sessions button
+            if (button.id === 'linkSelectedSessions') {
+                const checkboxes = document.querySelectorAll('.session-checkbox:checked');
+                const sessionIds = Array.from(checkboxes).map(cb => cb.dataset.sessionId);
+                if (sessionIds.length < 2) {
+                    alert('Please select at least 2 sessions to link');
+                    return;
+                }
+                fetch('/api/session-group/link', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_ids: sessionIds })
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        console.log('Sessions linked:', data);
+                        fetchSessions();
+                    })
+                    .catch(error => console.error('Error linking sessions:', error));
+                return;
+            }
+            
+            // Handle unlink button
+            if (button.classList.contains('unlink-btn')) {
+                const sessionId = button.dataset.sessionId;
+                if (confirm('Unlink this session from its group?')) {
+                    fetch('/api/session-group/unlink', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ session_id: sessionId })
+                    })
+                        .then(response => response.json())
+                        .then(data => {
+                            console.log('Session unlinked:', data);
+                            fetchSessions();
+                        })
+                        .catch(error => console.error('Error unlinking session:', error));
+                }
+                return;
+            }
+            
             if (button.dataset.sessionTab) {
                 activeSessionId = button.dataset.sessionTab;
                 isTabLocked = true;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -195,8 +195,15 @@
         ];
 
         const sessionsById = new Map();
+        const selectedSessionIds = new Set();
+        const pendingFailureEdits = new Map();
+        const controlRevisionBySession = new Map();
         let activeSessionId = null;
         let isTabLocked = false;
+        let sessionsStream = null;
+        let sessionsPollTimer = null;
+        const failureSaveTimers = new Map();
+        const failureSaveFields = new Map();
         const bandwidthHistory = new Map();
         const bandwidthCharts = new Map();
         const bandwidthVisibility = new Map();
@@ -452,12 +459,26 @@
             const hasMultipleSessions = sessions.length > 1;
             const hasUngroupedSessions = sessions.some(s => !s.group_id);
             const showGroupControls = hasMultipleSessions && hasUngroupedSessions;
+            if (!showGroupControls) {
+                selectedSessionIds.clear();
+            } else {
+                const eligible = new Set(
+                    sessions
+                        .filter(session => !session.group_id)
+                        .map(session => String(session.session_id))
+                );
+                Array.from(selectedSessionIds).forEach(id => {
+                    if (!eligible.has(String(id))) {
+                        selectedSessionIds.delete(id);
+                    }
+                });
+            }
             
             return `
                 ${showGroupControls ? `
                 <div class="group-controls">
-                    <button class="btn btn-sm btn-secondary" id="linkSelectedSessions">Link Selected Sessions</button>
-                    <span class="status-message">Select 2+ sessions to link</span>
+                    <button class="btn btn-sm btn-secondary" id="linkSelectedSessions">Group Selected Sessions</button>
+                    <span class="status-message" data-role="link-status">Select 2+ sessions to group</span>
                 </div>
                 ` : ''}
                 <div class="session-tabs">
@@ -465,17 +486,70 @@
                         const id = session.session_id;
                         const isActive = id === activeSessionId ? 'active' : '';
                         const isGrouped = session.group_id ? 'grouped' : '';
-                        const portSuffix = session.x_forwarded_port ? ` (Port ${session.x_forwarded_port})` : '';
+                        const portValue = session.x_forwarded_port_external || session.x_forwarded_port || '';
+                        const portSuffix = portValue ? ` (Port ${portValue})` : '';
                         const label = `Session ${id}${portSuffix} · ${session.player_id || 'Unknown Player'}`;
                         const groupBadge = session.group_id ? `<span class="group-badge">${session.group_id}</span>` : '';
+                        const isChecked = selectedSessionIds.has(String(id)) ? 'checked' : '';
                         const checkbox = showGroupControls && !session.group_id ? 
-                            `<input type="checkbox" class="session-checkbox" data-session-id="${id}">` : '';
+                            `<input type="checkbox" class="session-checkbox" data-session-id="${id}" ${isChecked}>` : '';
                         return `<button class="session-tab ${isActive} ${isGrouped}" data-session-tab="${id}">
                             ${checkbox}${label}${groupBadge}
                         </button>`;
                     }).join('')}
                 </div>
             `;
+        }
+
+        function updateTabsAndGroupInfo(container, sessions, activeSession) {
+            if (!container) return;
+            const tabsHost = document.createElement('div');
+            tabsHost.innerHTML = renderSessionTabs(sessions);
+            const nextGroupControls = tabsHost.querySelector('.group-controls');
+            const nextTabs = tabsHost.querySelector('.session-tabs');
+            const existingGroupControls = container.querySelector('.group-controls');
+            const existingTabs = container.querySelector('.session-tabs');
+            if (nextGroupControls) {
+                if (existingGroupControls) {
+                    existingGroupControls.replaceWith(nextGroupControls);
+                } else {
+                    container.prepend(nextGroupControls);
+                }
+            } else if (existingGroupControls) {
+                existingGroupControls.remove();
+            }
+            if (nextTabs) {
+                if (existingTabs) {
+                    existingTabs.replaceWith(nextTabs);
+                } else {
+                    const insertAfter = container.querySelector('.group-controls');
+                    if (insertAfter) {
+                        insertAfter.insertAdjacentElement('afterend', nextTabs);
+                    } else {
+                        container.prepend(nextTabs);
+                    }
+                }
+            }
+            const groupHost = document.createElement('div');
+            groupHost.innerHTML = activeSession ? renderGroupInfo(activeSession, sessions) : '';
+            const nextGroupInfo = groupHost.firstElementChild;
+            const existingGroupInfo = container.querySelector('.group-info');
+            if (nextGroupInfo) {
+                if (existingGroupInfo) {
+                    existingGroupInfo.replaceWith(nextGroupInfo);
+                } else {
+                    const card = container.querySelector('.session-card');
+                    if (card) {
+                        card.insertAdjacentElement('beforebegin', nextGroupInfo);
+                    } else if (nextTabs) {
+                        nextTabs.insertAdjacentElement('afterend', nextGroupInfo);
+                    } else {
+                        container.appendChild(nextGroupInfo);
+                    }
+                }
+            } else if (existingGroupInfo) {
+                existingGroupInfo.remove();
+            }
         }
 
         function normalizeTransportFaultType(session) {
@@ -496,10 +570,66 @@
             return 'failures_per_seconds';
         }
 
+        function getControlRevision(session) {
+            const revision = session ? session.control_revision : null;
+            if (revision === undefined || revision === null || revision === '') {
+                return null;
+            }
+            return String(revision);
+        }
+
+        function shouldSyncControls(sessionId, session) {
+            const key = String(sessionId || session?.session_id || '');
+            if (!key) return true;
+            const revision = getControlRevision(session);
+            const lastRevision = controlRevisionBySession.get(key);
+            if (revision === null) {
+                if (lastRevision === undefined) {
+                    controlRevisionBySession.set(key, null);
+                    return true;
+                }
+                return false;
+            }
+            if (lastRevision !== revision) {
+                controlRevisionBySession.set(key, revision);
+                return true;
+            }
+            return false;
+        }
+
         function syncServerFaultControls(card, session) {
             if (!card || !session) return;
             const sessionId = String(card.dataset.sessionId || session.session_id || '');
             if (!sessionId) return;
+            const syncSelect = (namePrefix, value) => {
+                const select = card.querySelector(`select[name="${namePrefix}_${sessionId}"]`);
+                if (select && value) {
+                    select.value = value;
+                }
+            };
+            const syncRange = (field, value, fallback) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (!input) return;
+                const numeric = Number(value);
+                const resolved = Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+                input.value = String(resolved);
+                const valueEl = input.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = input.value;
+            };
+            const syncFailureScope = (field, values, allWhenEmpty) => {
+                const selected = Array.isArray(values) ? values.map(String) : [];
+                const selectedSet = new Set(selected);
+                const allChecked = allWhenEmpty
+                    ? (selected.length === 0 || selectedSet.has('All'))
+                    : selectedSet.has('All');
+                card.querySelectorAll(`input[data-field="${field}"]`).forEach(input => {
+                    if (input.value === 'All') {
+                        input.checked = allChecked;
+                        return;
+                    }
+                    input.checked = allChecked || selectedSet.has(input.value);
+                });
+            };
             const syncRadio = (namePrefix, value) => {
                 const radios = card.querySelectorAll(`input[name="${namePrefix}_${sessionId}"]`);
                 radios.forEach((radio) => {
@@ -511,6 +641,17 @@
             syncRadio('master_manifest_failure_type', String(session.master_manifest_failure_type || 'none'));
             syncRadio('transport_failure_type', normalizeTransportFaultType(session));
             syncRadio('transport_failure_mode', normalizeTransportFailureMode(session));
+            syncSelect('segment_failure_mode', String(session.segment_failure_mode || 'failures_per_seconds'));
+            syncSelect('manifest_failure_mode', String(session.manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('master_manifest_failure_mode', String(session.master_manifest_failure_mode || 'failures_per_seconds'));
+            syncRange('segment_consecutive_failures', session.segment_consecutive_failures, 1);
+            syncRange('segment_failure_frequency', session.segment_failure_frequency, 6);
+            syncRange('manifest_consecutive_failures', session.manifest_consecutive_failures, 1);
+            syncRange('manifest_failure_frequency', session.manifest_failure_frequency, 6);
+            syncRange('master_manifest_consecutive_failures', session.master_manifest_consecutive_failures, 1);
+            syncRange('master_manifest_failure_frequency', session.master_manifest_failure_frequency, 6);
+            syncFailureScope('segment_failure_urls', session.segment_failure_urls, true);
+            syncFailureScope('manifest_failure_urls', session.manifest_failure_urls, true);
             TestingSessionUI.updateTransportModeUi(card);
             const transportConsecutiveInput = card.querySelector('input[data-field="transport_consecutive_failures"]');
             const transportFrequencyInput = card.querySelector('input[data-field="transport_failure_frequency"]');
@@ -536,6 +677,10 @@
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
+        }
+
+        function syncServerFaultData(card, session) {
+            if (!card || !session) return;
             const stateEl = card.querySelector('[data-field="transport_fault_state"]');
             if (stateEl) {
                 stateEl.textContent = session.transport_fault_active ? 'Active' : 'Idle';
@@ -546,6 +691,84 @@
                 const rejectPackets = Number(session.transport_fault_reject_packets || 0);
                 countersEl.textContent = `Drop ${dropPackets} pkts · Reject ${rejectPackets} pkts`;
             }
+        }
+
+        function closestStepDuration(seconds) {
+            const options = [6, 12, 18, 24];
+            const numeric = Number(seconds);
+            if (!Number.isFinite(numeric) || numeric <= 0) return 12;
+            let best = options[0];
+            let bestDiff = Math.abs(numeric - best);
+            options.forEach((value) => {
+                const diff = Math.abs(numeric - value);
+                if (diff < bestDiff) {
+                    best = value;
+                    bestDiff = diff;
+                }
+            });
+            return best;
+        }
+
+        function inferSegmentDurationSeconds(session) {
+            const explicit = Number(session?.nftables_pattern_segment_duration_seconds || 0);
+            if (Number.isFinite(explicit) && explicit > 0) {
+                return explicit;
+            }
+            const candidates = [
+                session?.manifest_url || '',
+                session?.master_manifest_url || '',
+                session?.last_request_url || ''
+            ];
+            for (const value of candidates) {
+                const match = value.match(/(?:_|\/)(\d+)s(?:[._/?]|$)/i);
+                if (match) {
+                    const parsed = Number(match[1]);
+                    if (Number.isFinite(parsed) && parsed > 0) {
+                        return parsed;
+                    }
+                }
+            }
+            return 1;
+        }
+
+        function resolvePatternDefaults(session) {
+            const segmentDurationSeconds = inferSegmentDurationSeconds(session);
+            const defaultSegments = Number(session?.nftables_pattern_default_segments || 2);
+            const storedDefaultStepSeconds = Number(session?.nftables_pattern_default_step_seconds || 0);
+            const defaultStepSeconds = Number.isFinite(storedDefaultStepSeconds) && storedDefaultStepSeconds > 0
+                ? storedDefaultStepSeconds
+                : segmentDurationSeconds * defaultSegments;
+            return {
+                segmentDurationSeconds,
+                selectedStepSeconds: closestStepDuration(defaultStepSeconds)
+            };
+        }
+
+        function syncNetworkShapingControls(card, session) {
+            if (!card || !session) return;
+            const sessionId = String(card.dataset.sessionId || session.session_id || '');
+            if (!sessionId) return;
+            const templateModeRaw = String(session.nftables_pattern_template_mode || '').toLowerCase();
+            const templateMode = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid'].includes(templateModeRaw)
+                ? templateModeRaw
+                : 'sliders';
+            card.querySelectorAll(`input[name="shaping_template_mode_${sessionId}"]`).forEach((radio) => {
+                radio.checked = radio.value === templateMode;
+            });
+            const marginRaw = Number(session.nftables_pattern_margin_pct);
+            const marginPct = [0, 10, 25, 50].includes(marginRaw) ? marginRaw : 0;
+            card.querySelectorAll(`input[name="shaping_template_margin_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === marginPct;
+            });
+            const defaults = resolvePatternDefaults(session);
+            card.querySelectorAll(`input[name="shaping_default_step_seconds_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === defaults.selectedStepSeconds;
+            });
+            const label = card.querySelector('[data-field="shaping_default_seconds_label"]');
+            if (label) {
+                label.textContent = `segment ${defaults.segmentDurationSeconds}s`;
+            }
+            updateTemplateModeUi(card);
         }
 
         function renderSessions() {
@@ -563,11 +786,18 @@
             let activeSession = sessions.find(session => session.session_id === activeSessionId);
             const sessionKey = String(activeSession?.session_id || '');
             const existingCard = container.querySelector('.session-card');
-            const pending = activeSession ? pendingShaping.get(activeSession.session_id) : null;
+            const pending = activeSession ? pendingShaping.get(String(activeSession.session_id)) : null;
             if (activeSession && pending && Date.now() - pending.timestamp < 5000) {
                 activeSession = {
                     ...activeSession,
                     ...pending.values
+                };
+            }
+            const pendingFailure = activeSession ? pendingFailureEdits.get(String(activeSession.session_id)) : null;
+            if (activeSession && pendingFailure && Date.now() - pendingFailure.timestamp < 5000) {
+                activeSession = {
+                    ...activeSession,
+                    ...pendingFailure.values
                 };
             }
             if (activeSession) {
@@ -581,7 +811,13 @@
             }
             if (activeSession && existingCard && container.contains(document.activeElement) &&
                 String(existingCard.dataset.sessionId || '') === sessionKey) {
-                syncServerFaultControls(existingCard, activeSession);
+                updateTabsAndGroupInfo(container, sessions, activeSession);
+                const shouldSync = shouldSyncControls(sessionKey, activeSession);
+                if (shouldSync) {
+                    syncServerFaultControls(existingCard, activeSession);
+                    syncNetworkShapingControls(existingCard, activeSession);
+                }
+                syncServerFaultData(existingCard, activeSession);
                 pushBandwidthSample(activeSession);
                 return;
             }
@@ -609,13 +845,14 @@
             const groupMembers = allSessions.filter(s => s.group_id === session.group_id && s.session_id !== session.session_id);
             if (groupMembers.length === 0) return '';
             const memberLabels = groupMembers.map(s => {
-                const portSuffix = s.x_forwarded_port ? ` (Port ${s.x_forwarded_port})` : '';
+                const portValue = s.x_forwarded_port_external || s.x_forwarded_port || '';
+                const portSuffix = portValue ? ` (Port ${portValue})` : '';
                 return `Session ${s.session_id}${portSuffix}`;
             }).join(', ');
             return `
                 <div class="group-info">
-                    🔗 Linked with: ${memberLabels}
-                    <button class="unlink-btn" data-session-id="${session.session_id}">Unlink</button>
+                    🔗 Grouped with: ${memberLabels}
+                    <button class="unlink-btn" data-session-id="${session.session_id}" data-group-id="${session.group_id}">Ungroup</button>
                 </div>
             `;
         }
@@ -817,11 +1054,8 @@
 
         function saveSettingsForCard(card) {
             const data = TestingSessionUI.readSessionSettings(card);
-            return fetch(`/api/failure-settings/${data.session_id}`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(data)
-            });
+            const fields = Object.keys(data || {}).filter(field => field !== 'session_id');
+            return sendSessionPatch(card, fields);
         }
 
         function applyNetworkShapingForCard(card) {
@@ -895,19 +1129,229 @@
                     }
                     return response.json();
                 })
-                .then(sessions => {
-                    const next = new Map();
-                    sessions.forEach(session => {
-                        next.set(session.session_id, session);
-                    });
-                    sessionsById.clear();
-                    next.forEach((value, key) => sessionsById.set(key, value));
-                    renderSessions();
-                })
+                .then(sessions => applySessionsList(sessions))
                 .catch(error => {
                     console.error('Error fetching sessions:', error);
                     document.getElementById('sessionsContainer').innerHTML = '<div class="status-message">Failed to load sessions.</div>';
                 });
+        }
+
+        function applySessionsList(sessions) {
+            const next = new Map();
+            sessions.forEach(session => {
+                const key = String(session.session_id);
+                next.set(key, session);
+            });
+            sessionsById.clear();
+            next.forEach((value, key) => sessionsById.set(key, value));
+            const validIds = new Set(next.keys());
+            Array.from(controlRevisionBySession.keys()).forEach((id) => {
+                if (!validIds.has(id)) {
+                    controlRevisionBySession.delete(id);
+                }
+            });
+            renderSessions();
+        }
+
+        function isFailureRangeField(field) {
+            return [
+                'segment_consecutive_failures',
+                'segment_failure_frequency',
+                'manifest_consecutive_failures',
+                'manifest_failure_frequency',
+                'master_manifest_consecutive_failures',
+                'master_manifest_failure_frequency',
+                'transport_consecutive_failures',
+                'transport_failure_frequency'
+            ].includes(field);
+        }
+
+        function getSessionBaseRevision(sessionId) {
+            const session = sessionsById.get(String(sessionId || ''));
+            const revision = session ? session.control_revision : null;
+            if (revision === undefined || revision === null) {
+                return '';
+            }
+            return String(revision);
+        }
+
+        function queuePendingFailureEdits(sessionId, values) {
+            if (!sessionId || !values) return;
+            const key = String(sessionId);
+            const existing = pendingFailureEdits.get(key);
+            const merged = {
+                ...(existing ? existing.values : {}),
+                ...values
+            };
+            pendingFailureEdits.set(key, {
+                timestamp: Date.now(),
+                values: merged
+            });
+            setTimeout(() => {
+                const pending = pendingFailureEdits.get(key);
+                if (pending && Date.now() - pending.timestamp > 4500) {
+                    pendingFailureEdits.delete(key);
+                }
+            }, 5000);
+        }
+
+        function resolvePendingFailureEdits(sessionId, fields) {
+            const key = String(sessionId || '');
+            const pending = pendingFailureEdits.get(key);
+            if (!pending) return;
+            const values = { ...pending.values };
+            (fields || []).forEach(field => {
+                delete values[field];
+            });
+            if (Object.keys(values).length === 0) {
+                pendingFailureEdits.delete(key);
+            } else {
+                pendingFailureEdits.set(key, {
+                    timestamp: pending.timestamp,
+                    values
+                });
+            }
+        }
+
+        function buildSessionPatch(card, fields) {
+            const data = TestingSessionUI.readSessionSettings(card);
+            const set = {};
+            (fields || []).forEach(field => {
+                if (Object.prototype.hasOwnProperty.call(data, field)) {
+                    set[field] = data[field];
+                }
+            });
+            return {
+                sessionId: data.session_id,
+                set,
+                fields: fields || []
+            };
+        }
+
+        function applySessionPatchResponse(session) {
+            if (!session || !session.session_id) return;
+            sessionsById.set(String(session.session_id), session);
+            renderSessions();
+        }
+
+        function sendSessionPatch(card, fields) {
+            const patch = buildSessionPatch(card, fields);
+            if (!patch.sessionId || Object.keys(patch.set).length === 0) {
+                return Promise.resolve();
+            }
+            queuePendingFailureEdits(patch.sessionId, patch.set);
+            return fetch(`/api/session/${patch.sessionId}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    set: patch.set,
+                    fields: patch.fields,
+                    base_revision: getSessionBaseRevision(patch.sessionId)
+                })
+            }).then(async response => {
+                const body = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    if (response.status === 409 && body.session) {
+                        resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                        pendingFailureEdits.delete(String(patch.sessionId));
+                        applySessionPatchResponse(body.session);
+                        return;
+                    }
+                    throw new Error(body.error || `HTTP ${response.status}`);
+                }
+                if (body.session) {
+                    resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                    applySessionPatchResponse(body.session);
+                }
+            }).catch(error => {
+                console.error('Error saving settings:', error);
+            });
+        }
+
+        function scheduleFailureSave(card, field) {
+            const sessionId = card?.dataset?.sessionId;
+            if (!sessionId || !field) return;
+            const key = String(sessionId);
+            if (!failureSaveFields.has(key)) {
+                failureSaveFields.set(key, new Set());
+            }
+            failureSaveFields.get(key).add(field);
+            if (failureSaveTimers.has(key)) {
+                clearTimeout(failureSaveTimers.get(key));
+            }
+            failureSaveTimers.set(key, setTimeout(() => {
+                const fields = Array.from(failureSaveFields.get(key) || []);
+                failureSaveFields.delete(key);
+                failureSaveTimers.delete(key);
+                if (fields.length) {
+                    sendSessionPatch(card, fields);
+                }
+            }, 200));
+        }
+
+        function parseSessionControlName(name, sessionId) {
+            if (!name || !sessionId) return '';
+            const suffix = `_${sessionId}`;
+            if (!name.endsWith(suffix)) return '';
+            return name.slice(0, -suffix.length);
+        }
+
+        function resolveSessionPatchFields(target, sessionId, field) {
+            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls') {
+                return [field];
+            }
+            const prefix = parseSessionControlName(target.name, sessionId);
+            if (!prefix) return [];
+            if (prefix.endsWith('_failure_type')) {
+                return [prefix];
+            }
+            if (prefix.endsWith('_failure_mode')) {
+                const base = prefix.replace('_failure_mode', '');
+                if (base === 'transport') {
+                    return [
+                        'transport_failure_mode',
+                        'transport_failure_units',
+                        'transport_consecutive_units',
+                        'transport_frequency_units',
+                        'transport_consecutive_failures',
+                        'transport_failure_frequency'
+                    ];
+                }
+                return [
+                    `${base}_failure_mode`,
+                    `${base}_failure_units`,
+                    `${base}_consecutive_units`,
+                    `${base}_frequency_units`
+                ];
+            }
+            return [];
+        }
+
+        function startSessionsPolling() {
+            if (sessionsPollTimer) return;
+            sessionsPollTimer = setInterval(fetchSessions, 5000);
+        }
+
+        function startSessionsStream() {
+            if (!window.EventSource) return false;
+            const source = new EventSource('/api/sessions/stream');
+            sessionsStream = source;
+            source.addEventListener('sessions', (event) => {
+                try {
+                    const sessions = JSON.parse(event.data);
+                    applySessionsList(sessions);
+                } catch (err) {
+                    console.error('Error parsing sessions stream payload', err);
+                }
+            });
+            source.addEventListener('error', () => {
+                if (source.readyState === EventSource.CLOSED) {
+                    source.close();
+                    sessionsStream = null;
+                    startSessionsPolling();
+                }
+            });
+            return true;
         }
 
 
@@ -925,6 +1369,9 @@
                 const value = input.value;
                 const valueEl = input.parentElement.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = value;
+                if (card && isFailureRangeField(input.dataset.field)) {
+                    scheduleFailureSave(card, input.dataset.field);
+                }
             }
             if (input.dataset.field === 'shaping_step_mbps') {
                 const row = input.closest('.shape-step-row');
@@ -942,6 +1389,18 @@
 
         document.getElementById('sessionsContainer').addEventListener('change', (event) => {
             const target = event.target;
+            if (target.classList.contains('session-checkbox')) {
+                const sessionId = target.dataset.sessionId;
+                if (sessionId) {
+                    if (target.checked) {
+                        selectedSessionIds.add(String(sessionId));
+                    } else {
+                        selectedSessionIds.delete(String(sessionId));
+                    }
+                }
+                event.stopPropagation();
+                return;
+            }
             const card = target.closest('.session-card');
             if (!card) return;
             if (target.dataset.field === 'manifest_failure_urls' && target.value === 'All') {
@@ -950,11 +1409,33 @@
                     input.checked = target.checked;
                 });
             }
+            if (target.dataset.field === 'manifest_failure_urls' && target.value !== 'All') {
+                const checks = Array.from(card.querySelectorAll('input[data-field="manifest_failure_urls"]'));
+                const allBox = checks.find(input => input.value === 'All');
+                const scopedChecks = checks.filter(input => input.value !== 'All');
+                if (allBox && allBox.checked) {
+                    allBox.checked = false;
+                }
+                if (!scopedChecks.some(input => input.checked) && allBox) {
+                    allBox.checked = true;
+                }
+            }
             if (target.dataset.field === 'segment_failure_urls' && target.value === 'All') {
                 const checks = card.querySelectorAll('input[data-field="segment_failure_urls"]');
                 checks.forEach(input => {
                     input.checked = target.checked;
                 });
+            }
+            if (target.dataset.field === 'segment_failure_urls' && target.value !== 'All') {
+                const checks = Array.from(card.querySelectorAll('input[data-field="segment_failure_urls"]'));
+                const allBox = checks.find(input => input.value === 'All');
+                const scopedChecks = checks.filter(input => input.value !== 'All');
+                if (allBox && allBox.checked) {
+                    allBox.checked = false;
+                }
+                if (!scopedChecks.some(input => input.checked) && allBox) {
+                    allBox.checked = true;
+                }
             }
             if (target.dataset.field === 'shaping_step_enabled') {
                 const row = target.closest('.shape-step-row');
@@ -997,51 +1478,76 @@
                 scheduleShapingApply(card);
                 return;
             }
-            saveSettingsForCard(card).catch(error => console.error('Error saving settings:', error));
+            if (isFailureRangeField(target.dataset.field)) {
+                scheduleFailureSave(card, target.dataset.field);
+                return;
+            }
+            const sessionId = String(card.dataset.sessionId || '');
+            const field = target.dataset.field || '';
+            const fields = resolveSessionPatchFields(target, sessionId, field);
+            if (fields.length) {
+                sendSessionPatch(card, fields);
+            }
         });
 
         document.getElementById('sessionsContainer').addEventListener('click', (event) => {
+            const checkbox = event.target.closest('.session-checkbox');
+            if (checkbox) {
+                event.stopPropagation();
+                return;
+            }
             const button = event.target.closest('button');
             if (!button) return;
             
             // Handle link selected sessions button
             if (button.id === 'linkSelectedSessions') {
-                const checkboxes = document.querySelectorAll('.session-checkbox:checked');
-                const sessionIds = Array.from(checkboxes).map(cb => cb.dataset.sessionId);
+                const statusEl = button.closest('.group-controls')?.querySelector('[data-role="link-status"]');
+                const sessionIds = Array.from(selectedSessionIds);
                 if (sessionIds.length < 2) {
-                    alert('Please select at least 2 sessions to link');
+                    alert('Please select at least 2 sessions to group');
                     return;
                 }
+                if (statusEl) statusEl.textContent = 'Linking sessions...';
+                console.log('Group sessions request', { sessionIds });
                 fetch('/api/session-group/link', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ session_ids: sessionIds })
                 })
-                    .then(response => response.json())
+                    .then(async response => {
+                        if (!response.ok) {
+                            const body = await response.text();
+                            throw new Error(body || `HTTP ${response.status}`);
+                        }
+                        return response.json();
+                    })
                     .then(data => {
-                        console.log('Sessions linked:', data);
+                        console.log('Sessions grouped:', data);
+                        if (statusEl) statusEl.textContent = `Grouped ${data.group_id || ''}`.trim();
                         fetchSessions();
                     })
-                    .catch(error => console.error('Error linking sessions:', error));
+                    .catch(error => {
+                        console.error('Error grouping sessions:', error);
+                        if (statusEl) statusEl.textContent = `Group failed: ${error.message || 'unknown error'}`;
+                    });
                 return;
             }
             
-            // Handle unlink button
+            // Handle ungroup button
             if (button.classList.contains('unlink-btn')) {
                 const sessionId = button.dataset.sessionId;
-                if (confirm('Unlink this session from its group?')) {
-                    fetch('/api/session-group/unlink', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ session_id: sessionId })
+                const groupId = button.dataset.groupId;
+                fetch('/api/session-group/unlink', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_id: sessionId, group_id: groupId, unlink_group: true })
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        console.log('Group unlinked:', data);
+                        fetchSessions();
                     })
-                        .then(response => response.json())
-                        .then(data => {
-                            console.log('Session unlinked:', data);
-                            fetchSessions();
-                        })
-                        .catch(error => console.error('Error unlinking session:', error));
-                }
+                    .catch(error => console.error('Error unlinking session:', error));
                 return;
             }
             
@@ -1093,7 +1599,9 @@
         });
 
         fetchSessions();
-        setInterval(fetchSessions, 5000);
+        if (!startSessionsStream()) {
+            startSessionsPolling();
+        }
     </script>
 </body>
 </html>

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -40,11 +40,71 @@ type App struct {
 	upstreamPort string
 	maxSessions  int
 	client       *http.Client
+	portMap      PortMapping
 	shapeMu      sync.Mutex
 	shapeLoops   map[int]context.CancelFunc
 	shapeStates  map[int]NftShapePattern
 	faultMu      sync.Mutex
 	faultLoops   map[int]context.CancelFunc
+	sessionsHub              *SessionEventHub
+	sessionsBroadcastMu      sync.Mutex
+	sessionsBroadcastPending bool
+	sessionsBroadcastLatest  []SessionData
+}
+
+type SessionEventHub struct {
+	mu      sync.Mutex
+	nextID  int
+	clients map[int]chan string
+}
+
+type SessionPatchRequest struct {
+	Set          map[string]interface{} `json:"set"`
+	Fields       []string               `json:"fields"`
+	BaseRevision string                 `json:"base_revision"`
+}
+
+type PortMapping struct {
+	externalBase int
+	internalBase int
+	count        int
+}
+
+func NewSessionEventHub() *SessionEventHub {
+	return &SessionEventHub{clients: map[int]chan string{}}
+}
+
+func (h *SessionEventHub) AddClient() (int, <-chan string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.nextID++
+	id := h.nextID
+	ch := make(chan string, 8)
+	h.clients[id] = ch
+	return id, ch
+}
+
+func (h *SessionEventHub) RemoveClient(id int) {
+	h.mu.Lock()
+	ch, ok := h.clients[id]
+	if ok {
+		delete(h.clients, id)
+	}
+	h.mu.Unlock()
+	if ok {
+		close(ch)
+	}
+}
+
+func (h *SessionEventHub) Broadcast(payload string) {
+	h.mu.Lock()
+	for _, ch := range h.clients {
+		select {
+		case ch <- payload:
+		default:
+		}
+	}
+	h.mu.Unlock()
 }
 
 type PlaylistInfo struct {
@@ -55,6 +115,7 @@ type PlaylistInfo struct {
 
 type TcTrafficManager struct {
 	interfaceName string
+	debug         bool
 }
 
 type NftShapeStep struct {
@@ -106,8 +167,8 @@ func (s *NftShapeStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func NewTcTrafficManager(interfaceName string) *TcTrafficManager {
-	return &TcTrafficManager{interfaceName: interfaceName}
+func NewTcTrafficManager(interfaceName string, debug bool) *TcTrafficManager {
+	return &TcTrafficManager{interfaceName: interfaceName, debug: debug}
 }
 
 func (t *TcTrafficManager) IsActive() bool {
@@ -210,6 +271,7 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 		_ = t.UpdateNetem(port, 0, 0)
 		_ = t.RemoveFilter(port)
 		_ = t.RemoveClass(port)
+		t.logTcState("rate_clear", port)
 		return nil
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)
@@ -239,7 +301,8 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 
 	showFilters := exec.Command("tc", "filter", "show", "dev", t.interfaceName)
 	filterOut, _ := showFilters.CombinedOutput()
-	if !strings.Contains(string(filterOut), fmt.Sprintf("flowid %s", classid)) {
+	desiredHex := fmt.Sprintf("%04x0000/ffff0000", port)
+	if !strings.Contains(string(filterOut), desiredHex) {
 		filterCmd := exec.Command(
 			"tc", "filter", "add", "dev", t.interfaceName, "protocol", "ip", "parent", "1:0", "prio", "1", "u32",
 			"match", "ip", "sport", fmt.Sprintf("%d", port), "0xffff", "flowid", classid,
@@ -264,6 +327,7 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 	if !strings.Contains(string(verifyOut), fmt.Sprintf("class htb %s", classid)) {
 		return fmt.Errorf("tc class not present after update: %s", strings.TrimSpace(string(verifyOut)))
 	}
+	t.logTcState("rate_apply", port)
 	return nil
 }
 
@@ -317,6 +381,7 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 	handle := fmt.Sprintf("%s0:", portSuffix)
 	if delayMs <= 0 && lossPct <= 0 {
 		_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "parent", classid, "handle", handle, "netem").Run()
+		t.logTcState("netem_clear", port)
 		return nil
 	}
 	jitter := delayMs / 2
@@ -335,7 +400,44 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("tc netem failed: %s", strings.TrimSpace(string(out)))
 	}
+	t.logTcState("netem_apply", port)
 	return nil
+}
+
+func (t *TcTrafficManager) logTcState(reason string, port int) {
+	if !t.debug {
+		return
+	}
+	type tcCmd struct {
+		label string
+		args  []string
+	}
+	cmds := []tcCmd{
+		{label: "qdisc", args: []string{"qdisc", "show", "dev", t.interfaceName}},
+		{label: "class", args: []string{"class", "show", "dev", t.interfaceName}},
+		{label: "filter", args: []string{"filter", "show", "dev", t.interfaceName}},
+	}
+	for _, cmd := range cmds {
+		out, err := exec.Command("tc", cmd.args...).CombinedOutput()
+		if err != nil {
+			log.Printf("NETSHAPE_TC_STATE tc_%s dev=%s reason=%s port=%d error=%v output=%s",
+				cmd.label,
+				t.interfaceName,
+				reason,
+				port,
+				err,
+				strings.TrimSpace(string(out)),
+			)
+			continue
+		}
+		log.Printf("NETSHAPE_TC_STATE tc_%s dev=%s reason=%s port=%d output=%s",
+			cmd.label,
+			t.interfaceName,
+			reason,
+			port,
+			strings.TrimSpace(string(out)),
+		)
+	}
 }
 
 func (t *TcTrafficManager) GetNetemConfig(port int) (map[string]interface{}, error) {
@@ -449,20 +551,66 @@ func parseTcBytes(line string) int64 {
 	return 0
 }
 
+func loadPortMapping() PortMapping {
+	externalBase := getenvIntAny([]string{"EXTERNAL_PORT_BASE"}, 0)
+	internalBase := getenvIntAny([]string{"INTERNAL_PORT_BASE"}, 0)
+	count := getenvIntAny([]string{"PORT_RANGE_COUNT", "PORT_MAP_COUNT"}, 0)
+	if externalBase <= 0 || internalBase <= 0 || count <= 0 {
+		return PortMapping{}
+	}
+	return PortMapping{
+		externalBase: externalBase,
+		internalBase: internalBase,
+		count:        count,
+	}
+}
+
+func (m PortMapping) MapExternalPort(port string) (string, bool) {
+	if m.count <= 0 || m.externalBase <= 0 || m.internalBase <= 0 {
+		return port, false
+	}
+	value, err := strconv.Atoi(port)
+	if err != nil {
+		return port, false
+	}
+	externalGroup := m.externalBase / 1000
+	internalGroup := m.internalBase / 1000
+	if externalGroup <= 0 || internalGroup <= 0 {
+		return port, false
+	}
+	if value/1000 != externalGroup {
+		return port, false
+	}
+	if m.count > 0 {
+		digit := thirdFromLastDigit(strconv.Itoa(value))
+		if digit == "" {
+			return port, false
+		}
+		sessionDigit := int(digit[0] - '0')
+		if sessionDigit < 0 || sessionDigit > m.count {
+			return port, false
+		}
+	}
+	mapped := (internalGroup * 1000) + (value % 1000)
+	return strconv.Itoa(mapped), true
+}
+
 func main() {
 	memcachedAddr := getenv("MEMCACHED_ADDR", "memcached:11211")
 	upstreamHost := getenvAny([]string{"INFINITE_STREAM_UPSTREAM_HOST", "INFINITE_UPSTREAM_HOST", "BOSS_UPSTREAM_HOST"}, "go-server")
 	upstreamPort := getenvAny([]string{"INFINITE_STREAM_UPSTREAM_PORT", "INFINITE_UPSTREAM_PORT", "BOSS_UPSTREAM_PORT"}, "30000")
 	maxSessions := getenvIntAny([]string{"INFINITE_STREAM_MAX_SESSIONS", "INFINITE_MAX_SESSIONS", "BOSS_MAX_SESSIONS"}, 8)
 	interfaceName := getenvAny([]string{"INFINITE_STREAM_TC_INTERFACE", "INFINITE_TC_INTERFACE", "TC_INTERFACE"}, "eth0")
+	tcDebug := getenvBoolAny([]string{"INFINITE_STREAM_TC_DEBUG", "INFINITE_TC_DEBUG", "TC_DEBUG"}, false)
 
 	mc := memcache.New(memcachedAddr)
 	app := &App{
 		memcache:     mc,
-		traffic:      NewTcTrafficManager(interfaceName),
+		traffic:      NewTcTrafficManager(interfaceName, tcDebug),
 		upstreamHost: upstreamHost,
 		upstreamPort: upstreamPort,
 		maxSessions:  maxSessions,
+		portMap:      loadPortMapping(),
 		client: &http.Client{
 			Transport: &http.Transport{
 				DialContext:           (&net.Dialer{Timeout: 6 * time.Second}).DialContext,
@@ -472,6 +620,7 @@ func main() {
 		shapeLoops:  map[int]context.CancelFunc{},
 		shapeStates: map[int]NftShapePattern{},
 		faultLoops:  map[int]context.CancelFunc{},
+		sessionsHub: NewSessionEventHub(),
 	}
 
 	go app.trackPortThroughput()
@@ -482,8 +631,11 @@ func main() {
 
 	router.HandleFunc("/index.html", app.handleIndex).Methods(http.MethodGet)
 	router.HandleFunc("/api/sessions", app.handleGetSessions).Methods(http.MethodGet)
+	router.HandleFunc("/api/sessions/stream", app.handleSessionStream).Methods(http.MethodGet)
 	router.HandleFunc("/api/failure-settings/{id}", app.handleUpdateFailureSettings).Methods(http.MethodPost)
+	router.HandleFunc("/api/session/{id}/update", app.handleUpdateSessionSettings).Methods(http.MethodPost)
 	router.HandleFunc("/api/session/{id}", app.handleSession).Methods(http.MethodGet, http.MethodDelete)
+	router.HandleFunc("/api/session/{id}", app.handlePatchSession).Methods(http.MethodPatch)
 	router.HandleFunc("/api/clear-sessions", app.handleClearSessions).Methods(http.MethodPost)
 	router.HandleFunc("/api/session-group/link", app.handleLinkSessions).Methods(http.MethodPost)
 	router.HandleFunc("/api/session-group/unlink", app.handleUnlinkSession).Methods(http.MethodPost)
@@ -726,6 +878,102 @@ func (a *App) handleGetSessions(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, sessions)
 }
 
+func (a *App) handleSessionStream(w http.ResponseWriter, r *http.Request) {
+	if a.sessionsHub == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, map[string]string{"error": "stream unavailable"})
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "stream unsupported"})
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	a.removeInactiveSessions()
+	sessions := a.getSessionList()
+	payload := a.buildSessionsEvent(sessions)
+	if payload != "" {
+		_, _ = w.Write([]byte(payload))
+		flusher.Flush()
+	}
+
+	clientID, ch := a.sessionsHub.AddClient()
+	defer a.sessionsHub.RemoveClient(clientID)
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			_, _ = w.Write([]byte(msg))
+			flusher.Flush()
+		}
+	}
+}
+
+func (a *App) handlePatchSession(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	var payload SessionPatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid json"})
+		return
+	}
+	set := payload.Set
+	if set == nil {
+		set = map[string]interface{}{}
+	}
+	fields := payload.Fields
+	if len(fields) == 0 {
+		for key := range set {
+			fields = append(fields, key)
+		}
+	}
+	filtered := map[string]interface{}{}
+	for _, key := range fields {
+		if value, ok := set[key]; ok {
+			filtered[key] = value
+		}
+	}
+	if len(filtered) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "no fields provided"})
+		return
+	}
+	session, status, errMsg := a.applySessionSettingsUpdate(id, filtered, payload.BaseRevision)
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+		if status == http.StatusConflict {
+			normalized := a.normalizeSessionForResponse(session)
+			writeJSON(w, map[string]interface{}{
+				"error":            errMsg,
+				"session":          normalized,
+				"control_revision": getString(normalized, "control_revision"),
+			})
+			return
+		}
+		if errMsg == "" {
+			errMsg = "update failed"
+		}
+		writeJSON(w, map[string]string{"error": errMsg})
+		return
+	}
+	normalized := a.normalizeSessionForResponse(session)
+	writeJSON(w, map[string]interface{}{
+		"session":          normalized,
+		"control_revision": getString(normalized, "control_revision"),
+	})
+}
+
 func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	var payload map[string]interface{}
@@ -733,6 +981,24 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 		writeJSON(w, map[string]string{"error": "invalid json"})
 		return
 	}
+	_, status, errMsg := a.applySessionSettingsUpdate(id, payload, "")
+	if status != http.StatusOK {
+		if errMsg == "" {
+			errMsg = "update failed"
+		}
+		w.WriteHeader(status)
+		writeJSON(w, map[string]string{"error": errMsg})
+		return
+	}
+	writeJSON(w, map[string]string{"message": "Settings updated successfully"})
+}
+
+func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface{}, baseRevision string) (SessionData, int, string) {
+	if payload == nil {
+		payload = map[string]interface{}{}
+	}
+	log.Printf("SESSION GROUP UPDATE request session_id=%s keys=%d", id, len(payload))
+	controlRevision := newControlRevision()
 	transportKeys := []string{
 		"transport_failure_type",
 		"transport_consecutive_failures",
@@ -756,8 +1022,23 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 	}
 
 	sessions := a.getSessionList()
+	var target SessionData
+	for _, session := range sessions {
+		if getString(session, "session_id") == id {
+			target = session
+			break
+		}
+	}
+	if target == nil {
+		return nil, http.StatusNotFound, "Session not found"
+	}
+	currentRevision := getString(target, "control_revision")
+	if baseRevision != "" && currentRevision != "" && baseRevision != currentRevision {
+		return target, http.StatusConflict, "revision_conflict"
+	}
+
 	var targetPort string
-	var targetGroupID string
+	targetGroupID := getString(target, "group_id")
 	var transportSnapshot map[string]interface{}
 	manualTransportDisarm := false
 	var transportLogSession SessionData
@@ -766,134 +1047,131 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 	transportConsecutive := 1
 	transportConsecutiveUnits := transportUnitsSeconds
 	transportFrequency := 0
-	for _, session := range sessions {
-		if getString(session, "session_id") == id {
-			previousTransportType := normalizeTransportFaultType(getString(session, "transport_failure_type"))
-			if previousTransportType == "none" {
-				previousTransportType = normalizeTransportFaultType(getString(session, "transport_fault_type"))
-			}
-			targetGroupID = getString(session, "group_id")
-			for key, value := range payload {
-				session[key] = value
-			}
-			for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
-				typeKey := prefix + "_failure_type"
-				failureType := normalizeRequestFailureType(getString(session, typeKey))
-				if failureType == "" {
-					failureType = "none"
-				}
-				session[typeKey] = failureType
-				resetKey := prefix + "_reset_failure_type"
-				if resetType := getString(session, resetKey); resetType != "" {
-					session[resetKey] = normalizeRequestFailureType(resetType)
-				}
-			}
-			targetPort = getString(session, "x_forwarded_port")
-			if transportUpdated {
-				typeRaw := getString(session, "transport_failure_type")
-				if typeRaw == "" {
-					typeRaw = getString(session, "transport_fault_type")
-				}
-				if value, ok := payload["transport_failure_type"]; ok {
-					typeRaw = fmt.Sprintf("%v", value)
-				} else if value, ok := payload["transport_fault_type"]; ok {
-					typeRaw = fmt.Sprintf("%v", value)
-				}
-				session["transport_failure_type"] = normalizeTransportFaultType(typeRaw)
-				if session["transport_failure_type"] == "" {
-					session["transport_failure_type"] = "none"
-				}
 
-				unitsRaw := getString(session, "transport_consecutive_units")
-				if unitsRaw == "" {
-					unitsRaw = getString(session, "transport_failure_units")
-				}
-				if unitsRaw == "" {
-					unitsRaw = getString(session, "transport_failure_mode")
-				}
-				if value, ok := payload["transport_consecutive_units"]; ok {
-					unitsRaw = fmt.Sprintf("%v", value)
-				} else if value, ok := payload["transport_failure_units"]; ok {
-					unitsRaw = fmt.Sprintf("%v", value)
-				} else if value, ok := payload["transport_failure_mode"]; ok {
-					unitsRaw = fmt.Sprintf("%v", value)
-				}
-				consecutiveUnits := normalizeTransportConsecutiveUnits(unitsRaw)
-				if strings.Contains(strings.ToLower(strings.TrimSpace(unitsRaw)), "packet") {
-					consecutiveUnits = transportUnitsPackets
-				}
+	previousTransportType := normalizeTransportFaultType(getString(target, "transport_failure_type"))
+	if previousTransportType == "none" {
+		previousTransportType = normalizeTransportFaultType(getString(target, "transport_fault_type"))
+	}
 
-				onValue := floatFromInterface(session["transport_consecutive_failures"])
-				if value, ok := payload["transport_consecutive_failures"]; ok {
-					onValue = floatFromInterface(value)
-				} else if value, ok := payload["transport_consecutive_seconds"]; ok {
-					onValue = floatFromInterface(value)
-				} else if value, ok := payload["transport_fault_on_seconds"]; ok {
-					onValue = floatFromInterface(value)
-				}
-				onValue = math.Max(0, onValue)
-				session["transport_consecutive_failures"] = int(math.Round(onValue))
+	for key, value := range payload {
+		target[key] = value
+	}
+	applyControlRevision(target, controlRevision)
+	for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
+		typeKey := prefix + "_failure_type"
+		failureType := normalizeRequestFailureType(getString(target, typeKey))
+		if failureType == "" {
+			failureType = "none"
+		}
+		target[typeKey] = failureType
+		resetKey := prefix + "_reset_failure_type"
+		if resetType := getString(target, resetKey); resetType != "" {
+			target[resetKey] = normalizeRequestFailureType(resetType)
+		}
+	}
+	targetPort = getString(target, "x_forwarded_port")
+	if transportUpdated {
+		typeRaw := getString(target, "transport_failure_type")
+		if typeRaw == "" {
+			typeRaw = getString(target, "transport_fault_type")
+		}
+		if value, ok := payload["transport_failure_type"]; ok {
+			typeRaw = fmt.Sprintf("%v", value)
+		} else if value, ok := payload["transport_fault_type"]; ok {
+			typeRaw = fmt.Sprintf("%v", value)
+		}
+		target["transport_failure_type"] = normalizeTransportFaultType(typeRaw)
+		if target["transport_failure_type"] == "" {
+			target["transport_failure_type"] = "none"
+		}
 
-				offSeconds := floatFromInterface(session["transport_failure_frequency"])
-				if value, ok := payload["transport_failure_frequency"]; ok {
-					offSeconds = floatFromInterface(value)
-				} else if value, ok := payload["transport_frequency_seconds"]; ok {
-					offSeconds = floatFromInterface(value)
-				} else if value, ok := payload["transport_fault_off_seconds"]; ok {
-					offSeconds = floatFromInterface(value)
-				}
-				offSeconds = math.Max(0, offSeconds)
-				session["transport_failure_frequency"] = int(math.Round(offSeconds))
+		unitsRaw := getString(target, "transport_consecutive_units")
+		if unitsRaw == "" {
+			unitsRaw = getString(target, "transport_failure_units")
+		}
+		if unitsRaw == "" {
+			unitsRaw = getString(target, "transport_failure_mode")
+		}
+		if value, ok := payload["transport_consecutive_units"]; ok {
+			unitsRaw = fmt.Sprintf("%v", value)
+		} else if value, ok := payload["transport_failure_units"]; ok {
+			unitsRaw = fmt.Sprintf("%v", value)
+		} else if value, ok := payload["transport_failure_mode"]; ok {
+			unitsRaw = fmt.Sprintf("%v", value)
+		}
+		consecutiveUnits := normalizeTransportConsecutiveUnits(unitsRaw)
+		if strings.Contains(strings.ToLower(strings.TrimSpace(unitsRaw)), "packet") {
+			consecutiveUnits = transportUnitsPackets
+		}
 
-				session["transport_failure_units"] = consecutiveUnits
-				session["transport_consecutive_units"] = consecutiveUnits
-				session["transport_frequency_units"] = transportUnitsSeconds
-				session["transport_failure_mode"] = transportModeFromConsecutiveUnits(consecutiveUnits)
-				session["transport_fault_type"] = session["transport_failure_type"]
-				session["transport_fault_on_seconds"] = float64(getInt(session, "transport_consecutive_failures"))
-				session["transport_fault_off_seconds"] = float64(getInt(session, "transport_failure_frequency"))
-				session["transport_consecutive_seconds"] = session["transport_fault_on_seconds"]
-				session["transport_frequency_seconds"] = session["transport_fault_off_seconds"]
-				session["transport_failure_at"] = nil
-				session["transport_failure_recover_at"] = nil
-				session["transport_reset_failure_type"] = nil
-				session["transport_fault_started_at"] = nil
-				session["transport_fault_active"] = false
-				session["transport_fault_phase_seconds"] = 0.0
-				session["transport_fault_cycle_seconds"] = 0.0
-				transportShouldApply = true
-				transportFaultType = normalizeTransportFaultType(getString(session, "transport_failure_type"))
-				transportConsecutive = getInt(session, "transport_consecutive_failures")
-				transportConsecutiveUnits = normalizeTransportConsecutiveUnits(getString(session, "transport_consecutive_units"))
-				transportFrequency = getInt(session, "transport_failure_frequency")
-				currentTransportType := normalizeTransportFaultType(getString(session, "transport_failure_type"))
-				if previousTransportType != "none" && currentTransportType == "none" {
-					manualTransportDisarm = true
-					transportLogSession = session
-				}
-				transportSnapshot = map[string]interface{}{
-					"transport_failure_type":         session["transport_failure_type"],
-					"transport_consecutive_failures": session["transport_consecutive_failures"],
-					"transport_failure_frequency":    session["transport_failure_frequency"],
-					"transport_failure_units":        session["transport_failure_units"],
-					"transport_consecutive_units":    session["transport_consecutive_units"],
-					"transport_frequency_units":      session["transport_frequency_units"],
-					"transport_failure_mode":         session["transport_failure_mode"],
-					"transport_failure_at":           nil,
-					"transport_failure_recover_at":   nil,
-					"transport_reset_failure_type":   nil,
-					"transport_fault_type":           session["transport_fault_type"],
-					"transport_fault_on_seconds":     session["transport_fault_on_seconds"],
-					"transport_fault_off_seconds":    session["transport_fault_off_seconds"],
-					"transport_consecutive_seconds":  session["transport_consecutive_seconds"],
-					"transport_frequency_seconds":    session["transport_frequency_seconds"],
-					"transport_fault_started_at":     session["transport_fault_started_at"],
-					"transport_fault_active":         false,
-					"transport_fault_phase_seconds":  0.0,
-					"transport_fault_cycle_seconds":  0.0,
-				}
-			}
-			break
+		onValue := floatFromInterface(target["transport_consecutive_failures"])
+		if value, ok := payload["transport_consecutive_failures"]; ok {
+			onValue = floatFromInterface(value)
+		} else if value, ok := payload["transport_consecutive_seconds"]; ok {
+			onValue = floatFromInterface(value)
+		} else if value, ok := payload["transport_fault_on_seconds"]; ok {
+			onValue = floatFromInterface(value)
+		}
+		onValue = math.Max(0, onValue)
+		target["transport_consecutive_failures"] = int(math.Round(onValue))
+
+		offSeconds := floatFromInterface(target["transport_failure_frequency"])
+		if value, ok := payload["transport_failure_frequency"]; ok {
+			offSeconds = floatFromInterface(value)
+		} else if value, ok := payload["transport_frequency_seconds"]; ok {
+			offSeconds = floatFromInterface(value)
+		} else if value, ok := payload["transport_fault_off_seconds"]; ok {
+			offSeconds = floatFromInterface(value)
+		}
+		offSeconds = math.Max(0, offSeconds)
+		target["transport_failure_frequency"] = int(math.Round(offSeconds))
+
+		target["transport_failure_units"] = consecutiveUnits
+		target["transport_consecutive_units"] = consecutiveUnits
+		target["transport_frequency_units"] = transportUnitsSeconds
+		target["transport_failure_mode"] = transportModeFromConsecutiveUnits(consecutiveUnits)
+		target["transport_fault_type"] = target["transport_failure_type"]
+		target["transport_fault_on_seconds"] = float64(getInt(target, "transport_consecutive_failures"))
+		target["transport_fault_off_seconds"] = float64(getInt(target, "transport_failure_frequency"))
+		target["transport_consecutive_seconds"] = target["transport_fault_on_seconds"]
+		target["transport_frequency_seconds"] = target["transport_fault_off_seconds"]
+		target["transport_failure_at"] = nil
+		target["transport_failure_recover_at"] = nil
+		target["transport_reset_failure_type"] = nil
+		target["transport_fault_started_at"] = nil
+		target["transport_fault_active"] = false
+		target["transport_fault_phase_seconds"] = 0.0
+		target["transport_fault_cycle_seconds"] = 0.0
+		transportShouldApply = true
+		transportFaultType = normalizeTransportFaultType(getString(target, "transport_failure_type"))
+		transportConsecutive = getInt(target, "transport_consecutive_failures")
+		transportConsecutiveUnits = normalizeTransportConsecutiveUnits(getString(target, "transport_consecutive_units"))
+		transportFrequency = getInt(target, "transport_failure_frequency")
+		currentTransportType := normalizeTransportFaultType(getString(target, "transport_failure_type"))
+		if previousTransportType != "none" && currentTransportType == "none" {
+			manualTransportDisarm = true
+			transportLogSession = target
+		}
+		transportSnapshot = map[string]interface{}{
+			"transport_failure_type":         target["transport_failure_type"],
+			"transport_consecutive_failures": target["transport_consecutive_failures"],
+			"transport_failure_frequency":    target["transport_failure_frequency"],
+			"transport_failure_units":        target["transport_failure_units"],
+			"transport_consecutive_units":    target["transport_consecutive_units"],
+			"transport_frequency_units":      target["transport_frequency_units"],
+			"transport_failure_mode":         target["transport_failure_mode"],
+			"transport_failure_at":           nil,
+			"transport_failure_recover_at":   nil,
+			"transport_reset_failure_type":   nil,
+			"transport_fault_type":           target["transport_fault_type"],
+			"transport_fault_on_seconds":     target["transport_fault_on_seconds"],
+			"transport_fault_off_seconds":    target["transport_fault_off_seconds"],
+			"transport_consecutive_seconds":  target["transport_consecutive_seconds"],
+			"transport_frequency_seconds":    target["transport_frequency_seconds"],
+			"transport_fault_started_at":     target["transport_fault_started_at"],
+			"transport_fault_active":         false,
+			"transport_fault_phase_seconds":  0.0,
+			"transport_fault_cycle_seconds":  0.0,
 		}
 	}
 	if transportUpdated && targetPort != "" && transportSnapshot != nil {
@@ -910,20 +1188,19 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 		logFaultEvent(transportLogSession, targetPort, "transport_none", "control", "transport_disarm_manual")
 	}
 
-	// Propagate settings to group members if this session is part of a group
 	if targetGroupID != "" {
+		log.Printf("SESSION GROUP UPDATE propagate session_id=%s group_id=%s", id, targetGroupID)
 		for _, session := range sessions {
 			sessionGroupID := getString(session, "group_id")
 			sessionID := getString(session, "session_id")
-			// Skip the original session (already updated) and non-group members
 			if sessionID == id || sessionGroupID != targetGroupID {
 				continue
 			}
-			// Apply all payload updates to group members
+			log.Printf("SESSION GROUP UPDATE member session_id=%s group_id=%s", sessionID, sessionGroupID)
 			for key, value := range payload {
 				session[key] = value
 			}
-			// Apply normalized failure types
+			applyControlRevision(session, controlRevision)
 			for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
 				typeKey := prefix + "_failure_type"
 				failureType := normalizeRequestFailureType(getString(session, typeKey))
@@ -936,12 +1213,10 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 					session[resetKey] = normalizeRequestFailureType(resetType)
 				}
 			}
-			// Apply transport updates if needed
 			if transportUpdated && transportSnapshot != nil {
 				for key, value := range transportSnapshot {
 					session[key] = value
 				}
-				// Apply transport fault to the group member's port
 				groupMemberPort := getString(session, "x_forwarded_port")
 				if groupMemberPort != "" && transportShouldApply {
 					if portNum, err := strconv.Atoi(groupMemberPort); err == nil {
@@ -951,6 +1226,9 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 			}
 		}
 	}
+	if targetGroupID == "" {
+		log.Printf("SESSION GROUP UPDATE no group for session_id=%s", id)
+	}
 
 	a.saveSessionList(sessions)
 	if transportShouldApply {
@@ -958,7 +1236,11 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 			a.armTransportFaultLoop(portNum, transportFaultType, transportConsecutive, transportConsecutiveUnits, transportFrequency)
 		}
 	}
-	writeJSON(w, map[string]string{"message": "Settings updated successfully"})
+	return target, http.StatusOK, ""
+}
+
+func (a *App) handleUpdateSessionSettings(w http.ResponseWriter, r *http.Request) {
+	a.handleUpdateFailureSettings(w, r)
 }
 
 func (a *App) handleSession(w http.ResponseWriter, r *http.Request) {
@@ -1053,6 +1335,8 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "at least 2 sessions required"})
 		return
 	}
+	log.Printf("SESSION GROUP LINK request sessions=%v group_id=%s", payload.SessionIds, payload.GroupId)
+	controlRevision := newControlRevision()
 
 	// Generate a group ID if not provided
 	groupID := payload.GroupId
@@ -1067,6 +1351,7 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 		for _, targetID := range payload.SessionIds {
 			if sessionID == targetID {
 				session["group_id"] = groupID
+				applyControlRevision(session, controlRevision)
 				linkedCount++
 				break
 			}
@@ -1076,6 +1361,7 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 	if linkedCount > 0 {
 		a.saveSessionList(sessions)
 	}
+	log.Printf("SESSION GROUP LINK result group_id=%s linked=%d", groupID, linkedCount)
 
 	writeJSON(w, map[string]interface{}{
 		"message":      "Sessions linked successfully",
@@ -1086,7 +1372,9 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
 	var payload struct {
-		SessionId string `json:"session_id"`
+		SessionId   string `json:"session_id"`
+		GroupId     string `json:"group_id"`
+		UnlinkGroup bool   `json:"unlink_group"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -1096,17 +1384,44 @@ func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
 
 	sessions := a.getSessionList()
 	found := false
-	for _, session := range sessions {
-		if getString(session, "session_id") == payload.SessionId {
-			session["group_id"] = ""
-			found = true
-			break
+	updated := 0
+	groupID := payload.GroupId
+	if groupID == "" && payload.SessionId != "" {
+		for _, session := range sessions {
+			if getString(session, "session_id") == payload.SessionId {
+				groupID = getString(session, "group_id")
+				break
+			}
+		}
+	}
+	if payload.UnlinkGroup && groupID != "" {
+		for _, session := range sessions {
+			if getString(session, "group_id") == groupID {
+				session["group_id"] = ""
+				applyControlRevision(session, newControlRevision())
+				updated++
+				found = true
+			}
+		}
+	} else if payload.SessionId != "" {
+		for _, session := range sessions {
+			if getString(session, "session_id") == payload.SessionId {
+				session["group_id"] = ""
+				applyControlRevision(session, newControlRevision())
+				updated++
+				found = true
+				break
+			}
 		}
 	}
 
 	if found {
 		a.saveSessionList(sessions)
-		writeJSON(w, map[string]string{"message": "Session unlinked successfully"})
+		writeJSON(w, map[string]interface{}{
+			"message":        "Session group updated successfully",
+			"group_id":       groupID,
+			"unlinked_count": updated,
+		})
 	} else {
 		w.WriteHeader(http.StatusNotFound)
 		writeJSON(w, map[string]string{"error": "Session not found"})
@@ -1222,7 +1537,9 @@ func (a *App) handleNftPort(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Manager not initialized"})
 		return
 	}
-	port, err := strconv.Atoi(mux.Vars(r)["port"])
+	portStr := mux.Vars(r)["port"]
+	mappedPort, _ := a.portMap.MapExternalPort(portStr)
+	port, err := strconv.Atoi(mappedPort)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "invalid port"})
@@ -1321,10 +1638,10 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, delayMs int, los
 	cleanSteps := sanitizeShapeSteps(steps)
 	if len(cleanSteps) == 0 {
 		a.stopShapeLoop(port)
-		a.updateSessionsByPort(port, map[string]interface{}{
+		a.updateSessionsByPortWithControl(port, map[string]interface{}{
 			"nftables_pattern_enabled": false,
 			"nftables_pattern_steps":   []NftShapeStep{},
-		})
+		}, "")
 		return nil
 	}
 	if err := a.traffic.UpdateNetem(port, delayMs, loss); err != nil {
@@ -1345,12 +1662,12 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, delayMs int, los
 	if oldCancel != nil {
 		oldCancel()
 	}
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_pattern_enabled": true,
 		"nftables_pattern_steps":   cleanSteps,
 		"nftables_delay_ms":        delayMs,
 		"nftables_packet_loss":     loss,
-	})
+	}, "")
 	go a.runShapePatternLoop(ctx, port, cleanSteps, delayMs, loss)
 	return nil
 }
@@ -1453,11 +1770,11 @@ func (a *App) runShapePatternLoop(ctx context.Context, port int, steps []NftShap
 
 func (a *App) disablePatternForPort(port int) {
 	a.stopShapeLoop(port)
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_pattern_enabled": false,
 		"nftables_pattern_steps":   []NftShapeStep{},
 		"nftables_pattern_step":    nil,
-	})
+	}, "")
 }
 
 func transportRuleComment(port int) string {
@@ -1651,15 +1968,45 @@ func (a *App) getFirstSessionByPort(port int) SessionData {
 }
 
 func (a *App) setTransportFaultSessionState(port int, faultType string, active bool, startedAt string, phaseSeconds float64, cycleSeconds float64) {
-	updates := map[string]interface{}{
-		"transport_failure_type":        faultType,
-		"transport_fault_type":          faultType,
-		"transport_fault_active":        active,
-		"transport_fault_started_at":    startedAt,
-		"transport_fault_phase_seconds": math.Round(phaseSeconds*1000) / 1000,
-		"transport_fault_cycle_seconds": math.Round(cycleSeconds*1000) / 1000,
+	sessions := a.getSessionList()
+	changed := false
+	controlRevision := ""
+	phaseRounded := math.Round(phaseSeconds*1000) / 1000
+	cycleRounded := math.Round(cycleSeconds*1000) / 1000
+	for _, session := range sessions {
+		portStr := getString(session, "x_forwarded_port")
+		if portStr == "" {
+			continue
+		}
+		if portNum, err := strconv.Atoi(portStr); err == nil && portNum == port {
+			prevType := getString(session, "transport_fault_type")
+			if prevType == "" {
+				prevType = getString(session, "transport_failure_type")
+			}
+			prevActive := getBool(session, "transport_fault_active")
+			prevStarted := getString(session, "transport_fault_started_at")
+			session["transport_failure_type"] = faultType
+			session["transport_fault_type"] = faultType
+			session["transport_fault_active"] = active
+			session["transport_fault_started_at"] = startedAt
+			session["transport_fault_phase_seconds"] = phaseRounded
+			session["transport_fault_cycle_seconds"] = cycleRounded
+			controlChanged := prevType != faultType || prevActive != active
+			if !controlChanged && startedAt != "" && prevStarted != startedAt {
+				controlChanged = true
+			}
+			if controlChanged {
+				if controlRevision == "" {
+					controlRevision = newControlRevision()
+				}
+				applyControlRevision(session, controlRevision)
+			}
+			changed = true
+		}
 	}
-	a.updateSessionsByPort(port, updates)
+	if changed {
+		a.saveSessionList(sessions)
+	}
 }
 
 func (a *App) resetTransportFaultCounters(port int) {
@@ -1832,7 +2179,9 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Manager not initialized"})
 		return
 	}
-	port, err := strconv.Atoi(mux.Vars(r)["port"])
+	portStr := mux.Vars(r)["port"]
+	mappedPort, _ := a.portMap.MapExternalPort(portStr)
+	port, err := strconv.Atoi(mappedPort)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "invalid port"})
@@ -1868,13 +2217,13 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(payload.Steps) == 0 {
 		a.disablePatternForPort(port)
-		a.updateSessionsByPort(port, map[string]interface{}{
+		a.updateSessionsByPortWithControl(port, map[string]interface{}{
 			"nftables_pattern_segment_duration_seconds": payload.SegmentDurationSeconds,
 			"nftables_pattern_default_segments":         payload.DefaultSegments,
 			"nftables_pattern_default_step_seconds":     payload.DefaultStepSeconds,
 			"nftables_pattern_template_mode":            payload.TemplateMode,
 			"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
-		})
+		}, "")
 		writeJSON(w, map[string]interface{}{
 			"success":         true,
 			"port":            port,
@@ -1890,13 +2239,13 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Failed to apply pattern", "details": err.Error()})
 		return
 	}
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_pattern_segment_duration_seconds": payload.SegmentDurationSeconds,
 		"nftables_pattern_default_segments":         payload.DefaultSegments,
 		"nftables_pattern_default_step_seconds":     payload.DefaultStepSeconds,
 		"nftables_pattern_template_mode":            payload.TemplateMode,
 		"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
-	})
+	}, "")
 
 	// Propagate to group members
 	groupID := a.getGroupIdByPort(port)
@@ -1910,13 +2259,13 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 				log.Printf("NETSHAPE group pattern propagation failed port=%d: %v", groupPort, err)
 				continue
 			}
-			a.updateSessionsByPort(groupPort, map[string]interface{}{
+			a.updateSessionsByPortWithControl(groupPort, map[string]interface{}{
 				"nftables_pattern_segment_duration_seconds": payload.SegmentDurationSeconds,
 				"nftables_pattern_default_segments":         payload.DefaultSegments,
 				"nftables_pattern_default_step_seconds":     payload.DefaultStepSeconds,
 				"nftables_pattern_template_mode":            payload.TemplateMode,
 				"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
-			})
+			}, "")
 			log.Printf("NETSHAPE group pattern propagation applied port=%d group=%s", groupPort, groupID)
 		}
 	}
@@ -1937,7 +2286,9 @@ func (a *App) handleNftBandwidth(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Manager not initialized"})
 		return
 	}
-	port, err := strconv.Atoi(mux.Vars(r)["port"])
+	portStr := mux.Vars(r)["port"]
+	mappedPort, _ := a.portMap.MapExternalPort(portStr)
+	port, err := strconv.Atoi(mappedPort)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "invalid port"})
@@ -1975,9 +2326,9 @@ func (a *App) handleNftBandwidth(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Failed to update rate limit", "details": err.Error()})
 		return
 	}
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_bandwidth_mbps": rateMbps,
-	})
+	}, "")
 	writeJSON(w, map[string]interface{}{"success": true, "port": port, "rate": fmt.Sprintf("%g Mbps", rateMbps)})
 }
 
@@ -1987,7 +2338,9 @@ func (a *App) handleNftLoss(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Manager not initialized"})
 		return
 	}
-	port, err := strconv.Atoi(mux.Vars(r)["port"])
+	portStr := mux.Vars(r)["port"]
+	mappedPort, _ := a.portMap.MapExternalPort(portStr)
+	port, err := strconv.Atoi(mappedPort)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "invalid port"})
@@ -2018,9 +2371,9 @@ func (a *App) handleNftLoss(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Failed to update packet loss", "details": err.Error()})
 		return
 	}
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_packet_loss": loss,
-	})
+	}, "")
 	writeJSON(w, map[string]interface{}{"success": true, "port": port, "loss_pct": loss})
 }
 
@@ -2030,7 +2383,9 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Manager not initialized"})
 		return
 	}
-	port, err := strconv.Atoi(mux.Vars(r)["port"])
+	portStr := mux.Vars(r)["port"]
+	mappedPort, _ := a.portMap.MapExternalPort(portStr)
+	port, err := strconv.Atoi(mappedPort)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "invalid port"})
@@ -2091,11 +2446,11 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "Failed to update delay/loss", "details": err.Error()})
 		return
 	}
-	a.updateSessionsByPort(port, map[string]interface{}{
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
 		"nftables_bandwidth_mbps": rateMbps,
 		"nftables_delay_ms":       delayMs,
 		"nftables_packet_loss":    loss,
-	})
+	}, "")
 
 	// Propagate to group members
 	groupID := a.getGroupIdByPort(port)
@@ -2114,11 +2469,11 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 				log.Printf("NETSHAPE group propagation netem failed port=%d delay=%d loss=%.2f: %v", groupPort, delayMs, loss, err)
 				continue
 			}
-			a.updateSessionsByPort(groupPort, map[string]interface{}{
+			a.updateSessionsByPortWithControl(groupPort, map[string]interface{}{
 				"nftables_bandwidth_mbps": rateMbps,
 				"nftables_delay_ms":       delayMs,
 				"nftables_packet_loss":    loss,
-			})
+			}, "")
 			log.Printf("NETSHAPE group propagation applied port=%d rate=%g delay=%d loss=%.2f group=%s", groupPort, rateMbps, delayMs, loss, groupID)
 		}
 	}
@@ -2456,6 +2811,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if externalPort == "" {
 		externalPort = hostPortOrDefault(r.Host, "30181")
 	}
+	internalPort := externalPort
+	if mapped, ok := a.portMap.MapExternalPort(externalPort); ok {
+		internalPort = mapped
+	}
 	log.Printf("Original URL: %s", r.URL.String())
 	log.Printf("Original Host: %s", r.Host)
 	log.Printf("X-Forwarded-Port: %s", r.Header.Get("X-Forwarded-Port"))
@@ -2498,6 +2857,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"session_id":                               fmt.Sprintf("%d", allocated),
 			"player_id":                                playerID,
 			"group_id":                                 groupID,
+			"control_revision":                         newControlRevision(),
 			"headers_player_id":                        playerHeader,
 			"headers_player-ID":                        playerHeaderAlt,
 			"headers_x_playback_session_id":            playbackSessionHeader,
@@ -2566,6 +2926,8 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"fault_count_request_body_hang":            0,
 			"fault_count_request_body_reset":           0,
 			"fault_count_request_body_delayed":         0,
+			"x_forwarded_port":                         internalPort,
+			"x_forwarded_port_external":                externalPort,
 		}
 		sessionList = append(sessionList, sessionData)
 		a.saveSessionList(sessionList)
@@ -2602,13 +2964,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	sessionData["last_request_url"] = filename
 	sessionData["user_agent"] = r.UserAgent()
 	sessionData["player_ip"] = remoteIP(r.RemoteAddr)
-	sessionData["x_forwarded_port"] = externalPort
+	sessionData["x_forwarded_port"] = internalPort
+	sessionData["x_forwarded_port_external"] = externalPort
 	requestBytes := int64(0)
 	if r.ContentLength > 0 {
 		requestBytes = r.ContentLength
 	}
 
-	portNum, _ := strconv.Atoi(externalPort)
+	portNum, _ := strconv.Atoi(internalPort)
 	if portNum > 0 {
 		a.applySessionShaping(sessionData, portNum)
 	}
@@ -3015,15 +3378,96 @@ func (a *App) getSessionData(identifier string) SessionData {
 	return nil
 }
 
+func newControlRevision() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func applyControlRevision(session SessionData, revision string) {
+	rev := revision
+	if rev == "" {
+		rev = newControlRevision()
+	}
+	session["control_revision"] = rev
+}
+
+func cloneSession(session SessionData) SessionData {
+	if session == nil {
+		return nil
+	}
+	clone := make(SessionData, len(session))
+	for key, value := range session {
+		clone[key] = value
+	}
+	return clone
+}
+
+func (a *App) normalizeSessionForResponse(session SessionData) SessionData {
+	if session == nil {
+		return nil
+	}
+	clone := cloneSession(session)
+	normalized := a.normalizeSessionsForResponse([]SessionData{clone})
+	if len(normalized) == 0 {
+		return clone
+	}
+	return normalized[0]
+}
+
+func (a *App) updateSessionsByPortWithControl(port int, updates map[string]interface{}, controlRevision string) {
+	sessions := a.getSessionList()
+	changed := false
+	rev := controlRevision
+	if rev == "" {
+		rev = newControlRevision()
+	}
+	for _, session := range sessions {
+		if a.sessionMatchesPort(session, port) {
+			for key, value := range updates {
+				session[key] = value
+			}
+			applyControlRevision(session, rev)
+			changed = true
+		}
+	}
+	if changed {
+		a.saveSessionList(sessions)
+	}
+}
+
+func (a *App) sessionPortToInternal(portStr string) (int, bool) {
+	if portStr == "" {
+		return 0, false
+	}
+	if mapped, ok := a.portMap.MapExternalPort(portStr); ok {
+		if port, err := strconv.Atoi(mapped); err == nil {
+			return port, true
+		}
+	}
+	if port, err := strconv.Atoi(portStr); err == nil {
+		return port, true
+	}
+	return 0, false
+}
+
+func (a *App) sessionMatchesPort(session SessionData, port int) bool {
+	if portStr := getString(session, "x_forwarded_port"); portStr != "" {
+		if portNum, ok := a.sessionPortToInternal(portStr); ok && portNum == port {
+			return true
+		}
+	}
+	if portStr := getString(session, "x_forwarded_port_external"); portStr != "" {
+		if portNum, ok := a.sessionPortToInternal(portStr); ok && portNum == port {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *App) updateSessionsByPort(port int, updates map[string]interface{}) {
 	sessions := a.getSessionList()
 	changed := false
 	for _, session := range sessions {
-		portStr := getString(session, "x_forwarded_port")
-		if portStr == "" {
-			continue
-		}
-		if portNum, err := strconv.Atoi(portStr); err == nil && portNum == port {
+		if a.sessionMatchesPort(session, port) {
 			for key, value := range updates {
 				session[key] = value
 			}
@@ -3051,6 +3495,181 @@ func (a *App) saveSessionList(sessions []SessionData) {
 	if data, err := json.Marshal(sessions); err == nil {
 		_ = a.memcache.Set(&memcache.Item{Key: "session_list", Value: data})
 	}
+	a.queueSessionsBroadcast(sessions)
+}
+
+func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData {
+	transportCountersByPort := getTransportFaultRuleCounters()
+	for _, session := range sessions {
+		for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
+			typeKey := prefix + "_failure_type"
+			failureType := normalizeRequestFailureType(getString(session, typeKey))
+			if failureType == "" {
+				failureType = "none"
+			}
+			session[typeKey] = failureType
+			resetKey := prefix + "_reset_failure_type"
+			if resetType := getString(session, resetKey); resetType != "" {
+				session[resetKey] = normalizeRequestFailureType(resetType)
+			}
+		}
+		if getString(session, "transport_failure_type") == "" {
+			session["transport_failure_type"] = normalizeTransportFaultType(getString(session, "transport_fault_type"))
+		}
+		if getString(session, "transport_failure_type") == "" {
+			session["transport_failure_type"] = "none"
+		}
+		units := normalizeTransportConsecutiveUnits(getString(session, "transport_consecutive_units"))
+		if units == transportUnitsSeconds {
+			units = normalizeTransportConsecutiveUnits(getString(session, "transport_failure_units"))
+		}
+		if units == transportUnitsSeconds {
+			units = transportConsecutiveUnitsFromMode(getString(session, "transport_failure_mode"))
+		}
+		session["transport_failure_units"] = units
+		session["transport_consecutive_units"] = units
+		session["transport_frequency_units"] = transportUnitsSeconds
+		session["transport_failure_mode"] = transportModeFromConsecutiveUnits(units)
+		if _, ok := session["transport_consecutive_failures"]; !ok {
+			legacyOn := floatFromInterface(session["transport_consecutive_seconds"])
+			if legacyOn <= 0 {
+				legacyOn = floatFromInterface(session["transport_fault_on_seconds"])
+			}
+			if legacyOn <= 0 {
+				legacyOn = 1
+			}
+			session["transport_consecutive_failures"] = int(math.Round(legacyOn))
+		}
+		if _, ok := session["transport_failure_frequency"]; !ok {
+			legacyOff := floatFromInterface(session["transport_frequency_seconds"])
+			if legacyOff < 0 {
+				legacyOff = floatFromInterface(session["transport_fault_off_seconds"])
+			}
+			if legacyOff < 0 {
+				legacyOff = 0
+			}
+			session["transport_failure_frequency"] = int(math.Round(legacyOff))
+		}
+		session["transport_fault_type"] = normalizeTransportFaultType(getString(session, "transport_failure_type"))
+		session["transport_fault_on_seconds"] = float64(getInt(session, "transport_consecutive_failures"))
+		session["transport_fault_off_seconds"] = float64(getInt(session, "transport_failure_frequency"))
+		session["transport_consecutive_seconds"] = session["transport_fault_on_seconds"]
+		session["transport_frequency_seconds"] = session["transport_fault_off_seconds"]
+		if _, ok := session["transport_fault_active"]; !ok {
+			session["transport_fault_active"] = false
+		}
+		if _, ok := session["fault_count_total"]; !ok {
+			session["fault_count_total"] = 0
+		}
+		if _, ok := session["fault_count_socket_reject"]; !ok {
+			session["fault_count_socket_reject"] = 0
+		}
+		if _, ok := session["fault_count_socket_drop"]; !ok {
+			session["fault_count_socket_drop"] = 0
+		}
+		if _, ok := session["fault_count_socket_drop_before_headers"]; !ok {
+			session["fault_count_socket_drop_before_headers"] = 0
+		}
+		if _, ok := session["fault_count_socket_reject_before_headers"]; !ok {
+			session["fault_count_socket_reject_before_headers"] = 0
+		}
+		if _, ok := session["fault_count_socket_drop_after_headers"]; !ok {
+			session["fault_count_socket_drop_after_headers"] = 0
+		}
+		if _, ok := session["fault_count_socket_reject_after_headers"]; !ok {
+			session["fault_count_socket_reject_after_headers"] = 0
+		}
+		if _, ok := session["fault_count_socket_drop_mid_body"]; !ok {
+			session["fault_count_socket_drop_mid_body"] = 0
+		}
+		if _, ok := session["fault_count_socket_reject_mid_body"]; !ok {
+			session["fault_count_socket_reject_mid_body"] = 0
+		}
+		if _, ok := session["fault_count_request_connect_hang"]; !ok {
+			session["fault_count_request_connect_hang"] = getInt(session, "fault_count_socket_drop_before_headers")
+		}
+		if _, ok := session["fault_count_request_connect_reset"]; !ok {
+			session["fault_count_request_connect_reset"] = getInt(session, "fault_count_socket_reject_before_headers")
+		}
+		if _, ok := session["fault_count_request_connect_delayed"]; !ok {
+			session["fault_count_request_connect_delayed"] = 0
+		}
+		if _, ok := session["fault_count_request_first_byte_hang"]; !ok {
+			session["fault_count_request_first_byte_hang"] = getInt(session, "fault_count_socket_drop_after_headers")
+		}
+		if _, ok := session["fault_count_request_first_byte_reset"]; !ok {
+			session["fault_count_request_first_byte_reset"] = getInt(session, "fault_count_socket_reject_after_headers")
+		}
+		if _, ok := session["fault_count_request_first_byte_delayed"]; !ok {
+			session["fault_count_request_first_byte_delayed"] = 0
+		}
+		if _, ok := session["fault_count_request_body_hang"]; !ok {
+			session["fault_count_request_body_hang"] = getInt(session, "fault_count_socket_drop_mid_body")
+		}
+		if _, ok := session["fault_count_request_body_reset"]; !ok {
+			session["fault_count_request_body_reset"] = getInt(session, "fault_count_socket_reject_mid_body")
+		}
+		if _, ok := session["fault_count_request_body_delayed"]; !ok {
+			session["fault_count_request_body_delayed"] = 0
+		}
+		if transportCountersByPort != nil {
+			portStr := getString(session, "x_forwarded_port")
+			if portStr != "" {
+				if portNum, err := strconv.Atoi(portStr); err == nil {
+					if counters, ok := transportCountersByPort[portNum]; ok {
+						session["transport_fault_drop_packets"] = counters.DropPackets
+						session["transport_fault_reject_packets"] = counters.RejectPackets
+					}
+				}
+			}
+		}
+	}
+	return sessions
+}
+
+func (a *App) buildSessionsEvent(sessions []SessionData) string {
+	if len(sessions) > 10 {
+		sessions = sessions[:10]
+	}
+	normalized := a.normalizeSessionsForResponse(sessions)
+	data, err := json.Marshal(normalized)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("event: sessions\ndata: %s\n\n", data)
+}
+
+func (a *App) queueSessionsBroadcast(sessions []SessionData) {
+	if a.sessionsHub == nil {
+		return
+	}
+	a.sessionsBroadcastMu.Lock()
+	a.sessionsBroadcastLatest = sessions
+	if a.sessionsBroadcastPending {
+		a.sessionsBroadcastMu.Unlock()
+		return
+	}
+	a.sessionsBroadcastPending = true
+	a.sessionsBroadcastMu.Unlock()
+	time.AfterFunc(250*time.Millisecond, func() {
+		a.flushSessionsBroadcast()
+	})
+}
+
+func (a *App) flushSessionsBroadcast() {
+	a.sessionsBroadcastMu.Lock()
+	sessions := a.sessionsBroadcastLatest
+	a.sessionsBroadcastLatest = nil
+	a.sessionsBroadcastPending = false
+	a.sessionsBroadcastMu.Unlock()
+	if sessions == nil {
+		return
+	}
+	payload := a.buildSessionsEvent(sessions)
+	if payload == "" {
+		return
+	}
+	a.sessionsHub.Broadcast(payload)
 }
 
 func (a *App) saveSession(identifier string, session SessionData) {
@@ -3372,6 +3991,22 @@ func getenvIntAny(keys []string, fallback int) int {
 	return fallback
 }
 
+func getenvBoolAny(keys []string, fallback bool) bool {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			switch strings.TrimSpace(strings.ToLower(value)) {
+			case "1", "true", "yes", "y", "on":
+				return true
+			case "0", "false", "no", "n", "off":
+				return false
+			default:
+				return fallback
+			}
+		}
+	}
+	return fallback
+}
+
 type FailureHandler struct {
 	failureType      string
 	failureUnits     string
@@ -3629,13 +4264,13 @@ func (a *App) getSessionsByGroupId(groupID string) []SessionData {
 // getGroupIdByPort returns the group ID for sessions on the specified port
 func (a *App) getGroupIdByPort(port int) string {
 	sessions := a.getSessionList()
-	portStr := fmt.Sprintf("%d", port)
 	for _, session := range sessions {
-		if getString(session, "x_forwarded_port") == portStr {
-			groupID := getString(session, "group_id")
-			if groupID != "" {
-				return groupID
-			}
+		if !a.sessionMatchesPort(session, port) {
+			continue
+		}
+		groupID := getString(session, "group_id")
+		if groupID != "" {
+			return groupID
 		}
 	}
 	return ""
@@ -3651,7 +4286,12 @@ func (a *App) getPortsForGroup(groupID string) []int {
 	for _, session := range sessions {
 		if getString(session, "group_id") == groupID {
 			if portStr := getString(session, "x_forwarded_port"); portStr != "" {
-				if port, err := strconv.Atoi(portStr); err == nil {
+				if port, ok := a.sessionPortToInternal(portStr); ok {
+					portMap[port] = true
+				}
+			}
+			if portStr := getString(session, "x_forwarded_port_external"); portStr != "" {
+				if port, ok := a.sessionPortToInternal(portStr); ok {
 					portMap[port] = true
 				}
 			}
@@ -3742,6 +4382,7 @@ func (h *RequestHandler) handleFailure(prefix, countKey string) string {
 	if failure.resetFailureType != nil {
 		h.session[prefix+"_failure_type"] = failure.resetFailureType
 		h.session[prefix+"_reset_failure_type"] = nil
+		h.session["control_revision"] = newControlRevision()
 	}
 	return failureType
 }
@@ -3760,6 +4401,7 @@ func (h *RequestHandler) handleManifestFailure(filename string) string {
 	if failure.resetFailureType != nil {
 		h.session["manifest_failure_type"] = failure.resetFailureType
 		h.session["manifest_reset_failure_type"] = nil
+		h.session["control_revision"] = newControlRevision()
 	}
 	return failureType
 }
@@ -3791,6 +4433,7 @@ func (h *RequestHandler) handleSegmentFailure(filename string) string {
 	if failure.resetFailureType != nil {
 		h.session["segment_failure_type"] = failure.resetFailureType
 		h.session["segment_reset_failure_type"] = nil
+		h.session["control_revision"] = newControlRevision()
 	}
 	return failureType
 }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -465,7 +465,7 @@ func main() {
 		maxSessions:  maxSessions,
 		client: &http.Client{
 			Transport: &http.Transport{
-				DialContext: (&net.Dialer{Timeout: 6 * time.Second}).DialContext,
+				DialContext:           (&net.Dialer{Timeout: 6 * time.Second}).DialContext,
 				ResponseHeaderTimeout: 6 * time.Second,
 			},
 		},
@@ -479,7 +479,7 @@ func main() {
 
 	router := mux.NewRouter()
 	router.Use(corsMiddleware)
-	
+
 	router.HandleFunc("/index.html", app.handleIndex).Methods(http.MethodGet)
 	router.HandleFunc("/api/sessions", app.handleGetSessions).Methods(http.MethodGet)
 	router.HandleFunc("/api/failure-settings/{id}", app.handleUpdateFailureSettings).Methods(http.MethodPost)
@@ -872,25 +872,25 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 					transportLogSession = session
 				}
 				transportSnapshot = map[string]interface{}{
-					"transport_failure_type":        session["transport_failure_type"],
+					"transport_failure_type":         session["transport_failure_type"],
 					"transport_consecutive_failures": session["transport_consecutive_failures"],
-					"transport_failure_frequency":   session["transport_failure_frequency"],
-					"transport_failure_units":       session["transport_failure_units"],
-					"transport_consecutive_units":   session["transport_consecutive_units"],
-					"transport_frequency_units":     session["transport_frequency_units"],
-					"transport_failure_mode":        session["transport_failure_mode"],
-					"transport_failure_at":          nil,
-					"transport_failure_recover_at":  nil,
-					"transport_reset_failure_type":  nil,
-					"transport_fault_type":         session["transport_fault_type"],
-					"transport_fault_on_seconds":   session["transport_fault_on_seconds"],
-					"transport_fault_off_seconds":  session["transport_fault_off_seconds"],
-					"transport_consecutive_seconds": session["transport_consecutive_seconds"],
-					"transport_frequency_seconds":   session["transport_frequency_seconds"],
-					"transport_fault_started_at":   session["transport_fault_started_at"],
-					"transport_fault_active":       false,
-					"transport_fault_phase_seconds": 0.0,
-					"transport_fault_cycle_seconds": 0.0,
+					"transport_failure_frequency":    session["transport_failure_frequency"],
+					"transport_failure_units":        session["transport_failure_units"],
+					"transport_consecutive_units":    session["transport_consecutive_units"],
+					"transport_frequency_units":      session["transport_frequency_units"],
+					"transport_failure_mode":         session["transport_failure_mode"],
+					"transport_failure_at":           nil,
+					"transport_failure_recover_at":   nil,
+					"transport_reset_failure_type":   nil,
+					"transport_fault_type":           session["transport_fault_type"],
+					"transport_fault_on_seconds":     session["transport_fault_on_seconds"],
+					"transport_fault_off_seconds":    session["transport_fault_off_seconds"],
+					"transport_consecutive_seconds":  session["transport_consecutive_seconds"],
+					"transport_frequency_seconds":    session["transport_frequency_seconds"],
+					"transport_fault_started_at":     session["transport_fault_started_at"],
+					"transport_fault_active":         false,
+					"transport_fault_phase_seconds":  0.0,
+					"transport_fault_cycle_seconds":  0.0,
 				}
 			}
 			break
@@ -909,7 +909,7 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 	if manualTransportDisarm {
 		logFaultEvent(transportLogSession, targetPort, "transport_none", "control", "transport_disarm_manual")
 	}
-	
+
 	// Propagate settings to group members if this session is part of a group
 	if targetGroupID != "" {
 		for _, session := range sessions {
@@ -951,7 +951,7 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 			}
 		}
 	}
-	
+
 	a.saveSessionList(sessions)
 	if transportShouldApply {
 		if portNum, err := strconv.Atoi(targetPort); err == nil {
@@ -1053,13 +1053,13 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "at least 2 sessions required"})
 		return
 	}
-	
+
 	// Generate a group ID if not provided
 	groupID := payload.GroupId
 	if groupID == "" {
 		groupID = fmt.Sprintf("G%d", time.Now().Unix()%10000)
 	}
-	
+
 	sessions := a.getSessionList()
 	linkedCount := 0
 	for _, session := range sessions {
@@ -1072,11 +1072,11 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	
+
 	if linkedCount > 0 {
 		a.saveSessionList(sessions)
 	}
-	
+
 	writeJSON(w, map[string]interface{}{
 		"message":      "Sessions linked successfully",
 		"group_id":     groupID,
@@ -1093,7 +1093,7 @@ func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "invalid json"})
 		return
 	}
-	
+
 	sessions := a.getSessionList()
 	found := false
 	for _, session := range sessions {
@@ -1103,7 +1103,7 @@ func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	
+
 	if found {
 		a.saveSessionList(sessions)
 		writeJSON(w, map[string]string{"message": "Session unlinked successfully"})
@@ -1120,7 +1120,7 @@ func (a *App) handleGetGroup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, map[string]string{"error": "group_id required"})
 		return
 	}
-	
+
 	groupSessions := a.getSessionsByGroupId(groupID)
 	writeJSON(w, map[string]interface{}{
 		"group_id": groupID,
@@ -1652,10 +1652,10 @@ func (a *App) getFirstSessionByPort(port int) SessionData {
 
 func (a *App) setTransportFaultSessionState(port int, faultType string, active bool, startedAt string, phaseSeconds float64, cycleSeconds float64) {
 	updates := map[string]interface{}{
-		"transport_failure_type":      faultType,
-		"transport_fault_type":        faultType,
-		"transport_fault_active":      active,
-		"transport_fault_started_at":  startedAt,
+		"transport_failure_type":        faultType,
+		"transport_fault_type":          faultType,
+		"transport_fault_active":        active,
+		"transport_fault_started_at":    startedAt,
 		"transport_fault_phase_seconds": math.Round(phaseSeconds*1000) / 1000,
 		"transport_fault_cycle_seconds": math.Round(cycleSeconds*1000) / 1000,
 	}
@@ -1897,7 +1897,7 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		"nftables_pattern_template_mode":            payload.TemplateMode,
 		"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
 	})
-	
+
 	// Propagate to group members
 	groupID := a.getGroupIdByPort(port)
 	if groupID != "" {
@@ -1920,7 +1920,7 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 			log.Printf("NETSHAPE group pattern propagation applied port=%d group=%s", groupPort, groupID)
 		}
 	}
-	
+
 	writeJSON(w, map[string]interface{}{
 		"success":         true,
 		"port":            port,
@@ -2096,7 +2096,7 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 		"nftables_delay_ms":       delayMs,
 		"nftables_packet_loss":    loss,
 	})
-	
+
 	// Propagate to group members
 	groupID := a.getGroupIdByPort(port)
 	if groupID != "" {
@@ -2122,7 +2122,7 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 			log.Printf("NETSHAPE group propagation applied port=%d rate=%g delay=%d loss=%.2f group=%s", groupPort, rateMbps, delayMs, loss, groupID)
 		}
 	}
-	
+
 	log.Printf("NETSHAPE applied port=%d rate=%g delay=%d loss=%.2f", port, rateMbps, delayMs, loss)
 	writeJSON(w, map[string]interface{}{
 		"success":   true,
@@ -2493,64 +2493,64 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		allocated := allocateSessionNumber(sessionList, a.maxSessions)
 		groupID := extractGroupId(playerID)
 		sessionData := SessionData{
-			"session_number":              fmt.Sprintf("%d", allocated),
-			"sid":                         fmt.Sprintf("%d", allocated),
-			"session_id":                  fmt.Sprintf("%d", allocated),
-			"player_id":                   playerID,
-			"group_id":                    groupID,
-			"headers_player_id":           playerHeader,
-			"headers_player-ID":           playerHeaderAlt,
-			"headers_x_playback_session_id": playbackSessionHeader,
-			"manifest_requests_count":     0,
-			"master_manifest_requests_count": 0,
-			"segments_count":              0,
-			"last_request":                nowISO(),
-			"first_request_time":          nowISO(),
-			"segment_failure_type":        "none",
-			"segment_failure_frequency":   0,
-			"segment_consecutive_failures": 0,
-			"segment_failure_units":       "requests",
-			"manifest_failure_type":       "none",
-			"manifest_failure_frequency":  0,
-			"manifest_failure_units":      "requests",
-			"manifest_consecutive_failures": 0,
-			"master_manifest_failure_type":       "none",
-			"master_manifest_failure_frequency":  0,
-			"master_manifest_failure_units":      "requests",
-			"master_manifest_consecutive_failures": 0,
-			"current_failures":            0,
-			"consecutive_failures_count":  0,
-			"player_ip":                   "",
-			"user_agent":                  "",
-			"manifest_failure_at":         nil,
-			"manifest_failure_recover_at": nil,
-			"manifest_failure_urls":       []string{},
-			"segment_failure_urls":        []string{},
-			"segment_failure_at":          nil,
-			"segment_failure_recover_at":  nil,
-			"master_manifest_failure_at":         nil,
-			"master_manifest_failure_recover_at": nil,
-			"transport_failure_type":      "none",
-			"transport_failure_frequency": 0,
-			"transport_consecutive_failures": 1,
-			"transport_failure_units":     "seconds",
-			"transport_consecutive_units": "seconds",
-			"transport_frequency_units":   "seconds",
-			"transport_failure_mode":      "failures_per_seconds",
-			"transport_failure_at":        nil,
-			"transport_failure_recover_at": nil,
-			"transport_fault_type":        "none",
-			"transport_fault_on_seconds":  1,
-			"transport_fault_off_seconds": 0,
-			"transport_consecutive_seconds": 1,
-			"transport_frequency_seconds":   0,
-			"transport_fault_active":      false,
-			"transport_fault_started_at":  nil,
-			"transport_fault_drop_packets":   0,
-			"transport_fault_reject_packets": 0,
-			"fault_count_total":           0,
-			"fault_count_socket_reject":   0,
-			"fault_count_socket_drop":     0,
+			"session_number":                           fmt.Sprintf("%d", allocated),
+			"sid":                                      fmt.Sprintf("%d", allocated),
+			"session_id":                               fmt.Sprintf("%d", allocated),
+			"player_id":                                playerID,
+			"group_id":                                 groupID,
+			"headers_player_id":                        playerHeader,
+			"headers_player-ID":                        playerHeaderAlt,
+			"headers_x_playback_session_id":            playbackSessionHeader,
+			"manifest_requests_count":                  0,
+			"master_manifest_requests_count":           0,
+			"segments_count":                           0,
+			"last_request":                             nowISO(),
+			"first_request_time":                       nowISO(),
+			"segment_failure_type":                     "none",
+			"segment_failure_frequency":                0,
+			"segment_consecutive_failures":             0,
+			"segment_failure_units":                    "requests",
+			"manifest_failure_type":                    "none",
+			"manifest_failure_frequency":               0,
+			"manifest_failure_units":                   "requests",
+			"manifest_consecutive_failures":            0,
+			"master_manifest_failure_type":             "none",
+			"master_manifest_failure_frequency":        0,
+			"master_manifest_failure_units":            "requests",
+			"master_manifest_consecutive_failures":     0,
+			"current_failures":                         0,
+			"consecutive_failures_count":               0,
+			"player_ip":                                "",
+			"user_agent":                               "",
+			"manifest_failure_at":                      nil,
+			"manifest_failure_recover_at":              nil,
+			"manifest_failure_urls":                    []string{},
+			"segment_failure_urls":                     []string{},
+			"segment_failure_at":                       nil,
+			"segment_failure_recover_at":               nil,
+			"master_manifest_failure_at":               nil,
+			"master_manifest_failure_recover_at":       nil,
+			"transport_failure_type":                   "none",
+			"transport_failure_frequency":              0,
+			"transport_consecutive_failures":           1,
+			"transport_failure_units":                  "seconds",
+			"transport_consecutive_units":              "seconds",
+			"transport_frequency_units":                "seconds",
+			"transport_failure_mode":                   "failures_per_seconds",
+			"transport_failure_at":                     nil,
+			"transport_failure_recover_at":             nil,
+			"transport_fault_type":                     "none",
+			"transport_fault_on_seconds":               1,
+			"transport_fault_off_seconds":              0,
+			"transport_consecutive_seconds":            1,
+			"transport_frequency_seconds":              0,
+			"transport_fault_active":                   false,
+			"transport_fault_started_at":               nil,
+			"transport_fault_drop_packets":             0,
+			"transport_fault_reject_packets":           0,
+			"fault_count_total":                        0,
+			"fault_count_socket_reject":                0,
+			"fault_count_socket_drop":                  0,
 			"fault_count_socket_drop_before_headers":   0,
 			"fault_count_socket_reject_before_headers": 0,
 			"fault_count_socket_drop_after_headers":    0,
@@ -3373,15 +3373,15 @@ func getenvIntAny(keys []string, fallback int) int {
 }
 
 type FailureHandler struct {
-	failureType       string
-	failureUnits      string
-	consecutiveUnits  string
-	frequencyUnits    string
-	failureFrequency  int
-	consecutive       int
-	failureAt         interface{}
-	failureRecoverAt  interface{}
-	resetFailureType  interface{}
+	failureType      string
+	failureUnits     string
+	consecutiveUnits string
+	frequencyUnits   string
+	failureFrequency int
+	consecutive      int
+	failureAt        interface{}
+	failureRecoverAt interface{}
+	resetFailureType interface{}
 }
 
 func NewFailureHandler(prefix string, session SessionData) *FailureHandler {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -485,6 +485,9 @@ func main() {
 	router.HandleFunc("/api/failure-settings/{id}", app.handleUpdateFailureSettings).Methods(http.MethodPost)
 	router.HandleFunc("/api/session/{id}", app.handleSession).Methods(http.MethodGet, http.MethodDelete)
 	router.HandleFunc("/api/clear-sessions", app.handleClearSessions).Methods(http.MethodPost)
+	router.HandleFunc("/api/session-group/link", app.handleLinkSessions).Methods(http.MethodPost)
+	router.HandleFunc("/api/session-group/unlink", app.handleUnlinkSession).Methods(http.MethodPost)
+	router.HandleFunc("/api/session-group/{groupId}", app.handleGetGroup).Methods(http.MethodGet)
 	router.HandleFunc("/myshows", app.handleMyShows).Methods(http.MethodGet)
 	router.HandleFunc("/debug", app.handleDebug).Methods(http.MethodGet)
 	router.HandleFunc("/api/nftables/status", app.handleNftStatus).Methods(http.MethodGet)
@@ -754,6 +757,7 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 
 	sessions := a.getSessionList()
 	var targetPort string
+	var targetGroupID string
 	var transportSnapshot map[string]interface{}
 	manualTransportDisarm := false
 	var transportLogSession SessionData
@@ -768,6 +772,7 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 			if previousTransportType == "none" {
 				previousTransportType = normalizeTransportFaultType(getString(session, "transport_fault_type"))
 			}
+			targetGroupID = getString(session, "group_id")
 			for key, value := range payload {
 				session[key] = value
 			}
@@ -904,6 +909,49 @@ func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request
 	if manualTransportDisarm {
 		logFaultEvent(transportLogSession, targetPort, "transport_none", "control", "transport_disarm_manual")
 	}
+	
+	// Propagate settings to group members if this session is part of a group
+	if targetGroupID != "" {
+		for _, session := range sessions {
+			sessionGroupID := getString(session, "group_id")
+			sessionID := getString(session, "session_id")
+			// Skip the original session (already updated) and non-group members
+			if sessionID == id || sessionGroupID != targetGroupID {
+				continue
+			}
+			// Apply all payload updates to group members
+			for key, value := range payload {
+				session[key] = value
+			}
+			// Apply normalized failure types
+			for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
+				typeKey := prefix + "_failure_type"
+				failureType := normalizeRequestFailureType(getString(session, typeKey))
+				if failureType == "" {
+					failureType = "none"
+				}
+				session[typeKey] = failureType
+				resetKey := prefix + "_reset_failure_type"
+				if resetType := getString(session, resetKey); resetType != "" {
+					session[resetKey] = normalizeRequestFailureType(resetType)
+				}
+			}
+			// Apply transport updates if needed
+			if transportUpdated && transportSnapshot != nil {
+				for key, value := range transportSnapshot {
+					session[key] = value
+				}
+				// Apply transport fault to the group member's port
+				groupMemberPort := getString(session, "x_forwarded_port")
+				if groupMemberPort != "" && transportShouldApply {
+					if portNum, err := strconv.Atoi(groupMemberPort); err == nil {
+						a.armTransportFaultLoop(portNum, transportFaultType, transportConsecutive, transportConsecutiveUnits, transportFrequency)
+					}
+				}
+			}
+		}
+	}
+	
 	a.saveSessionList(sessions)
 	if transportShouldApply {
 		if portNum, err := strconv.Atoi(targetPort); err == nil {
@@ -988,6 +1036,97 @@ func (a *App) handleClearSessions(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = a.memcache.FlushAll()
 	writeJSON(w, map[string]string{"message": "All sessions cleared successfully"})
+}
+
+func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		SessionIds []string `json:"session_ids"`
+		GroupId    string   `json:"group_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid json"})
+		return
+	}
+	if len(payload.SessionIds) < 2 {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "at least 2 sessions required"})
+		return
+	}
+	
+	// Generate a group ID if not provided
+	groupID := payload.GroupId
+	if groupID == "" {
+		groupID = fmt.Sprintf("G%d", time.Now().Unix()%10000)
+	}
+	
+	sessions := a.getSessionList()
+	linkedCount := 0
+	for _, session := range sessions {
+		sessionID := getString(session, "session_id")
+		for _, targetID := range payload.SessionIds {
+			if sessionID == targetID {
+				session["group_id"] = groupID
+				linkedCount++
+				break
+			}
+		}
+	}
+	
+	if linkedCount > 0 {
+		a.saveSessionList(sessions)
+	}
+	
+	writeJSON(w, map[string]interface{}{
+		"message":      "Sessions linked successfully",
+		"group_id":     groupID,
+		"linked_count": linkedCount,
+	})
+}
+
+func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		SessionId string `json:"session_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid json"})
+		return
+	}
+	
+	sessions := a.getSessionList()
+	found := false
+	for _, session := range sessions {
+		if getString(session, "session_id") == payload.SessionId {
+			session["group_id"] = ""
+			found = true
+			break
+		}
+	}
+	
+	if found {
+		a.saveSessionList(sessions)
+		writeJSON(w, map[string]string{"message": "Session unlinked successfully"})
+	} else {
+		w.WriteHeader(http.StatusNotFound)
+		writeJSON(w, map[string]string{"error": "Session not found"})
+	}
+}
+
+func (a *App) handleGetGroup(w http.ResponseWriter, r *http.Request) {
+	groupID := mux.Vars(r)["groupId"]
+	if groupID == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "group_id required"})
+		return
+	}
+	
+	groupSessions := a.getSessionsByGroupId(groupID)
+	writeJSON(w, map[string]interface{}{
+		"group_id": groupID,
+		"sessions": groupSessions,
+		"count":    len(groupSessions),
+	})
 }
 
 func (a *App) handleMyShows(w http.ResponseWriter, r *http.Request) {
@@ -1758,6 +1897,30 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		"nftables_pattern_template_mode":            payload.TemplateMode,
 		"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
 	})
+	
+	// Propagate to group members
+	groupID := a.getGroupIdByPort(port)
+	if groupID != "" {
+		groupPorts := a.getPortsForGroup(groupID)
+		for _, groupPort := range groupPorts {
+			if groupPort == port {
+				continue // Skip the original port
+			}
+			if err := a.applyShapePattern(groupPort, cleanSteps, payload.DelayMs, payload.LossPct); err != nil {
+				log.Printf("NETSHAPE group pattern propagation failed port=%d: %v", groupPort, err)
+				continue
+			}
+			a.updateSessionsByPort(groupPort, map[string]interface{}{
+				"nftables_pattern_segment_duration_seconds": payload.SegmentDurationSeconds,
+				"nftables_pattern_default_segments":         payload.DefaultSegments,
+				"nftables_pattern_default_step_seconds":     payload.DefaultStepSeconds,
+				"nftables_pattern_template_mode":            payload.TemplateMode,
+				"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
+			})
+			log.Printf("NETSHAPE group pattern propagation applied port=%d group=%s", groupPort, groupID)
+		}
+	}
+	
 	writeJSON(w, map[string]interface{}{
 		"success":         true,
 		"port":            port,
@@ -1933,6 +2096,33 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 		"nftables_delay_ms":       delayMs,
 		"nftables_packet_loss":    loss,
 	})
+	
+	// Propagate to group members
+	groupID := a.getGroupIdByPort(port)
+	if groupID != "" {
+		groupPorts := a.getPortsForGroup(groupID)
+		for _, groupPort := range groupPorts {
+			if groupPort == port {
+				continue // Skip the original port
+			}
+			a.disablePatternForPort(groupPort)
+			if err := a.traffic.UpdateRateLimit(groupPort, rateMbps); err != nil {
+				log.Printf("NETSHAPE group propagation rate limit failed port=%d rate=%g: %v", groupPort, rateMbps, err)
+				continue
+			}
+			if err := a.traffic.UpdateNetem(groupPort, delayMs, loss); err != nil {
+				log.Printf("NETSHAPE group propagation netem failed port=%d delay=%d loss=%.2f: %v", groupPort, delayMs, loss, err)
+				continue
+			}
+			a.updateSessionsByPort(groupPort, map[string]interface{}{
+				"nftables_bandwidth_mbps": rateMbps,
+				"nftables_delay_ms":       delayMs,
+				"nftables_packet_loss":    loss,
+			})
+			log.Printf("NETSHAPE group propagation applied port=%d rate=%g delay=%d loss=%.2f group=%s", groupPort, rateMbps, delayMs, loss, groupID)
+		}
+	}
+	
 	log.Printf("NETSHAPE applied port=%d rate=%g delay=%d loss=%.2f", port, rateMbps, delayMs, loss)
 	writeJSON(w, map[string]interface{}{
 		"success":   true,
@@ -2301,11 +2491,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		allocated := allocateSessionNumber(sessionList, a.maxSessions)
+		groupID := extractGroupId(playerID)
 		sessionData := SessionData{
 			"session_number":              fmt.Sprintf("%d", allocated),
 			"sid":                         fmt.Sprintf("%d", allocated),
 			"session_id":                  fmt.Sprintf("%d", allocated),
 			"player_id":                   playerID,
+			"group_id":                    groupID,
 			"headers_player_id":           playerHeader,
 			"headers_player-ID":           playerHeaderAlt,
 			"headers_x_playback_session_id": playbackSessionHeader,
@@ -3401,6 +3593,96 @@ func timeFromInterface(val interface{}) time.Time {
 		return parsed
 	}
 	return time.Time{}
+}
+
+// extractGroupId extracts group ID from player_id with pattern _G###
+// e.g., "hlsjs_G001" returns "G001", "safari_G001" returns "G001"
+func extractGroupId(playerID string) string {
+	if playerID == "" {
+		return ""
+	}
+	// Look for _G### pattern
+	re := regexp.MustCompile(`_G(\d+)$`)
+	matches := re.FindStringSubmatch(playerID)
+	if len(matches) > 1 {
+		return "G" + matches[1]
+	}
+	return ""
+}
+
+// getSessionsByGroupId returns all sessions that belong to the specified group
+func (a *App) getSessionsByGroupId(groupID string) []SessionData {
+	if groupID == "" {
+		return []SessionData{}
+	}
+	sessions := a.getSessionList()
+	var groupSessions []SessionData
+	for _, session := range sessions {
+		sessionGroupID := getString(session, "group_id")
+		if sessionGroupID == groupID {
+			groupSessions = append(groupSessions, session)
+		}
+	}
+	return groupSessions
+}
+
+// getGroupIdByPort returns the group ID for sessions on the specified port
+func (a *App) getGroupIdByPort(port int) string {
+	sessions := a.getSessionList()
+	portStr := fmt.Sprintf("%d", port)
+	for _, session := range sessions {
+		if getString(session, "x_forwarded_port") == portStr {
+			groupID := getString(session, "group_id")
+			if groupID != "" {
+				return groupID
+			}
+		}
+	}
+	return ""
+}
+
+// getPortsForGroup returns all ports used by sessions in the specified group
+func (a *App) getPortsForGroup(groupID string) []int {
+	if groupID == "" {
+		return []int{}
+	}
+	sessions := a.getSessionList()
+	portMap := make(map[int]bool)
+	for _, session := range sessions {
+		if getString(session, "group_id") == groupID {
+			if portStr := getString(session, "x_forwarded_port"); portStr != "" {
+				if port, err := strconv.Atoi(portStr); err == nil {
+					portMap[port] = true
+				}
+			}
+		}
+	}
+	var ports []int
+	for port := range portMap {
+		ports = append(ports, port)
+	}
+	return ports
+}
+
+// updateSessionGroup updates all sessions in a group with the given updates
+func (a *App) updateSessionGroup(groupID string, updates map[string]interface{}) {
+	if groupID == "" {
+		return
+	}
+	sessions := a.getSessionList()
+	changed := false
+	for _, session := range sessions {
+		sessionGroupID := getString(session, "group_id")
+		if sessionGroupID == groupID {
+			for key, value := range updates {
+				session[key] = value
+			}
+			changed = true
+		}
+	}
+	if changed {
+		a.saveSessionList(sessions)
+	}
 }
 
 type RequestHandler struct {

--- a/hls-player-error-testing-guide.md
+++ b/hls-player-error-testing-guide.md
@@ -180,3 +180,163 @@ This guide provides a comprehensive list of error scenarios to test HLS video pl
 | HTTP Code | Shaka Player | hls.js | Video.js/VHS |
 |-----------|-------------|---------|--------------|
 | **404/410** | Skips segment if possible in live. Retries, may fatal if persistent. | Sk
+
+---
+
+## Session Grouping for Comparative Testing
+
+### Overview
+
+InfiniteStream supports **session grouping** to apply identical failure scenarios and network conditions across multiple streaming sessions simultaneously. This enables direct comparison of how different players (e.g., HLS.js vs Safari native, or desktop vs mobile) handle the exact same test conditions.
+
+### Method 1: Player ID Suffix Pattern (Automatic Grouping)
+
+Sessions are automatically grouped when their `player_id` parameter contains a matching `_G###` suffix pattern.
+
+#### Usage Example
+
+```bash
+# Tab 1: HLS.js player
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=hlsjs_desktop_G001
+
+# Tab 2: Safari native player  
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=safari_native_G001
+
+# Tab 3: Video.js player (same group)
+http://localhost:30081/go-live/bbb/master.m3u8?player_id=videojs_G001
+```
+
+All sessions with `_G001` suffix will be automatically grouped. Any control changes applied to one session (failure injection, network shaping, etc.) will be synchronized to all other sessions in the group.
+
+#### Group ID Format
+
+- Pattern: `_G` followed by digits (e.g., `_G001`, `_G042`, `_G999`)
+- The player identifier before the suffix can be anything descriptive
+- Group IDs are case-sensitive
+
+#### Example Test Scenarios
+
+**Compare HLS.js vs Safari Native:**
+```
+player_id=hlsjs_macos_G100
+player_id=safari_native_G100
+```
+
+**Compare Desktop vs Mobile:**
+```
+player_id=safari_desktop_G200
+player_id=safari_ios_G200
+```
+
+**Compare Multiple Player Libraries:**
+```
+player_id=hlsjs_v1.4_G300
+player_id=shaka_v4.3_G300
+player_id=videojs_v8_G300
+```
+
+### Method 2: UI-Based Manual Grouping
+
+Sessions can also be grouped manually through the Testing UI, regardless of their `player_id`.
+
+#### Steps:
+
+1. Open the Testing page (`/dashboard/testing.html`)
+2. Ensure you have 2 or more active sessions
+3. Check the checkbox next to each session you want to group
+4. Click the "Link Selected Sessions" button
+5. Sessions are now grouped and will show a green group badge
+
+#### Unlinking Sessions
+
+- Click the "Unlink" button in the group info banner below the session tabs
+- Or use the API: `POST /api/session-group/unlink` with `{"session_id": "1"}`
+
+### Visual Indicators
+
+Grouped sessions are displayed with:
+- **Green left border** on session tabs
+- **Group badge** showing the group ID (e.g., `G001`)
+- **Group info banner** showing linked session details
+- **Unlink button** for easy separation
+
+### Synchronized Controls
+
+When sessions are grouped, the following controls are synchronized across all group members:
+
+#### Failure Injection:
+- Segment failure type and frequency
+- Manifest failure type and frequency  
+- Master manifest failure type and frequency
+- Transport fault type (DROP/REJECT)
+- Transport fault timing and frequency
+
+#### Network Shaping:
+- Bandwidth throttling (rate_mbps)
+- Network delay (delay_ms)
+- Packet loss percentage (loss_pct)
+- Network shaping patterns (multi-step bandwidth profiles)
+
+### API Endpoints
+
+#### Link Sessions
+```bash
+POST /api/session-group/link
+Content-Type: application/json
+
+{
+  "session_ids": ["1", "2", "3"],
+  "group_id": "G001"  # Optional - auto-generated if omitted
+}
+```
+
+#### Unlink Session
+```bash
+POST /api/session-group/unlink
+Content-Type: application/json
+
+{
+  "session_id": "1"
+}
+```
+
+#### Get Group Members
+```bash
+GET /api/session-group/{groupId}
+```
+
+Returns all sessions in the specified group.
+
+### Testing Workflow Example
+
+1. **Setup**: Open 2 browser tabs/windows:
+   - Tab A: HLS.js player with `?player_id=hlsjs_G500`
+   - Tab B: Safari native with `?player_id=safari_G500`
+
+2. **Configure**: In the Testing UI, select session from group G500
+
+3. **Apply Failures**: 
+   - Set segment failure to "404" every 10 requests
+   - Both players will experience identical failures
+
+4. **Apply Network Shaping**:
+   - Set bandwidth to 2 Mbps
+   - Both sessions will have identical bandwidth constraints
+
+5. **Observe**: Compare how each player handles the same conditions:
+   - Buffer behavior
+   - ABR switching decisions
+   - Error recovery timing
+   - User experience differences
+
+6. **Iterate**: Adjust failure patterns and network conditions while maintaining synchronization
+
+### Notes
+
+- Session grouping works with both LL-HLS and LL-DASH streams
+- Groups persist until sessions are released or explicitly unlinked
+- Up to 10 sessions can be grouped together
+- Group settings propagate in real-time (no page refresh needed)
+- Each session maintains its own performance metrics and bandwidth measurements
+
+---

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -81,6 +81,14 @@ spec:
           value: "8"
         - name: INFINITE_STREAM_TC_INTERFACE
           value: "eth0"
+        - name: EXTERNAL_PORT_BASE
+          value: "40081"
+        - name: INTERNAL_PORT_BASE
+          value: "30081"
+        - name: PORT_RANGE_COUNT
+          value: "9"
+        - name: INFINITE_STREAM_TC_DEBUG
+          value: "1"
         securityContext:
           privileged: true
           capabilities:

--- a/screenshots/session-grouping-mockup.html
+++ b/screenshots/session-grouping-mockup.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Session Grouping UI Mockup</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            padding: 20px;
+            background: #f8f9fa;
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        h1 {
+            color: #1e40af;
+            margin-bottom: 30px;
+        }
+        .mockup-section {
+            background: white;
+            padding: 20px;
+            margin-bottom: 30px;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .mockup-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #334155;
+            margin-bottom: 16px;
+        }
+        
+        /* Session tabs styling */
+        .session-tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 16px;
+        }
+        .session-tab {
+            border: 1px solid #c7d2fe;
+            background: #eef2ff;
+            color: #1e1b4b;
+            padding: 10px 14px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.1s ease, box-shadow 0.2s ease;
+        }
+        .session-tab:hover {
+            background: #e0e7ff;
+            box-shadow: 0 6px 14px rgba(59, 130, 246, 0.2);
+            transform: translateY(-1px);
+        }
+        .session-tab.active {
+            background: #1e40af;
+            color: #fff;
+            border-color: #1e40af;
+            box-shadow: 0 8px 18px rgba(30, 64, 175, 0.35);
+        }
+        .session-tab.grouped {
+            border-left: 4px solid #10b981;
+            padding-left: 10px;
+        }
+        .session-tab.grouped.active {
+            border-left-color: #34d399;
+        }
+        .group-badge {
+            display: inline-block;
+            background: #10b981;
+            color: white;
+            font-size: 10px;
+            font-weight: 700;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 6px;
+        }
+        .session-tab.active .group-badge {
+            background: #34d399;
+        }
+        .session-checkbox {
+            margin-right: 8px;
+            cursor: pointer;
+            width: 18px;
+            height: 18px;
+            vertical-align: middle;
+        }
+        .group-controls {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+        .btn {
+            padding: 8px 16px;
+            border-radius: 6px;
+            border: 1px solid #cbd5e1;
+            background: #f8fafc;
+            color: #334155;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .btn:hover {
+            background: #e2e8f0;
+        }
+        .group-info {
+            font-size: 12px;
+            color: #10b981;
+            font-weight: 600;
+            margin-top: 8px;
+            padding: 8px 12px;
+            background: #d1fae5;
+            border-radius: 6px;
+            display: inline-block;
+        }
+        .unlink-btn {
+            font-size: 11px;
+            padding: 4px 10px;
+            margin-left: 8px;
+            background: #ef4444;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+        .unlink-btn:hover {
+            background: #dc2626;
+        }
+        .note {
+            background: #fef3c7;
+            padding: 12px;
+            border-radius: 6px;
+            font-size: 13px;
+            color: #92400e;
+            margin-top: 16px;
+        }
+    </style>
+</head>
+<body>
+    <h1>🔗 Session Grouping Feature - UI Mockup</h1>
+    
+    <div class="mockup-section">
+        <div class="mockup-title">Scenario 1: Ungrouped Sessions (Ready to Link)</div>
+        <div class="group-controls">
+            <button class="btn">Link Selected Sessions</button>
+            <span style="font-size: 12px; color: #64748b;">Select 2+ sessions to link</span>
+        </div>
+        <div class="session-tabs">
+            <button class="session-tab active">
+                <input type="checkbox" class="session-checkbox" checked>
+                Session 1 (Port 30081) · hlsjs_desktop
+            </button>
+            <button class="session-tab">
+                <input type="checkbox" class="session-checkbox" checked>
+                Session 2 (Port 30181) · safari_native
+            </button>
+            <button class="session-tab">
+                <input type="checkbox" class="session-checkbox">
+                Session 3 (Port 30281) · videojs
+            </button>
+        </div>
+        <div class="note">
+            ℹ️ Two sessions are selected (Session 1 and 2). Clicking "Link Selected Sessions" will group them together.
+        </div>
+    </div>
+    
+    <div class="mockup-section">
+        <div class="mockup-title">Scenario 2: Grouped Sessions via Player ID Suffix</div>
+        <div class="session-tabs">
+            <button class="session-tab grouped active">
+                Session 1 (Port 30081) · hlsjs_G001
+                <span class="group-badge">G001</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 2 (Port 30181) · safari_native_G001
+                <span class="group-badge">G001</span>
+            </button>
+            <button class="session-tab">
+                Session 3 (Port 30281) · videojs
+            </button>
+        </div>
+        <div class="group-info">
+            🔗 Linked with: Session 2 (Port 30181)
+            <button class="unlink-btn">Unlink</button>
+        </div>
+        <div class="note">
+            ℹ️ Sessions 1 and 2 are automatically grouped because both use player_id with "_G001" suffix. Green border and badge indicate grouping. Any control changes apply to both sessions.
+        </div>
+    </div>
+    
+    <div class="mockup-section">
+        <div class="mockup-title">Scenario 3: Multiple Groups</div>
+        <div class="session-tabs">
+            <button class="session-tab grouped active">
+                Session 1 (Port 30081) · hlsjs_desktop_G100
+                <span class="group-badge">G100</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 2 (Port 30181) · safari_mac_G100
+                <span class="group-badge">G100</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 3 (Port 30281) · hlsjs_mobile_G200
+                <span class="group-badge">G200</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 4 (Port 30381) · safari_ios_G200
+                <span class="group-badge">G200</span>
+            </button>
+            <button class="session-tab">
+                Session 5 (Port 30481) · shaka_test
+            </button>
+        </div>
+        <div class="group-info">
+            🔗 Linked with: Session 2 (Port 30181)
+            <button class="unlink-btn">Unlink</button>
+        </div>
+        <div class="note">
+            ℹ️ Two separate groups: G100 (desktop players) and G200 (mobile players). Each group synchronizes independently. Session 5 is ungrouped.
+        </div>
+    </div>
+    
+    <div class="mockup-section">
+        <div class="mockup-title">Scenario 4: Large Group (HLS.js vs Shaka vs Video.js)</div>
+        <div class="session-tabs">
+            <button class="session-tab grouped active">
+                Session 1 (Port 30081) · hlsjs_v1.4_G999
+                <span class="group-badge">G999</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 2 (Port 30181) · shaka_v4.3_G999
+                <span class="group-badge">G999</span>
+            </button>
+            <button class="session-tab grouped">
+                Session 3 (Port 30281) · videojs_v8_G999
+                <span class="group-badge">G999</span>
+            </button>
+        </div>
+        <div class="group-info">
+            🔗 Linked with: Session 2 (Port 30181), Session 3 (Port 30281)
+            <button class="unlink-btn">Unlink</button>
+        </div>
+        <div class="note">
+            ℹ️ Three different player implementations in the same group. Perfect for comparing how different libraries handle identical failure scenarios.
+        </div>
+    </div>
+    
+    <div class="mockup-section" style="background: #f0fdf4; border: 2px solid #10b981;">
+        <div class="mockup-title" style="color: #065f46;">✅ Key Features Demonstrated</div>
+        <ul style="margin: 0; padding-left: 20px; color: #065f46;">
+            <li><strong>Green Left Border:</strong> Immediately identifies grouped sessions</li>
+            <li><strong>Group Badge:</strong> Shows which group ID sessions belong to</li>
+            <li><strong>Linked Info Banner:</strong> Displays other members of the group</li>
+            <li><strong>Unlink Button:</strong> Easy way to break group association</li>
+            <li><strong>Checkboxes:</strong> Select multiple ungrouped sessions for linking</li>
+            <li><strong>Visual Hierarchy:</strong> Active session highlighted in blue</li>
+        </ul>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a major new feature: session grouping for synchronized control of multiple streaming sessions, enabling comparative player testing and easier failure injection management. The implementation covers backend, frontend, and documentation updates, as well as new API endpoints and improved port mapping for NodePort deployments. It also includes enhancements to UI visual indicators and range input handling.

**Session Grouping and Synchronization**

* Implemented hybrid session grouping (automatic via `player_id` suffix and manual via UI) for synchronized control changes across multiple sessions, including propagation of failure injection and network shaping settings. Visual indicators and group badges added to the UI. [[1]](diffhunk://#diff-45dd8184b56b411848509d372d108ed7da1bd949ff03c5d2f2dd560b2b971ea4R1-R152) [[2]](diffhunk://#diff-a6c8d1a2b5067d5ab806bef00446696ffc9f33d21d4cf59ae64b95ddd99f6fe7R1-R83)
* Updated documentation with a quick start guide, use cases, API reference, and UI mockups for session grouping. Added new files: `SESSION-GROUPING.md` and `screenshots/session-grouping-mockup.html`. [[1]](diffhunk://#diff-45dd8184b56b411848509d372d108ed7da1bd949ff03c5d2f2dd560b2b971ea4R1-R152) [[2]](diffhunk://#diff-a6c8d1a2b5067d5ab806bef00446696ffc9f33d21d4cf59ae64b95ddd99f6fe7R1-R83)

**Backend and API Changes**

* Added new API endpoints for session grouping (`/api/session-group/link`, `/api/session-group/unlink`, `/api/session-group/{groupId}`), and updated NGINX proxy configuration to support these endpoints and session streaming. [[1]](diffhunk://#diff-45dd8184b56b411848509d372d108ed7da1bd949ff03c5d2f2dd560b2b971ea4R1-R152) [[2]](diffhunk://#diff-fa154161b68ab3484972a628687b9b7930f3197ae7d759dc3d9c263f97819dd7R159-R170) [[3]](diffhunk://#diff-fa154161b68ab3484972a628687b9b7930f3197ae7d759dc3d9c263f97819dd7R195-R202)

**UI and Usability Improvements**

* Enhanced session tab UI to show external/internal port mapping, group badges, and linked session info. Updated port display logic to use external port when available. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L202-R204) [[2]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6R451) [[3]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L466-R467) [[4]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L481-R482)
* Improved range input handling in session controls to ensure valid values and prevent UI errors, making the controls more robust for consecutive/frequency settings. [[1]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L527-R534) [[2]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L555-R562)

**Documentation and Product Requirements**

* Updated `PRD.md` and `README.md` to reflect session grouping, server-authoritative control updates, and external/internal port mapping for NodePort deployments. Clarified network shaping limitations and added new features to the product requirements. [[1]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1R103-R104) [[2]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1R157) [[3]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1L170-R173) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R260-R261)

---

**References:**  
[[1]](diffhunk://#diff-45dd8184b56b411848509d372d108ed7da1bd949ff03c5d2f2dd560b2b971ea4R1-R152) [[2]](diffhunk://#diff-a6c8d1a2b5067d5ab806bef00446696ffc9f33d21d4cf59ae64b95ddd99f6fe7R1-R83) [[3]](diffhunk://#diff-fa154161b68ab3484972a628687b9b7930f3197ae7d759dc3d9c263f97819dd7R159-R170) [[4]](diffhunk://#diff-fa154161b68ab3484972a628687b9b7930f3197ae7d759dc3d9c263f97819dd7R195-R202) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L202-R204) [[6]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6R451) [[7]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L466-R467) [[8]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L481-R482) [[9]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L527-R534) [[10]](diffhunk://#diff-abc7ace9412af30920c865aa9051419b49a5abd8c159c9f7bccaca3b58a399c6L555-R562) [[11]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1R103-R104) [[12]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1R157) [[13]](diffhunk://#diff-f3f7b39d67748ec7d5da458a1bb1f98cf05f47d4e121c582f090e23280afd8f1L170-R173) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R260-R261)