### PR TITLE
Allow 4K on native playback

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
@@ -86,6 +86,9 @@ struct ContentView: View {
                         }
                     }
                     .buttonStyle(.bordered)
+                    Spacer()
+                    Toggle("Allow 4K", isOn: $viewModel.prefer4kNative)
+                        .toggleStyle(.switch)
                 }
 
                 PlayerView(player: viewModel.player)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Combine
+import CoreGraphics
 import Foundation
 
 @MainActor
@@ -43,6 +44,9 @@ final class PlaybackViewModel: ObservableObject {
     @Published var primePlayback: Bool = true
     @Published var forcePlayerIdOnPlayback: Bool = false
     @Published var allowPlayerIdOnContentPort: Bool = false
+    @Published var prefer4kNative: Bool = false {
+        didSet { persist(.prefer4kNative, prefer4kNative ? "true" : "false") }
+    }
 
     let player = AVPlayer()
     let diagnostics = PlaybackDiagnostics()
@@ -284,6 +288,7 @@ final class PlaybackViewModel: ObservableObject {
 
         let asset = AVURLAsset(url: url, options: nil)
         let item = AVPlayerItem(asset: asset)
+        apply4kPreference(to: item)
         player.replaceCurrentItem(with: item)
         player.isMuted = isMuted
         player.automaticallyWaitsToMinimizeStalling = true
@@ -373,6 +378,7 @@ final class PlaybackViewModel: ObservableObject {
         case baseURL = "bossBaseURL"
         case playbackBaseURL = "bossPlaybackBaseURL"
         case playerId = "bossPlayerId"
+        case prefer4kNative = "bossPrefer4kNative"
     }
 
     private func loadDefaults() {
@@ -411,6 +417,9 @@ final class PlaybackViewModel: ObservableObject {
         }
         if let storedPlayerId = defaults.string(forKey: DefaultsKey.playerId.rawValue) {
             playerId = storedPlayerId
+        }
+        if let storedPrefer4k = defaults.string(forKey: DefaultsKey.prefer4kNative.rawValue) {
+            prefer4kNative = storedPrefer4k == "true"
         }
     }
 
@@ -743,6 +752,17 @@ final class PlaybackViewModel: ObservableObject {
             return UInt64(seconds * 1000)
         }
         return nil
+    }
+
+    private func apply4kPreference(to item: AVPlayerItem) {
+        if prefer4kNative {
+            item.preferredPeakBitRate = 0
+            if #available(iOS 15.0, tvOS 15.0, *) {
+                item.preferredMaximumResolution = CGSize(width: 3840, height: 2160)
+            }
+        } else if #available(iOS 15.0, tvOS 15.0, *) {
+            item.preferredMaximumResolution = .zero
+        }
     }
 
     private func logPlaylistBodies(for masterURL: URL) async {

--- a/content/dashboard/playback.html
+++ b/content/dashboard/playback.html
@@ -286,6 +286,13 @@
                     <option value="shaka">Shaka</option>
                 </select>
             </div>
+            <div class="content-control-group">
+                <label class="content-control-label">Allow 4K</label>
+                <label style="display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary);">
+                    <input id="prefer4kToggle" type="checkbox">
+                    Allow 4K (native)
+                </label>
+            </div>
             <div class="control-actions">
                 <button onclick="playStream()">▶ Play</button>
                 <button onclick="pauseStream()">⏸ Pause</button>
@@ -323,6 +330,7 @@
         const playerState = { instance: null, type: null, url: null };
         let availableContent = [];
         const AUDIO_MUTED_KEY = 'bossAudioMuted';
+        const NATIVE_4K_KEY = 'bossPrefer4kNative';
 
         function getStoredContent() {
             return localStorage.getItem('bossSelectedContentFull') || localStorage.getItem('bossSelectedContent') || '';
@@ -345,6 +353,21 @@
             localStorage.setItem(AUDIO_MUTED_KEY, isMuted ? 'true' : 'false');
             const frame = document.getElementById('videoFrame');
             if (frame) frame.classList.toggle('audio-active', !isMuted);
+        }
+
+        function getPrefer4kNative() {
+            return localStorage.getItem(NATIVE_4K_KEY) === 'true';
+        }
+
+        function setPrefer4kNative(enabled) {
+            localStorage.setItem(NATIVE_4K_KEY, enabled ? 'true' : 'false');
+        }
+
+        function applyNative4kPreference(videoEl) {
+            if (!videoEl) return;
+            if (!getPrefer4kNative()) return;
+            videoEl.setAttribute('width', '3840');
+            videoEl.setAttribute('height', '2160');
         }
 
         function setBadge(container, label, klass) {
@@ -379,6 +402,7 @@
             video.muted = mutedState;
 
             if (playerChoice === 'native') {
+                applyNative4kPreference(video);
                 video.src = url;
                 playerState.type = 'native';
                 return;
@@ -411,6 +435,7 @@
             if (playerChoice === 'hlsjs') {
                 if (!Hls.isSupported()) {
                     console.warn('HLS.js not supported, falling back to native');
+                    applyNative4kPreference(video);
                     video.src = url;
                     playerState.type = 'native';
                     return;
@@ -717,6 +742,14 @@
             populateContentSelect();
             const initialMuted = getGlobalMuted();
             setGlobalMuted(initialMuted);
+            const prefer4kToggle = document.getElementById('prefer4kToggle');
+            if (prefer4kToggle) {
+                prefer4kToggle.checked = getPrefer4kNative();
+                prefer4kToggle.addEventListener('change', () => {
+                    setPrefer4kNative(prefer4kToggle.checked);
+                    applySelection();
+                });
+            }
             applySelection();
             setInterval(updateStats, 500);
         }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1036,6 +1036,16 @@
                     if (section) {
                         setCollapsibleState(section, nextOpen);
                     }
+                    if (section === 'bitrate-chart' && nextOpen) {
+                        const card = sectionEl ? sectionEl.closest('.session-card') : null;
+                        const sessionId = card ? card.dataset.sessionId : null;
+                        if (sessionId) {
+                            const event = new CustomEvent('testing-session:charts-resize', {
+                                detail: { sessionId }
+                            });
+                            document.dispatchEvent(event);
+                        }
+                    }
                     if (section === 'network-shaping' && nextOpen) {
                         const card = sectionEl ? sectionEl.closest('.session-card') : null;
                         const scope = card || document;
@@ -1045,6 +1055,13 @@
                             chartContent.style.display = 'block';
                             chartIcon.textContent = '▼';
                             setCollapsibleState('bitrate-chart', true);
+                            const sessionId = card ? card.dataset.sessionId : null;
+                            if (sessionId) {
+                                const event = new CustomEvent('testing-session:charts-resize', {
+                                    detail: { sessionId }
+                                });
+                                document.dispatchEvent(event);
+                            }
                         }
                     }
                 }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -541,6 +541,10 @@
                         <option value="native">Native</option>
                     </select>
                 </label>
+                <label>
+                    Allow 4K
+                    <input id="prefer4kToggle" type="checkbox">
+                </label>
             </div>
             <div class="player-frame">
                 <video id="player" controls autoplay muted playsinline></video>
@@ -585,6 +589,7 @@
         const logEl = document.getElementById('debugLog');
         const sseMissedEl = document.getElementById('statSseMissed');
         const video = document.getElementById('player');
+        const NATIVE_4K_KEY = 'bossPrefer4kNative';
         let hlsInstance = null;
         let shakaPlayer = null;
         let videojsPlayer = null;
@@ -1128,6 +1133,13 @@
             }
         }
 
+        function applyNative4kPreference(videoEl) {
+            if (!videoEl) return;
+            if (localStorage.getItem(NATIVE_4K_KEY) !== 'true') return;
+            videoEl.setAttribute('width', '3840');
+            videoEl.setAttribute('height', '2160');
+        }
+
         function loadStream(url) {
             currentUrl = url;
             autoRetryCount = 0;
@@ -1187,6 +1199,7 @@
                     hlsInstance.loadSource(url);
                     hlsInstance.attachMedia(video);
                 } else {
+                    applyNative4kPreference(video);
                     video.src = url;
                     video.play().catch(err => {
                         log(`PLAY ERROR: ${err.message}`);
@@ -1233,6 +1246,7 @@
                     });
                 });
             } else {
+                applyNative4kPreference(video);
                 video.src = url;
                 video.play().catch(err => {
                     log(`PLAY ERROR: ${err.message}`);
@@ -2883,6 +2897,12 @@
             }
         }
 
+        document.addEventListener('testing-session:charts-resize', (event) => {
+            const sessionId = event.detail && event.detail.sessionId;
+            if (!sessionId) return;
+            requestAnimationFrame(() => renderBandwidthChart(sessionId));
+        });
+
         function applySessionUpdate(session) {
             if (!session) return;
             const container = document.getElementById('sessionControls');
@@ -3117,6 +3137,17 @@
             if (playerSelect) {
                 playerSelect.addEventListener('change', () => {
                     localStorage.setItem('testing_session_player', playerSelect.value);
+                    if (currentUrl) {
+                        resetPlayback();
+                        loadStream(currentUrl);
+                    }
+                });
+            }
+            const prefer4kToggle = document.getElementById('prefer4kToggle');
+            if (prefer4kToggle) {
+                prefer4kToggle.checked = localStorage.getItem(NATIVE_4K_KEY) === 'true';
+                prefer4kToggle.addEventListener('change', () => {
+                    localStorage.setItem(NATIVE_4K_KEY, prefer4kToggle.checked ? 'true' : 'false');
                     if (currentUrl) {
                         resetPlayback();
                         loadStream(currentUrl);


### PR DESCRIPTION
## Summary
- add Allow 4K toggles in web playback/testing and iOS app
- persist 4K preference and apply it to native AVPlayer items
- redraw bitrate/buffer charts on open for Safari

## Testing
- Not run (manual)

Fixes #22
