### PR TITLE
feat(apple): local HTTP forward proxy for wire-level metrics (closes #123)

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
@@ -20,6 +20,8 @@
     <dict/>
     <key>NSAppTransportSecurity</key>
     <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
         <key>NSExceptionDomains</key>
         <dict>
             <key>infinitestreaming.jeoliver.com</key>
@@ -37,6 +39,13 @@
                 <true/>
             </dict>
             <key>jonathanoliver-ubuntu.local</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+            <key>192.168.0.106</key>
             <dict>
                 <key>NSExceptionAllowsInsecureHTTPLoads</key>
                 <true/>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
@@ -16,6 +16,8 @@
     <string>1</string>
     <key>NSAppTransportSecurity</key>
     <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
         <key>NSExceptionDomains</key>
         <dict>
             <key>infinitestreaming.jeoliver.com</key>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.pbxproj
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		A1A1A1A1A1A1A1A1A1A1000A /* TestingSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100A /* TestingSessionAPI.swift */; };
 		A1A1A1A1A1A1A1A1A1A1000B /* TestingSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100B /* TestingSessionViewModel.swift */; };
 		A1A1A1A1A1A1A1A1A1A1000C /* TestingSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100C /* TestingSessionView.swift */; };
+		A1A1A1A1A1A1A1A1A1A1000D /* RequestTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */; };
+		A1A1A1A1A1A1A1A1A1A1000F /* LocalHTTPProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */; };
 		A1A1A1A1A1A1A1A1A1A12001 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A13001 /* AVKit.framework */; };
 		A1A1A1A1A1A1A1A1A1A12002 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A13002 /* AVFoundation.framework */; };
 		A2A2A2A2A2A2A2A2A2A20001 /* InfiniteStreamPlayerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11001 /* InfiniteStreamPlayerApp.swift */; };
@@ -33,6 +35,8 @@
 		A2A2A2A2A2A2A2A2A2A2000A /* TestingSessionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100A /* TestingSessionAPI.swift */; };
 		A2A2A2A2A2A2A2A2A2A2000B /* TestingSessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100B /* TestingSessionViewModel.swift */; };
 		A2A2A2A2A2A2A2A2A2A2000C /* TestingSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100C /* TestingSessionView.swift */; };
+		A2A2A2A2A2A2A2A2A2A2000D /* RequestTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */; };
+		A2A2A2A2A2A2A2A2A2A2000F /* LocalHTTPProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */; };
 		A2A2A2A2A2A2A2A2A2A22001 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A13001 /* AVKit.framework */; };
 		A2A2A2A2A2A2A2A2A2A22002 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A13002 /* AVFoundation.framework */; };
 /* End PBXBuildFile section */
@@ -50,6 +54,8 @@
 		A1A1A1A1A1A1A1A1A1A1100A /* TestingSessionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSession/TestingSessionAPI.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A1100B /* TestingSessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSession/TestingSessionViewModel.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A1100C /* TestingSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingSession/TestingSessionView.swift; sourceTree = "<group>"; };
+		A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTracker.swift; sourceTree = "<group>"; };
+		A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHTTPProxy.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11010 /* InfiniteStreamPlayer-iOS/Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "InfiniteStreamPlayer-iOS/Info.plist"; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11011 /* InfiniteStreamPlayer-tvOS/Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "InfiniteStreamPlayer-tvOS/Info.plist"; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11020 /* InfiniteStreamPlayer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = InfiniteStreamPlayer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -105,6 +111,8 @@
 				A1A1A1A1A1A1A1A1A1A1100A /* TestingSessionAPI.swift */,
 				A1A1A1A1A1A1A1A1A1A1100B /* TestingSessionViewModel.swift */,
 				A1A1A1A1A1A1A1A1A1A1100C /* TestingSessionView.swift */,
+				A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */,
+				A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */,
 			);
 			path = InfiniteStreamPlayer;
 			sourceTree = "<group>";
@@ -243,6 +251,8 @@
 				A1A1A1A1A1A1A1A1A1A1000A /* TestingSessionAPI.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A1000B /* TestingSessionViewModel.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A1000C /* TestingSessionView.swift in Sources */,
+				A1A1A1A1A1A1A1A1A1A1000D /* RequestTracker.swift in Sources */,
+				A1A1A1A1A1A1A1A1A1A1000F /* LocalHTTPProxy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,6 +272,8 @@
 				A2A2A2A2A2A2A2A2A2A2000A /* TestingSessionAPI.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A2000B /* TestingSessionViewModel.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A2000C /* TestingSessionView.swift in Sources */,
+				A2A2A2A2A2A2A2A2A2A2000D /* RequestTracker.swift in Sources */,
+				A2A2A2A2A2A2A2A2A2A2000F /* LocalHTTPProxy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/ContentView.swift
@@ -111,6 +111,12 @@ struct ContentView: View {
                             .toggleStyle(.switch)
                         Text("Auto-Recovery")
                     }
+                    HStack(spacing: 6) {
+                        Toggle("", isOn: $viewModel.localProxyEnabled)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                        Text("Local Proxy")
+                    }
                 }
 
                 PlayerView(player: viewModel.player)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LocalHTTPProxy.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LocalHTTPProxy.swift
@@ -1,0 +1,456 @@
+import Foundation
+import Network
+
+/// A tiny HTTP/1.1 forward proxy running on 127.0.0.1:<ephemeral>. The app
+/// rewrites the master HLS URL from http://origin/path → http://127.0.0.1:port/proxy/http/origin/path
+/// and hands the rewritten URL to AVPlayer. AVPlayer then uses its native
+/// HTTP stack — not AVAssetResourceLoader — so all HLS / fMP4 semantics work
+/// normally. The proxy forwards each request to the real origin via URLSession
+/// and streams the response back, feeding per-chunk timing events to
+/// `RequestTracker` for throughput measurement.
+///
+/// Scope: HTTP only (no TLS termination), GET/HEAD only, HTTP/1.1 with
+/// Connection: close (one request per connection). Sufficient for our test
+/// environment where the origin is unencrypted HTTP on a LAN.
+final class LocalHTTPProxy: NSObject {
+    static let shared = LocalHTTPProxy()
+
+    private let queue = DispatchQueue(label: "com.jeoliver.LocalHTTPProxy", qos: .userInitiated)
+    fileprivate var session: URLSession!
+    private var listener: NWListener?
+    private(set) var port: UInt16 = 0
+    fileprivate let tracker: RequestTracker
+    // Current origin to forward all incoming requests to. Set from the main
+    // thread (via rewrite()) and read from the proxy's delegate queue. Guarded
+    // by its own NSLock rather than `queue` because delegate callbacks already
+    // run on `queue` — a queue.sync from within would deadlock.
+    private let originLock = NSLock()
+    private var originScheme: String = "http"
+    private var originHost: String = ""
+    private var originPort: Int?
+
+    // Map URLSession task id → the connection session that owns it. Serialized
+    // on `queue`. URLSession delegate callbacks come in on the session's
+    // operation queue (which we back with `queue`).
+    fileprivate var sessionsByTaskID: [Int: ConnectionSession] = [:]
+
+    init(tracker: RequestTracker = .shared) {
+        self.tracker = tracker
+        super.init()
+        let config = URLSessionConfiguration.ephemeral
+        config.httpAdditionalHeaders = nil
+        config.timeoutIntervalForRequest = 60
+        config.timeoutIntervalForResource = 300
+        let opQueue = OperationQueue()
+        opQueue.underlyingQueue = queue
+        self.session = URLSession(configuration: config, delegate: self, delegateQueue: opQueue)
+    }
+
+    // MARK: - Lifecycle
+
+    func startIfNeeded() {
+        guard listener == nil else { return }
+        do {
+            let params = NWParameters.tcp
+            // Bind explicitly to IPv4 loopback; otherwise NWListener may come
+            // up on IPv6 only and AVPlayer's HTTP client — which resolves
+            // 127.0.0.1 as IPv4 — never connects.
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(host: "127.0.0.1", port: .any)
+            let listener = try NWListener(using: params)
+            listener.stateUpdateHandler = { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .ready:
+                    if let p = listener.port?.rawValue {
+                        self.port = p
+                        Swift.print("[LOCAL_PROXY] listening on 127.0.0.1:\(p)")
+                    }
+                case .failed(let err):
+                    Swift.print("[LOCAL_PROXY] listener failed: \(err)")
+                default: break
+                }
+            }
+            listener.newConnectionHandler = { [weak self] conn in
+                self?.handle(conn)
+            }
+            listener.start(queue: queue)
+            self.listener = listener
+        } catch {
+            Swift.print("[LOCAL_PROXY] failed to start: \(error)")
+        }
+    }
+
+    /// Rewrite `<scheme>://origin[:port]/path?query` → `http://127.0.0.1:<local>/path?query`
+    /// and remember the origin so every subsequent request the proxy receives
+    /// is forwarded to the same origin. This preserves AVPlayer's URL
+    /// resolution — absolute paths inside manifests (e.g.
+    /// `#EXT-X-MAP:URI="/go-live/.../init.mp4"`) resolve against the proxy base
+    /// and land on our proxy with the original path intact.
+    ///
+    /// Returns nil if the scheme is unsupported or the listener failed. If
+    /// the listener is still starting up, this call waits up to 1s for the
+    /// OS-assigned port to appear — NWListener reports it asynchronously in
+    /// its state-update handler.
+    func rewrite(originURL: URL) -> URL? {
+        if port == 0 {
+            for _ in 0..<20 {
+                if port > 0 { break }
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        guard port > 0 else { return nil }
+        guard let scheme = originURL.scheme, (scheme == "http" || scheme == "https"),
+              let host = originURL.host else { return nil }
+        originLock.lock()
+        self.originScheme = scheme
+        self.originHost = host
+        self.originPort = originURL.port
+        originLock.unlock()
+        // Reconstruct via URL string — URLComponents.percentEncodedPath/Query
+        // setters precondition-fail if the value isn't already percent-encoded,
+        // and URLComponents.path/query auto-encoding occasionally trips on
+        // query-param characters. String concatenation of already-valid pieces
+        // from originURL is the safest path.
+        let pathPart = originURL.path.isEmpty ? "/" : originURL.path
+        var built = "http://127.0.0.1:\(port)\(pathPart)"
+        if let q = originURL.query, !q.isEmpty { built += "?\(q)" }
+        return URL(string: built)
+    }
+
+    fileprivate func currentOrigin() -> (scheme: String, host: String, port: Int?) {
+        originLock.lock(); defer { originLock.unlock() }
+        return (originScheme, originHost, originPort)
+    }
+
+    // MARK: - Connection handling
+
+    private func handle(_ conn: NWConnection) {
+        let session = ConnectionSession(conn: conn, proxy: self, queue: queue)
+        conn.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                session.start()
+            case .failed(let err):
+                Swift.print("[LOCAL_PROXY] conn failed \(conn.endpoint) \(err)")
+                conn.cancel()
+            case .cancelled:
+                break
+            default:
+                break
+            }
+        }
+        conn.start(queue: queue)
+    }
+
+    fileprivate func registerTask(_ id: Int, session: ConnectionSession) {
+        sessionsByTaskID[id] = session
+    }
+
+    fileprivate func unregisterTask(_ id: Int) -> ConnectionSession? {
+        return sessionsByTaskID.removeValue(forKey: id)
+    }
+
+    fileprivate func lookupTask(_ id: Int) -> ConnectionSession? {
+        return sessionsByTaskID[id]
+    }
+}
+
+extension LocalHTTPProxy: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        lookupTask(dataTask.taskIdentifier)?.onUpstreamResponse(response)
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession,
+                    dataTask: URLSessionDataTask,
+                    didReceive data: Data) {
+        lookupTask(dataTask.taskIdentifier)?.onUpstreamChunk(data)
+    }
+
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    didCompleteWithError error: Error?) {
+        unregisterTask(task.taskIdentifier)?.onUpstreamComplete(error: error)
+    }
+}
+
+/// Handles a single inbound HTTP/1.1 connection: reads the request line and
+/// headers, forwards the request to the upstream origin via URLSession, and
+/// streams the response back chunk-by-chunk to the client connection. One
+/// request per connection (Connection: close).
+final class ConnectionSession {
+    private let conn: NWConnection
+    private unowned let proxy: LocalHTTPProxy
+    private let queue: DispatchQueue
+    private var headerBuffer = Data()
+    private var didEmitStart = false
+    private var finished = false
+    private var method = "GET"
+    private var headersSentToClient = false
+    // Queued writes back to the client — we process sequentially to avoid
+    // overlapping sends on the same NWConnection.
+    private var writeQueue: [Data] = []
+    private var writing = false
+
+    init(conn: NWConnection, proxy: LocalHTTPProxy, queue: DispatchQueue) {
+        self.conn = conn
+        self.proxy = proxy
+        self.queue = queue
+    }
+
+    func start() {
+        readMoreHeaderBytes()
+    }
+
+    private func readMoreHeaderBytes() {
+        conn.receive(minimumIncompleteLength: 1, maximumLength: 16 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let error = error {
+                self.fail("receive error: \(error)")
+                return
+            }
+            if let data = data, !data.isEmpty {
+                self.headerBuffer.append(data)
+                if self.headerBuffer.count > 64 * 1024 {
+                    self.fail("headers too long")
+                    return
+                }
+                if let terminator = self.findHeaderTerminator() {
+                    self.onHeadersReady(terminatorEnd: terminator)
+                    return
+                }
+            }
+            if isComplete {
+                self.fail("connection closed before headers")
+                return
+            }
+            self.readMoreHeaderBytes()
+        }
+    }
+
+    private func findHeaderTerminator() -> Int? {
+        // Look for \r\n\r\n; return index of end-of-headers.
+        let pattern = Data([0x0D, 0x0A, 0x0D, 0x0A])
+        if let r = headerBuffer.range(of: pattern) {
+            return r.upperBound
+        }
+        return nil
+    }
+
+    private func onHeadersReady(terminatorEnd: Int) {
+        let headerData = headerBuffer.subdata(in: 0..<terminatorEnd)
+        guard let raw = String(data: headerData, encoding: .utf8) else {
+            fail("non-utf8 headers")
+            return
+        }
+        let lines = raw.replacingOccurrences(of: "\r\n", with: "\n")
+                       .split(separator: "\n", omittingEmptySubsequences: false)
+        guard let requestLine = lines.first else {
+            fail("empty request")
+            return
+        }
+        let parts = requestLine.split(separator: " ", maxSplits: 2)
+        guard parts.count >= 2 else {
+            fail("bad request line: \(requestLine)")
+            return
+        }
+        let method = String(parts[0])
+        let path = String(parts[1])
+        guard method == "GET" || method == "HEAD" else {
+            writeStatusLineAndClose(status: 405, reason: "Method Not Allowed")
+            return
+        }
+        // Parse headers into dict (last value wins — good enough).
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            if line.isEmpty { break }
+            if let colon = line.firstIndex(of: ":") {
+                let key = String(line[..<colon]).trimmingCharacters(in: .whitespaces)
+                let value = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+                if !key.isEmpty { headers[key.lowercased()] = value }
+            }
+        }
+        guard let originURL = buildOriginURL(fromPath: path) else {
+            writeStatusLineAndClose(status: 400, reason: "No Origin Set")
+            return
+        }
+        forward(method: method, originURL: originURL, clientHeaders: headers)
+    }
+
+    /// Maps inbound `/path?query` 1:1 to the currently configured origin.
+    private func buildOriginURL(fromPath pathWithQuery: String) -> URL? {
+        let origin = proxy.currentOrigin()
+        guard !origin.host.isEmpty else { return nil }
+        let hostPart: String = {
+            if let p = origin.port { return "\(origin.host):\(p)" }
+            return origin.host
+        }()
+        // pathWithQuery is what came in on the HTTP request line, so it's
+        // already valid URL syntax (AVPlayer / URLSession always sends
+        // pre-encoded). Pass through as-is.
+        var built = "\(origin.scheme)://\(hostPart)"
+        if pathWithQuery.isEmpty { built += "/" } else { built += pathWithQuery }
+        return URL(string: built)
+    }
+
+    private func forward(method: String, originURL: URL, clientHeaders: [String: String]) {
+        self.method = method
+        var req = URLRequest(url: originURL)
+        req.httpMethod = method
+        req.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        // Forward a small safe subset of client headers.
+        let passThrough = ["range", "accept", "accept-encoding", "if-none-match", "if-modified-since", "user-agent"]
+        for key in passThrough {
+            if let v = clientHeaders[key] { req.setValue(v, forHTTPHeaderField: key.capitalized) }
+        }
+        let task = proxy.session.dataTask(with: req)
+        proxy.registerTask(task.taskIdentifier, session: self)
+        proxy.tracker.requestStarted()
+        didEmitStart = true
+        task.resume()
+    }
+
+    // MARK: - URLSession delegate callbacks (forwarded from LocalHTTPProxy)
+
+    fileprivate func onUpstreamResponse(_ response: URLResponse) {
+        guard let http = response as? HTTPURLResponse else {
+            writeStatusLineAndClose(status: 502, reason: "Non-HTTP upstream")
+            return
+        }
+        writeHeaders(status: http.statusCode, headers: http.allHeaderFields, responseURL: http.url)
+    }
+
+    fileprivate func onUpstreamChunk(_ data: Data) {
+        guard !data.isEmpty else { return }
+        proxy.tracker.chunkReceived(byteCount: data.count)
+        if method != "HEAD" {
+            enqueueWrite(data)
+        }
+    }
+
+    fileprivate func onUpstreamComplete(error: Error?) {
+        if let error = error {
+            if !headersSentToClient {
+                writeStatusLineAndClose(status: 502, reason: "Upstream Error")
+            } else {
+                Swift.print("[LOCAL_PROXY] upstream error after headers: \(error)")
+                finishAndClose()
+            }
+            return
+        }
+        finishAndClose()
+    }
+
+    // MARK: - Client-facing writes
+
+    private func writeHeaders(status: Int, headers: [AnyHashable: Any], responseURL: URL?) {
+        var lines: [String] = ["HTTP/1.1 \(status) \(Self.reason(for: status))"]
+        var headersOut: [String: String] = [:]
+        for (k, v) in headers {
+            guard let key = k as? String, let value = v as? String else { continue }
+            let lower = key.lowercased()
+            // Drop hop-by-hop and Content-Length / Transfer-Encoding — we'll use
+            // chunked TE for the body so AVPlayer can start consuming before we
+            // know the total size.
+            if ["connection", "keep-alive", "transfer-encoding", "content-length",
+                "content-encoding", "te", "trailer", "upgrade",
+                "proxy-authenticate", "proxy-authorization"].contains(lower) {
+                continue
+            }
+            headersOut[key] = value
+        }
+        headersOut["Transfer-Encoding"] = "chunked"
+        headersOut["Connection"] = "close"
+        for (k, v) in headersOut { lines.append("\(k): \(v)") }
+        lines.append("")
+        lines.append("")
+        let headerBytes = lines.joined(separator: "\r\n").data(using: .utf8) ?? Data()
+        headersSentToClient = true
+        enqueueRaw(headerBytes)
+    }
+
+    private func enqueueWrite(_ chunk: Data) {
+        // HTTP/1.1 chunked-transfer framing: "<hex-size>\r\n<bytes>\r\n"
+        let size = String(chunk.count, radix: 16)
+        var framed = Data()
+        framed.append((size + "\r\n").data(using: .utf8) ?? Data())
+        framed.append(chunk)
+        framed.append("\r\n".data(using: .utf8) ?? Data())
+        enqueueRaw(framed)
+    }
+
+    private func enqueueTerminator() {
+        // "0\r\n\r\n" ends a chunked body.
+        enqueueRaw(Data("0\r\n\r\n".utf8))
+    }
+
+    private func enqueueRaw(_ data: Data) {
+        writeQueue.append(data)
+        drainWrites()
+    }
+
+    private func drainWrites() {
+        guard !writing, let next = writeQueue.first else { return }
+        writing = true
+        writeQueue.removeFirst()
+        conn.send(content: next, completion: .contentProcessed { [weak self] error in
+            guard let self else { return }
+            self.writing = false
+            if let error = error {
+                Swift.print("[LOCAL_PROXY] send error: \(error)")
+                self.finishAndClose()
+                return
+            }
+            self.drainWrites()
+        })
+    }
+
+    private func writeStatusLineAndClose(status: Int, reason: String) {
+        let payload = "HTTP/1.1 \(status) \(reason)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        enqueueRaw(payload.data(using: .utf8) ?? Data())
+        finishAndClose(afterDrain: true)
+    }
+
+    private func fail(_ why: String) {
+        Swift.print("[LOCAL_PROXY] \(why)")
+        finishAndClose()
+    }
+
+    private func finishAndClose(afterDrain: Bool = false) {
+        guard !finished else { return }
+        finished = true
+        if didEmitStart { proxy.tracker.requestFinished() }
+        if headersSentToClient && method != "HEAD" {
+            // Flush the chunked-encoding terminator so the client sees a clean
+            // end-of-body before we tear the socket down.
+            let terminator = Data("0\r\n\r\n".utf8)
+            writeQueue.append(terminator)
+            drainWrites()
+        }
+        // Give the queue a moment to drain before cancelling. Simple deferred cancel.
+        queue.asyncAfter(deadline: .now() + .milliseconds(50)) { [conn = self.conn] in
+            conn.cancel()
+        }
+    }
+
+    static func reason(for status: Int) -> String {
+        switch status {
+        case 200: return "OK"
+        case 206: return "Partial Content"
+        case 301: return "Moved Permanently"
+        case 302: return "Found"
+        case 304: return "Not Modified"
+        case 400: return "Bad Request"
+        case 404: return "Not Found"
+        case 405: return "Method Not Allowed"
+        case 416: return "Range Not Satisfiable"
+        case 500: return "Internal Server Error"
+        case 502: return "Bad Gateway"
+        case 504: return "Gateway Timeout"
+        default: return "OK"
+        }
+    }
+}

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -2,6 +2,21 @@ import AVFoundation
 import Combine
 import Foundation
 
+fileprivate let consoleTimestampFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "HH:mm:ss.SSS"
+    f.locale = Locale(identifier: "en_US_POSIX")
+    return f
+}()
+
+// Shadows Swift.print for this target — every print() call in the module
+// gets a [HH:mm:ss.SSS] prefix in the Xcode console.
+func print(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+    let stamp = consoleTimestampFormatter.string(from: Date())
+    let body = items.map { String(describing: $0) }.joined(separator: separator)
+    Swift.print("[\(stamp)] \(body)", terminator: terminator)
+}
+
 struct MetricSample: Identifiable {
     let id = UUID()
     let timestamp: Date
@@ -27,6 +42,8 @@ final class PlaybackDiagnostics: ObservableObject {
     @Published var lastStallDurationSeconds: Double = 0
     @Published var observedBitrate: Double?
     @Published var indicatedBitrate: Double?
+    @Published var networkWindowBitrate: Double?
+    @Published var networkWireBitrate: Double?
     @Published var averageVideoBitrate: Double?
     @Published var droppedVideoFrames: Double?
     @Published var estimatedDisplayedFrames: Double?
@@ -50,21 +67,168 @@ final class PlaybackDiagnostics: ObservableObject {
     @Published var bufferDepthSamples: [MetricSample] = []
     @Published var liveOffsetSamples: [MetricSample] = []
 
+    @Published var frozenDetected: Bool = false
+    @Published var segmentStallDetected: Bool = false
+
     private var timeObserverToken: Any?
+    private var bitrateSampleTimer: Timer?
     private var cancellables: Set<AnyCancellable> = []
     private weak var player: AVPlayer?
     private var lastBufferSampleAt: Date?
     private var lastPlayerSampleAt: Date?
     private var stallStartAt: Date?
     private var hasRenderedFirstFrame: Bool = false
+    private var lastAdvancingTime: Double = 0
+    private var lastAdvancingAt: Date?
+    private var frozenLoggedAt: Date?
     private var lastObservedSegmentSequence: Int?
     private var maxObservedSegmentSequence: Int?
     private let maxSeriesSamples = 600
+    private var variantDwellSeconds: [String: Double] = [:]  // variant label -> total seconds (prior + current)
+    private var priorVariantDwellSeconds: [String: Double] = [:]  // accumulated across restarts
+    private var priorDroppedVideoFrames: Double = 0
+    private var priorEstimatedDisplayedFrames: Double = 0
+    private var knownVariants: Set<String> = []
+    private var lastVariantSummaryAt: Date?
+    private var lastAccessLogEventCount: Int = 0
+    private var lastVariantDwellTotal: Double = 0
+    private var lastVariantDwellChangeAt: Date?
+    private let segmentStallThresholdSeconds: TimeInterval = 30
     private let seriesWindowSeconds: TimeInterval = 300
+    private let networkWindowSeconds: TimeInterval = 6
+    private var networkByteSamples: [(timestamp: Date, bytes: Int64, xfer: Double)] = []
+    // Rolling samples for the proxy-based bitrate. `flowingMs` is cumulative
+    // ms during which a chunk arrived within the last 100 ms (from RequestTracker).
+    // Using flowingMs as the denominator gives a transfer-time rate that tracks
+    // the actual wire delivery rate instead of being diluted by idle gaps
+    // between segment requests.
+    private var wireByteSamples: [(timestamp: Date, bytes: Int64, flowingMs: Double)] = []
+    private let wireWindowSeconds: TimeInterval = 6
+    private let wireMinFlowingSeconds: TimeInterval = 0.3
+    private static let bitrateSampleFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
 
     func bind(to player: AVPlayer) {
         self.player = player
         observePlayer(player)
+        startBitrateSampleTimer()
+    }
+
+    deinit {
+        bitrateSampleTimer?.invalidate()
+    }
+
+    private func startBitrateSampleTimer() {
+        bitrateSampleTimer?.invalidate()
+        bitrateSampleTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            self?.emitBitrateSample()
+        }
+    }
+
+    private func emitBitrateSample() {
+        guard let item = player?.currentItem,
+              let events = item.accessLog()?.events, !events.isEmpty else { return }
+        var totalBytes: Int64 = 0
+        var totalXfer: Double = 0
+        for ev in events {
+            if ev.numberOfBytesTransferred > 0 { totalBytes += ev.numberOfBytesTransferred }
+            if ev.transferDuration > 0 { totalXfer += ev.transferDuration }
+        }
+        let observedBps = events.last?.observedBitrate ?? 0
+        let now = Date()
+        let ts = Self.bitrateSampleFormatter.string(from: now)
+        let windowBps = networkWindowBitrate ?? -1
+        let approxBps = computeApproxActiveBitrate(now: now) ?? -1
+        let wire = RequestTracker.shared.snapshot(now: now)
+        let wireLastChunkMsAgo = wire.wireLastChunkMsAgo ?? -1
+        updateNetworkWireBitrate(wire: wire, now: now)
+        // BITRATE_SAMPLE logging disabled — re-enable when offline analysis needed.
+        // let line = String(
+        //     format: "[BITRATE_SAMPLE] {\"t\":\"%@\",\"bytes\":%lld,\"xfer\":%.3f,\"observed_bps\":%.0f,\"network_window_bps\":%.0f,\"approx_xfer_bps\":%.0f,\"wire_bytes\":%lld,\"wire_active_ms\":%.1f,\"wire_flowing_ms\":%.1f,\"wire_inflight\":%d,\"wire_last_chunk_ms_ago\":%.1f,\"network_wire_bps\":%.0f}",
+        //     ts, totalBytes, totalXfer, observedBps, windowBps, approxBps,
+        //     wire.wireBytesTotal, wire.wireActiveMsTotal, wire.wireFlowingMsTotal,
+        //     wire.wireInflightCount, wireLastChunkMsAgo,
+        //     networkWireBitrate ?? -1
+        // )
+        // Swift.print(line)
+        _ = (ts, totalBytes, totalXfer, observedBps, windowBps, approxBps, wireLastChunkMsAgo)
+    }
+
+    // Rolling wire-bytes bitrate: like `networkWindowBitrate`, but fed from
+    // the LocalHTTPProxy's per-chunk accounting. Report nil when there are no
+    // outstanding requests AND no new bytes arrived since the previous sample —
+    // this gives the chart a clean gap during idle gaps between segment fetches.
+    private func updateNetworkWireBitrate(wire: RequestTracker.Snapshot, now: Date) {
+        wireByteSamples.append((timestamp: now, bytes: wire.wireBytesTotal, flowingMs: wire.wireFlowingMsTotal))
+        let cutoff = now.addingTimeInterval(-(wireWindowSeconds + 1))
+        wireByteSamples.removeAll { $0.timestamp < cutoff }
+        // Idle gate: no requests in flight AND last chunk arrived > 250ms ago.
+        // Covers the ~200ms gap between LL-HLS partials but goes nil promptly
+        // when the player truly stops fetching (buffer full) — otherwise the
+        // flowing-ms denominator would trail a stale rate for up to 6s as
+        // the window rolls off.
+        if wire.wireInflightCount == 0,
+           (wire.wireLastChunkMsAgo ?? .infinity) > 250 {
+            networkWireBitrate = nil
+            return
+        }
+        let windowStart = now.addingTimeInterval(-wireWindowSeconds)
+        guard let oldest = wireByteSamples.first(where: { $0.timestamp >= windowStart })
+                ?? wireByteSamples.first,
+              oldest.timestamp < now else {
+            networkWireBitrate = nil
+            return
+        }
+        // Transfer-time denominator: count only ms during which bytes were
+        // actually flowing on the wire. This matches the shaper limit during
+        // bursty fetches instead of diluting by idle gaps between segments.
+        let flowingSec = max(0, (wire.wireFlowingMsTotal - oldest.flowingMs) / 1000.0)
+        let dBytes = Double(max(0, wire.wireBytesTotal - oldest.bytes))
+        guard flowingSec >= wireMinFlowingSeconds, dBytes > 0 else {
+            networkWireBitrate = nil
+            return
+        }
+        networkWireBitrate = dBytes * 8.0 / flowingSec
+    }
+
+    // Approximate "active transfer" rate: sum wall time of 100ms sub-intervals
+    // where cumulative bytes grew (i.e. data was flowing). Denominator is that
+    // active time only, so idle gaps between segments don't dilute the rate.
+    // Result tends to match the TCP burst delivery rate rather than the
+    // sustained shaper rate. Returns nil while warming up.
+    private func computeApproxActiveBitrate(now: Date) -> Double? {
+        let windowStart = now.addingTimeInterval(-networkWindowSeconds)
+        let recent = networkByteSamples.filter { $0.timestamp >= windowStart }
+        guard recent.count >= 2, let oldest = recent.first, let newest = recent.last,
+              newest.timestamp > oldest.timestamp else {
+            return nil
+        }
+        let wall = newest.timestamp.timeIntervalSince(oldest.timestamp)
+        let dBytes = Double(max(0, newest.bytes - oldest.bytes))
+        if wall >= networkWindowSeconds && dBytes == 0 { return 0 }
+        guard wall >= 1.0 else { return nil }
+        var activeTime: TimeInterval = 0
+        for i in 1..<recent.count {
+            let dt = recent[i].timestamp.timeIntervalSince(recent[i-1].timestamp)
+            let db = recent[i].bytes - recent[i-1].bytes
+            if db > 0 { activeTime += dt }
+        }
+        guard activeTime >= 0.1 else { return 0 }
+        return dBytes * 8.0 / activeTime
+    }
+
+    /// Call before replacing the player item to preserve cumulative stats across restarts.
+    func snapshotForRestart() {
+        // Accumulate variant dwell times
+        for (label, seconds) in variantDwellSeconds {
+            priorVariantDwellSeconds[label, default: 0] = seconds
+        }
+        // Accumulate frame counters
+        priorDroppedVideoFrames = droppedVideoFrames ?? 0
+        priorEstimatedDisplayedFrames = estimatedDisplayedFrames ?? 0
     }
 
     func reset() {
@@ -86,6 +250,10 @@ final class PlaybackDiagnostics: ObservableObject {
         lastStallDurationSeconds = 0
         observedBitrate = nil
         indicatedBitrate = nil
+        networkWindowBitrate = nil
+        networkByteSamples = []
+        networkWireBitrate = nil
+        wireByteSamples = []
         averageVideoBitrate = nil
         droppedVideoFrames = nil
         estimatedDisplayedFrames = nil
@@ -114,6 +282,19 @@ final class PlaybackDiagnostics: ObservableObject {
         hasRenderedFirstFrame = false
         lastObservedSegmentSequence = nil
         maxObservedSegmentSequence = nil
+        frozenDetected = false
+        lastAdvancingTime = 0
+        lastAdvancingAt = nil
+        frozenLoggedAt = nil
+        // Reset current-item tracking but keep prior accumulators
+        variantDwellSeconds = priorVariantDwellSeconds
+        lastVariantSummaryAt = nil
+        lastAccessLogEventCount = 0
+        segmentStallDetected = false
+        lastVariantDwellTotal = priorVariantDwellSeconds.values.reduce(0, +)
+        lastVariantDwellChangeAt = nil
+        // Don't clear: priorVariantDwellSeconds, priorDroppedVideoFrames,
+        // priorEstimatedDisplayedFrames, knownVariants
     }
 
     func markFirstFrameRendered() {
@@ -126,17 +307,24 @@ final class PlaybackDiagnostics: ObservableObject {
         player.publisher(for: \.timeControlStatus)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
+                guard let self else { return }
+                let prev = self.state
+                let item = self.player?.currentItem
+                let bufEmpty = item?.isPlaybackBufferEmpty ?? false
+                let keepUp = item?.isPlaybackLikelyToKeepUp ?? false
+                let rate = self.player?.rate ?? 0
                 switch status {
                 case .paused:
-                    self?.state = "Paused"
+                    self.state = "Paused"
                 case .waitingToPlayAtSpecifiedRate:
-                    self?.state = "Buffering"
-                    self?.startStallIfNeeded()
+                    self.state = "Buffering"
+                    self.startStallIfNeeded()
                 case .playing:
-                    self?.state = "Playing"
-                    self?.endStallIfNeeded()
-                @unknown default: self?.state = "Unknown"
+                    self.state = "Playing"
+                    self.endStallIfNeeded()
+                @unknown default: self.state = "Unknown"
                 }
+                print("[STATE] \(prev) -> \(self.state) rate=\(rate) bufferEmpty=\(bufEmpty) likelyToKeepUp=\(keepUp) time=\(String(format: "%.2f", self.currentTime))")
             }
             .store(in: &cancellables)
 
@@ -145,7 +333,11 @@ final class PlaybackDiagnostics: ObservableObject {
             .sink { [weak self] reason in
                 if let reason = reason {
                     self?.waitingReason = reason.rawValue
+                    print("[WAITING] reason=\(reason.rawValue) state=\(self?.state ?? "?") time=\(String(format: "%.2f", self?.currentTime ?? 0))")
                 } else {
+                    if !(self?.waitingReason.isEmpty ?? true) {
+                        print("[WAITING] reason=cleared state=\(self?.state ?? "?") time=\(String(format: "%.2f", self?.currentTime ?? 0))")
+                    }
                     self?.waitingReason = ""
                 }
             }
@@ -153,12 +345,25 @@ final class PlaybackDiagnostics: ObservableObject {
 
         player.publisher(for: \.rate)
             .receive(on: DispatchQueue.main)
-            .assign(to: &$playbackRate)
+            .sink { [weak self] rate in
+                guard let self else { return }
+                let prev = self.playbackRate
+                self.playbackRate = rate
+                if abs(rate - prev) > 0.001 {
+                    print("[RATE] \(prev) -> \(rate) state=\(self.state) time=\(String(format: "%.2f", self.currentTime))")
+                }
+            }
+            .store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: .AVPlayerItemPlaybackStalled)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.startStallIfNeeded()
+                guard let self else { return }
+                let item = self.player?.currentItem
+                let bufEmpty = item?.isPlaybackBufferEmpty ?? false
+                let keepUp = item?.isPlaybackLikelyToKeepUp ?? false
+                print("[STALL] bufferEmpty=\(bufEmpty) likelyToKeepUp=\(keepUp) state=\(self.state) time=\(String(format: "%.2f", self.currentTime))")
+                self.startStallIfNeeded()
             }
             .store(in: &cancellables)
 
@@ -166,8 +371,10 @@ final class PlaybackDiagnostics: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
                 if let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? Error {
+                    print("[FAILURE] \(error.localizedDescription) state=\(self?.state ?? "?") time=\(String(format: "%.2f", self?.currentTime ?? 0))")
                     self?.lastFailure = error.localizedDescription
                 } else {
+                    print("[FAILURE] Playback failed state=\(self?.state ?? "?") time=\(String(format: "%.2f", self?.currentTime ?? 0))")
                     self?.lastFailure = "Playback failed"
                 }
             }
@@ -205,6 +412,8 @@ final class PlaybackDiagnostics: ObservableObject {
             self.currentTime = time.seconds
             self.updateBufferMetrics()
             self.updateItemState()
+            self.checkFrozenState()
+            self.periodicVariantSummary()
         }
     }
 
@@ -234,6 +443,19 @@ final class PlaybackDiagnostics: ObservableObject {
                 }
             }
         }
+        // Fallback: try async track load if sync method returned nothing
+        if nominalFrameRate == nil || (nominalFrameRate ?? 0) <= 0 {
+            Task { @MainActor [weak self] in
+                guard let self, let item = self.player?.currentItem else { return }
+                if let tracks = try? await item.asset.loadTracks(withMediaType: .video),
+                   let track = tracks.first {
+                    let fps = try? await track.load(.nominalFrameRate)
+                    if let fps, fps > 0 {
+                        self.nominalFrameRate = Double(fps)
+                    }
+                }
+            }
+        }
     }
 
     func updateDisplaySize(_ size: CGSize) {
@@ -249,13 +471,18 @@ final class PlaybackDiagnostics: ObservableObject {
     private func updateBufferMetrics() {
         guard let item = player?.currentItem else { return }
         let ranges = item.loadedTimeRanges
-        if let range = ranges.last?.timeRangeValue {
+        if item.isPlaybackBufferEmpty {
+            bufferDepth = 0
+            if let range = ranges.last?.timeRangeValue {
+                bufferedEnd = range.start.seconds + range.duration.seconds
+            }
+        } else if let range = ranges.last?.timeRangeValue {
             let end = range.start.seconds + range.duration.seconds
             bufferedEnd = end
             bufferDepth = max(0, end - currentTime)
         } else {
             bufferedEnd = nil
-            bufferDepth = nil
+            bufferDepth = 0
         }
         if let depth = bufferDepth {
             let now = Date()
@@ -286,6 +513,47 @@ final class PlaybackDiagnostics: ObservableObject {
         stallCount += 1
     }
 
+    private func checkFrozenState() {
+        let now = Date()
+        let time = currentTime
+        if abs(time - lastAdvancingTime) > 0.01 {
+            lastAdvancingTime = time
+            lastAdvancingAt = now
+            if frozenDetected {
+                frozenDetected = false
+            }
+            return
+        }
+        guard state != "Idle" && state != "Paused" else {
+            lastAdvancingAt = now
+            return
+        }
+        guard let advancedAt = lastAdvancingAt else {
+            lastAdvancingAt = now
+            return
+        }
+        let stalledFor = now.timeIntervalSince(advancedAt)
+        if stalledFor >= 3.0 && !frozenDetected {
+            frozenDetected = true
+            let item = player?.currentItem
+            let bufEmpty = item?.isPlaybackBufferEmpty ?? false
+            let keepUp = item?.isPlaybackLikelyToKeepUp ?? false
+            let rate = player?.rate ?? 0
+            let status = player?.timeControlStatus.rawValue ?? -1
+            let reason = player?.reasonForWaitingToPlay?.rawValue ?? "none"
+            let ranges = item?.loadedTimeRanges.map { $0.timeRangeValue }
+            let rangeDesc = ranges?.map { String(format: "%.1f-%.1f", $0.start.seconds, $0.start.seconds + $0.duration.seconds) }.joined(separator: ", ") ?? "none"
+            print("[FROZEN] time=\(String(format: "%.2f", time)) stalled_for=\(String(format: "%.1fs", stalledFor)) state=\(state) rate=\(rate) timeControlStatus=\(status) waitingReason=\(reason) bufferEmpty=\(bufEmpty) likelyToKeepUp=\(keepUp) loadedRanges=[\(rangeDesc)]")
+        }
+        if stalledFor >= 3.0 && frozenDetected {
+            // Log every 3 seconds while frozen
+            if frozenLoggedAt == nil || now.timeIntervalSince(frozenLoggedAt!) >= 3.0 {
+                frozenLoggedAt = now
+                print("[FROZEN] still frozen at time=\(String(format: "%.2f", time)) for \(String(format: "%.0fs", stalledFor)) state=\(state) rate=\(player?.rate ?? 0)")
+            }
+        }
+    }
+
     private func endStallIfNeeded() {
         guard let start = stallStartAt else { return }
         let duration = max(0, Date().timeIntervalSince(start))
@@ -294,7 +562,7 @@ final class PlaybackDiagnostics: ObservableObject {
         stallStartAt = nil
     }
 
-    private func updateAccessLog(from item: AVPlayerItem) {
+    private func refreshLiveAccessLogMetrics(from item: AVPlayerItem) {
         guard let event = item.accessLog()?.events.last else { return }
         observedBitrate = event.observedBitrate
         indicatedBitrate = event.indicatedBitrate
@@ -302,12 +570,6 @@ final class PlaybackDiagnostics: ObservableObject {
         if let uri = event.uri {
             lastSegmentURI = uri
             if let sequence = extractSegmentSequence(from: uri) {
-                if let previous = lastObservedSegmentSequence,
-                   let maxSeen = maxObservedSegmentSequence,
-                   maxSeen >= 5,
-                   sequence+5 < previous {
-                    loopCountPlayer = max(0, loopCountPlayer) + 1
-                }
                 if let maxSeen = maxObservedSegmentSequence {
                     maxObservedSegmentSequence = max(maxSeen, sequence)
                 } else {
@@ -316,10 +578,70 @@ final class PlaybackDiagnostics: ObservableObject {
                 lastObservedSegmentSequence = sequence
             }
         }
-        if event.numberOfDroppedVideoFrames > 0 {
-            droppedVideoFrames = Double(event.numberOfDroppedVideoFrames)
+        if let events = item.accessLog()?.events {
+            var totalDropped: Double = 0
+            var totalBytes: Int64 = 0
+            var totalXfer: Double = 0
+            for ev in events {
+                if ev.numberOfDroppedVideoFrames > 0 {
+                    totalDropped += Double(ev.numberOfDroppedVideoFrames)
+                }
+                if ev.numberOfBytesTransferred > 0 {
+                    totalBytes += ev.numberOfBytesTransferred
+                }
+                if ev.transferDuration > 0 {
+                    totalXfer += ev.transferDuration
+                }
+            }
+            droppedVideoFrames = priorDroppedVideoFrames + totalDropped
+            updateNetworkWindowBitrate(totalBytes: totalBytes, totalXfer: totalXfer, now: Date())
         }
-        // Samples are collected on a steady interval in samplePlayerMetrics().
+        updateVariantDwellTimes(from: item)
+    }
+
+    private func updateNetworkWindowBitrate(totalBytes: Int64, totalXfer: Double, now: Date) {
+        // Detect access-log purge (cumulative bytes decreased) — AVFoundation
+        // can retire old events, which resets our running totals. Drop all
+        // prior samples in that case so deltas aren't computed against stale
+        // baselines.
+        if let last = networkByteSamples.last,
+           totalBytes < last.bytes || totalXfer < last.xfer {
+            networkByteSamples.removeAll()
+        }
+        networkByteSamples.append((timestamp: now, bytes: totalBytes, xfer: totalXfer))
+        let cutoff = now.addingTimeInterval(-(networkWindowSeconds + 1))
+        networkByteSamples.removeAll { $0.timestamp < cutoff }
+        // Oldest sample within the 6s wall-clock window.
+        let windowStart = now.addingTimeInterval(-networkWindowSeconds)
+        let withinWindow = networkByteSamples.filter { $0.timestamp >= windowStart }
+        guard let oldest = withinWindow.first ?? networkByteSamples.first,
+              oldest.timestamp < now else {
+            networkWindowBitrate = nil
+            return
+        }
+        let wall = now.timeIntervalSince(oldest.timestamp)
+        let dBytes = Double(max(0, totalBytes - oldest.bytes))
+        // Idle detection — full window with zero byte growth means no data
+        // made it through for the entire window: report a genuine 0 Mbps.
+        if wall >= networkWindowSeconds && dBytes == 0 {
+            networkWindowBitrate = 0
+            return
+        }
+        // Warmup — need at least 1s of wall-clock history for a stable rate.
+        guard wall >= 1.0 else {
+            networkWindowBitrate = nil
+            return
+        }
+        // Wall-time denominator: the rate cannot exceed the shaper limit
+        // because over wall time, bytes that arrive must have passed through
+        // the shaper. xfer-time denominator, by contrast, only counts active
+        // transfer duration and can overshoot during TCP bursts.
+        networkWindowBitrate = dBytes * 8.0 / wall
+    }
+
+    private func updateAccessLog(from item: AVPlayerItem) {
+        refreshLiveAccessLogMetrics(from: item)
+        guard let event = item.accessLog()?.events.last else { return }
         var parts: [String] = []
         if let uri = event.uri {
             parts.append("uri=\(uri)")
@@ -331,10 +653,112 @@ final class PlaybackDiagnostics: ObservableObject {
         if event.transferDuration > 0 { parts.append("xfer=\(String(format: "%.2fs", event.transferDuration))") }
         if event.numberOfBytesTransferred > 0 { parts.append("bytes=\(event.numberOfBytesTransferred)") }
         if event.numberOfDroppedVideoFrames > 0 { parts.append("dropped=\(Int(event.numberOfDroppedVideoFrames))") }
-        // numberOfSegmentsDownloaded is unavailable on iOS/tvOS; omit.
         if let server = event.serverAddress { parts.append("server=\(server)") }
         if let session = event.playbackSessionID { parts.append("session=\(session)") }
         lastAccessLog = parts.joined(separator: " ")
+    }
+
+    private func variantLabel(from uri: String) -> String {
+        // Extract resolution label like "360p", "1080p", "2160p" from playlist URI
+        let base = (uri as NSString).lastPathComponent
+            .replacingOccurrences(of: ".m3u8", with: "")
+            .replacingOccurrences(of: "playlist_6s_", with: "")
+            .replacingOccurrences(of: "playlist_2s_", with: "")
+            .replacingOccurrences(of: "playlist_", with: "")
+        return base.isEmpty ? uri : base
+    }
+
+    private func updateVariantDwellTimes(from item: AVPlayerItem) {
+        guard let events = item.accessLog()?.events else { return }
+        // Discover new variant labels
+        let newEvents = events.dropFirst(lastAccessLogEventCount)
+        for event in newEvents {
+            guard let uri = event.uri else { continue }
+            let label = variantLabel(from: uri)
+            if label == "audio" { continue }
+            knownVariants.insert(label)
+        }
+        // Sum dwell from current item's access log
+        var currentDwell: [String: Double] = [:]
+        for event in events {
+            guard let uri = event.uri else { continue }
+            let label = variantLabel(from: uri)
+            if label == "audio" { continue }
+            let watched = event.durationWatched
+            if watched > 0 {
+                currentDwell[label, default: 0] += watched
+            }
+        }
+        lastAccessLogEventCount = events.count
+        // Merge prior + current
+        var merged = priorVariantDwellSeconds
+        for (label, seconds) in currentDwell {
+            merged[label, default: 0] += seconds
+        }
+        variantDwellSeconds = merged
+    }
+
+    private func periodicVariantSummary() {
+        if let item = player?.currentItem {
+            refreshLiveAccessLogMetrics(from: item)
+        }
+        guard !knownVariants.isEmpty else { return }
+        let now = Date()
+        if lastVariantSummaryAt == nil || now.timeIntervalSince(lastVariantSummaryAt!) >= 10.0 {
+            lastVariantSummaryAt = now
+            logVariantSummary()
+        }
+        checkSegmentStall(now: now)
+    }
+
+    private func checkSegmentStall(now: Date) {
+        let total = variantDwellSeconds.values.reduce(0, +)
+        if abs(total - lastVariantDwellTotal) > 0.1 {
+            lastVariantDwellTotal = total
+            lastVariantDwellChangeAt = now
+            if segmentStallDetected {
+                segmentStallDetected = false
+                print("[SEGMENT_STALL] resolved — segments downloading again total=\(String(format: "%.1f", total))")
+            }
+            return
+        }
+        guard state == "Playing" else {
+            lastVariantDwellChangeAt = now
+            return
+        }
+        guard let changeAt = lastVariantDwellChangeAt else {
+            lastVariantDwellChangeAt = now
+            return
+        }
+        let stalledFor = now.timeIntervalSince(changeAt)
+        if stalledFor >= segmentStallThresholdSeconds && !segmentStallDetected {
+            segmentStallDetected = true
+            print("[SEGMENT_STALL] no new segments for \(String(format: "%.0fs", stalledFor)) while state=\(state) time=\(String(format: "%.2f", currentTime)) variantTotal=\(String(format: "%.1f", total))")
+        }
+    }
+
+    private func logVariantSummary() {
+        let allLabels = knownVariants.sorted { a, b in
+            let aNum = Int(a.replacingOccurrences(of: "p", with: "")) ?? 0
+            let bNum = Int(b.replacingOccurrences(of: "p", with: "")) ?? 0
+            return aNum < bNum
+        }
+        let total = variantDwellSeconds.values.reduce(0, +)
+        let parts = allLabels.map { label in
+            let secs = variantDwellSeconds[label] ?? 0
+            let pct = total > 0 ? (secs / total) * 100 : 0
+            return "\(label)=\(String(format: "%.1fs", secs))(\(String(format: "%.0f%%", pct)))"
+        }
+        print("[VARIANTS] total=\(String(format: "%.1fs", total)) \(parts.joined(separator: " "))")
+        logBitrateSummary()
+    }
+
+    private func logBitrateSummary() {
+        // [BITRATE] summary print disabled — uncomment when investigating ABR.
+        // let observedMbps = (observedBitrate ?? 0) / 1_000_000
+        // let indicatedMbps = (indicatedBitrate ?? 0) / 1_000_000
+        // let windowMbps = (networkWindowBitrate ?? 0) / 1_000_000
+        // print("[BITRATE] observed=\(String(format: "%.2fMbps", observedMbps)) window\(Int(networkWindowSeconds))s=\(String(format: "%.2fMbps", windowMbps)) indicated=\(String(format: "%.2fMbps", indicatedMbps))")
     }
 
     private func updateErrorLog(from item: AVPlayerItem) {
@@ -384,7 +808,7 @@ final class PlaybackDiagnostics: ObservableObject {
             }
             if let fps = nominalFrameRate, fps > 0 {
                 let dropped = droppedVideoFrames ?? 0
-                let estimated = max(0, (currentTime * fps) - dropped)
+                let estimated = priorEstimatedDisplayedFrames + max(0, (currentTime * fps) - (dropped - priorDroppedVideoFrames))
                 estimatedDisplayedFrames = estimated
             }
             let variant = (indicatedBitrate ?? 0) > 0 ? (indicatedBitrate ?? 0) : (averageVideoBitrate ?? 0)
@@ -450,16 +874,21 @@ final class PlaybackDiagnostics: ObservableObject {
         item.publisher(for: \.status)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in
+                guard let self else { return }
+                let prev = self.itemStatus
                 switch status {
-                case .unknown: self?.itemStatus = "Unknown"
-                case .readyToPlay: self?.itemStatus = "Ready"
+                case .unknown: self.itemStatus = "Unknown"
+                case .readyToPlay: self.itemStatus = "Ready"
                 case .failed:
-                    self?.itemStatus = "Failed"
+                    self.itemStatus = "Failed"
                     if let err = item.error {
-                        self?.itemError = self?.describeError(err) ?? err.localizedDescription
+                        self.itemError = self.describeError(err)
                     }
-                @unknown default: self?.itemStatus = "Unknown"
+                @unknown default: self.itemStatus = "Unknown"
                 }
+                let bufEmpty = item.isPlaybackBufferEmpty
+                let keepUp = item.isPlaybackLikelyToKeepUp
+                print("[ITEM_STATUS] \(prev) -> \(self.itemStatus) bufferEmpty=\(bufEmpty) likelyToKeepUp=\(keepUp) error=\(item.error?.localizedDescription ?? "none") time=\(String(format: "%.2f", self.currentTime))")
             }
             .store(in: &cancellables)
     }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -56,6 +56,12 @@ final class PlaybackViewModel: ObservableObject {
     @Published var autoRecoveryEnabled: Bool = false {
         didSet { persist(.autoRecoveryEnabled, autoRecoveryEnabled ? "true" : "false") }
     }
+    @Published var goLiveMode: Bool = false {
+        didSet { persist(.goLiveMode, goLiveMode ? "true" : "false") }
+    }
+    @Published var localProxyEnabled: Bool = true {
+        didSet { persist(.localProxyEnabled, localProxyEnabled ? "true" : "false") }
+    }
     @Published var playerRestarts: Int = 0
     @Published var profileShiftCount: Int = 0
 
@@ -78,12 +84,16 @@ final class PlaybackViewModel: ObservableObject {
     private var lastReportedStallCount: Int = 0
     private var lastReportedStallDuration: Double = 0
     private var lastReportedLoopCount: Int = 0
-    private let metricsHeartbeatSeconds: TimeInterval = 5
+    private let metricsHeartbeatSeconds: TimeInterval = 1
     private let metricsSessionLookupSeconds: TimeInterval = 30
     private let autoRecoveryThresholdSeconds: TimeInterval = 60
-    private let autoRecoveryCooldownSeconds: TimeInterval = 60
+    private let autoRecoveryBaseDelaySeconds: TimeInterval = 2
+    private let autoRecoveryMaxAttempts: Int = 3
+    private let autoRecoveryVerifyDelaySeconds: TimeInterval = 10
+    private var autoRecoveryAttempts: Int = 0
+    private var autoRecoveryRestartTimer: Timer?
+    private var autoRecoveryVerifyTimer: Timer?
     private var zeroBufferStartedAt: Date?
-    private var lastAutoRecoveryRestartAt: Date?
     private let diagnosticsProbesEnabled = false
     private let logPlaylistsOnPlay = false
     private let masterPreflightEnabled = true
@@ -92,6 +102,9 @@ final class PlaybackViewModel: ObservableObject {
 
     init() {
         loadDefaults()
+        if localProxyEnabled {
+            LocalHTTPProxy.shared.startIfNeeded()
+        }
         diagnostics.bind(to: player)
         if playerId.isEmpty {
             playerId = UUID().uuidString
@@ -208,9 +221,14 @@ final class PlaybackViewModel: ObservableObject {
 
     func restartPlayback(reason: String = "manual") {
         playerRestarts = max(0, playerRestarts) + 1
-        if reason == "auto_recovery_zero_buffer" {
-            lastAutoRecoveryRestartAt = Date()
+        if reason.hasPrefix("auto_recovery") {
             zeroBufferStartedAt = nil
+        } else {
+            autoRecoveryAttempts = 0
+            autoRecoveryRestartTimer?.invalidate()
+            autoRecoveryRestartTimer = nil
+            autoRecoveryVerifyTimer?.invalidate()
+            autoRecoveryVerifyTimer = nil
         }
         Task {
             await sendPlayerMetrics(event: "restart", extra: [
@@ -219,6 +237,7 @@ final class PlaybackViewModel: ObservableObject {
                 "player_auto_recovery_enabled": autoRecoveryEnabled
             ])
         }
+        diagnostics.snapshotForRestart()
         player.pause()
         player.replaceCurrentItem(with: nil)
         reload()
@@ -330,7 +349,21 @@ final class PlaybackViewModel: ObservableObject {
             statusMessage = "Playing \(contentName)"
         }
 
-        let asset = AVURLAsset(url: url, options: nil)
+        let assetURL: URL
+        if localProxyEnabled {
+            LocalHTTPProxy.shared.startIfNeeded()
+            assetURL = LocalHTTPProxy.shared.rewrite(originURL: url) ?? url
+            if assetURL != url {
+                log("Intercept ON — asset URL: \(assetURL.absoluteString)")
+            } else {
+                log("Intercept OFF (proxy unavailable) — asset URL: \(assetURL.absoluteString)")
+            }
+        } else {
+            assetURL = url
+            log("Intercept OFF (disabled) — asset URL: \(assetURL.absoluteString)")
+        }
+        let asset = AVURLAsset(url: assetURL, options: nil)
+        RequestTracker.shared.reset()
         let item = AVPlayerItem(asset: asset)
         apply4kPreference(to: item)
         playbackStartAt = Date()
@@ -436,6 +469,8 @@ final class PlaybackViewModel: ObservableObject {
         case playerId = "bossPlayerId"
         case prefer4kNative = "bossPrefer4kNative"
         case autoRecoveryEnabled = "bossAutoRecovery"
+        case goLiveMode = "bossGoLiveMode"
+        case localProxyEnabled = "bossLocalProxyEnabled"
     }
 
     private func loadDefaults() {
@@ -481,6 +516,12 @@ final class PlaybackViewModel: ObservableObject {
         if let storedAutoRecovery = defaults.string(forKey: DefaultsKey.autoRecoveryEnabled.rawValue) {
             autoRecoveryEnabled = storedAutoRecovery == "true"
         }
+        if let storedGoLive = defaults.string(forKey: DefaultsKey.goLiveMode.rawValue) {
+            goLiveMode = storedGoLive == "true"
+        }
+        if let storedLocalProxy = defaults.string(forKey: DefaultsKey.localProxyEnabled.rawValue) {
+            localProxyEnabled = storedLocalProxy == "true"
+        }
     }
 
     private func persist(_ key: DefaultsKey, _ value: String) {
@@ -496,12 +537,11 @@ final class PlaybackViewModel: ObservableObject {
 
     private func log(_ message: String) {
         let stamp = ISO8601DateFormatter().string(from: Date())
-        let line = "[\(stamp)] \(message)"
-        logLines.append(line)
+        logLines.append("[\(stamp)] \(message)")
         if logLines.count > 200 {
             logLines.removeFirst(logLines.count - 200)
         }
-        print(line)
+        print(message)
     }
 
 
@@ -519,8 +559,13 @@ final class PlaybackViewModel: ObservableObject {
             .removeDuplicates()
             .filter { !$0.isEmpty }
             .sink { [weak self] value in
-                self?.log("Playback failure: \(value)")
-                Task { await self?.sendPlayerMetrics(event: "error", extra: ["player_metrics_error": value]) }
+                guard let self else { return }
+                self.log("Playback failure: \(value)")
+                Task { await self.sendPlayerMetrics(event: "error", extra: ["player_metrics_error": value]) }
+                if self.autoRecoveryEnabled {
+                    print("[AUTO_RECOVERY] triggered failure=\(value) state=\(self.diagnostics.state) bufferEmpty=\(self.diagnostics.bufferEmpty) time=\(String(format: "%.2f", self.diagnostics.currentTime))")
+                    self.scheduleAutoRecoveryRestart(reason: "auto_recovery_failure")
+                }
             }
             .store(in: &cancellables)
 
@@ -569,6 +614,40 @@ final class PlaybackViewModel: ObservableObject {
             .filter { !$0.isEmpty }
             .sink { [weak self] value in
                 self?.log("Waiting reason: \(value)")
+            }
+            .store(in: &cancellables)
+
+        diagnostics.$frozenDetected
+            .removeDuplicates()
+            .sink { [weak self] frozen in
+                guard let self else { return }
+                if frozen {
+                    self.log("FROZEN: video time stopped advancing while state=\(self.diagnostics.state) bufferEmpty=\(self.diagnostics.bufferEmpty) likelyToKeepUp=\(self.diagnostics.likelyToKeepUp)")
+                    Task { await self.sendPlayerMetrics(event: "frozen") }
+                    if self.autoRecoveryEnabled {
+                        print("[AUTO_RECOVERY] triggered frozen state=\(self.diagnostics.state) bufferEmpty=\(self.diagnostics.bufferEmpty) time=\(String(format: "%.2f", self.diagnostics.currentTime))")
+                        self.scheduleAutoRecoveryRestart(reason: "auto_recovery_frozen")
+                    }
+                } else if self.diagnostics.state == "Playing" {
+                    self.log("UNFROZEN: video time advancing again")
+                }
+            }
+            .store(in: &cancellables)
+
+        diagnostics.$segmentStallDetected
+            .removeDuplicates()
+            .sink { [weak self] stalled in
+                guard let self else { return }
+                if stalled {
+                    self.log("SEGMENT_STALL: no new segments downloading while playing")
+                    Task { await self.sendPlayerMetrics(event: "segment_stall") }
+                    if self.autoRecoveryEnabled {
+                        print("[AUTO_RECOVERY] triggered segment_stall time=\(String(format: "%.2f", self.diagnostics.currentTime))")
+                        self.scheduleAutoRecoveryRestart(reason: "auto_recovery_segment_stall")
+                    }
+                } else {
+                    self.log("SEGMENT_STALL resolved: segments downloading again")
+                }
             }
             .store(in: &cancellables)
 
@@ -626,7 +705,9 @@ final class PlaybackViewModel: ObservableObject {
             .sink { [weak self] currentTime in
                 guard let self else { return }
                 guard let startAt = self.playbackStartAt else { return }
-                if !self.firstFrameReported && currentTime > 0 {
+                let isActivelyPlaying = self.diagnostics.state == "Playing"
+                    && self.diagnostics.playbackRate > 0
+                if !self.firstFrameReported && currentTime > 0 && isActivelyPlaying {
                     let elapsed = self.roundSeconds(Date().timeIntervalSince(startAt))
                     self.videoFirstFrameSeconds = elapsed
                     self.firstFrameReported = true
@@ -637,7 +718,7 @@ final class PlaybackViewModel: ObservableObject {
                         ])
                     }
                 }
-                if !self.playingReported && currentTime >= 0.1 && self.diagnostics.playbackRate > 0 {
+                if !self.playingReported && currentTime >= 0.1 && isActivelyPlaying {
                     let elapsed = self.roundSeconds(Date().timeIntervalSince(startAt))
                     self.videoPlayingTimeSeconds = elapsed
                     self.playingReported = true
@@ -661,9 +742,72 @@ final class PlaybackViewModel: ObservableObject {
     private func startMetricsHeartbeat() {
         metricsHeartbeatTimer?.invalidate()
         metricsHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: metricsHeartbeatSeconds, repeats: true) { [weak self] _ in
-            Task {
+            Task { @MainActor [weak self] in
                 self?.evaluateAutoRecoveryIfNeeded()
                 await self?.sendPlayerMetrics(event: "heartbeat")
+            }
+        }
+    }
+
+    private func scheduleAutoRecoveryRestart(reason: String) {
+        if autoRecoveryRestartTimer != nil {
+            print("[AUTO_RECOVERY] ignoring \(reason) — restart already scheduled")
+            return
+        }
+        if autoRecoveryAttempts >= autoRecoveryMaxAttempts {
+            print("[AUTO_RECOVERY] exhausted — \(autoRecoveryAttempts) attempts in a row — giving up on \(reason)")
+            log("Auto-recovery: exhausted after \(autoRecoveryAttempts) consecutive attempts — giving up")
+            return
+        }
+        let attempt = autoRecoveryAttempts + 1
+        let delay = autoRecoveryBaseDelaySeconds * pow(2, Double(attempt - 1))
+        let scheduledAtTime = diagnostics.currentTime
+        log("Auto-recovery: attempt \(attempt)/\(autoRecoveryMaxAttempts) scheduled in \(Int(delay))s (\(reason))")
+        print("[AUTO_RECOVERY] scheduling attempt \(attempt)/\(autoRecoveryMaxAttempts) in \(Int(delay))s reason=\(reason) state=\(diagnostics.state) time=\(String(format: "%.2f", scheduledAtTime))")
+        autoRecoveryRestartTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.autoRecoveryRestartTimer = nil
+                let timeAdvanced = self.diagnostics.currentTime > scheduledAtTime + 0.5
+                let recovered = self.diagnostics.state == "Playing"
+                    && !self.diagnostics.frozenDetected
+                    && !self.diagnostics.segmentStallDetected
+                    && timeAdvanced
+                if recovered {
+                    self.log("Auto-recovery: cancelled — recovered naturally (\(reason))")
+                    print("[AUTO_RECOVERY] cancelled — recovered reason=\(reason) state=\(self.diagnostics.state) time=\(String(format: "%.2f", self.diagnostics.currentTime))")
+                    self.autoRecoveryAttempts = 0
+                    return
+                }
+                self.autoRecoveryAttempts = attempt
+                self.log("Auto-recovery: attempt \(attempt)/\(self.autoRecoveryMaxAttempts) restarting (\(reason))")
+                print("[AUTO_RECOVERY] executing attempt \(attempt)/\(self.autoRecoveryMaxAttempts) reason=\(reason) state=\(self.diagnostics.state) time=\(String(format: "%.2f", self.diagnostics.currentTime))")
+                self.restartPlayback(reason: reason)
+                self.scheduleAutoRecoverySuccessCheck()
+            }
+        }
+    }
+
+    private func scheduleAutoRecoverySuccessCheck() {
+        autoRecoveryVerifyTimer?.invalidate()
+        autoRecoveryVerifyTimer = Timer.scheduledTimer(withTimeInterval: autoRecoveryVerifyDelaySeconds, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.autoRecoveryVerifyTimer = nil
+                if self.autoRecoveryRestartTimer != nil {
+                    print("[AUTO_RECOVERY] verify: another restart pending — keeping attempts=\(self.autoRecoveryAttempts)")
+                    return
+                }
+                let playingCleanly = self.diagnostics.state == "Playing"
+                    && !self.diagnostics.frozenDetected
+                    && !self.diagnostics.segmentStallDetected
+                if playingCleanly {
+                    self.log("Auto-recovery: restart succeeded — resetting attempt counter (was \(self.autoRecoveryAttempts))")
+                    print("[AUTO_RECOVERY] verify: playing cleanly — resetting attempts (was \(self.autoRecoveryAttempts))")
+                    self.autoRecoveryAttempts = 0
+                } else {
+                    print("[AUTO_RECOVERY] verify: not clean — keeping attempts=\(self.autoRecoveryAttempts) state=\(self.diagnostics.state) frozen=\(self.diagnostics.frozenDetected) segStall=\(self.diagnostics.segmentStallDetected)")
+                }
             }
         }
     }
@@ -697,13 +841,9 @@ final class PlaybackViewModel: ObservableObject {
         if zeroDuration < autoRecoveryThresholdSeconds {
             return
         }
-        if let last = lastAutoRecoveryRestartAt,
-           now.timeIntervalSince(last) < autoRecoveryCooldownSeconds {
-            return
-        }
 
-        log("Auto-recovery: restarting playback after \(Int(zeroDuration))s at zero buffer depth")
-        restartPlayback(reason: "auto_recovery_zero_buffer")
+        print("[AUTO_RECOVERY] triggered zero_buffer after \(Int(zeroDuration))s time=\(String(format: "%.2f", diagnostics.currentTime))")
+        scheduleAutoRecoveryRestart(reason: "auto_recovery_zero_buffer")
     }
 
     private func handleRenditionShift(indicated: Double?, average: Double?) {
@@ -825,6 +965,19 @@ final class PlaybackViewModel: ObservableObject {
             if let value {
                 compact[key] = value
             }
+        }
+        // Always include network_window_mbps — send explicit null when unknown
+        // so the chart shows a gap instead of carrying the previous value.
+        if let mbpsValue = mbps(from: diagnostics.networkWindowBitrate) {
+            compact["player_metrics_network_window_mbps"] = mbpsValue
+        } else {
+            compact["player_metrics_network_window_mbps"] = NSNull()
+        }
+        // Same treatment for the wire bitrate (from local HTTP proxy).
+        if let mbpsValue = mbps(from: diagnostics.networkWireBitrate) {
+            compact["player_metrics_network_wire_mbps"] = mbpsValue
+        } else {
+            compact["player_metrics_network_wire_mbps"] = NSNull()
         }
         return compact
     }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/RequestTracker.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/RequestTracker.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Thread-safe accounting for HTTP requests going through HTTPProxyResourceLoader.
+/// Maintains cumulative counters that PlaybackDiagnostics samples periodically
+/// and emits as columns on the [BITRATE_SAMPLE] line for offline analysis.
+///
+/// Conventions:
+///   - `wireBytesTotal` — monotonic, cumulative bytes from URLSession data
+///     delegate callbacks (post-TLS, pre-content-decryption).
+///   - `wireActiveMsTotal` — wall-clock ms during which at least one request is
+///     in-flight (started, not yet completed/cancelled/failed). Overlapping
+///     requests do NOT double-count; it's wall time only.
+///   - `wireFlowingMsTotal` — wall-clock ms during which a chunk was received
+///     within the last 100 ms. Turns off after 100 ms of no new chunks.
+final class RequestTracker {
+    static let shared = RequestTracker()
+
+    private let lock = NSLock()
+    private var inflightCount: Int = 0
+    private var totalBytes: Int64 = 0
+    private var activeStartAt: Date?
+    private var cumulativeActiveMs: Double = 0
+    private var flowingStartAt: Date?
+    private var cumulativeFlowingMs: Double = 0
+    private var lastChunkAt: Date?
+
+    private let flowingGap: TimeInterval = 0.1
+
+    struct Snapshot {
+        let wireBytesTotal: Int64
+        let wireActiveMsTotal: Double
+        let wireFlowingMsTotal: Double
+        let wireInflightCount: Int
+        let wireLastChunkMsAgo: Double?
+    }
+
+    func requestStarted() {
+        lock.lock(); defer { lock.unlock() }
+        if inflightCount == 0 {
+            activeStartAt = Date()
+        }
+        inflightCount += 1
+    }
+
+    func chunkReceived(byteCount: Int) {
+        lock.lock(); defer { lock.unlock() }
+        let now = Date()
+        totalBytes += Int64(byteCount)
+        lastChunkAt = now
+        if flowingStartAt == nil {
+            flowingStartAt = now
+        }
+    }
+
+    func requestFinished() {
+        lock.lock(); defer { lock.unlock() }
+        inflightCount = max(0, inflightCount - 1)
+        if inflightCount == 0, let start = activeStartAt {
+            cumulativeActiveMs += Date().timeIntervalSince(start) * 1000
+            activeStartAt = nil
+        }
+    }
+
+    func snapshot(now: Date = Date()) -> Snapshot {
+        lock.lock(); defer { lock.unlock() }
+
+        // Lazy close flowing window if the gap has elapsed since the last chunk.
+        if let lastChunk = lastChunkAt, let flowStart = flowingStartAt,
+           now.timeIntervalSince(lastChunk) >= flowingGap {
+            cumulativeFlowingMs += lastChunk.timeIntervalSince(flowStart) * 1000
+            flowingStartAt = nil
+        }
+
+        var active = cumulativeActiveMs
+        if let start = activeStartAt {
+            active += now.timeIntervalSince(start) * 1000
+        }
+        var flowing = cumulativeFlowingMs
+        if let flowStart = flowingStartAt {
+            flowing += now.timeIntervalSince(flowStart) * 1000
+        }
+        let msAgo = lastChunkAt.map { now.timeIntervalSince($0) * 1000 }
+
+        return Snapshot(
+            wireBytesTotal: totalBytes,
+            wireActiveMsTotal: active,
+            wireFlowingMsTotal: flowing,
+            wireInflightCount: inflightCount,
+            wireLastChunkMsAgo: msAgo
+        )
+    }
+
+    /// Reset all counters — call on player restart / new session.
+    func reset() {
+        lock.lock(); defer { lock.unlock() }
+        inflightCount = 0
+        totalBytes = 0
+        activeStartAt = nil
+        cumulativeActiveMs = 0
+        flowingStartAt = nil
+        cumulativeFlowingMs = 0
+        lastChunkAt = nil
+    }
+}


### PR DESCRIPTION
## Summary

Adds an in-process HTTP/1.1 forward proxy on \`127.0.0.1:<ephemeral>\` so the iOS / tvOS app can collect on-device wire-byte and timing telemetry that AVPlayer's public API does not expose. The player URL is rewritten to point at the local proxy; the proxy forwards each request to the real origin via \`URLSession\` and feeds per-chunk events to \`RequestTracker\`. \`PlaybackDiagnostics\` derives a transfer-time \`networkWireBitrate\` from those samples, reported as \`player_metrics_network_wire_mbps\`.

- New: \`LocalHTTPProxy.swift\`, \`RequestTracker.swift\` (wired into iOS + tvOS targets in pbxproj).
- \`PlaybackDiagnostics\`: rolling wire bitrate, idle gate at 250 ms.
- \`PlaybackViewModel\`: \`localProxyEnabled\` toggle (default ON, persisted).
- \`ContentView\`: "Local Proxy" toggle in the toolbar.
- ATS: \`NSAllowsLocalNetworking\` (iOS + tvOS) and \`192.168.0.106\` exception (iOS).

Closes #123.

## Test plan

- [ ] Default-on: launch app, confirm log line \`[LOCAL_PROXY] listening on 127.0.0.1:<port>\` and \`Intercept ON — asset URL: http://127.0.0.1:...\` once playback starts.
- [ ] Toggle off: turn off Local Proxy, restart playback, confirm \`Intercept OFF (disabled)\` log line and origin URL used directly.
- [ ] Wire bitrate chart in dashboard: confirm "Player Wire Bitrate" line tracks the TC shaper limit during bursty fetches and gaps when the buffer fills.
- [ ] tvOS build runs and plays back with proxy on.