### PR TITLE
feat(android): ExoPlayer test app for ABR characterization

### DIFF
--- a/android/ExoPlayerTestApp/.gitignore
+++ b/android/ExoPlayerTestApp/.gitignore
@@ -1,0 +1,9 @@
+*.iml
+.gradle/
+.idea/
+local.properties
+build/
+app/build/
+captures/
+.externalNativeBuild/
+.cxx/

--- a/android/ExoPlayerTestApp/app/build.gradle.kts
+++ b/android/ExoPlayerTestApp/app/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+android {
+    namespace = "com.jeoliver.exoplayertest"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.jeoliver.exoplayertest"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.activity:activity-compose:1.9.3")
+
+    val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
+    implementation(composeBom)
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+
+    val media3Version = "1.5.1"
+    implementation("androidx.media3:media3-exoplayer:$media3Version")
+    implementation("androidx.media3:media3-exoplayer-hls:$media3Version")
+    implementation("androidx.media3:media3-exoplayer-dash:$media3Version")
+    implementation("androidx.media3:media3-ui:$media3Version")
+
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:okhttp-sse:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")
+}

--- a/android/ExoPlayerTestApp/app/src/main/AndroidManifest.xml
+++ b/android/ExoPlayerTestApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <application
+        android:allowBackup="true"
+        android:label="ExoPlayer Test"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:theme="@style/Theme.ExoPlayerTest">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/ContentApi.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/ContentApi.kt
@@ -1,0 +1,32 @@
+package com.jeoliver.exoplayertest
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+@Serializable
+data class ContentItem(
+    val name: String,
+    val has_dash: Boolean = false,
+    val has_hls: Boolean = false,
+    val segment_duration: Int = 0,
+    val max_resolution: String = "",
+    val max_height: Int = 0
+)
+
+private val json = Json { ignoreUnknownKeys = true }
+private val client = OkHttpClient()
+
+suspend fun fetchContent(baseUrl: String): List<ContentItem> = withContext(Dispatchers.IO) {
+    val request = Request.Builder().url("$baseUrl/api/content").build()
+    val response = client.newCall(request).execute()
+    val body = response.body?.string() ?: return@withContext emptyList()
+    try {
+        json.decodeFromString<List<ContentItem>>(body)
+    } catch (_: Exception) {
+        emptyList()
+    }
+}

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/MainActivity.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/MainActivity.kt
@@ -1,0 +1,235 @@
+package com.jeoliver.exoplayertest
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.media3.ui.PlayerView
+
+enum class ProtocolFilter(val label: String) { HLS("HLS"), DASH("DASH") }
+enum class SegmentFilter(val label: String) { ALL("All"), S2("2s"), S6("6s") }
+enum class CodecFilter(val label: String) { ALL("Auto"), H264("H264"), HEVC("HEVC"), AV1("AV1") }
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    AppScreen()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppScreen(vm: PlayerViewModel = viewModel()) {
+    val context = LocalContext.current
+    val env by vm.env.collectAsState()
+    val contentList by vm.contentList.collectAsState()
+    val currentContent by vm.currentContent.collectAsState()
+    val playerState by vm.playerState.collectAsState()
+    val statusMessage by vm.statusMessage.collectAsState()
+
+    var protocolFilter by remember { mutableStateOf(ProtocolFilter.HLS) }
+    var segmentFilter by remember { mutableStateOf(SegmentFilter.S2) }
+    var codecFilter by remember { mutableStateOf(CodecFilter.H264) }
+    var showContentPicker by remember { mutableStateOf(false) }
+
+    val filteredContent = contentList.filter { item ->
+        val hasProtocol = when (protocolFilter) {
+            ProtocolFilter.HLS -> item.has_hls
+            ProtocolFilter.DASH -> item.has_dash
+        }
+        val matchesCodec = when (codecFilter) {
+            CodecFilter.ALL -> true
+            CodecFilter.H264 -> item.name.contains("h264", ignoreCase = true)
+            CodecFilter.HEVC -> item.name.contains("hevc", ignoreCase = true)
+            CodecFilter.AV1 -> item.name.contains("av1", ignoreCase = true)
+        }
+        hasProtocol && matchesCodec
+    }
+
+    LaunchedEffect(Unit) {
+        vm.initPlayer(context)
+        vm.loadContent()
+    }
+
+    // Content picker dialog
+    if (showContentPicker) {
+        Dialog(onDismissRequest = { showContentPicker = false }) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .fillMaxHeight(0.7f)
+            ) {
+                Column {
+                    Text(
+                        "Select Content (${filteredContent.size} items)",
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(16.dp)
+                    )
+                    HorizontalDivider()
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(filteredContent) { item ->
+                            val isPlaying = item.name == currentContent
+                            ListItem(
+                                modifier = Modifier.clickable {
+                                    vm.playContent(item.name, protocolFilter, segmentFilter)
+                                    showContentPicker = false
+                                },
+                                headlineContent = {
+                                    Text(
+                                        item.name.replace("_", " "),
+                                        color = if (isPlaying) MaterialTheme.colorScheme.primary
+                                                else MaterialTheme.colorScheme.onSurface,
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                },
+                                supportingContent = {
+                                    val formats = listOfNotNull(
+                                        if (item.has_hls) "HLS" else null,
+                                        if (item.has_dash) "DASH" else null
+                                    ).joinToString(" · ")
+                                    Text(
+                                        "$formats · ${item.max_resolution} · ${item.segment_duration}s",
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Server picker
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Server:", style = MaterialTheme.typography.labelMedium)
+            ServerEnvironment.entries.forEach { serverEnv ->
+                FilterChip(
+                    selected = serverEnv == env,
+                    onClick = { vm.setEnvironment(serverEnv) },
+                    label = { Text(serverEnv.label, style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+        }
+
+        // Filters row
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("Protocol:", style = MaterialTheme.typography.labelSmall)
+            ProtocolFilter.entries.forEach { pf ->
+                FilterChip(
+                    selected = pf == protocolFilter,
+                    onClick = { protocolFilter = pf },
+                    label = { Text(pf.label, style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+            Text("Seg:", style = MaterialTheme.typography.labelSmall)
+            SegmentFilter.entries.forEach { sf ->
+                FilterChip(
+                    selected = sf == segmentFilter,
+                    onClick = { segmentFilter = sf },
+                    label = { Text(sf.label, style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+            Text("Codec:", style = MaterialTheme.typography.labelSmall)
+            CodecFilter.entries.forEach { cf ->
+                FilterChip(
+                    selected = cf == codecFilter,
+                    onClick = { codecFilter = cf },
+                    label = { Text(cf.label, style = MaterialTheme.typography.labelSmall) }
+                )
+            }
+        }
+
+        // Content selector + status
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Button(onClick = { showContentPicker = true }) {
+                Text(currentContent?.replace("_", " ")?.take(30) ?: "Select Content")
+            }
+            if (currentContent != null) {
+                OutlinedButton(onClick = {
+                    currentContent?.let { vm.playContent(it, protocolFilter, segmentFilter) }
+                }) { Text("Restart") }
+                OutlinedButton(onClick = { vm.stopPlayback() }) { Text("Stop") }
+            }
+            Spacer(Modifier.weight(1f))
+            Text(
+                "ID: ${vm.playerId} · $playerState",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        // Status message
+        if (statusMessage.isNotEmpty()) {
+            Text(
+                statusMessage,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(horizontal = 8.dp)
+            )
+        }
+
+        // Player view — fills remaining space
+        val player = vm.player
+        if (currentContent != null && player != null) {
+            AndroidView(
+                factory = { ctx ->
+                    PlayerView(ctx).apply {
+                        this.player = player
+                        useController = true
+                    }
+                },
+                update = { view ->
+                    view.player = player
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .padding(8.dp)
+            )
+        } else {
+            Box(
+                modifier = Modifier.fillMaxWidth().weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    if (contentList.isEmpty()) "Loading content..." else "Select content to play",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/MetricsReporter.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/MetricsReporter.kt
@@ -1,0 +1,52 @@
+package com.jeoliver.exoplayertest
+
+import kotlinx.coroutines.*
+import kotlinx.serialization.json.*
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+class MetricsReporter(
+    private val controlBaseUrl: String
+) {
+    private val client = OkHttpClient()
+    private val jsonMediaType = "application/json".toMediaType()
+    private val isoFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        .withZone(ZoneOffset.UTC)
+
+    fun nowISO(): String = isoFormatter.format(Instant.now())
+
+    suspend fun postMetrics(sessionId: String, metrics: Map<String, Any?>) = withContext(Dispatchers.IO) {
+        val filtered = metrics.filterValues { it != null }
+        if (filtered.isEmpty()) return@withContext
+
+        val set = buildJsonObject {
+            for ((key, value) in filtered) {
+                when (value) {
+                    is String -> put(key, value)
+                    is Int -> put(key, value)
+                    is Long -> put(key, value)
+                    is Double -> put(key, value)
+                    is Float -> put(key, value.toDouble())
+                    is Boolean -> put(key, value)
+                    else -> put(key, value.toString())
+                }
+            }
+        }
+        val body = buildJsonObject {
+            put("set", set)
+            put("fields", JsonArray(filtered.keys.map { JsonPrimitive(it) }))
+        }
+
+        val request = Request.Builder()
+            .url("$controlBaseUrl/api/session/$sessionId/metrics")
+            .post(body.toString().toRequestBody(jsonMediaType))
+            .build()
+        try {
+            client.newCall(request).execute().close()
+        } catch (_: Exception) {}
+    }
+}

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
@@ -1,0 +1,272 @@
+package com.jeoliver.exoplayertest
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.*
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.UUID
+
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+class PlayerViewModel : ViewModel() {
+
+    private val _env = MutableStateFlow(ServerEnvironment.UBUNTU)
+    val env = _env.asStateFlow()
+
+    private val _contentList = MutableStateFlow<List<ContentItem>>(emptyList())
+    val contentList = _contentList.asStateFlow()
+
+    private val _currentContent = MutableStateFlow<String?>(null)
+    val currentContent = _currentContent.asStateFlow()
+
+    private val _playerState = MutableStateFlow("idle")
+    val playerState = _playerState.asStateFlow()
+
+    private val _statusMessage = MutableStateFlow("Select content to play")
+    val statusMessage = _statusMessage.asStateFlow()
+
+    val playerId: String = UUID.randomUUID().toString().take(8)
+
+    var player: ExoPlayer? = null
+        private set
+
+    private var sessionId: String? = null
+    private var metricsReporter: MetricsReporter? = null
+    private var sessionResolver: SessionResolver? = null
+    private var metricsJob: Job? = null
+    private var stallCount = 0
+    private var stallStartMs = 0L
+    private var totalStallMs = 0L
+    private var profileShiftCount = 0
+    private var lastVideoBitrate = 0L
+    private var restartCount = 0
+
+    fun setEnvironment(env: ServerEnvironment) {
+        _env.value = env
+        stopPlayback()
+        loadContent()
+    }
+
+    fun loadContent() {
+        viewModelScope.launch {
+            _statusMessage.value = "Loading content..."
+            val items = fetchContent(_env.value.contentBaseUrl)
+            _contentList.value = items
+            _statusMessage.value = if (items.isEmpty()) "No content found" else "Select content to play"
+        }
+    }
+
+    fun initPlayer(context: Context) {
+        if (player != null) return
+        player = ExoPlayer.Builder(context).build().apply {
+            playWhenReady = true
+            addListener(playerListener)
+            trackSelectionParameters = trackSelectionParameters.buildUpon()
+                .setMaxVideoSize(1280, 720)
+                .build()
+        }
+    }
+
+    fun playContent(
+        contentName: String,
+        protocol: ProtocolFilter = ProtocolFilter.HLS,
+        segment: SegmentFilter = SegmentFilter.S2
+    ) {
+        val p = player ?: return
+        stopMetrics()
+        _currentContent.value = contentName
+        stallCount = 0
+        totalStallMs = 0
+        stallStartMs = 0
+        profileShiftCount = 0
+        lastVideoBitrate = 0
+        restartCount = 0
+
+        val segmentSuffix = when (segment) {
+            SegmentFilter.ALL -> "2s"
+            SegmentFilter.S2 -> "2s"
+            SegmentFilter.S6 -> "6s"
+        }
+        val masterFile = if (protocol == ProtocolFilter.DASH) "manifest_${segmentSuffix}.mpd" else "master_${segmentSuffix}.m3u8"
+        val url = "${_env.value.playbackBaseUrl}/go-live/$contentName/$masterFile?player_id=$playerId"
+        _statusMessage.value = "Playing $contentName ($masterFile)"
+
+        val dataSourceFactory = DefaultHttpDataSource.Factory()
+        if (protocol == ProtocolFilter.DASH) {
+            val dashSource = androidx.media3.exoplayer.dash.DashMediaSource.Factory(dataSourceFactory)
+                .createMediaSource(MediaItem.fromUri(url))
+            p.setMediaSource(dashSource)
+        } else {
+            val hlsSource = HlsMediaSource.Factory(dataSourceFactory)
+                .createMediaSource(MediaItem.fromUri(url))
+            p.setMediaSource(hlsSource)
+        }
+        p.prepare()
+
+        metricsReporter = MetricsReporter(_env.value.contentBaseUrl)
+        sessionResolver?.stop()
+        sessionResolver = SessionResolver(_env.value.contentBaseUrl, playerId) { sid ->
+            sessionId = sid
+        }
+        sessionResolver?.start(viewModelScope)
+        startMetrics()
+    }
+
+    fun stopPlayback() {
+        stopMetrics()
+        sessionResolver?.stop()
+        sessionResolver = null
+        sessionId = null
+        player?.stop()
+        player?.clearMediaItems()
+        _currentContent.value = null
+        _playerState.value = "idle"
+        _statusMessage.value = "Select content to play"
+    }
+
+    private fun startMetrics() {
+        metricsJob?.cancel()
+        metricsJob = viewModelScope.launch {
+            while (isActive) {
+                delay(5000)
+                sendMetrics("heartbeat")
+            }
+        }
+    }
+
+    private fun stopMetrics() {
+        metricsJob?.cancel()
+        metricsJob = null
+    }
+
+    private suspend fun sendMetrics(eventType: String) {
+        val sid = sessionId ?: return
+        val p = player ?: return
+        val reporter = metricsReporter ?: return
+
+        val positionMs: Long
+        val bufferedMs: Long
+        val videoFormat: Format?
+        val counters: androidx.media3.exoplayer.DecoderCounters?
+        val playbackState: Int
+        val playWhenReady: Boolean
+        val speed: Float
+
+        withContext(Dispatchers.Main) {
+            positionMs = p.currentPosition
+            bufferedMs = p.bufferedPosition
+            videoFormat = p.videoFormat
+            counters = p.videoDecoderCounters
+            playbackState = p.playbackState
+            playWhenReady = p.playWhenReady
+            speed = p.playbackParameters.speed
+        }
+
+        val state = when (playbackState) {
+            Player.STATE_IDLE -> "idle"
+            Player.STATE_BUFFERING -> "buffering"
+            Player.STATE_READY -> if (playWhenReady) "playing" else "paused"
+            Player.STATE_ENDED -> "ended"
+            else -> "unknown"
+        }
+
+        val metrics = mapOf<String, Any?>(
+            "player_metrics_source" to "android",
+            "player_metrics_playback_engine" to "exoplayer",
+            "player_metrics_last_event" to eventType,
+            "player_metrics_trigger_type" to eventType,
+            "player_metrics_last_event_at" to reporter.nowISO(),
+            "player_metrics_event_time" to reporter.nowISO(),
+            "player_metrics_state" to state,
+            "player_metrics_position_s" to round3(positionMs / 1000.0),
+            "player_metrics_playback_rate" to speed.toDouble(),
+            "player_metrics_buffer_depth_s" to round3((bufferedMs - positionMs) / 1000.0),
+            "player_metrics_buffer_end_s" to round3(bufferedMs / 1000.0),
+            "player_metrics_video_bitrate_mbps" to videoFormat?.bitrate?.let { round3(it / 1_000_000.0) },
+            "player_metrics_video_resolution" to videoFormat?.let { "${it.width}x${it.height}" },
+            "player_metrics_network_bitrate_mbps" to null,
+            "player_metrics_frames_displayed" to (counters?.renderedOutputBufferCount ?: 0),
+            "player_metrics_dropped_frames" to (counters?.droppedBufferCount ?: 0),
+            "player_metrics_total_video_frames" to ((counters?.renderedOutputBufferCount ?: 0) + (counters?.droppedBufferCount ?: 0)),
+            "player_metrics_stall_count" to stallCount,
+            "player_metrics_stall_time_s" to round3(totalStallMs / 1000.0),
+            "player_metrics_profile_shift_count" to profileShiftCount,
+            "player_metrics_loop_count_player" to 0,
+            "player_restarts" to restartCount,
+            "player_auto_recovery_enabled" to true
+        )
+
+        reporter.postMetrics(sid, metrics)
+    }
+
+    private val playerListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(state: Int) {
+            val name = when (state) {
+                Player.STATE_IDLE -> "idle"
+                Player.STATE_BUFFERING -> {
+                    if (stallStartMs == 0L) {
+                        stallStartMs = System.currentTimeMillis()
+                        stallCount++
+                    }
+                    "buffering"
+                }
+                Player.STATE_READY -> {
+                    if (stallStartMs > 0) {
+                        totalStallMs += System.currentTimeMillis() - stallStartMs
+                        stallStartMs = 0
+                    }
+                    "playing"
+                }
+                Player.STATE_ENDED -> "ended"
+                else -> "unknown"
+            }
+            _playerState.value = name
+            viewModelScope.launch { sendMetrics("state_change") }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            _statusMessage.value = "Error: ${error.message}"
+            _playerState.value = "error"
+            viewModelScope.launch {
+                sendMetrics("error")
+                delay(3000)
+                val content = _currentContent.value
+                if (content != null) {
+                    restartCount++
+                    playContent(content)
+                }
+            }
+        }
+
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            viewModelScope.launch { sendMetrics("video_size_change") }
+        }
+
+        override fun onTracksChanged(tracks: Tracks) {
+            val videoTrack = tracks.groups.firstOrNull { it.type == C.TRACK_TYPE_VIDEO }
+            val format = videoTrack?.getTrackFormat(0)
+            val newBitrate = format?.bitrate?.toLong() ?: 0
+            if (lastVideoBitrate > 0 && newBitrate > 0 && newBitrate != lastVideoBitrate) {
+                profileShiftCount++
+                viewModelScope.launch { sendMetrics("bitrate_change") }
+            }
+            lastVideoBitrate = newBitrate
+        }
+    }
+
+    override fun onCleared() {
+        stopMetrics()
+        sessionResolver?.stop()
+        player?.removeListener(playerListener)
+        player?.release()
+        player = null
+    }
+
+    private fun round3(v: Double) = Math.round(v * 1000.0) / 1000.0
+}

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/ServerEnvironment.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/ServerEnvironment.kt
@@ -1,0 +1,15 @@
+package com.jeoliver.exoplayertest
+
+enum class ServerEnvironment(
+    val label: String,
+    val host: String,
+    val contentPort: Int,
+    val playbackPort: Int
+) {
+    DEV("Dev (40000)", "100.111.190.54", 40000, 40081),
+    RELEASE("Release (30000)", "infinitestreaming.jeoliver.com", 30000, 30081),
+    UBUNTU("Ubuntu (21000)", "192.168.0.106", 21000, 21081);
+
+    val contentBaseUrl get() = "http://$host:$contentPort"
+    val playbackBaseUrl get() = "http://$host:$playbackPort"
+}

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/SessionResolver.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/SessionResolver.kt
@@ -1,0 +1,78 @@
+package com.jeoliver.exoplayertest
+
+import kotlinx.coroutines.*
+import kotlinx.serialization.json.*
+import okhttp3.*
+import okhttp3.sse.*
+import java.util.concurrent.TimeUnit
+
+class SessionResolver(
+    private val controlBaseUrl: String,
+    private val playerId: String,
+    private val onSessionId: (String) -> Unit
+) {
+    private var eventSource: EventSource? = null
+    private var pollJob: Job? = null
+    private val client = OkHttpClient.Builder()
+        .readTimeout(0, TimeUnit.MILLISECONDS)
+        .build()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun start(scope: CoroutineScope) {
+        startSSE()
+        pollJob = scope.launch(Dispatchers.IO) {
+            while (isActive) {
+                pollSessions()
+                delay(5000)
+            }
+        }
+    }
+
+    fun stop() {
+        eventSource?.cancel()
+        eventSource = null
+        pollJob?.cancel()
+        pollJob = null
+    }
+
+    private fun startSSE() {
+        val url = "$controlBaseUrl/api/sessions/stream?player_id=${playerId}"
+        val request = Request.Builder().url(url).build()
+        eventSource = EventSources.createFactory(client).newEventSource(request, object : EventSourceListener() {
+            override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                if (type != "sessions") return
+                try {
+                    val payload = json.parseToJsonElement(data).jsonObject
+                    val sessions = payload["sessions"]?.jsonArray ?: return
+                    for (session in sessions) {
+                        val obj = session.jsonObject
+                        val pid = obj["player_id"]?.jsonPrimitive?.contentOrNull
+                        val sid = obj["session_id"]?.jsonPrimitive?.contentOrNull
+                        if (pid == playerId && sid != null) {
+                            onSessionId(sid)
+                            return
+                        }
+                    }
+                } catch (_: Exception) {}
+            }
+        })
+    }
+
+    private fun pollSessions() {
+        try {
+            val request = Request.Builder().url("$controlBaseUrl/api/sessions").build()
+            val response = client.newCall(request).execute()
+            val body = response.body?.string() ?: return
+            val sessions = json.parseToJsonElement(body).jsonArray
+            for (session in sessions) {
+                val obj = session.jsonObject
+                val pid = obj["player_id"]?.jsonPrimitive?.contentOrNull
+                val sid = obj["session_id"]?.jsonPrimitive?.contentOrNull
+                if (pid == playerId && sid != null) {
+                    onSessionId(sid)
+                    return
+                }
+            }
+        } catch (_: Exception) {}
+    }
+}

--- a/android/ExoPlayerTestApp/app/src/main/res/values/themes.xml
+++ b/android/ExoPlayerTestApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.ExoPlayerTest" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/android/ExoPlayerTestApp/app/src/main/res/xml/network_security_config.xml
+++ b/android/ExoPlayerTestApp/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">100.111.190.54</domain>
+        <domain includeSubdomains="true">infinitestreaming.jeoliver.com</domain>
+        <domain includeSubdomains="true">jonathanoliver-ubuntu.local</domain>
+        <domain includeSubdomains="true">192.168.0.106</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/android/ExoPlayerTestApp/build.gradle.kts
+++ b/android/ExoPlayerTestApp/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
+}

--- a/android/ExoPlayerTestApp/gradle.properties
+++ b/android/ExoPlayerTestApp/gradle.properties
@@ -1,0 +1,3 @@
+android.useAndroidX=true
+kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8

--- a/android/ExoPlayerTestApp/gradle/wrapper/gradle-wrapper.properties
+++ b/android/ExoPlayerTestApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/ExoPlayerTestApp/settings.gradle.kts
+++ b/android/ExoPlayerTestApp/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ExoPlayerTestApp"
+include(":app")


### PR DESCRIPTION
## Summary

New Android app for testing ExoPlayer's ABR behavior and error handling under network shaping. Equivalent of the iOS InfiniteStreamPlayer app.

- **Server picker** — Dev / Release / Ubuntu chip toggles
- **Content picker** — scrollable popup dialog from `/api/content`
- **Filters** — Protocol (HLS/DASH), Segment (2s/6s), Codec (H264/HEVC/AV1)
- **Media3 ExoPlayer** — HLS + DASH, `?player_id=` session binding
- **Metrics** — POST `/api/session/{id}/metrics` every 5s (state, bitrate, buffer, frames, stalls, ABR shifts)
- **SSE** — `/api/sessions/stream?player_id=` for session resolution
- **Auto-recovery** — restarts after 3s on error
- **720p cap** — for emulator performance

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
