### PR TITLE
chore(ci): ignore release-drafter major bumps until v7 migration is done

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(ci)"
+    ignore:
+      # release-drafter v7 splits the autolabeler into a separate action
+      # and changes token handling. Merging a major bump as-is silently
+      # disables our PR autolabeling. Re-enable by removing this entry
+      # and migrating .github/workflows/release-drafter.yml to the v7
+      # two-step pattern (action + autolabeler) plus `with: token`.
+      - dependency-name: "release-drafter/release-drafter"
+        update-types: ["version-update:semver-major"]
 
   # Go modules — one entry per module.
   - package-ecosystem: "gomod"


### PR DESCRIPTION
PR #228 (release-drafter v6→v7) was closed as deferred — v7 splits
the autolabeler into a separate action and changes token handling, so
merging the bump as-is would silently disable PR autolabeling.

This entry stops Dependabot from re-opening the PR every week. Patch
and minor bumps to release-drafter still come through. To re-enable
the major flow, remove this ignore entry and migrate the workflow to
v7's two-step pattern (action + autolabeler step) plus `with: token`.
