### PR TITLE
feat(apple): metrics POST endpoint, SSE player_id filter, ubuntu server

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
@@ -36,6 +36,13 @@
                 <key>NSIncludesSubdomains</key>
                 <true/>
             </dict>
+            <key>jonathanoliver-ubuntu.local</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
         </dict>
     </dict>
     <key>UISupportedInterfaceOrientations</key>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
@@ -32,6 +32,13 @@
                 <key>NSIncludesSubdomains</key>
                 <true/>
             </dict>
+            <key>jonathanoliver-ubuntu.local</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
         </dict>
     </dict>
 </dict>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
@@ -5,6 +5,7 @@ import Charts
 enum ServerEnvironment: String, CaseIterable, Identifiable {
     case dev
     case release
+    case ubuntu
 
     var id: String { rawValue }
 
@@ -12,6 +13,7 @@ enum ServerEnvironment: String, CaseIterable, Identifiable {
         switch self {
         case .dev: return "Dev (40000)"
         case .release: return "Release (30000)"
+        case .ubuntu: return "Ubuntu (21000)"
         }
     }
 
@@ -19,6 +21,7 @@ enum ServerEnvironment: String, CaseIterable, Identifiable {
         switch self {
         case .dev: return "100.111.190.54"
         case .release: return "infinitestreaming.jeoliver.com"
+        case .ubuntu: return "jonathanoliver-ubuntu.local"
         }
     }
 
@@ -26,6 +29,7 @@ enum ServerEnvironment: String, CaseIterable, Identifiable {
         switch self {
         case .dev: return "40000"
         case .release: return "30000"
+        case .ubuntu: return "21000"
         }
     }
 
@@ -33,6 +37,7 @@ enum ServerEnvironment: String, CaseIterable, Identifiable {
         switch self {
         case .dev: return "40081"
         case .release: return "30081"
+        case .ubuntu: return "21081"
         }
     }
 }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -317,7 +317,7 @@ final class PlaybackDiagnostics: ObservableObject {
             }
         }
         if event.numberOfDroppedVideoFrames > 0 {
-            droppedVideoFrames = event.numberOfDroppedVideoFrames
+            droppedVideoFrames = Double(event.numberOfDroppedVideoFrames)
         }
         // Samples are collected on a steady interval in samplePlayerMetrics().
         var parts: [String] = []
@@ -468,13 +468,100 @@ final class PlaybackDiagnostics: ObservableObject {
         let ns = error as NSError
         var parts: [String] = [ns.localizedDescription]
         if !ns.domain.isEmpty { parts.append("domain=\(ns.domain)") }
-        if ns.code != 0 { parts.append("code=\(ns.code)") }
+        if ns.code != 0 { 
+            parts.append("code=\(ns.code)")
+            // Add human-readable interpretation of common error codes
+            if ns.domain == AVFoundationErrorDomain {
+                parts.append("(\(interpretAVErrorCode(ns.code)))")
+            }
+        }
         if let reason = ns.userInfo[NSLocalizedFailureReasonErrorKey] as? String, !reason.isEmpty {
             parts.append("reason=\(reason)")
         }
         if let suggestion = ns.userInfo[NSLocalizedRecoverySuggestionErrorKey] as? String, !suggestion.isEmpty {
             parts.append("suggestion=\(suggestion)")
         }
+        if let underlyingError = ns.userInfo[NSUnderlyingErrorKey] as? NSError {
+            parts.append("underlying=[\(underlyingError.domain) \(underlyingError.code)]")
+        }
         return parts.joined(separator: " ")
+    }
+    
+    private func interpretAVErrorCode(_ code: Int) -> String {
+        switch code {
+        case -11800: return "AVErrorUnknown"
+        case -11801: return "AVErrorOutOfMemory"
+        case -11802: return "AVErrorSessionNotRunning"
+        case -11803: return "AVErrorDeviceAlreadyUsedByAnotherSession"
+        case -11804: return "AVErrorNoDataCaptured"
+        case -11805: return "AVErrorSessionConfigurationChanged"
+        case -11806: return "AVErrorDiskFull"
+        case -11807: return "AVErrorDeviceWasDisconnected"
+        case -11808: return "AVErrorMediaChanged"
+        case -11809: return "AVErrorMaximumDurationReached"
+        case -11810: return "AVErrorMaximumFileSizeReached"
+        case -11811: return "AVErrorMediaDiscontinuity"
+        case -11812: return "AVErrorMaximumNumberOfSamplesForFileFormatReached"
+        case -11813: return "AVErrorDeviceNotConnected"
+        case -11814: return "AVErrorDeviceInUseByAnotherApplication"
+        case -11815: return "AVErrorDeviceLockedForConfigurationByAnotherProcess"
+        case -11816: return "AVErrorSessionWasInterrupted"
+        case -11817: return "AVErrorMediaServicesWereReset"
+        case -11818: return "AVErrorExportFailed"
+        case -11819: return "AVErrorDecodeFailed"
+        case -11820: return "AVErrorInvalidSourceMedia"
+        case -11821: return "AVErrorFileAlreadyExists"
+        case -11822: return "AVErrorCompositionTrackSegmentsNotContiguous"
+        case -11823: return "AVErrorInvalidCompositionTrackSegmentDuration"
+        case -11824: return "AVErrorInvalidCompositionTrackSegmentSourceStartTime"
+        case -11825: return "AVErrorInvalidCompositionTrackSegmentSourceDuration"
+        case -11826: return "AVErrorFileFormatNotRecognized"
+        case -11827: return "AVErrorFileFailedToParse"
+        case -11828: return "AVErrorMaximumStillImageCaptureRequestsExceeded"
+        case -11829: return "AVErrorContentIsProtected"
+        case -11830: return "AVErrorNoImageAtTime"
+        case -11831: return "AVErrorDecoderNotFound"
+        case -11832: return "AVErrorEncoderNotFound"
+        case -11833: return "AVErrorContentIsNotAuthorized"
+        case -11834: return "AVErrorApplicationIsNotAuthorized"
+        case -11835: return "AVErrorDeviceIsNotAvailableInBackground"
+        case -11836: return "AVErrorOperationNotSupportedForAsset"
+        case -11837: return "AVErrorDecoderTemporarilyUnavailable"
+        case -11838: return "AVErrorEncoderTemporarilyUnavailable"
+        case -11839: return "AVErrorInvalidVideoComposition"
+        case -11840: return "AVErrorReferenceForbiddenByReferencePolicy"
+        case -11841: return "AVErrorInvalidOutputURLPathExtension"
+        case -11842: return "AVErrorScreenCaptureFailed"
+        case -11843: return "AVErrorDisplayWasDisabled"
+        case -11844: return "AVErrorTorchLevelUnavailable"
+        case -11845: return "AVErrorOperationInterrupted"
+        case -11846: return "AVErrorIncompatibleAsset"
+        case -11847: return "AVErrorFailedToLoadMediaData"
+        case -11848: return "AVErrorServerIncorrectlyConfigured"
+        case -11849: return "AVErrorApplicationIsNotAuthorizedForPlayback"
+        case -11850: return "AVErrorContentIsUnavailable"
+        case -11851: return "AVErrorFormatUnsupported"
+        case -11852: return "AVErrorAirPlayControllerRequiresInternet"
+        case -11853: return "AVErrorAirPlayReceiverRequiresInternet"
+        case -11854: return "AVErrorVideoCompositorFailed"
+        case -11855: return "AVErrorRecordingAlreadyInProgress"
+        case -11856: return "AVErrorUnsupportedOutputSettings"
+        case -11857: return "AVErrorOperationNotAllowed"
+        case -11858: return "AVErrorContentNotUpdated"
+        case -11859: return "AVErrorNoLongerPlayable"
+        case -11860: return "AVErrorNoCompatibleAlternatesForExternalDisplay"
+        case -11861: return "AVErrorNoSourceTrack"
+        case -11862: return "AVErrorExternalPlaybackNotSupportedForAsset"
+        case -11863: return "AVErrorOperationNotSupportedForPreset"
+        case -11864: return "AVErrorSessionHardwareCostOverage"
+        case -11865: return "AVErrorUnsupportedDeviceActiveFormat"
+        case -12782: return "AVErrorInvalidSampleCursor"
+        case -12783: return "AVErrorFailedToLoadSampleData"
+        case -12784: return "AVErrorAirPlayReceiverTemporarilyUnavailable"
+        case -12785: return "AVErrorEncodeFailed"
+        case -12786: return "AVErrorSandboxExtensionDenied"
+        case -12900: return "AVErrorUnknown/Generic"
+        default: return "Unknown(\(code))"
+        }
     }
 }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -830,14 +830,13 @@ final class PlaybackViewModel: ObservableObject {
     }
 
     private func patchSessionMetrics(sessionId: String, baseURL: URL, payload: [String: Any]) async {
-        let url = baseURL.appendingPathComponent("api/session").appendingPathComponent(sessionId)
+        let url = baseURL.appendingPathComponent("api/session").appendingPathComponent(sessionId).appendingPathComponent("metrics")
         var request = URLRequest(url: url)
-        request.httpMethod = "PATCH"
+        request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let body: [String: Any] = [
             "set": payload,
-            "fields": Array(payload.keys),
-            "base_revision": ""
+            "fields": Array(payload.keys)
         ]
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionAPI.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionAPI.swift
@@ -7,8 +7,14 @@ final class TestingSessionAPI {
         self.controlBaseURL = controlBaseURL
     }
 
-    func sessionsStreamURL() -> URL {
-        controlBaseURL.appendingPathComponent("api/sessions/stream")
+    func sessionsStreamURL(playerIdFilter: String? = nil) -> URL {
+        let base = controlBaseURL.appendingPathComponent("api/sessions/stream")
+        guard let playerId = playerIdFilter, !playerId.isEmpty,
+              var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            return base
+        }
+        components.queryItems = [URLQueryItem(name: "player_id", value: playerId)]
+        return components.url ?? base
     }
 
     func listSessions() async throws -> [SessionData] {

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionViewModel.swift
@@ -215,7 +215,7 @@ final class TestingSessionViewModel: ObservableObject {
     }
 
     private func startSSE() {
-        let url = api.sessionsStreamURL()
+        let url = api.sessionsStreamURL(playerIdFilter: playerId)
         sse = SSEClient(url: url, onEvent: { [weak self] event in
             self?.handleSSE(event)
         }, onError: { [weak self] error in


### PR DESCRIPTION
## Summary

Update iOS/tvOS InfiniteStreamPlayer for recent server-side changes:

- **Metrics endpoint** — POST to `/api/session/{id}/metrics` instead of PATCH `/api/session/{id}`. Drops `base_revision`. Avoids revision conflicts with control PATCHes.
- **SSE filtering** — connects to `/api/sessions/stream?player_id=` for per-session events
- **Ubuntu server** — new "Ubuntu (21000)" environment option, ATS exceptions for `jonathanoliver-ubuntu.local`
- **Minor** — `Double()` cast fix in PlaybackDiagnostics

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
