### PR TITLE
chore: open-source readiness — externalize config, clean up personal refs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# InfiniteStream environment configuration
+# Copy this to .env and fill in your values:
+#   cp .env.example .env
+#   source .env   # to use $K3S_HOST etc. in shell commands
+
+# Docker Compose content directory (absolute path to your media library)
+BOSS_CONTENT_DIR=/path/to/your/media
+
+# k3s deployment host (hostname only, and user@host for SSH)
+K3S_HOST=your-k3s-host
+K3S_SSH_HOST=user@your-k3s-host
+K3S_REGISTRY=your-registry-ip:5000
+K3S_KUBECONFIG=/home/user/.kube/config
+K3S_BOSS_DIR=/home/user/boss
+K3S_CERTS_DIR=/home/user/smashing/certs
+
+# GHCR (GitHub Container Registry)
+GHCR_ORG=ghcr.io/your-org

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,24 @@ content/myshows
 content/skatedog/**
 content/skatedog_drm_fixed/**
 
-# generate_abr output files
+# generate_abr output files and encoding artifacts
 generate_abr/**/*.mp4
 generate_abr/**/*.log
 generate_abr/**/__pycache__/
 generate_abr/*_hevc/
 generate_abr/*_hevc_*/
+generate_abr/output/
+generate_abr/*.csv
+
+# Encoding output directories
+*_h264/
+*_hevc/
+*_tmp/
+resume_*/
+
+# Build temporaries
+.tmp-*/
+buildcheck-*/
 
 # hlstools
 hlstools/
@@ -21,6 +33,12 @@ certs/
 # macOS system files
 .DS_Store
 **/.DS_Store
+
+# Python virtual environments
+venv/
+.venv/
+**/venv/
+**/.venv/
 
 # Python cache
 __pycache__/
@@ -35,8 +53,23 @@ __pycache__/
 # macOS Internet Location shortcuts
 *.webloc
 
+# IDE / editor
 .vscode/
+
+# Test artifacts
 tests/.hls_failure_probe_last_failed
+tests/integration/test_run.log
+
+# Go module files (generated in Docker build)
 go-proxy/go.mod
 go-proxy/go.sum
-apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.xcworkspace/xcuserdata/jonathanoliver.xcuserdatad/UserInterfaceState.xcuserstate
+
+# Xcode user state
+apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.xcworkspace/xcuserdata/
+
+# Environment config (contains local paths/IPs)
+.env
+
+# Private documents (do not commit)
+BusinessPlan.md
+Sponsors.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Docker-based HLS/DASH media server for testing video players under various netwo
 - **Stop**: `make stop` or `./boss.sh 1 stop` or `docker compose down`
 - **Logs**: `docker compose logs -f boss-codex` (when using docker-compose)
 - **Shell**: `make shell` (access running container)
-- **Test**: Manual testing via browser at `http://localhost:21081/` (Docker Compose) or `http://lenovo.local:30000/` (k3s)
+- **Test**: Manual testing via browser at `http://localhost:21081/` (Docker Compose) or `http://$K3S_HOST:30000/` (k3s)
 
 ## Development Workflow
 
@@ -55,8 +55,8 @@ Go-live manages all live generation and updates internally (no external Python p
 ## Skills
 A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.
 ### Available skills
-- skill-creator: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations. (file: /Users/jonathanoliver/.codex/skills/.system/skill-creator/SKILL.md)
-- skill-installer: Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos). (file: /Users/jonathanoliver/.codex/skills/.system/skill-installer/SKILL.md)
+- skill-creator: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations. (file: $CODEX_HOME/skills/.system/skill-creator/SKILL.md)
+- skill-installer: Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos). (file: $CODEX_HOME/skills/.system/skill-installer/SKILL.md)
 ### How to use skills
 - Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.
 - Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,14 +19,14 @@ make stop
 # Shell into running container
 make shell
 
-# Deploy to Lenovo k3s (dev stack)
+# Deploy to k3s (dev stack)
 make deploy
 
-# Deploy to Lenovo k3s (release)
+# Deploy to k3s (release)
 make deploy-release
 ```
 
-UI is available at `http://localhost:21081/` (Docker Compose) or `http://lenovo.local:30000/` (k3s release) / `http://lenovo.local:40000/` (k3s dev).
+UI is available at `http://localhost:21081/` (Docker Compose) or `http://$K3S_HOST:30000/` (k3s release) / `http://$K3S_HOST:40000/` (k3s dev).
 
 ## Testing
 
@@ -46,7 +46,7 @@ pytest -k test_name
 
 # Run player ABR characterization tests
 pytest test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081
 
 # Run against local Docker Compose
 pytest test_player_characterization_pytest.py -m abrchar -v \
@@ -58,7 +58,7 @@ pytest test_player_characterization_pytest.py -m abrchar -v \
   --abrchar-test-mode steps --abrchar-repeat-count 10
 ```
 
-Default server target for tests is `lenovo:30000/30081`. Override with `--host`, `--api-port`, `--hls-port`, or `--api-base`.
+Default server target for tests is `$K3S_HOST:30000/30081`. Override with `--host`, `--api-port`, `--hls-port`, or `--api-base`.
 
 ## Code Style
 
@@ -141,7 +141,7 @@ When creating issues/PRs/comments with `gh`, pass the body using a heredoc or `-
 | Environment | UI | HLS/Proxy |
 |---|---|---|
 | Docker Compose | `localhost:21081` | `localhost:21081` |
-| k3s release | `lenovo.local:30000` | `lenovo.local:30081` |
-| k3s dev | `lenovo.local:40000` | `lenovo.local:40081` |
+| k3s release | `$K3S_HOST:30000` | `$K3S_HOST:30081` |
+| k3s dev | `$K3S_HOST:40000` | `$K3S_HOST:40081` |
 
-k3s images are pushed to `100.111.190.54:5000` (Lenovo local registry) or GHCR (`ghcr.io/jonathaneoliver/`).
+k3s images are pushed to your local registry (`$K3S_REGISTRY`) or GHCR (`ghcr.io/jonathaneoliver/`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,4 +29,4 @@ any redistribution.
 
 ## Testing
 
-Use the UI at `http://localhost:21081/` (Docker Compose) or `http://lenovo.local:30000/` (k3s) and verify playback for HLS and DASH.
+Use the UI at `http://localhost:21081/` (Docker Compose) or `http://$K3S_HOST:30000/` (k3s) and verify playback for HLS and DASH.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 
+# Load .env if present (provides K3S_SSH_HOST, K3S_REGISTRY, etc.)
+-include .env
+export
 
-LENOVO_HOST ?= jonathanoliver@lenovo
-K3S_KUBECONFIG ?= /home/jonathanoliver/.kube/config
+K3S_SSH_HOST ?= user@your-k3s-host
+K3S_KUBECONFIG ?= /home/user/.kube/config
 GO_SERVER_IMAGE ?= ghcr.io/jonathaneoliver/infinite-streaming:latest
 GO_PROXY_IMAGE ?= ghcr.io/jonathaneoliver/go-proxy:latest
 K8S_MANIFESTS ?= k8s-infinite-streaming.yaml
 K8S_DEPLOYMENT ?= infinite-streaming
 IOS_SIM_DEVICE ?= iPad Pro 13-inch (M5)
 IOS_APP_BUNDLE_ID ?= com.jeoliver.InfiniteStreamPlayer
-IOS_API_BASE ?= http://lenovo:40000
+IOS_API_BASE ?= http://$(K3S_HOST):40000
 IOS_METRICS_DURATION ?= 900
 IOS_SCORE_MIN ?= 60
 
@@ -40,81 +43,81 @@ buildx-arm64:
 buildx-push:
 	docker buildx build --platform linux/amd64,linux/arm64 -t infinite-streaming:latest --push .
 
-LENOVO_REGISTRY ?= 100.111.190.54:5000
-LENOVO_SERVER_REPO ?= infinite-streaming
-LENOVO_PROXY_REPO ?= go-proxy
+K3S_REGISTRY ?= your-registry:5000
+K3S_SERVER_REPO ?= infinite-streaming
+K3S_PROXY_REPO ?= go-proxy
 
-build-lenovo:
-	docker build --no-cache --progress=plain -t $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):latest .
+build-k3s:
+	docker build --no-cache --progress=plain -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):latest .
 
-buildx-lenovo-amd64:
-	docker buildx build --platform linux/amd64 -t $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):amd64 --load .
+buildx-k3s-amd64:
+	docker buildx build --platform linux/amd64 -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):amd64 --load .
 
-buildx-lenovo-arm64:
-	docker buildx build --platform linux/arm64 -t $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):arm64 --load .
+buildx-k3s-arm64:
+	docker buildx build --platform linux/arm64 -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):arm64 --load .
 
-buildx-lenovo-all:
-	$(MAKE) buildx-lenovo-amd64
-	$(MAKE) buildx-lenovo-arm64
+buildx-k3s-all:
+	$(MAKE) buildx-k3s-amd64
+	$(MAKE) buildx-k3s-arm64
 
-push-lenovo:
-	docker push $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):latest
+push-k3s:
+	docker push $(K3S_REGISTRY)/$(K3S_SERVER_REPO):latest
 
-push-lenovo-all:
-	docker push $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):amd64
-	docker push $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):arm64
+push-k3s-all:
+	docker push $(K3S_REGISTRY)/$(K3S_SERVER_REPO):amd64
+	docker push $(K3S_REGISTRY)/$(K3S_SERVER_REPO):arm64
 
-build-push-lenovo: build-lenovo push-lenovo
+build-push-k3s: build-k3s push-k3s
 
-build-push-lenovo-all: buildx-lenovo-all push-lenovo-all
+build-push-k3s-all: buildx-k3s-all push-k3s-all
 
-build-go-proxy-lenovo:
-	docker build --no-cache --progress=plain --build-arg VERSION=$(shell cat VERSION) -t $(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):latest ./go-proxy
+build-go-proxy-k3s:
+	docker build --no-cache --progress=plain --build-arg VERSION=$(shell cat VERSION) -t $(K3S_REGISTRY)/$(K3S_PROXY_REPO):latest ./go-proxy
 
-push-go-proxy-lenovo:
-	docker push $(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):latest
+push-go-proxy-k3s:
+	docker push $(K3S_REGISTRY)/$(K3S_PROXY_REPO):latest
 
-build-push-go-proxy-lenovo: build-go-proxy-lenovo push-go-proxy-lenovo
+build-push-go-proxy-k3s: build-go-proxy-k3s push-go-proxy-k3s
 
-LENOVO_SERVER_IMAGE ?= $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):latest
-LENOVO_PROXY_IMAGE ?= $(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):latest
+K3S_SERVER_IMAGE ?= $(K3S_REGISTRY)/$(K3S_SERVER_REPO):latest
+K3S_PROXY_IMAGE ?= $(K3S_REGISTRY)/$(K3S_PROXY_REPO):latest
 
-deploy-lenovo-k3s-local:
+deploy-k3s-local:
 	@set -e; \
 	echo "Cleaning up legacy split deployments/services"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl delete service go-server go-proxy memcached boss-server --ignore-not-found=true"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl delete deployment go-server go-proxy memcached boss-server --ignore-not-found=true"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl delete service go-server go-proxy memcached boss-server --ignore-not-found=true"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl delete deployment go-server go-proxy memcached boss-server --ignore-not-found=true"; \
 	for manifest in $(K8S_MANIFESTS); do \
-		echo "Applying $$manifest to $(LENOVO_HOST)"; \
-		ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl apply -f -" < $$manifest; \
+		echo "Applying $$manifest to $(K3S_SSH_HOST)"; \
+		envsubst < $$manifest | ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl apply -f -"; \
 	done; \
 	echo "Updating deployment images"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-server=$(LENOVO_SERVER_IMAGE)"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-proxy=$(LENOVO_PROXY_IMAGE)"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-server=$(K3S_SERVER_IMAGE)"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl set image deployment/$(K8S_DEPLOYMENT) go-proxy=$(K3S_PROXY_IMAGE)"; \
 	echo "Restarting deployments explicitly"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout restart deployment/$(K8S_DEPLOYMENT)"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout restart deployment/$(K8S_DEPLOYMENT)"; \
 	echo "Waiting for rollout"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout status deployment/$(K8S_DEPLOYMENT) --timeout=180s"; \
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl rollout status deployment/$(K8S_DEPLOYMENT) --timeout=180s"; \
 	echo "Deployment status"; \
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get pods -n default -o wide; echo; kubectl get svc -n default"
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get pods -n default -o wide; echo; kubectl get svc -n default"
 
-deploy-lenovo-k3s: deploy-lenovo-k3s-local
+deploy-k3s: deploy-k3s-local
 
-status-lenovo-k3s:
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get nodes; echo; kubectl get pods -A"
+status-k3s:
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get nodes; echo; kubectl get pods -A"
 
 deploy:
-	docker buildx build --platform linux/amd64 -t $(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):dev --push .
-	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):dev --push ./go-proxy
-	$(MAKE) deploy-lenovo-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K8S_MANIFESTS=k8s-infinite-streaming-dev.yaml K8S_DEPLOYMENT=infinite-streaming-dev LENOVO_SERVER_IMAGE=$(LENOVO_REGISTRY)/$(LENOVO_SERVER_REPO):dev LENOVO_PROXY_IMAGE=$(LENOVO_REGISTRY)/$(LENOVO_PROXY_REPO):dev
+	docker buildx build --platform linux/amd64 -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev --push .
+	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_REGISTRY)/$(K3S_PROXY_REPO):dev --push ./go-proxy
+	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K8S_MANIFESTS=k8s-infinite-streaming-dev.yaml K8S_DEPLOYMENT=infinite-streaming-dev K3S_SERVER_IMAGE=$(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev K3S_PROXY_IMAGE=$(K3S_REGISTRY)/$(K3S_PROXY_REPO):dev
 
 logs:
-	ssh $(LENOVO_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl logs deploy/infinite-streaming-dev --all-containers -f"
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl logs deploy/infinite-streaming-dev --all-containers -f"
 
 deploy-release:
-	docker buildx build --platform linux/amd64 -t $(LENOVO_SERVER_IMAGE) --push .
-	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(LENOVO_PROXY_IMAGE) --push ./go-proxy
-	$(MAKE) deploy-lenovo-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) LENOVO_SERVER_IMAGE=$(LENOVO_SERVER_IMAGE) LENOVO_PROXY_IMAGE=$(LENOVO_PROXY_IMAGE)
+	docker buildx build --platform linux/amd64 -t $(K3S_SERVER_IMAGE) --push .
+	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_PROXY_IMAGE) --push ./go-proxy
+	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K3S_SERVER_IMAGE=$(K3S_SERVER_IMAGE) K3S_PROXY_IMAGE=$(K3S_PROXY_IMAGE)
 
 test-ios-sim-metrics:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ make run
 
 Open the UI:
 - Docker Compose: http://localhost:21081/
-- k3s (Lenovo): http://lenovo.local:30000/
+- k3s: http://$K3S_HOST:30000/
 
-## Lenovo k3s: release vs dev
+## k3s: release vs dev
 
 Run release and dev side-by-side by using separate NodePort ranges and image tags.
 
 Release (stable):
-- UI: http://lenovo.local:30000/
+- UI: http://$K3S_HOST:30000/
 - Ports: 30000 (UI), 30081 (initial proxy), 30181-30881 (session ports)
 - Images: `:latest` (or your pinned release tag)
 - Deploy: `make deploy-release`
 
 Dev (active development):
-- UI: http://lenovo.local:40000/
+- UI: http://$K3S_HOST:40000/
 - Ports: 40000 (UI), 40081 (initial proxy), 40181-40881 (session ports)
 - Images: `:dev`
 - Deploy: `make deploy`
@@ -49,14 +49,14 @@ Use an immutable tag for releases (for example, `v1.2.3` or a commit SHA) and ke
 Suggested flow:
 1) Create a tag and push it (example: `git tag v1.2.3 && git push origin v1.2.3`).
 2) Build/push images with that tag (example: `:v1.2.3`).
-3) Deploy release using the pinned tag (set `LENOVO_SERVER_IMAGE` and `LENOVO_PROXY_IMAGE` to the release tag).
+3) Deploy release using the pinned tag (set `K3S_SERVER_IMAGE` and `K3S_PROXY_IMAGE` to the release tag).
 
 Example deploy (release tag `v1.2.3`):
 
 ```bash
 make deploy-release \
-  LENOVO_SERVER_IMAGE=100.111.190.54:5000/infinite-streaming:v1.2.3 \
-  LENOVO_PROXY_IMAGE=100.111.190.54:5000/go-proxy:v1.2.3
+  K3S_SERVER_IMAGE=$K3S_REGISTRY/infinite-streaming:v1.2.3 \
+  K3S_PROXY_IMAGE=$K3S_REGISTRY/go-proxy:v1.2.3
 ```
 
 ## GitHub Container Registry (GHCR)
@@ -128,21 +128,21 @@ Directory layout inside `/boss`:
 - **go-upload** (port 8003): upload API, job orchestration, content discovery
 - **nginx**: routing + static dashboard
   - **Host UI (docker-compose)**: `http://localhost:21081/`
-  - **Host UI (k3s/NodePort)**: `http://lenovo.local:30000/`
+  - **Host UI (k3s/NodePort)**: `http://$K3S_HOST:30000/`
 
 ## Primary endpoints (host)
 
 ### HLS (LL/2s/6s)
 - Docker Compose: `http://localhost:21081/go-live/{content}/master.m3u8`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/master.m3u8`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/master_2s.m3u8`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/master_6s.m3u8`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/master.m3u8`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/master_2s.m3u8`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/master_6s.m3u8`
 
 ### DASH (LL/2s/6s)
 - Docker Compose: `http://localhost:21081/go-live/{content}/manifest.mpd`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/manifest.mpd`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/manifest_2s.mpd`
-- k3s NodePort: `http://lenovo.local:30081/go-live/{content}/manifest_6s.mpd`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/manifest.mpd`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/manifest_2s.mpd`
+- k3s NodePort: `http://$K3S_HOST:30081/go-live/{content}/manifest_6s.mpd`
 
 ### APIs
 - `GET /api/content`
@@ -193,7 +193,7 @@ Open via the Mosaic (Grid) right‑click menu → “Open in Testing Window”, 
 http://localhost:21081/dashboard/testing-session.html?player_id=<uuid>&url=<encoded-stream-url>
 
 # k3s
-http://lenovo.local:30000/dashboard/testing-session.html?player_id=<uuid>&url=<encoded-stream-url>
+http://$K3S_HOST:30000/dashboard/testing-session.html?player_id=<uuid>&url=<encoded-stream-url>
 ```
 
 The `player_id` is required. The proxy uses it to bind the playback session to a dedicated port, so requests to the original port are redirected to a session‑specific port. This allows per‑session failure injection and traffic shaping without affecting other sessions.

--- a/android/InfiniteStreamPlayer/README.md
+++ b/android/InfiniteStreamPlayer/README.md
@@ -106,7 +106,7 @@ The app automatically rebuilds the stream URL when you change any selection:
 - The app requires an active internet connection
 - Cleartext traffic is enabled for testing (HTTP URLs)
 - Ensure your device can reach the InfiniteStream server:
-  - Dev: `http://100.111.190.54:40081`
+  - Dev: `http://$K3S_HOST:40081`
   - Release: `http://infinitestreaming.jeoliver.com:30081`
 
 ### Troubleshooting

--- a/android/InfiniteStreamPlayer/TESTING.md
+++ b/android/InfiniteStreamPlayer/TESTING.md
@@ -120,7 +120,7 @@ Test connectivity to both servers:
 
 ```bash
 # Dev server
-curl -I http://100.111.190.54:40081/go-live/bbb/master.m3u8
+curl -I http://$K3S_HOST:40081/go-live/bbb/master.m3u8
 
 # Release server
 curl -I http://infinitestreaming.jeoliver.com:30081/go-live/bbb/master.m3u8

--- a/android/InfiniteStreamPlayer/UI-LAYOUT.md
+++ b/android/InfiniteStreamPlayer/UI-LAYOUT.md
@@ -30,7 +30,7 @@ This document describes the visual layout of the InfiniteStream Android Player a
 │                                                                     │
 │ Content:   [bbb                       ▼]                           │
 │                                                                     │
-│ Status: Ready - http://100.111.190.54:40081/go-live/bbb/master... │
+│ Status: Ready - http://$K3S_HOST:40081/go-live/bbb/master... │
 │                                                                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -10,9 +10,9 @@ services:
     ports:
       - "30000:30000"
     volumes:
-      #- /home/jonathanoliver/smashing/content:/content
-      - /home/jonathanoliver/boss:/boss
-      - /home/jonathanoliver/smashing/certs:/etc/nginx/certs:ro
+      #- ./content:/content
+      - ${BOSS_CONTENT_DIR:-./sample-content}:/boss
+      - ${K3S_CERTS_DIR:-./certs}:/etc/nginx/certs:ro
     environment:
       # Path Configuration - Single source of truth for all path references
       - INFINITE_STREAM_ROOT=/boss

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     ports:
       - "30000:30000"
     volumes:
-      - /Users/jonathanoliver/Projects/smashing/content:/content
-      - /Volumes/4TB/Boss:/boss
-      - /Users/jonathanoliver/Projects/smashing/certs:/etc/nginx/certs:ro
+      - ./content:/content
+      - ${BOSS_CONTENT_DIR:-./sample-content}:/boss
+      - ./certs:/etc/nginx/certs:ro
     environment:
       # Path Configuration - Single source of truth for all path references
       - INFINITE_STREAM_ROOT=/boss

--- a/generate_abr/ENCODING_CHARACTERIZATION.md
+++ b/generate_abr/ENCODING_CHARACTERIZATION.md
@@ -6,7 +6,7 @@ This document records measured encoding results produced by:
 
 Source used for this run:
 
-- `/Volumes/4TB/Boss/originals/INSANE_FPV_SHOTS：_Hydrofoil_Windsurfing.mkv`
+- `your-source-video.mkv`
 
 Run shape:
 
@@ -36,7 +36,7 @@ Important:
 
 The combined CSV below includes baseline `sw`, baseline `hw`, and `hwmatch` rows:
 
-- `/Users/jonathanoliver/Projects/smashing/generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv`
+- `generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv`
 
 Coverage:
 
@@ -69,7 +69,7 @@ Observed behavior:
 
 Source of truth for the latest combined run (including `sw`, `hw`, and `hwmatch`) is:
 
-- `/Users/jonathanoliver/Projects/smashing/generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv`
+- `generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv`
 
 This file contains all 180 rows:
 
@@ -78,7 +78,7 @@ This file contains all 180 rows:
 To view the full raw results:
 
 ```bash
-cat /Users/jonathanoliver/Projects/smashing/generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv
+cat generate_abr/output/crf_sweep_vmaf/crf_bandwidth_sweep_new.csv
 ```
 
 Preview (header + first 15 rows):

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: go-server
-        image: 100.111.190.54:5000/infinite-streaming:dev
+        image: ${K3S_REGISTRY}/infinite-streaming:dev
         imagePullPolicy: Always
         command: ["/sbin/launch.sh", "1"]
         ports:
@@ -58,7 +58,7 @@ spec:
           mountPath: /var/cache/nginx/live_playlists
 
       - name: go-proxy
-        image: 100.111.190.54:5000/go-proxy:dev
+        image: ${K3S_REGISTRY}/go-proxy:dev
         imagePullPolicy: Always
         ports:
         - containerPort: 30081
@@ -102,11 +102,11 @@ spec:
       volumes:
       - name: boss-vol
         hostPath:
-          path: /home/jonathanoliver/boss
+          path: ${K3S_BOSS_DIR}
           type: Directory
       - name: certs-vol
         hostPath:
-          path: /home/jonathanoliver/smashing/certs
+          path: ${K3S_CERTS_DIR}
           type: Directory
       - name: go-live-tmpfs
         emptyDir:

--- a/k8s-infinite-streaming.yaml
+++ b/k8s-infinite-streaming.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: go-server
-        image: 192.168.0.189:5000/infinite-streaming:latest
+        image: ${K3S_REGISTRY}/infinite-streaming:latest
         command: ["/sbin/launch.sh", "1"]
         ports:
         - containerPort: 30000
@@ -57,7 +57,7 @@ spec:
           mountPath: /var/cache/nginx/live_playlists
 
       - name: go-proxy
-        image: 192.168.0.189:5000/go-proxy:latest
+        image: ${K3S_REGISTRY}/go-proxy:latest
         ports:
         - containerPort: 30081
         - containerPort: 30181
@@ -92,11 +92,11 @@ spec:
       volumes:
       - name: boss-vol
         hostPath:
-          path: /home/jonathanoliver/boss
+          path: ${K3S_BOSS_DIR}
           type: Directory
       - name: certs-vol
         hostPath:
-          path: /home/jonathanoliver/smashing/certs
+          path: ${K3S_CERTS_DIR}
           type: Directory
       - name: go-live-tmpfs
         emptyDir:

--- a/roku/InfiniteStreamPlayer/README.md
+++ b/roku/InfiniteStreamPlayer/README.md
@@ -32,7 +32,7 @@ This Roku channel replicates the functionality of the iOS app, providing:
 - **Auto**: Automatic codec selection
 
 ### Server Environments
-- **Dev**: Development server (100.111.190.54:40000)
+- **Dev**: Development server ($K3S_HOST:40000)
 - **Release**: Production server (infinitestreaming.jeoliver.com:30000)
 
 ## Remote Control Navigation
@@ -77,7 +77,7 @@ roku/InfiniteStreamPlayer/
 
 2. **Configure Network Access**
    - Ensure your Roku device can reach the InfiniteStream server
-   - Default Dev server: `100.111.190.54:40000`
+   - Default Dev server: `$K3S_HOST:40000`
    - Default Release server: `infinitestreaming.jeoliver.com:30000`
 
 3. **Package the Channel**

--- a/tests/hls_failure_probe.md
+++ b/tests/hls_failure_probe.md
@@ -11,12 +11,12 @@ python3 tests/hls_failure_probe.py
 With an explicit URL:
 
 ```bash
-python3 tests/hls_failure_probe.py http://lenovo:30081/go-live/<content>/master_6s.m3u8
+python3 tests/hls_failure_probe.py http://$K3S_HOST:30081/go-live/<content>/master_6s.m3u8
 ```
 
 ## Auto-selection behavior
 
-If no URL is provided, the script calls `http://lenovo:30000/api/content`, sorts by `name`, and selects the first item that:
+If no URL is provided, the script calls `http://$K3S_HOST:30000/api/content`, sorts by `name`, and selects the first item that:
 
 - has HLS content
 - has a reachable `master_6s.m3u8`
@@ -74,7 +74,7 @@ The probe treats `master.m3u8` as the one-time **master manifest** fetch and med
 
 ```bash
 # Override ports or base URLs
-python3 tests/hls_failure_probe.py --host lenovo --api-port 30000 --hls-port 30081
+python3 tests/hls_failure_probe.py --host $K3S_HOST --api-port 30000 --hls-port 30081
 
 # Provide a specific player_id
 python3 tests/hls_failure_probe.py --player-id my-debug-session

--- a/tests/hls_failure_probe.py
+++ b/tests/hls_failure_probe.py
@@ -1604,7 +1604,7 @@ def run_failure_tests(url, api_base, session, args, manifest_url=None, master_ur
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("url", nargs="?", help="master or media m3u8 URL")
-    ap.add_argument("--host", default="lenovo", help="server host (default: lenovo)")
+    ap.add_argument("--host", default="localhost", help="server host (default: localhost)")
     ap.add_argument("--scheme", default="http", help="http or https")
     ap.add_argument("--api-port", type=int, default=30000, help="API/UI port")
     ap.add_argument("--hls-port", type=int, default=30081, help="HLS port")

--- a/tests/integration/PLAYER_CHARACTERIZATION_PYTEST.md
+++ b/tests/integration/PLAYER_CHARACTERIZATION_PYTEST.md
@@ -50,7 +50,7 @@ Notes:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 30000 --hls-port 30081 --follow-redirects
+  --host $K3S_HOST --scheme http --api-port 30000 --hls-port 30081 --follow-redirects
 ```
 
 Or against local Docker compose:
@@ -64,15 +64,15 @@ If auto-discovery returns HTTP 429, provide a known-good URL directly:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
-  --url "http://lenovo:40081/go-live/redbull_p200_h264/master_6s.m3u8" --follow-redirects
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
+  --url "http://$K3S_HOST:40081/go-live/redbull_p200_h264/master_6s.m3u8" --follow-redirects
 ```
 
 Run step-jump mode (10 cycles of down then up):
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode steps --abrchar-repeat-count 10
 ```
 
@@ -80,7 +80,7 @@ Run transient-shock mode:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode transient-shock
 ```
 
@@ -88,7 +88,7 @@ Run startup-caps mode:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode startup-caps
 ```
 
@@ -96,7 +96,7 @@ Run downshift-severity mode:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode downshift-severity
 ```
 
@@ -104,7 +104,7 @@ Run hysteresis-gap mode:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode hysteresis-gap
 ```
 
@@ -112,7 +112,7 @@ Run emergency-downshift mode:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-test-mode emergency-downshift
 ```
 
@@ -153,7 +153,7 @@ Attach by `player_id`:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-player-id "<simulator-player-id>" \
   --abrchar-launch-ios-simulator \
   --abrchar-attach-timeout 90
@@ -163,7 +163,7 @@ Attach by known `session_id`:
 
 ```bash
 pytest tests/integration/test_player_characterization_pytest.py -m abrchar -v \
-  --host lenovo --scheme http --api-port 40000 --hls-port 40081 \
+  --host $K3S_HOST --scheme http --api-port 40000 --hls-port 40081 \
   --abrchar-session-id "<existing-session-id>"
 ```
 

--- a/tests/integration/QUICKSTART.md
+++ b/tests/integration/QUICKSTART.md
@@ -99,7 +99,7 @@ tests/integration/
 ### Server Settings
 
 ```bash
-# Default (uses lenovo:30000/30081)
+# Default (uses $K3S_HOST:30000/30081)
 pytest
 
 # Custom server
@@ -142,10 +142,10 @@ pytest
 ### Tests fail to find stream
 ```bash
 # Check server is running
-curl http://lenovo:30000/api/content
+curl http://$K3S_HOST:30000/api/content
 
 # Specify correct host
-pytest --host=your-server-name
+pytest --host=$K3S_HOST
 ```
 
 ### Need to see what's happening

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -391,10 +391,10 @@ def pytest_configure(config):
 
 ```bash
 # Ensure server is running
-curl http://lenovo:30000/api/content
+curl http://$K3S_HOST:30000/api/content
 
 # Check connectivity
-pytest --host=your-server --api-port=30000
+pytest --host=$K3S_HOST --api-port=30000
 ```
 
 ### Session Not Found
@@ -404,7 +404,7 @@ pytest --host=your-server --api-port=30000
 pytest --timeout=30
 
 # Check session endpoint
-curl http://lenovo:30000/api/sessions
+curl http://$K3S_HOST:30000/api/sessions
 ```
 
 ### Import Errors

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,7 +33,7 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     """Add custom command-line options."""
-    parser.addoption("--host", default="lenovo", help="Server host")
+    parser.addoption("--host", default="localhost", help="Server host")
     parser.addoption("--scheme", default="http", help="http or https")
     parser.addoption("--api-port", type=int, default=30000, help="API/UI port")
     parser.addoption("--hls-port", type=int, default=30081, help="HLS port")


### PR DESCRIPTION
## Summary
Prepare the repository for open-source release by externalizing all environment-specific configuration and removing personal references.

### Configuration
- **`.env.example`**: Documents all configurable values (registry, paths, hosts)
- **`.env`**: Gitignored, contains actual local values
- **Makefile**: Reads `.env` via `-include` for all deployment variables
- **docker-compose**: Uses `${BOSS_CONTENT_DIR}` instead of hardcoded absolute paths
- **k8s manifests**: Use `${LENOVO_REGISTRY}`, `${K3S_BOSS_DIR}`, `${K3S_CERTS_DIR}`

### Cleanup
- Replace internal IPs (100.111.190.54, 192.168.0.189) with generic placeholders in all docs
- Expand `.gitignore`: encoding outputs, build temps, venvs, test logs, private docs
- Remove personal paths from AGENTS.md and ENCODING_CHARACTERIZATION.md
- Remove empty `entrypoint.sh`

## Test plan
- [ ] `cp .env.example .env` and fill in values
- [ ] `make build && make run` — verify Docker Compose reads from .env
- [ ] Check k8s manifests render correctly with `envsubst < k8s-infinite-streaming.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)