### PR TITLE
fix(apple): 'Allow 4K' OFF actually caps at 1080p (closes #141)

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -1272,7 +1272,13 @@ final class PlaybackViewModel: ObservableObject {
                 item.preferredMaximumResolution = CGSize(width: 3840, height: 2160)
             }
         } else if #available(iOS 15.0, tvOS 15.0, *) {
-            item.preferredMaximumResolution = .zero
+            // Cap at 1080p when 4K is not explicitly allowed. .zero means
+            // "no preference" — on capable targets like iPad simulator that
+            // lets AVPlayer pick the 2160p variant, which the simulator's
+            // software decoder cannot keep up with and which spams the
+            // console with URLAsset err=-12174 / Fig err=-12900 back-pressure
+            // signals. The toggle is named "Allow 4K" — OFF should mean cap.
+            item.preferredMaximumResolution = CGSize(width: 1920, height: 1080)
         }
     }
 


### PR DESCRIPTION
## Summary

Make the OFF state of the \"Allow 4K\" toggle actually cap \`preferredMaximumResolution\` at 1920×1080. Was \`.zero\` (no preference), which on iPad simulator lets AVPlayer pick the 4K variant and overwhelm the sim's software decoder — floods the console with URLAsset err=-12174 and Fig err=-12900.

Closes #141.

## Test plan

- [ ] iPad simulator: launch with Allow 4K OFF, play, confirm \`[VARIANTS]\` line shows time spent at 1080p or below (no 1440p/2160p), and console no longer floods with URLAsset/Fig errors.
- [ ] iPad simulator: turn Allow 4K ON, restart playback, confirm 4K variants are now selected (errors will return — that's expected, simulator decoder limitation).
- [ ] Real iPhone: confirm playback still works with toggle OFF (should be unchanged in practice — phone screens stay below 4K anyway).