### PR TITLE
feat: add live edge offset radio buttons to Content tab

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -817,8 +817,17 @@
                                                 ${renderContentVariantOptions(sessionId, manifestVariants, getStringSlice(session, 'content_allowed_variants'))}
                                             </div>
                                         </div>
+                                        <div class="fault-control-row">
+                                            <label>Live Offset</label>
+                                            <div class="radio-group">
+                                                <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="none" ${!session.content_live_offset || session.content_live_offset === 'none' ? 'checked' : ''}> None</label>
+                                                <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="6" ${String(session.content_live_offset) === '6' ? 'checked' : ''}> 6s</label>
+                                                <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="18" ${String(session.content_live_offset) === '18' ? 'checked' : ''}> 18s</label>
+                                                <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="24" ${String(session.content_live_offset) === '24' ? 'checked' : ''}> 24s</label>
+                                            </div>
+                                        </div>
                                         <div class="content-tab-note">
-                                            <strong>Note:</strong> Content modifications apply to master playlist requests. 
+                                            <strong>Note:</strong> Content modifications apply to master playlist requests.
                                             For HLS, play content once to populate variant list, configure settings, then replay to apply changes.
                                         </div>
                                     </div>
@@ -1104,6 +1113,8 @@
         const contentOverstateBandwidth = !!card.querySelector('input[data-field="content_overstate_bandwidth"]')?.checked;
         const contentAllowedVariants = Array.from(card.querySelectorAll('input[data-field="content_allowed_variants"]:checked'))
             .map(input => input.value);
+        const liveOffsetRaw = card.querySelector('input[data-field="content_live_offset"]:checked')?.value || 'none';
+        const contentLiveOffset = liveOffsetRaw === 'none' ? 0 : Number(liveOffsetRaw) || 0;
 
         return {
             session_id: sessionId,
@@ -1153,6 +1164,7 @@
             content_strip_codecs: contentStripCodecs,
             content_strip_average_bandwidth: contentStripAvgBandwidth,
             content_overstate_bandwidth: contentOverstateBandwidth,
+            content_live_offset: contentLiveOffset,
             content_allowed_variants: contentAllowedVariants.length > 0 ? contentAllowedVariants : []
         };
     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -789,6 +789,10 @@
                     Allow 4K
                 </label>
                 <label>
+                    <input id="disableLiveSyncToggle" type="checkbox">
+                    Disable Live Sync
+                </label>
+                <label>
                     <input id="autoRecoveryToggle" type="checkbox">
                     Auto-Recovery
                 </label>
@@ -2199,6 +2203,14 @@
                     return;
                 }
                 shakaPlayer = new shaka.Player(video);
+                {
+                    const disableLiveSync = document.getElementById('disableLiveSyncToggle')?.checked;
+                    if (disableLiveSync) {
+                        shakaPlayer.configure('streaming.liveSync', false);
+                        shakaPlayer.configure('streaming.safeSeekOffset', 18);
+                        log('LIVE SYNC: disabled — using fixed safe seek offset');
+                    }
+                }
                 shakaPlayer.addEventListener('error', (e) => {
                     log(`ERROR: ${e.detail.code} ${e.detail.message}`);
                     const shakaHttp = extractShakaHttpFailure(e.detail);
@@ -2222,7 +2234,14 @@
                 });
             } else if (playerType === 'hlsjs') {
                 if (Hls.isSupported()) {
-                    hlsInstance = new Hls({ enableWorker: true, lowLatencyMode: false });
+                    const hlsConfig = { enableWorker: true, lowLatencyMode: false };
+                    const disableLiveSync = document.getElementById('disableLiveSyncToggle')?.checked;
+                    if (disableLiveSync) {
+                        hlsConfig.liveSyncDurationCount = 3;
+                        hlsConfig.liveMaxLatencyDurationCount = 6;
+                        log('LIVE SYNC: disabled — using 3x segment duration offset');
+                    }
+                    hlsInstance = new Hls(hlsConfig);
                     hlsInstance.on(Hls.Events.ERROR, (evt, data) => {
                         log(`HLS ERROR: ${data.type} ${data.details}`);
                         const hlsHttp = extractHlsHttpFailure(data);

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -789,10 +789,6 @@
                     Allow 4K
                 </label>
                 <label>
-                    <input id="disableLiveSyncToggle" type="checkbox">
-                    Disable Live Sync
-                </label>
-                <label>
                     <input id="autoRecoveryToggle" type="checkbox">
                     Auto-Recovery
                 </label>
@@ -2203,14 +2199,6 @@
                     return;
                 }
                 shakaPlayer = new shaka.Player(video);
-                {
-                    const disableLiveSync = document.getElementById('disableLiveSyncToggle')?.checked;
-                    if (disableLiveSync) {
-                        shakaPlayer.configure('streaming.liveSync', false);
-                        shakaPlayer.configure('streaming.safeSeekOffset', 18);
-                        log('LIVE SYNC: disabled — using fixed safe seek offset');
-                    }
-                }
                 shakaPlayer.addEventListener('error', (e) => {
                     log(`ERROR: ${e.detail.code} ${e.detail.message}`);
                     const shakaHttp = extractShakaHttpFailure(e.detail);
@@ -2234,14 +2222,7 @@
                 });
             } else if (playerType === 'hlsjs') {
                 if (Hls.isSupported()) {
-                    const hlsConfig = { enableWorker: true, lowLatencyMode: false };
-                    const disableLiveSync = document.getElementById('disableLiveSyncToggle')?.checked;
-                    if (disableLiveSync) {
-                        hlsConfig.liveSyncDurationCount = 3;
-                        hlsConfig.liveMaxLatencyDurationCount = 6;
-                        log('LIVE SYNC: disabled — using 3x segment duration offset');
-                    }
-                    hlsInstance = new Hls(hlsConfig);
+                    hlsInstance = new Hls({ enableWorker: true, lowLatencyMode: false });
                     hlsInstance.on(Hls.Events.ERROR, (evt, data) => {
                         log(`HLS ERROR: ${data.type} ${data.details}`);
                         const hlsHttp = extractHlsHttpFailure(data);
@@ -2661,6 +2642,10 @@
             if (overstateBw) {
                 overstateBw.checked = !!session.content_overstate_bandwidth;
             }
+            const liveOffsetVal = String(session.content_live_offset || 'none');
+            card.querySelectorAll('input[data-field="content_live_offset"]').forEach(radio => {
+                radio.checked = (radio.value === liveOffsetVal) || (liveOffsetVal === '0' && radio.value === 'none');
+            });
             const allowed = Array.isArray(session.content_allowed_variants)
                 ? session.content_allowed_variants.map(String)
                 : [];
@@ -3574,8 +3559,8 @@
                         allBox.checked = true;
                     }
                 }
-                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs' || event.target.dataset.field === 'content_strip_average_bandwidth' || event.target.dataset.field === 'content_overstate_bandwidth') {
-                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_strip_average_bandwidth', 'content_overstate_bandwidth']);
+                if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs' || event.target.dataset.field === 'content_strip_average_bandwidth' || event.target.dataset.field === 'content_overstate_bandwidth' || event.target.dataset.field === 'content_live_offset') {
+                    sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_strip_average_bandwidth', 'content_overstate_bandwidth', 'content_live_offset']);
                     return;
                 }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_')) {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1215,6 +1215,10 @@ maybe a histogram of b
             if (strip) {
                 strip.checked = !!session.content_strip_codecs;
             }
+            const liveOffsetVal = String(session.content_live_offset || 'none');
+            card.querySelectorAll('input[data-field="content_live_offset"]').forEach(radio => {
+                radio.checked = (radio.value === liveOffsetVal) || (liveOffsetVal === '0' && radio.value === 'none');
+            });
             const allowed = Array.isArray(session.content_allowed_variants)
                 ? session.content_allowed_variants.map(String)
                 : [];
@@ -3233,8 +3237,8 @@ maybe a histogram of b
                     allBox.checked = true;
                 }
             }
-            if (target.dataset.field === 'content_allowed_variants' || target.dataset.field === 'content_strip_codecs') {
-                sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs']);
+            if (target.dataset.field === 'content_allowed_variants' || target.dataset.field === 'content_strip_codecs' || target.dataset.field === 'content_live_offset') {
+                sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_live_offset']);
                 return;
             }
             if (target.dataset.field === 'shaping_step_enabled') {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3919,6 +3919,9 @@ func shouldApplyContentManipulation(session SessionData) bool {
 	if getBool(session, "content_overstate_bandwidth") {
 		return true
 	}
+	if getInt(session, "content_live_offset") > 0 {
+		return true
+	}
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 	if len(allowedVariants) > 0 {
 		return true
@@ -3931,23 +3934,24 @@ func (a *App) applyContentManipulation(body []byte, session SessionData, content
 	stripCodecs := getBool(session, "content_strip_codecs")
 	stripAvgBandwidth := getBool(session, "content_strip_average_bandwidth")
 	overstateBandwidth := getBool(session, "content_overstate_bandwidth")
+	liveOffset := getInt(session, "content_live_offset")
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
 
 	// Handle HLS master playlists
 	if strings.Contains(strings.ToLower(contentType), "mpegurl") || strings.Contains(strings.ToLower(contentType), "m3u8") {
-		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, allowedVariants)
+		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, liveOffset, allowedVariants)
 	}
 
 	// Handle DASH manifests
 	if strings.Contains(strings.ToLower(contentType), "dash") || strings.Contains(strings.ToLower(contentType), "mpd") {
-		return manipulateDASHManifest(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, allowedVariants)
+		return manipulateDASHManifest(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, liveOffset, allowedVariants)
 	}
 
 	return body, nil
 }
 
 // manipulateHLSMaster modifies an HLS master playlist
-func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, allowedVariants []string) ([]byte, error) {
+func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, liveOffset int, allowedVariants []string) ([]byte, error) {
 	playlist, listType, err := m3u8.DecodeFrom(bufio.NewReader(bytes.NewReader(body)), true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode HLS playlist: %w", err)
@@ -4022,6 +4026,11 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 		}
 	}
 
+	// Inject #EXT-X-START with negative offset for live edge positioning
+	if liveOffset > 0 {
+		modified = true
+	}
+
 	if !modified {
 		return body, nil
 	}
@@ -4033,18 +4042,28 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 		return nil, fmt.Errorf("failed to encode HLS playlist: %w", err)
 	}
 
+	// Inject EXT-X-START tag (not supported by m3u8 library) after #EXTM3U
+	if liveOffset > 0 {
+		encoded := buf.String()
+		startTag := fmt.Sprintf("#EXT-X-START:TIME-OFFSET=-%d\n", liveOffset)
+		encoded = strings.Replace(encoded, "#EXTM3U\n", "#EXTM3U\n"+startTag, 1)
+		buf.Reset()
+		buf.WriteString(encoded)
+	}
+
 	return buf.Bytes(), nil
 }
 
 // manipulateDASHManifest modifies a DASH manifest
 // Note: stripCodecs and allowedVariants parameters are reserved for future DASH implementation
-func manipulateDASHManifest(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, allowedVariants []string) ([]byte, error) {
+func manipulateDASHManifest(body []byte, stripCodecs bool, stripAvgBandwidth bool, overstateBandwidth bool, liveOffset int, allowedVariants []string) ([]byte, error) {
 	// DASH manifest manipulation would require XML parsing and manipulation
 	// using libraries like encoding/xml or third-party XML processors.
 	// This is deferred to keep the initial implementation focused on HLS.
 	_ = stripCodecs        // Silence unused parameter warning
 	_ = stripAvgBandwidth  // Silence unused parameter warning
 	_ = overstateBandwidth // Silence unused parameter warning
+	_ = liveOffset         // Silence unused parameter warning
 	_ = allowedVariants    // Silence unused parameter warning
 	log.Printf("[GO-PROXY][CONTENT] DASH manifest manipulation not yet implemented")
 	return body, nil


### PR DESCRIPTION
## Summary
Add **Live Offset** radio buttons (None, 6s, 18s, 24s) to the Fault Injection Content tab. When a non-zero offset is selected, `#EXT-X-START:TIME-OFFSET=-{value}` is injected into the HLS master playlist, controlling where the player begins playback relative to the live edge.

- Radio group in Content Manipulation tab
- Session state: `content_live_offset` (integer seconds, 0 = disabled)
- go-proxy: injects `EXT-X-START` tag in `manipulateHLSMaster()`
- Session sync in both testing-session.html and testing.html
- DASH parameter plumbed for future implementation

## Test plan
- [ ] Deploy, open Content tab — verify radio buttons appear with "None" selected
- [ ] Select "18s", inspect master playlist — confirm `#EXT-X-START:TIME-OFFSET=-18` present after `#EXTM3U`
- [ ] Select "None" — confirm no `EXT-X-START` tag
- [ ] Reload page — verify selection persists via session

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)