### PR TITLE
feat(android): preserve live offset to match Apple TV semantics

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
@@ -788,7 +788,23 @@ public class MainActivity extends AppCompatActivity {
 
     private void loadStream(String url) {
         if (player != null && !url.isEmpty()) {
-            MediaItem mediaItem = MediaItem.fromUri(url);
+            // Target offset + min/max offsets stay UNSET so the manifest's
+            // EXT-X-SERVER-CONTROL HOLD-BACK / PART-HOLD-BACK picks the start
+            // point — same first-play position as Apple tvOS. Narrow the
+            // playback-speed window so ExoPlayer catches up via rate
+            // adjustment after a stall instead of seeking toward the live
+            // edge, mirroring AVPlayer's automaticallyPreservesTimeOffsetFromLive.
+            MediaItem.LiveConfiguration liveConfig = new MediaItem.LiveConfiguration.Builder()
+                .setTargetOffsetMs(C.TIME_UNSET)
+                .setMinOffsetMs(C.TIME_UNSET)
+                .setMaxOffsetMs(C.TIME_UNSET)
+                .setMinPlaybackSpeed(0.97f)
+                .setMaxPlaybackSpeed(1.03f)
+                .build();
+            MediaItem mediaItem = new MediaItem.Builder()
+                .setUri(url)
+                .setLiveConfiguration(liveConfig)
+                .build();
             player.setMediaItem(mediaItem);
             player.prepare();
             player.setPlayWhenReady(true);


### PR DESCRIPTION
## Summary

- Build the Android `MediaItem` with an explicit `LiveConfiguration`. `targetOffsetMs` / `minOffsetMs` / `maxOffsetMs` stay `C.TIME_UNSET` so the manifest's `EXT-X-SERVER-CONTROL HOLD-BACK` / `PART-HOLD-BACK` picks the start point — same first-play position as Apple tvOS.
- Narrow the playback-speed window to `[0.97, 1.03]` so ExoPlayer catches up via subtle rate adjustment after a stall instead of seeking toward the live edge. This mirrors `AVPlayerItem.automaticallyPreservesTimeOffsetFromLive = true` on tvOS (`PlaybackViewModel.swift:380`).
- Without this, after a few failure-injection stalls AndroidTV drifts closer to the live edge than Apple TV even though both started at the same manifest-advertised offset, making cross-platform comparison noisy.

Closes #238

## Test plan

- [x] `./gradlew assembleDebug` — builds clean.
- [ ] `make deploy-androidtv` — install on the Google TV Streamer.
- [ ] Start playback; verify initial live offset matches Apple TV (both should sit at manifest's `PART-HOLD-BACK` distance from live edge).
- [ ] Inject a stall (proxy fault or network drop); verify AndroidTV returns to approximately the same offset after recovery rather than snapping toward live.
- [ ] Run a side-by-side cross-platform comparison (Apple TV + Android TV on the same content) for 5 minutes with intermittent stalls — the two players' live offsets should track each other throughout.