### PR TITLE
ci: release automation — semver GHCR tags, Release Drafter, version-tagged k3s image

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,56 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Bump major/minor/patch based on PR labels (or commit-message conventional
+# prefixes if no label is set). Labels win — add `breaking` to a PR for a
+# major bump, `feat` for minor, `fix`/`chore`/`docs` for patch.
+version-resolver:
+  major:
+    labels: ['breaking', 'major']
+  minor:
+    labels: ['enhancement', 'feat', 'minor']
+  patch:
+    labels: ['bug', 'fix', 'chore', 'docs', 'patch']
+  default: patch
+
+# Group merged PRs into sections in the changelog. Anything without a
+# matching label falls under "Other changes".
+categories:
+  - title: '🚀 Features'
+    labels: ['enhancement', 'feat']
+  - title: '🐛 Fixes'
+    labels: ['bug', 'fix']
+  - title: '📚 Documentation'
+    labels: ['documentation', 'docs']
+  - title: '🧰 Maintenance'
+    labels: ['chore', 'ci', 'refactor']
+  - title: '⚠️ Breaking changes'
+    labels: ['breaking']
+    collapse-after: 0
+
+# Auto-detect labels from conventional-commit prefixes in PR titles.
+# Lets you skip manually labelling every PR.
+autolabeler:
+  - label: 'enhancement'
+    title: ['/^feat[\\(:]/']
+  - label: 'bug'
+    title: ['/^fix[\\(:]/']
+  - label: 'documentation'
+    title: ['/^docs[\\(:]/']
+  - label: 'chore'
+    title: ['/^chore[\\(:]/']
+  - label: 'ci'
+    title: ['/^ci[\\(:]/']
+  - label: 'refactor'
+    title: ['/^refactor[\\(:]/']
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# Top of the release notes — short summary line + a render of the categories.
+template: |
+  ## What's changed since $PREVIOUS_TAG
+
+  $CHANGES
+
+  **Full changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,7 @@ name: Build and publish Docker image
 on:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
   workflow_dispatch:
 
 permissions:
@@ -32,6 +33,10 @@ jobs:
             type=ref,event=branch
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
+            # Semver tags: v1.2.3 → :v1.2.3, :v1.2, :v1
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
 
       - name: Build and push server
         uses: docker/build-push-action@v5
@@ -50,6 +55,9 @@ jobs:
             type=ref,event=branch
             type=sha
             type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
 
       - name: Build and push go-proxy
         uses: docker/build-push-action@v5

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,27 @@
+name: Release Drafter
+
+# Drafts the next release on every push to main and on every PR (so the
+# autolabeler can tag PRs as they're opened/edited). Publishing the draft
+# is still manual via the GitHub UI ("Releases → Draft → Edit → Publish")
+# or `gh release edit … --draft=false`.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types: [ opened, reopened, synchronize, edited ]
+  workflow_dispatch:
+
+permissions:
+  contents: write       # to create/update the draft release
+  pull-requests: write  # to apply autolabeler labels
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,11 @@ logs:
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl logs deploy/infinite-streaming-dev --all-containers -f"
 
 deploy-release:
-	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_SERVER_IMAGE) --push .
+	docker buildx build --platform linux/amd64 \
+		--build-arg VERSION=$(shell cat VERSION) \
+		-t $(K3S_SERVER_IMAGE) \
+		-t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):$(shell cat VERSION) \
+		--push .
 	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K3S_SERVER_IMAGE=$(K3S_SERVER_IMAGE)
 
 # ── Remote deployment testing ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
Three small CI changes that make tagged releases produce proper artifacts and auto-draft their changelog:

1. **GHCR tag-on-release** (`.github/workflows/docker-publish.yml`) — workflow now triggers on `tags: ['v*']` and emits semver tags (`:v1.2.3`, `:v1.2`, `:v1`) alongside `:latest` and `:sha-…`.
2. **Release Drafter** (`.github/release-drafter.yml` + `.github/workflows/release-drafter.yml`) — drafts the next release on every PR merge, categorises PRs into Features / Fixes / Docs / Maintenance / Breaking, and autolabels from conventional-commit prefixes (`feat:`, `fix:`, …). Publishing stays manual.
3. **Makefile `deploy-release`** — also tags the k3s registry image with the `VERSION` file contents, matching the GHCR semver tagging.

## Why
Once these land, the next step is cutting `v1.0.0`: `git tag v1.0.0 && git push origin v1.0.0` will trigger #1 (GHCR `:v1.0.0` published) and the Release Drafter will have already accumulated notes since the last tagged release. Repo visitors then see "Latest release v1.0.0" in the right sidebar instead of the stale Feb v0.2.0.

## Test plan
- [ ] After merge, push `v1.0.0` tag and confirm GHCR receives `:v1.0.0`, `:v1.0`, `:v1`.
- [ ] Confirm release-drafter creates a draft release with auto-generated notes.