### PR TITLE
docs: add docker run quickstart and run-image Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,17 @@ IOS_SCORE_MIN ?= 60
 run:
 	./start.sh 1 run
 
+run-image:
+	docker run -d --name infinite-streaming \
+		--cap-add NET_ADMIN \
+		-p 21081:30000 \
+		-v $${CONTENT_DIR:-./sample-content}:/media \
+		ghcr.io/jonathaneoliver/infinite-streaming:latest \
+		/sbin/launch.sh 1
+
+stop-image:
+	docker stop infinite-streaming && docker rm infinite-streaming
+
 stop:
 	./start.sh 1 stop
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,64 @@ InfiniteStream is a Docker‑based HLS/DASH media server for testing video playe
 
 ## Quick start
 
+### Option 1: Run from pre-built image (fastest)
+
 ```bash
-# Build
+# Pull and run — no build required
+docker run -d --name infinite-streaming \
+  --cap-add NET_ADMIN \
+  -p 21081:30000 \
+  -v ${CONTENT_DIR:-./sample-content}:/media \
+  ghcr.io/jonathaneoliver/infinite-streaming:latest \
+  /sbin/launch.sh 1
+
+# Open the UI
+open http://localhost:21081/
+```
+
+To use your own media library, set `CONTENT_DIR` in `.env` or pass it directly:
+
+```bash
+CONTENT_DIR=/path/to/your/media docker run -d --name infinite-streaming \
+  --cap-add NET_ADMIN \
+  -p 21081:30000 \
+  -v $CONTENT_DIR:/media \
+  ghcr.io/jonathaneoliver/infinite-streaming:latest \
+  /sbin/launch.sh 1
+```
+
+Or use the Makefile target:
+
+```bash
+make run-image
+```
+
+### Option 2: Build from source
+
+```bash
+# Clone and configure
+git clone https://github.com/jonathaneoliver/infinite-streaming.git
+cd infinite-streaming
+cp .env.example .env    # edit .env with your paths
+
+# Build and run
 make build
-# or
-# docker build --no-cache -t infinite-streaming .
+make run
+```
+
+### Option 3: Docker Compose
+
+```bash
+# Configure
+cp .env.example .env    # edit .env with your paths
 
 # Run
-make run
-# or
-# docker compose up -d
+docker compose up -d
 ```
 
 Open the UI:
 - Docker Compose: http://localhost:21081/
-- k3s (Lenovo): http://lenovo.local:30000/
+- k3s: http://$K3S_HOST:30000/
 
 ## Lenovo k3s: release vs dev
 


### PR DESCRIPTION
## Summary
Make it easy for new users to try InfiniteStream without building from source.

- README: three quick start options (docker run, build from source, docker compose)
- Makefile: `make run-image` / `make stop-image` for single-container usage from GHCR image
- Uses `$CONTENT_DIR` from `.env` for media volume mount

## Test plan
- [ ] `make run-image` pulls and starts container
- [ ] `open http://localhost:21081/` shows dashboard
- [ ] `make stop-image` stops and removes container

🤖 Generated with [Claude Code](https://claude.com/claude-code)