### PR TITLE
fix(go-proxy): shouldApplyFailure returns false on empty entries (closes #121)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6880,7 +6880,7 @@ func (h *RequestHandler) handleSegmentFailure(filename string) string {
 
 func shouldApplyFailure(entries []string, filename, variant string) bool {
 	if len(entries) == 0 {
-		return true
+		return false
 	}
 	decodedFilename := filename
 	if unescaped, err := url.PathUnescape(filename); err == nil {


### PR DESCRIPTION
## Summary

\`shouldApplyFailure(entries, filename, variant)\` was returning \`true\` when \`entries\` was empty — sessions with no failure rules configured had failures applied to every segment. Flip the empty-entries branch to return \`false\` so empty rule set means no failures.

Closes #121.

## Test plan

- [ ] Start a session with no failure rules configured, confirm clean playback (no injected errors).
- [ ] Configure a single failure rule, confirm it still fires.