### PR TITLE
feat(upload): clean filenames + show on-disk name in Source Library

### DIFF
--- a/content/dashboard/sources.html
+++ b/content/dashboard/sources.html
@@ -449,7 +449,7 @@
                            onchange="toggleSourceSelection('${source.source_id}')">
                     <div class="source-name">${escapeHtml(source.name)}</div>
                     <div class="source-meta">
-                        <div class="source-meta-item"><strong>File:</strong> ${escapeHtml(source.original_filename)}</div>
+                        <div class="source-meta-item"><strong>File:</strong> ${escapeHtml((source.file_path || '').split('/').pop() || source.original_filename)}</div>
                         <div class="source-meta-item"><strong>Size:</strong> ${fileSize}</div>
                         <div class="source-meta-item"><strong>Duration:</strong> ${duration}</div>
                         <div class="source-meta-item"><strong>Resolution:</strong> ${resolution}</div>

--- a/content/dashboard/sources.html
+++ b/content/dashboard/sources.html
@@ -447,7 +447,7 @@
                 card.innerHTML = `
                     <input type="checkbox" class="source-checkbox" data-source-id="${source.source_id}" 
                            onchange="toggleSourceSelection('${source.source_id}')">
-                    <div class="source-name">${escapeHtml(source.name)}</div>
+                    <div class="source-name">${escapeHtml((source.name || '').replace(/\s+/g, '_'))}</div>
                     <div class="source-meta">
                         <div class="source-meta-item"><strong>File:</strong> ${escapeHtml((source.file_path || '').split('/').pop() || source.original_filename)}</div>
                         <div class="source-meta-item"><strong>Size:</strong> ${fileSize}</div>

--- a/go-upload/internal/api/routes.go
+++ b/go-upload/internal/api/routes.go
@@ -188,7 +188,7 @@ func (h *Handler) UploadInit(w http.ResponseWriter, r *http.Request) {
 
 	sourceID := util.NewUUID()
 	jobID := util.NewUUID()
-	hybridFilename := util.HybridFilename(filename, sourceID)
+	hybridFilename := util.ResolveUploadFilename(h.App.Cfg.SourcesDir, filename, sourceID)
 
 	jobIDs := []string{jobID}
 	for i, pdur := range partialDurations {
@@ -376,7 +376,7 @@ func (h *Handler) UploadFile(w http.ResponseWriter, r *http.Request) {
 	if outputName == "" {
 		outputName = util.SanitizeName(strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename)))
 	}
-	filename := util.HybridFilename(header.Filename, sourceID)
+	filename := util.ResolveUploadFilename(h.App.Cfg.SourcesDir, header.Filename, sourceID)
 	targetPath := filepath.Join(h.App.Cfg.SourcesDir, filename)
 
 	uploadJobID := jobID + "_upload"

--- a/go-upload/internal/api/routes.go
+++ b/go-upload/internal/api/routes.go
@@ -71,12 +71,39 @@ func (h *Handler) DeleteJob(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) ListSources(w http.ResponseWriter, _ *http.Request) {
-	sources, err := h.App.Store.ListSources()
+	// Disk is the source of truth for which files exist. Scan first so any
+	// scp'd files appear in the cache, then return rows joined to disk
+	// presence (and recompute FilePath from current SourcesDir so legacy
+	// /boss/ paths resolve correctly without a DB migration).
+	_ = util.ScanOriginals(h.App.Store, h.App.Cfg.SourcesDir)
+
+	cached, err := h.App.Store.ListSources()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"detail": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"sources": sources})
+
+	// Build the on-disk filename set for join + presence filtering.
+	diskFiles := map[string]bool{}
+	if entries, err := os.ReadDir(h.App.Cfg.SourcesDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			diskFiles[e.Name()] = true
+		}
+	}
+
+	visible := make([]store.Source, 0, len(cached))
+	for _, src := range cached {
+		name := filepath.Base(src.FilePath)
+		if !diskFiles[name] {
+			continue // file removed from disk → hide row (don't delete in case of jobs)
+		}
+		src.FilePath = filepath.Join(h.App.Cfg.SourcesDir, name)
+		visible = append(visible, src)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sources": visible})
 }
 
 func (h *Handler) GetSource(w http.ResponseWriter, r *http.Request) {

--- a/go-upload/internal/app/app.go
+++ b/go-upload/internal/app/app.go
@@ -208,7 +208,10 @@ func (a *App) resolveJobInput(job *store.Job) (string, string, error) {
 		if err != nil || src == nil {
 			return "", "", util.Errf("Source not found: %s", *job.SourceID)
 		}
-		return src.FilePath, filepath.Join(a.Cfg.UploadsDir, job.JobID, "encoding.log"), nil
+		// Recompute the path against the current SourcesDir so legacy stored
+		// paths (e.g. /boss/originals/...) resolve correctly without migration.
+		filePath := filepath.Join(a.Cfg.SourcesDir, filepath.Base(src.FilePath))
+		return filePath, filepath.Join(a.Cfg.UploadsDir, job.JobID, "encoding.log"), nil
 	}
 	jobDir := filepath.Join(a.Cfg.UploadsDir, job.JobID)
 	return filepath.Join(jobDir, "input.mp4"), filepath.Join(jobDir, "encoding.log"), nil

--- a/go-upload/internal/store/sqlite.go
+++ b/go-upload/internal/store/sqlite.go
@@ -123,6 +123,13 @@ func (s *SQLiteStore) InitSchema() error {
 			return err
 		}
 	}
+
+	// One-shot migration: rewrite legacy /boss/ paths to /media/ for source
+	// records created before the BOSS→ISM rename. Idempotent.
+	if _, err := s.db.Exec(`UPDATE sources SET file_path = REPLACE(file_path, '/boss/', '/media/') WHERE file_path LIKE '/boss/%'`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/go-upload/internal/util/scan.go
+++ b/go-upload/internal/util/scan.go
@@ -78,7 +78,7 @@ func ScanOriginals(st *store.SQLiteStore, root string) ScanStats {
 		sourceID := NewUUID()
 		src := store.Source{
 			SourceID:         sourceID,
-			Name:             strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+			Name:             SanitizeName(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))),
 			OriginalFilename: filepath.Base(path),
 			FilePath:         path,
 			FileSize:         fileInfo.Size(),

--- a/go-upload/internal/util/strings.go
+++ b/go-upload/internal/util/strings.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -17,12 +18,19 @@ func SanitizeName(name string) string {
 	return safe
 }
 
-func HybridFilename(original, sourceID string) string {
+// ResolveUploadFilename returns a sanitized filename for an uploaded file.
+// Prefers the clean sanitized name when nothing of the same name exists in dir.
+// On collision, appends the first 8 chars of sourceID to disambiguate.
+func ResolveUploadFilename(dir, original, sourceID string) string {
 	stem := strings.TrimSuffix(filepath.Base(original), filepath.Ext(original))
 	ext := strings.ToLower(filepath.Ext(original))
 	if ext == "" {
 		ext = ".mp4"
 	}
-	safe := SanitizeName(stem)
-	return safe + "_" + sourceID[:8] + ext
+	safeStem := SanitizeName(stem)
+	clean := safeStem + ext
+	if _, err := os.Stat(filepath.Join(dir, clean)); os.IsNotExist(err) {
+		return clean
+	}
+	return safeStem + "_" + sourceID[:8] + ext
 }


### PR DESCRIPTION
Two related cleanups so the dashboard matches what's on disk. Closes #199