### PR TITLE
chore(apple): drop redundant ISO timestamp from TestingSession stdout log (closes #125)

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/TestingSession/TestingSessionViewModel.swift
@@ -351,12 +351,11 @@ final class TestingSessionViewModel: ObservableObject {
 
     private func log(_ message: String) {
         let stamp = ISO8601DateFormatter().string(from: Date())
-        let line = "[\(stamp)] \(message)"
-        logs.append(line)
+        logs.append("[\(stamp)] \(message)")
         if logs.count > 200 {
             logs.removeFirst(logs.count - 200)
         }
-        print(line)
+        print(message)
     }
 
     private func appendLimitSample(from session: SessionData, now: Date) {


### PR DESCRIPTION
## Summary

\`TestingSessionViewModel.log()\` prints only the message to stdout (Xcode's console already timestamps every line). The in-app log array still gets the \`[<ISO>] <message>\` form.

Closes #125.

## Test plan

- [ ] Run app, trigger something that calls \`log()\`, confirm the in-app log view still shows ISO timestamps and Xcode console no longer shows duplicate ISO.