### PR TITLE
feat(go-proxy): broadcast significant player events + log abandoned transfers (closes #117)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1358,8 +1358,19 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 	metricsOnly["session_id"] = id
 	a.saveSessionByID(id, metricsOnly)
+	if isSignificantPlayerEvent(getString(metricsOnly, "player_metrics_last_event")) {
+		a.flushSessionsBroadcast()
+	}
 	w.WriteHeader(http.StatusOK)
 	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+func isSignificantPlayerEvent(event string) bool {
+	switch strings.ToLower(strings.TrimSpace(event)) {
+	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker":
+		return true
+	}
+	return false
 }
 
 
@@ -4036,8 +4047,21 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				externalPort,
 			)
 		}
-		bytesOut, _ = io.Copy(writer, resp.Body)
-		_ = writer.Flush()
+		var copyErr error
+		bytesOut, copyErr = io.Copy(writer, resp.Body)
+		flushErr := writer.Flush()
+		if copyErr != nil || flushErr != nil {
+			writeErr := copyErr
+			if writeErr == nil {
+				writeErr = flushErr
+			}
+			log.Printf("[GO-PROXY][ABANDONED] client disconnected mid-transfer url=%s bytes_sent=%d content_length=%s request_kind=%s session_id=%s external_port=%s err=%v",
+				upstreamURL, bytesOut, resp.Header.Get("Content-Length"), requestKind, getString(sessionData, "session_id"), externalPort, writeErr)
+		}
+		if isManifest || isMasterManifest {
+			log.Printf("[GO-PROXY][MANIFEST] url=%s bytes_sent=%d upstream_content_length=%s status=%d session_id=%s external_port=%s",
+				upstreamURL, bytesOut, resp.Header.Get("Content-Length"), resp.StatusCode, getString(sessionData, "session_id"), externalPort)
+		}
 		// On the segment success path, hand flight-end off to the socket drain goroutine
 		// so it waits for the TC backlog to drain before marking the flight as done.
 		// Only launch on Linux where a.traffic is available (TC backlog polling requires TC).


### PR DESCRIPTION
## Summary

- \`handlePostSessionMetrics\` flushes the SSE broadcast immediately when the incoming \`player_metrics_last_event\` is one of: \`stall_start\`, \`stall_end\`, \`segment_stall\`, \`restart\`, \`frozen\`, \`error\`, \`loop_marker\`. Heartbeats still ride the periodic flush.
- \`handleProxy\` now captures \`io.Copy\` + \`Flush\` errors and logs \`[GO-PROXY][ABANDONED]\` when a client drops mid-segment. Also logs every manifest serve as \`[GO-PROXY][MANIFEST]\`.
- No timeout/abort behavior added — purely observability. Separate from #111.

Closes #117.

## Test plan

- [ ] Open testing.html, induce a stall (failure injection), confirm STALL event appears on the bandwidth chart with no perceptible delay.
- [ ] Tail container logs while killing a client mid-segment fetch, confirm \`[GO-PROXY][ABANDONED]\` line with non-zero \`bytes_sent\`.
- [ ] Tail container logs during normal playback, confirm \`[GO-PROXY][MANIFEST]\` lines appear and segment fetches do not flood logs.