### PR TITLE
fix(go-live): cap live window at loop wrap (closes #109)

### DIFF
--- a/go-live/pkg/generator/range_hls.go
+++ b/go-live/pkg/generator/range_hls.go
@@ -207,16 +207,25 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 		if segmentMap != "" {
 			sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", absoluteSegmentURI(prefix, content, joinRelPath(relPath, segmentMap))))
 		}
-		for i := 0; i <= availableIdx; i++ {
+		remainingDuration := MAX_LIVE_WINDOW_DURATION - tailDuration
+		for i := 0; i <= availableIdx && remainingDuration > 0; i++ {
 			writeSegmentRange(segments[i])
+			remainingDuration -= segments[i].Duration
 		}
 	} else {
-		for i := windowStartIdx; i <= availableIdx; i++ {
+		windowDuration := 0.0
+		for i := windowStartIdx; i <= availableIdx && windowDuration < MAX_LIVE_WINDOW_DURATION; i++ {
 			writeSegmentRange(segments[i])
+			windowDuration += segments[i].Duration
 		}
 	}
 
-	return sb.String(), nil
+	result := sb.String()
+	if len(result) > 5000 {
+		fmt.Fprintf(os.Stderr, "WARNING: large range playlist (%d bytes) wrap=%t tailCount=%d availableIdx=%d segments=%d\n",
+			len(result), wrap, len(segments)-windowStartIdx, availableIdx, len(segments))
+	}
+	return result, nil
 }
 
 func parseDurationSeconds(raw string) (float64, error) {


### PR DESCRIPTION
## Summary

- Cap both wrap and non-wrap branches of `GenerateVariantPlaylist` against `MAX_LIVE_WINDOW_DURATION` so the playlist can no longer grow to the full segment list at a loop boundary.
- Add a stderr warning if the rendered playlist exceeds 5 KB to catch future regressions.

Closes #109.

## Test plan

- [ ] Loop a stream past the wrap boundary and confirm the variant playlist stays within the live window in size.
- [ ] Verify no `WARNING: large range playlist` line appears under normal playback.
- [ ] Smoke test client playback (iOS / web / Android) across a wrap boundary — no rebuffer or manifest-parse errors.