### PR TITLE
feat: add 10% bandwidth overstatement checkbox to Content tab

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -803,6 +803,15 @@
                                             </div>
                                         </div>
                                         <div class="fault-control-row">
+                                            <label>Overstate Bandwidth</label>
+                                            <div class="checkbox-group">
+                                                <label>
+                                                    <input type="checkbox" data-field="content_overstate_bandwidth" ${getBool(session, 'content_overstate_bandwidth') ? 'checked' : ''}>
+                                                    Increase BANDWIDTH and AVERAGE-BANDWIDTH by 10%
+                                                </label>
+                                            </div>
+                                        </div>
+                                        <div class="fault-control-row">
                                             <label>Allowed Variants</label>
                                             <div class="checkbox-group">
                                                 ${renderContentVariantOptions(sessionId, manifestVariants, getStringSlice(session, 'content_allowed_variants'))}
@@ -1092,6 +1101,7 @@
         // Content manipulation settings
         const contentStripCodecs = !!card.querySelector('input[data-field="content_strip_codecs"]')?.checked;
         const contentStripAvgBandwidth = !!card.querySelector('input[data-field="content_strip_average_bandwidth"]')?.checked;
+        const contentOverstateBandwidth = !!card.querySelector('input[data-field="content_overstate_bandwidth"]')?.checked;
         const contentAllowedVariants = Array.from(card.querySelectorAll('input[data-field="content_allowed_variants"]:checked'))
             .map(input => input.value);
 
@@ -1142,6 +1152,7 @@
             // Content manipulation
             content_strip_codecs: contentStripCodecs,
             content_strip_average_bandwidth: contentStripAvgBandwidth,
+            content_overstate_bandwidth: contentOverstateBandwidth,
             content_allowed_variants: contentAllowedVariants.length > 0 ? contentAllowedVariants : []
         };
     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -2638,6 +2638,10 @@
             if (stripAvgBw) {
                 stripAvgBw.checked = !!session.content_strip_average_bandwidth;
             }
+            const overstateBw = card.querySelector('input[data-field="content_overstate_bandwidth"]');
+            if (overstateBw) {
+                overstateBw.checked = !!session.content_overstate_bandwidth;
+            }
             const allowed = Array.isArray(session.content_allowed_variants)
                 ? session.content_allowed_variants.map(String)
                 : [];
@@ -3551,8 +3555,8 @@
                         allBox.checked = true;
                     }
                 }
-                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs' || event.target.dataset.field === 'content_strip_average_bandwidth') {
-                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_strip_average_bandwidth']);
+                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs' || event.target.dataset.field === 'content_strip_average_bandwidth' || event.target.dataset.field === 'content_overstate_bandwidth') {
+                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_strip_average_bandwidth', 'content_overstate_bandwidth']);
                     return;
                 }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_')) {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3916,6 +3916,9 @@ func shouldApplyContentManipulation(session SessionData) bool {
 	if getBool(session, "content_strip_average_bandwidth") {
 		return true
 	}
+	if getBool(session, "content_overstate_bandwidth") {
+		return true
+	}
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 	if len(allowedVariants) > 0 {
 		return true
@@ -3927,23 +3930,24 @@ func shouldApplyContentManipulation(session SessionData) bool {
 func (a *App) applyContentManipulation(body []byte, session SessionData, contentType string) ([]byte, error) {
 	stripCodecs := getBool(session, "content_strip_codecs")
 	stripAvgBandwidth := getBool(session, "content_strip_average_bandwidth")
+	overstateBandwidth := getBool(session, "content_overstate_bandwidth")
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 
 	// Handle HLS master playlists
 	if strings.Contains(strings.ToLower(contentType), "mpegurl") || strings.Contains(strings.ToLower(contentType), "m3u8") {
-		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, allowedVariants)
+		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, allowedVariants)
 	}
 
 	// Handle DASH manifests
 	if strings.Contains(strings.ToLower(contentType), "dash") || strings.Contains(strings.ToLower(contentType), "mpd") {
-		return manipulateDASHManifest(body, stripCodecs, stripAvgBandwidth, allowedVariants)
+		return manipulateDASHManifest(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, allowedVariants)
 	}
 
 	return body, nil
 }
 
 // manipulateHLSMaster modifies an HLS master playlist
-func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, allowedVariants []string) ([]byte, error) {
+func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, allowedVariants []string) ([]byte, error) {
 	playlist, listType, err := m3u8.DecodeFrom(bufio.NewReader(bytes.NewReader(body)), true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode HLS playlist: %w", err)
@@ -4001,6 +4005,23 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 		}
 	}
 
+	// Overstate BANDWIDTH and AVERAGE-BANDWIDTH by 10% if requested
+	if overstateBandwidth {
+		for _, variant := range master.Variants {
+			if variant == nil {
+				continue
+			}
+			if variant.Bandwidth > 0 {
+				variant.Bandwidth = uint32(float64(variant.Bandwidth) * 1.10)
+				modified = true
+			}
+			if variant.AverageBandwidth > 0 {
+				variant.AverageBandwidth = uint32(float64(variant.AverageBandwidth) * 1.10)
+				modified = true
+			}
+		}
+	}
+
 	if !modified {
 		return body, nil
 	}
@@ -4017,12 +4038,13 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 
 // manipulateDASHManifest modifies a DASH manifest
 // Note: stripCodecs and allowedVariants parameters are reserved for future DASH implementation
-func manipulateDASHManifest(body []byte, stripCodecs bool, stripAvgBandwidth bool, allowedVariants []string) ([]byte, error) {
+func manipulateDASHManifest(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, allowedVariants []string) ([]byte, error) {
 	// DASH manifest manipulation would require XML parsing and manipulation
 	// using libraries like encoding/xml or third-party XML processors.
 	// This is deferred to keep the initial implementation focused on HLS.
 	_ = stripCodecs        // Silence unused parameter warning
 	_ = stripAvgBandwidth  // Silence unused parameter warning
+	_ = overstateBandwidth // Silence unused parameter warning
 	_ = allowedVariants    // Silence unused parameter warning
 	log.Printf("[GO-PROXY][CONTENT] DASH manifest manipulation not yet implemented")
 	return body, nil


### PR DESCRIPTION
## Summary
Add an **Overstate Bandwidth** checkbox to the Fault Injection Content tab. When enabled, `BANDWIDTH` and `AVERAGE-BANDWIDTH` values in HLS master playlists are increased by 10%, simulating over-provisioned streaming scenarios.

- New checkbox in Content Manipulation tab
- Session state: `content_overstate_bandwidth`
- go-proxy: multiplies `variant.Bandwidth` and `variant.AverageBandwidth` by 1.10
- Applied after variant filtering and codec/avg-bandwidth stripping
- DASH parameter plumbed through for future implementation

## Test plan
- [ ] Deploy, open testing session Content tab — verify new checkbox appears
- [ ] Enable checkbox, inspect master playlist — confirm BANDWIDTH values are 10% higher
- [ ] Disable checkbox — confirm original values return
- [ ] Combine with Strip AVERAGE-BANDWIDTH — verify overstate is skipped for avg (already stripped)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)