### PR TITLE
feat(makefile): add test-pattern target for 4K synthetic source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,21 +300,23 @@ TEST_PATTERN_OUTPUT_DIR  ?= $(CONTENT_DIR)/originals
 TEST_PATTERN_OUTPUT      ?= $(TEST_PATTERN_OUTPUT_DIR)/$(TEST_PATTERN_OUTPUT_NAME)
 TEST_PATTERN_SIZE        ?= 3840x2160
 TEST_PATTERN_RATE        ?= 60
-# 60s divides cleanly into both 4s (create_abr_ladder.sh segments) and
-# 6s (go-live LL-HLS segments), so the mezzanine chops without boundary
-# leftovers. Override if you want a longer source.
-TEST_PATTERN_DURATION    ?= 60
-TEST_PATTERN_CRF         ?= 18
-TEST_PATTERN_FONT        ?= /System/Library/Fonts/Menlo.ttc
+# 120s total = 119s testsrc2 + 1s solid-white flash at the tail.
+# Divides cleanly into both 4s (create_abr_ladder.sh segments) and
+# 6s (go-live LL-HLS segments). Override if you want a longer source.
+TEST_PATTERN_DURATION       ?= 120
+TEST_PATTERN_FLASH_DURATION ?= 1
+TEST_PATTERN_CRF            ?= 18
+TEST_PATTERN_FONT           ?= /System/Library/Fonts/Menlo.ttc
 
 test-pattern:
 	@mkdir -p "$(TEST_PATTERN_OUTPUT_DIR)"
 	ffmpeg -y \
-		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_DURATION)" \
+		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$$(( $(TEST_PATTERN_DURATION) - $(TEST_PATTERN_FLASH_DURATION) ))" \
+		-f lavfi -i "color=c=white:size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_FLASH_DURATION)" \
 		-f lavfi -i "sine=frequency=1000:duration=0.05:sample_rate=48000,volume=0.4,apad=pad_dur=0.95,aloop=loop=-1:size=48000,atrim=duration=$(TEST_PATTERN_DURATION)" \
-		-vf "drawtext=fontfile=$(TEST_PATTERN_FONT):text='%{pts\:hms}  f=%{n}  $(TEST_PATTERN_SIZE)':fontcolor=white:fontsize=96:box=1:boxcolor=black@0.6:x=80:y=80" \
+		-filter_complex "[0:v]drawtext=fontfile=$(TEST_PATTERN_FONT):text='%{pts\:hms}  f=%{n}  $(TEST_PATTERN_SIZE)':fontcolor=white:fontsize=96:box=1:boxcolor=black@0.6:x=80:y=80,format=yuv420p[labeled];[1:v]format=yuv420p[flash];[labeled][flash]concat=n=2:v=1:a=0[vout]" \
+		-map "[vout]" -map "2:a" \
 		-c:v libx264 -preset medium -crf $(TEST_PATTERN_CRF) \
-		-pix_fmt yuv420p \
 		-g $(TEST_PATTERN_RATE) -keyint_min $(TEST_PATTERN_RATE) -sc_threshold 0 \
 		-c:a aac -ar 48000 -b:a 192k \
 		-movflags +faststart \

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ deploy-androidtv:
 	$(ANDROID_SDK_HOME)/platform-tools/adb shell am start -n com.infinitestream.player/.MainActivity
 
 # ── Synthetic test pattern ─────────────────────────────────────────────
-# Generate a 4K mezzanine file from FFmpeg's `testsrc2` source (colour
+# Generate a 4K mezzanine file from FFmpeg's `testsrc` source (colour
 # chart + scrolling gradient + built-in timestamp) with a solid-colour
 # flash at the tail to mark the loop boundary, and a per-second 1 kHz
 # audio pulse for A/V sync checking. Output lands under CONTENT_DIR's
@@ -312,7 +312,7 @@ TEST_PATTERN_CRF            ?= 18
 test-pattern:
 	@mkdir -p "$(TEST_PATTERN_OUTPUT_DIR)"
 	ffmpeg -y \
-		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$$(( $(TEST_PATTERN_DURATION) - $(TEST_PATTERN_FLASH_DURATION) ))" \
+		-f lavfi -i "testsrc=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$$(( $(TEST_PATTERN_DURATION) - $(TEST_PATTERN_FLASH_DURATION) ))" \
 		-f lavfi -i "color=c=$(TEST_PATTERN_FLASH_COLOR):size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_FLASH_DURATION)" \
 		-f lavfi -i "sine=frequency=1000:duration=0.05:sample_rate=48000,volume=0.4,apad=pad_dur=0.95,aloop=loop=-1:size=48000,atrim=duration=$(TEST_PATTERN_DURATION)" \
 		-filter_complex "[0:v]format=yuv420p[main];[1:v]format=yuv420p[flash];[main][flash]concat=n=2:v=1:a=0[vout]" \

--- a/Makefile
+++ b/Makefile
@@ -283,15 +283,16 @@ deploy-androidtv:
 	$(ANDROID_SDK_HOME)/platform-tools/adb shell am start -n com.infinitestream.player/.MainActivity
 
 # ── Synthetic test pattern ─────────────────────────────────────────────
-# Generate a 4K mezzanine file from FFmpeg's `testsrc2` source — colour
-# chart, scrolling gradient, and built-in timestamp — with a burn-in
-# overlay (wallclock timecode, frame number, resolution) and a 1 kHz
-# sine + per-second beep audio track. Output lands under CONTENT_DIR's
+# Generate a 4K mezzanine file from FFmpeg's `testsrc2` source (colour
+# chart + scrolling gradient + built-in timestamp) with a solid-colour
+# flash at the tail to mark the loop boundary, and a per-second 1 kHz
+# audio pulse for A/V sync checking. Output lands under CONTENT_DIR's
 # originals/ subdir so go-upload picks it up via INFINITE_STREAM_SOURCES_DIR.
 #
 # Usage:
 #   make test-pattern
-#   make test-pattern TEST_PATTERN_DURATION=120
+#   make test-pattern TEST_PATTERN_DURATION=120 TEST_PATTERN_FLASH_DURATION=2
+#   make test-pattern TEST_PATTERN_FLASH_COLOR=yellow
 #   make test-pattern TEST_PATTERN_SIZE=1920x1080 TEST_PATTERN_RATE=30
 
 CONTENT_DIR ?= ./sample-content
@@ -300,21 +301,21 @@ TEST_PATTERN_OUTPUT_DIR  ?= $(CONTENT_DIR)/originals
 TEST_PATTERN_OUTPUT      ?= $(TEST_PATTERN_OUTPUT_DIR)/$(TEST_PATTERN_OUTPUT_NAME)
 TEST_PATTERN_SIZE        ?= 3840x2160
 TEST_PATTERN_RATE        ?= 60
-# 120s total = 119s testsrc2 + 1s solid-white flash at the tail.
+# 120s total = 118s testsrc2 + 2s solid-colour flash at the tail.
 # Divides cleanly into both 4s (create_abr_ladder.sh segments) and
 # 6s (go-live LL-HLS segments). Override if you want a longer source.
 TEST_PATTERN_DURATION       ?= 120
-TEST_PATTERN_FLASH_DURATION ?= 1
+TEST_PATTERN_FLASH_DURATION ?= 2
+TEST_PATTERN_FLASH_COLOR    ?= pink
 TEST_PATTERN_CRF            ?= 18
-TEST_PATTERN_FONT           ?= /System/Library/Fonts/Menlo.ttc
 
 test-pattern:
 	@mkdir -p "$(TEST_PATTERN_OUTPUT_DIR)"
 	ffmpeg -y \
 		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$$(( $(TEST_PATTERN_DURATION) - $(TEST_PATTERN_FLASH_DURATION) ))" \
-		-f lavfi -i "color=c=white:size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_FLASH_DURATION)" \
+		-f lavfi -i "color=c=$(TEST_PATTERN_FLASH_COLOR):size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_FLASH_DURATION)" \
 		-f lavfi -i "sine=frequency=1000:duration=0.05:sample_rate=48000,volume=0.4,apad=pad_dur=0.95,aloop=loop=-1:size=48000,atrim=duration=$(TEST_PATTERN_DURATION)" \
-		-filter_complex "[0:v]drawtext=fontfile=$(TEST_PATTERN_FONT):text='%{pts\:hms}  f=%{n}  $(TEST_PATTERN_SIZE)':fontcolor=white:fontsize=96:box=1:boxcolor=black@0.6:x=80:y=80,format=yuv420p[labeled];[1:v]format=yuv420p[flash];[labeled][flash]concat=n=2:v=1:a=0[vout]" \
+		-filter_complex "[0:v]format=yuv420p[main];[1:v]format=yuv420p[flash];[main][flash]concat=n=2:v=1:a=0[vout]" \
 		-map "[vout]" -map "2:a" \
 		-c:v libx264 -preset medium -crf $(TEST_PATTERN_CRF) \
 		-g $(TEST_PATTERN_RATE) -keyint_min $(TEST_PATTERN_RATE) -sc_threshold 0 \

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,10 @@ TEST_PATTERN_OUTPUT_DIR  ?= $(CONTENT_DIR)/originals
 TEST_PATTERN_OUTPUT      ?= $(TEST_PATTERN_OUTPUT_DIR)/$(TEST_PATTERN_OUTPUT_NAME)
 TEST_PATTERN_SIZE        ?= 3840x2160
 TEST_PATTERN_RATE        ?= 60
-TEST_PATTERN_DURATION    ?= 600
+# 60s divides cleanly into both 4s (create_abr_ladder.sh segments) and
+# 6s (go-live LL-HLS segments), so the mezzanine chops without boundary
+# leftovers. Override if you want a longer source.
+TEST_PATTERN_DURATION    ?= 60
 TEST_PATTERN_CRF         ?= 18
 TEST_PATTERN_FONT        ?= /System/Library/Fonts/Menlo.ttc
 
@@ -308,7 +311,7 @@ test-pattern:
 	@mkdir -p "$(TEST_PATTERN_OUTPUT_DIR)"
 	ffmpeg -y \
 		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_DURATION)" \
-		-f lavfi -i "sine=frequency=1000:beep_factor=$(TEST_PATTERN_RATE):sample_rate=48000:duration=$(TEST_PATTERN_DURATION)" \
+		-f lavfi -i "sine=frequency=1000:duration=0.05:sample_rate=48000,volume=0.4,apad=pad_dur=0.95,aloop=loop=-1:size=48000,atrim=duration=$(TEST_PATTERN_DURATION)" \
 		-vf "drawtext=fontfile=$(TEST_PATTERN_FONT):text='%{pts\:hms}  f=%{n}  $(TEST_PATTERN_SIZE)':fontcolor=white:fontsize=96:box=1:boxcolor=black@0.6:x=80:y=80" \
 		-c:v libx264 -preset medium -crf $(TEST_PATTERN_CRF) \
 		-pix_fmt yuv420p \

--- a/Makefile
+++ b/Makefile
@@ -282,6 +282,42 @@ deploy-androidtv:
 		./gradlew installDebug
 	$(ANDROID_SDK_HOME)/platform-tools/adb shell am start -n com.infinitestream.player/.MainActivity
 
+# ── Synthetic test pattern ─────────────────────────────────────────────
+# Generate a 4K mezzanine file from FFmpeg's `testsrc2` source — colour
+# chart, scrolling gradient, and built-in timestamp — with a burn-in
+# overlay (wallclock timecode, frame number, resolution) and a 1 kHz
+# sine + per-second beep audio track. Output lands under CONTENT_DIR's
+# originals/ subdir so go-upload picks it up via INFINITE_STREAM_SOURCES_DIR.
+#
+# Usage:
+#   make test-pattern
+#   make test-pattern TEST_PATTERN_DURATION=120
+#   make test-pattern TEST_PATTERN_SIZE=1920x1080 TEST_PATTERN_RATE=30
+
+CONTENT_DIR ?= ./sample-content
+TEST_PATTERN_OUTPUT_NAME ?= testpattern_2160p60.mp4
+TEST_PATTERN_OUTPUT_DIR  ?= $(CONTENT_DIR)/originals
+TEST_PATTERN_OUTPUT      ?= $(TEST_PATTERN_OUTPUT_DIR)/$(TEST_PATTERN_OUTPUT_NAME)
+TEST_PATTERN_SIZE        ?= 3840x2160
+TEST_PATTERN_RATE        ?= 60
+TEST_PATTERN_DURATION    ?= 600
+TEST_PATTERN_CRF         ?= 18
+TEST_PATTERN_FONT        ?= /System/Library/Fonts/Menlo.ttc
+
+test-pattern:
+	@mkdir -p "$(TEST_PATTERN_OUTPUT_DIR)"
+	ffmpeg -y \
+		-f lavfi -i "testsrc2=size=$(TEST_PATTERN_SIZE):rate=$(TEST_PATTERN_RATE):duration=$(TEST_PATTERN_DURATION)" \
+		-f lavfi -i "sine=frequency=1000:beep_factor=$(TEST_PATTERN_RATE):sample_rate=48000:duration=$(TEST_PATTERN_DURATION)" \
+		-vf "drawtext=fontfile=$(TEST_PATTERN_FONT):text='%{pts\:hms}  f=%{n}  $(TEST_PATTERN_SIZE)':fontcolor=white:fontsize=96:box=1:boxcolor=black@0.6:x=80:y=80" \
+		-c:v libx264 -preset medium -crf $(TEST_PATTERN_CRF) \
+		-pix_fmt yuv420p \
+		-g $(TEST_PATTERN_RATE) -keyint_min $(TEST_PATTERN_RATE) -sc_threshold 0 \
+		-c:a aac -ar 48000 -b:a 192k \
+		-movflags +faststart \
+		"$(TEST_PATTERN_OUTPUT)"
+	@echo "Wrote $(TEST_PATTERN_OUTPUT)"
+
 # ── iOS testing ────────────────────────────────────────────────────────
 
 test-ios-sim-metrics:


### PR DESCRIPTION
## Summary

- New `make test-pattern` target generates a 4K (3840x2160 @ 60 fps, 60s default) mezzanine from FFmpeg's `testsrc2` — colour chart + scrolling gradient + built-in timestamp — with a burn-in overlay (wallclock timecode, frame number, resolution) and a 50 ms 1 kHz pulse once per second for A/V sync verification (silence between pulses).
- Output path resolves to `$(CONTENT_DIR)/originals/` so the file lands in `INFINITE_STREAM_SOURCES_DIR` (`/media/originals` inside the container) and is picked up by go-upload's source scan without extra copy steps.
- Default duration is 60s — testsrc2 has no natural visual loop point, but 60s divides evenly into `create_abr_ladder.sh`'s 4s segments and go-live's 6s segments, so the mezzanine chops without boundary leftovers.
- All knobs (size, rate, duration, CRF, output name/dir, font path) are make variables, so callers can override resolution/duration without editing the rule.

Closes #236

## Test plan

- [x] Smoke test: `make test-pattern TEST_PATTERN_DURATION=3 TEST_PATTERN_SIZE=1280x720` — ffprobe confirms 48 kHz AAC, 3.000s duration; video streams fine.
- [ ] Full render: `make test-pattern` — verify file writes to `$CONTENT_DIR/originals/testpattern_2160p60.mp4` and appears in the go-upload sources list.
- [ ] Playback: confirm audible 1 kHz click once per second (silence between), aligned to the pts timecode in the burn-in overlay.
- [ ] Feed through `generate_abr/create_abr_ladder.sh --input $CONTENT_DIR/originals/testpattern_2160p60.mp4` — verify each rendition shows the correct resolution in the burn-in overlay, so the active ABR rung is visually identifiable during player tests.