### PR TITLE
feat: netlink TC stats, wire rate measurement, metric cleanup, chart improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,22 +269,30 @@ See `PRD.md` for the full list.
 - Session grouping controls (group/ungroup/merge) that propagate failure settings and network shaping.
 
 ### Wire metric implementation notes
-- Sampling cadence is 100ms and metrics are computed from `tc` class counters per session port.
-- Scope clarification: these counters include packet-level transport/application overhead that traverses the measured interface (for example TCP/IP headers and TLS/HTTP bytes), but do not include physical link-layer overhead (for example Ethernet preamble/IFG/FCS).
-- `mbps_wire_sustained` and `mbps_wire_sustained_18s` are equivalent 18s wall‑time sustained rates: total bytes / wall time in the window.
-- `mbps_wire_active` reports active‑only throughput for the 18s window (idle periods excluded).
-- `mbps_wire_sustained_6s` and `mbps_wire_sustained_1s` are wall‑time sustained variants for shorter windows.
-- `mbps_wire_throughput` is the rolling max over the last 6 seconds of `mbps_wire_active_1s`.
-- Session hydration selects the freshest throughput sample across external/internal session ports to avoid stale values.
+- TC class byte/backlog counters are read via netlink (vishvananda/netlink) — no subprocess fork per poll.
+- Per-port TC stats are cached with a 5ms TTL to deduplicate concurrent readers.
+- Only one `awaitSocketDrain` goroutine runs per port at a time (singleton guard).
+- Scope clarification: TC counters include packet-level transport/application overhead (TCP/IP headers, TLS/HTTP bytes) but not physical link-layer overhead (Ethernet preamble/IFG/FCS).
+
+### Throughput metrics
+
+| Metric | Update cadence | What it measures |
+|---|---|---|
+| `mbps_shaper_rate` | 100ms | Instantaneous shaped rate during active queue drain (1s contiguous backlog-active run) |
+| `mbps_shaper_avg` | 100ms | Rolling 6s average of `mbps_shaper_rate` values |
+| `mbps_transfer_rate` | 250ms | Byte-change-gated rate during segment transfer, aligned to HTB burst edges. Reports at drain/refill boundaries |
+| `mbps_transfer_complete` | per segment | Total bytes / total time for one completed segment transfer (backlog drained to 0) |
 
 ### Metric semantics (expected differences)
 - **Limit value** (`nftables` shaping rate): configured ceiling for the session port; this is the control target, not a measured throughput.
-- **Wire throughput value** (`mbps_wire_*`, especially `mbps_wire_throughput`): measured bytes on the shaped interface over time windows; includes transport/application overhead seen by `tc` counters.
-- **Player estimate value** (`player_metrics_network_bitrate_mbps`): player-side ABR estimate inferred by the player algorithm; this is model-based and can lag/lead observed wire metrics.
+- **Shaper metrics** (`mbps_shaper_rate`, `mbps_shaper_avg`): measured from TC class byte counters on the 100ms updatePort loop. Only active when TC shaping is configured (backlog > 0). `shaper_rate` goes to 0 on drain; `shaper_avg` smooths across segments.
+- **Transfer metrics** (`mbps_transfer_rate`, `mbps_transfer_complete`): measured from the 10ms awaitSocketDrain goroutine. `transfer_rate` aligns to actual TC burst edges (250ms min gap, drain/refill boundaries). `transfer_complete` is the ground-truth per-segment rate.
+- **Player estimate** (`player_metrics_network_bitrate_mbps`): player-side ABR estimate; model-based and can lag/lead observed wire metrics.
 
 Expected behavior under steady conditions:
-- `wire throughput` should approach but usually stay below `limit`.
-- `player estimate` should broadly track `wire throughput` trends but may be smoother/noisier depending on player.
+- `shaper_rate` and `transfer_rate` should track near the configured limit.
+- `transfer_complete` is the most trustworthy single number — it spans the full transfer.
+- `player estimate` should broadly track shaper/transfer trends but may be smoother/noisier depending on player.
 - Temporary divergence is normal during startup, stalls, retransmissions, or step transitions.
 
 ## Why unified error injection?

--- a/content/dashboard/player-characterization.js
+++ b/content/dashboard/player-characterization.js
@@ -1922,6 +1922,7 @@
             ladder: [],
             limitMbps: null,
             throughputMbps: null,
+            wireActive1sMbps: null,
             wireThroughputMbps: null,
             playerEstimateMbps: null,
             currentVariantMbps: null
@@ -1937,6 +1938,7 @@
             });
             const limit = toNumber(rulerState.limitMbps, null);
             const throughput = toNumber(rulerState.throughputMbps, null);
+            const wireActive1s = toNumber(rulerState.wireActive1sMbps, null);
             const wireThroughput = toNumber(rulerState.wireThroughputMbps, null);
             const playerEstimate = toNumber(rulerState.playerEstimateMbps, null);
             const currentVariant = toNumber(rulerState.currentVariantMbps, null);
@@ -1944,6 +1946,7 @@
             const topRangeLimit = topVariant !== null ? (topVariant * 2) : null;
             if (limit !== null) values.push(limit);
             if (throughput !== null) values.push(throughput);
+            if (wireActive1s !== null) values.push(wireActive1s);
             if (wireThroughput !== null) values.push(wireThroughput);
             if (playerEstimate !== null) values.push(playerEstimate);
             if (currentVariant !== null) values.push(currentVariant);
@@ -2007,6 +2010,14 @@
                     markerType: 'throughput'
                 });
             }
+            if (wireActive1s !== null) {
+                markers.push({
+                    cls: 'wire-active-1s',
+                    left: toPct(wireActive1s),
+                    label: `Active 1s ${wireActive1s.toFixed(2)} Mbps`,
+                    markerType: 'wire-active-1s'
+                });
+            }
             if (wireThroughput !== null) {
                 markers.push({
                     cls: 'wire-throughput',
@@ -2040,9 +2051,10 @@
                 'limit': 1,
                 'current-variant': 2,
                 'throughput': 3,
-                'wire-throughput': 4,
-                'player-estimate': 5,
-                'top-range': 6
+                'wire-active-1s': 4,
+                'wire-throughput': 5,
+                'player-estimate': 6,
+                'top-range': 7
             };
             const markersWithLanes = markers.map((marker) => ({
                 ...marker,
@@ -2090,6 +2102,9 @@
             }
             if (Object.prototype.hasOwnProperty.call(partial, 'throughputMbps')) {
                 rulerState.throughputMbps = toNumber(partial.throughputMbps, null);
+            }
+            if (Object.prototype.hasOwnProperty.call(partial, 'wireActive1sMbps')) {
+                rulerState.wireActive1sMbps = toNumber(partial.wireActive1sMbps, null);
             }
             if (Object.prototype.hasOwnProperty.call(partial, 'wireThroughputMbps')) {
                 rulerState.wireThroughputMbps = toNumber(partial.wireThroughputMbps, null);
@@ -2824,6 +2839,7 @@
 
                 const recordSample = (latest, index, step) => {
                     const throughput = extractThroughput(latest);
+                    const wireActive1s = toNumber(latest.mbps_wire_active_1s, null);
                     const active6sThroughput = toNumber(latest.mbps_wire_active_6s, null);
                     const wireThroughput = toNumber(latest.mbps_wire_throughput, null);
                     const playerEstimate = toNumber(latest.player_metrics_network_bitrate_mbps, null);
@@ -2835,6 +2851,7 @@
                         stepTargetMbps: step.targetMbps,
                         stepDirection: step.direction,
                         throughputMbps: throughput,
+                        wireActive1sMbps: wireActive1s,
                         active6sThroughputMbps: active6sThroughput,
                         wireThroughputMbps: wireThroughput,
                         playerEstimateMbps: playerEstimate,
@@ -2880,6 +2897,7 @@
                     updateRuler({
                         limitMbps: step.targetMbps,
                         throughputMbps: throughput,
+                        wireActive1sMbps: wireActive1s,
                         wireThroughputMbps: wireThroughput,
                         playerEstimateMbps: playerEstimate,
                         currentVariantMbps: variant
@@ -3076,6 +3094,7 @@
                             continue;
                         }
                         const throughput = extractThroughput(latest);
+                        const wireActive1s = toNumber(latest.mbps_wire_active_1s, null);
                         const wireThroughput = toNumber(latest.mbps_wire_throughput, null);
                         const playerEstimate = toNumber(latest.player_metrics_network_bitrate_mbps, null);
                         const variant = extractVariant(latest);
@@ -3092,6 +3111,7 @@
                             updateRuler({
                                 limitMbps: step.targetMbps,
                                 throughputMbps: throughput,
+                                wireActive1sMbps: wireActive1s,
                                 wireThroughputMbps: wireThroughput,
                                 playerEstimateMbps: playerEstimate,
                                 currentVariantMbps: variant

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -964,7 +964,8 @@
                                     <span>50 Mbps</span>
                                 </label>
                             </div>
-                            <button type="button" class="btn btn-secondary btn-mini" data-action="toggle-variants">Hide Variants</button>
+                            <button type="button" class="btn btn-secondary btn-mini" data-action="reset-bitrate-zoom">Reset Zoom</button>
+                            <button type="button" class="btn btn-secondary btn-mini" data-action="pause-bitrate-chart">⏸ Pause</button>
                         </div>
                         <div data-field="bandwidth_chart_range">Window: —</div>
                         <div class="chart-wrap">

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -495,12 +495,50 @@
         }
 
         .chart-wrap {
+            position: relative;
             margin-top: 10px;
             background: #ffffff;
             border-radius: 8px;
             padding: 6px;
             border: 1px solid #e5e7eb;
             width: 100%;
+        }
+
+        .chart-paused-badge {
+            display: none;
+            position: absolute;
+            top: 8px;
+            right: 10px;
+            background: rgba(30, 41, 59, 0.72);
+            color: #f8fafc;
+            font-family: 'Courier New', monospace;
+            font-size: 10px;
+            font-weight: bold;
+            letter-spacing: 0.1em;
+            padding: 2px 7px;
+            border-radius: 4px;
+            pointer-events: none;
+            z-index: 10;
+        }
+        .chart-wrap.chart-paused .chart-paused-badge {
+            display: block;
+        }
+        .chart-wrap.chart-paused {
+            cursor: pointer;
+        }
+
+        button[data-action="pause-bitrate-chart"].chart-live {
+            color: #16a34a;
+            border-color: #16a34a;
+            font-weight: 600;
+        }
+        @keyframes chart-pulse-dot {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.35; }
+        }
+        button[data-action="pause-bitrate-chart"].chart-live::before {
+            content: '● ';
+            animation: chart-pulse-dot 1.2s ease-in-out infinite;
         }
 
         .bandwidth-chart {
@@ -661,6 +699,7 @@
         .abrchar-ruler-marker.variant .abrchar-ruler-line { background: #64748b; }
         .abrchar-ruler-marker.limit .abrchar-ruler-line { background: #f59e0b; }
         .abrchar-ruler-marker.throughput .abrchar-ruler-line { background: #14b8a6; }
+        .abrchar-ruler-marker.wire-active-1s .abrchar-ruler-line { background: #059669; }
         .abrchar-ruler-marker.wire-throughput .abrchar-ruler-line { background: #2563eb; }
         .abrchar-ruler-marker.player-estimate .abrchar-ruler-line { background: #0ea5e9; }
         .abrchar-ruler-marker.top-range .abrchar-ruler-line { background: #dc2626; }
@@ -690,6 +729,7 @@
         }
         .abrchar-ruler-marker.limit .abrchar-ruler-label { color: #b45309; }
         .abrchar-ruler-marker.throughput .abrchar-ruler-label { color: #0f766e; }
+        .abrchar-ruler-marker.wire-active-1s .abrchar-ruler-label { color: #047857; }
         .abrchar-ruler-marker.wire-throughput .abrchar-ruler-label { color: #1d4ed8; }
         .abrchar-ruler-marker.player-estimate .abrchar-ruler-label { color: #0369a1; }
         .abrchar-ruler-marker.top-range .abrchar-ruler-label { color: #b91c1c; }
@@ -791,6 +831,7 @@
     </script>
     <script src="/shared-nav.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/styles/vis-timeline-graph2d.min.css">
     <script src="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/standalone/umd/vis-timeline-graph2d.min.js"></script>
     <link rel="stylesheet" href="/dashboard/testing-session-refactored.css">
@@ -823,6 +864,9 @@
         let currentSessionId = null;
         let currentPlayerId = '';
         let currentUrl = '';
+        let desiredLiveOffsetSeconds = 0;
+        let liveOffsetSeekTimer = null;
+        let liveOffsetSeekDeadlineMs = 0;
         let autoRecoveryEnabled = false;
         let autoRecoveryZeroStartedAtMs = null;
         let autoRecoveryLastRestartAtMs = 0;
@@ -839,8 +883,9 @@
         const bandwidthCharts = new Map();
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
+        const chartViewportBySession = new Map();
+        const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
-        const bandwidthVariantsEnabledBySession = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
@@ -853,6 +898,16 @@
         let groupSelectSessionId = '';
         let sessionPollController = null;
         let sessionPollInFlight = false;
+        if (window.Chart && window['chartjs-plugin-zoom']) {
+            const zoomPlugin = window['chartjs-plugin-zoom'].default || window['chartjs-plugin-zoom'];
+            if (zoomPlugin && typeof Chart.register === 'function') {
+                try {
+                    Chart.register(zoomPlugin);
+                } catch (_) {
+                    // Ignore duplicate registration errors.
+                }
+            }
+        }
         let sessionPollRequestSeq = 0;
         let sessionPollLastAppliedSeq = 0;
         let sessionsStream = null;
@@ -1316,7 +1371,7 @@
             const displayResolution = formatResolution(video.clientWidth, video.clientHeight);
             const videoResolution = formatResolution(video.videoWidth, video.videoHeight);
             let bufferedEnd = null;
-            let bufferDepth = null;
+            let bufferDepth = 0;
             let seekableEnd = null;
             if (buffered && buffered.length > 0) {
                 const end = buffered.end(buffered.length - 1);
@@ -1327,6 +1382,9 @@
                 const end = seekable.end(seekable.length - 1);
                 seekableEnd = toMetricSeconds(end);
             }
+            const liveOffset = (seekableEnd !== null)
+                ? toMetricSeconds(Math.max(0, seekableEnd - current))
+                : null;
             const quality = video.getVideoPlaybackQuality ? video.getVideoPlaybackQuality() : null;
             const totalFrames = quality ? Number(quality.totalVideoFrames || 0) : null;
             const droppedFrames = quality ? Number(quality.droppedVideoFrames || 0) : null;
@@ -1348,7 +1406,7 @@
                 player_metrics_buffer_end_s: bufferedEnd,
                 player_metrics_seekable_end_s: seekableEnd,
                 player_metrics_live_edge_s: seekableEnd,
-                player_metrics_live_offset_s: null,
+                player_metrics_live_offset_s: liveOffset,
                 player_metrics_display_resolution: displayResolution,
                 player_metrics_video_resolution: videoResolution,
                 player_metrics_video_first_frame_time_s: toMetricSeconds(videoFirstFrameS),
@@ -1413,7 +1471,7 @@
             }
             metricsHeartbeatTimer = setInterval(() => {
                 sendSessionMetrics('heartbeat');
-            }, 5000);
+            }, 1000);
         }
 
         function normalizeBitrateAxisMaxMode(value) {
@@ -1591,6 +1649,48 @@
             }, delay);
         }
 
+        function clearLiveOffsetSeekTimer() {
+            if (!liveOffsetSeekTimer) return;
+            clearInterval(liveOffsetSeekTimer);
+            liveOffsetSeekTimer = null;
+        }
+
+        function tryApplyLiveOffset(reason = 'startup') {
+            if (!(Number.isFinite(desiredLiveOffsetSeconds) && desiredLiveOffsetSeconds > 0)) return false;
+            if (!video || !video.seekable || video.seekable.length <= 0) return false;
+            const liveEdge = Number(video.seekable.end(video.seekable.length - 1));
+            if (!Number.isFinite(liveEdge)) return false;
+            const target = Math.max(0, liveEdge - desiredLiveOffsetSeconds);
+            if (!Number.isFinite(target)) return false;
+            try {
+                video.currentTime = target;
+            } catch (err) {
+                return false;
+            }
+            log(`LIVE OFFSET: applied ${desiredLiveOffsetSeconds.toFixed(1)}s behind live (${reason})`);
+            return true;
+        }
+
+        function scheduleLiveOffsetSeek(reason = 'startup') {
+            clearLiveOffsetSeekTimer();
+            if (!(Number.isFinite(desiredLiveOffsetSeconds) && desiredLiveOffsetSeconds > 0)) return;
+            liveOffsetSeekDeadlineMs = Date.now() + 20000;
+            const tick = () => {
+                if (tryApplyLiveOffset(reason)) {
+                    clearLiveOffsetSeekTimer();
+                    return;
+                }
+                if (Date.now() >= liveOffsetSeekDeadlineMs) {
+                    log(`LIVE OFFSET: unable to apply ${desiredLiveOffsetSeconds.toFixed(1)}s (seekable not ready)`);
+                    clearLiveOffsetSeekTimer();
+                }
+            };
+            tick();
+            if (!liveOffsetSeekTimer) {
+                liveOffsetSeekTimer = setInterval(tick, 250);
+            }
+        }
+
         function getParams() {
             const params = new URLSearchParams(window.location.search);
             let url = params.get('url') || '';
@@ -1636,11 +1736,16 @@
                     console.warn('Failed to persist selected url', err);
                 }
             }
+            let liveOffsetSeconds = Number(params.get('live_offset_s') || '0');
+            if (!Number.isFinite(liveOffsetSeconds) || liveOffsetSeconds < 0) {
+                liveOffsetSeconds = 0;
+            }
             return {
                 playerId: playerId,
                 url: url,
                 player: params.get('player') || '',
-                autoRecovery: params.get('auto_recovery')
+                autoRecovery: params.get('auto_recovery'),
+                liveOffsetSeconds: liveOffsetSeconds
             };
         }
 
@@ -1999,6 +2104,7 @@
         }
 
         function resetPlayback() {
+            clearLiveOffsetSeekTimer();
             if (hlsInstance) {
                 hlsInstance.destroy();
                 hlsInstance = null;
@@ -2065,6 +2171,7 @@
         function loadStream(url) {
             currentUrl = url;
             markPlaybackStart();
+            clearLiveOffsetSeekTimer();
             clearStreamAccessAlert();
             autoRetryCount = 0;
             if (autoRetryTimer) {
@@ -2207,6 +2314,7 @@
                     scheduleAutoRetry('native play error');
                 });
             }
+            scheduleLiveOffsetSeek('load_stream');
         }
 
         function renderSessionControls(session) {
@@ -2249,8 +2357,10 @@
                 }
             }
 
+            const buffered = video && video.buffered ? video.buffered : null;
+            const current = Number(video && Number.isFinite(video.currentTime) ? video.currentTime : 0);
             const depthValue = (buffered && buffered.length > 0)
-                ? Math.max(0, Number(buffered.end(buffered.length - 1) || 0) - Number(current || 0))
+                ? Math.max(0, Number(buffered.end(buffered.length - 1) || 0) - current)
                 : 0;
             if (autoRecoveryEnabled && currentUrl && !video.paused) {
                 if (Number.isFinite(depthValue) && depthValue <= 0.01) {
@@ -2895,9 +3005,29 @@
         function buildSessionPatch(card, fields) {
             const data = TestingSessionUI.readSessionSettings(card);
             const set = {};
+            const getShapingNumber = (field, fallback = 0) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                const value = input ? Number(input.value) : fallback;
+                return Number.isFinite(value) ? value : fallback;
+            };
+            const shapingPattern = TestingSessionUI.readShapingPattern(card);
+            const shapingFieldValues = {
+                nftables_bandwidth_mbps: getShapingNumber('shaping_throughput_mbps', 0),
+                nftables_delay_ms: getShapingNumber('shaping_delay_ms', 0),
+                nftables_packet_loss: getShapingNumber('shaping_loss_pct', 0),
+                nftables_pattern_enabled: shapingPattern.template_mode !== 'sliders' && Array.isArray(shapingPattern.steps) && shapingPattern.steps.length > 0,
+                nftables_pattern_steps: Array.isArray(shapingPattern.steps) ? shapingPattern.steps : [],
+                nftables_pattern_segment_duration_seconds: shapingPattern.segment_duration_seconds,
+                nftables_pattern_default_segments: shapingPattern.default_segments,
+                nftables_pattern_default_step_seconds: shapingPattern.default_step_seconds,
+                nftables_pattern_template_mode: shapingPattern.template_mode,
+                nftables_pattern_margin_pct: shapingPattern.template_margin_pct
+            };
             (fields || []).forEach(field => {
                 if (Object.prototype.hasOwnProperty.call(data, field)) {
                     set[field] = data[field];
+                } else if (Object.prototype.hasOwnProperty.call(shapingFieldValues, field)) {
+                    set[field] = shapingFieldValues[field];
                 }
             });
             return {
@@ -3313,11 +3443,29 @@
                     TestingSessionUI.updateTransportModeUi(card);
                 }
                 if (event.target.dataset.field === 'bitrate_chart_max_mbps') {
-                    bitrateAxisMaxBySession.set(
-                        String(card.dataset.sessionId || ''),
-                        normalizeBitrateAxisMaxMode(event.target.value)
-                    );
-                    renderBandwidthChart(card.dataset.sessionId);
+                    const sessionId = String(card.dataset.sessionId || '');
+                    const axisMode = normalizeBitrateAxisMaxMode(event.target.value);
+                    bitrateAxisMaxBySession.set(sessionId, axisMode);
+                    if (isChartPaused(sessionId)) {
+                        // renderBandwidthChart is a no-op while paused, so apply directly.
+                        const chart = bandwidthCharts.get(sessionId);
+                        if (chart) {
+                            let maxY;
+                            if (axisMode === 'auto') {
+                                const visibleMax = chart.data.datasets
+                                    .filter((_, idx) => chart.isDatasetVisible(idx))
+                                    .flatMap(ds => ds.data.map(pt => Number(pt.y) || 0))
+                                    .reduce((m, v) => Math.max(m, v), 1);
+                                maxY = Math.min(100, Math.max(1, Math.ceil(visibleMax * 1.05 * 10) / 10));
+                            } else {
+                                maxY = Number(axisMode);
+                            }
+                            chart.options.scales.y.max = maxY;
+                            chart.update('none');
+                        }
+                    } else {
+                        renderBandwidthChart(sessionId);
+                    }
                     return;
                 }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_template_')) {
@@ -3423,11 +3571,22 @@
                 if (!button) return;
                 const card = button.closest('.session-card');
                 if (!card) return;
-                if (button.dataset.action === 'toggle-variants') {
+                if (button.dataset.action === 'reset-bitrate-zoom') {
                     const sessionId = String(card.dataset.sessionId || '');
-                    const variantsEnabled = bandwidthVariantsEnabledBySession.get(sessionId) !== false;
-                    bandwidthVariantsEnabledBySession.set(sessionId, !variantsEnabled);
-                    renderBandwidthChart(sessionId);
+                    chartViewportBySession.delete(sessionId);
+                    if (rightPanDragState && rightPanDragState.sessionId === sessionId) {
+                        rightPanDragState = null;
+                    }
+                    for (const chart of getChartsForSession(sessionId)) {
+                        if (chart && typeof chart.resetZoom === 'function') {
+                            chart.resetZoom('none');
+                        }
+                    }
+                    return;
+                }
+                if (button.dataset.action === 'pause-bitrate-chart') {
+                    const sessionId = String(card.dataset.sessionId || '');
+                    toggleChartPause(sessionId);
                     return;
                 }
                 if (button.dataset.action === 'apply-pattern') {
@@ -3545,12 +3704,6 @@
                 delay: payload.delay_ms,
                 loss: payload.loss_pct
             });
-            setTimeout(() => {
-                const pending = pendingShaping.get(sessionId);
-                if (pending && Date.now() - pending.timestamp > 4500) {
-                    pendingShaping.delete(sessionId);
-                }
-            }, 5000);
             const fields = [
                 'nftables_bandwidth_mbps',
                 'nftables_delay_ms',
@@ -3564,6 +3717,34 @@
                 'nftables_pattern_margin_pct'
             ];
             sendSessionPatch(card, fields);
+        }
+
+        function shapingValuesMatch(serverSession, pendingValues) {
+            if (!serverSession || !pendingValues) return false;
+            const sameNumber = (a, b, tolerance = 0.001) => {
+                const left = Number(a);
+                const right = Number(b);
+                if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+                return Math.abs(left - right) <= tolerance;
+            };
+            const sameBool = (a, b) => {
+                const toBool = (value) => value === true || value === 1 || value === 'true';
+                return toBool(a) === toBool(b);
+            };
+            const sameJson = (a, b) => {
+                try {
+                    return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+                } catch {
+                    return false;
+                }
+            };
+
+            if (!sameNumber(serverSession.nftables_bandwidth_mbps, pendingValues.nftables_bandwidth_mbps, 0.01)) return false;
+            if (!sameNumber(serverSession.nftables_delay_ms, pendingValues.nftables_delay_ms, 0.1)) return false;
+            if (!sameNumber(serverSession.nftables_packet_loss, pendingValues.nftables_packet_loss, 0.01)) return false;
+            if (!sameBool(serverSession.nftables_pattern_enabled, pendingValues.nftables_pattern_enabled)) return false;
+            if (!sameJson(serverSession.nftables_pattern_steps, pendingValues.nftables_pattern_steps)) return false;
+            return true;
         }
 
         function findSessionByPlayerId(playerId, signal) {
@@ -3584,13 +3765,8 @@
                     const lastRequest = Date.parse(session.last_request || '') || 0;
                     const firstRequest = Date.parse(session.first_request_time || '') || 0;
                     const wireScore =
-                        Number.isFinite(Number(session.mbps_wire_sustained)) ||
-                        Number.isFinite(Number(session.mbps_wire_active)) ||
-                        Number.isFinite(Number(session.mbps_wire_sustained_6s)) ||
-                        Number.isFinite(Number(session.mbps_wire_active_6s)) ||
-                        Number.isFinite(Number(session.mbps_wire_sustained_1s)) ||
-                        Number.isFinite(Number(session.mbps_wire_active_1s)) ||
-                        Number.isFinite(Number(session.mbps_wire_throughput))
+                        Number.isFinite(Number(session.mbps_shaper_rate)) ||
+                        Number.isFinite(Number(session.mbps_transfer_rate))
                             ? 1
                             : 0;
                     return { wireScore, lastRequest, firstRequest };
@@ -3729,12 +3905,6 @@
             setText('[data-field="session_measurement_window_io_1s"]', formatMetricNumber(session.measurement_window_io_1s, 's'));
             setText('[data-field="session_measurement_window_active"]', formatMetricNumber(session.measurement_window_active, 's'));
             setText('[data-field="session_measurement_window_segment_active"]', formatMetricNumber(session.measurement_window_segment_active, 's'));
-            setText('[data-field="session_mbps_wire_sustained"]', formatMetricNumber(session.mbps_wire_sustained, ' Mbps'));
-            setText('[data-field="session_mbps_wire_active"]', formatMetricNumber(session.mbps_wire_active, ' Mbps'));
-            setText('[data-field="session_mbps_wire_sustained_6s"]', formatMetricNumber(session.mbps_wire_sustained_6s, ' Mbps'));
-            setText('[data-field="session_mbps_wire_active_6s"]', formatMetricNumber(session.mbps_wire_active_6s, ' Mbps'));
-            setText('[data-field="session_mbps_wire_sustained_1s"]', formatMetricNumber(session.mbps_wire_sustained_1s, ' Mbps'));
-            setText('[data-field="session_mbps_wire_throughput"]', formatMetricNumber(session.mbps_wire_throughput, ' Mbps'));
             const masterCount = session.master_manifest_requests_count || 0;
             const manifestCount = session.manifest_requests_count || 0;
             const segmentCount = session.segments_count || 0;
@@ -3778,9 +3948,7 @@
             return String(label || '').replace(/\s*\(V\d+\)$/, '');
         }
 
-        function isVariantSeriesLabel(label) {
-            return /^Variant V\d+$/.test(String(label || ''));
-        }
+
 
         function buildVariantLadder(variants) {
             if (!Array.isArray(variants) || !variants.length) return [];
@@ -3838,15 +4006,284 @@
             return `Window: ${start} → ${end}`;
         }
 
+        function pinBitrateChartToLiveEdge(chartRef) {
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return;
+            const domainMin = 0;
+            const domainMax = 600;
+            const currentMin = Number(xScale.min);
+            const currentMax = Number(xScale.max);
+            if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
+            const span = Math.max(2, Math.min(domainMax - domainMin, currentMax - currentMin));
+            const nextMax = domainMax;
+            const nextMin = Math.max(domainMin, nextMax - span);
+            if (typeof chartRef.zoomScale === 'function') {
+                // Store via plugin so the pin survives future chart.update() calls.
+                // zoomScale does not fire onZoomComplete so this is safe to call here.
+                chartRef.zoomScale('x', { min: nextMin, max: nextMax }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = nextMin;
+                chartRef.options.scales.x.max = nextMax;
+            }
+        }
+
+        function normalizeChartViewport(minValue, maxValue) {
+            const domainMin = 0;
+            const domainMax = 600;
+            let min = Number(minValue);
+            let max = Number(maxValue);
+            if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+            if (max < min) {
+                const tmp = min;
+                min = max;
+                max = tmp;
+            }
+            let span = max - min;
+            if (!Number.isFinite(span) || span <= 0) {
+                return { min: domainMin, max: domainMax };
+            }
+            span = Math.max(2, Math.min(domainMax - domainMin, span));
+            max = Math.min(domainMax, max);
+            min = Math.max(domainMin, max - span);
+            max = min + span;
+            if (max > domainMax) {
+                max = domainMax;
+                min = domainMax - span;
+            }
+            if (min < domainMin) {
+                min = domainMin;
+                max = domainMin + span;
+            }
+            return { min, max };
+        }
+
+        function readChartViewport(chartRef) {
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return null;
+            return normalizeChartViewport(xScale.min, xScale.max);
+        }
+
+        function applyChartViewport(chartRef, viewport) {
+            if (!chartRef || !viewport) return;
+            if (typeof chartRef.zoomScale === 'function') {
+                // Use the plugin API so the zoom state is stored inside the plugin and
+                // survives future chart.update() calls (direct options writes get overridden
+                // by the plugin's beforeUpdate hook).  zoomScale does NOT fire onZoomComplete.
+                chartRef.zoomScale('x', { min: viewport.min, max: viewport.max }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = viewport.min;
+                chartRef.options.scales.x.max = viewport.max;
+            }
+        }
+
+        function applyStoredChartViewport(sessionId, chartRef) {
+            const viewport = chartViewportBySession.get(String(sessionId || ''));
+            if (!viewport) return false;
+            applyChartViewport(chartRef, viewport);
+            return true;
+        }
+
+        function getChartsForSession(sessionId) {
+            const key = String(sessionId || '');
+            return [
+                bandwidthCharts.get(key),
+                bufferDepthCharts.get(key),
+                videoFpsCharts.get(key)
+            ].filter((chartRef) => !!chartRef);
+        }
+
+        function syncChartViewportAcrossSession(sessionId, sourceChart) {
+            const key = String(sessionId || '');
+            const viewport = readChartViewport(sourceChart);
+            if (!viewport) return;
+            chartViewportBySession.set(key, viewport);
+            for (const chartRef of getChartsForSession(key)) {
+                if (!chartRef || chartRef === sourceChart) continue;
+                applyChartViewport(chartRef, viewport);
+                // zoomScale (used inside applyChartViewport) calls update internally;
+                // only call update explicitly when falling back to direct options writes.
+                if (typeof chartRef.zoomScale !== 'function') {
+                    chartRef.update('none');
+                }
+            }
+        }
+
+        function buildUnifiedChartZoomOptions(sessionId) {
+            const key = String(sessionId || '');
+            return {
+                pan: {
+                    enabled: true,
+                    mode: 'x',
+                    threshold: 2,
+                    // Must be inside pan{} in chartjs-plugin-zoom v2
+                    onPanComplete: ({ chart: chartRef }) => {
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                },
+                limits: {
+                    x: { min: 0, max: 600, minRange: 2 }
+                },
+                zoom: {
+                    wheel: {
+                        enabled: true
+                    },
+                    drag: {
+                        enabled: true,
+                        modifierKey: 'alt',
+                        borderColor: '#1d4ed8',
+                        borderWidth: 1,
+                        backgroundColor: 'rgba(37, 99, 235, 0.12)'
+                    },
+                    mode: 'x',
+                    // Must be inside zoom{} in chartjs-plugin-zoom v2
+                    onZoomComplete: ({ chart: chartRef }) => {
+                        pinBitrateChartToLiveEdge(chartRef);
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                }
+            };
+        }
+
+        let rightPanDragState = null;
+        let rightPanListenersInstalled = false;
+
+        function installRightMousePanHandlers(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.rightPanBound === '1') return;
+            canvas.dataset.rightPanBound = '1';
+            const key = String(sessionId || '');
+            canvas.addEventListener('contextmenu', (event) => {
+                event.preventDefault();
+            });
+            canvas.addEventListener('mousedown', (event) => {
+                if (event.button !== 2) return;
+                event.preventDefault();
+                const viewport = readChartViewport(chartRef) || { min: 0, max: 600 };
+                rightPanDragState = {
+                    sessionId: key,
+                    sourceChart: chartRef,
+                    startClientX: event.clientX,
+                    startViewport: viewport
+                };
+            });
+            if (rightPanListenersInstalled) return;
+            rightPanListenersInstalled = true;
+            window.addEventListener('mousemove', (event) => {
+                if (!rightPanDragState) return;
+                const sourceChart = rightPanDragState.sourceChart;
+                const chartArea = sourceChart?.chartArea;
+                if (!sourceChart || !chartArea) return;
+                const widthPx = Math.max(1, chartArea.right - chartArea.left);
+                const span = rightPanDragState.startViewport.max - rightPanDragState.startViewport.min;
+                if (!Number.isFinite(span) || span <= 0) return;
+                const deltaPx = event.clientX - rightPanDragState.startClientX;
+                const deltaValue = (deltaPx / widthPx) * span;
+                const viewport = normalizeChartViewport(
+                    rightPanDragState.startViewport.min - deltaValue,
+                    rightPanDragState.startViewport.max - deltaValue
+                );
+                if (!viewport) return;
+                chartViewportBySession.set(rightPanDragState.sessionId, viewport);
+                for (const chart of getChartsForSession(rightPanDragState.sessionId)) {
+                    applyChartViewport(chart, viewport);
+                    if (typeof chart.zoomScale !== 'function') {
+                        chart.update('none');
+                    }
+                }
+            });
+            window.addEventListener('mouseup', (event) => {
+                if (!rightPanDragState) return;
+                if (event.button === 2) {
+                    rightPanDragState = null;
+                }
+            });
+            window.addEventListener('blur', () => {
+                rightPanDragState = null;
+            });
+        }
+
+        function isChartPaused(sessionId) {
+            return chartPausedBySession.get(String(sessionId || '')) === true;
+        }
+
+        function updatePauseButtonAndOverlays(sessionId) {
+            const key = String(sessionId || '');
+            const paused = isChartPaused(key);
+            const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+            if (!card) return;
+            const btn = card.querySelector('button[data-action="pause-bitrate-chart"]');
+            if (btn) {
+                if (paused) {
+                    btn.textContent = 'Live';
+                    btn.classList.add('chart-live');
+                } else {
+                    btn.textContent = '⏸ Pause';
+                    btn.classList.remove('chart-live');
+                }
+            }
+            for (const wrap of card.querySelectorAll('.chart-wrap')) {
+                let badge = wrap.querySelector('.chart-paused-badge');
+                if (!badge) {
+                    badge = document.createElement('div');
+                    badge.className = 'chart-paused-badge';
+                    badge.textContent = 'PAUSED';
+                    wrap.appendChild(badge);
+                }
+                wrap.classList.toggle('chart-paused', paused);
+            }
+        }
+
+        function toggleChartPause(sessionId) {
+            const key = String(sessionId || '');
+            const wasPaused = isChartPaused(key);
+            chartPausedBySession.set(key, !wasPaused);
+            updatePauseButtonAndOverlays(key);
+            if (wasPaused) {
+                renderBandwidthChart(key);
+            }
+        }
+
+        function installChartClickPauseHandler(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.pauseHandlerBound === '1') return;
+            canvas.dataset.pauseHandlerBound = '1';
+            let startX = 0;
+            let startY = 0;
+            canvas.addEventListener('mousedown', (e) => {
+                if (e.button !== 0) return;
+                startX = e.clientX;
+                startY = e.clientY;
+            });
+            canvas.addEventListener('click', (e) => {
+                if (e.altKey) return;
+                if (Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5) return;
+                // Only toggle pause for clicks inside the plot area.
+                // Clicks in the legend / title regions (outside chartArea) are for
+                // Chart.js legend interaction and must not trigger pause.
+                const chartArea = chartRef.chartArea;
+                if (chartArea) {
+                    const rect = canvas.getBoundingClientRect();
+                    const cx = e.clientX - rect.left;
+                    const cy = e.clientY - rect.top;
+                    if (cx < chartArea.left || cx > chartArea.right || cy < chartArea.top || cy > chartArea.bottom) {
+                        return;
+                    }
+                }
+                toggleChartPause(sessionId);
+            });
+        }
+
         function pushBandwidthSample(session) {
             const now = Date.now();
             const windowMs = 10 * 60 * 1000;
-            const wireSustained = Number.isFinite(Number(session.mbps_wire_sustained)) ? Number(session.mbps_wire_sustained) : null;
-            const wireActive = Number.isFinite(Number(session.mbps_wire_active)) ? Number(session.mbps_wire_active) : null;
-            const wireSustained6s = Number.isFinite(Number(session.mbps_wire_sustained_6s)) ? Number(session.mbps_wire_sustained_6s) : null;
-            const wireActive6s = Number.isFinite(Number(session.mbps_wire_active_6s)) ? Number(session.mbps_wire_active_6s) : null;
-            const wireSustained1s = Number.isFinite(Number(session.mbps_wire_sustained_1s)) ? Number(session.mbps_wire_sustained_1s) : null;
-            const wireThroughput = Number.isFinite(Number(session.mbps_wire_throughput)) ? Number(session.mbps_wire_throughput) : null;
+            const key = session.session_id;
+            const shaperRate = Number.isFinite(Number(session.mbps_shaper_rate)) ? Number(session.mbps_shaper_rate) : null;
+            const shaperAvg = Number.isFinite(Number(session.mbps_shaper_avg)) ? Number(session.mbps_shaper_avg) : null;
+            const transferRate = session.mbps_transfer_rate != null && Number.isFinite(Number(session.mbps_transfer_rate)) ? Number(session.mbps_transfer_rate) : null;
+            const transferComplete = session.mbps_transfer_complete != null && Number.isFinite(Number(session.mbps_transfer_complete)) ? Number(session.mbps_transfer_complete) : null;
+            const fullSegmentNetworkBitrate = Number.isFinite(Number(session.full_segment_network_bitrate_mbps))
+                ? Number(session.full_segment_network_bitrate_mbps)
+                : null;
             let bufferDepth = null;
             if (video && video.buffered && video.buffered.length > 0) {
                 const current = Number(video.currentTime || 0);
@@ -3860,6 +4297,9 @@
             const currentRendition = Number(currentRenditionMbps || 0);
             const framesDisplayed = Number.isFinite(Number(session.player_metrics_frames_displayed))
                 ? Number(session.player_metrics_frames_displayed)
+                : null;
+            const metricsAtMs = session.player_metrics_event_time
+                ? Date.parse(session.player_metrics_event_time) || null
                 : null;
             const framesDropped = Number.isFinite(Number(session.player_metrics_dropped_frames))
                 ? Number(session.player_metrics_dropped_frames)
@@ -3921,7 +4361,6 @@
                     target = stepRate;
                 }
             }
-            const key = session.session_id;
             if (!patternEnabled) {
                 const applied = lastAppliedShaping.get(key);
                 if (applied && Date.now() - applied.timestamp < 20000) {
@@ -3995,16 +4434,16 @@
             }
             series.push({
                 ts: now,
-                wireSustained,
-                wireActive,
-                wireSustained6s,
-                wireActive6s,
-                wireSustained1s,
-                wireThroughput,
+                shaperRate,
+                shaperAvg,
+                transferRate,
+                transferComplete,
+                fullSegmentNetworkBitrate,
                 bufferDepth,
                 playerEstimate,
                 currentRendition,
                 framesDisplayed,
+                metricsAtMs,
                 framesDropped,
                 serverRendition,
                 target,
@@ -4017,6 +4456,7 @@
         }
 
         function renderBandwidthChart(sessionId) {
+            if (isChartPaused(sessionId)) return;
             const series = bandwidthHistory.get(sessionId) || [];
             const eventSeries = bandwidthEventHistory.get(sessionId) || [];
             const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
@@ -4035,16 +4475,16 @@
                 .filter(point => point.ts >= windowStart)
                 .map(point => ({
                     x: (point.ts - windowStart) / 1000,
-                    wireSustained: point.wireSustained,
-                    wireActive: point.wireActive,
-                    wireSustained6s: point.wireSustained6s,
-                    wireActive6s: point.wireActive6s,
-                    wireSustained1s: point.wireSustained1s,
-                    wireThroughput: point.wireThroughput,
+                    shaperRate: point.shaperRate,
+                    shaperAvg: point.shaperAvg,
+                    transferRate: point.transferRate,
+                    transferComplete: point.transferComplete,
+                    fullSegmentNetworkBitrate: point.fullSegmentNetworkBitrate,
                     bufferDepth: point.bufferDepth,
                     playerEstimate: point.playerEstimate,
                     currentRendition: point.currentRendition,
                     framesDisplayed: point.framesDisplayed,
+                    metricsAtMs: point.metricsAtMs,
                     framesDropped: point.framesDropped,
                     serverRendition: point.serverRendition,
                     target: point.target,
@@ -4057,15 +4497,14 @@
                     type: event.type
                 }))
                 .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
-            const wireSustainedData = points.map(point => ({ x: point.x, y: point.wireSustained }));
-            const wireActiveData = points.map(point => ({ x: point.x, y: point.wireActive }));
-            const wireSustained6sData = points.map(point => ({ x: point.x, y: point.wireSustained6s }));
-            const wireActive6sData = points.map(point => ({ x: point.x, y: point.wireActive6s }));
-            const wireSustained1sData = points.map(point => ({ x: point.x, y: point.wireSustained1s }));
-            const wireThroughputData = points.map(point => ({ x: point.x, y: point.wireThroughput }));
+            const shaperRateData = points.map(point => ({ x: point.x, y: point.shaperRate }));
+            const shaperAvgData = points.map(point => ({ x: point.x, y: point.shaperAvg }));
+            const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));
+            const transferCompleteData = points.map(point => ({ x: point.x, y: point.transferComplete }));
+            const fullSegmentNetworkBitrateData = points.map(point => ({ x: point.x, y: point.fullSegmentNetworkBitrate }));
             const bufferDepthData = points.map(point => ({ x: point.x, y: Number.isFinite(point.bufferDepth) ? point.bufferDepth : null }));
-            const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null }));
-            const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null }));
+            const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null, atMs: point.metricsAtMs || null }));
+            const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null, atMs: point.metricsAtMs || null }));
             const estimateData = points.map(point => ({ x: point.x, y: point.playerEstimate || null }));
             const renditionData = points.map(point => ({ x: point.x, y: point.currentRendition || null }));
             const serverRenditionData = points.map(point => ({ x: point.x, y: point.serverRendition || null }));
@@ -4078,18 +4517,15 @@
                 }
             }
             const visibility = bandwidthVisibility.get(sessionId) || {};
-            const variantsEnabled = bandwidthVariantsEnabledBySession.get(String(sessionId)) !== false;
-            const variantToggleButton = card.querySelector('button[data-action="toggle-variants"]');
-            if (variantToggleButton) {
-                variantToggleButton.textContent = variantsEnabled ? 'Hide Variants' : 'Show Variants';
-                variantToggleButton.setAttribute('aria-pressed', variantsEnabled ? 'true' : 'false');
-            }
             const defaultVisibleLabels = new Set([
-                'Wire Sustained (6s)',
-                'Wire Throughput',
+                'mbps_shaper_rate',
+                'mbps_shaper_avg',
+                'mbps_transfer_rate',
+                'mbps_transfer_complete',
                 'Player est.',
                 'Rendition',
                 'Server Rendition',
+                'Variants',
                 'Limit',
                 'STALL',
                 'RESTART',
@@ -4098,17 +4534,11 @@
             ]);
             const isSeriesHidden = (label) => {
                 const key = bandwidthSeriesKey(label);
-                if (isVariantSeriesLabel(key) && !variantsEnabled) {
-                    return true;
-                }
                 if (Object.prototype.hasOwnProperty.call(visibility, label)) {
                     return visibility[label] === true;
                 }
                 if (Object.prototype.hasOwnProperty.call(visibility, key)) {
                     return visibility[key] === true;
-                }
-                if (isVariantSeriesLabel(key)) {
-                    return false;
                 }
                 return !defaultVisibleLabels.has(key);
             };
@@ -4120,12 +4550,10 @@
             bitrateAxisMaxBySession.set(String(sessionId), axisMode);
             const maxFor = (hidden, data) => (hidden ? [0] : data.map(point => point.y || 0));
             const maxYAutoRaw = Math.max(1,
-                ...maxFor(isSeriesHidden('Wire Sustained (18s)'), wireSustainedData),
-                ...maxFor(isSeriesHidden('Wire Active'), wireActiveData),
-                ...maxFor(isSeriesHidden('Wire Sustained (6s)'), wireSustained6sData),
-                ...maxFor(isSeriesHidden('Wire Active (6s)'), wireActive6sData),
-                ...maxFor(isSeriesHidden('Wire Sustained (1s)'), wireSustained1sData),
-                ...maxFor(isSeriesHidden('Wire Throughput'), wireThroughputData),
+                ...maxFor(isSeriesHidden('mbps_shaper_rate'), shaperRateData),
+                ...maxFor(isSeriesHidden('mbps_shaper_avg'), shaperAvgData),
+                ...maxFor(isSeriesHidden('mbps_transfer_rate'), transferRateData),
+                ...maxFor(isSeriesHidden('mbps_transfer_complete'), transferCompleteData),
                 ...maxFor(isSeriesHidden('Player est.'), estimateData),
                 ...maxFor(isSeriesHidden('Rendition'), renditionData),
                 ...maxFor(isSeriesHidden('Server Rendition'), serverRenditionData),
@@ -4147,10 +4575,10 @@
             const restartMarkerData = buildEventMarkerData('RESTART');
             const loopPlayerMarkerData = buildEventMarkerData('LOOP_PLAYER');
             const loopServerMarkerData = buildEventMarkerData('LOOP_SERVER');
+            const variantsHidden = isSeriesHidden('Variants');
             const variantDatasets = variantLadder.map((variant, index) => {
-                const label = `Variant ${variant.vx}`;
                 return {
-                    label,
+                    label: index === 0 ? 'Variants' : `_Variant ${variant.vx}`,
                     data: points.map(point => ({ x: point.x, y: variant.mbps })),
                     borderColor: '#9ca3af',
                     backgroundColor: 'rgba(156,163,175,0.12)',
@@ -4158,75 +4586,54 @@
                     pointRadius: 0,
                     tension: 0,
                     borderDash: index % 2 === 0 ? [2, 6] : [6, 3],
-                    hidden: isSeriesHidden(label)
+                    hidden: variantsHidden
                 };
             });
             const datasets = [
                 {
-                    label: 'Wire Sustained (18s)',
-                    data: wireSustainedData,
-                    borderColor: '#0891b2',
-                    backgroundColor: 'rgba(8,145,178,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [6, 3],
-                    hidden: isSeriesHidden('Wire Sustained (18s)')
-                },
-                {
-                    label: 'Wire Active',
-                    data: wireActiveData,
+                    label: 'mbps_shaper_rate',
+                    data: shaperRateData,
                     borderColor: '#0f766e',
                     backgroundColor: 'rgba(15,118,110,0.12)',
-                    borderWidth: 1.5,
+                    borderWidth: 1.7,
                     pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [2, 4],
-                    hidden: isSeriesHidden('Wire Active')
+                    tension: 0.15,
+                    borderDash: [8, 2],
+                    hidden: isSeriesHidden('mbps_shaper_rate')
                 },
                 {
-                    label: 'Wire Sustained (6s)',
-                    data: wireSustained6sData,
-                    borderColor: '#155e75',
-                    backgroundColor: 'rgba(21,94,117,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [8, 3],
-                    hidden: isSeriesHidden('Wire Sustained (6s)')
-                },
-                {
-                    label: 'Wire Active (6s)',
-                    data: wireActive6sData,
-                    borderColor: '#115e59',
-                    backgroundColor: 'rgba(17,94,89,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [3, 5],
-                    hidden: isSeriesHidden('Wire Active (6s)')
-                },
-                {
-                    label: 'Wire Sustained (1s)',
-                    data: wireSustained1sData,
-                    borderColor: '#0e7490',
-                    backgroundColor: 'rgba(14,116,144,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [4, 4],
-                    hidden: isSeriesHidden('Wire Sustained (1s)')
-                },
-                {
-                    label: 'Wire Throughput',
-                    data: wireThroughputData,
+                    label: 'mbps_shaper_avg',
+                    data: shaperAvgData,
                     borderColor: '#0d9488',
                     backgroundColor: 'rgba(13,148,136,0.12)',
-                    borderWidth: 1.5,
+                    borderWidth: 1.7,
                     pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [1, 3],
-                    hidden: isSeriesHidden('Wire Throughput')
+                    tension: 0.15,
+                    borderDash: [10, 3],
+                    hidden: isSeriesHidden('mbps_shaper_avg')
+                },
+                {
+                    label: 'mbps_transfer_rate',
+                    data: transferRateData,
+                    borderColor: '#f97316',
+                    backgroundColor: 'rgba(249,115,22,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [4, 2],
+                    hidden: isSeriesHidden('mbps_transfer_rate')
+                },
+                {
+                    label: 'mbps_transfer_complete',
+                    data: transferCompleteData,
+                    borderColor: '#dc2626',
+                    backgroundColor: 'rgba(220,38,38,0.15)',
+                    borderWidth: 3,
+                    pointRadius: 3,
+                    pointBackgroundColor: '#dc2626',
+                    tension: 0,
+                    stepped: 'after',
+                    hidden: isSeriesHidden('mbps_transfer_complete')
                 },
                 {
                     label: 'Player est.',
@@ -4335,7 +4742,8 @@
                                 position: 'bottom',
                                 labels: {
                                     color: '#6b7280',
-                                    font: { family: 'Courier New, monospace', size: 10 }
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    filter: (item) => !item.text.startsWith('_')
                                 },
                                 onClick: (evt, item, legend) => {
                                     const index = item.datasetIndex;
@@ -4344,10 +4752,32 @@
                                     if (!label) return;
                                     const state = bandwidthVisibility.get(sessionId) || {};
                                     const isVisible = chartRef.isDatasetVisible(index);
-                                    chartRef.setDatasetVisibility(index, !isVisible);
-                                    state[label] = isVisible;
-                                    state[bandwidthSeriesKey(label)] = isVisible;
+                                    if (label === 'Variants') {
+                                        // Toggle all variant datasets together.
+                                        const newVisible = !isVisible;
+                                        chartRef.data.datasets.forEach((ds, i) => {
+                                            if (ds.label === 'Variants' || (ds.label && ds.label.startsWith('_Variant'))) {
+                                                chartRef.setDatasetVisibility(i, newVisible);
+                                            }
+                                        });
+                                        state['Variants'] = !newVisible;
+                                    } else {
+                                        chartRef.setDatasetVisibility(index, !isVisible);
+                                        state[label] = isVisible;
+                                        state[bandwidthSeriesKey(label)] = isVisible;
+                                    }
                                     bandwidthVisibility.set(sessionId, state);
+                                    // Recalculate Y-axis max from visible datasets.
+                                    const currentAxisMode = normalizeBitrateAxisMaxMode(
+                                        bitrateAxisMaxBySession.get(String(sessionId)) || 'auto'
+                                    );
+                                    if (currentAxisMode === 'auto') {
+                                        const visibleMax = chartRef.data.datasets
+                                            .filter((_, i) => chartRef.isDatasetVisible(i))
+                                            .flatMap(ds => ds.data.map(pt => Number(pt.y) || 0))
+                                            .reduce((m, v) => Math.max(m, v), 1);
+                                        chartRef.options.scales.y.max = Math.min(100, Math.max(1, Math.ceil(visibleMax * 1.05 * 10) / 10));
+                                    }
                                     chartRef.update('none');
                                 }
                             },
@@ -4361,7 +4791,8 @@
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -4403,11 +4834,20 @@
                     }
                 });
                 chart.$windowStartMs = windowStart;
+                const restoredBitrateViewport = applyStoredChartViewport(sessionId, chart);
+                installRightMousePanHandlers(sessionId, chart);
+                installChartClickPauseHandler(sessionId, chart);
+                if (restoredBitrateViewport) {
+                    chart.update('none');
+                }
                 bandwidthCharts.set(sessionId, chart);
             } else {
                 chart.data.datasets = datasets;
                 chart.data.datasets.forEach((dataset, idx) => {
-                    const hidden = isSeriesHidden(dataset.label);
+                    const label = dataset.label;
+                    const hidden = (label && label.startsWith('_Variant'))
+                        ? isSeriesHidden('Variants')
+                        : isSeriesHidden(label);
                     dataset.hidden = hidden;
                     chart.setDatasetVisibility(idx, !hidden);
                 });
@@ -4473,7 +4913,8 @@
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -4515,6 +4956,12 @@
                     }
                 });
                 bufferChart.$windowStartMs = windowStart;
+                const restoredBufferViewport = applyStoredChartViewport(sessionId, bufferChart);
+                installRightMousePanHandlers(sessionId, bufferChart);
+                installChartClickPauseHandler(sessionId, bufferChart);
+                if (restoredBufferViewport) {
+                    bufferChart.update('none');
+                }
                 bufferDepthCharts.set(sessionId, bufferChart);
             } else {
                 bufferChart.data.datasets[0].data = bufferDepthData;
@@ -4531,7 +4978,7 @@
             }
             const fpsData = [];
             const droppedFpsDataRaw = [];
-            const fpsWindowSeconds = 1.0;
+            const fpsWindowSeconds = 2.0;
             const maxReasonableFps = 120;
             const buildRateSeries = (counterSeries) => {
                 const out = [];
@@ -4558,10 +5005,15 @@
                         continue;
                     }
                     const anchorCount = Number(anchorPoint.y);
-                    const anchorX = Number(anchorPoint.x);
-                    const deltaSeconds = currentX - anchorX;
+                    // Use actual measurement timestamps (atMs) when available,
+                    // falling back to chart x-axis positions.
+                    const currentMs = Number(currentPoint.atMs);
+                    const anchorMs = Number(anchorPoint.atMs);
+                    const deltaSeconds = (Number.isFinite(currentMs) && Number.isFinite(anchorMs) && currentMs > anchorMs)
+                        ? (currentMs - anchorMs) / 1000
+                        : currentX - Number(anchorPoint.x);
                     const deltaCount = currentCount - anchorCount;
-                    if (!Number.isFinite(anchorCount) || !Number.isFinite(anchorX) || deltaSeconds <= 0 || deltaCount < 0) {
+                    if (!Number.isFinite(anchorCount) || deltaSeconds <= 0 || deltaCount < 0) {
                         out.push({ x: currentPoint.x, y: null });
                         continue;
                     }
@@ -4586,7 +5038,7 @@
                 .filter((value) => Number.isFinite(value) && value >= 0);
             const fpsSmoothedData = [];
             let smooth = null;
-            const smoothingAlpha = 0.3;
+            const smoothingAlpha = 0.15;
             for (const point of fpsData) {
                 const y = Number(point.y);
                 if (!Number.isFinite(y) || y < 0) {
@@ -4701,7 +5153,14 @@
                         maintainAspectRatio: false,
                         animation: false,
                         plugins: {
-                            legend: { display: false },
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
                             tooltip: {
                                 callbacks: {
                                     title: (items) => {
@@ -4712,7 +5171,8 @@
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -4770,6 +5230,12 @@
                     }
                 });
                 fpsChart.$windowStartMs = windowStart;
+                const restoredFpsViewport = applyStoredChartViewport(sessionId, fpsChart);
+                installRightMousePanHandlers(sessionId, fpsChart);
+                installChartClickPauseHandler(sessionId, fpsChart);
+                if (restoredFpsViewport) {
+                    fpsChart.update('none');
+                }
                 videoFpsCharts.set(sessionId, fpsChart);
             } else {
                 fpsChart.data.datasets[0].data = fpsSmoothedData;
@@ -4841,11 +5307,16 @@
             }
             const sessionKey = String(serverSession.session_id || '');
             const pending = pendingShaping.get(String(serverSession.session_id));
-            if (pending && Date.now() - pending.timestamp < 5000) {
-                session = {
-                    ...serverSession,
-                    ...pending.values
-                };
+            if (pending) {
+                if (shapingValuesMatch(serverSession, pending.values)) {
+                    pendingShaping.delete(String(serverSession.session_id));
+                } else {
+                    // Keep local slider state until backend snapshot catches up.
+                    session = {
+                        ...serverSession,
+                        ...pending.values
+                    };
+                }
             }
             const pendingFailure = pendingFailureEdits.get(String(serverSession.session_id));
             if (pendingFailure && Date.now() - pendingFailure.timestamp < 5000) {
@@ -5029,6 +5500,10 @@
         function bootstrap() {
             const params = getParams();
             currentPlayerId = params.playerId || '';
+            desiredLiveOffsetSeconds = Number(params.liveOffsetSeconds || 0);
+            if (!Number.isFinite(desiredLiveOffsetSeconds) || desiredLiveOffsetSeconds < 0) {
+                desiredLiveOffsetSeconds = 0;
+            }
             if (params.playerId) {
                 const titleText = `Testing Playback · ${params.playerId}`;
                 document.title = titleText;
@@ -5040,6 +5515,9 @@
             if (!params.url) {
                 document.getElementById('playerUrl').textContent = 'Missing stream URL.';
                 return;
+            }
+            if (desiredLiveOffsetSeconds > 0) {
+                log(`LIVE OFFSET: target ${desiredLiveOffsetSeconds.toFixed(1)}s behind live`);
             }
             const savedPlayer = localStorage.getItem('testing_session_player');
             setPlayerChoice(params.player || savedPlayer || 'auto');

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -601,12 +601,24 @@ maybe a histogram of b
         })();
     </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/styles/vis-timeline-graph2d.min.css">
     <script src="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/standalone/umd/vis-timeline-graph2d.min.js"></script>
     <link rel="stylesheet" href="/dashboard/testing-session-refactored.css">
     <script src="/dashboard/testing-session-ui.js"></script>
     <script src="/dashboard/player-characterization.js"></script>
     <script>
+        if (window.Chart && window['chartjs-plugin-zoom']) {
+            const zoomPlugin = window['chartjs-plugin-zoom'].default || window['chartjs-plugin-zoom'];
+            if (zoomPlugin && typeof Chart.register === 'function') {
+                try {
+                    Chart.register(zoomPlugin);
+                } catch (_) {
+                    // Ignore duplicate registration errors.
+                }
+            }
+        }
+
         const failureTypes = [
             { value: 'none', text: 'None' },
             { value: '404', text: '404' },
@@ -641,8 +653,9 @@ maybe a histogram of b
         const bandwidthCharts = new Map();
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
+        const chartViewportBySession = new Map();
+        const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
-        const bandwidthVariantsEnabledBySession = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const pendingShaping = new Map();
@@ -1115,12 +1128,10 @@ maybe a histogram of b
             setField('session_master_manifest_url', session.master_manifest_url || '—');
             setField('session_last_request_url', session.last_request_url || '—');
             setField('session_measured_mbps', session.measured_mbps ?? '—');
-            setField('session_mbps_wire_sustained', session.mbps_wire_sustained ?? '—');
-            setField('session_mbps_wire_active', session.mbps_wire_active ?? '—');
-            setField('session_mbps_wire_sustained_6s', session.mbps_wire_sustained_6s ?? '—');
-            setField('session_mbps_wire_active_6s', session.mbps_wire_active_6s ?? '—');
-            setField('session_mbps_wire_sustained_1s', session.mbps_wire_sustained_1s ?? '—');
-            setField('session_mbps_wire_throughput', session.mbps_wire_throughput ?? '—');
+            setField('session_mbps_shaper_rate', session.mbps_shaper_rate ?? '—');
+            setField('session_mbps_shaper_avg', session.mbps_shaper_avg ?? '—');
+            setField('session_mbps_transfer_rate', session.mbps_transfer_rate ?? '—');
+            setField('session_mbps_transfer_complete', session.mbps_transfer_complete ?? '—');
             const counts = card.querySelector('[data-field="session_detail_counts"]');
             if (counts) {
                 const masterCount = session.master_manifest_requests_count || 0;
@@ -1659,9 +1670,7 @@ maybe a histogram of b
             return String(label || '').replace(/\s*\(V\d+\)$/, '');
         }
 
-        function isVariantSeriesLabel(label) {
-            return /^Variant V\d+$/.test(String(label || ''));
-        }
+
 
         function buildVariantLadder(variants) {
             if (!Array.isArray(variants) || !variants.length) return [];
@@ -1718,15 +1727,212 @@ maybe a histogram of b
             return `Window: ${start} → ${end}`;
         }
 
+        function pinBitrateChartToLiveEdge(chartRef) {
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return;
+            const domainMin = 0;
+            const domainMax = 600;
+            const currentMin = Number(xScale.min);
+            const currentMax = Number(xScale.max);
+            if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
+            const span = Math.max(2, Math.min(domainMax - domainMin, currentMax - currentMin));
+            const nextMax = domainMax;
+            const nextMin = Math.max(domainMin, nextMax - span);
+            if (typeof chartRef.zoomScale === 'function') {
+                chartRef.zoomScale('x', { min: nextMin, max: nextMax }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = nextMin;
+                chartRef.options.scales.x.max = nextMax;
+            }
+        }
+
+        function normalizeChartViewport(minValue, maxValue) {
+            const domainMin = 0;
+            const domainMax = 600;
+            let min = Number(minValue);
+            let max = Number(maxValue);
+            if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+            if (max < min) { const tmp = min; min = max; max = tmp; }
+            let span = max - min;
+            if (!Number.isFinite(span) || span <= 0) return { min: domainMin, max: domainMax };
+            span = Math.max(2, Math.min(domainMax - domainMin, span));
+            max = Math.min(domainMax, max);
+            min = Math.max(domainMin, max - span);
+            max = min + span;
+            if (max > domainMax) { max = domainMax; min = domainMax - span; }
+            if (min < domainMin) { min = domainMin; max = domainMin + span; }
+            return { min, max };
+        }
+
+        function readChartViewport(chartRef) {
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return null;
+            return normalizeChartViewport(xScale.min, xScale.max);
+        }
+
+        function applyChartViewport(chartRef, viewport) {
+            if (!chartRef || !viewport) return;
+            if (typeof chartRef.zoomScale === 'function') {
+                chartRef.zoomScale('x', { min: viewport.min, max: viewport.max }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = viewport.min;
+                chartRef.options.scales.x.max = viewport.max;
+            }
+        }
+
+        function applyStoredChartViewport(sessionId, chartRef) {
+            const viewport = chartViewportBySession.get(String(sessionId || ''));
+            if (!viewport) return false;
+            applyChartViewport(chartRef, viewport);
+            return true;
+        }
+
+        function getChartsForSession(sessionId) {
+            const key = String(sessionId || '');
+            return [
+                bandwidthCharts.get(key),
+                bufferDepthCharts.get(key),
+                videoFpsCharts.get(key)
+            ].filter((chartRef) => !!chartRef);
+        }
+
+        function syncChartViewportAcrossSession(sessionId, sourceChart) {
+            const key = String(sessionId || '');
+            const viewport = readChartViewport(sourceChart);
+            if (!viewport) return;
+            chartViewportBySession.set(key, viewport);
+            for (const chartRef of getChartsForSession(key)) {
+                if (!chartRef || chartRef === sourceChart) continue;
+                applyChartViewport(chartRef, viewport);
+                if (typeof chartRef.zoomScale !== 'function') {
+                    chartRef.update('none');
+                }
+            }
+        }
+
+        function buildUnifiedChartZoomOptions(sessionId) {
+            const key = String(sessionId || '');
+            return {
+                pan: {
+                    enabled: true,
+                    mode: 'x',
+                    threshold: 2,
+                    onPanComplete: ({ chart: chartRef }) => {
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                },
+                limits: {
+                    x: { min: 0, max: 600, minRange: 2 }
+                },
+                zoom: {
+                    wheel: { enabled: true },
+                    drag: {
+                        enabled: true,
+                        modifierKey: 'alt',
+                        borderColor: '#1d4ed8',
+                        borderWidth: 1,
+                        backgroundColor: 'rgba(37, 99, 235, 0.12)'
+                    },
+                    mode: 'x',
+                    onZoomComplete: ({ chart: chartRef }) => {
+                        pinBitrateChartToLiveEdge(chartRef);
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                }
+            };
+        }
+
+        let rightPanDragState = null;
+        let rightPanListenersInstalled = false;
+
+        function installRightMousePanHandlers(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.rightPanBound === '1') return;
+            canvas.dataset.rightPanBound = '1';
+            const key = String(sessionId || '');
+            canvas.addEventListener('contextmenu', (event) => { event.preventDefault(); });
+            canvas.addEventListener('mousedown', (event) => {
+                if (event.button !== 2) return;
+                event.preventDefault();
+                const viewport = readChartViewport(chartRef) || { min: 0, max: 600 };
+                rightPanDragState = { sessionId: key, sourceChart: chartRef, startClientX: event.clientX, startViewport: viewport };
+            });
+            if (rightPanListenersInstalled) return;
+            rightPanListenersInstalled = true;
+            window.addEventListener('mousemove', (event) => {
+                if (!rightPanDragState) return;
+                const sourceChart = rightPanDragState.sourceChart;
+                const chartArea = sourceChart?.chartArea;
+                if (!sourceChart || !chartArea) return;
+                const widthPx = Math.max(1, chartArea.right - chartArea.left);
+                const span = rightPanDragState.startViewport.max - rightPanDragState.startViewport.min;
+                if (!Number.isFinite(span) || span <= 0) return;
+                const deltaPx = event.clientX - rightPanDragState.startClientX;
+                const deltaValue = (deltaPx / widthPx) * span;
+                const viewport = normalizeChartViewport(
+                    rightPanDragState.startViewport.min - deltaValue,
+                    rightPanDragState.startViewport.max - deltaValue
+                );
+                if (!viewport) return;
+                chartViewportBySession.set(rightPanDragState.sessionId, viewport);
+                for (const chart of getChartsForSession(rightPanDragState.sessionId)) {
+                    applyChartViewport(chart, viewport);
+                    if (typeof chart.zoomScale !== 'function') { chart.update('none'); }
+                }
+            });
+            window.addEventListener('mouseup', (event) => {
+                if (!rightPanDragState) return;
+                if (event.button === 2) { rightPanDragState = null; }
+            });
+            window.addEventListener('blur', () => { rightPanDragState = null; });
+        }
+
+        function isChartPaused(sessionId) {
+            return chartPausedBySession.get(String(sessionId || '')) === true;
+        }
+
+        function toggleChartPause(sessionId) {
+            const key = String(sessionId || '');
+            const wasPaused = isChartPaused(key);
+            chartPausedBySession.set(key, !wasPaused);
+            if (wasPaused) { renderBandwidthChart(key); }
+        }
+
+        function installChartClickPauseHandler(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.pauseHandlerBound === '1') return;
+            canvas.dataset.pauseHandlerBound = '1';
+            let startX = 0;
+            let startY = 0;
+            canvas.addEventListener('mousedown', (e) => {
+                if (e.button !== 0) return;
+                startX = e.clientX;
+                startY = e.clientY;
+            });
+            canvas.addEventListener('click', (e) => {
+                if (e.altKey) return;
+                if (Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5) return;
+                const chartArea = chartRef.chartArea;
+                if (chartArea) {
+                    const rect = canvas.getBoundingClientRect();
+                    const cx = e.clientX - rect.left;
+                    const cy = e.clientY - rect.top;
+                    if (cx < chartArea.left || cx > chartArea.right || cy < chartArea.top || cy > chartArea.bottom) return;
+                }
+                toggleChartPause(sessionId);
+            });
+        }
+
         function pushBandwidthSample(session) {
             const now = Date.now();
             const windowMs = 10 * 60 * 1000;
-            const wireSustained = Number.isFinite(Number(session.mbps_wire_sustained)) ? Number(session.mbps_wire_sustained) : null;
-            const wireActive = Number.isFinite(Number(session.mbps_wire_active)) ? Number(session.mbps_wire_active) : null;
-            const wireSustained6s = Number.isFinite(Number(session.mbps_wire_sustained_6s)) ? Number(session.mbps_wire_sustained_6s) : null;
-            const wireActive6s = Number.isFinite(Number(session.mbps_wire_active_6s)) ? Number(session.mbps_wire_active_6s) : null;
-            const wireSustained1s = Number.isFinite(Number(session.mbps_wire_sustained_1s)) ? Number(session.mbps_wire_sustained_1s) : null;
-            const wireThroughput = Number.isFinite(Number(session.mbps_wire_throughput)) ? Number(session.mbps_wire_throughput) : null;
+            const shaperRate = Number.isFinite(Number(session.mbps_shaper_rate)) ? Number(session.mbps_shaper_rate) : null;
+            const shaperAvg = Number.isFinite(Number(session.mbps_shaper_avg)) ? Number(session.mbps_shaper_avg) : null;
+            const transferRate = session.mbps_transfer_rate != null && Number.isFinite(Number(session.mbps_transfer_rate)) ? Number(session.mbps_transfer_rate) : null;
+            const transferComplete = session.mbps_transfer_complete != null && Number.isFinite(Number(session.mbps_transfer_complete)) ? Number(session.mbps_transfer_complete) : null;
+            const metricsAtMs = session.player_metrics_event_time
+                ? Date.parse(session.player_metrics_event_time) || null
+                : null;
             const bufferDepth = Number.isFinite(Number(session.player_metrics_buffer_depth_s))
                 ? Number(session.player_metrics_buffer_depth_s)
                 : null;
@@ -1788,12 +1994,11 @@ maybe a histogram of b
             }
             series.push({
                 ts: now,
-                wireSustained,
-                wireActive,
-                wireSustained6s,
-                wireActive6s,
-                wireSustained1s,
-                wireThroughput,
+                shaperRate,
+                shaperAvg,
+                transferRate,
+                transferComplete,
+                metricsAtMs,
                 bufferDepth,
                 playerEstimate,
                 currentRendition,
@@ -1810,6 +2015,7 @@ maybe a histogram of b
         }
 
         function renderBandwidthChart(sessionId) {
+            if (isChartPaused(sessionId)) return;
             const series = bandwidthHistory.get(sessionId) || [];
             const eventSeries = bandwidthEventHistory.get(sessionId) || [];
             const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
@@ -1827,12 +2033,11 @@ maybe a histogram of b
                 .filter(point => point.ts >= windowStart)
                 .map(point => ({
                     x: (point.ts - windowStart) / 1000,
-                    wireSustained: point.wireSustained,
-                    wireActive: point.wireActive,
-                    wireSustained6s: point.wireSustained6s,
-                    wireActive6s: point.wireActive6s,
-                    wireSustained1s: point.wireSustained1s,
-                    wireThroughput: point.wireThroughput,
+                    shaperRate: point.shaperRate,
+                    shaperAvg: point.shaperAvg,
+                    transferRate: point.transferRate,
+                    transferComplete: point.transferComplete,
+                    metricsAtMs: point.metricsAtMs,
                     bufferDepth: point.bufferDepth,
                     playerEstimate: point.playerEstimate,
                     currentRendition: point.currentRendition,
@@ -1849,18 +2054,16 @@ maybe a histogram of b
                     type: event.type
                 }))
                 .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
-            const wireSustainedData = points.map(point => ({ x: point.x, y: point.wireSustained }));
-            const wireActiveData = points.map(point => ({ x: point.x, y: point.wireActive }));
-            const wireSustained6sData = points.map(point => ({ x: point.x, y: point.wireSustained6s }));
-            const wireActive6sData = points.map(point => ({ x: point.x, y: point.wireActive6s }));
-            const wireSustained1sData = points.map(point => ({ x: point.x, y: point.wireSustained1s }));
-            const wireThroughputData = points.map(point => ({ x: point.x, y: point.wireThroughput }));
+            const shaperRateData = points.map(point => ({ x: point.x, y: point.shaperRate }));
+            const shaperAvgData = points.map(point => ({ x: point.x, y: point.shaperAvg }));
+            const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));
+            const transferCompleteData = points.map(point => ({ x: point.x, y: point.transferComplete }));
             const bufferDepthData = points.map(point => ({ x: point.x, y: Number.isFinite(point.bufferDepth) ? point.bufferDepth : null }));
             const estimateData = points.map(point => ({ x: point.x, y: point.playerEstimate || null }));
             const renditionData = points.map(point => ({ x: point.x, y: point.currentRendition || null }));
             const serverRenditionData = points.map(point => ({ x: point.x, y: point.serverRendition || null }));
-            const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null }));
-            const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null }));
+            const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null, atMs: point.metricsAtMs || null }));
+            const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null, atMs: point.metricsAtMs || null }));
             const targetData = points.map(point => ({ x: point.x, y: point.target }));
 
             let variantLadder = [];
@@ -1872,35 +2075,26 @@ maybe a histogram of b
             }
 
             const visibility = bandwidthVisibility.get(sessionId) || {};
-            const variantsEnabled = bandwidthVariantsEnabledBySession.get(String(sessionId)) !== false;
-            const variantToggleButton = card.querySelector('button[data-action="toggle-variants"]');
-            if (variantToggleButton) {
-                variantToggleButton.textContent = variantsEnabled ? 'Hide Variants' : 'Show Variants';
-                variantToggleButton.setAttribute('aria-pressed', variantsEnabled ? 'true' : 'false');
-            }
             const defaultVisibleLabels = new Set([
-                'Wire Sustained (6s)',
-                'Wire Throughput',
+                'mbps_shaper_rate',
+                'mbps_shaper_avg',
+                'mbps_transfer_rate',
+                'mbps_transfer_complete',
                 'Player est.',
                 'Rendition',
                 'Server Rendition',
+                'Variants',
                 'Limit',
                 'STALL',
                 'RESTART'
             ]);
             const isSeriesHidden = (label) => {
                 const key = bandwidthSeriesKey(label);
-                if (isVariantSeriesLabel(key) && !variantsEnabled) {
-                    return true;
-                }
                 if (Object.prototype.hasOwnProperty.call(visibility, label)) {
                     return visibility[label] === true;
                 }
                 if (Object.prototype.hasOwnProperty.call(visibility, key)) {
                     return visibility[key] === true;
-                }
-                if (isVariantSeriesLabel(key)) {
-                    return false;
                 }
                 return !defaultVisibleLabels.has(key);
             };
@@ -1912,12 +2106,10 @@ maybe a histogram of b
             bitrateAxisMaxBySession.set(String(sessionId), axisMode);
             const maxFor = (hidden, data) => (hidden ? [0] : data.map(point => point.y || 0));
             const maxYAutoRaw = Math.max(1,
-                ...maxFor(isSeriesHidden('Wire Sustained (18s)'), wireSustainedData),
-                ...maxFor(isSeriesHidden('Wire Active'), wireActiveData),
-                ...maxFor(isSeriesHidden('Wire Sustained (6s)'), wireSustained6sData),
-                ...maxFor(isSeriesHidden('Wire Active (6s)'), wireActive6sData),
-                ...maxFor(isSeriesHidden('Wire Sustained (1s)'), wireSustained1sData),
-                ...maxFor(isSeriesHidden('Wire Throughput'), wireThroughputData),
+                ...maxFor(isSeriesHidden('mbps_shaper_rate'), shaperRateData),
+                ...maxFor(isSeriesHidden('mbps_shaper_avg'), shaperAvgData),
+                ...maxFor(isSeriesHidden('mbps_transfer_rate'), transferRateData),
+                ...maxFor(isSeriesHidden('mbps_transfer_complete'), transferCompleteData),
                 ...maxFor(isSeriesHidden('Player est.'), estimateData),
                 ...maxFor(isSeriesHidden('Rendition'), renditionData),
                 ...maxFor(isSeriesHidden('Server Rendition'), serverRenditionData),
@@ -1939,87 +2131,66 @@ maybe a histogram of b
             const stallMarkerData = buildEventMarkerData('STALL');
             const restartMarkerData = buildEventMarkerData('RESTART');
 
+            const variantsHidden = isSeriesHidden('Variants');
             const variantDatasets = variantLadder.map((variant, index) => {
-                const label = `Variant ${variant.vx}`;
                 return {
-                    label,
+                    label: index === 0 ? 'Variants' : `_Variant ${variant.vx}`,
                     data: points.map(point => ({ x: point.x, y: variant.mbps })),
                     borderColor: '#9ca3af',
                     backgroundColor: 'rgba(156,163,175,0.12)',
                     borderWidth: 1,
                     pointRadius: 0,
                     tension: 0,
-                    borderDash: [4, 4],
-                    hidden: isSeriesHidden(label)
+                    borderDash: index % 2 === 0 ? [2, 6] : [6, 3],
+                    hidden: variantsHidden
                 };
             });
 
             const datasets = [
                 {
-                    label: 'Wire Sustained (18s)',
-                    data: wireSustainedData,
-                    borderColor: '#0891b2',
-                    backgroundColor: 'rgba(8,145,178,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [6, 3],
-                    hidden: isSeriesHidden('Wire Sustained (18s)')
-                },
-                {
-                    label: 'Wire Active',
-                    data: wireActiveData,
+                    label: 'mbps_shaper_rate',
+                    data: shaperRateData,
                     borderColor: '#0f766e',
                     backgroundColor: 'rgba(15,118,110,0.12)',
-                    borderWidth: 1.5,
+                    borderWidth: 1.7,
                     pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [2, 4],
-                    hidden: isSeriesHidden('Wire Active')
+                    tension: 0.15,
+                    borderDash: [8, 2],
+                    hidden: isSeriesHidden('mbps_shaper_rate')
                 },
                 {
-                    label: 'Wire Sustained (6s)',
-                    data: wireSustained6sData,
-                    borderColor: '#155e75',
-                    backgroundColor: 'rgba(21,94,117,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [8, 3],
-                    hidden: isSeriesHidden('Wire Sustained (6s)')
-                },
-                {
-                    label: 'Wire Active (6s)',
-                    data: wireActive6sData,
-                    borderColor: '#115e59',
-                    backgroundColor: 'rgba(17,94,89,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [3, 5],
-                    hidden: isSeriesHidden('Wire Active (6s)')
-                },
-                {
-                    label: 'Wire Sustained (1s)',
-                    data: wireSustained1sData,
-                    borderColor: '#0e7490',
-                    backgroundColor: 'rgba(14,116,144,0.12)',
-                    borderWidth: 1.5,
-                    pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [4, 4],
-                    hidden: isSeriesHidden('Wire Sustained (1s)')
-                },
-                {
-                    label: 'Wire Throughput',
-                    data: wireThroughputData,
+                    label: 'mbps_shaper_avg',
+                    data: shaperAvgData,
                     borderColor: '#0d9488',
                     backgroundColor: 'rgba(13,148,136,0.12)',
-                    borderWidth: 1.5,
+                    borderWidth: 1.7,
                     pointRadius: 0,
-                    tension: 0.2,
-                    borderDash: [1, 3],
-                    hidden: isSeriesHidden('Wire Throughput')
+                    tension: 0.15,
+                    borderDash: [10, 3],
+                    hidden: isSeriesHidden('mbps_shaper_avg')
+                },
+                {
+                    label: 'mbps_transfer_rate',
+                    data: transferRateData,
+                    borderColor: '#f97316',
+                    backgroundColor: 'rgba(249,115,22,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [4, 2],
+                    hidden: isSeriesHidden('mbps_transfer_rate')
+                },
+                {
+                    label: 'mbps_transfer_complete',
+                    data: transferCompleteData,
+                    borderColor: '#dc2626',
+                    backgroundColor: 'rgba(220,38,38,0.15)',
+                    borderWidth: 3,
+                    pointRadius: 3,
+                    pointBackgroundColor: '#dc2626',
+                    tension: 0,
+                    stepped: 'after',
+                    hidden: isSeriesHidden('mbps_transfer_complete')
                 },
                 {
                     label: 'Player est.',
@@ -2120,7 +2291,8 @@ maybe a histogram of b
                                 position: 'bottom',
                                 labels: {
                                     color: '#6b7280',
-                                    font: { family: 'Courier New, monospace', size: 10 }
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    filter: (item) => !item.text.startsWith('_')
                                 },
                                 onClick: (evt, item, legend) => {
                                     const index = item.datasetIndex;
@@ -2129,10 +2301,30 @@ maybe a histogram of b
                                     if (!label) return;
                                     const state = bandwidthVisibility.get(sessionId) || {};
                                     const isVisible = chartRef.isDatasetVisible(index);
-                                    chartRef.setDatasetVisibility(index, !isVisible);
-                                    state[label] = isVisible;
-                                    state[bandwidthSeriesKey(label)] = isVisible;
+                                    if (label === 'Variants') {
+                                        const newVisible = !isVisible;
+                                        chartRef.data.datasets.forEach((ds, i) => {
+                                            if (ds.label === 'Variants' || (ds.label && ds.label.startsWith('_Variant'))) {
+                                                chartRef.setDatasetVisibility(i, newVisible);
+                                            }
+                                        });
+                                        state['Variants'] = !newVisible;
+                                    } else {
+                                        chartRef.setDatasetVisibility(index, !isVisible);
+                                        state[label] = isVisible;
+                                        state[bandwidthSeriesKey(label)] = isVisible;
+                                    }
                                     bandwidthVisibility.set(sessionId, state);
+                                    const currentAxisMode = normalizeBitrateAxisMaxMode(
+                                        bitrateAxisMaxBySession.get(String(sessionId)) || 'auto'
+                                    );
+                                    if (currentAxisMode === 'auto') {
+                                        const visibleMax = chartRef.data.datasets
+                                            .filter((_, i) => chartRef.isDatasetVisible(i))
+                                            .flatMap(ds => ds.data.map(pt => Number(pt.y) || 0))
+                                            .reduce((m, v) => Math.max(m, v), 1);
+                                        chartRef.options.scales.y.max = Math.min(100, Math.max(1, Math.ceil(visibleMax * 1.05 * 10) / 10));
+                                    }
                                     chartRef.update('none');
                                 }
                             },
@@ -2146,7 +2338,8 @@ maybe a histogram of b
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -2188,11 +2381,17 @@ maybe a histogram of b
                     }
                 });
                 chart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, chart);
+                installRightMousePanHandlers(sessionId, chart);
+                installChartClickPauseHandler(sessionId, chart);
                 bandwidthCharts.set(sessionId, chart);
             } else {
                 chart.data.datasets = datasets;
                 chart.data.datasets.forEach((dataset, idx) => {
-                    const hidden = isSeriesHidden(dataset.label);
+                    const label = dataset.label;
+                    const hidden = (label && label.startsWith('_Variant'))
+                        ? isSeriesHidden('Variants')
+                        : isSeriesHidden(label);
                     dataset.hidden = hidden;
                     chart.setDatasetVisibility(idx, !hidden);
                 });
@@ -2238,7 +2437,14 @@ maybe a histogram of b
                         maintainAspectRatio: false,
                         animation: false,
                         plugins: {
-                            legend: { display: false },
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
                             tooltip: {
                                 callbacks: {
                                     title: (items) => {
@@ -2249,7 +2455,8 @@ maybe a histogram of b
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -2291,6 +2498,9 @@ maybe a histogram of b
                     }
                 });
                 bufferChart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, bufferChart);
+                installRightMousePanHandlers(sessionId, bufferChart);
+                installChartClickPauseHandler(sessionId, bufferChart);
                 bufferDepthCharts.set(sessionId, bufferChart);
             } else {
                 bufferChart.data.datasets[0].data = bufferDepthData;
@@ -2304,81 +2514,59 @@ maybe a histogram of b
             const fpsChartRangeLabel = card.querySelector('[data-field="video_fps_chart_range"]');
             const fpsData = [];
             const droppedFpsDataRaw = [];
-            let fpsAnchor = null;
-            let droppedAnchor = null;
-            const minFpsWindowSeconds = 0.75;
+            const fpsWindowSeconds = 2.0;
             const maxReasonableFps = 120;
-            for (let idx = 0; idx < framesDisplayedData.length; idx += 1) {
-                const currentPoint = framesDisplayedData[idx];
-                const currentFrames = Number(currentPoint.y);
-                const currentX = Number(currentPoint.x);
-                if (!Number.isFinite(currentFrames) || !Number.isFinite(currentX)) {
-                    fpsData.push({ x: currentPoint.x, y: null });
-                    continue;
+            const buildRateSeries = (counterSeries) => {
+                const out = [];
+                for (let idx = 0; idx < counterSeries.length; idx += 1) {
+                    const currentPoint = counterSeries[idx];
+                    const currentCount = Number(currentPoint.y);
+                    const currentX = Number(currentPoint.x);
+                    if (!Number.isFinite(currentCount) || !Number.isFinite(currentX)) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const targetX = currentX - fpsWindowSeconds;
+                    let anchorPoint = null;
+                    for (let j = idx - 1; j >= 0; j -= 1) {
+                        const candidateX = Number(counterSeries[j]?.x);
+                        if (!Number.isFinite(candidateX)) continue;
+                        if (candidateX <= targetX) {
+                            anchorPoint = counterSeries[j];
+                            break;
+                        }
+                    }
+                    if (!anchorPoint) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const anchorCount = Number(anchorPoint.y);
+                    const currentMs = Number(currentPoint.atMs);
+                    const anchorMs = Number(anchorPoint.atMs);
+                    const deltaSeconds = (Number.isFinite(currentMs) && Number.isFinite(anchorMs) && currentMs > anchorMs)
+                        ? (currentMs - anchorMs) / 1000
+                        : currentX - Number(anchorPoint.x);
+                    const deltaCount = currentCount - anchorCount;
+                    if (!Number.isFinite(anchorCount) || deltaSeconds <= 0 || deltaCount < 0) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const rate = deltaCount / deltaSeconds;
+                    if (!Number.isFinite(rate) || rate < 0 || rate > maxReasonableFps) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    out.push({ x: currentPoint.x, y: rate });
                 }
-                if (!fpsAnchor) {
-                    fpsAnchor = { x: currentX, frames: currentFrames };
-                    fpsData.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                const deltaSeconds = currentX - fpsAnchor.x;
-                const deltaFrames = currentFrames - fpsAnchor.frames;
-                if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0 || deltaFrames < 0) {
-                    fpsAnchor = { x: currentX, frames: currentFrames };
-                    fpsData.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                if (deltaSeconds < minFpsWindowSeconds) {
-                    fpsData.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                const fps = deltaFrames / deltaSeconds;
-                if (!Number.isFinite(fps) || fps < 0 || fps > maxReasonableFps) {
-                    fpsAnchor = { x: currentX, frames: currentFrames };
-                    fpsData.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                fpsData.push({ x: currentPoint.x, y: fps });
-                fpsAnchor = { x: currentX, frames: currentFrames };
-            }
-            for (let idx = 0; idx < framesDroppedData.length; idx += 1) {
-                const currentPoint = framesDroppedData[idx];
-                const currentDropped = Number(currentPoint.y);
-                const currentX = Number(currentPoint.x);
-                if (!Number.isFinite(currentDropped) || !Number.isFinite(currentX)) {
-                    droppedFpsDataRaw.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                if (!droppedAnchor) {
-                    droppedAnchor = { x: currentX, frames: currentDropped };
-                    droppedFpsDataRaw.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                const deltaSeconds = currentX - droppedAnchor.x;
-                const deltaDropped = currentDropped - droppedAnchor.frames;
-                if (!Number.isFinite(deltaSeconds) || deltaSeconds <= 0 || deltaDropped < 0) {
-                    droppedAnchor = { x: currentX, frames: currentDropped };
-                    droppedFpsDataRaw.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                if (deltaSeconds < minFpsWindowSeconds) {
-                    droppedFpsDataRaw.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                const droppedFps = deltaDropped / deltaSeconds;
-                if (!Number.isFinite(droppedFps) || droppedFps < 0 || droppedFps > maxReasonableFps) {
-                    droppedAnchor = { x: currentX, frames: currentDropped };
-                    droppedFpsDataRaw.push({ x: currentPoint.x, y: null });
-                    continue;
-                }
-                droppedFpsDataRaw.push({ x: currentPoint.x, y: droppedFps });
-                droppedAnchor = { x: currentX, frames: currentDropped };
-            }
+                return out;
+            };
+            fpsData.push(...buildRateSeries(framesDisplayedData));
+            droppedFpsDataRaw.push(...buildRateSeries(framesDroppedData));
             const fpsValues = fpsData.map((point) => Number(point.y)).filter((value) => Number.isFinite(value) && value >= 0);
             const droppedFpsValues = droppedFpsDataRaw.map((point) => Number(point.y)).filter((value) => Number.isFinite(value) && value >= 0);
             const fpsSmoothedData = [];
             let smooth = null;
-            const smoothingAlpha = 0.3;
+            const smoothingAlpha = 0.15;
             for (const point of fpsData) {
                 const y = Number(point.y);
                 if (!Number.isFinite(y) || y < 0) {
@@ -2511,7 +2699,8 @@ maybe a histogram of b
                                         return formatBitrateChartAbsoluteTick(startMs, xValue);
                                     }
                                 }
-                            }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
                         scales: {
                             x: {
@@ -2569,6 +2758,9 @@ maybe a histogram of b
                     }
                 });
                 fpsChart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, fpsChart);
+                installRightMousePanHandlers(sessionId, fpsChart);
+                installChartClickPauseHandler(sessionId, fpsChart);
                 videoFpsCharts.set(sessionId, fpsChart);
             } else {
                 fpsChart.data.datasets[0].data = fpsSmoothedData;
@@ -3189,13 +3381,6 @@ maybe a histogram of b
             const card = button.closest('.session-card');
             if (!card) return;
             const sessionId = card.dataset.sessionId;
-            if (button.dataset.action === 'toggle-variants') {
-                const key = String(sessionId || '');
-                const variantsEnabled = bandwidthVariantsEnabledBySession.get(key) !== false;
-                bandwidthVariantsEnabledBySession.set(key, !variantsEnabled);
-                renderBandwidthChart(sessionId);
-                return;
-            }
             if (button.dataset.action === 'apply-pattern') {
                 scheduleShapingApply(card);
                 return;

--- a/go-proxy/Dockerfile
+++ b/go-proxy/Dockerfile
@@ -6,10 +6,12 @@ ARG VERSION=unknown
 RUN go mod init github.com/boss/go-proxy
 
 COPY . .
+
 RUN go get github.com/gorilla/mux
 RUN go get github.com/bradfitz/gomemcache/memcache
 RUN go get github.com/grafov/m3u8
 RUN go get modernc.org/sqlite@v1.29.0
+RUN go get github.com/vishvananda/netlink@v1.3.0
 
 RUN go build -ldflags "-X main.versionString=${VERSION}" -o go-proxy cmd/server/main.go
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -30,7 +30,9 @@ import (
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/gorilla/mux"
 	"github.com/grafov/m3u8"
+	"github.com/vishvananda/netlink"
 	_ "modernc.org/sqlite"
+
 )
 
 //go:embed templates/index.html
@@ -40,6 +42,50 @@ var versionString = "unknown"
 var segmentSequenceDigitsRegex = regexp.MustCompile(`\d+`)
 
 type SessionData map[string]interface{}
+
+// segmentFlightInfo tracks an active segment download for throughput measurement.
+type segmentFlightInfo struct {
+	startTime time.Time
+	id        uint64 // generation counter; markSegmentFlightEnd only fires if id matches
+}
+
+// segmentRunRecord holds the precise start/end timestamps and TC byte counter
+// values captured by awaitSocketDrain at TC-backlog transition points.
+// startTime/startBytes are set when backlog first goes non-zero (Phase 1 end).
+// endTime/endBytes are set when backlog returns to zero (Phase 2 end).
+type segmentRunRecord struct {
+	startTime  time.Time
+	startBytes int64
+	endTime    time.Time
+	endBytes   int64
+}
+
+// tcSample holds a single 10ms TC poll result from awaitSocketDrain.
+type tcSample struct {
+	at      time.Time
+	bytes   int64
+	backlog int64
+}
+
+// wireRateSample holds a byte-change-gated throughput measurement computed in
+// awaitSocketDrain. Rate is only computed when bytes change AND ≥100ms has
+// elapsed since the previous report — this eliminates HTB burst aliasing.
+type wireRateSample struct {
+	at    time.Time
+	mbps  float64
+	bytes int64 // delta bytes in this measurement window
+}
+
+// tcStatsCache holds the latest TC stats for a port, shared across concurrent
+// awaitSocketDrain goroutines. Only one netlink call is made per refresh interval.
+type tcStatsCache struct {
+	mu      sync.Mutex
+	at      time.Time
+	bytes   int64
+	backlog int64
+}
+
+
 
 // NetworkLogEntry represents a single network request/response in the session
 type NetworkLogEntry struct {
@@ -146,6 +192,22 @@ type App struct {
 	sessionsBroadcastLatest  []SessionData
 	sessionsBroadcastSeq     uint64
 	uiStateVersionSeq        uint64
+	segmentFlightMu          sync.Mutex
+	segmentFlight            map[int]segmentFlightInfo // internal port -> segment transfer info
+	segmentFlightSeq         uint64                    // atomic generation counter for flight IDs
+	segmentRunMu             sync.Mutex
+	segmentRun               map[int]segmentRunRecord // internal port -> last completed run record
+	drainActiveMu            sync.Mutex
+	drainActive              map[int]bool // per-port: true while awaitSocketDrain is running
+	tcSamplesMu              sync.Mutex
+	tcSamples                map[int][]tcSample
+	wireRateMu               sync.Mutex
+	wireRate                 map[int]wireRateSample // latest byte-change-gated rate per port
+	tcCacheMu                sync.Mutex
+	tcCache                  map[int]*tcStatsCache // per-port TC stats cache
+	transferCompleteMu           sync.Mutex
+	transferCompleteMbps         map[int]float64   // latest completed segment Mbps per port
+	transferCompleteAt           map[int]time.Time // when the drain completed
 }
 
 type ServerLoopState struct {
@@ -250,6 +312,9 @@ type PlaylistInfo struct {
 type TcTrafficManager struct {
 	interfaceName string
 	debug         bool
+	nlMu          sync.Mutex
+	nlHandle      *netlink.Handle // persistent netlink handle, created lazily
+	nlLink        netlink.Link    // resolved once from interfaceName
 }
 
 type ShapeApplyState struct {
@@ -479,11 +544,44 @@ func (t *TcTrafficManager) EnsureRootClass() error {
 	addCmd := exec.Command(
 		"tc", "class", "add", "dev", t.interfaceName, "parent", "1:",
 		"classid", "1:1", "htb", "rate", "10000mbit", "ceil", "10000mbit",
+		"burst", "16k", "cburst", "16k", "quantum", "1514",
 	)
 	if out, err := addCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("tc root class add failed: %s", strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+func htbClassParams(rateMbps float64) (burstBytes, cburstBytes, quantumBytes int) {
+	const (
+		mtuBytes            = 1514
+		minBurstBytes       = mtuBytes
+		maxBurstBytes       = 4 * 1024
+		targetBurstSeconds  = 0.004
+		mediumRateMbps      = 20.0
+		highRateMbps        = 100.0
+		mediumQuantumFactor = 2
+		highQuantumFactor   = 4
+	)
+
+	rateBps := math.Max(0, rateMbps) * 1_000_000.0
+	computedBurst := int(math.Round((rateBps / 8.0) * targetBurstSeconds))
+	if computedBurst < minBurstBytes {
+		computedBurst = minBurstBytes
+	}
+	if computedBurst > maxBurstBytes {
+		computedBurst = maxBurstBytes
+	}
+	burstBytes = computedBurst
+	cburstBytes = computedBurst
+
+	quantumBytes = mtuBytes
+	if rateMbps >= highRateMbps {
+		quantumBytes = highQuantumFactor * mtuBytes
+	} else if rateMbps >= mediumRateMbps {
+		quantumBytes = mediumQuantumFactor * mtuBytes
+	}
+	return burstBytes, cburstBytes, quantumBytes
 }
 
 func (t *TcTrafficManager) GetPortConfig(port int) (map[string]interface{}, error) {
@@ -548,23 +646,32 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)
 	classid := fmt.Sprintf("1:%s", portSuffix)
+	burstBytes, cburstBytes, quantumBytes := htbClassParams(rateMbps)
+	burstArg := fmt.Sprintf("%db", burstBytes)
+	cburstArg := fmt.Sprintf("%db", cburstBytes)
+	quantumArg := strconv.Itoa(quantumBytes)
 	changeCmd := exec.Command(
 		"tc", "class", "change", "dev", t.interfaceName, "parent", "1:1",
 		"classid", classid, "htb", "rate", fmt.Sprintf("%gmbit", rateMbps), "ceil", fmt.Sprintf("%gmbit", rateMbps),
+		"burst", burstArg, "cburst", cburstArg, "quantum", quantumArg,
 	)
 	log.Printf(
-		"NETSHAPE throughput_set ts=%s port=%d rate_mbps=%.3f action=apply classid=%s iface=%s",
+		"NETSHAPE throughput_set ts=%s port=%d rate_mbps=%.3f action=apply classid=%s iface=%s burst_bytes=%d cburst_bytes=%d quantum_bytes=%d",
 		time.Now().UTC().Format(time.RFC3339Nano),
 		port,
 		rateMbps,
 		classid,
 		t.interfaceName,
+		burstBytes,
+		cburstBytes,
+		quantumBytes,
 	)
 	if out, err := changeCmd.CombinedOutput(); err != nil {
 		log.Printf("NETSHAPE tc class change failed port=%d: %s", port, strings.TrimSpace(string(out)))
 		addCmd := exec.Command(
 			"tc", "class", "add", "dev", t.interfaceName, "parent", "1:1",
 			"classid", classid, "htb", "rate", fmt.Sprintf("%gmbit", rateMbps), "ceil", fmt.Sprintf("%gmbit", rateMbps),
+			"burst", burstArg, "cburst", cburstArg, "quantum", quantumArg,
 		)
 		if outAdd, errAdd := addCmd.CombinedOutput(); errAdd != nil {
 			return fmt.Errorf("tc class change failed: %s; add failed: %s", strings.TrimSpace(string(out)), strings.TrimSpace(string(outAdd)))
@@ -755,37 +862,82 @@ func (t *TcTrafficManager) GetNetemConfig(port int) (map[string]interface{}, err
 	return config, nil
 }
 
-func (t *TcTrafficManager) GetPortBytes(port int) (int64, error) {
-	cmd := exec.Command("tc", "-s", "class", "show", "dev", t.interfaceName, "parent", "1:1")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		cmd = exec.Command("tc", "-s", "class", "show", "dev", t.interfaceName)
-		output, err = cmd.CombinedOutput()
-		if err != nil {
-			return 0, err
-		}
+// ensureNL initialises the persistent netlink handle and resolves the interface
+// on first call. Subsequent calls are a fast mutex-check and return. The caller
+// must hold no locks.
+func (t *TcTrafficManager) ensureNL() (*netlink.Handle, netlink.Link, error) {
+	t.nlMu.Lock()
+	defer t.nlMu.Unlock()
+	if t.nlHandle != nil {
+		return t.nlHandle, t.nlLink, nil
 	}
-	portSuffix := fmt.Sprintf("%03d", port%1000)
-	classid := fmt.Sprintf("1:%s", portSuffix)
-	lines := strings.Split(string(output), "\n")
-	found := false
-	for i := 0; i < len(lines); i++ {
-		line := lines[i]
-		if strings.Contains(line, classid) && strings.Contains(line, "class htb") {
-			found = true
+	h, err := netlink.NewHandle()
+	if err != nil {
+		return nil, nil, fmt.Errorf("netlink: new handle: %w", err)
+	}
+	link, err := h.LinkByName(t.interfaceName)
+	if err != nil {
+		h.Delete()
+		return nil, nil, fmt.Errorf("netlink: link %s: %w", t.interfaceName, err)
+	}
+	t.nlHandle = h
+	t.nlLink = link
+	return h, link, nil
+}
+
+// GetPortStats returns the cumulative bytes sent and the current TC queue backlog
+// for the HTB class associated with port. Uses a persistent netlink handle
+// (no fork/exec); backlog returns -1 when queue stats are absent.
+func (t *TcTrafficManager) GetPortStats(port int) (bytes int64, backlog int64, err error) {
+	h, link, err := t.ensureNL()
+	if err != nil {
+		return 0, -1, err
+	}
+
+	// TC classids are written as "1:<portSuffix>" where portSuffix is the decimal
+	// port%1000 formatted as a string — but TC interprets the minor part as hex.
+	// e.g. port 30181 → classid "1:181" → TC reads minor as 0x181 = 385 decimal.
+	portSuffix := port % 1000
+	minorHex, _ := strconv.ParseUint(fmt.Sprintf("%03d", portSuffix), 16, 16)
+	targetHandle := netlink.MakeHandle(1, uint16(minorHex))
+
+	// Pass HANDLE_NONE (0) to dump all classes on the interface, then filter
+	// by handle. Kernel-side parent filtering in RTM_GETTCLASS|NLM_F_DUMP is
+	// unreliable across kernel versions — iproute2's tc does the same.
+	t.nlMu.Lock()
+	classes, classErr := h.ClassList(link, netlink.HANDLE_NONE)
+	t.nlMu.Unlock()
+	if classErr != nil {
+		return 0, -1, classErr
+	}
+
+	for _, class := range classes {
+		attrs := class.Attrs()
+		if attrs.Handle != targetHandle {
 			continue
 		}
-		if found {
-			bytes := parseTcBytes(line)
-			if bytes > 0 {
-				return bytes, nil
-			}
-			if strings.HasPrefix(strings.TrimSpace(line), "class") {
-				break
-			}
+		if attrs.Statistics == nil {
+			return 0, -1, nil
 		}
+		if attrs.Statistics.Basic != nil {
+			bytes = int64(attrs.Statistics.Basic.Bytes)
+		}
+		backlog = -1
+		if attrs.Statistics.Queue != nil {
+			backlog = int64(attrs.Statistics.Queue.Backlog)
+		}
+		return bytes, backlog, nil
 	}
-	return 0, nil
+	if t.debug {
+		log.Printf("NL_GET_PORT_STATS port=%d handle=0x%08x class_not_found total_classes=%d", port, targetHandle, len(classes))
+	}
+	return 0, -1, nil
+}
+
+// GetPortBytes is a convenience wrapper kept for callers that only need byte counters.
+func (t *TcTrafficManager) GetPortBytes(port int) (int64, error) {
+	b, _, err := t.GetPortStats(port)
+	return b, err
 }
 
 func rateToMbps(rateStr string) interface{} {
@@ -837,6 +989,21 @@ func parseTcBytes(line string) int64 {
 	return 0
 }
 
+// parseTcBacklog parses the TC queue backlog bytes from a line like:
+//
+//	rate 1.99Mbit 123pps backlog 45678b 20p requeues 0
+//
+// Returns -1 if the pattern is not found (so callers can distinguish zero-backlog from absent).
+func parseTcBacklog(line string) int64 {
+	re := regexp.MustCompile(`backlog\s+(\d+)b`)
+	match := re.FindStringSubmatch(line)
+	if len(match) == 2 {
+		val, _ := strconv.ParseInt(match[1], 10, 64)
+		return val
+	}
+	return -1
+}
+
 func loadPortMapping() PortMapping {
 	externalBase := getenvIntAny([]string{"EXTERNAL_PORT_BASE"}, 0)
 	internalBase := getenvIntAny([]string{"INTERNAL_PORT_BASE"}, 0)
@@ -882,18 +1049,19 @@ func (m PortMapping) MapExternalPort(port string) (string, bool) {
 }
 
 func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 	memcachedAddr := getenv("MEMCACHED_ADDR", "memcached:11211")
 	upstreamHost := getenvAny([]string{"INFINITE_STREAM_UPSTREAM_HOST", "INFINITE_UPSTREAM_HOST", "BOSS_UPSTREAM_HOST"}, "go-server")
 	upstreamPort := getenvAny([]string{"INFINITE_STREAM_UPSTREAM_PORT", "INFINITE_UPSTREAM_PORT", "BOSS_UPSTREAM_PORT"}, "30000")
 	maxSessions := getenvIntAny([]string{"INFINITE_STREAM_MAX_SESSIONS", "INFINITE_MAX_SESSIONS", "BOSS_MAX_SESSIONS"}, 8)
 	interfaceName := getenvAny([]string{"INFINITE_STREAM_TC_INTERFACE", "INFINITE_TC_INTERFACE", "TC_INTERFACE"}, "eth0")
 	tcDebug := getenvBoolAny([]string{"INFINITE_STREAM_TC_DEBUG", "INFINITE_TC_DEBUG", "TC_DEBUG"}, false)
-
 	mc := memcache.New(memcachedAddr)
 	eventStore, eventStoreErr := newSessionEventStore(getenv("GO_PROXY_SESSION_EVENTS_DB", defaultSessionEventsDB))
 	if eventStoreErr != nil {
 		log.Printf("session event store disabled: %v", eventStoreErr)
 	}
+
 	app := &App{
 		memcache:      mc,
 		sessionEvents: eventStore,
@@ -915,6 +1083,14 @@ func main() {
 		sessionsHub:        NewSessionEventHub(),
 		networkLogs:        map[string]*NetworkLogRingBuffer{},
 		loopStateBySession: map[string]ServerLoopState{},
+		segmentFlight:      map[int]segmentFlightInfo{},
+		segmentRun:         map[int]segmentRunRecord{},
+		drainActive:        map[int]bool{},
+		tcSamples:          map[int][]tcSample{},
+		wireRate:            map[int]wireRateSample{},
+		tcCache:             map[int]*tcStatsCache{},
+		transferCompleteMbps:    map[int]float64{},
+		transferCompleteAt:      map[int]time.Time{},
 	}
 
 	go app.trackPortThroughput()
@@ -959,7 +1135,11 @@ func main() {
 		addr := fmt.Sprintf(":%d", port)
 		go func(bind string) {
 			log.Printf("go-proxy listening on %s", bind)
-			errorCh <- http.ListenAndServe(bind, router)
+			srv := &http.Server{
+				Addr:    bind,
+				Handler: router,
+			}
+			errorCh <- srv.ListenAndServe()
 		}(addr)
 	}
 
@@ -1159,10 +1339,11 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 	}
 	shapeRateFields := []string{"nftables_bandwidth_mbps", "nftables_delay_ms", "nftables_packet_loss"}
 	shapeRateUpdated := false
+	shapeFieldsPresent := make([]string, 0, len(shapeRateFields))
 	for _, key := range shapeRateFields {
 		if _, ok := payload[key]; ok {
 			shapeRateUpdated = true
-			break
+			shapeFieldsPresent = append(shapeFieldsPresent, key)
 		}
 	}
 
@@ -1227,6 +1408,11 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 	shapeCommandSource := "session_patch"
 	if shapeRateUpdated && getBool(target, "abrchar_run_lock") {
 		shapeCommandSource = "abrchar"
+	}
+	if !shapeRateUpdated {
+		log.Printf("SESSION_LIMIT_SKIP source=%s session_id=%s reason=shape_fields_missing expected=%s", shapeCommandSource, id, strings.Join(shapeRateFields, ","))
+	} else {
+		log.Printf("SESSION_LIMIT_UPDATE source=%s session_id=%s shape_fields_present=%s", shapeCommandSource, id, strings.Join(shapeFieldsPresent, ","))
 	}
 	for _, prefix := range []string{"segment", "manifest", "master_manifest"} {
 		typeKey := prefix + "_failure_type"
@@ -1423,19 +1609,29 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 	}
 	if shapeRateUpdated {
 		portsApplied := map[int]struct{}{}
+		skippedNil := 0
+		skippedNoPort := 0
+		skippedInvalidPort := 0
+		skippedDuplicatePort := 0
 		for _, session := range updatedSessions {
 			if session == nil {
+				skippedNil++
 				continue
 			}
 			portStr := getString(session, "x_forwarded_port")
 			if portStr == "" {
+				skippedNoPort++
+				log.Printf("SESSION_LIMIT_SKIP source=%s session_id=%s reason=missing_x_forwarded_port", shapeCommandSource, getString(session, "session_id"))
 				continue
 			}
 			portNum, err := strconv.Atoi(portStr)
 			if err != nil {
+				skippedInvalidPort++
+				log.Printf("SESSION_LIMIT_SKIP source=%s session_id=%s reason=invalid_x_forwarded_port value=%q", shapeCommandSource, getString(session, "session_id"), portStr)
 				continue
 			}
 			if _, exists := portsApplied[portNum]; exists {
+				skippedDuplicatePort++
 				continue
 			}
 			portsApplied[portNum] = struct{}{}
@@ -1456,6 +1652,17 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 			}
 			a.applySessionShaping(session, portNum)
 		}
+		log.Printf(
+			"SESSION_LIMIT_DISPATCH source=%s session_id=%s updated_sessions=%d applied_ports=%d skipped_nil=%d skipped_missing_port=%d skipped_invalid_port=%d skipped_duplicate_port=%d",
+			shapeCommandSource,
+			id,
+			len(updatedSessions),
+			len(portsApplied),
+			skippedNil,
+			skippedNoPort,
+			skippedInvalidPort,
+			skippedDuplicatePort,
+		)
 	}
 	return target, http.StatusOK, ""
 }
@@ -3367,6 +3574,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	upstreamURL := fmt.Sprintf("http://%s:%s/%s", a.upstreamHost, a.upstreamPort, escapedPath)
 	contentType, isMasterManifest, isManifest, isSegment, playlistInfo := a.getContentType(upstreamURL)
 	requestKind := requestKindLabel(isSegment, isManifest, isMasterManifest)
+	segmentTransferStartedAt := time.Time{}
+	segmentTransferStartBytes := int64(0)
+	var flightPortNum int
+	if isSegment {
+		segmentTransferStartedAt = time.Now()
+		segmentTransferStartBytes, _ = a.getSessionWireTCBytesNow(sessionData)
+		if fp, err := strconv.Atoi(internalPort); err == nil {
+			flightPortNum = fp
+			log.Printf("SEGMENT_FLIGHT_INIT port=%d internalPort=%s externalPort=%s", fp, internalPort, externalPort)
+		}
+	}
 
 	if isMasterManifest {
 		sessionData["master_manifest_url"] = filename
@@ -3472,6 +3690,9 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			bumpFaultCounter(sessionData, failureType)
 			logFaultEvent(sessionData, externalPort, failureType, requestKind, actionTaken)
 			updateSessionTraffic(sessionData, requestBytes, bytesOut)
+			if isSegment {
+				a.applyFullSegmentNetworkBitrate(sessionData, segmentTransferStartBytes, segmentTransferStartedAt)
+			}
 			// Log network entry for corruption (has timing + bytes transferred, but zeroed)
 			sessionID := getString(sessionData, "session_id")
 			netEntry.RequestKind = requestKind
@@ -3664,9 +3885,19 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 		bytesOut, _ = io.Copy(writer, resp.Body)
 		_ = writer.Flush()
+		// On the segment success path, hand flight-end off to the socket drain goroutine
+		// so it waits for the TC backlog to drain before marking the flight as done.
+		// Only launch on Linux where a.traffic is available (TC backlog polling requires TC).
+		if flightPortNum > 0 && a.traffic != nil {
+			port := flightPortNum
+			go a.awaitSocketDrain(port)
+		}
 	}
 
 	updateSessionTraffic(sessionData, requestBytes, bytesOut)
+	if isSegment {
+		a.applyFullSegmentNetworkBitrate(sessionData, segmentTransferStartBytes, segmentTransferStartedAt)
+	}
 	// Log successful network entry
 	sessionID := getString(sessionData, "session_id")
 	netEntry.RequestKind = requestKind
@@ -3789,10 +4020,12 @@ func manipulateDASHManifest(body []byte, stripCodecs bool, allowedVariants []str
 
 func (a *App) applySessionShaping(session SessionData, port int) {
 	if a.traffic == nil || runtime.GOOS != "linux" {
+		log.Printf("NETSHAPE apply skipped port=%d reason=traffic_unavailable_or_non_linux runtime=%s traffic_nil=%t", port, runtime.GOOS, a.traffic == nil)
 		return
 	}
 	if getBool(session, "nftables_pattern_enabled") || sessionHasPatternSteps(session) {
 		// Pattern loop owns the rate while enabled; avoid per-request overrides.
+		log.Printf("NETSHAPE apply skipped port=%d reason=pattern_enabled pattern_enabled=%t pattern_steps=%t", port, getBool(session, "nftables_pattern_enabled"), sessionHasPatternSteps(session))
 		return
 	}
 	rate := getFloat(session, "nftables_bandwidth_mbps")
@@ -3838,9 +4071,11 @@ func (a *App) applyShapeIfChanged(port int, rate float64, delay int, loss float6
 	desired := ShapeApplyState{rate: rate, delay: delay, loss: loss}
 	last, ok := a.getShapeApplyState(port)
 	if ok && almostEqualShape(last, desired) {
+		log.Printf("NETSHAPE apply skipped port=%d reason=unchanged rate_mbps=%.3f delay_ms=%d loss_pct=%.3f", port, rate, delay, loss)
 		return nil
 	}
 	if rate == 0 && delay == 0 && loss == 0 {
+		log.Printf("NETSHAPE apply clear port=%d", port)
 		if err := a.traffic.UpdateRateLimit(port, 0); err != nil {
 			return err
 		}
@@ -3849,6 +4084,7 @@ func (a *App) applyShapeIfChanged(port int, rate float64, delay int, loss float6
 	}
 	rateChanged := !ok || math.Abs(last.rate-rate) > eps
 	if rateChanged {
+		log.Printf("NETSHAPE apply rate_change port=%d from_mbps=%.3f to_mbps=%.3f", port, last.rate, rate)
 		if err := a.traffic.UpdateRateLimit(port, rate); err != nil {
 			return err
 		}
@@ -3856,6 +4092,7 @@ func (a *App) applyShapeIfChanged(port int, rate float64, delay int, loss float6
 	delayChanged := !ok || last.delay != delay
 	lossChanged := !ok || math.Abs(last.loss-loss) > eps
 	if delayChanged || lossChanged {
+		log.Printf("NETSHAPE apply netem_change port=%d from_delay_ms=%d to_delay_ms=%d from_loss_pct=%.3f to_loss_pct=%.3f", port, last.delay, delay, last.loss, loss)
 		if err := a.traffic.UpdateNetem(port, delay, loss); err != nil {
 			return err
 		}
@@ -3945,40 +4182,46 @@ func (a *App) getContentType(target string) (string, bool, bool, bool, []Playlis
 
 func (a *App) trackPortThroughput() {
 	type throughputSample struct {
-		at         time.Time
-		deltaBytes int64
-		dtSeconds  float64
-		active     bool
+		at            time.Time
+		deltaBytes    int64
+		dtSeconds     float64
+		active        bool
+		inFlight      bool
+		backlogActive bool // true when TC queue backlog > 0 (active segment transfer)
 	}
-	type throughputValueSample struct {
-		at    time.Time
-		value float64
+	type a1sSample struct {
+		at   time.Time
+		mbps float64
 	}
 	type throughputState struct {
-		bytes          int64
-		timestamp      time.Time
-		samples        []throughputSample
-		active1sValues []throughputValueSample
+		bytes                int64
+		timestamp            time.Time
+		samples              []throughputSample
+		a1sHistory           []a1sSample // rolling buffer of a1s values for a6s averaging
 	}
 	const (
 		sampleInterval      = 100 * time.Millisecond
-		activeWindow        = 18 * time.Second
-		mediumWindow        = 6 * time.Second
 		shortWindow         = 1 * time.Second
-		activeByteThreshold = int64(1024)
-		minActiveSeconds    = 1.0
+		mediumWindow        = 6 * time.Second
+		transferRateWindow   = 400 * time.Millisecond
+		activeByteThreshold = int64(8192)
 	)
 	cache := map[int]throughputState{}
 	counterReady := map[int]bool{}
 	activePorts := map[int]struct{}{}
 	lastPortsRefresh := time.Time{}
-	updatePort := func(port int, bytesValue int64, now time.Time) {
+	updatePort := func(port int, bytesValue int64, backlogBytes int64, now time.Time) {
 		if bytesValue <= 0 {
 			return
 		}
 		state, ok := cache[port]
 		if !ok || state.timestamp.IsZero() {
-			cache[port] = throughputState{bytes: bytesValue, timestamp: now, samples: state.samples, active1sValues: state.active1sValues}
+			cache[port] = throughputState{
+				bytes:                bytesValue,
+				timestamp:            now,
+				samples:              state.samples,
+				a1sHistory:           state.a1sHistory,
+			}
 			return
 		}
 		deltaBytes := bytesValue - state.bytes
@@ -3989,189 +4232,150 @@ func (a *App) trackPortThroughput() {
 			cache[port] = state
 			return
 		}
+		flightInfo, inFlight := a.getSegmentFlightInfo(port)
+		flightStart := flightInfo.startTime
+		backlogActive := backlogBytes > 0
+		if inFlight {
+			log.Printf("SEGMENT_INFLIGHT port=%d age_ms=%d tc_backlog_bytes=%d backlog_active=%t", port, now.Sub(flightStart).Milliseconds(), backlogBytes, backlogActive)
+		}
+		// Sample TC queue backlog for mbps_video_app (TC drain rate).
 		sample := throughputSample{
-			at:         now,
-			deltaBytes: deltaBytes,
-			dtSeconds:  deltaSeconds,
-			active:     deltaBytes > activeByteThreshold,
+			at:            now,
+			deltaBytes:    deltaBytes,
+			dtSeconds:     deltaSeconds,
+			active:        deltaBytes > activeByteThreshold,
+			inFlight:      inFlight,
+			backlogActive: backlogActive,
 		}
 		state.samples = append(state.samples, sample)
-		cutoff := now.Add(-activeWindow)
+		// Trim samples older than 6s (needed for adjacentBacklogActiveRate).
 		mediumCutoff := now.Add(-mediumWindow)
 		shortCutoff := now.Add(-shortWindow)
-		trimmed := make([]throughputSample, 0, len(state.samples))
-		var totalBytes int64
-		var activeBytes int64
-		var mediumTotalBytes int64
-		var mediumActiveBytes int64
-		var shortTotalBytes int64
-		var shortActiveBytes int64
-		totalSeconds := 0.0
-		activeSeconds := 0.0
-		mediumTotalSeconds := 0.0
-		mediumActiveSeconds := 0.0
-		shortTotalSeconds := 0.0
-		shortActiveSeconds := 0.0
-		for _, existing := range state.samples {
-			if existing.at.Before(cutoff) {
-				continue
-			}
-			trimmed = append(trimmed, existing)
-			if existing.deltaBytes > 0 {
-				totalBytes += existing.deltaBytes
-			}
-			if existing.dtSeconds > 0 {
-				totalSeconds += existing.dtSeconds
-			}
-			if existing.active {
-				if existing.deltaBytes > 0 {
-					activeBytes += existing.deltaBytes
-				}
-				if existing.dtSeconds > 0 {
-					activeSeconds += existing.dtSeconds
+		{
+			trimmed := state.samples[:0]
+			for _, s := range state.samples {
+				if !s.at.Before(mediumCutoff) {
+					trimmed = append(trimmed, s)
 				}
 			}
-			if !existing.at.Before(mediumCutoff) {
-				if existing.deltaBytes > 0 {
-					mediumTotalBytes += existing.deltaBytes
-				}
-				if existing.dtSeconds > 0 {
-					mediumTotalSeconds += existing.dtSeconds
-				}
-				if existing.active {
-					if existing.deltaBytes > 0 {
-						mediumActiveBytes += existing.deltaBytes
-					}
-					if existing.dtSeconds > 0 {
-						mediumActiveSeconds += existing.dtSeconds
-					}
-				}
-			}
-			if !existing.at.Before(shortCutoff) {
-				if existing.deltaBytes > 0 {
-					shortTotalBytes += existing.deltaBytes
-				}
-				if existing.dtSeconds > 0 {
-					shortTotalSeconds += existing.dtSeconds
-				}
-				if existing.active {
-					if existing.deltaBytes > 0 {
-						shortActiveBytes += existing.deltaBytes
-					}
-					if existing.dtSeconds > 0 {
-						shortActiveSeconds += existing.dtSeconds
-					}
-				}
-			}
+			state.samples = trimmed
 		}
-		state.samples = trimmed
+		// adjacentBacklogActiveRate computes throughput over the most recent contiguous
+		// run of samples where backlogActive==true (TC queue had queued bytes).
+		adjacentBacklogActiveRate := func(samples []throughputSample, cutoff time.Time) (float64, bool) {
+			var runBytes int64
+			runSeconds := 0.0
+			inRun := false
+			for idx := len(samples) - 1; idx >= 0; idx-- {
+				existing := samples[idx]
+				if existing.at.Before(cutoff) {
+					break
+				}
+				if !inRun {
+					if !existing.backlogActive {
+						continue
+					}
+					inRun = true
+				}
+				if !existing.backlogActive {
+					break
+				}
+				if existing.deltaBytes > 0 {
+					runBytes += existing.deltaBytes
+				}
+				if existing.dtSeconds > 0 {
+					runSeconds += existing.dtSeconds
+				}
+			}
+			if !inRun || runSeconds <= 0 {
+				return 0, false
+			}
+			return (float64(runBytes) * 8) / (runSeconds * 1024 * 1024), true
+		}
+		adjacent1sRate, hasAdjacent1s := adjacentBacklogActiveRate(state.samples, shortCutoff)
 
-		mbpsSustained := 0.0
-		if totalSeconds > 0 {
-			mbpsSustained = (float64(totalBytes) * 8) / (totalSeconds * 1024 * 1024)
-		}
-		mbpsSustained1s := 0.0
-		if shortTotalSeconds > 0 {
-			mbpsSustained1s = (float64(shortTotalBytes) * 8) / (shortTotalSeconds * 1024 * 1024)
-		}
-		mbpsSustained6s := 0.0
-		if mediumTotalSeconds > 0 {
-			mbpsSustained6s = (float64(mediumTotalBytes) * 8) / (mediumTotalSeconds * 1024 * 1024)
-		}
-		var mbpsActive interface{}
-		if activeSeconds >= minActiveSeconds {
-			mbpsActive = math.Round((((float64(activeBytes) * 8) / (activeSeconds * 1024 * 1024)) * 100)) / 100
+		var mbpsShaperRate interface{}
+		if backlogActive && hasAdjacent1s {
+			mbpsShaperRate = math.Round((adjacent1sRate * 100)) / 100
 		} else {
-			mbpsActive = nil
+			mbpsShaperRate = nil
 		}
-		var mbpsActive1s interface{}
-		currentActive1s := 0.0
-		hasCurrentActive1s := false
-		if shortActiveSeconds > 0 {
-			currentActive1s = (float64(shortActiveBytes) * 8) / (shortActiveSeconds * 1024 * 1024)
-			hasCurrentActive1s = true
-			mbpsActive1s = math.Round((currentActive1s * 100)) / 100
-		} else {
-			mbpsActive1s = nil
+		// Record non-nil a1s values and compute a6s as their rolling average over 6s.
+		if v, ok := mbpsShaperRate.(float64); ok {
+			state.a1sHistory = append(state.a1sHistory, a1sSample{at: now, mbps: v})
 		}
-		if hasCurrentActive1s {
-			state.active1sValues = append(state.active1sValues, throughputValueSample{at: now, value: currentActive1s})
-		}
-		throughputCutoff := now.Add(-mediumWindow)
-		trimmedActive1sValues := make([]throughputValueSample, 0, len(state.active1sValues))
-		maxActive1s := -1.0
-		for _, valueSample := range state.active1sValues {
-			if valueSample.at.Before(throughputCutoff) {
-				continue
+		{
+			trimmed := state.a1sHistory[:0]
+			for _, s := range state.a1sHistory {
+				if !s.at.Before(mediumCutoff) {
+					trimmed = append(trimmed, s)
+				}
 			}
-			trimmedActive1sValues = append(trimmedActive1sValues, valueSample)
-			if valueSample.value > maxActive1s {
-				maxActive1s = valueSample.value
+			state.a1sHistory = trimmed
+		}
+		var mbpsShaperAvg interface{}
+		if len(state.a1sHistory) > 0 {
+			sum := 0.0
+			for _, s := range state.a1sHistory {
+				sum += s.mbps
+			}
+			mbpsShaperAvg = math.Round((sum/float64(len(state.a1sHistory)))*100) / 100
+		}
+		// mbps_transfer_rate: byte-change-gated rate computed in awaitSocketDrain.
+		// Rate is only emitted when TC bytes change AND ≥100ms since previous
+		// report, eliminating HTB burst aliasing.
+		var mbpsTransferRate interface{}
+		{
+			a.wireRateMu.Lock()
+			wr, ok := a.wireRate[port]
+			a.wireRateMu.Unlock()
+			if ok && now.Sub(wr.at) < transferRateWindow {
+				mbpsTransferRate = wr.mbps
 			}
 		}
-		state.active1sValues = trimmedActive1sValues
-		var mbpsWireThroughput interface{}
-		if maxActive1s >= 0 {
-			mbpsWireThroughput = math.Round((maxActive1s * 100)) / 100
-		} else {
-			mbpsWireThroughput = nil
+		// mbps_transfer_complete: completed-segment bitrate from SOCKET_DRAIN_DONE.
+		// Emitted for one SSE tick after each drain completes.
+		var mbpsTransferComplete interface{}
+		{
+			a.transferCompleteMu.Lock()
+			drainMbps, ok := a.transferCompleteMbps[port]
+			drainAt, _ := a.transferCompleteAt[port]
+			a.transferCompleteMu.Unlock()
+			// Only emit if the drain completed within the last SSE tick (~100ms).
+			if ok && now.Sub(drainAt) < 2*sampleInterval {
+				mbpsTransferComplete = drainMbps
+			}
 		}
-		var mbpsActive6s interface{}
-		if mediumActiveSeconds > 0 {
-			mbpsActive6s = math.Round((((float64(mediumActiveBytes) * 8) / (mediumActiveSeconds * 1024 * 1024)) * 100)) / 100
-		} else {
-			mbpsActive6s = nil
-		}
+
+
+
+
 		cache[port] = state
 		payload := map[string]interface{}{
-			"mbps":                       math.Round(mbpsSustained*100) / 100,
-			"bytes":                      deltaBytes,
-			"window_seconds":             math.Round(totalSeconds*100) / 100,
-			"timestamp":                  now.Unix(),
-			"mbps_wire_sustained":        math.Round(mbpsSustained*100) / 100,
-			"mbps_wire_sustained_18s":    math.Round(mbpsSustained*100) / 100,
-			"mbps_wire_active":           mbpsActive,
-			"mbps_wire_active_1s":        mbpsActive1s,
-			"mbps_wire_throughput":       mbpsWireThroughput,
-			"mbps_wire_sustained_1s":     math.Round(mbpsSustained1s*100) / 100,
-			"mbps_wire_sustained_6s":     math.Round(mbpsSustained6s*100) / 100,
-			"mbps_wire_active_6s":        mbpsActive6s,
-			"wire_active_bytes":          activeBytes,
-			"wire_total_bytes":           totalBytes,
-			"wire_active_window_seconds": math.Round(activeSeconds*100) / 100,
-			"wire_window_seconds":        math.Round(totalSeconds*100) / 100,
+			"bytes":                       deltaBytes,
+			"wire_tc_bytes_now":           bytesValue,
+			"timestamp":                   now.Unix(),
+			"timestamp_ms":                now.UnixMilli(),
+			"mbps_shaper_rate":               mbpsShaperRate,
+			"mbps_shaper_avg":               mbpsShaperAvg,
+			"mbps_transfer_rate":           mbpsTransferRate,
+			"mbps_transfer_complete":          mbpsTransferComplete,
 		}
 		if bytes, err := json.Marshal(payload); err == nil {
 			_ = a.memcache.Set(&memcache.Item{Key: fmt.Sprintf("throughput_%d", port), Value: bytes, Expiration: 30})
 		}
 		log.Printf(
-			"WIRE_TC_METRIC port=%d bytes_now=%d delta_bytes=%d dt_s=%.3f active=%t active_threshold_bytes=%d wire_total_bytes=%d wire_active_bytes=%d wire_window_s=%.3f wire_active_window_s=%.3f mbps_wire_sustained=%.2f mbps_wire_active=%v mbps_wire_sustained_6s=%.2f mbps_wire_active_6s=%v wire_window_6s_s=%.3f wire_active_window_6s_s=%.3f mbps_wire_sustained_1s=%.2f mbps_wire_active_1s=%v mbps_wire_throughput=%v wire_window_1s_s=%.3f wire_active_window_1s_s=%.3f",
+			"WIRE_TC_METRIC port=%d bytes_now=%d delta_bytes=%d dt_s=%.3f active=%t",
 			port,
 			bytesValue,
 			deltaBytes,
 			deltaSeconds,
 			sample.active,
-			activeByteThreshold,
-			totalBytes,
-			activeBytes,
-			totalSeconds,
-			activeSeconds,
-			math.Round(mbpsSustained*100)/100,
-			mbpsActive,
-			math.Round(mbpsSustained6s*100)/100,
-			mbpsActive6s,
-			mediumTotalSeconds,
-			mediumActiveSeconds,
-			math.Round(mbpsSustained1s*100)/100,
-			mbpsActive1s,
-			mbpsWireThroughput,
-			shortTotalSeconds,
-			shortActiveSeconds,
 		)
 	}
 	for {
-		now := time.Now()
-		if lastPortsRefresh.IsZero() || now.Sub(lastPortsRefresh) >= time.Second {
+		tickNow := time.Now()
+		if lastPortsRefresh.IsZero() || tickNow.Sub(lastPortsRefresh) >= time.Second {
 			sessions := a.getSessionList()
 			refreshed := map[int]struct{}{}
 			addPort := func(portStr string) {
@@ -4183,11 +4387,17 @@ func (a *App) trackPortThroughput() {
 				}
 			}
 			for _, session := range sessions {
-				addPort(getString(session, "x_forwarded_port_external"))
 				addPort(getString(session, "x_forwarded_port"))
 			}
+			// Clear state for ports that are no longer active.
+			for port := range cache {
+				if _, ok := refreshed[port]; !ok {
+					delete(cache, port)
+					delete(counterReady, port)
+				}
+			}
 			activePorts = refreshed
-			lastPortsRefresh = now
+			lastPortsRefresh = tickNow
 		}
 		if len(activePorts) == 0 {
 			time.Sleep(sampleInterval)
@@ -4198,17 +4408,19 @@ func (a *App) trackPortThroughput() {
 				if !counterReady[port] {
 					if err := a.traffic.EnsureClass(port, 10000); err != nil {
 						log.Printf("WIRE_TC_METRIC port=%d counter_ready=false ensure_class_err=%v", port, err)
+						delete(cache, port) // clear stale state (a1sHistory etc.)
 						continue
 					}
 					counterReady[port] = true
 					log.Printf("WIRE_TC_METRIC port=%d counter_ready=true mode=unlimited_counter", port)
 				}
-				bytesValue, err := a.traffic.GetPortBytes(port)
+				bytesValue, backlogBytes, err := a.traffic.GetPortStats(port)
 				if err != nil {
 					log.Printf("WIRE_TC_METRIC port=%d counter_read_err=%v", port, err)
 					continue
 				}
-				updatePort(port, bytesValue, now)
+				sampleNow := time.Now()
+				updatePort(port, bytesValue, backlogBytes, sampleNow)
 			}
 			time.Sleep(sampleInterval)
 			continue
@@ -4219,7 +4431,8 @@ func (a *App) trackPortThroughput() {
 			bytesValue := parseNftBytes(string(output))
 			if bytesValue >= 0 {
 				for port := range activePorts {
-					updatePort(port, bytesValue, now)
+					sampleNow := time.Now()
+					updatePort(port, bytesValue, -1, sampleNow) // no backlog info on non-Linux path
 				}
 			}
 		}
@@ -4693,39 +4906,337 @@ func applySessionThroughput(session SessionData, throughput map[string]interface
 	}
 	session["measured_mbps"] = throughput["mbps"]
 	session["measured_bytes"] = throughput["bytes"]
+	session["wire_tc_bytes_now"] = throughput["wire_tc_bytes_now"]
 	session["measurement_window"] = throughput["window_seconds"]
-	session["mbps_wire_sustained"] = throughput["mbps_wire_sustained"]
-	session["mbps_wire_sustained_18s"] = throughput["mbps_wire_sustained_18s"]
-	session["mbps_wire_active"] = throughput["mbps_wire_active"]
-	session["mbps_wire_active_1s"] = throughput["mbps_wire_active_1s"]
-	session["mbps_wire_throughput"] = throughput["mbps_wire_throughput"]
-	session["mbps_wire_sustained_1s"] = throughput["mbps_wire_sustained_1s"]
-	session["mbps_wire_sustained_6s"] = throughput["mbps_wire_sustained_6s"]
-	session["mbps_wire_active_6s"] = throughput["mbps_wire_active_6s"]
+	session["mbps_shaper_rate"] = throughput["mbps_shaper_rate"]
+	session["mbps_shaper_avg"] = throughput["mbps_shaper_avg"]
+	session["mbps_transfer_rate"] = throughput["mbps_transfer_rate"]
+	session["mbps_transfer_complete"] = throughput["mbps_transfer_complete"]
 	session["wire_active_bytes"] = throughput["wire_active_bytes"]
 	session["wire_total_bytes"] = throughput["wire_total_bytes"]
 	session["wire_active_window_seconds"] = throughput["wire_active_window_seconds"]
 	session["wire_window_seconds"] = throughput["wire_window_seconds"]
 }
 
+func (a *App) getSessionWireTCBytesNow(session SessionData) (int64, int64) {
+	throughput := a.getSessionThroughput(session)
+	if throughput == nil {
+		return 0, 0
+	}
+	return int64FromInterface(throughput["wire_tc_bytes_now"]), int64FromInterface(throughput["timestamp_ms"])
+}
+
+func (a *App) markSegmentFlightStart(port int) uint64 {
+	id := atomic.AddUint64(&a.segmentFlightSeq, 1)
+	a.segmentFlightMu.Lock()
+	a.segmentFlight[port] = segmentFlightInfo{startTime: time.Now(), id: id}
+	a.segmentFlightMu.Unlock()
+	log.Printf("SEGMENT_FLIGHT_START port=%d id=%d", port, id)
+	return id
+}
+
+func (a *App) markSegmentFlightEnd(port int, id uint64) {
+	a.segmentFlightMu.Lock()
+	if info, ok := a.segmentFlight[port]; ok && info.id == id {
+		delete(a.segmentFlight, port)
+		log.Printf("SEGMENT_FLIGHT_END port=%d id=%d", port, id)
+	} else if ok {
+		log.Printf("SEGMENT_FLIGHT_END_SKIP port=%d id=%d current_id=%d (stale goroutine)", port, id, info.id)
+	}
+	a.segmentFlightMu.Unlock()
+}
+
+// getPortStatsForDrain returns (bytes, backlog, active, err) for a port.
+//
+// When eBPF stats are available it reads the BPF map (no subprocess).
+// When eBPF is unavailable it falls back to netlink TC stats.
+// active is derived from backlog > 0 (TC) or eBPF activeTTL.
+const tcCacheTTL = 5 * time.Millisecond
+
+func (a *App) getPortStatsForDrain(port int) (bytes int64, backlog int64, active bool, err error) {
+	// Use per-port cache to avoid duplicate netlink calls from concurrent goroutines.
+	a.tcCacheMu.Lock()
+	cache := a.tcCache[port]
+	if cache == nil {
+		cache = &tcStatsCache{}
+		a.tcCache[port] = cache
+	}
+	a.tcCacheMu.Unlock()
+
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if time.Since(cache.at) < tcCacheTTL {
+		return cache.bytes, cache.backlog, cache.backlog > 0, nil
+	}
+	b, bl, tcErr := a.traffic.GetPortStats(port)
+	if tcErr != nil {
+		return 0, 0, false, tcErr
+	}
+	cache.bytes = b
+	cache.backlog = bl
+	cache.at = time.Now()
+	return b, bl, bl > 0, nil
+}
+
+// awaitSocketDrain tracks a segment transfer lifecycle via TC queue / eBPF byte counters.
+//
+// Phase 0 (5ms poll): confirms port is idle (backlog=0 / bytes stable) before watching.
+// Phase 1 (5ms poll): waits for 0→active transition; fires SEGMENT_FLIGHT_START.
+// Phase 2 (10ms poll): accumulates tcSamples; fires SEGMENT_FLIGHT_END when idle.
+//
+// tcSamples.backlog is set to 1 when bytes changed vs the previous poll, 0 when
+// stable. This makes the mbps_transfer_rate backwards walk break precisely at the
+// point bytes stopped incrementing — more accurate than TC backlog which can
+// reflect queued-but-not-yet-sent data.
+func (a *App) awaitSocketDrain(port int) {
+	if a.traffic == nil {
+		return
+	}
+	// Only one drain goroutine per port at a time.
+	a.drainActiveMu.Lock()
+	if a.drainActive[port] {
+		a.drainActiveMu.Unlock()
+		return
+	}
+	a.drainActive[port] = true
+	a.drainActiveMu.Unlock()
+	defer func() {
+		a.drainActiveMu.Lock()
+		delete(a.drainActive, port)
+		a.drainActiveMu.Unlock()
+	}()
+	// Quick check: if there's no TC class for this port (no shaping configured),
+	// we have no byte counters to work with — bail silently.
+	// Quick check: if there's no TC class for this port (no shaping configured),
+	// we have no byte counters to work with — bail silently.
+	_, backlog, err := a.traffic.GetPortStats(port)
+	if err != nil || backlog == -1 {
+		return // no TC class → no stats available
+	}
+	// Phase 0: confirm port is idle before watching for a new transfer start.
+	// Idle = bytes stable AND backlog == 0.
+	var phase0Prev int64 = -1
+	phase0Deadline := time.Now().Add(100 * time.Millisecond)
+	for {
+		bytes, backlog, _, err := a.getPortStatsForDrain(port)
+		if err != nil {
+			return
+		}
+		bytesStable := phase0Prev >= 0 && bytes == phase0Prev
+		if bytesStable && backlog <= 0 {
+			break
+		}
+		phase0Prev = bytes
+		if time.Now().After(phase0Deadline) {
+			// Port continuously active — skip Phase 0/1, go straight to Phase 2.
+			// Use current bytes/time as the run start.
+			log.Printf("SOCKET_DRAIN_BUSY port=%d backlog=%d (skipping to phase2)", port, backlog)
+			phase0Prev = bytes
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Phase 1: wait for idle→active transition (up to 500ms).
+	// Active = bytes incrementing OR backlog > 0.
+	// If Phase 0 timed out (port busy), backlog is already > 0 so Phase 1
+	// activates immediately.
+	var runStartBytes int64
+	var runStartTime time.Time
+	var phase1PrevBytes int64 = phase0Prev
+	phase1Deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(phase1Deadline) {
+		t := time.Now()
+		bytes, backlog, _, err := a.getPortStatsForDrain(port)
+		if err != nil {
+			return
+		}
+		if bytes > phase1PrevBytes || backlog > 0 {
+			runStartBytes = bytes
+			runStartTime = t
+			break
+		}
+		phase1PrevBytes = bytes
+		time.Sleep(5 * time.Millisecond)
+	}
+	if runStartTime.IsZero() {
+		log.Printf("SOCKET_DRAIN_SKIP port=%d (port never became active)", port)
+		return
+	}
+	// Active transition detected: fire SEGMENT_FLIGHT_START.
+	id := a.markSegmentFlightStart(port)
+	defer a.markSegmentFlightEnd(port, id)
+	// Phase 2: poll every 10ms, accumulate tcSamples, until transfer completes.
+	// Active = bytes incrementing OR backlog > 0.
+	// Drain = backlog == 0 AND bytes stable for 2 consecutive polls.
+	//
+	// Wire rate (mbps_transfer_rate) is computed at byte-change events that are
+	// ≥100ms after the previous report. This aligns measurement boundaries to
+	// actual TC burst edges, eliminating HTB burst aliasing.
+	var prevBytes int64 = -1
+	var prevBacklog int64 = -1
+	idleStreak := 0
+	const idleThreshold = 2
+	const wireRateMinGap = 250 * time.Millisecond
+	var wireAnchorBytes int64 = runStartBytes
+	var wireAnchorTime time.Time = runStartTime
+	stallReported := false
+	phase2Deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(phase2Deadline) {
+		sampleTime := time.Now()
+		bytes, backlogBytes, _, err := a.getPortStatsForDrain(port)
+		if err != nil {
+			return
+		}
+		bytesChanged := prevBytes >= 0 && bytes > prevBytes
+		active := bytesChanged || backlogBytes > 0
+		var backlogVal int64
+		if active {
+			backlogVal = 1
+			idleStreak = 0
+		} else if prevBytes >= 0 {
+			idleStreak++
+		}
+		// Wire rate reporting with backlog-aware boundaries:
+		//
+		// 1. Normal: report on first byte-change ≥250ms after anchor.
+		// 2. Drain: when backlog hits 0 AND bytes changed, report immediately
+		//    (natural segment boundary — clean endpoint regardless of timer).
+		// 3. Refill: when backlog transitions 0→>0, reset anchor (new segment
+		//    starts flowing — begin fresh 250ms window).
+		// 4. Stall: if bytes unchanged for ≥500ms, report 0 once.
+		sinceLast := sampleTime.Sub(wireAnchorTime)
+		backlogDrained := bytesChanged && backlogBytes <= 0 && prevBacklog > 0
+		backlogRefilled := backlogBytes > 0 && prevBacklog == 0 && prevBacklog >= 0
+
+		if backlogRefilled {
+			// New data entering empty queue — reset anchor for fresh measurement.
+			wireAnchorBytes = bytes
+			wireAnchorTime = sampleTime
+			stallReported = false
+		} else if backlogDrained || (bytesChanged && sinceLast >= wireRateMinGap) {
+			// Report rate: either backlog just drained (immediate) or ≥250ms elapsed.
+			// Suppress tiny drain reports (< 1KB) — not meaningful rate data.
+			// Stall reports (0 bytes) are handled separately and still fire.
+			deltaBytes := bytes - wireAnchorBytes
+			elapsed := sinceLast.Seconds()
+			if !(backlogDrained && deltaBytes < 1024) && deltaBytes > 0 && elapsed > 0 {
+				rate := math.Round(float64(deltaBytes)*8/(elapsed*1024*1024)*100) / 100
+				tag := "interval"
+				if backlogDrained {
+					tag = "drain"
+				}
+				a.wireRateMu.Lock()
+				a.wireRate[port] = wireRateSample{at: sampleTime, mbps: rate, bytes: deltaBytes}
+				a.wireRateMu.Unlock()
+				log.Printf("SEGMENT_WIRE_RATE port=%d mbps=%.2f delta_bytes=%d elapsed_ms=%d backlog=%d tag=%s",
+					port, rate, deltaBytes, sinceLast.Milliseconds(), backlogBytes, tag)
+			}
+			wireAnchorBytes = bytes
+			wireAnchorTime = sampleTime
+			stallReported = false
+		} else if !bytesChanged && !stallReported && sinceLast >= 2*wireRateMinGap {
+			// Bytes stalled for ≥500ms — report 0 once.
+			a.wireRateMu.Lock()
+			a.wireRate[port] = wireRateSample{at: sampleTime, mbps: 0, bytes: 0}
+			a.wireRateMu.Unlock()
+			log.Printf("SEGMENT_WIRE_RATE port=%d mbps=0.00 stall_ms=%d backlog=%d tag=stall",
+				port, sinceLast.Milliseconds(), backlogBytes)
+			stallReported = true
+		}
+		prevBacklog = backlogBytes
+		prevBytes = bytes
+		sample := tcSample{at: sampleTime, bytes: bytes, backlog: backlogVal}
+		a.tcSamplesMu.Lock()
+		samples := a.tcSamples[port]
+		samples = append(samples, sample)
+		if len(samples) > 20 {
+			samples = samples[len(samples)-20:]
+		}
+		a.tcSamples[port] = samples
+		a.tcSamplesMu.Unlock()
+		log.Printf("SEGMENT_WIRE_10MS port=%d bytes=%d backlog_bytes=%d active=%t idle_streak=%d", port, bytes, backlogBytes, active, idleStreak)
+		if idleStreak >= idleThreshold {
+			runEndTime := sampleTime
+			elapsed := runEndTime.Sub(runStartTime).Seconds()
+			runBytes := bytes - runStartBytes
+			runMbps := 0.0
+			if elapsed > 0 {
+				runMbps = math.Round((float64(runBytes)*8)/(elapsed*1024*1024)*100) / 100
+			}
+			log.Printf("SOCKET_DRAIN_DONE port=%d run_bytes=%d elapsed_s=%.3f mbps=%.2f", port, runBytes, elapsed, runMbps)
+			if runMbps > 0 {
+				a.transferCompleteMu.Lock()
+				a.transferCompleteMbps[port] = runMbps
+				a.transferCompleteAt[port] = sampleTime
+				a.transferCompleteMu.Unlock()
+			}
+			a.segmentRunMu.Lock()
+			a.segmentRun[port] = segmentRunRecord{
+				startTime:  runStartTime,
+				startBytes: runStartBytes,
+				endTime:    runEndTime,
+				endBytes:   bytes,
+			}
+			a.segmentRunMu.Unlock()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	log.Printf("SOCKET_DRAIN_TIMEOUT port=%d (timed out waiting for port to go idle)", port)
+}
+
+func (a *App) getSegmentFlightInfo(port int) (segmentFlightInfo, bool) {
+	a.segmentFlightMu.Lock()
+	info, ok := a.segmentFlight[port]
+	a.segmentFlightMu.Unlock()
+	return info, ok
+}
+
+func (a *App) getSegmentFlightStart(port int) (time.Time, bool) {
+	info, ok := a.getSegmentFlightInfo(port)
+	return info.startTime, ok
+}
+
+func (a *App) applyFullSegmentNetworkBitrate(session SessionData, startBytes int64, startedAt time.Time) {
+	if session == nil || startBytes <= 0 || startedAt.IsZero() {
+		return
+	}
+	endBytes, _ := a.getSessionWireTCBytesNow(session)
+	if endBytes <= startBytes {
+		// Allow a brief wait for throughput sampler to publish post-transfer bytes.
+		for i := 0; i < 6; i++ {
+			time.Sleep(50 * time.Millisecond)
+			endBytes, _ = a.getSessionWireTCBytesNow(session)
+			if endBytes > startBytes {
+				break
+			}
+		}
+	}
+	if endBytes <= startBytes {
+		return
+	}
+	durationS := time.Since(startedAt).Seconds()
+	if durationS <= 0 {
+		return
+	}
+	bytesDelta := endBytes - startBytes
+	mbps := (float64(bytesDelta) * 8.0) / (durationS * 1024.0 * 1024.0)
+	session["full_segment_network_bitrate_mbps"] = math.Round(mbps*1000) / 1000
+	session["full_segment_network_bytes"] = bytesDelta
+	session["full_segment_network_duration_s"] = math.Round(durationS*1000) / 1000
+}
+
 func (a *App) getSessionThroughput(session SessionData) map[string]interface{} {
 	if session == nil {
 		return nil
 	}
-	port := getString(session, "x_forwarded_port_external")
-	if port == "" {
-		port = getString(session, "x_forwarded_port")
-	}
+	port := getString(session, "x_forwarded_port")
 	if port == "" {
 		return nil
 	}
-	throughputKeys := []string{fmt.Sprintf("throughput_%s", port)}
-	if internalPort := getString(session, "x_forwarded_port"); internalPort != "" && internalPort != port {
-		throughputKeys = append(throughputKeys, fmt.Sprintf("throughput_%s", internalPort))
-	}
 	var best map[string]interface{}
 	bestTimestamp := int64(0)
-	for _, throughputKey := range throughputKeys {
+	for _, throughputKey := range []string{fmt.Sprintf("throughput_%s", port)} {
 		item, err := a.memcache.Get(throughputKey)
 		if err != nil {
 			continue


### PR DESCRIPTION
## Summary

### go-proxy: netlink TC stats + wire rate measurement
- Replace `exec.Command("tc", ...)` with `vishvananda/netlink` ClassList — eliminates fork cost
- Per-port TC stats cache (5ms TTL) deduplicates concurrent readers
- Singleton `awaitSocketDrain` goroutine per port
- Byte-change-gated wire rate (`mbps_transfer_rate`): 250ms min gap, aligned to HTB burst edges
- Drain/refill boundary detection with completed segment metric (`mbps_transfer_complete`)

### Throughput metric cleanup
- Renamed: `wire_a1s` → `shaper_rate`, `wire_a6s` → `shaper_avg`, `segment_wire` → `transfer_rate`, `segment_drain` → `transfer_complete`
- `shaper_avg` changed to rolling 6s average of shaper_rate values
- Removed: sustained, active 18s/6s/1s, wire_throughput, video_app, EWMA metrics + dead code
- Removed 3s metric hold windows

### Dashboard charts
- Single "Variants" legend toggle (replaces per-variant toggles + external button)
- Y-axis auto recalculates on legend toggle, capped at 100 Mbps
- Zoom/pan via chartjs-plugin-zoom on all charts, viewport sync
- FPS chart: legend, 2s lookback with measurement timestamps, 0.15 smoothing alpha
- Heartbeat 5s → 1s for responsive FPS/buffer depth
- Synced all changes to testing.html
- Removed unused eBPF scaffolding

## Test plan
- [ ] Deploy to dev stack, verify shaper_rate/shaper_avg/transfer_rate/transfer_complete appear in SSE and chart
- [ ] Set rate limit, confirm transfer_complete values track near the limit
- [ ] Toggle Variants in legend — all variant lines toggle together
- [ ] Zoom/pan bitrate chart — buffer and FPS charts sync
- [ ] Verify FPS chart shows ~30fps for 29.97 content
- [ ] Remove shaping — confirm shaper metrics go nil, no stale a6s values

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)