### PR TITLE
fix(go-live): emit EXT-X-DISCONTINUITY-SEQUENCE, enlarge live window

### DIFF
--- a/go-live/pkg/generator/ll_hls.go
+++ b/go-live/pkg/generator/ll_hls.go
@@ -13,7 +13,14 @@ import (
 )
 
 const (
-	MAX_LIVE_WINDOW_DURATION = 36.0 // 36 seconds
+	// Sliding live window. Must be comfortably larger than the player's
+	// forward buffer so a throttled/stalled player doesn't fall off the
+	// oldest edge before it can catch up. With a ~20s forward buffer,
+	// 36s left only ~16s of real slack — any drift triggered
+	// `-12642 No matching mediaFile found from playlist` on speculative
+	// ABR playlist polls. 120s keeps the window well ahead of realistic
+	// drift while staying bounded.
+	MAX_LIVE_WINDOW_DURATION = 120.0 // 120 seconds
 )
 
 var (
@@ -95,6 +102,21 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	// Calculate media sequence (segment number)
 	sequence := (loopCount * numSegments) + currentSegmentIdx
 
+	// Pre-compute the window wrap decision here so we can emit the correct
+	// EXT-X-DISCONTINUITY-SEQUENCE in the playlist header below. The actual
+	// window-building logic further down uses the same computation.
+	segmentsNeededForDiscSeq := int(MAX_LIVE_WINDOW_DURATION / idealSegmentDuration)
+	wrapAroundForDiscSeq := currentSegmentIdx < segmentsNeededForDiscSeq-1
+	firstSegLoop := loopCount
+	if wrapAroundForDiscSeq {
+		// Wrapping: first segment in window comes from the previous loop,
+		// and this playlist contains the discontinuity marker itself.
+		firstSegLoop = loopCount - 1
+		if firstSegLoop < 0 {
+			firstSegLoop = 0
+		}
+	}
+
 	// Build playlist
 	var sb strings.Builder
 
@@ -103,6 +125,11 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	sb.WriteString("#EXT-X-VERSION:10\n") // Version 10 for LL-HLS
 	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", int(segmentDuration)))
 	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", sequence))
+	// EXT-X-DISCONTINUITY-SEQUENCE is REQUIRED by RFC 8216 §4.3.3.3 when the
+	// playlist contains an EXT-X-DISCONTINUITY tag. Required for cross-variant
+	// synchronization during ABR evaluation; absence causes AVPlayer -12642
+	// "No matching mediaFile found from playlist".
+	sb.WriteString(fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", firstSegLoop))
 
 	// LL-HLS specific tags
 	sb.WriteString(fmt.Sprintf("#EXT-X-PART-INF:PART-TARGET=%.3f\n", partialDuration))

--- a/go-live/pkg/generator/range_hls.go
+++ b/go-live/pkg/generator/range_hls.go
@@ -181,6 +181,15 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 	sb.WriteString("#EXT-X-VERSION:7\n")
 	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", int(math.Ceil(maxSegDuration))))
 	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", firstSeq))
+	// EXT-X-DISCONTINUITY-SEQUENCE is REQUIRED by RFC 8216 §4.3.3.3 whenever
+	// the playlist contains an EXT-X-DISCONTINUITY tag (see `wrap` path
+	// below). It allows the player to synchronize across variant switches
+	// over discontinuity boundaries; its absence causes AVPlayer to emit
+	// -12642 "No matching mediaFile found from playlist" when probing a
+	// higher variant during ABR evaluation. startLoop is the loop number of
+	// the first segment in this window — i.e. the count of discontinuities
+	// that have occurred before that first segment.
+	sb.WriteString(fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", startLoop))
 	sb.WriteString(fmt.Sprintf("#EXT-X-PROGRAM-DATE-TIME:%s\n", pdt.Format("2006-01-02T15:04:05.000Z")))
 
 	if segmentMap != "" {


### PR DESCRIPTION
Closes #149.

## Summary

- **LL-HLS + range-HLS**: emit `#EXT-X-DISCONTINUITY-SEQUENCE` with the loop count of the playlist's first segment. Required by RFC 8216 §4.3.3.3 whenever `EXT-X-DISCONTINUITY` is present; fixes AVPlayer `-12642 "No matching mediaFile from playlist"` during ABR variant switches across the loop boundary.
- **`MAX_LIVE_WINDOW_DURATION`**: 36s → 120s. With a typical 20s forward buffer, 36s left only ~16s of real slack before the player's position fell off the oldest window edge.

## Test plan

- [x] `go build ./...` clean
- [ ] Deploy to test-dev, verify master/media playlists include `#EXT-X-DISCONTINUITY-SEQUENCE`
- [ ] Play under rate-limit profile that previously triggered `-12642 Cannot Open` — should now recover via native downshift without the hard failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)