### PR TITLE
fix(ios,tvos): ATS exception for the public HTTP deployment + cleartext docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,21 @@ That's it — no third-party services beyond a Cloudflare account.
 | `INFINITE_STREAM_ANNOUNCE_LABEL` | Optional friendly label. Defaults to `host:port` from the announce URL. |
 | `INFINITE_STREAM_SERVER_ID` | Optional explicit announce ID (4–64 chars `[A-Za-z0-9_-]`). Defaults to a stable random ID persisted at `<data_dir>/server_id`. Set this when multiple deployments share the same data directory (e.g. dev + release pods on the same k3s node), otherwise their announces overwrite each other on the rendezvous. |
 
+### HTTP, HTTPS, and iOS App Transport Security
+
+The server defaults to plain HTTP on its dashboard / API / playback ports. That's fine for **LAN use** and **HTTPS-fronted public deployments**, but **plain HTTP to a public hostname** trips the platform-specific cleartext-traffic rules baked into modern OSes:
+
+| Client | Cleartext to LAN (`localhost`, `*.local`, RFC1918) | Cleartext to public hostname |
+|---|---|---|
+| iOS / tvOS | ✅ via `NSAllowsLocalNetworking` in `Info.plist` | ❌ — rejected by App Transport Security unless the domain is in `NSExceptionDomains` |
+| Android | ✅ via `usesCleartextTraffic="true"` (currently set) | ✅ same flag covers all hosts |
+| Roku | ✅ | ✅ no cleartext restriction |
+| Browser dashboard | ✅ | ⚠️ mixed-content warnings if the dashboard itself is HTTPS |
+
+The iOS/tvOS Info.plist files in this repo include an explicit `NSExceptionDomains` entry for `infinitestreaming.jeoliver.com` (the upstream maintainer's public domain). **If you fork and ship apps that talk to a different public-HTTP hostname** (your own server, a Tailscale MagicDNS name like `*.ts.net`, a Tailscale CGNAT IP in `100.64.0.0/10`, etc.) you must add it to both Info.plists or those clients will silently fail to load anything.
+
+The cleaner long-term answer is to terminate TLS at the server so all clients use HTTPS and no per-domain ATS / cleartext exceptions are needed. The k3s manifests already mount a `certs-vol` for this; flipping the nginx template to `listen … ssl` and pointing it at a Let's Encrypt cert (or whichever cert lives in `K3S_CERTS_DIR`) gets you there.
+
 ---
 
 ## Other ways to run it

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
@@ -23,9 +23,23 @@
     <key>NSAppTransportSecurity</key>
     <dict>
         <!-- Allow http to local-network addresses (RFC 1918, link-local, .local). -->
-        <!-- Add specific exception domains here for non-LAN hosts (Tailscale, public DNS, etc.). -->
         <key>NSAllowsLocalNetworking</key>
         <true/>
+        <!-- Per-domain exceptions for non-LAN servers reachable over plain HTTP.
+             NOTE FOR FORKS: this list contains the upstream maintainer's own
+             public hostnames. Add (and remove) entries for *your* deployments;
+             the better long-term answer is to terminate TLS at the server so
+             clients can use HTTPS and no exception is needed. -->
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>infinitestreaming.jeoliver.com</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
     <key>UISupportedInterfaceOrientations</key>
     <array>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-tvOS/Info.plist
@@ -17,9 +17,23 @@
     <key>NSAppTransportSecurity</key>
     <dict>
         <!-- Allow http to local-network addresses (RFC 1918, link-local, .local). -->
-        <!-- Add specific exception domains here for non-LAN hosts (Tailscale, public DNS, etc.). -->
         <key>NSAllowsLocalNetworking</key>
         <true/>
+        <!-- Per-domain exceptions for non-LAN servers reachable over plain HTTP.
+             NOTE FOR FORKS: this list contains the upstream maintainer's own
+             public hostnames. Add (and remove) entries for *your* deployments;
+             the better long-term answer is to terminate TLS at the server so
+             clients can use HTTPS and no exception is needed. -->
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>infinitestreaming.jeoliver.com</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
 </dict>
 </plist>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -181,4 +181,6 @@ The native client apps (iOS/tvOS, Android TV, Roku) need a way to *find* the ser
 
 **Distinct `server_id` per deployment.** Multiple deployments sharing a data directory (typical of dev + release pods on the same k3s host that both mount `/media`) end up with the same persisted `<data_dir>/server_id` and overwrite each other on the rendezvous. Set `INFINITE_STREAM_SERVER_ID` explicitly per deployment (e.g. `infinite-streaming-dev` / `infinite-streaming-release`) to make them appear as independent entries in the announce list.
 
+**Cleartext HTTP and ATS.** The server defaults to plain HTTP on every listening port. iOS/tvOS' App Transport Security blocks plain HTTP to public hostnames unless the domain is in the app's `NSExceptionDomains`; the iOS/tvOS Info.plists in this repo include an exception for `infinitestreaming.jeoliver.com` so the upstream public deployment is reachable. Forks that ship apps pointing at a different public-HTTP host need to add their own exception (or — better — terminate TLS at the server so HTTPS works without exceptions; the `certs-vol` mount in the k3s manifests is the hook for that). Android has `usesCleartextTraffic="true"` so it isn't affected.
+
 See the [Server discovery section in the README](../README.md#server-discovery) for the user-facing summary.


### PR DESCRIPTION
## Summary
- Adds an `NSExceptionDomains` entry for `infinitestreaming.jeoliver.com` to both iOS and tvOS Info.plists, with a `NOTE FOR FORKS` comment.
- README "Server discovery" gets a new "HTTP, HTTPS, and iOS App Transport Security" subsection with a per-platform cleartext-rules table.
- ARCHITECTURE.md gets a matching "Cleartext HTTP and ATS" callout.

## Why
Once iOS users added the lenovo public deployment via discovery, every media URL was silently rejected by ATS. The exception unblocks playback today; the docs explain the underlying constraint and point at the cleaner long-term fix (HTTPS termination at the server, which the existing `certs-vol` mount is the hook for).

Android (`usesCleartextTraffic="true"`) and Roku aren't affected.

## Test plan
- [ ] `make deploy-iphone`, switch to the `infinitestreaming.jeoliver.com:40000` server in the picker, verify content plays.