### PR TITLE
feat: add Remove AVERAGE-BANDWIDTH checkbox to Content tab

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -794,6 +794,15 @@
                                             </div>
                                         </div>
                                         <div class="fault-control-row">
+                                            <label>Strip AVERAGE-BANDWIDTH</label>
+                                            <div class="checkbox-group">
+                                                <label>
+                                                    <input type="checkbox" data-field="content_strip_average_bandwidth" ${getBool(session, 'content_strip_average_bandwidth') ? 'checked' : ''}>
+                                                    Remove AVERAGE-BANDWIDTH from master playlist
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <div class="fault-control-row">
                                             <label>Allowed Variants</label>
                                             <div class="checkbox-group">
                                                 ${renderContentVariantOptions(sessionId, manifestVariants, getStringSlice(session, 'content_allowed_variants'))}
@@ -1082,6 +1091,7 @@
         
         // Content manipulation settings
         const contentStripCodecs = !!card.querySelector('input[data-field="content_strip_codecs"]')?.checked;
+        const contentStripAvgBandwidth = !!card.querySelector('input[data-field="content_strip_average_bandwidth"]')?.checked;
         const contentAllowedVariants = Array.from(card.querySelectorAll('input[data-field="content_allowed_variants"]:checked'))
             .map(input => input.value);
 
@@ -1131,6 +1141,7 @@
             transport_fault_off_seconds: getRangeValue('transport_failure_frequency'),
             // Content manipulation
             content_strip_codecs: contentStripCodecs,
+            content_strip_average_bandwidth: contentStripAvgBandwidth,
             content_allowed_variants: contentAllowedVariants.length > 0 ? contentAllowedVariants : []
         };
     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -2634,6 +2634,10 @@
             if (strip) {
                 strip.checked = !!session.content_strip_codecs;
             }
+            const stripAvgBw = card.querySelector('input[data-field="content_strip_average_bandwidth"]');
+            if (stripAvgBw) {
+                stripAvgBw.checked = !!session.content_strip_average_bandwidth;
+            }
             const allowed = Array.isArray(session.content_allowed_variants)
                 ? session.content_allowed_variants.map(String)
                 : [];
@@ -3547,8 +3551,8 @@
                         allBox.checked = true;
                     }
                 }
-                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs') {
-                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs']);
+                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs' || event.target.dataset.field === 'content_strip_average_bandwidth') {
+                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_strip_average_bandwidth']);
                     return;
                 }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_')) {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3913,6 +3913,9 @@ func shouldApplyContentManipulation(session SessionData) bool {
 	if getBool(session, "content_strip_codecs") {
 		return true
 	}
+	if getBool(session, "content_strip_average_bandwidth") {
+		return true
+	}
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 	if len(allowedVariants) > 0 {
 		return true
@@ -3923,23 +3926,24 @@ func shouldApplyContentManipulation(session SessionData) bool {
 // applyContentManipulation modifies master playlist/manifest content based on session settings
 func (a *App) applyContentManipulation(body []byte, session SessionData, contentType string) ([]byte, error) {
 	stripCodecs := getBool(session, "content_strip_codecs")
+	stripAvgBandwidth := getBool(session, "content_strip_average_bandwidth")
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 
 	// Handle HLS master playlists
 	if strings.Contains(strings.ToLower(contentType), "mpegurl") || strings.Contains(strings.ToLower(contentType), "m3u8") {
-		return manipulateHLSMaster(body, stripCodecs, allowedVariants)
+		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, allowedVariants)
 	}
 
 	// Handle DASH manifests
 	if strings.Contains(strings.ToLower(contentType), "dash") || strings.Contains(strings.ToLower(contentType), "mpd") {
-		return manipulateDASHManifest(body, stripCodecs, allowedVariants)
+		return manipulateDASHManifest(body, stripCodecs, stripAvgBandwidth, allowedVariants)
 	}
 
 	return body, nil
 }
 
 // manipulateHLSMaster modifies an HLS master playlist
-func manipulateHLSMaster(body []byte, stripCodecs bool, allowedVariants []string) ([]byte, error) {
+func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, allowedVariants []string) ([]byte, error) {
 	playlist, listType, err := m3u8.DecodeFrom(bufio.NewReader(bytes.NewReader(body)), true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode HLS playlist: %w", err)
@@ -3987,6 +3991,16 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, allowedVariants []string
 		}
 	}
 
+	// Strip AVERAGE-BANDWIDTH if requested
+	if stripAvgBandwidth {
+		for _, variant := range master.Variants {
+			if variant != nil && variant.AverageBandwidth > 0 {
+				variant.AverageBandwidth = 0
+				modified = true
+			}
+		}
+	}
+
 	if !modified {
 		return body, nil
 	}
@@ -4003,17 +4017,13 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, allowedVariants []string
 
 // manipulateDASHManifest modifies a DASH manifest
 // Note: stripCodecs and allowedVariants parameters are reserved for future DASH implementation
-func manipulateDASHManifest(body []byte, stripCodecs bool, allowedVariants []string) ([]byte, error) {
+func manipulateDASHManifest(body []byte, stripCodecs bool, stripAvgBandwidth bool, allowedVariants []string) ([]byte, error) {
 	// DASH manifest manipulation would require XML parsing and manipulation
 	// using libraries like encoding/xml or third-party XML processors.
 	// This is deferred to keep the initial implementation focused on HLS.
-	// When implemented, this function should:
-	// 1. Parse the MPD XML
-	// 2. Filter AdaptationSet/Representation elements based on allowedVariants
-	// 3. Remove codecs attributes from Representation elements if stripCodecs is true
-	// 4. Re-serialize and return the modified XML
-	_ = stripCodecs     // Silence unused parameter warning
-	_ = allowedVariants // Silence unused parameter warning
+	_ = stripCodecs        // Silence unused parameter warning
+	_ = stripAvgBandwidth  // Silence unused parameter warning
+	_ = allowedVariants    // Silence unused parameter warning
 	log.Printf("[GO-PROXY][CONTENT] DASH manifest manipulation not yet implemented")
 	return body, nil
 }


### PR DESCRIPTION
## Summary
Add a **Remove AVERAGE-BANDWIDTH** checkbox to the Fault Injection Content tab. When enabled, HLS master playlists are delivered without the `AVERAGE-BANDWIDTH` attribute, allowing observation of player ABR behavior without this hint.

- New checkbox in Content Manipulation tab alongside existing "Strip CODEC"
- Session state: `content_strip_average_bandwidth`
- go-proxy: zeroes `variant.AverageBandwidth` in `manipulateHLSMaster()`
- DASH parameter plumbed through for future implementation

## Test plan
- [ ] Deploy, open testing session Content tab — verify new checkbox appears
- [ ] Enable checkbox, inspect master playlist — confirm `AVERAGE-BANDWIDTH` attribute is absent
- [ ] Disable checkbox, inspect master playlist — confirm `AVERAGE-BANDWIDTH` returns
- [ ] Verify "Strip CODEC" still works independently

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)