### PR TITLE
chore(ci): ignore gohlslib bumps until pkg/playlist migration is done

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,13 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      # gohlslib v1.4.1 removed the pkg/playlist package that 4 files in
+      # pkg/generator and pkg/parser import. PR #229 pinned us back to
+      # v1.4.0 after #217 broke the build. Re-enable by porting our 4
+      # import sites off pkg/playlist (or using a fork that retains it),
+      # then removing this ignore.
+      - dependency-name: "github.com/bluenviron/gohlslib"
 
   - package-ecosystem: "gomod"
     directory: "/go-proxy"


### PR DESCRIPTION
PR #232 (gohlslib v1.4.0→v1.4.1) was closed because v1.4.1 dropped
pkg/playlist, which 4 files in this repo import. PR #229 pinned us
back at v1.4.0 to restore main's build.

This entry stops Dependabot from re-opening the bump every week. To
re-enable, port the 4 import sites in pkg/generator and pkg/parser
off pkg/playlist (or move to a fork that retains it), then remove
this ignore.
