### PR TITLE
fix(tvos): keep screensaver disabled during streaming

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/InfiniteStreamPlayerApp.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/InfiniteStreamPlayerApp.swift
@@ -2,11 +2,20 @@ import SwiftUI
 import UIKit
 
 private class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        application.isIdleTimerDisabled = true
+        return true
+    }
+
+    // Re-assert on every activation. On tvOS, AVPlayerViewController only
+    // suppresses the screensaver during active playback — stalls, pauses,
+    // and menu navigation let the system timer resume. Keep it disabled
+    // app-wide so streaming sessions don't get interrupted.
     func applicationDidBecomeActive(_ application: UIApplication) {
         application.isIdleTimerDisabled = true
-    }
-    func applicationWillResignActive(_ application: UIApplication) {
-        application.isIdleTimerDisabled = false
     }
 }
 


### PR DESCRIPTION
## Summary

- Set `UIApplication.isIdleTimerDisabled = true` at `didFinishLaunchingWithOptions` and re-assert on `applicationDidBecomeActive`; remove the `willResignActive` reset that was turning it back off.
- On tvOS, `AVPlayerViewController` only suppresses the screensaver during active playback — stalls, buffering, pauses, and menu navigation (all common in this testing-oriented app) let the system screensaver timer resume. Keeping the idle timer disabled app-wide avoids interrupting streaming sessions regardless of player state.

Closes #234

## Test plan

- [ ] Install tvOS build; start a stream; leave the remote untouched for longer than the system screensaver timeout — verify playback keeps running and no screensaver appears.
- [ ] Pause playback from the control bar; wait past the screensaver timeout — verify no screensaver.
- [ ] Navigate back to the server/content list and idle past the timeout — verify no screensaver.
- [ ] iOS regression: launch the iOS app, leave foregrounded and idle — verify the screen doesn't dim/lock during a live session.