### PR TITLE
chore: add issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The more reproducible the report, the faster it can be fixed.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear, concrete description. Screenshots / log snippets welcome.
+      placeholder: e.g. "Player stalls forever after a 503 fault is injected on segment 5."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      placeholder: e.g. "Player should retry the failed segment and resume playback."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Be specific — content name, fault settings, player, browser/OS.
+      value: |
+        1. Start the server with `make run`
+        2. Open `http://localhost:30000/dashboard/testing-session.html?player_id=...`
+        3. Inject fault: ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `cat VERSION` or the GHCR image tag you're running.
+      placeholder: e.g. v1.0.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment mode
+      options:
+        - Docker Compose (local)
+        - Docker run (single container)
+        - k3s release
+        - k3s dev
+        - Pre-built GHCR image
+        - Other (describe in "What happened")
+    validations:
+      required: true
+
+  - type: input
+    id: client
+    attributes:
+      label: Client
+      description: Browser + OS, or native app version (iOS / tvOS / Android TV / Roku).
+      placeholder: e.g. Chrome 147 on macOS 26.3
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Paste the smallest possible log snippet that shows the issue.
+        Container logs: `docker logs <container>` or `kubectl logs deploy/<name>`.
+      render: shell
+
+  - type: checkboxes
+    id: checked
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm running the latest release (or `main`) and the bug still reproduces.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions / Q&A
+    url: https://github.com/jonathaneoliver/infinite-streaming/discussions
+    about: For usage questions, design discussions, or anything that isn't a clear bug or feature request.
+  - name: Security report
+    url: https://github.com/jonathaneoliver/infinite-streaming/security/advisories/new
+    about: Report a security vulnerability privately. See SECURITY.md for the full policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest a new capability or enhancement
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Heads up: this project is intentionally focused on testing video players under deterministic faults — it's not a production streaming origin. Features that move it toward "production media server" are likely out of scope. See the README "When not to use it" section.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user / testing scenario you're trying to support.
+      placeholder: e.g. "I want to characterize how a player handles a 4-rung ladder when the highest rung is suddenly removed mid-stream."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you change or add? UI? API? Encoding pipeline?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing tools / workarounds you've tried, and why they fall short.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Dashboard / UI
+        - Failure injection (HTTP)
+        - Failure injection (transport / nftables)
+        - Traffic shaping
+        - Manifest manipulation
+        - Encoding pipeline
+        - Native client app (iOS / tvOS)
+        - Native client app (Android)
+        - Native client app (Roku)
+        - Server discovery / pairing
+        - Documentation
+        - Other

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for the PR. A couple of conventions for this repo:
+
+- Use a conventional-commit prefix in the title: feat:, fix:, docs:, chore:, ci:, refactor:.
+  Release Drafter autolabels from these and uses them for changelog grouping. Add a
+  `breaking` label by hand if your change is a breaking change.
+
+- The repo squash-merges only — your PR title and this body become the single commit
+  message on main. Write the title as you'd want it to read in `git log`.
+-->
+
+## Summary
+<!-- 1–3 bullets on what this PR does and why. -->
+
+## Why
+<!-- The user-visible problem or use case this addresses. Skip if obvious from the title. -->
+
+## Test plan
+<!-- How you (or a reviewer) can verify the change works. -->
+
+- [ ] Tested locally via `make run` / `make test-deploy-dev` / etc.
+- [ ] Added or updated tests where appropriate (`tests/integration/`).
+- [ ] Updated docs (README / docs/ARCHITECTURE.md / docs/API.md) if behaviour or env changed.
+- [ ] No personal info, secrets, or per-user URLs in the diff.
+
+## Screenshots
+<!-- For UI changes — drag-and-drop a before/after. Skip otherwise. -->


### PR DESCRIPTION
- .github/ISSUE_TEMPLATE/bug_report.yml — structured bug form (what
  happened, expected, repro, version, deployment mode, client, logs)
  with a "before submitting" checklist. Auto-labels `bug` and
  prefixes the title with `[bug]`.
- .github/ISSUE_TEMPLATE/feature_request.yml — structured feature form
  with the project's "not a production media server" reminder up top
  and an Area dropdown. Auto-labels `enhancement`.
- .github/ISSUE_TEMPLATE/config.yml — disables blank issues; routes
  questions to Discussions and security reports to private advisories.
- .github/PULL_REQUEST_TEMPLATE.md — short Summary / Why / Test plan
  with conventional-commit reminder for the autolabeler and a checklist
  covering tests, docs, and personal-info scrub.

All four signal contribution-friendliness without adding maintenance
burden — the autolabels feed Release Drafter's existing categorisation.
