### PR TITLE
feat(dashboard): cross-session legend hover highlight in compare mode

### DIFF
--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2312,29 +2312,96 @@ maybe a histogram of b
         };
         let legendHoverIndex = null;
         let legendHoverChartId = null;
+        let legendHoverMetricKind = null;
+
+        // Maps a bitrate-chart legend label to a canonical metric kind so that
+        // a hover on one session's series can half-highlight the same metric on
+        // other sessions' series (compare mode appends "(Sn)" per session, and
+        // a couple of labels differ from the own-session name, e.g.
+        // "mbps_shaper_avg" vs "Shaper Avg (S2)").
+        function bitrateLegendMetricKind(label) {
+            if (!label) return null;
+            const base = String(label).replace(/\s*\(S[^)]+\)\s*$/, '').trim();
+            switch (base) {
+                case 'Player avg_network_bitrate':
+                    return 'player_est';
+                case 'Player network_bitrate':
+                    return 'player_wire';
+                case 'Player Variant':
+                    return 'player_variant';
+                case 'Server Variant':
+                    return 'server_variant';
+                case 'mbps_shaper_avg':
+                case 'Shaper Avg':
+                    return 'shaper_avg';
+                default:
+                    return null;
+            }
+        }
+
         const legendHoverCallbacks = {
             onHover: (event, legendItem, legend) => {
                 legendHoverIndex = legendItem.datasetIndex;
                 legendHoverChartId = legend.chart.id;
                 const ds = legend.chart.data.datasets[legendItem.datasetIndex];
-                if (!ds._origWidth) ds._origWidth = ds.borderWidth;
-                ds.borderWidth = ds._origWidth + 3;
-                legend.chart.update('none');
+                legendHoverMetricKind = bitrateLegendMetricKind(ds && ds.label);
+                refreshLegendHoverAll();
             },
-            onLeave: (event, legendItem, legend) => {
+            onLeave: () => {
                 legendHoverIndex = null;
                 legendHoverChartId = null;
-                const ds = legend.chart.data.datasets[legendItem.datasetIndex];
-                if (ds._origWidth) { ds.borderWidth = ds._origWidth; delete ds._origWidth; }
-                legend.chart.update('none');
+                legendHoverMetricKind = null;
+                refreshLegendHoverAll();
             }
         };
+
+        // Apply primary (+3) and cross-session (+1.5) borderWidth boosts based
+        // on the current hover state, clearing any stale boost on other datasets.
         function applyLegendHover(chart) {
-            if (legendHoverChartId !== chart.id || legendHoverIndex == null) return;
-            const ds = chart.data.datasets[legendHoverIndex];
-            if (ds) {
-                if (!ds._origWidth) ds._origWidth = ds.borderWidth;
-                ds.borderWidth = ds._origWidth + 3;
+            if (!chart || !chart.data || !Array.isArray(chart.data.datasets)) return;
+            chart.data.datasets.forEach((ds, idx) => {
+                const isPrimary = legendHoverChartId === chart.id
+                    && legendHoverIndex != null
+                    && idx === legendHoverIndex;
+                const kind = bitrateLegendMetricKind(ds.label);
+                const isCross = !isPrimary
+                    && legendHoverMetricKind != null
+                    && kind === legendHoverMetricKind;
+                if (isPrimary) {
+                    if (ds._origWidth === undefined) ds._origWidth = ds.borderWidth;
+                    if (ds._origWidthXHover !== undefined) {
+                        delete ds._origWidthXHover;
+                    }
+                    ds.borderWidth = ds._origWidth + 6;
+                } else if (isCross) {
+                    if (ds._origWidthXHover === undefined) ds._origWidthXHover = ds.borderWidth;
+                    if (ds._origWidth !== undefined) {
+                        ds.borderWidth = ds._origWidth;
+                        delete ds._origWidth;
+                    }
+                    ds.borderWidth = ds._origWidthXHover + 2.5;
+                } else {
+                    if (ds._origWidth !== undefined) {
+                        ds.borderWidth = ds._origWidth;
+                        delete ds._origWidth;
+                    }
+                    if (ds._origWidthXHover !== undefined) {
+                        ds.borderWidth = ds._origWidthXHover;
+                        delete ds._origWidthXHover;
+                    }
+                }
+            });
+        }
+
+        function refreshLegendHoverAll() {
+            const pools = [bandwidthCharts, bufferDepthCharts, videoFpsCharts];
+            for (const pool of pools) {
+                if (!pool) continue;
+                pool.forEach((chart) => {
+                    if (!chart) return;
+                    applyLegendHover(chart);
+                    chart.update('none');
+                });
             }
         }
 
@@ -2543,7 +2610,7 @@ maybe a histogram of b
                     if (sid === sessionId) continue;
                     const tag = `S${sid}`;
                     compareVisibleLabels.add(`Player Variant (${tag})`);
-                    compareVisibleLabels.add(`Player Est (${tag})`);
+                    compareVisibleLabels.add(`Player avg_network_bitrate (${tag})`);
                     compareVisibleLabels.add(`Player network_bitrate (${tag})`);
                     compareVisibleLabels.add(`Server Variant (${tag})`);
                     compareVisibleLabels.add(`Shaper Avg (${tag})`);
@@ -2737,16 +2804,16 @@ maybe a histogram of b
                         borderDash: [3, 3],
                         hidden: isSeriesHidden(`Player Variant (${tag})`)
                     });
-                    // Player Estimate (visible by default in compare)
+                    // Player avg_network_bitrate (visible by default in compare)
                     datasets.push({
-                        label: `Player Est (${tag})`,
+                        label: `Player avg_network_bitrate (${tag})`,
                         data: otherSeries.map(p => ({ x: p.x, y: p.y.playerEstimate || null })),
                         borderColor: color.light,
                         borderWidth: 1.5,
                         pointRadius: 0,
                         tension: 0.2,
                         borderDash: [6, 4],
-                        hidden: isSeriesHidden(`Player Est (${tag})`)
+                        hidden: isSeriesHidden(`Player avg_network_bitrate (${tag})`)
                     });
                     // Player Network Rate (visible by default in compare; null when session has no wire metric)
                     datasets.push({


### PR DESCRIPTION
## Summary

- Hovering a legend item in compare mode now bolds the primary series (+6 borderWidth) and half-highlights the same metric across other sessions (+2.5 borderWidth)
- Applies across bitrate, buffer depth, and FPS charts
- Renames cross-session label from `Player Est (Sn)` → `Player avg_network_bitrate (Sn)` for consistency with single-session labels

## Test plan

- [ ] Open compare mode with 2+ sessions
- [ ] Hover a bitrate legend item — confirm primary line boldens, same metric in other sessions gets a lighter boost
- [ ] Verify buffer depth and FPS charts respond the same way
- [ ] Confirm label reads `Player avg_network_bitrate (S2)` etc. in compare mode

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)