### PR TITLE
chore(go-live): remove dead legacy spawn/continuous/once/LoadByteranges

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -16,7 +16,6 @@ Prefix: `/go-live/`
 | GET | `/go-live/api/status` | All active workers, streams, and per-stream stats |
 | GET | `/go-live/api/tick-stats/{content}` | LL-HLS tick cadence for one content worker (last tick, 5m avg, variant/audio counts) |
 | GET | `/go-live/api/dash-tick-stats/{content}?duration=ll\|2s\|6s` | DASH tick stats per window |
-| POST | `/go-live/api/spawn` | Explicitly start a worker. Body: `{input_path, output_dir, prefix}` |
 | DELETE | `/go-live/api/stop/{id}` | Stop a running worker |
 
 Streaming URLs (generated on demand):

--- a/go-live/cmd/server/main.go
+++ b/go-live/cmd/server/main.go
@@ -50,7 +50,6 @@ func main() {
 	router.HandleFunc("/go-live/healthz", h.Healthz).Methods(http.MethodGet, http.MethodHead)
 	router.HandleFunc("/go-live/api/status", h.Status).Methods(http.MethodGet, http.MethodHead)
 	router.HandleFunc("/go-live/api/stop/{id}", h.Stop).Methods("DELETE")
-	router.HandleFunc("/go-live/api/spawn", h.Spawn).Methods("POST")
 	router.HandleFunc("/go-live/api/tick-stats/{content}", h.TickStats).Methods(http.MethodGet, http.MethodHead)
 	router.HandleFunc("/go-live/api/dash-tick-stats/{content}", h.DashTickStats).Methods(http.MethodGet, http.MethodHead)
 
@@ -78,7 +77,6 @@ func main() {
 	fmt.Println("  GET  /health - Health check")
 	fmt.Println("  GET  /go-live/healthz - LL-HLS service health")
 	fmt.Println("  GET  /go-live/api/status - Active processes status")
-	fmt.Println("  POST /go-live/api/spawn - Spawn continuous generator")
 	fmt.Println("  DEL  /go-live/api/stop/{id} - Stop generator")
 	fmt.Println("  GET  /go-live/{content}/master.m3u8 - On-demand master playlist")
 	fmt.Println("  GET  /go-live/{content}/{variant}.m3u8 - On-demand variant playlist")

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jonathaneoliver/infinite-streaming/go-live/pkg/fileutil"
 	"github.com/jonathaneoliver/infinite-streaming/go-live/pkg/generator"
 	"github.com/jonathaneoliver/infinite-streaming/go-live/pkg/parser"
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -1346,32 +1345,6 @@ func (h *Handler) ServeDashSegment(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, segmentPath)
 }
 
-func (h *Handler) Spawn(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		Input  string `json:"input"`
-		Output string `json:"output"`
-		Mode   string `json:"mode"` // "continuous" or "once"
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("invalid request"))
-		return
-	}
-
-	id := uuid.New().String()
-	ctx, cancel := context.WithCancel(context.Background())
-	h.Manager.Spawn(id, req.Input, req.Output, cancel)
-
-	if req.Mode == "continuous" {
-		go runContinuous(ctx, req.Input, req.Output)
-	} else {
-		go runOnce(ctx, req.Input, req.Output)
-	}
-
-	w.Header().Set("X-Served-By", "go-live")
-	json.NewEncoder(w).Encode(map[string]string{"id": id, "status": "running"})
-}
-
 // OnDemandMasterPlaylist handles requests like /go-live/{content}/master.m3u8
 // This is the main entry point matching Python's lazy continuous mode
 func (h *Handler) OnDemandMasterPlaylist(w http.ResponseWriter, r *http.Request) {
@@ -2036,8 +2009,8 @@ func injectMasterStartTag(data []byte, offsetSeconds float64) []byte {
 	}
 	// Insert after the #EXT-X-VERSION line so AVPlayer sees the version
 	// declaration before any higher-version tags. Inserting between #EXTM3U
-	// and #EXT-X-VERSION (as a naive after-#EXTM3U approach does) triggers
-	// AVPlayer's -12646 "playlist parse error".
+	// and #EXT-X-VERSION (as the previous approach did) triggers AVPlayer's
+	// -12646 "playlist parse error".
 	if idx := strings.Index(text, "#EXT-X-VERSION:"); idx >= 0 {
 		end := strings.Index(text[idx:], "\n")
 		if end >= 0 {
@@ -2071,17 +2044,6 @@ func masterStartOffsetForDuration(duration string) float64 {
 	}
 }
 
-// Legacy functions for backwards compatibility (not used in LL-HLS mode)
-
-func runContinuous(ctx context.Context, input, output string) {
-	// Legacy continuous mode - not used for LL-HLS
-	fmt.Fprintf(os.Stderr, "WARN: Legacy runContinuous called\n")
-}
-
-func runOnce(ctx context.Context, input, output string) {
-	// Legacy once mode - not used for LL-HLS
-	fmt.Fprintf(os.Stderr, "WARN: Legacy runOnce called\n")
-}
 
 func (h *Handler) trackRequest(r *http.Request, content, mode string) {
 	if h == nil || h.Tracker == nil || r == nil {

--- a/go-live/pkg/parser/byterange.go
+++ b/go-live/pkg/parser/byterange.go
@@ -151,20 +151,3 @@ func loadByterangesFile(path string) ([]ByteRange, error) {
 	return data.Fragments, nil
 }
 
-// LoadByteranges is the legacy function for backwards compatibility
-// Deprecated: Use LoadByterangesForPlaylist instead
-func LoadByteranges(path string) (map[string][]ByteRange, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	var m map[string][]ByteRange
-	err = json.NewDecoder(f).Decode(&m)
-	if err != nil {
-		return nil, err
-	}
-
-	return m, nil
-}


### PR DESCRIPTION
Closes #155.

## Summary

- Deleted \`runContinuous\`, \`runOnce\`, \`Handler.Spawn\` (all stubs / sole-stub-dispatcher)
- Deleted \`parser.LoadByteranges\` (Deprecated, zero callers)
- Deleted \`/go-live/api/spawn\` route registration and its help-text line
- Deleted \`uuid\` import (only Spawn used it)
- Deleted docs/API.md row

## Test plan

- [x] \`go build ./...\` clean
- [ ] Server still starts and serves master/media playlists

🤖 Generated with [Claude Code](https://claude.com/claude-code)