### PR TITLE
refactor(go-proxy): per-session save for group link/unlink + auto-ungroup singles (closes #119)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -2016,22 +2016,15 @@ func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
 		groupID = fmt.Sprintf("G%d", time.Now().Unix()%10000)
 	}
 
-	sessions := a.getSessionList()
 	linkedCount := 0
-	for _, session := range sessions {
-		sessionID := getString(session, "session_id")
-		for _, targetID := range payload.SessionIds {
-			if sessionID == targetID {
-				session["group_id"] = groupID
-				applyControlRevision(session, controlRevision)
-				linkedCount++
-				break
-			}
+	for _, targetID := range payload.SessionIds {
+		update := SessionData{
+			"session_id":       targetID,
+			"group_id":         groupID,
+			"control_revision": controlRevision,
 		}
-	}
-
-	if linkedCount > 0 {
-		a.saveSessionList(sessions)
+		a.saveSessionByID(targetID, update)
+		linkedCount++
 	}
 	log.Printf("SESSION GROUP LINK result group_id=%s linked=%d", groupID, linkedCount)
 
@@ -2066,29 +2059,31 @@ func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	controlRevision := newControlRevision()
 	if payload.UnlinkGroup && groupID != "" {
 		for _, session := range sessions {
 			if getString(session, "group_id") == groupID {
-				session["group_id"] = ""
-				applyControlRevision(session, newControlRevision())
+				sid := getString(session, "session_id")
+				a.saveSessionByID(sid, SessionData{
+					"session_id":       sid,
+					"group_id":         "",
+					"control_revision": controlRevision,
+				})
 				updated++
 				found = true
 			}
 		}
 	} else if payload.SessionId != "" {
-		for _, session := range sessions {
-			if getString(session, "session_id") == payload.SessionId {
-				session["group_id"] = ""
-				applyControlRevision(session, newControlRevision())
-				updated++
-				found = true
-				break
-			}
-		}
+		a.saveSessionByID(payload.SessionId, SessionData{
+			"session_id":       payload.SessionId,
+			"group_id":         "",
+			"control_revision": controlRevision,
+		})
+		updated++
+		found = true
 	}
 
 	if found {
-		a.saveSessionList(sessions)
 		writeJSON(w, map[string]interface{}{
 			"message":        "Session group updated successfully",
 			"group_id":       groupID,
@@ -5823,6 +5818,22 @@ func (a *App) removeInactiveSessions() {
 	for port := range removedPorts {
 		a.disablePatternForPort(port)
 		a.armTransportFaultLoop(port, "none", 1, transportUnitsSeconds, 0)
+	}
+	// Auto-ungroup single-member groups
+	groupMembers := map[string][]string{}
+	for _, session := range active {
+		gid := getString(session, "group_id")
+		if gid != "" {
+			groupMembers[gid] = append(groupMembers[gid], getString(session, "session_id"))
+		}
+	}
+	for _, members := range groupMembers {
+		if len(members) == 1 {
+			a.saveSessionByID(members[0], SessionData{
+				"session_id": members[0],
+				"group_id":   "",
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- \`handleLinkSessions\` and \`handleUnlinkSession\` rewrite to use \`saveSessionByID\` per affected session instead of \`saveSessionList\` over the full list — narrows the write window and removes the race with concurrent metric updates.
- \`removeInactiveSessions\` now scans surviving sessions by \`group_id\` and clears \`group_id\` for any group reduced to a single member, so the UI does not show meaningless 1-member groups.

Closes #119.

## Test plan

- [ ] Open testing.html with two active sessions, group them, confirm group_id is set on both via SSE.
- [ ] Unlink one session, confirm only that session's group_id is cleared (other session still grouped — but per the new auto-ungroup logic, the survivor's group_id should clear on the next \`removeInactiveSessions\` tick).
- [ ] Group three sessions, kill one (let it go inactive), confirm the remaining two stay grouped (group has >=2 members).
- [ ] Group two sessions, kill one, confirm the survivor's group_id clears once the dead session is pruned.