### PR TITLE
feat(dashboard): buffer depth chart y-axis rounds to 5-second steps

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5137,7 +5137,10 @@
             const bufferValues = bufferDepthData
                 .map((point) => Number(point.y))
                 .filter((value) => Number.isFinite(value) && value >= 0);
-            const maxBufferDepth = Math.min(60, Math.max(5, ...bufferValues, 0));
+            // Round up to the next 5-second step so the chart y-axis ticks
+            // land on 5, 10, 15, ..., 60. Cap at 60, floor at 5.
+            const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
+            const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
             let bufferChart = bufferDepthCharts.get(sessionId);
             if (bufferChart && bufferChart.canvas !== bufferCanvas) {
                 bufferChart.destroy();

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2932,7 +2932,10 @@ maybe a histogram of b
             const bufferValues = bufferDepthData
                 .map((point) => Number(point.y))
                 .filter((value) => Number.isFinite(value) && value >= 0);
-            const maxBufferDepth = Math.min(60, Math.max(5, ...bufferValues, 0));
+            // Round up to the next 5-second step so the chart y-axis maxes
+            // land on 5, 10, 15, ..., 60. Cap at 60, floor at 5.
+            const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
+            const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
             let bufferChart = bufferDepthCharts.get(sessionId);
             if (bufferChart && bufferChart.canvas !== bufferCanvas) {
                 bufferChart.destroy();


### PR DESCRIPTION
Closes #163.

## Summary

Round Buffer Depth chart y-axis max up to nearest multiple of 5 (cap 60, floor 5). Applied to \`testing.html\` and \`testing-session.html\`.

## Test plan

- [ ] Verify y-axis max of 5/10/15/…/60 across various buffer conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)