### PR TITLE
feat(android): fullscreen toggle, layout improvements, app icon banner

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/AndroidManifest.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/AndroidManifest.xml
@@ -4,9 +4,13 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
+        android:banner="@drawable/ic_banner"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
@@ -18,6 +22,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
     </application>

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
@@ -13,6 +13,8 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
+
 import androidx.annotation.OptIn;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -61,6 +63,10 @@ public class MainActivity extends AppCompatActivity {
     private MaterialButtonToggleGroup codecToggle;
     private MaterialButton contentButton;
     private TextView statusText;
+    private MaterialButton fullscreenButton;
+    private View rightPanel;
+    private View panelGuideline;
+    private boolean isFullscreen = false;
 
     private String currentUrl = "";
     private final String playerId = UUID.randomUUID().toString();
@@ -80,7 +86,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         String label() {
-            return name + " (" + port + ")";
+            return name;
         }
     }
 
@@ -135,8 +141,20 @@ public class MainActivity extends AppCompatActivity {
         codecToggle = findViewById(R.id.codec_toggle);
         contentButton = findViewById(R.id.content_button);
         statusText = findViewById(R.id.status_text);
+        fullscreenButton = findViewById(R.id.fullscreen_button);
+        rightPanel = findViewById(R.id.right_panel);
+        panelGuideline = findViewById(R.id.panel_guideline);
+
+        fullscreenButton.setOnClickListener(v -> toggleFullscreen());
+
+        styleActionButton(retryButton);
+        styleActionButton(restartButton);
+        styleActionButton(reloadButton);
+        styleActionButton(contentButton);
+        styleActionButton(fullscreenButton);
 
         initializePlayer();
+        retryButton.requestFocus(); // start focus top-left of left panel
         setupToggles();
 
         retryButton.setOnClickListener(v -> retryFetch());
@@ -248,6 +266,14 @@ public class MainActivity extends AppCompatActivity {
             addToggleButton(codecToggle, i, codecs[i]);
         }
 
+        // Only the leftmost button in each group escapes to the left panel
+        for (MaterialButtonToggleGroup group :
+                new MaterialButtonToggleGroup[]{ serverToggle, protocolToggle, segmentToggle, codecToggle }) {
+            if (group.getChildCount() > 0) {
+                group.getChildAt(0).setNextFocusLeftId(R.id.fullscreen_button);
+            }
+        }
+
         serverToggle.check(serverToggle.getChildAt(0).getId());
         protocolToggle.check(protocolToggle.getChildAt(0).getId());
         segmentToggle.check(segmentToggle.getChildAt(DEFAULT_SEGMENT_INDEX).getId());
@@ -269,6 +295,19 @@ public class MainActivity extends AppCompatActivity {
         fetchContentList();
     }
 
+    private void styleActionButton(MaterialButton button) {
+        int[][] states = {
+            { android.R.attr.state_focused },
+            { -android.R.attr.state_focused }
+        };
+        button.setTextColor(new ColorStateList(states,
+            new int[]{ 0xFFFFFFFF, 0xFFFFFFFF }));
+        button.setBackgroundTintList(new ColorStateList(states,
+            new int[]{ 0xFF1A3A4A, 0x00000000 }));
+        button.setStrokeColor(new ColorStateList(states,
+            new int[]{ 0xFF00B4D8, 0xFF555555 }));
+    }
+
     private void addToggleButton(MaterialButtonToggleGroup group, int index, String text) {
         MaterialButton button = new MaterialButton(
             new androidx.appcompat.view.ContextThemeWrapper(this,
@@ -276,9 +315,22 @@ public class MainActivity extends AppCompatActivity {
             null, com.google.android.material.R.attr.materialButtonOutlinedStyle);
         button.setId(View.generateViewId());
         button.setText(text);
-        button.setTextColor(0xFFFFFFFF);
-        button.setStrokeColor(ColorStateList.valueOf(0xFFFFFFFF));
         button.setCheckable(true);
+        button.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, 12);
+
+        int[][] states = {
+            { android.R.attr.state_focused,  android.R.attr.state_checked },
+            {                                android.R.attr.state_checked },
+            { android.R.attr.state_focused, -android.R.attr.state_checked },
+            {                               -android.R.attr.state_checked }
+        };
+        button.setTextColor(new ColorStateList(states,
+            new int[]{ 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFF888888 }));
+        button.setBackgroundTintList(new ColorStateList(states,
+            new int[]{ 0xFF00B4D8, 0xFF0077B6, 0xFF1A3A4A, 0x00000000 }));
+        button.setStrokeColor(new ColorStateList(states,
+            new int[]{ 0xFFFFFFFF, 0xFF00B4D8, 0xFF00B4D8, 0xFF444444 }));
+
         LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT);
@@ -465,6 +517,27 @@ public class MainActivity extends AppCompatActivity {
             player.stop();
             player.clearMediaItems();
             buildUrlAndLoad();
+        }
+    }
+
+    private void toggleFullscreen() {
+        isFullscreen = !isFullscreen;
+        ConstraintLayout.LayoutParams params =
+            (ConstraintLayout.LayoutParams) panelGuideline.getLayoutParams();
+        params.guidePercent = isFullscreen ? 1.0f : 0.65f;
+        panelGuideline.setLayoutParams(params);
+        rightPanel.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
+        fullscreenButton.setText(isFullscreen
+            ? getString(R.string.exit_fullscreen)
+            : getString(R.string.fullscreen));
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (isFullscreen) {
+            toggleFullscreen();
+        } else {
+            super.onBackPressed();
         }
     }
 

--- a/android/InfiniteStreamPlayer/app/src/main/res/drawable/ic_banner.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/res/drawable/ic_banner.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="320dp"
+    android:height="180dp"
+    android:viewportWidth="320"
+    android:viewportHeight="180">
+
+    <!-- Background -->
+    <path android:fillColor="#091929"
+        android:pathData="M0,0 L320,0 L320,180 L0,180 Z" />
+
+    <!-- Subtle centre band -->
+    <path android:fillColor="#0A2040"
+        android:pathData="M0,55 L320,55 L320,125 L0,125 Z" />
+
+    <!-- Right lobe centred at (115,90) — wavy -->
+    <path android:strokeColor="#012E47" android:strokeWidth="22"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C98,72 112,58 124,63 C136,68 142,80 142,90 C142,100 136,112 124,117 C112,122 98,108 90,90 Z" />
+    <path android:strokeColor="#0077B6" android:strokeWidth="15"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C98,72 112,58 124,63 C136,68 142,80 142,90 C142,100 136,112 124,117 C112,122 98,108 90,90 Z" />
+    <path android:strokeColor="#00B4D8" android:strokeWidth="8"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C98,72 112,58 124,63 C136,68 142,80 142,90 C142,100 136,112 124,117 C112,122 98,108 90,90 Z" />
+    <path android:strokeColor="#ADE8F4" android:strokeWidth="2.5"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C98,72 112,58 124,63 C136,68 142,80 142,90 C142,100 136,112 124,117 C112,122 98,108 90,90 Z" />
+
+    <!-- Left lobe — mirror -->
+    <path android:strokeColor="#012E47" android:strokeWidth="22"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C82,72 68,58 56,63 C44,68 38,80 38,90 C38,100 44,112 56,117 C68,122 82,108 90,90 Z" />
+    <path android:strokeColor="#0077B6" android:strokeWidth="15"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C82,72 68,58 56,63 C44,68 38,80 38,90 C38,100 44,112 56,117 C68,122 82,108 90,90 Z" />
+    <path android:strokeColor="#00B4D8" android:strokeWidth="8"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C82,72 68,58 56,63 C44,68 38,80 38,90 C38,100 44,112 56,117 C68,122 82,108 90,90 Z" />
+    <path android:strokeColor="#ADE8F4" android:strokeWidth="2.5"
+        android:strokeLineCap="round" android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M90,90 C82,72 68,58 56,63 C44,68 38,80 38,90 C38,100 44,112 56,117 C68,122 82,108 90,90 Z" />
+
+    <!-- Foam dots at wave crests -->
+    <path android:fillColor="#90E0EF"
+        android:pathData="M114,59m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0" />
+    <path android:fillColor="#90E0EF"
+        android:pathData="M66,59m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0" />
+
+    <!-- Centre node -->
+    <path android:fillColor="#0077B6"
+        android:pathData="M90,90m-9,0a9,9 0,1 1,18 0a9,9 0,1 1,-18 0" />
+    <path android:fillColor="#48CAE4"
+        android:pathData="M90,90m-5,0a5,5 0,1 1,10 0a5,5 0,1 1,-10 0" />
+
+    <!-- Accent lines flanking logo -->
+    <path android:strokeColor="#0077B6" android:strokeWidth="1"
+        android:pathData="M0,90 L25,90" />
+    <path android:strokeColor="#0077B6" android:strokeWidth="1"
+        android:pathData="M155,90 L320,90" />
+
+</vector>

--- a/android/InfiniteStreamPlayer/app/src/main/res/drawable/ic_launcher.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/res/drawable/ic_launcher.xml
@@ -4,14 +4,93 @@
     android:height="48dp"
     android:viewportWidth="48"
     android:viewportHeight="48">
-    
-    <!-- Background circle -->
+
+    <!-- Deep ocean background -->
     <path
-        android:fillColor="#2196F3"
+        android:fillColor="#091929"
         android:pathData="M24,24m-24,0a24,24 0,1 1,48 0a24,24 0,1 1,-48 0" />
-    
-    <!-- Play triangle -->
+
+    <!-- Right lobe — wavy path: peaks at top (~y=12) and troughs at bottom (~y=36) -->
+    <!-- Shadow -->
     <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M18,14 L18,34 L34,24 Z" />
+        android:strokeColor="#012E47"
+        android:strokeWidth="11"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C28,17 34,12 38,15 C42,18 44,22 44,24 C44,26 42,30 38,33 C34,36 28,31 24,24 Z" />
+    <!-- Main water -->
+    <path
+        android:strokeColor="#0077B6"
+        android:strokeWidth="7.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C28,17 34,12 38,15 C42,18 44,22 44,24 C44,26 42,30 38,33 C34,36 28,31 24,24 Z" />
+    <!-- Mid water -->
+    <path
+        android:strokeColor="#00B4D8"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C28,17 34,12 38,15 C42,18 44,22 44,24 C44,26 42,30 38,33 C34,36 28,31 24,24 Z" />
+    <!-- Surface highlight -->
+    <path
+        android:strokeColor="#ADE8F4"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C28,17 34,12 38,15 C42,18 44,22 44,24 C44,26 42,30 38,33 C34,36 28,31 24,24 Z" />
+    <!-- Left lobe — mirror of right lobe -->
+    <!-- Shadow -->
+    <path
+        android:strokeColor="#012E47"
+        android:strokeWidth="11"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C20,17 14,12 10,15 C6,18 4,22 4,24 C4,26 6,30 10,33 C14,36 20,31 24,24 Z" />
+    <!-- Main water -->
+    <path
+        android:strokeColor="#0077B6"
+        android:strokeWidth="7.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C20,17 14,12 10,15 C6,18 4,22 4,24 C4,26 6,30 10,33 C14,36 20,31 24,24 Z" />
+    <!-- Mid water -->
+    <path
+        android:strokeColor="#00B4D8"
+        android:strokeWidth="4"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C20,17 14,12 10,15 C6,18 4,22 4,24 C4,26 6,30 10,33 C14,36 20,31 24,24 Z" />
+    <!-- Surface highlight -->
+    <path
+        android:strokeColor="#ADE8F4"
+        android:strokeWidth="1.5"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:fillColor="#00000000"
+        android:pathData="M24,24 C20,17 14,12 10,15 C6,18 4,22 4,24 C4,26 6,30 10,33 C14,36 20,31 24,24 Z" />
+    <!-- Sparkle dashes -->
+    <!-- Foam dots at wave crests (top of each lobe) -->
+    <path
+        android:fillColor="#90E0EF"
+        android:pathData="M34,12m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0" />
+    <path
+        android:fillColor="#90E0EF"
+        android:pathData="M14,12m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0" />
+
+    <!-- Centre crossing node -->
+    <path
+        android:fillColor="#0077B6"
+        android:pathData="M24,24m-4,0a4,4 0,1 1,8 0a4,4 0,1 1,-8 0" />
+    <path
+        android:fillColor="#48CAE4"
+        android:pathData="M24,24m-2.2,0a2.2,2.2 0,1 1,4.4 0a2.2,2.2 0,1 1,-4.4 0" />
+
 </vector>

--- a/android/InfiniteStreamPlayer/app/src/main/res/layout/activity_main.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/res/layout/activity_main.xml
@@ -1,40 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#000000"
-    android:fillViewport="true">
+    android:background="#000000">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/panel_guideline"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="24dp">
+        app:layout_constraintGuide_percent="0.65" />
 
-        <TextView
-            android:id="@+id/title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/app_name"
-            android:textColor="#FFFFFF"
-            android:textSize="28sp"
-            android:textStyle="bold" />
+    <!-- Left panel: action bar + video -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/left_panel"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="#000000"
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/panel_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
+        <!-- Action bar: Retry | Restart | Reload | Fullscreen -->
         <LinearLayout
-            android:id="@+id/action_row"
-            android:layout_width="wrap_content"
+            android:id="@+id/left_action_row"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/retry_button"
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="12dp"
+                android:layout_marginEnd="8dp"
+                android:nextFocusRight="@id/restart_button"
+                android:nextFocusDown="@id/player_view"
                 android:text="@string/retry_fetch"
+                android:textSize="12sp"
                 android:textColor="#FFFFFF"
                 app:strokeColor="#FFFFFF" />
 
@@ -43,8 +54,12 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="12dp"
+                android:layout_marginEnd="8dp"
+                android:nextFocusLeft="@id/retry_button"
+                android:nextFocusRight="@id/reload_button"
+                android:nextFocusDown="@id/player_view"
                 android:text="@string/restart_playback"
+                android:textSize="12sp"
                 android:textColor="#FFFFFF"
                 app:strokeColor="#FFFFFF" />
 
@@ -53,122 +68,174 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:nextFocusLeft="@id/restart_button"
+                android:nextFocusRight="@id/fullscreen_button"
+                android:nextFocusDown="@id/player_view"
                 android:text="@string/reload_page"
+                android:textSize="12sp"
+                android:textColor="#FFFFFF"
+                app:strokeColor="#FFFFFF" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/fullscreen_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:nextFocusLeft="@id/reload_button"
+                android:nextFocusRight="@id/server_toggle"
+                android:nextFocusDown="@id/player_view"
+                android:text="@string/fullscreen"
+                android:textSize="12sp"
                 android:textColor="#FFFFFF"
                 app:strokeColor="#FFFFFF" />
         </LinearLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.media3.ui.PlayerView
+            android:id="@+id/player_view"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="#000000"
+            android:layout_marginTop="8dp"
+            app:layout_constraintDimensionRatio="16:9"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/left_action_row"
+            app:show_buffering="when_playing"
+            app:use_controller="true" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Divider -->
+    <View
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="#333333"
+        app:layout_constraintStart_toStartOf="@id/panel_guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+    <!-- Right panel: content configuration -->
+    <ScrollView
+        android:id="@+id/right_panel"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toEndOf="@id/panel_guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp">
+            android:orientation="vertical"
+            android:padding="16dp">
 
-            <androidx.media3.ui.PlayerView
-                android:id="@+id/player_view"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:background="#000000"
-                app:layout_constraintDimensionRatio="16:9"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:show_buffering="when_playing"
-                app:use_controller="true" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/app_name"
+                android:textColor="#FFFFFF"
+                android:textSize="22sp"
+                android:textStyle="bold" />
 
-        <TextView
-            style="@style/SectionHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:text="@string/content_control" />
+            <TextView
+                style="@style/SectionHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/content_control" />
 
-        <TextView
-            style="@style/FieldLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/server" />
+            <TextView
+                style="@style/FieldLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/server" />
 
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/server_toggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            app:selectionRequired="true"
-            app:singleSelection="true" />
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/server_toggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                app:selectionRequired="true"
+                app:singleSelection="true" />
 
-        <TextView
-            style="@style/FieldLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/protocol" />
+            <TextView
+                style="@style/FieldLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/protocol" />
 
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/protocol_toggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            app:selectionRequired="true"
-            app:singleSelection="true" />
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/protocol_toggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                app:selectionRequired="true"
+                app:singleSelection="true" />
 
-        <TextView
-            style="@style/FieldLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/segment" />
+            <TextView
+                style="@style/FieldLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/segment" />
 
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/segment_toggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            app:selectionRequired="true"
-            app:singleSelection="true" />
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/segment_toggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                app:selectionRequired="true"
+                app:singleSelection="true" />
 
-        <TextView
-            style="@style/FieldLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/codec" />
+            <TextView
+                style="@style/FieldLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/codec" />
 
-        <com.google.android.material.button.MaterialButtonToggleGroup
-            android:id="@+id/codec_toggle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            app:selectionRequired="true"
-            app:singleSelection="true" />
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/codec_toggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                app:selectionRequired="true"
+                app:singleSelection="true" />
 
-        <TextView
-            style="@style/FieldLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:text="@string/content" />
+            <TextView
+                style="@style/FieldLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="@string/content" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/content_button"
-            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:gravity="start|center_vertical"
-            android:text="@string/select_content"
-            android:textColor="#FFFFFF"
-            app:strokeColor="#FFFFFF" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/content_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="start|center_vertical"
+                android:nextFocusLeft="@id/fullscreen_button"
+                android:text="@string/select_content"
+                android:textSize="12sp"
+                android:textColor="#FFFFFF"
+                app:strokeColor="#FFFFFF" />
 
-        <TextView
-            android:id="@+id/status_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/ready"
-            android:textColor="#888888"
-            android:textSize="12sp" />
+            <TextView
+                android:id="@+id/status_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/ready"
+                android:textColor="#888888"
+                android:textSize="11sp" />
 
-    </LinearLayout>
-</ScrollView>
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/InfiniteStreamPlayer/app/src/main/res/values/strings.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
     <string name="content">Content</string>
     <string name="select_content">Select content</string>
     <string name="ready">Ready</string>
+    <string name="fullscreen">Fullscreen</string>
+    <string name="exit_fullscreen">Exit Fullscreen</string>
 </resources>


### PR DESCRIPTION
## Summary
- Fullscreen toggle button collapses right panel and expands player to fill screen
- `ic_banner.xml` TV banner asset added
- `ic_launcher.xml` app icon updated
- Layout restructured with ConstraintLayout guideline for clean panel split
- Server label simplified (name only)
- D-pad navigation: initial focus on retry button; toggle groups only escape to left panel from leftmost button

## Test plan
- [ ] `make deploy-androidtv` installs to Google TV Streamer
- [ ] Fullscreen button hides right panel and fills player to screen width
- [ ] Toggle button restores panel layout
- [ ] D-pad navigation stays within panel until leftmost button is reached
- [ ] App icon and banner display correctly in launcher

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)