### PR TITLE
fix(k3s): distinct server_id per deployment so dev + release both appear in discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ That's it — no third-party services beyond a Cloudflare account.
 | `INFINITE_STREAM_RENDEZVOUS_URL` | Rendezvous Worker base URL. Required to enable any pairing. |
 | `INFINITE_STREAM_ANNOUNCE_URL` | URL that clients should use to reach this server (e.g. `http://lenovo.local:30000`). When set, this server appears in same-WAN auto-discovery. |
 | `INFINITE_STREAM_ANNOUNCE_LABEL` | Optional friendly label. Defaults to `host:port` from the announce URL. |
+| `INFINITE_STREAM_SERVER_ID` | Optional explicit announce ID (4–64 chars `[A-Za-z0-9_-]`). Defaults to a stable random ID persisted at `<data_dir>/server_id`. Set this when multiple deployments share the same data directory (e.g. dev + release pods on the same k3s node), otherwise their announces overwrite each other on the rendezvous. |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,4 +179,6 @@ The native client apps (iOS/tvOS, Android TV, Roku) need a way to *find* the ser
 
 **Same-WAN check.** The rendezvous derives a stable hash from `CF-Connecting-IP`; entries are stored under `announce:<ip-hash>:<server_id>`. A `GET /announce` from the client only lists entries with the caller's same IP hash, so the discovery list is automatically scoped to "servers visible from your public IP". Code-based pairing uses the same check (different public IP → 403, with `RENDEZVOUS_ALLOW_CROSS_NETWORK=1` to opt out).
 
+**Distinct `server_id` per deployment.** Multiple deployments sharing a data directory (typical of dev + release pods on the same k3s host that both mount `/media`) end up with the same persisted `<data_dir>/server_id` and overwrite each other on the rendezvous. Set `INFINITE_STREAM_SERVER_ID` explicitly per deployment (e.g. `infinite-streaming-dev` / `infinite-streaming-release`) to make them appear as independent entries in the announce list.
+
 See the [Server discovery section in the README](../README.md#server-discovery) for the user-facing summary.

--- a/go-upload/internal/announce/announce.go
+++ b/go-upload/internal/announce/announce.go
@@ -93,10 +93,22 @@ func (m *Manager) Run(ctx context.Context) {
 	}
 	rendezvous = strings.TrimRight(rendezvous, "/")
 
-	serverID, err := loadOrCreateServerID(m.dataDir)
-	if err != nil {
-		log.Printf("announce: cannot persist server_id (%v) — generating ephemeral", err)
-		serverID = randomID()
+	// Allow an explicit server_id override (mainly for k8s deployments
+	// that share a data dir between distinct workloads — without this the
+	// persisted /media/data/server_id collides and the announces overwrite
+	// each other on the rendezvous, leaving only one of them visible).
+	serverID := strings.TrimSpace(os.Getenv("INFINITE_STREAM_SERVER_ID"))
+	if serverID != "" && !isValidID(serverID) {
+		log.Printf("announce: INFINITE_STREAM_SERVER_ID=%q is invalid (need 4-64 chars [A-Za-z0-9_-]); ignoring", serverID)
+		serverID = ""
+	}
+	if serverID == "" {
+		var err error
+		serverID, err = loadOrCreateServerID(m.dataDir)
+		if err != nil {
+			log.Printf("announce: cannot persist server_id (%v) — generating ephemeral", err)
+			serverID = randomID()
+		}
 	}
 
 	label := strings.TrimSpace(os.Getenv("INFINITE_STREAM_ANNOUNCE_LABEL"))

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -76,6 +76,11 @@ spec:
           value: "${INFINITE_STREAM_ANNOUNCE_URL_K3S_DEV}"
         - name: INFINITE_STREAM_ANNOUNCE_LABEL
           value: "${INFINITE_STREAM_ANNOUNCE_LABEL_K3S_DEV}"
+        # Distinct from k8s-infinite-streaming.yaml so dev + release don't
+        # share the persisted /media/data/server_id and overwrite each
+        # other's announces on the rendezvous.
+        - name: INFINITE_STREAM_SERVER_ID
+          value: "infinite-streaming-dev"
         securityContext:
           privileged: true
           capabilities:

--- a/k8s-infinite-streaming.yaml
+++ b/k8s-infinite-streaming.yaml
@@ -68,6 +68,11 @@ spec:
           value: "${INFINITE_STREAM_ANNOUNCE_URL_K3S_RELEASE}"
         - name: INFINITE_STREAM_ANNOUNCE_LABEL
           value: "${INFINITE_STREAM_ANNOUNCE_LABEL_K3S_RELEASE}"
+        # Distinct from k8s-infinite-streaming-dev.yaml so dev + release
+        # don't share the persisted /media/data/server_id and overwrite
+        # each other's announces on the rendezvous.
+        - name: INFINITE_STREAM_SERVER_ID
+          value: "infinite-streaming-release"
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
## Summary
- Adds `INFINITE_STREAM_SERVER_ID` env override to the announce loop.
- Sets distinct values in `k8s-infinite-streaming.yaml` (`infinite-streaming-release`) and `k8s-infinite-streaming-dev.yaml` (`infinite-streaming-dev`).
- Documents the new env in README and ARCHITECTURE.

## Why
Both lenovo pods mount the same `/media` hostPath, sharing `/media/data/server_id`. Their heartbeats overwrite each other on the rendezvous and only one is visible to clients at a time. Verified: after the fix, `GET /announce` returns both `infinite-streaming-dev` and `infinite-streaming-release` as independent entries.

No behaviour change for Docker Compose or any single-deployment use — the persisted-file path is still the default when the env is unset.

## Test plan
- [x] Verified both pods appear distinctly in `https://pair-infinitestream.jeoliver.com/announce` after redeploy.