### PR TITLE
chore: dashboard cleanup batch

### DIFF
--- a/content/dashboard/dashboard.html
+++ b/content/dashboard/dashboard.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <!-- Content will be injected by shared-nav.js -->
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         
         <!-- Welcome Section -->
         <div style="margin-bottom: 32px;">

--- a/content/dashboard/job-detail.html
+++ b/content/dashboard/job-detail.html
@@ -114,7 +114,7 @@
     </style>
 </head>
 <body data-ism-active-page="jobs">
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         <div id="loadingState" class="text-center text-secondary" style="padding: 60px;">
             <div class="spinner"></div>
             <div style="margin-top: 12px;">Loading job details...</div>

--- a/content/dashboard/jobs.html
+++ b/content/dashboard/jobs.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/shared-styles.css">
 </head>
 <body data-ism-active-page="jobs">
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         <div class="card">
             <div class="card-header">
                 <h1>Encoding Jobs</h1>

--- a/content/dashboard/sources.html
+++ b/content/dashboard/sources.html
@@ -121,7 +121,7 @@
     </style>
 </head>
 <body data-ism-active-page="sources">
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         <div class="card">
             <div class="card-header">
                 <div class="header-actions">
@@ -184,56 +184,64 @@
                     </select>
                 </div>
 
-                <div class="form-group">
-    <label>Partial Segment Durations</label>
-    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="batchPartialDuration" value="1000" style="margin-right: 5px;">
-            1s partials (p1000)
-        </label>
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="batchPartialDuration" value="200" checked style="margin-right: 5px;">
-            200ms partials (p200)
-        </label>
-    </div>
-</div>
-<div class="form-group">
-    <label for="batchHlsFormat">HLS Format</label>
-    <select id="batchHlsFormat" name="hls_format" class="form-select">
-        <option value="fmp4">fMP4 segments (modern)</option>
-        <option value="ts">MPEG-TS segments (legacy)</option>
-        <option value="both">Both formats</option>
-    </select>
-</div>
+                <!-- Advanced Options Toggle -->
+                <button type="button" class="advanced-toggle" id="batchAdvancedToggle">
+                    Show Advanced Options ▼
+                </button>
 
-                <div class="form-group">
-                    <label for="batchDurationLimit">Duration Limit (seconds)</label>
-                    <input type="number" id="batchDurationLimit" name="duration_limit" class="form-input" min="1" placeholder="Leave empty for full video">
-                    <small>Optionally trim videos to the first N seconds</small>
-                </div>
-                <div class="form-group">
-                    <label>Segment Duration</label>
-                    <label class="form-checkbox"><input type="radio" name="batchSegmentDuration" value="2"> 2s segments</label>
-                    <label class="form-checkbox"><input type="radio" name="batchSegmentDuration" value="6" checked> 6s segments</label>
-                </div>
+                <div class="advanced-options" id="batchAdvancedOptions">
+                    <div class="form-group">
+                        <label>Partial Segment Durations</label>
+                        <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="batchPartialDuration" value="1000" style="margin-right: 5px;">
+                                1s partials (p1000)
+                            </label>
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="batchPartialDuration" value="200" checked style="margin-right: 5px;">
+                                200ms partials (p200)
+                            </label>
+                        </div>
+                    </div>
 
-                <div class="form-group">
-                    <label>GOP Duration</label>
-                    <label class="form-checkbox"><input type="radio" name="batchGopDuration" value="1.0" checked> 1s GOPs</label>
-                    <label class="form-checkbox"><input type="radio" name="batchGopDuration" value="2.0"> 2s GOPs</label>
-                </div>
+                    <div class="form-group">
+                        <label for="batchHlsFormat">HLS Format</label>
+                        <select id="batchHlsFormat" name="hls_format" class="form-select">
+                            <option value="fmp4">fMP4 segments (modern)</option>
+                            <option value="ts">MPEG-TS segments (legacy)</option>
+                            <option value="both">Both formats</option>
+                        </select>
+                    </div>
 
-                <div class="form-group">
-                    <label class="form-checkbox">
-                        <input type="checkbox" id="batchForceSoftware" name="force_software" checked>
-                        Force software encoding (disable hardware acceleration)
-                    </label>
-                </div>
+                    <div class="form-group">
+                        <label>Segment Duration</label>
+                        <label class="form-checkbox"><input type="radio" name="batchSegmentDuration" value="2"> 2s segments</label>
+                        <label class="form-checkbox"><input type="radio" name="batchSegmentDuration" value="6" checked> 6s segments</label>
+                    </div>
 
-                <div class="form-group">
-                    <label style="display: block; margin-bottom: 8px; font-weight: 500;">
-                        Padding to Segment Boundaries:
-                    </label>
+                    <div class="form-group">
+                        <label>GOP Duration</label>
+                        <label class="form-checkbox"><input type="radio" name="batchGopDuration" value="1.0" checked> 1s GOPs</label>
+                        <label class="form-checkbox"><input type="radio" name="batchGopDuration" value="2.0"> 2s GOPs</label>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="batchDurationLimit">Duration Limit (seconds)</label>
+                        <input type="number" id="batchDurationLimit" name="duration_limit" class="form-input" min="1" placeholder="Leave empty for full video">
+                        <small>Optionally trim videos to the first N seconds</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-checkbox">
+                            <input type="checkbox" id="batchForceSoftware" name="force_software" checked>
+                            Force software encoding (disable hardware acceleration)
+                        </label>
+                    </div>
+
+                    <div class="form-group">
+                        <label style="display: block; margin-bottom: 8px; font-weight: 500;">
+                            Padding to Segment Boundaries:
+                        </label>
                     <label class="form-checkbox" style="margin-bottom: 6px;">
                         <input type="radio" id="batchPaddingNone" name="batchPadding" value="none" checked>
                         No padding (default)
@@ -246,6 +254,7 @@
                         <input type="radio" id="batchPaddingPink" name="batchPadding" value="pink">
                         Pink padding frames with "PADDING" label
                     </label>
+                    </div>
                 </div>
 
                 <div class="form-actions">
@@ -303,56 +312,60 @@
                     <small>Limit the highest resolution tier to save time and storage</small>
                 </div>
 
-                <div class="form-group">
-    <label>Partial Segment Durations</label>
-    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="reencodePartialDuration" value="1000" style="margin-right: 5px;">
-            1s partials (p1000)
-        </label>
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="reencodePartialDuration" value="200" checked style="margin-right: 5px;">
-            200ms partials (p200)
-        </label>
-    </div>
-</div>
-<div class="form-group">
-    <label>Segment Duration</label>
-    <label class="form-checkbox"><input type="radio" name="reencodeSegmentDuration" value="2"> 2s segments</label>
-    <label class="form-checkbox"><input type="radio" name="reencodeSegmentDuration" value="6" checked> 6s segments</label>
-</div>
-<div class="form-group">
-    <label>GOP Duration</label>
-    <label class="form-checkbox"><input type="radio" name="reencodeGopDuration" value="1.0" checked> 1s GOPs</label>
-    <label class="form-checkbox"><input type="radio" name="reencodeGopDuration" value="2.0"> 2s GOPs</label>
-</div>
-<div class="form-group">
-    <label style="display: flex; align-items: center; gap: 8px;">
-        <input type="checkbox" id="reencodeKeepMezzanine" name="keep_mezzanine" checked>
-        Preserve intermediate mezzanine files
-    </label>
-</div>
-<div class="form-group">
-    <label>HLS Format</label>
-    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="reencodeHlsFormat" value="fmp4" checked style="margin-right: 5px;">
-            fMP4 (modern)
-        </label>
-        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-            <input type="checkbox" name="reencodeHlsFormat" value="ts" style="margin-right: 5px;">
-            MPEG-TS (legacy)
-        </label>
-    </div>
-    <small>Select which HLS segment formats to generate</small>
-</div>
-
                 <!-- Advanced Options Toggle -->
                 <button type="button" class="advanced-toggle" id="reencodeAdvancedToggle">
                     Show Advanced Options ▼
                 </button>
-                
+
                 <div class="advanced-options" id="reencodeAdvancedOptions">
+                    <div class="form-group">
+                        <label style="display: flex; align-items: center; gap: 8px;">
+                            <input type="checkbox" id="reencodeKeepMezzanine" name="keep_mezzanine" checked>
+                            Preserve intermediate mezzanine files
+                        </label>
+                    </div>
+
+                    <div class="form-group">
+                        <label>Partial Segment Durations</label>
+                        <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="reencodePartialDuration" value="1000" style="margin-right: 5px;">
+                                1s partials (p1000)
+                            </label>
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="reencodePartialDuration" value="200" checked style="margin-right: 5px;">
+                                200ms partials (p200)
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>Segment Duration</label>
+                        <label class="form-checkbox"><input type="radio" name="reencodeSegmentDuration" value="2"> 2s segments</label>
+                        <label class="form-checkbox"><input type="radio" name="reencodeSegmentDuration" value="6" checked> 6s segments</label>
+                    </div>
+
+                    <div class="form-group">
+                        <label>GOP Duration</label>
+                        <label class="form-checkbox"><input type="radio" name="reencodeGopDuration" value="1.0" checked> 1s GOPs</label>
+                        <label class="form-checkbox"><input type="radio" name="reencodeGopDuration" value="2.0"> 2s GOPs</label>
+                    </div>
+
+                    <div class="form-group">
+                        <label>HLS Format</label>
+                        <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="reencodeHlsFormat" value="fmp4" checked style="margin-right: 5px;">
+                                fMP4 (modern)
+                            </label>
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="reencodeHlsFormat" value="ts" style="margin-right: 5px;">
+                                MPEG-TS (legacy)
+                            </label>
+                        </div>
+                        <small>Select which HLS segment formats to generate</small>
+                    </div>
+
                     <div class="form-group">
                         <label for="reencodeDurationLimit">Duration Limit (seconds)</label>
                         <input type="number" id="reencodeDurationLimit" name="duration_limit" class="form-input" min="1" placeholder="Leave empty for full video">
@@ -514,6 +527,8 @@
             }
 
             document.getElementById('selectedCount').textContent = selectedSourceIds.size;
+            document.getElementById('batchAdvancedOptions').classList.remove('show');
+            document.getElementById('batchAdvancedToggle').textContent = 'Show Advanced Options ▼';
             document.getElementById('batchModal').classList.add('active');
         }
 
@@ -529,6 +544,18 @@
         document.getElementById('reencodeAdvancedToggle').addEventListener('click', () => {
             const advancedOptions = document.getElementById('reencodeAdvancedOptions');
             const toggle = document.getElementById('reencodeAdvancedToggle');
+            advancedOptions.classList.toggle('show');
+            if (advancedOptions.classList.contains('show')) {
+                toggle.textContent = 'Hide Advanced Options ▲';
+            } else {
+                toggle.textContent = 'Show Advanced Options ▼';
+            }
+        });
+
+        // Advanced options toggle for batch re-encode modal
+        document.getElementById('batchAdvancedToggle').addEventListener('click', () => {
+            const advancedOptions = document.getElementById('batchAdvancedOptions');
+            const toggle = document.getElementById('batchAdvancedToggle');
             advancedOptions.classList.toggle('show');
             if (advancedOptions.classList.contains('show')) {
                 toggle.textContent = 'Hide Advanced Options ▲';

--- a/content/dashboard/upload.html
+++ b/content/dashboard/upload.html
@@ -58,26 +58,6 @@
             font-weight: 500;
         }
 
-        .advanced-toggle {
-            background: none;
-            border: none;
-            color: var(--primary-color);
-            cursor: pointer;
-            font-size: 1em;
-            padding: 10px 0;
-            text-decoration: underline;
-            font-weight: 500;
-        }
-
-        .advanced-options {
-            display: none;
-            padding-top: 10px;
-        }
-
-        .advanced-options.show {
-            display: block;
-        }
-
         .progress-container {
             display: none;
             margin-top: 24px;
@@ -117,7 +97,7 @@
     </style>
 </head>
 <body data-ism-active-page="upload">
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         <div class="card">
             <div class="card-header">
                 <h1>Upload Content</h1>
@@ -139,24 +119,6 @@
                 </div>
 
                 <!-- Configuration -->
-                <div class="form-group">
-                    <label>Partial Segment Durations</label>
-                    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
-                        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-                            <input type="checkbox" name="partialDuration" value="1000" style="margin-right: 5px;">
-                            1s partials (p1000)
-                        </label>
-                        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-                            <input type="checkbox" name="partialDuration" value="200" checked style="margin-right: 5px;">
-                            200ms partials (p200)
-                        </label>
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label>Segment Duration</label>
-                    <label class="form-checkbox"><input type="radio" name="segmentDuration" value="2"> 2s segments</label>
-                    <label class="form-checkbox"><input type="radio" name="segmentDuration" value="6" checked> 6s segments</label>
-                </div>
                 <div class="form-group">
                     <label>Codec Selection</label>
                     <div style="display: flex; gap: 15px; margin-top: 8px;">
@@ -197,27 +159,47 @@
                     <small>Limit the highest resolution tier to save time and storage</small>
                 </div>
 
-                <div class="form-group">
-                    <label>HLS Format</label>
-                    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
-                        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-                            <input type="checkbox" name="hlsFormat" value="fmp4" checked style="margin-right: 5px;">
-                            fMP4 (modern)
-                        </label>
-                        <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
-                            <input type="checkbox" name="hlsFormat" value="ts" style="margin-right: 5px;">
-                            MPEG-TS (legacy)
-                        </label>
-                    </div>
-                    <small>Select which HLS segment formats to generate</small>
-                </div>
-
                 <!-- Advanced Options -->
                 <button type="button" class="advanced-toggle" id="advancedToggle">
                     Show Advanced Options ▼
                 </button>
-                
+
                 <div class="advanced-options" id="advancedOptions">
+                    <div class="form-group">
+                        <label>Partial Segment Durations</label>
+                        <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="partialDuration" value="1000" style="margin-right: 5px;">
+                                1s partials (p1000)
+                            </label>
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="partialDuration" value="200" checked style="margin-right: 5px;">
+                                200ms partials (p200)
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>Segment Duration</label>
+                        <label class="form-checkbox"><input type="radio" name="segmentDuration" value="2"> 2s segments</label>
+                        <label class="form-checkbox"><input type="radio" name="segmentDuration" value="6" checked> 6s segments</label>
+                    </div>
+
+                    <div class="form-group">
+                        <label>HLS Format</label>
+                        <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 8px;">
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="hlsFormat" value="fmp4" checked style="margin-right: 5px;">
+                                fMP4 (modern)
+                            </label>
+                            <label style="display: flex; align-items: center; font-weight: normal; cursor: pointer;">
+                                <input type="checkbox" name="hlsFormat" value="ts" style="margin-right: 5px;">
+                                MPEG-TS (legacy)
+                            </label>
+                        </div>
+                        <small>Select which HLS segment formats to generate</small>
+                    </div>
+
                     <div class="form-group">
                         <label for="durationLimit">Duration Limit (seconds)</label>
                         <input type="number" id="durationLimit" name="durationLimit" class="form-input" min="1" placeholder="Leave empty for full video">

--- a/content/shared-styles.css
+++ b/content/shared-styles.css
@@ -368,6 +368,26 @@ body {
     color: white;
 }
 
+.advanced-toggle {
+    background: none;
+    border: none;
+    color: var(--primary-color);
+    cursor: pointer;
+    font-size: 1em;
+    padding: 10px 0;
+    text-decoration: underline;
+    font-weight: 500;
+}
+
+.advanced-options {
+    display: none;
+    padding-top: 10px;
+}
+
+.advanced-options.show {
+    display: block;
+}
+
 .alpha-banner {
     background: var(--warning);
     color: white;

--- a/content/testing/shaka-player-test.html
+++ b/content/testing/shaka-player-test.html
@@ -181,7 +181,7 @@
     </style>
 </head>
 <body>
-    <div class="ism-content-standard">
+    <div class="ism-content-wide">
         <div style="margin-bottom: 16px;">
             <h1 style="font-size: 24px; font-weight: 500;">Shaka Player Analysis</h1>
             <p class="small">Local Shaka test harness with live metrics, buffered/seekable visualization, and event logging.</p>

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -132,15 +132,6 @@ server {
         add_header Pragma "no-cache" always;
         add_header Expires "0" always;
     }
-    
-    # Back-compat: older dashboards call /api/sources
-    location = /api/sources {
-        proxy_pass http://go_upload_service/api/content;
-        add_header Access-Control-Allow-Origin * always;
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-    }
 
     location = /api/sessions {
         proxy_pass http://go_proxy;

--- a/generate_abr/create_abr_ladder.sh
+++ b/generate_abr/create_abr_ladder.sh
@@ -593,7 +593,21 @@ log_warn() {
 
 ffmpeg() {
     log "FFmpeg command: ffmpeg $*"
-    command ffmpeg "$@"
+    # For encoding calls (those with -i input), add -progress pipe:1 so progress
+    # lines are emitted unbuffered. ffmpeg's normal stderr progress is block-
+    # buffered when piped, which makes the dashboard meter jump in chunks.
+    local has_input=false
+    for arg in "$@"; do
+        if [ "$arg" = "-i" ]; then
+            has_input=true
+            break
+        fi
+    done
+    if $has_input; then
+        command ffmpeg -progress pipe:1 -stats_period 0.5 "$@"
+    else
+        command ffmpeg "$@"
+    fi
     local rc=$?
     if [[ $rc -eq 0 ]]; then
         log "FFmpeg finished (rc=0)"

--- a/go-upload/internal/app/app.go
+++ b/go-upload/internal/app/app.go
@@ -128,8 +128,14 @@ func (a *App) ExecuteEncodingJob(ctx context.Context, jobID string) error {
 		return a.failJob(jobID, err.Error())
 	}
 
-	logLines, err := util.StreamLines(stdout, func(line string) {
-		a.LogHub.Broadcast(jobID, line)
+	var humanLines []string
+	_, err = util.StreamLines(stdout, func(line string) {
+		// Always feed the parser so `-progress pipe:1` lines (out_time=...) drive
+		// the meter; only broadcast/persist the human-readable lines.
+		if !isFFmpegProgressLine(line) {
+			a.LogHub.Broadcast(jobID, line)
+			humanLines = append(humanLines, line+"\n")
+		}
 		if progress := a.Progress.Parse(jobID, line, cfg); progress != nil {
 			_ = a.Store.UpdateJobStatus(jobID, store.JobStatusUpdate{
 				Status:   "encoding",
@@ -145,7 +151,7 @@ func (a *App) ExecuteEncodingJob(ctx context.Context, jobID string) error {
 	}
 
 	waitErr := cmd.Wait()
-	util.WriteLines(logFile, logLines)
+	util.WriteLines(logFile, humanLines)
 
 	a.ActiveMu.Lock()
 	delete(a.ActiveProcs, jobID)

--- a/go-upload/internal/app/progress.go
+++ b/go-upload/internal/app/progress.go
@@ -15,6 +15,32 @@ func NewProgressTracker() *ProgressTracker {
 	return &ProgressTracker{trackers: make(map[string]*EncodingProgressTracker)}
 }
 
+// isFFmpegProgressLine reports whether line looks like a single key=value pair
+// emitted by ffmpeg's `-progress pipe:1` output (e.g. "out_time=00:00:00.44",
+// "frame=11", "progress=continue"). Used to filter the noisy progress stream
+// out of human-readable encoding logs while still allowing the parser to read
+// `out_time=` for smooth meter updates.
+func isFFmpegProgressLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return false
+	}
+	eq := strings.Index(trimmed, "=")
+	if eq <= 0 || eq == len(trimmed)-1 {
+		return false
+	}
+	for i := 0; i < eq; i++ {
+		c := trimmed[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	// Value must not contain spaces (ffmpeg's normal stderr lines have multiple
+	// space-separated key=value pairs and would fail this check).
+	value := trimmed[eq+1:]
+	return !strings.ContainsAny(value, " \t")
+}
+
 func (p *ProgressTracker) tracker(jobID string, cfg map[string]interface{}) *EncodingProgressTracker {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/go-upload/internal/store/sqlite.go
+++ b/go-upload/internal/store/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -68,7 +69,11 @@ func DatabasePathFromEnv() string {
 }
 
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	// WAL mode allows concurrent reads alongside a single writer.
+	// busy_timeout makes writers wait briefly on contention instead of failing
+	// immediately with SQLITE_BUSY.
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +127,14 @@ func (s *SQLiteStore) InitSchema() error {
 }
 
 func (s *SQLiteStore) ListJobs() ([]Job, error) {
-	rows, err := s.db.Query(`SELECT job_id, name, status, progress, config, created_at, started_at, completed_at, error_message, log_path, output_paths, source_id FROM jobs ORDER BY created_at DESC`)
+	// Hide completed/failed jobs older than 48h. Always keep active jobs
+	// (queued/uploading/encoding) regardless of age so a long-running encode
+	// never disappears from the list mid-run.
+	cutoff := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339Nano)
+	rows, err := s.db.Query(`SELECT job_id, name, status, progress, config, created_at, started_at, completed_at, error_message, log_path, output_paths, source_id
+		FROM jobs
+		WHERE created_at >= ? OR status IN ('queued','uploading','encoding')
+		ORDER BY created_at DESC`, cutoff)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Six small fixes shaken out while polishing the Source/Jobs/Upload pages.

- **Advanced options** — collapse Partial Segment, Segment Duration, GOP Duration, HLS Format, Preserve Mezzanine under "Show Advanced Options" in Upload form + both Re-encode modals; promote toggle styles to shared sheet
- **Full width** — switch Upload / Source Library / Encoding Jobs / Job Detail / Dashboard home / Shaka Player Test to \`ism-content-wide\`
- **Fix /api/sources alias** — nginx back-compat shadowed the real \`ListSources\` handler; Source Library was rendering encoded content records with broken metadata
- **Fix SQLite contention** — open DB with WAL + busy_timeout; batch re-encode was silently dropping the second job
- **Smooth progress meter** — inject \`-progress pipe:1\` for ffmpeg encoding calls, filter the resulting key=value spam out of the human log
- **Hide stale jobs** — \`ListJobs\` filters anything completed/failed older than 48h; active jobs always returned

Closes #187

## Test plan
- [x] \`make test-deploy-dev\` succeeds
- [x] Upload form / both Re-encode modals: defaults visible, Advanced toggle hides/shows correctly
- [x] Source Library renders source uploads with correct metadata (file size, duration, upload date)
- [x] Batch re-encode of 2 sources creates 2 jobs (no SQLITE_BUSY)
- [x] Encoding progress meter ticks every ~0.5s; log panel shows only human-readable lines
- [x] Jobs page only shows recent jobs (last 48h) plus active ones