### PR TITLE
chore: gitignore .claude/ (closes #129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ Sponsors.md
 
 # Internal working docs (not for public consumption)
 docs/internal/
+
+# Claude Code project-local state (per-developer)
+.claude/


### PR DESCRIPTION
Add Claude Code's project-local state directory to .gitignore. Closes #129.