### PR TITLE
docs(rendezvous): note that fork builds should change the baked-in Worker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ Camera-less TVs (Apple TV, Android TV) can't scan a QR. Instead the TV shows a 6
 
 - **Cloudflare Workers + KV** for the rendezvous. Fits comfortably in the free plan: each server costs ~2 KV writes/day at the default cadence (1,000 writes/day total budget, account-wide). The default Worker is at `https://pair-infinitestream.jeoliver.com` — to self-host, follow [`cloudflare/pair-rendezvous/README.md`](cloudflare/pair-rendezvous/README.md) and override `INFINITE_STREAM_RENDEZVOUS_URL` (server) plus `InfiniteStreamRendezvousURL` (UserDefaults / SharedPreferences on the clients).
 
+> **Forking?** That default URL is the upstream maintainer's personal Worker. Please deploy your own Worker and change the `defaultURL` constant in `apple/.../RendezvousService.swift` and `android/.../RendezvousService.java` (plus the `routes` block in `wrangler.toml`) before shipping builds — otherwise your users hammer someone else's free-tier KV budget.
+
 That's it — no third-party services beyond a Cloudflare account.
 
 ### Server-side env

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/RendezvousService.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/RendezvousService.java
@@ -30,7 +30,14 @@ public final class RendezvousService {
 
     /** Default Worker URL baked into the build. Override in SharedPreferences
      *  ("InfiniteStreamRendezvousURL") if you self-host the Worker. Empty
-     *  disables discovery. */
+     *  disables discovery.
+     *
+     *  NOTE FOR FORKS: this points at the upstream maintainer's personal
+     *  Cloudflare Worker. If you fork this repo and ship your own builds,
+     *  please change this to your own Worker URL (or set it to "" to
+     *  require runtime configuration) so your users don't accidentally
+     *  hammer someone else's free-tier KV write budget. See
+     *  cloudflare/pair-rendezvous/ for how to deploy your own. */
     public static final String DEFAULT_URL =
         "https://pair-infinitestream.jeoliver.com";
 

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/RendezvousService.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/RendezvousService.swift
@@ -30,6 +30,13 @@ struct RendezvousService {
     /// Default rendezvous URL baked into the build. Override with the
     /// "InfiniteStreamRendezvousURL" key in UserDefaults (e.g. via Settings).
     /// Empty string means pairing is disabled.
+    ///
+    /// NOTE FOR FORKS: this points at the upstream maintainer's personal
+    /// Cloudflare Worker. If you fork this repo and ship your own builds,
+    /// please change this to your own Worker URL (or set it to "" to
+    /// require runtime configuration) so your users don't accidentally
+    /// hammer someone else's free-tier KV write budget. See
+    /// `cloudflare/pair-rendezvous/` for how to deploy your own.
     static let defaultURL = "https://pair-infinitestream.jeoliver.com"
 
     /// Effective rendezvous URL after applying the UserDefaults override.

--- a/cloudflare/pair-rendezvous/wrangler.toml
+++ b/cloudflare/pair-rendezvous/wrangler.toml
@@ -20,6 +20,12 @@ workers_dev = false
 
 # Brandable hostname for clients. Wrangler creates the DNS record + cert
 # automatically on deploy (free on Workers Free plan).
+#
+# NOTE FOR FORKS: the pattern below is the upstream maintainer's own
+# domain. If you're deploying your own Worker, change it to a hostname
+# in a Cloudflare zone *you* own — wrangler can't create DNS records in
+# someone else's account. Or remove this `routes` block entirely and
+# set `workers_dev = true` to use the auto-assigned *.workers.dev URL.
 routes = [
   { pattern = "pair-infinitestream.jeoliver.com", custom_domain = true }
 ]


### PR DESCRIPTION
## Summary
- Adds a "NOTE FOR FORKS" callout next to the baked-in Worker URL in iOS `RendezvousService.swift`, Android `RendezvousService.java`, and the `routes` block in `cloudflare/pair-rendezvous/wrangler.toml`.
- Adds a brief mention in the README's "External services" section.

## Why
Pre-publishing scrub. The `https://pair-infinitestream.jeoliver.com` default URL points at the maintainer's own Cloudflare Worker. A fork that ships builds without changing it would unknowingly send announces to and poll from someone else's Worker, eating their free-tier KV write budget. Runtime override paths (UserDefaults / SharedPreferences / wrangler.toml edit) already exist — this just makes the fork-time obligation visible.

No behaviour change.

## Test plan
- [ ] Visual diff review of the four files