### PR TITLE
chore(ci): add Dependabot config for all package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+# Dependabot config — opens PRs for security and version updates across
+# every ecosystem in this repo. Weekly cadence keeps the PR volume low.
+# All PRs land via the same squash-merge workflow as everything else.
+
+updates:
+
+  # GitHub Actions used by .github/workflows/*
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Go modules — one entry per module.
+  - package-ecosystem: "gomod"
+    directory: "/go-upload"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "gomod"
+    directory: "/go-live"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "gomod"
+    directory: "/go-proxy"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # npm — pair-rendezvous Cloudflare Worker (wrangler etc.)
+  - package-ecosystem: "npm"
+    directory: "/cloudflare/pair-rendezvous"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker base images in the Dockerfile (alpine, golang).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
Weekly auto-PRs for:
- GitHub Actions (all workflows)
- Go modules: go-upload, go-live, go-proxy
- npm: cloudflare/pair-rendezvous (wrangler etc.)
- Docker base images in the Dockerfile (alpine, golang)

Conventional-commit prefixes (`chore(ci)`, `chore(deps)`) align with
the Release Drafter autolabeler so these land under "🧰 Maintenance"
in the changelog without manual labelling.
