### PR TITLE
feat(player): emit "playing" event on new content start

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
@@ -230,6 +230,32 @@ public class MainActivity extends AppCompatActivity {
                     metrics.onBufferingEnd();
                 }
             }
+
+            @Override
+            public void onPositionDiscontinuity(
+                    androidx.media3.common.Player.PositionInfo oldPosition,
+                    androidx.media3.common.Player.PositionInfo newPosition,
+                    int reason) {
+                // Equivalent of AVPlayerItemTimeJumped on iOS — fires
+                // on HLS discontinuity boundaries, explicit seeks,
+                // auto-transitions between media items, etc. Reason
+                // tag lets the dashboard tell them apart.
+                String reasonName;
+                switch (reason) {
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_AUTO_TRANSITION: reasonName = "auto_transition"; break;
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK:            reasonName = "seek"; break;
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT: reasonName = "seek_adjustment"; break;
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_SKIP:            reasonName = "skip"; break;
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_REMOVE:          reasonName = "remove"; break;
+                    case androidx.media3.common.Player.DISCONTINUITY_REASON_INTERNAL:        reasonName = "internal"; break;
+                    default:                                                                  reasonName = "unknown"; break;
+                }
+                metrics.onTimeJump(
+                    oldPosition != null ? oldPosition.positionMs : 0L,
+                    newPosition != null ? newPosition.positionMs : 0L,
+                    reasonName
+                );
+            }
         });
 
         player.addAnalyticsListener(new AnalyticsListener() {

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
@@ -221,10 +221,13 @@ public class MainActivity extends AppCompatActivity {
 
             @Override
             public void onPlaybackStateChanged(int state) {
-                if (state == Player.STATE_BUFFERING
-                    && player.getPlayWhenReady()
-                    && !player.isPlaying()) {
-                    metrics.onStallStart();
+                if (state == Player.STATE_BUFFERING) {
+                    metrics.onBufferingStart();
+                    if (player.getPlayWhenReady() && !player.isPlaying()) {
+                        metrics.onStallStart();
+                    }
+                } else {
+                    metrics.onBufferingEnd();
                 }
             }
         });

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -372,6 +372,7 @@ final class PlaybackMetrics {
             p.put("player_metrics_last_event_at", timestamp);
             p.put("player_metrics_event_time", timestamp);
             p.put("player_metrics_state", mapState());
+            p.put("player_metrics_waiting_reason", mapWaitingReason());
             p.put("player_metrics_position_s", roundSeconds(player.getCurrentPosition() / 1000.0));
             p.put("player_metrics_playback_rate", round2(player.getPlaybackParameters().speed));
 
@@ -449,12 +450,48 @@ final class PlaybackMetrics {
         switch (player.getPlaybackState()) {
             case Player.STATE_IDLE: return "idle";
             case Player.STATE_ENDED: return "ended";
-            case Player.STATE_BUFFERING: return "buffering";
+            case Player.STATE_BUFFERING:
+                // Distinguish unexpected mid-play rebuffer ("stalled")
+                // from initial pre-roll buffering. ExoPlayer doesn't
+                // have a direct AVPlayerItemPlaybackStalled equivalent,
+                // so we use the same first-frame + playWhenReady gate
+                // that onStallStart uses. Initial-load buffering and
+                // explicit-pause buffering stay as "buffering".
+                return (firstFrameReported && player.getPlayWhenReady()) ? "stalled" : "buffering";
             case Player.STATE_READY:
                 return player.isPlaying() ? "playing" : "paused";
             default:
                 return "unknown";
         }
+    }
+
+    /**
+     * Synthesise a waiting_reason string mirroring the
+     * AVPlayer.reasonForWaitingToPlay we ship from iOS, so the
+     * dashboard PLAYERSTATE tooltip can disambiguate causes
+     * cross-platform. ExoPlayer doesn't expose an exact analog —
+     * derive from playbackState + playWhenReady + firstFrameReported
+     * + getPlaybackSuppressionReason. Empty string when there's no
+     * meaningful reason (e.g. actively playing).
+     */
+    private String mapWaitingReason() {
+        int state = player.getPlaybackState();
+        if (state == Player.STATE_BUFFERING) {
+            if (!firstFrameReported) return "initial";
+            if (!player.getPlayWhenReady()) return "paused";
+            return "rebuffer";
+        }
+        if (state == Player.STATE_READY && !player.isPlaying()) {
+            int suppression = player.getPlaybackSuppressionReason();
+            if (suppression == Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS) {
+                return "audio_focus_loss";
+            }
+            if (suppression != Player.PLAYBACK_SUPPRESSION_REASON_NONE) {
+                return "suppressed_" + suppression;
+            }
+            if (!player.getPlayWhenReady()) return "paused";
+        }
+        return "";
     }
 
     private String resolveSessionId() {

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -442,14 +442,18 @@ final class PlaybackMetrics {
     }
 
     private String mapState() {
+        // Lowercase canonical names — matches Apple PlaybackDiagnostics,
+        // Android-test ExoPlayerTestApp, web embed, and Roku, so the
+        // dashboard PLAYERSTATE lane shows the same colour for the same
+        // state regardless of source platform.
         switch (player.getPlaybackState()) {
-            case Player.STATE_IDLE: return "Idle";
-            case Player.STATE_ENDED: return "Ended";
-            case Player.STATE_BUFFERING: return "Buffering";
+            case Player.STATE_IDLE: return "idle";
+            case Player.STATE_ENDED: return "ended";
+            case Player.STATE_BUFFERING: return "buffering";
             case Player.STATE_READY:
-                return player.isPlaying() ? "Playing" : "Paused";
+                return player.isPlaying() ? "playing" : "paused";
             default:
-                return "Unknown";
+                return "unknown";
         }
     }
 

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -168,6 +168,9 @@ final class PlaybackMetrics {
         frozenReported = false;
         segmentStallReported = false;
         lastVideoLoadCompletedAtMs = System.currentTimeMillis();
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("player_metrics_content_url", urlProvider.currentStreamUrl());
+        sendEvent("playing", extra);
     }
 
     /**

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -98,6 +98,9 @@ final class PlaybackMetrics {
     private double lastStallDurationS;
     private long stallStartAtMs = -1;
 
+    // Buffering tracking (broader than stall — every BUFFERING transition).
+    private boolean buffering;
+
     // Frozen detection.
     private long lastHeartbeatPositionMs = -1;
     private int frozenTicks;
@@ -197,6 +200,24 @@ final class PlaybackMetrics {
         Map<String, Object> extra = new HashMap<>();
         extra.put("player_metrics_last_stall_time_s", lastStallDurationS);
         sendEvent("stall_end", extra);
+    }
+
+    /**
+     * Called on every transition into ExoPlayer STATE_BUFFERING. Distinct
+     * from onStallStart, which is gated on first-frame + playWhenReady so
+     * initial loads and short pre-roll buffering don't register as stalls.
+     */
+    void onBufferingStart() {
+        if (buffering) return;
+        buffering = true;
+        sendEvent("buffering_start", Collections.<String, Object>emptyMap());
+    }
+
+    /** Called when ExoPlayer leaves STATE_BUFFERING. */
+    void onBufferingEnd() {
+        if (!buffering) return;
+        buffering = false;
+        sendEvent("buffering_end", Collections.<String, Object>emptyMap());
     }
 
     /** Called from AnalyticsListener.onLoadCompleted for video track. */

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -220,6 +220,22 @@ final class PlaybackMetrics {
         sendEvent("buffering_end", Collections.<String, Object>emptyMap());
     }
 
+    /**
+     * Called from Player.Listener.onPositionDiscontinuity — fires on
+     * HLS discontinuity boundaries, explicit seeks, auto-transitions
+     * between media items, etc. Equivalent of AVPlayerItemTimeJumped
+     * on iOS; emits a `timejump` metrics event with from/to/delta in
+     * seconds plus the discontinuity reason name.
+     */
+    void onTimeJump(long fromMs, long toMs, String reason) {
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("player_metrics_timejump_from_s", roundSeconds(fromMs / 1000.0));
+        extra.put("player_metrics_timejump_to_s", roundSeconds(toMs / 1000.0));
+        extra.put("player_metrics_timejump_delta_s", roundSeconds((toMs - fromMs) / 1000.0));
+        extra.put("player_metrics_timejump_origin", reason == null ? "unknown" : reason);
+        sendEvent("timejump", extra);
+    }
+
     /** Called from AnalyticsListener.onLoadCompleted for video track. */
     void onVideoLoadCompleted() {
         lastVideoLoadCompletedAtMs = System.currentTimeMillis();

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -95,6 +95,12 @@ final class PlaybackDiagnostics: ObservableObject {
     private var lastBufferSampleAt: Date?
     private var lastPlayerSampleAt: Date?
     private var stallStartAt: Date?
+    /// Set when AVPlayerItemPlaybackStalled fires (an unexpected
+    /// mid-play rebuffer); cleared when timeControlStatus returns to
+    /// .playing. Used to pick "stalled" vs "buffering" for the
+    /// PLAYERSTATE lane — the latter being any other waiting state
+    /// (initial pre-roll, post-seek refill, etc.).
+    private var isStalled: Bool = false
     private var hasRenderedFirstFrame: Bool = false
     private var lastAdvancingTime: Double = 0
     private var lastAdvancingAt: Date?
@@ -297,6 +303,7 @@ final class PlaybackDiagnostics: ObservableObject {
         lastBufferSampleAt = nil
         lastPlayerSampleAt = nil
         stallStartAt = nil
+        isStalled = false
         hasRenderedFirstFrame = false
         lastObservedSegmentSequence = nil
         maxObservedSegmentSequence = nil
@@ -332,10 +339,19 @@ final class PlaybackDiagnostics: ObservableObject {
                 case .paused:
                     self.state = "paused"
                 case .waitingToPlayAtSpecifiedRate:
-                    self.state = "buffering"
-                    self.startStallIfNeeded()
+                    // Distinguish user-induced refill (initial pre-roll,
+                    // post-seek, post-play after a long pause) from an
+                    // unexpected mid-play rebuffer. Only the
+                    // AVPlayerItemPlaybackStalled notification (handled
+                    // below) signals the unexpected case; the
+                    // isStalled flag persists from there until we
+                    // return to .playing. Don't call
+                    // startStallIfNeeded() here — that would conflate
+                    // pre-roll with stalls.
+                    self.state = self.isStalled ? "stalled" : "buffering"
                 case .playing:
                     self.state = "playing"
+                    self.isStalled = false
                     self.endStallIfNeeded()
                 @unknown default: self.state = "unknown"
                 }
@@ -399,6 +415,11 @@ final class PlaybackDiagnostics: ObservableObject {
             .sink { [weak self] _ in
                 guard let self else { return }
                 print("[STALL] state=\(self.state) time=\(String(format: "%.2f", self.currentTime)) \(self.playbackSnapshot())")
+                // Mark the unexpected-rebuffer flag so the
+                // timeControlStatus sink can distinguish stalled vs
+                // pre-roll buffering on the next state read.
+                self.isStalled = true
+                if self.state == "buffering" { self.state = "stalled" }
                 self.startStallIfNeeded()
             }
             .store(in: &cancellables)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -234,7 +234,7 @@ final class PlaybackDiagnostics: ObservableObject {
     }
 
     func reset() {
-        state = "Idle"
+        state = "idle"
         currentTime = 0
         bufferedEnd = nil
         bufferDepth = nil
@@ -314,14 +314,14 @@ final class PlaybackDiagnostics: ObservableObject {
                 let rate = self.player?.rate ?? 0
                 switch status {
                 case .paused:
-                    self.state = "Paused"
+                    self.state = "paused"
                 case .waitingToPlayAtSpecifiedRate:
-                    self.state = "Buffering"
+                    self.state = "buffering"
                     self.startStallIfNeeded()
                 case .playing:
-                    self.state = "Playing"
+                    self.state = "playing"
                     self.endStallIfNeeded()
-                @unknown default: self.state = "Unknown"
+                @unknown default: self.state = "unknown"
                 }
                 print("[STATE] \(prev) -> \(self.state) rate=\(rate) time=\(String(format: "%.2f", self.currentTime)) \(self.playbackSnapshot())")
             }
@@ -735,7 +735,7 @@ final class PlaybackDiagnostics: ObservableObject {
             }
             return
         }
-        guard state == "Playing" else {
+        guard state == "playing" else {
             lastVariantDwellChangeAt = now
             return
         }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -23,7 +23,23 @@ struct MetricSample: Identifiable {
     let value: Double
 }
 
+/// Discrete time-jump event published from PlaybackDiagnostics for the
+/// ViewModel to forward as a `timejump` metrics event. Fires on HLS
+/// discontinuity boundaries, live-edge catchup seeks, and explicit seeks.
+struct TimeJumpEvent {
+    let from: Double
+    let to: Double
+    let origin: String
+    let at: Date
+}
+
 final class PlaybackDiagnostics: ObservableObject {
+    /// Discrete time-jump events. Subscribers (ViewModel) receive each
+    /// jump exactly once; not a Published property because we don't want
+    /// the deduplication-on-equal-values that an @Published+sink would
+    /// give us if two jumps happen to land at the same `to`.
+    let timeJumpSubject = PassthroughSubject<TimeJumpEvent, Never>()
+
     @Published var state: String = "Idle"
     @Published var currentTime: Double = 0
     @Published var bufferedEnd: Double?
@@ -365,8 +381,16 @@ final class PlaybackDiagnostics: ObservableObject {
                 guard let self else { return }
                 let item = notification.object as? AVPlayerItem
                 let original = (notification.userInfo?[AVPlayerItem.timeJumpedOriginatingParticipantKey] as? String) ?? "unknown"
+                let fromTime = self.currentTime
                 let newTime = item?.currentTime().seconds ?? self.currentTime
                 print("[TIMEJUMP] origin=\(original) time=\(String(format: "%.2f", newTime)) state=\(self.state) \(self.playbackSnapshot())")
+                // Publish for ViewModel to forward as a metrics event.
+                self.timeJumpSubject.send(TimeJumpEvent(
+                    from: fromTime,
+                    to: newTime,
+                    origin: original,
+                    at: Date()
+                ))
             }
             .store(in: &cancellables)
 

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -683,7 +683,7 @@ final class PlaybackViewModel: ObservableObject {
                         print("[AUTO_RECOVERY] triggered frozen state=\(self.diagnostics.state) bufferEmpty=\(self.diagnostics.bufferEmpty) time=\(String(format: "%.2f", self.diagnostics.currentTime))")
                         self.scheduleAutoRecoveryRestart(reason: "auto_recovery_frozen")
                     }
-                } else if self.diagnostics.state == "Playing" {
+                } else if self.diagnostics.state == "playing" {
                     self.log("UNFROZEN: video time advancing again")
                 }
             }
@@ -753,9 +753,9 @@ final class PlaybackViewModel: ObservableObject {
                     // the Buffering AVPlayer state, regardless of whether
                     // playback was previously interrupted. stall_* is
                     // gated on first-frame and stall threshold.
-                    if state == "Buffering" {
+                    if state == "buffering" {
                         Task { await self.sendPlayerMetrics(event: "buffering_start") }
-                    } else if previous == "Buffering" {
+                    } else if previous == "buffering" {
                         Task { await self.sendPlayerMetrics(event: "buffering_end") }
                     }
                 } else if previous == nil {
@@ -770,7 +770,7 @@ final class PlaybackViewModel: ObservableObject {
             .sink { [weak self] currentTime in
                 guard let self else { return }
                 guard let startAt = self.playbackStartAt else { return }
-                let isActivelyPlaying = self.diagnostics.state == "Playing"
+                let isActivelyPlaying = self.diagnostics.state == "playing"
                     && self.diagnostics.playbackRate > 0
                 if !self.firstFrameReported && currentTime > 0 && isActivelyPlaying {
                     let elapsed = self.roundSeconds(Date().timeIntervalSince(startAt))
@@ -834,7 +834,7 @@ final class PlaybackViewModel: ObservableObject {
                 guard let self else { return }
                 self.autoRecoveryRestartTimer = nil
                 let timeAdvanced = self.diagnostics.currentTime > scheduledAtTime + 0.5
-                let recovered = self.diagnostics.state == "Playing"
+                let recovered = self.diagnostics.state == "playing"
                     && !self.diagnostics.frozenDetected
                     && !self.diagnostics.segmentStallDetected
                     && timeAdvanced
@@ -863,7 +863,7 @@ final class PlaybackViewModel: ObservableObject {
                     print("[AUTO_RECOVERY] verify: another restart pending — keeping attempts=\(self.autoRecoveryAttempts)")
                     return
                 }
-                let playingCleanly = self.diagnostics.state == "Playing"
+                let playingCleanly = self.diagnostics.state == "playing"
                     && !self.diagnostics.frozenDetected
                     && !self.diagnostics.segmentStallDetected
                 if playingCleanly {

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -1019,7 +1019,16 @@ final class PlaybackViewModel: ObservableObject {
             "player_metrics_profile_shift_count": profileShiftCount,
             "player_restarts": playerRestarts,
             "player_auto_recovery_enabled": autoRecoveryEnabled,
-            "player_metrics_video_bitrate_mbps": mbps(from: diagnostics.indicatedBitrate ?? diagnostics.averageVideoBitrate)
+            // Variant identity must be the manifest BANDWIDTH attribute
+            // (AVPlayer's accessLog indicatedBitrate). DO NOT fall back
+            // to averageVideoBitrate — that's measured-bytes-per-second
+            // and fluctuates with scene complexity within a single
+            // rendition, which would make the dashboard's variant lanes
+            // split one rendition into multiple phantom variants.
+            // Anything wanting a measured throughput should read
+            // player_metrics_avg_network_bitrate_mbps or
+            // player_metrics_network_bitrate_mbps instead.
+            "player_metrics_video_bitrate_mbps": mbps(from: diagnostics.indicatedBitrate)
         ]
         extra.forEach { key, value in
             payload[key] = value

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -1020,6 +1020,11 @@ final class PlaybackViewModel: ObservableObject {
             "player_metrics_last_event_at": timestamp,
             "player_metrics_event_time": timestamp,
             "player_metrics_state": diagnostics.state,
+            // AVPlayer.reasonForWaitingToPlay raw value when present —
+            // disambiguates buffering causes (toMinimizeStalls,
+            // evaluatingBufferingRate, noItemToPlay, interstitialEvent).
+            // Empty string when not waiting.
+            "player_metrics_waiting_reason": diagnostics.waitingReason,
             "player_metrics_position_s": roundSeconds(diagnostics.currentTime),
             "player_metrics_playback_rate": roundMetric(Double(diagnostics.playbackRate)),
             "player_metrics_buffer_depth_s": diagnostics.bufferDepth.map { roundSeconds($0) },

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -748,6 +748,16 @@ final class PlaybackViewModel: ObservableObject {
                             "player_metrics_state_to": state
                         ])
                     }
+                    // buffering_start/buffering_end are distinct from
+                    // stall_*: they fire on every transition into/out of
+                    // the Buffering AVPlayer state, regardless of whether
+                    // playback was previously interrupted. stall_* is
+                    // gated on first-frame and stall threshold.
+                    if state == "Buffering" {
+                        Task { await self.sendPlayerMetrics(event: "buffering_start") }
+                    } else if previous == "Buffering" {
+                        Task { await self.sendPlayerMetrics(event: "buffering_end") }
+                    }
                 } else if previous == nil {
                     Task { await self.sendPlayerMetrics(event: "state_change") }
                 }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -918,6 +918,8 @@ final class PlaybackViewModel: ObservableObject {
         if let previous = lastReportedRenditionMbps {
             if mbps != previous {
                 profileShiftCount = max(0, profileShiftCount) + 1
+                let direction = mbps > previous ? "UP" : "DOWN"
+                print("[SHIFT] \(direction) \(previous) -> \(mbps) Mbps shifts=\(profileShiftCount) state=\(diagnostics.state) time=\(String(format: "%.2f", diagnostics.currentTime))")
                 Task {
                     await sendPlayerMetrics(event: "video_bitrate_change", extra: [
                         "player_metrics_video_bitrate_from_mbps": previous,

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -802,6 +802,26 @@ final class PlaybackViewModel: ObservableObject {
                 self?.handleRenditionShift(indicated: indicated, average: average)
             }
             .store(in: &cancellables)
+
+        // Forward AVPlayerItemTimeJumped events as `timejump` metrics
+        // so the dashboard's TIMEJUMP swim lane lights up on HLS
+        // discontinuity boundaries, live-edge catchup seeks, and
+        // explicit seeks. Origin tag (timeJumpedOriginatingParticipant)
+        // lets downstream tell discontinuities apart from explicit seeks.
+        diagnostics.timeJumpSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                guard let self else { return }
+                Task {
+                    await self.sendPlayerMetrics(event: "timejump", extra: [
+                        "player_metrics_timejump_from_s": self.roundSeconds(event.from),
+                        "player_metrics_timejump_to_s": self.roundSeconds(event.to),
+                        "player_metrics_timejump_delta_s": self.roundSeconds(event.to - event.from),
+                        "player_metrics_timejump_origin": event.origin
+                    ])
+                }
+            }
+            .store(in: &cancellables)
     }
 
     private func startMetricsHeartbeat() {

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -397,6 +397,13 @@ final class PlaybackViewModel: ObservableObject {
         metricsLastSessionLookup = nil
         log("AVPlayerItem created for \(url.absoluteString)")
         player.play()
+        Task {
+            await sendPlayerMetrics(event: "playing", extra: [
+                "player_metrics_content_url": url.absoluteString,
+                "player_metrics_content_name": contentName,
+                "player_metrics_codec_fallback": codecFallback
+            ])
+        }
         log("AVPlayer play() called")
     }
 

--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -491,8 +491,6 @@
 .buffer-depth-chart {
     width: 100%;
     height: auto;
-    border: 1px solid #e0e0e0;
-    border-radius: 4px;
 }
 
 .bandwidth-chart {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -994,9 +994,6 @@
                             <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
                             <div class="events-timeline" data-field="events_timeline"></div>
                         </div>
-                        <div class="chart-wrap events-chart-wrap">
-                            <canvas class="events-chart" data-field="events_chart"></canvas>
-                        </div>
                         <div class="chart-wrap">
                             <canvas class="bandwidth-chart" data-field="bandwidth_chart"></canvas>
                         </div>

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -991,6 +991,7 @@
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
                         </div>
                         <div class="chart-wrap events-timeline-wrap">
+                            <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
                             <div class="events-timeline" data-field="events_timeline"></div>
                         </div>
                         <div class="chart-wrap events-chart-wrap">

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -990,6 +990,9 @@
                             <button type="button" class="btn btn-secondary btn-mini" data-action="pause-bitrate-chart">⏸ Pause</button>
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
                         </div>
+                        <div class="chart-wrap events-timeline-wrap">
+                            <div class="events-timeline" data-field="events_timeline"></div>
+                        </div>
                         <div class="chart-wrap events-chart-wrap">
                             <canvas class="events-chart" data-field="events_chart"></canvas>
                         </div>

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4144,11 +4144,16 @@
         function parseBandwidthChartEventType(rawEventType) {
             const eventType = String(rawEventType || '').trim().toLowerCase();
             if (!eventType) return null;
-            if (eventType === 'stall_start' || eventType === 'segment_stall' || eventType === 'frozen') return 'STALL';
+            if (eventType === 'stall_start') return 'STALL';
+            if (eventType === 'frozen') return 'FROZEN';
+            if (eventType === 'segment_stall') return 'SEGMENT_STALL';
+            if (eventType === 'error') return 'ERROR';
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'loop_marker') return 'LOOP';
             if (eventType === 'playing') return 'PLAYING';
             if (eventType === 'buffering_start') return 'BUFFERING';
+            if (eventType === 'video_first_frame') return 'FIRST_FRAME';
+            if (eventType === 'video_start_time') return 'START_TIME';
             if (eventType === 'rate_shift_up') return 'SHIFT_UP';
             if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
             return null;
@@ -4761,17 +4766,22 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'VARIANT':     { y: 11, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES': { y: 10, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
-            'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
-            'SHIFT_UP':    { y: 6, color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':  { y: 5, color: '#ef4444', label: 'SHIFT DOWN' },
-            'STALL':       { y: 4, color: '#000000', label: 'STALL' },
-            'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
-            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
-            'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
+            'VARIANT':       { y: 16, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES':   { y: 15, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE':   { y: 14, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':       { y: 13, color: '#16a34a', label: 'PLAYING' },
+            'FIRST_FRAME':   { y: 12, color: '#14b8a6', label: 'FIRST FRAME' },
+            'START_TIME':    { y: 11, color: '#15803d', label: 'START TIME' },
+            'BUFFERING':     { y: 10, color: '#f59e0b', label: 'BUFFERING' },
+            'STALL':         { y: 9,  color: '#000000', label: 'STALL' },
+            'FROZEN':        { y: 8,  color: '#4c1d95', label: 'FROZEN' },
+            'SEGMENT_STALL': { y: 7,  color: '#c2410c', label: 'SEGMENT STALL' },
+            'SHIFT_UP':      { y: 6,  color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':    { y: 5,  color: '#ef4444', label: 'SHIFT DOWN' },
+            'ERROR':         { y: 4,  color: '#e11d48', label: 'ERROR' },
+            'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
+            'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
+            'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
         };
         // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
         // because clients emit a mix of casings ("Playing" on Apple,
@@ -4956,7 +4966,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 11.5,
+                                type: 'linear', min: 0.5, max: 16.5,
                                 title: {
                                     display: true,
                                     text: 'Events',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4628,18 +4628,17 @@
                 }
             }
 
-            // VARIANT lane: dedup by RESOLUTION, not bitrate.
-            // player_metrics_video_bitrate_mbps reports the actual
-            // segment bitrate which fluctuates with scene complexity
-            // even within one rendition. Resolution is stable per
-            // rendition, so it's the correct identity for an ABR
-            // variant. Skip ticks where resolution is missing.
+            // VARIANT lane: dedup by (resolution, indicated bitrate) so
+            // multi-bitrate-per-resolution variants (e.g. H.264 + HEVC
+            // at 1080p) get distinct lanes. Bitrate is the manifest
+            // BANDWIDTH attribute on both clients (iOS indicatedBitrate,
+            // Android Format.bitrate), stable per rendition. Skip ticks
+            // where either resolution or bitrate is missing.
             const variantRes = String(session.player_metrics_video_resolution || '').trim();
-            if (variantRes) {
-                const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-                const variantMbps = Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0
-                    ? Math.round(variantMbpsRaw * 10) / 10 : 0;
-                const variantKey = variantRes;
+            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+            if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
+                const variantKey = `${variantRes}|${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -4915,24 +4914,21 @@
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
-            // Lane key is RESOLUTION (each rendition has a unique
-            // resolution); bitrate fluctuates per segment within one
-            // rendition and is kept only for sorting / labelling.
+            // VARIANT subgroups: one lane per (resolution, bitrate).
+            // Multi-bitrate-per-resolution is a real ladder pattern.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            const seenVariants = new Map(); // resolution -> {mbps, resolution}
+            const seenVariants = new Map(); // res|mbps -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();
-                if (!res) continue;
                 const m = Number(v.mbps);
-                const existing = seenVariants.get(res);
-                if (!existing) {
-                    seenVariants.set(res, { mbps: m, resolution: res });
-                } else if (Number.isFinite(m) && m > 0) {
-                    existing.mbps = m;
+                if (!res || !Number.isFinite(m) || m <= 0) continue;
+                const k = `${res}|${m}`;
+                if (!seenVariants.has(k)) {
+                    seenVariants.set(k, { mbps: m, resolution: res });
                 }
             }
-            // Ordered DESCENDING by bitrate so an upshift walks UP the
-            // ladder visually.
+            // Ordered DESCENDING by bitrate so the visual ladder runs
+            // highest at the top, lowest at the bottom.
             const variantOrder = Array.from(seenVariants.entries())
                 .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
@@ -4977,22 +4973,20 @@
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each resolution gets its own swim lane; segment
-            // bitrate drives the segment's colour so motion-driven
-            // bitrate variation within a rendition shows as a colour
-            // shift inside the same row.
+            // VARIANT: each (resolution, bitrate) tuple gets its own
+            // swim lane. Lane key matches seenVariants.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
                 const res = String(v.resolution || '').trim();
-                if (!res) continue;
+                const m = Number(v.mbps);
+                if (!res || !Number.isFinite(m) || m <= 0) continue;
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
-                const m = Number(v.mbps);
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${res}`,
+                    group: `VARIANT::${res}|${m}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5187,8 +5187,17 @@
             // Compute explicit height from the actual lane count;
             // vis-timeline's height:'auto' collapses to 0 when the
             // container has no intrinsic height.
-            // Let vis-timeline compute its own height from rows + items.
-            container.style.removeProperty('height');
+            // Compute explicit height — height:'auto' collapses the
+            // container. Section headers are 18px (CSS), regular
+            // lanes ~22px under our slim styling, axis ≈ 32px.
+            const SECTION_ROW_PX = 18;
+            const LANE_ROW_PX = 22;
+            const AXIS_PAD_PX = 32;
+            const sectionRows = groups.filter((g) => Array.isArray(g.nestedGroups)).length;
+            const laneRows = groups.length - sectionRows;
+            const computedHeight = (sectionRows * SECTION_ROW_PX) + (laneRows * LANE_ROW_PX) + AXIS_PAD_PX;
+            const heightPx = `${computedHeight}px`;
+            container.style.height = heightPx;
 
             // If the session card was rebuilt, the cached timeline points
             // at an orphaned div; recreate it against the new container.
@@ -5210,7 +5219,7 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        height: 'auto',
+                        height: heightPx,
                         start: liveStart,
                         end: liveEnd,
                         // Match the Chart.js charts' HH:MM:SS 24-hour
@@ -5288,6 +5297,7 @@
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
+                timeline.setOptions({ height: heightPx });
                 timeline.$windowStartMs = liveStart.getTime();
                 // Live-edge tracking: unless paused, slide so right
                 // edge stays at "now"; preserve user's zoom width.

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -622,6 +622,10 @@
                 0 0 6px rgba(255, 255, 255, 0.85),
                 1px 0 0 rgba(255, 255, 255, 0.75),
                 -1px 0 0 rgba(255, 255, 255, 0.75);
+            border-color: rgba(0, 0, 0, 0.06) !important;
+            border-top: none !important;
+            border-left: none !important;
+            border-right: none !important;
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5006,12 +5006,18 @@
                 });
             }
 
-            // Live-edge window: same 10-minute span as the other charts,
-            // right edge anchored to "now" so events scroll left as time
-            // advances. Updated on every render so the view tracks live.
             const liveWindowMs = 10 * 60 * 1000;
             const liveStart = new Date(nowMs - liveWindowMs);
             const liveEnd = new Date(nowMs);
+
+            // Compute explicit height from the actual lane count;
+            // vis-timeline's height:'auto' collapses to 0 when the
+            // container has no intrinsic height.
+            const ROW_HEIGHT_PX = 30;
+            const AXIS_AND_PADDING_PX = 60;
+            const computedHeight = groups.length * ROW_HEIGHT_PX + AXIS_AND_PADDING_PX;
+            const heightPx = `${computedHeight}px`;
+            container.style.height = heightPx;
 
             let timeline = eventsTimelines.get(sessionId);
             if (!timeline) {
@@ -5026,22 +5032,18 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Auto-grow with no min/max so all lanes are
-                        // visible; vis-timeline scrolls internally and
-                        // hides top rows whenever a constraint kicks in.
-                        height: 'auto',
+                        height: heightPx,
                         start: liveStart,
                         end: liveEnd
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
                 requestAnimationFrame(() => timeline.redraw());
-                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
-                // Slide the visible window so "now" stays pinned to
-                // the right edge.
+                timeline.setOptions({ height: heightPx });
                 timeline.setWindow(liveStart, liveEnd, { animation: false });
             }
         }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -640,6 +640,26 @@
         .events-timeline-wrap .vis-time-axis .vis-text {
             padding: 0 4px !important;
         }
+        /* Hide vis-timeline's calendar-anchored tick labels — replaced
+         * by custom-time markers placed at real event timestamps. */
+        .events-timeline-wrap .vis-time-axis .vis-text.vis-minor {
+            visibility: hidden !important;
+        }
+        .events-timeline-wrap .vis-custom-time {
+            background-color: rgba(0, 0, 0, 0.15) !important;
+            width: 1px !important;
+            cursor: default !important;
+        }
+        .events-timeline-wrap .vis-custom-time .vis-custom-time-marker {
+            background: rgba(255, 255, 255, 0.92) !important;
+            border: 1px solid rgba(0, 0, 0, 0.08) !important;
+            border-radius: 2px !important;
+            color: #4b5563 !important;
+            font-family: 'Courier New', monospace !important;
+            font-size: 10px !important;
+            padding: 0 3px !important;
+            top: 2px !important;
+        }
         .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
             padding-left: 0 !important;
         }
@@ -5363,6 +5383,40 @@
                         { animation: false }
                     );
                 }
+            }
+
+            // Tick markers placed at real event timestamps — see
+            // testing.html for full rationale.
+            refreshEventTickMarkers(timeline, events, nowMs - liveWindowMs, nowMs);
+        }
+
+        function refreshEventTickMarkers(timeline, events, windowStartMs, windowEndMs) {
+            if (!timeline.$tickIds) timeline.$tickIds = new Set();
+            const fmt = (ms) => {
+                const d = new Date(ms);
+                return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
+            };
+            const desired = new Map();
+            for (const e of (events || [])) {
+                const ts = Number(e.ts);
+                if (!Number.isFinite(ts) || ts < windowStartMs || ts > windowEndMs) continue;
+                const sec = Math.floor(ts / 1000) * 1000;
+                const id = `event-tick-${sec}`;
+                if (!desired.has(id)) desired.set(id, sec);
+            }
+            for (const id of Array.from(timeline.$tickIds)) {
+                if (!desired.has(id)) {
+                    try { timeline.removeCustomTime(id); } catch (e) {}
+                    timeline.$tickIds.delete(id);
+                }
+            }
+            for (const [id, t] of desired) {
+                if (timeline.$tickIds.has(id)) continue;
+                try {
+                    timeline.addCustomTime(new Date(t), id);
+                    timeline.$tickIds.add(id);
+                    try { timeline.setCustomTimeMarker(fmt(t), id, false); } catch (e) {}
+                } catch (e) {}
             }
         }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5185,6 +5185,33 @@
                         height: heightPx,
                         start: liveStart,
                         end: liveEnd,
+                        // Match the Chart.js charts' HH:MM:SS 24-hour
+                        // tick format; suppress the "Sat 25 April"
+                        // major-label strip.
+                        format: {
+                            minorLabels: {
+                                millisecond: 'HH:mm:ss',
+                                second: 'HH:mm:ss',
+                                minute: 'HH:mm:ss',
+                                hour: 'HH:mm:ss',
+                                weekday: 'HH:mm:ss',
+                                day: 'HH:mm:ss',
+                                week: 'HH:mm:ss',
+                                month: 'HH:mm:ss',
+                                year: 'HH:mm:ss'
+                            },
+                            majorLabels: {
+                                millisecond: '',
+                                second: '',
+                                minute: '',
+                                hour: '',
+                                weekday: '',
+                                day: '',
+                                week: '',
+                                month: '',
+                                year: ''
+                            }
+                        },
                         // Match Chart.js zoom UX: plain wheel = page
                         // scroll; Alt/Option + wheel = zoom; left-drag
                         // = pan.

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5071,9 +5071,6 @@
                 );
                 eventsTimelines.set(sessionId, timeline);
                 eventsTimelineFollowLive.set(sessionId, true);
-                // Tag for the cross-chart viewport sync; anchor seconds-
-                // from-windowStart so vis-timeline ranges convert to the
-                // 0–600 units the Chart.js charts use.
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
                 applyStoredChartViewport(sessionId, timeline);
@@ -5084,7 +5081,21 @@
                     eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
                     syncChartViewportAcrossSession(sessionId, timeline);
                 });
-                requestAnimationFrame(() => timeline.redraw());
+                // ResizeObserver redraw — see testing.html for rationale.
+                if (typeof ResizeObserver !== 'undefined') {
+                    const ro = new ResizeObserver((entries) => {
+                        for (const entry of entries) {
+                            if (entry.contentRect.width > 0) {
+                                timeline.redraw();
+                                ro.disconnect();
+                                return;
+                            }
+                        }
+                    });
+                    ro.observe(container);
+                } else {
+                    requestAnimationFrame(() => timeline.redraw());
+                }
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
                 timeline.setItems(new vis.DataSet(items));

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4696,17 +4696,20 @@
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
-        // Per-state colour for the PLAYERSTATE lane — each dot's colour
-        // tells you what the player thought it was doing at that tick.
+        // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
+        // because clients emit a mix of casings ("Playing" on Apple,
+        // "playing" on Android-test/Roku/web) — playerStateColor()
+        // normalises before lookup so all map to the same colour.
         const PLAYER_STATE_COLOR = {
-            'Playing':   '#16a34a',
-            'Buffering': '#f59e0b',
-            'Paused':    '#9333ea',
-            'Idle':      '#6b7280',
-            'Unknown':   '#d1d5db'
+            'playing':   '#16a34a', // green
+            'buffering': '#f59e0b', // amber
+            'paused':    '#9333ea', // purple
+            'idle':      '#6b7280', // gray
+            'ended':     '#1f2937', // near-black
+            'unknown':   '#d1d5db'  // light gray
         };
         function playerStateColor(s) {
-            return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+            return PLAYER_STATE_COLOR[String(s || '').trim().toLowerCase()] || '#d1d5db';
         }
         // Variant colour buckets — lower bitrate = redder, higher = greener.
         function variantColor(mbps) {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4792,23 +4792,45 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'VARIANT':       { y: 17, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES':   { y: 16, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE':   { y: 15, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':       { y: 14, color: '#16a34a', label: 'PLAYING' },
-            'FIRST_FRAME':   { y: 13, color: '#14b8a6', label: 'FIRST FRAME' },
-            'START_TIME':    { y: 12, color: '#15803d', label: 'START TIME' },
-            'BUFFERING':     { y: 11, color: '#f59e0b', label: 'BUFFERING' },
-            'STALL':         { y: 10, color: '#000000', label: 'STALL' },
-            'FROZEN':        { y: 9,  color: '#4c1d95', label: 'FROZEN' },
-            'SEGMENT_STALL': { y: 8,  color: '#c2410c', label: 'SEGMENT STALL' },
-            'SHIFT_UP':      { y: 7,  color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':    { y: 6,  color: '#ef4444', label: 'SHIFT DOWN' },
-            'ERROR':         { y: 5,  color: '#e11d48', label: 'ERROR' },
-            'TIMEJUMP':      { y: 4,  color: '#d97706', label: 'TIMEJUMP' },
-            'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
-            'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
-            'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
+            'VARIANT':     { y: 8, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 7, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE': { y: 6, color: '#6b7280', label: 'PLAYERSTATE' },
+            'BUFFERING':   { y: 5, color: '#f59e0b', label: 'BUFFERING' },
+            'PLAYBACK':    { y: 4, color: '#16a34a', label: 'PLAYBACK' },
+            'IMPAIRMENT':  { y: 3, color: '#000000', label: 'IMPAIRMENT' },
+            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
+            'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
+        };
+        const EVENT_SUBTYPE_LANE = {
+            'PLAYING': 'PLAYBACK', 'FIRST_FRAME': 'PLAYBACK', 'START_TIME': 'PLAYBACK',
+            'RESTART': 'PLAYBACK', 'TIMEJUMP': 'PLAYBACK',
+            'SHIFT_UP': 'PLAYBACK', 'SHIFT_DOWN': 'PLAYBACK',
+            'STALL': 'IMPAIRMENT', 'FROZEN': 'IMPAIRMENT',
+            'SEGMENT_STALL': 'IMPAIRMENT', 'ERROR': 'IMPAIRMENT',
+            'BUFFERING': 'BUFFERING',
+            'LOOP_PLAYER': 'LOOP_PLAYER', 'LOOP_SERVER': 'LOOP_SERVER'
+        };
+        const EVENT_SUBTYPE_COLOR = {
+            'PLAYING':       '#16a34a',
+            'FIRST_FRAME':   '#14b8a6',
+            'START_TIME':    '#15803d',
+            'RESTART':       '#a855f7',
+            'TIMEJUMP':      '#d97706',
+            'SHIFT_UP':      '#3b82f6',
+            'SHIFT_DOWN':    '#ef4444',
+            'STALL':         '#000000',
+            'FROZEN':        '#4c1d95',
+            'SEGMENT_STALL': '#c2410c',
+            'ERROR':         '#e11d48',
+            'BUFFERING':     '#f59e0b'
+        };
+        const EVENT_SUBTYPE_LABEL = {
+            'PLAYING': 'PLAYING', 'FIRST_FRAME': 'FIRST FRAME', 'START_TIME': 'START TIME',
+            'RESTART': 'RESTART', 'TIMEJUMP': 'TIMEJUMP',
+            'SHIFT_UP': 'SHIFT UP', 'SHIFT_DOWN': 'SHIFT DOWN',
+            'STALL': 'STALL', 'FROZEN': 'FROZEN',
+            'SEGMENT_STALL': 'SEGMENT STALL', 'ERROR': 'ERROR',
+            'BUFFERING': 'BUFFERING'
         };
         // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
         // because clients emit a mix of casings ("Playing" on Apple,
@@ -4912,13 +4934,21 @@
                 .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
 
-            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
-                const points = chartEvents.filter((e) => e.type === type)
-                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state, mbps: e.mbps, resolution: e.resolution }));
+            const datasets = Object.entries(EVENT_LANES).map(([laneKey, cfg]) => {
+                const points = chartEvents.filter((e) => {
+                    const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                    return lane === laneKey;
+                }).map((e) => ({
+                    x: e.x, y: cfg.y, ts: e.ts,
+                    type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution
+                }));
                 let colors = cfg.color;
-                if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
-                else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
-                else if (type === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
+                if (laneKey === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
+                else if (laneKey === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
+                else if (laneKey === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
+                else if (laneKey === 'PLAYBACK' || laneKey === 'IMPAIRMENT') {
+                    colors = points.map(p => EVENT_SUBTYPE_COLOR[p.type] || cfg.color);
+                }
                 return {
                     label: cfg.label,
                     data: points,
@@ -4971,6 +5001,7 @@
                                         if (ctx && ctx.raw) {
                                             if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
                                             else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
+                                            else if (ctx.raw.type && EVENT_SUBTYPE_LABEL[ctx.raw.type]) extra = `: ${EVENT_SUBTYPE_LABEL[ctx.raw.type]}`;
                                         }
                                         return `${ctx.dataset.label}${extra}${offset}`;
                                     }
@@ -4993,7 +5024,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 17.5,
+                                type: 'linear', min: 0.5, max: 8.5,
                                 afterFit: (axis) => { axis.width = 90; },
                                 title: {
                                     display: true,
@@ -5173,17 +5204,20 @@
 
             for (const e of events) {
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
-                const cfg = EVENT_LANES[e.type];
+                const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                const cfg = EVENT_LANES[lane];
                 if (!cfg) continue;
+                const color = EVENT_SUBTYPE_COLOR[e.type] || cfg.color;
+                const subLabel = EVENT_SUBTYPE_LABEL[e.type] || e.type;
                 const ts = Number(e.ts);
                 items.push({
                     id: itemId++,
-                    group: e.type,
+                    group: lane,
                     content: '',
                     start: new Date(ts),
                     type: 'point',
-                    title: `${cfg.label}\n${formatHoverTime(ts)}`,
-                    style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
+                    title: `${subLabel}\n${formatHoverTime(ts)}`,
+                    style: `background-color: ${color}; border-color: ${color};`
                 });
             }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4905,10 +4905,28 @@
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
             const SERVER_LANES = new Set(['LOOP_SERVER']);
-            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k));
+            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
+
+            const variantEvents = events.filter((e) => e.type === 'VARIANT');
+            const seenVariants = new Map();
+            for (const v of variantEvents) {
+                const m = Number(v.mbps);
+                const k = `${m}|${v.resolution || ''}`;
+                if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+            }
+            const variantOrder = Array.from(seenVariants.entries())
+                .sort((a, b) => Number(a[1].mbps) - Number(b[1].mbps));
+            const variantGroups = variantOrder.map(([k, v]) => ({
+                id: `VARIANT::${k}`,
+                content: variantLabel(v.mbps, v.resolution)
+            }));
+            const variantGroupIds = variantGroups.map((g) => g.id);
+
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: playerLanes },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: ['VARIANT_GROUP', ...playerLanes] },
+                { id: 'VARIANT_GROUP', content: 'VARIANT', nestedGroups: variantGroupIds.length ? variantGroupIds : null },
+                ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
                 { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
                 ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
@@ -4940,9 +4958,27 @@
             pushRanges('PLAYERSTATE',
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
-            pushRanges('VARIANT',
-                (e) => variantLabel(e.mbps, e.resolution),
-                (e) => variantColor(e.mbps));
+
+            // VARIANT: each variant gets its own swim lane; an upshift
+            // visually walks UP the ladder.
+            const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
+            for (let i = 0; i < variantSeq.length; i++) {
+                const v = variantSeq[i];
+                const start = Number(v.ts);
+                const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
+                const m = Number(v.mbps);
+                const k = `${m}|${v.resolution || ''}`;
+                const color = variantColor(m);
+                items.push({
+                    id: itemId++,
+                    group: `VARIANT::${k}`,
+                    content: '',
+                    start: new Date(start),
+                    end: new Date(end),
+                    type: 'range',
+                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                });
+            }
 
             for (const e of events) {
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -966,6 +966,7 @@
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedVariantBySession = new Map();
+        const lastRecordedDisplayResBySession = new Map();
         // Two-sample debounce for VARIANT — see testing.html for details.
         const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
@@ -4652,29 +4653,50 @@
                 }
             }
 
-            // VARIANT lane: dedup by (resolution, indicated bitrate)
-            // with a two-sample debounce. Resolution and bitrate come
-            // from independent observers and can be briefly mismatched
-            // mid-shift; require a candidate to repeat once before
-            // committing it to avoid phantom lanes.
-            const variantRes = String(session.player_metrics_video_resolution || '').trim();
+            // VARIANT lane: bitrate is the leading-edge fetch-time
+            // signal; resolution lags. Drive resolution from the
+            // manifest BANDWIDTH lookup keyed off the bitrate. Fall
+            // back to player's reported resolution only when there's
+            // no manifest match. Manifest-validated changes commit
+            // immediately; the pure-player fallback path still uses
+            // the two-sample debounce as a belt.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-            if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
-                const variantKey = `${variantRes}|${variantMbps}`;
-                const prevVariant = lastRecordedVariantBySession.get(String(key));
-                const pending = pendingVariantBySession.get(String(key));
-                if (prevVariant === variantKey) {
-                    if (pending) pendingVariantBySession.delete(String(key));
-                } else if (pending && pending.key === variantKey) {
+                const reportedRes = String(session.player_metrics_video_resolution || '').trim();
+                const manifestRes = manifestResolutionForBitrate(session, variantMbps);
+                const variantRes = manifestRes || reportedRes;
+                if (variantRes) {
+                    const variantKey = `${variantRes}|${variantMbps}`;
+                    const prevVariant = lastRecordedVariantBySession.get(String(key));
+                    const pending = pendingVariantBySession.get(String(key));
+                    if (prevVariant === variantKey) {
+                        if (pending) pendingVariantBySession.delete(String(key));
+                    } else if (manifestRes || (pending && pending.key === variantKey)) {
+                        const eventSeries = bandwidthEventHistory.get(key) || [];
+                        eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                        const eventCutoff = now - windowMs;
+                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                        lastRecordedVariantBySession.set(String(key), variantKey);
+                        pendingVariantBySession.delete(String(key));
+                    } else {
+                        pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
+                    }
+                }
+            }
+
+            // DISPLAY_RES lane: presented frame resolution. Distinct
+            // from VARIANT — the gap between them is the fetch-to-
+            // render lag.
+            const displayRes = String(session.player_metrics_video_resolution || '').trim();
+            if (displayRes) {
+                const prevDisplayRes = lastRecordedDisplayResBySession.get(String(key));
+                if (prevDisplayRes !== displayRes) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedVariantBySession.set(String(key), variantKey);
-                    pendingVariantBySession.delete(String(key));
-                } else {
-                    pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
+                    lastRecordedDisplayResBySession.set(String(key), displayRes);
                 }
             }
 
@@ -4717,7 +4739,8 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'VARIANT':     { y: 10, color: '#16a34a', label: 'VARIANT' },
+            'VARIANT':     { y: 11, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 10, color: '#0ea5e9', label: 'DISPLAY RES' },
             'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
@@ -4760,6 +4783,35 @@
             const res = String(resolution || '').trim();
             if (res && mbpsStr) return `${res} · ${mbpsStr}`;
             return res || mbpsStr || '—';
+        }
+        function manifestResolutionForBitrate(session, mbps) {
+            const variants = Array.isArray(session?.manifest_variants) ? session.manifest_variants : [];
+            if (!variants.length) return null;
+            let best = null;
+            let bestDelta = Infinity;
+            for (const v of variants) {
+                const vMbps = Number(v?.bandwidth || 0) / 1_000_000;
+                if (!Number.isFinite(vMbps) || vMbps <= 0) continue;
+                const delta = Math.abs(vMbps - mbps);
+                const tol = Math.max(0.5, vMbps * 0.05);
+                if (delta < tol && delta < bestDelta) {
+                    bestDelta = delta;
+                    best = String(v.resolution || '').trim() || null;
+                }
+            }
+            return best;
+        }
+        function displayResColor(res) {
+            const m = /(\d+)\s*[xX]\s*(\d+)/.exec(String(res || ''));
+            if (!m) return '#9ca3af';
+            const h = Number(m[2]);
+            if (!Number.isFinite(h) || h <= 0) return '#9ca3af';
+            if (h <= 360)  return '#dc2626';
+            if (h <= 540)  return '#ea580c';
+            if (h <= 720)  return '#f59e0b';
+            if (h <= 1080) return '#84cc16';
+            if (h <= 1440) return '#16a34a';
+            return '#10b981';
         }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
@@ -4807,6 +4859,7 @@
                 let colors = cfg.color;
                 if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
                 else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
+                else if (type === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
                 return {
                     label: cfg.label,
                     data: points,
@@ -4881,7 +4934,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 10.5,
+                                type: 'linear', min: 0.5, max: 11.5,
                                 title: {
                                     display: true,
                                     text: 'Events',
@@ -5001,6 +5054,9 @@
             pushRanges('PLAYERSTATE',
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
+            pushRanges('DISPLAY_RES',
+                (e) => String(e.resolution || '?'),
+                (e) => displayResColor(e.resolution));
 
             // VARIANT: each (resolution, bitrate) tuple gets its own
             // swim lane. Lane key matches seenVariants.
@@ -5025,7 +5081,7 @@
             }
 
             for (const e of events) {
-                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;
+                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
                 items.push({

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4156,6 +4156,7 @@
             if (eventType === 'video_start_time') return 'START_TIME';
             if (eventType === 'rate_shift_up') return 'SHIFT_UP';
             if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
+            if (eventType === 'timejump') return 'TIMEJUMP';
             return null;
         }
 
@@ -4766,19 +4767,20 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'VARIANT':       { y: 16, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES':   { y: 15, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE':   { y: 14, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':       { y: 13, color: '#16a34a', label: 'PLAYING' },
-            'FIRST_FRAME':   { y: 12, color: '#14b8a6', label: 'FIRST FRAME' },
-            'START_TIME':    { y: 11, color: '#15803d', label: 'START TIME' },
-            'BUFFERING':     { y: 10, color: '#f59e0b', label: 'BUFFERING' },
-            'STALL':         { y: 9,  color: '#000000', label: 'STALL' },
-            'FROZEN':        { y: 8,  color: '#4c1d95', label: 'FROZEN' },
-            'SEGMENT_STALL': { y: 7,  color: '#c2410c', label: 'SEGMENT STALL' },
-            'SHIFT_UP':      { y: 6,  color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':    { y: 5,  color: '#ef4444', label: 'SHIFT DOWN' },
-            'ERROR':         { y: 4,  color: '#e11d48', label: 'ERROR' },
+            'VARIANT':       { y: 17, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES':   { y: 16, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE':   { y: 15, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':       { y: 14, color: '#16a34a', label: 'PLAYING' },
+            'FIRST_FRAME':   { y: 13, color: '#14b8a6', label: 'FIRST FRAME' },
+            'START_TIME':    { y: 12, color: '#15803d', label: 'START TIME' },
+            'BUFFERING':     { y: 11, color: '#f59e0b', label: 'BUFFERING' },
+            'STALL':         { y: 10, color: '#000000', label: 'STALL' },
+            'FROZEN':        { y: 9,  color: '#4c1d95', label: 'FROZEN' },
+            'SEGMENT_STALL': { y: 8,  color: '#c2410c', label: 'SEGMENT STALL' },
+            'SHIFT_UP':      { y: 7,  color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':    { y: 6,  color: '#ef4444', label: 'SHIFT DOWN' },
+            'ERROR':         { y: 5,  color: '#e11d48', label: 'ERROR' },
+            'TIMEJUMP':      { y: 4,  color: '#d97706', label: 'TIMEJUMP' },
             'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
@@ -4966,7 +4968,8 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 16.5,
+                                type: 'linear', min: 0.5, max: 17.5,
+                                afterFit: (axis) => { axis.width = 90; },
                                 title: {
                                     display: true,
                                     text: 'Events',
@@ -5544,6 +5547,7 @@
                             y: {
                                 min: 0,
                                 max: maxY,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',
@@ -5664,6 +5668,7 @@
                             y: {
                                 min: 0,
                                 max: maxBufferDepth,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',
@@ -5910,6 +5915,7 @@
                             y: {
                                 min: 0,
                                 max: maxFps,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -580,6 +580,21 @@
         .events-chart-wrap {
             margin-bottom: 0 !important;
         }
+        .events-timeline-wrap .events-timeline {
+            height: 220px;
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 4px;
+        }
+        .events-timeline .vis-item.vis-box,
+        .events-timeline .vis-item.vis-point {
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+        }
+        .events-timeline .vis-label {
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+        }
 
         .abrchar-panel {
             margin-bottom: 12px;
@@ -935,6 +950,7 @@
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
+        const eventsTimelines = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -4815,6 +4831,91 @@
             }
         }
 
+        // Real swim-lane chart using vis-timeline. Stacked above the
+        // Chart.js scatter approximation so we can compare. PLAYERSTATE
+        // becomes a continuous coloured ribbon (one segment per state
+        // span). Other lanes remain point markers since their underlying
+        // events are point-in-time. BUFFERING and STALL stay as points
+        // for now — pairing start/end into ranges needs the *_end events
+        // to flow through the dashboard event capture (currently only
+        // *_start variants reach parseBandwidthChartEventType).
+        function renderEventsTimelineChart(sessionId, windowStart, eventSeries) {
+            if (typeof vis === 'undefined' || !vis.Timeline) return;
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            const container = card.querySelector('.events-timeline');
+            if (!container) return;
+
+            const windowEndMs = windowStart + 600 * 1000;
+            const nowMs = Date.now();
+            const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
+
+            const groups = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
+                id: type,
+                content: cfg.label
+            }));
+
+            const items = [];
+            let itemId = 0;
+
+            const stateEvents = events.filter((e) => e.type === 'PLAYERSTATE')
+                .sort((a, b) => Number(a.ts) - Number(b.ts));
+            for (let i = 0; i < stateEvents.length; i++) {
+                const start = Number(stateEvents[i].ts);
+                const end = i + 1 < stateEvents.length ? Number(stateEvents[i + 1].ts) : nowMs;
+                const state = stateEvents[i].state || 'Unknown';
+                const color = playerStateColor(state);
+                items.push({
+                    id: itemId++,
+                    group: 'PLAYERSTATE',
+                    content: state,
+                    start: new Date(start),
+                    end: new Date(end),
+                    type: 'range',
+                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                });
+            }
+
+            for (const e of events) {
+                if (e.type === 'PLAYERSTATE') continue;
+                const cfg = EVENT_LANES[e.type];
+                if (!cfg) continue;
+                items.push({
+                    id: itemId++,
+                    group: e.type,
+                    content: '',
+                    start: new Date(Number(e.ts)),
+                    type: 'point',
+                    style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
+                });
+            }
+
+            let timeline = eventsTimelines.get(sessionId);
+            if (!timeline) {
+                timeline = new vis.Timeline(
+                    container,
+                    new vis.DataSet(items),
+                    new vis.DataSet(groups),
+                    {
+                        stack: false,
+                        showCurrentTime: false,
+                        zoomable: true,
+                        moveable: true,
+                        margin: { item: 4 },
+                        orientation: { axis: 'top' },
+                        min: new Date(windowStart - 60000),
+                        max: new Date(windowEndMs + 60000),
+                        start: new Date(windowStart),
+                        end: new Date(windowEndMs)
+                    }
+                );
+                eventsTimelines.set(sessionId, timeline);
+            } else {
+                timeline.setItems(new vis.DataSet(items));
+                timeline.setGroups(new vis.DataSet(groups));
+            }
+        }
+
         function renderBandwidthChart(sessionId) {
             if (isChartPaused(sessionId)) return;
             const series = bandwidthHistory.get(sessionId) || [];
@@ -4859,6 +4960,7 @@
                 .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
             // Render the separate events swim-lane chart with the same window
             renderEventsChart(sessionId, windowStart, eventSeries);
+            renderEventsTimelineChart(sessionId, windowStart, eventSeries);
             const wireActive6sData = points.map(point => ({ x: point.x, y: point.wireActive6s }));
             const wireActive1sData = points.map(point => ({ x: point.x, y: point.wireActive1s }));
             const segmentWireData = points.map(point => ({ x: point.x, y: point.segmentWire }));

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -629,20 +629,25 @@
             border-right: none !important;
         }
         /* Top-level section headers (PLAYER / SERVER) — flush left
-         * and compact since they're just dividers. */
+         * and compacted to a single label-height row. */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
-            height: 24px !important;
-            min-height: 24px !important;
-            max-height: 24px !important;
+            height: 18px !important;
+            min-height: 18px !important;
+            max-height: 18px !important;
+            line-height: 18px !important;
         }
-        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0 {
-            height: 24px !important;
-            min-height: 24px !important;
-            max-height: 24px !important;
-        }
+        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0,
         .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
-            height: 24px !important;
+            height: 18px !important;
+            min-height: 18px !important;
+            max-height: 18px !important;
+        }
+        .events-timeline-wrap .vis-time-axis {
+            font-size: 10px;
+        }
+        .events-timeline-wrap .vis-time-axis .vis-text {
+            padding: 0 4px !important;
         }
         .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
             padding-left: 0 !important;
@@ -5182,11 +5187,8 @@
             // Compute explicit height from the actual lane count;
             // vis-timeline's height:'auto' collapses to 0 when the
             // container has no intrinsic height.
-            const ROW_HEIGHT_PX = 30;
-            const AXIS_AND_PADDING_PX = 60;
-            const computedHeight = groups.length * ROW_HEIGHT_PX + AXIS_AND_PADDING_PX;
-            const heightPx = `${computedHeight}px`;
-            container.style.height = heightPx;
+            // Let vis-timeline compute its own height from rows + items.
+            container.style.removeProperty('height');
 
             // If the session card was rebuilt, the cached timeline points
             // at an orphaned div; recreate it against the new container.
@@ -5208,7 +5210,7 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        height: heightPx,
+                        height: 'auto',
                         start: liveStart,
                         end: liveEnd,
                         // Match the Chart.js charts' HH:MM:SS 24-hour
@@ -5282,11 +5284,10 @@
                 } else {
                     requestAnimationFrame(() => timeline.redraw());
                 }
-                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
-                timeline.setOptions({ height: heightPx });
                 timeline.$windowStartMs = liveStart.getTime();
                 // Live-edge tracking: unless paused, slide so right
                 // edge stays at "now"; preserve user's zoom width.

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -598,24 +598,18 @@
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
-        /* Float vis-timeline's left label panel over the chart so the
-         * time axis uses the full container width and aligns with the
-         * Chart.js charts; lane labels overlay on top of items. */
+        /* Lock vis-timeline's left label panel to 90px so its row
+         * positions stay aligned with the lane items AND the chart
+         * area's left edge matches the Chart.js Y-axis width. */
+        .events-timeline-wrap .vis-labelset,
         .events-timeline-wrap .vis-left.vis-panel {
-            position: absolute !important;
-            left: 0 !important;
-            top: 0 !important;
-            z-index: 5;
-            background: rgba(255, 255, 255, 0.85);
-            border-right: 1px solid rgba(0, 0, 0, 0.05);
-            pointer-events: none;
-        }
-        .events-timeline-wrap .vis-center.vis-panel {
-            left: 0 !important;
-            border-left: none !important;
+            width: 90px !important;
+            max-width: 90px !important;
         }
         .events-timeline-wrap .vis-label {
-            background: transparent !important;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -581,16 +581,14 @@
             margin-bottom: 0 !important;
         }
         .events-timeline-wrap {
-            height: 240px;
+            min-height: 240px;
             margin-bottom: 12px;
             position: relative;
         }
         .events-timeline-wrap .events-timeline {
-            height: 100%;
             background: #fff;
             border: 1px solid #e5e7eb;
             border-radius: 4px;
-            overflow: hidden;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {
@@ -5022,6 +5020,12 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
+                        // Auto-grow to fit dynamically-added variant
+                        // lanes; bounded so it doesn't take over the
+                        // whole page if the ladder is huge.
+                        height: 'auto',
+                        minHeight: '240px',
+                        maxHeight: '700px',
                         start: new Date(nowMs - 600 * 1000),
                         end: new Date(nowMs)
                     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4840,13 +4840,18 @@
         // to flow through the dashboard event capture (currently only
         // *_start variants reach parseBandwidthChartEventType).
         function renderEventsTimelineChart(sessionId, windowStart, eventSeries) {
-            if (typeof vis === 'undefined' || !vis.Timeline) return;
+            if (typeof vis === 'undefined' || !vis.Timeline) {
+                console.warn('[events-timeline] vis-timeline not loaded');
+                return;
+            }
             const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
             if (!card) return;
             const container = card.querySelector('.events-timeline');
-            if (!container) return;
+            if (!container) {
+                console.warn('[events-timeline] container .events-timeline not in DOM for session', sessionId);
+                return;
+            }
 
-            const windowEndMs = windowStart + 600 * 1000;
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
@@ -4898,18 +4903,19 @@
                     new vis.DataSet(groups),
                     {
                         stack: false,
-                        showCurrentTime: false,
+                        showCurrentTime: true,
                         zoomable: true,
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        min: new Date(windowStart - 60000),
-                        max: new Date(windowEndMs + 60000),
-                        start: new Date(windowStart),
-                        end: new Date(windowEndMs)
+                        // Default visible window = last 10 minutes through now.
+                        // No min/max so panning forward/back works freely.
+                        start: new Date(nowMs - 600 * 1000),
+                        end: new Date(nowMs)
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4918,8 +4918,10 @@
                 const k = `${m}|${v.resolution || ''}`;
                 if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
             }
+            // Ordered DESCENDING — highest bitrate at the top, lowest at
+            // the bottom — so an upshift walks UP the ladder visually.
             const variantOrder = Array.from(seenVariants.entries())
-                .sort((a, b) => Number(a[1].mbps) - Number(b[1].mbps));
+                .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
                 id: `VARIANT::${k}`,
                 content: variantLabel(v.mbps, v.resolution)
@@ -4962,8 +4964,9 @@
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each variant gets its own swim lane; an upshift
-            // visually walks UP the ladder.
+            // VARIANT: each variant gets its own swim lane. Variants are
+            // ordered highest-bitrate-at-top so an upshift visually
+            // walks UP the ladder and a downshift walks DOWN.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5267,8 +5267,7 @@
                 timeline.$container = container;
                 applyStoredChartViewport(sessionId, timeline);
                 // After a user-driven range change: if not paused,
-                // re-snap right edge to "now" preserving zoom width
-                // (matches the Chart.js charts' live-mode behaviour).
+                // re-snap right edge to "now" preserving zoom width.
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
                     syncChartViewportAcrossSession(sessionId, timeline);
@@ -5280,6 +5279,16 @@
                         new Date(nowMsLocal),
                         { animation: false }
                     );
+                });
+                // Click toggles pause (matches Chart.js
+                // installChartClickPauseHandler). Skip group-label
+                // clicks (collapse/expand) and Alt-clicks (zoom
+                // modifier).
+                timeline.on('click', (props) => {
+                    if (!props) return;
+                    if (props.event && props.event.altKey) return;
+                    if (props.what === 'group-label') return;
+                    toggleChartPause(sessionId);
                 });
                 // ResizeObserver redraw — see testing.html for rationale.
                 if (typeof ResizeObserver !== 'undefined') {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -598,18 +598,30 @@
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
-        /* Lock vis-timeline's left label panel to 90px so its row
-         * positions stay aligned with the lane items AND the chart
-         * area's left edge matches the Chart.js Y-axis width. */
+        /* Left panel pinned to 90px (matches Chart.js Y-axis width).
+         * Labels overflow to the right INTO the chart area on top of
+         * the swim lane items — text-shadow halo keeps them readable.
+         * Nested-group indent is neutralised. */
         .events-timeline-wrap .vis-labelset,
         .events-timeline-wrap .vis-left.vis-panel {
             width: 90px !important;
             max-width: 90px !important;
+            overflow: visible !important;
         }
-        .events-timeline-wrap .vis-label {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+        .events-timeline-wrap .vis-label,
+        .events-timeline-wrap .vis-label.vis-nested-group {
+            overflow: visible !important;
+            white-space: nowrap !important;
+            padding-left: 4px !important;
+            z-index: 10;
+            position: relative;
+            color: #1f2937;
+            font-weight: 600;
+            text-shadow:
+                0 0 3px rgba(255, 255, 255, 0.95),
+                0 0 6px rgba(255, 255, 255, 0.85),
+                1px 0 0 rgba(255, 255, 255, 0.75),
+                -1px 0 0 rgba(255, 255, 255, 0.75);
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4100,7 +4100,8 @@
             if (eventType === 'loop_marker') return 'LOOP';
             if (eventType === 'playing') return 'PLAYING';
             if (eventType === 'buffering_start') return 'BUFFERING';
-            if (eventType === 'rate_shift_up' || eventType === 'rate_shift_down') return 'SHIFT';
+            if (eventType === 'rate_shift_up') return 'SHIFT_UP';
+            if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
             return null;
         }
 
@@ -4643,10 +4644,11 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'PLAYERSTATE': { y: 8, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
-            'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
-            'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
+            'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
+            'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
+            'SHIFT_UP':    { y: 6, color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':  { y: 5, color: '#ef4444', label: 'SHIFT DOWN' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -4779,7 +4781,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 8.5,
+                                type: 'linear', min: 0.5, max: 9.5,
                                 title: {
                                     display: true,
                                     text: 'Events',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -583,11 +583,17 @@
         .events-timeline-wrap {
             margin-bottom: 12px;
             position: relative;
+            /* Reserve right padding equal to the FPS chart's right-side
+             * Y-axis (Dropped/s) so the events-timeline plot area's
+             * right edge aligns with the four Chart.js charts below. */
+            padding-right: 60px;
         }
         .events-timeline-wrap .events-timeline {
-            background: #fff;
-            border: 1px solid #e5e7eb;
-            border-radius: 4px;
+            /* Match the surrounding .collapsible-section background
+             * (#fafafa) — Chart.js canvases below are transparent so
+             * they show the same #fafafa, and a pure-white events-
+             * timeline stood out. */
+            background: #fafafa;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {
@@ -623,10 +629,24 @@
                 0 0 6px rgba(255, 255, 255, 0.85),
                 1px 0 0 rgba(255, 255, 255, 0.75),
                 -1px 0 0 rgba(255, 255, 255, 0.75);
-            border-color: rgba(0, 0, 0, 0.06) !important;
+            border-color: #e5e7eb !important;
             border-top: none !important;
             border-left: none !important;
             border-right: none !important;
+        }
+        /* Match the Chart.js grid colour (#e5e7eb) for the row
+         * separators inside the items panel — they were drawn in
+         * the vis-timeline default red/black and clashed with the
+         * gray grid in the four charts below. */
+        .events-timeline-wrap .vis-foreground .vis-group,
+        .events-timeline-wrap .vis-panel.vis-background .vis-group,
+        .events-timeline-wrap .vis-panel.vis-background .vis-horizontal {
+            border-color: #e5e7eb !important;
+        }
+        /* Slim grey border around the entire timeline matches the
+         * Chart.js charts' gridline tone. */
+        .events-timeline-wrap .vis-timeline {
+            border-color: #e5e7eb !important;
         }
         /* Top-level section headers — flush left, no row-height
          * override (CSS-only overrides drift labels out of alignment
@@ -645,20 +665,29 @@
         .events-timeline-wrap .vis-time-axis .vis-text.vis-minor {
             visibility: hidden !important;
         }
+        /* Hide vis-timeline's own calendar-snapped vertical grid lines —
+         * they slide left independently as time advances and clash with
+         * our right-edge-anchored custom-time markers. Only our markers
+         * should draw vertical lines. */
+        .events-timeline-wrap .vis-time-axis .vis-grid.vis-minor,
+        .events-timeline-wrap .vis-time-axis .vis-grid.vis-major,
+        .events-timeline-wrap .vis-panel.vis-background .vis-vertical {
+            border-color: transparent !important;
+        }
         .events-timeline-wrap .vis-custom-time {
-            background-color: rgba(0, 0, 0, 0.15) !important;
+            background-color: #e5e7eb !important;
             width: 1px !important;
             cursor: default !important;
         }
         .events-timeline-wrap .vis-custom-time .vis-custom-time-marker {
-            background: rgba(255, 255, 255, 0.92) !important;
-            border: 1px solid rgba(0, 0, 0, 0.08) !important;
-            border-radius: 2px !important;
+            background: transparent !important;
+            border: none !important;
             color: #4b5563 !important;
             font-family: 'Courier New', monospace !important;
             font-size: 10px !important;
             padding: 0 3px !important;
-            top: 2px !important;
+            top: auto !important;
+            bottom: 2px !important;
         }
         .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
             padding-left: 0 !important;
@@ -5385,33 +5414,53 @@
                 }
             }
 
-            // Tick markers placed at real event timestamps — see
-            // testing.html for full rationale.
-            refreshEventTickMarkers(timeline, events, nowMs - liveWindowMs, nowMs);
+            // Right-edge-anchored tick markers placed at the same
+            // wall-clock times as the Chart.js charts' axis ticks
+            // (every 100s for the 10-min window). Items keep their
+            // exact timestamp positions regardless of where these
+            // tick lines fall.
+            //
+            // When the chart is paused, anchor the ticks to the
+            // visible window's right edge (frozen in time) so the
+            // tick lines stay on top of the events that were visible
+            // when the user paused — not slide right with wall-clock
+            // time while the events stay frozen.
+            const tickAnchorMs = isChartPaused(sessionId)
+                ? timeline.getWindow().end.getTime()
+                : nowMs;
+            refreshLiveTickMarkers(timeline, tickAnchorMs, liveWindowMs);
         }
 
-        function refreshEventTickMarkers(timeline, events, windowStartMs, windowEndMs) {
+        // Add vis-timeline custom-time markers at fixed intervals
+        // back from "now" — matches the Chart.js charts' tick spacing
+        // so HH:MM:SS labels line up vertically across events-timeline
+        // / bandwidth / buffer / fps charts. We rebuild every render
+        // (remove all, add fresh) because vis-timeline's setCustomTime
+        // updates internal state but the DOM line element does not
+        // always reposition — leaving labels that move while the
+        // vertical lines stay put.
+        function refreshLiveTickMarkers(timeline, nowMs, windowMs) {
+            // 100s interval matches Chart.js's auto-pick for the
+            // [0, 600] (seconds) range with maxTicksLimit:8 → ticks
+            // every 100s = 7 visible labels in the 10-min window.
+            const TICK_INTERVAL_MS = 100000;
+            const tickCount = Math.floor(windowMs / TICK_INTERVAL_MS) + 1;
             if (!timeline.$tickIds) timeline.$tickIds = new Set();
             const fmt = (ms) => {
                 const d = new Date(ms);
                 return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
             };
-            const desired = new Map();
-            for (const e of (events || [])) {
-                const ts = Number(e.ts);
-                if (!Number.isFinite(ts) || ts < windowStartMs || ts > windowEndMs) continue;
-                const sec = Math.floor(ts / 1000) * 1000;
-                const id = `event-tick-${sec}`;
-                if (!desired.has(id)) desired.set(id, sec);
-            }
+            // Drop every existing tick marker; the DOM line for a
+            // setCustomTime'd marker doesn't always re-render at the
+            // new x even though its label does.
             for (const id of Array.from(timeline.$tickIds)) {
-                if (!desired.has(id)) {
-                    try { timeline.removeCustomTime(id); } catch (e) {}
-                    timeline.$tickIds.delete(id);
-                }
+                try { timeline.removeCustomTime(id); } catch (e) {}
             }
-            for (const [id, t] of desired) {
-                if (timeline.$tickIds.has(id)) continue;
+            timeline.$tickIds.clear();
+            // Re-add at the current wall-clock anchored positions.
+            for (let i = 0; i < tickCount; i++) {
+                const id = `live-tick-${i}`;
+                const t = nowMs - i * TICK_INTERVAL_MS;
                 try {
                     timeline.addCustomTime(new Date(t), id);
                     timeline.$tickIds.add(id);

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -628,20 +628,11 @@
             border-left: none !important;
             border-right: none !important;
         }
-        /* Top-level section headers (PLAYER / SERVER) — flush left
-         * and compacted to a single label-height row. */
+        /* Top-level section headers — flush left, no row-height
+         * override (CSS-only overrides drift labels out of alignment
+         * with chart rows). */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
-            height: 18px !important;
-            min-height: 18px !important;
-            max-height: 18px !important;
-            line-height: 18px !important;
-        }
-        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0,
-        .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
-            height: 18px !important;
-            min-height: 18px !important;
-            max-height: 18px !important;
         }
         .events-timeline-wrap .vis-time-axis {
             font-size: 10px;
@@ -5187,15 +5178,11 @@
             // Compute explicit height from the actual lane count;
             // vis-timeline's height:'auto' collapses to 0 when the
             // container has no intrinsic height.
-            // Compute explicit height — height:'auto' collapses the
-            // container. Section headers are 18px (CSS), regular
-            // lanes ~22px under our slim styling, axis ≈ 32px.
-            const SECTION_ROW_PX = 18;
-            const LANE_ROW_PX = 22;
-            const AXIS_PAD_PX = 32;
-            const sectionRows = groups.filter((g) => Array.isArray(g.nestedGroups)).length;
-            const laneRows = groups.length - sectionRows;
-            const computedHeight = (sectionRows * SECTION_ROW_PX) + (laneRows * LANE_ROW_PX) + AXIS_PAD_PX;
+            // Explicit height. Uniform per-row size since section
+            // headers no longer get a CSS row-height override.
+            const ROW_PX = 28;
+            const AXIS_PAD_PX = 50;
+            const computedHeight = (groups.length * ROW_PX) + AXIS_PAD_PX;
             const heightPx = `${computedHeight}px`;
             container.style.height = heightPx;
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -982,10 +982,6 @@
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
-        // Per-session "follow live" flag — see testing.html for the
-        // full rationale. Skips the per-tick setWindow when the user
-        // has zoomed/panned away from the live edge.
-        const eventsTimelineFollowLive = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -5188,17 +5184,24 @@
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
-                eventsTimelineFollowLive.set(sessionId, true);
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
                 timeline.$container = container;
                 applyStoredChartViewport(sessionId, timeline);
+                // After a user-driven range change: if not paused,
+                // re-snap right edge to "now" preserving zoom width
+                // (matches the Chart.js charts' live-mode behaviour).
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
-                    const rightEdge = props.end.getTime();
-                    const driftMs = Math.abs(Date.now() - rightEdge);
-                    eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
                     syncChartViewportAcrossSession(sessionId, timeline);
+                    if (isChartPaused(sessionId)) return;
+                    const width = props.end.getTime() - props.start.getTime();
+                    const nowMsLocal = Date.now();
+                    timeline.setWindow(
+                        new Date(nowMsLocal - width),
+                        new Date(nowMsLocal),
+                        { animation: false }
+                    );
                 });
                 // ResizeObserver redraw — see testing.html for rationale.
                 if (typeof ResizeObserver !== 'undefined') {
@@ -5221,8 +5224,16 @@
                 timeline.setGroups(new vis.DataSet(groups));
                 timeline.setOptions({ height: heightPx });
                 timeline.$windowStartMs = liveStart.getTime();
-                if (eventsTimelineFollowLive.get(sessionId) !== false) {
-                    timeline.setWindow(liveStart, liveEnd, { animation: false });
+                // Live-edge tracking: unless paused, slide so right
+                // edge stays at "now"; preserve user's zoom width.
+                if (!isChartPaused(sessionId)) {
+                    const win = timeline.getWindow();
+                    const width = win.end.getTime() - win.start.getTime();
+                    timeline.setWindow(
+                        new Date(nowMs - width),
+                        new Date(nowMs),
+                        { animation: false }
+                    );
                 }
             }
         }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5007,6 +5007,13 @@
                 });
             }
 
+            // Live-edge window: same 10-minute span as the other charts,
+            // right edge anchored to "now" so events scroll left as time
+            // advances. Updated on every render so the view tracks live.
+            const liveWindowMs = 10 * 60 * 1000;
+            const liveStart = new Date(nowMs - liveWindowMs);
+            const liveEnd = new Date(nowMs);
+
             let timeline = eventsTimelines.get(sessionId);
             if (!timeline) {
                 timeline = new vis.Timeline(
@@ -5020,14 +5027,11 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Auto-grow to fit dynamically-added variant
-                        // lanes; bounded so it doesn't take over the
-                        // whole page if the ladder is huge.
                         height: 'auto',
                         minHeight: '240px',
                         maxHeight: '700px',
-                        start: new Date(nowMs - 600 * 1000),
-                        end: new Date(nowMs)
+                        start: liveStart,
+                        end: liveEnd
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
@@ -5036,6 +5040,9 @@
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
+                // Slide the visible window so "now" stays pinned to
+                // the right edge.
+                timeline.setWindow(liveStart, liveEnd, { animation: false });
             }
         }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4838,7 +4838,8 @@
         // normalises before lookup so all map to the same colour.
         const PLAYER_STATE_COLOR = {
             'playing':   '#16a34a', // green
-            'buffering': '#f59e0b', // amber
+            'buffering': '#f59e0b', // amber — expected refill
+            'stalled':   '#dc2626', // red — unexpected mid-play rebuffer
             'paused':    '#9333ea', // purple
             'idle':      '#6b7280', // gray
             'ended':     '#1f2937', // near-black

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5044,7 +5044,14 @@
             const heightPx = `${computedHeight}px`;
             container.style.height = heightPx;
 
+            // If the session card was rebuilt, the cached timeline points
+            // at an orphaned div; recreate it against the new container.
             let timeline = eventsTimelines.get(sessionId);
+            if (timeline && timeline.$container !== container) {
+                timeline.destroy();
+                eventsTimelines.delete(sessionId);
+                timeline = null;
+            }
             if (!timeline) {
                 timeline = new vis.Timeline(
                     container,
@@ -5073,6 +5080,7 @@
                 eventsTimelineFollowLive.set(sessionId, true);
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
+                timeline.$container = container;
                 applyStoredChartViewport(sessionId, timeline);
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -964,6 +964,7 @@
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
+        const lastRecordedVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -4627,6 +4628,24 @@
                 }
             }
 
+            // VARIANT lane: sample player_metrics_video_bitrate_mbps on
+            // each refresh and emit a marker on every change. Quantise
+            // to one decimal so micro-fluctuations don't flood the lane.
+            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
+                const variantRes = String(session.player_metrics_video_resolution || '').trim();
+                const variantKey = `${variantMbps}|${variantRes}`;
+                const prevVariant = lastRecordedVariantBySession.get(String(key));
+                if (prevVariant !== variantKey) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                    lastRecordedVariantBySession.set(String(key), variantKey);
+                }
+            }
+
             const series = bandwidthHistory.get(key) || [];
             if (!Number.isFinite(target)) {
                 const lastTarget = series.length > 0 ? series[series.length - 1].target : null;
@@ -4666,6 +4685,7 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
+            'VARIANT':     { y: 10, color: '#16a34a', label: 'VARIANT' },
             'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
@@ -4687,6 +4707,24 @@
         };
         function playerStateColor(s) {
             return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+        }
+        // Variant colour buckets — lower bitrate = redder, higher = greener.
+        function variantColor(mbps) {
+            const m = Number(mbps);
+            if (!Number.isFinite(m) || m <= 0) return '#9ca3af';
+            if (m < 1)  return '#dc2626';
+            if (m < 2)  return '#ea580c';
+            if (m < 4)  return '#f59e0b';
+            if (m < 8)  return '#84cc16';
+            if (m < 16) return '#16a34a';
+            return '#10b981';
+        }
+        function variantLabel(mbps, resolution) {
+            const m = Number(mbps);
+            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)} Mbps` : '';
+            const res = String(resolution || '').trim();
+            if (res && mbpsStr) return `${res} · ${mbpsStr}`;
+            return res || mbpsStr || '—';
         }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
@@ -4725,14 +4763,15 @@
 
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
 
             const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
                 const points = chartEvents.filter((e) => e.type === type)
-                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state }));
-                const isPlayerState = type === 'PLAYERSTATE';
-                const colors = isPlayerState ? points.map(p => playerStateColor(p.state)) : cfg.color;
+                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state, mbps: e.mbps, resolution: e.resolution }));
+                let colors = cfg.color;
+                if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
+                else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
                 return {
                     label: cfg.label,
                     data: points,
@@ -4781,8 +4820,12 @@
                                         const offset = Number.isFinite(ts) && startMs > 0
                                             ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
                                             : '';
-                                        const state = ctx && ctx.raw && ctx.raw.state ? `: ${ctx.raw.state}` : '';
-                                        return `${ctx.dataset.label}${state}${offset}`;
+                                        let extra = '';
+                                        if (ctx && ctx.raw) {
+                                            if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
+                                            else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
+                                        }
+                                        return `${ctx.dataset.label}${extra}${offset}`;
                                     }
                                 }
                             },
@@ -4803,7 +4846,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 9.5,
+                                type: 'linear', min: 0.5, max: 10.5,
                                 title: {
                                     display: true,
                                     text: 'Events',
@@ -4861,34 +4904,48 @@
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
-            const groups = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
-                id: type,
-                content: cfg.label
-            }));
+            const SERVER_LANES = new Set(['LOOP_SERVER']);
+            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k));
+            const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
+            const groups = [
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: playerLanes },
+                ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
+                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
+                ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
+            ];
 
             const items = [];
             let itemId = 0;
 
-            const stateEvents = events.filter((e) => e.type === 'PLAYERSTATE')
-                .sort((a, b) => Number(a.ts) - Number(b.ts));
-            for (let i = 0; i < stateEvents.length; i++) {
-                const start = Number(stateEvents[i].ts);
-                const end = i + 1 < stateEvents.length ? Number(stateEvents[i + 1].ts) : nowMs;
-                const state = stateEvents[i].state || 'Unknown';
-                const color = playerStateColor(state);
-                items.push({
-                    id: itemId++,
-                    group: 'PLAYERSTATE',
-                    content: state,
-                    start: new Date(start),
-                    end: new Date(end),
-                    type: 'range',
-                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
-                });
+            function pushRanges(typeKey, getLabel, getColor) {
+                const seq = events.filter((e) => e.type === typeKey)
+                    .sort((a, b) => Number(a.ts) - Number(b.ts));
+                for (let i = 0; i < seq.length; i++) {
+                    const start = Number(seq[i].ts);
+                    const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
+                    const label = getLabel(seq[i]);
+                    const color = getColor(seq[i]);
+                    items.push({
+                        id: itemId++,
+                        group: typeKey,
+                        content: label,
+                        start: new Date(start),
+                        end: new Date(end),
+                        type: 'range',
+                        style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                    });
+                }
             }
 
+            pushRanges('PLAYERSTATE',
+                (e) => e.state || 'Unknown',
+                (e) => playerStateColor(e.state));
+            pushRanges('VARIANT',
+                (e) => variantLabel(e.mbps, e.resolution),
+                (e) => variantColor(e.mbps));
+
             for (const e of events) {
-                if (e.type === 'PLAYERSTATE') continue;
+                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
                 items.push({
@@ -4914,13 +4971,12 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Default visible window = last 10 minutes through now.
-                        // No min/max so panning forward/back works freely.
                         start: new Date(nowMs - 600 * 1000),
                         end: new Date(nowMs)
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -580,11 +580,17 @@
         .events-chart-wrap {
             margin-bottom: 0 !important;
         }
+        .events-timeline-wrap {
+            height: 240px;
+            margin-bottom: 12px;
+            position: relative;
+        }
         .events-timeline-wrap .events-timeline {
-            height: 220px;
+            height: 100%;
             background: #fff;
             border: 1px solid #e5e7eb;
             border-radius: 4px;
+            overflow: hidden;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4628,17 +4628,18 @@
                 }
             }
 
-            // VARIANT lane: sample player_metrics_video_bitrate_mbps on
-            // each refresh and emit a marker on every change. Dedup by
-            // BITRATE ONLY (rounded to 0.1 Mbps) — resolution can briefly
-            // be empty/null between samples, which would create spurious
-            // "new variant" entries with the same bitrate but different
-            // resolution strings. Resolution is kept for labelling only.
-            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
-                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
-                const variantRes = String(session.player_metrics_video_resolution || '').trim();
-                const variantKey = `${variantMbps}`;
+            // VARIANT lane: dedup by RESOLUTION, not bitrate.
+            // player_metrics_video_bitrate_mbps reports the actual
+            // segment bitrate which fluctuates with scene complexity
+            // even within one rendition. Resolution is stable per
+            // rendition, so it's the correct identity for an ABR
+            // variant. Skip ticks where resolution is missing.
+            const variantRes = String(session.player_metrics_video_resolution || '').trim();
+            if (variantRes) {
+                const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+                const variantMbps = Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0
+                    ? Math.round(variantMbpsRaw * 10) / 10 : 0;
+                const variantKey = variantRes;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -4914,24 +4915,24 @@
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
-            // Lane key is bitrate-only; we keep the latest non-empty
-            // resolution for the label so a brief empty-resolution sample
-            // doesn't spawn a phantom lane with the same bitrate but a
-            // different label.
+            // Lane key is RESOLUTION (each rendition has a unique
+            // resolution); bitrate fluctuates per segment within one
+            // rendition and is kept only for sorting / labelling.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            const seenVariants = new Map();
+            const seenVariants = new Map(); // resolution -> {mbps, resolution}
             for (const v of variantEvents) {
+                const res = String(v.resolution || '').trim();
+                if (!res) continue;
                 const m = Number(v.mbps);
-                const k = `${m}`;
-                const existing = seenVariants.get(k);
+                const existing = seenVariants.get(res);
                 if (!existing) {
-                    seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
-                } else if (v.resolution && !existing.resolution) {
-                    existing.resolution = v.resolution;
+                    seenVariants.set(res, { mbps: m, resolution: res });
+                } else if (Number.isFinite(m) && m > 0) {
+                    existing.mbps = m;
                 }
             }
-            // Ordered DESCENDING — highest bitrate at the top, lowest at
-            // the bottom — so an upshift walks UP the ladder visually.
+            // Ordered DESCENDING by bitrate so an upshift walks UP the
+            // ladder visually.
             const variantOrder = Array.from(seenVariants.entries())
                 .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
@@ -4976,21 +4977,22 @@
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each bitrate gets its own swim lane. Lane key
-            // matches seenVariants — bitrate-only, so the segment goes
-            // into the right row regardless of any flicker on the
-            // resolution string.
+            // VARIANT: each resolution gets its own swim lane; segment
+            // bitrate drives the segment's colour so motion-driven
+            // bitrate variation within a rendition shows as a colour
+            // shift inside the same row.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
+                const res = String(v.resolution || '').trim();
+                if (!res) continue;
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const m = Number(v.mbps);
-                const k = `${m}`;
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${k}`,
+                    group: `VARIANT::${res}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4629,13 +4629,16 @@
             }
 
             // VARIANT lane: sample player_metrics_video_bitrate_mbps on
-            // each refresh and emit a marker on every change. Quantise
-            // to one decimal so micro-fluctuations don't flood the lane.
+            // each refresh and emit a marker on every change. Dedup by
+            // BITRATE ONLY (rounded to 0.1 Mbps) — resolution can briefly
+            // be empty/null between samples, which would create spurious
+            // "new variant" entries with the same bitrate but different
+            // resolution strings. Resolution is kept for labelling only.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
                 const variantRes = String(session.player_metrics_video_resolution || '').trim();
-                const variantKey = `${variantMbps}|${variantRes}`;
+                const variantKey = `${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -4911,12 +4914,21 @@
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
+            // Lane key is bitrate-only; we keep the latest non-empty
+            // resolution for the label so a brief empty-resolution sample
+            // doesn't spawn a phantom lane with the same bitrate but a
+            // different label.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
             const seenVariants = new Map();
             for (const v of variantEvents) {
                 const m = Number(v.mbps);
-                const k = `${m}|${v.resolution || ''}`;
-                if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+                const k = `${m}`;
+                const existing = seenVariants.get(k);
+                if (!existing) {
+                    seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+                } else if (v.resolution && !existing.resolution) {
+                    existing.resolution = v.resolution;
+                }
             }
             // Ordered DESCENDING — highest bitrate at the top, lowest at
             // the bottom — so an upshift walks UP the ladder visually.
@@ -4964,16 +4976,17 @@
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each variant gets its own swim lane. Variants are
-            // ordered highest-bitrate-at-top so an upshift visually
-            // walks UP the ladder and a downshift walks DOWN.
+            // VARIANT: each bitrate gets its own swim lane. Lane key
+            // matches seenVariants — bitrate-only, so the segment goes
+            // into the right row regardless of any flicker on the
+            // resolution string.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const m = Number(v.mbps);
-                const k = `${m}|${v.resolution || ''}`;
+                const k = `${m}`;
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4791,13 +4791,11 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'VARIANT':     { y: 8, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES': { y: 7, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE': { y: 6, color: '#6b7280', label: 'PLAYERSTATE' },
-            'BUFFERING':   { y: 5, color: '#f59e0b', label: 'BUFFERING' },
-            'PLAYBACK':    { y: 4, color: '#16a34a', label: 'PLAYBACK' },
-            'IMPAIRMENT':  { y: 3, color: '#000000', label: 'IMPAIRMENT' },
-            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
+            'VARIANT':     { y: 6, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 5, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE': { y: 4, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYBACK':    { y: 3, color: '#16a34a', label: 'PLAYBACK' },
+            'IMPAIRMENT':  { y: 2, color: '#000000', label: 'IMPAIRMENT' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
         const EVENT_SUBTYPE_LANE = {
@@ -4806,8 +4804,9 @@
             'SHIFT_UP': 'PLAYBACK', 'SHIFT_DOWN': 'PLAYBACK',
             'STALL': 'IMPAIRMENT', 'FROZEN': 'IMPAIRMENT',
             'SEGMENT_STALL': 'IMPAIRMENT', 'ERROR': 'IMPAIRMENT',
-            'BUFFERING': 'BUFFERING',
-            'LOOP_PLAYER': 'LOOP_PLAYER', 'LOOP_SERVER': 'LOOP_SERVER'
+            // BUFFERING and LOOP_PLAYER intentionally omitted — see
+            // testing.html for rationale.
+            'LOOP_SERVER': 'LOOP_SERVER'
         };
         const EVENT_SUBTYPE_COLOR = {
             'PLAYING':       '#16a34a',
@@ -5028,7 +5027,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 8.5,
+                                type: 'linear', min: 0.5, max: 6.5,
                                 afterFit: (axis) => { axis.width = 90; },
                                 title: {
                                     display: true,

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5098,6 +5098,14 @@
             const items = [];
             let itemId = 0;
 
+            function formatHoverTime(ms) {
+                const d = new Date(ms);
+                const hh = String(d.getHours()).padStart(2, '0');
+                const mm = String(d.getMinutes()).padStart(2, '0');
+                const ss = String(d.getSeconds()).padStart(2, '0');
+                return `${hh}:${mm}:${ss}`;
+            }
+
             function pushRanges(typeKey, getLabel, getColor) {
                 const seq = events.filter((e) => e.type === typeKey)
                     .sort((a, b) => Number(a.ts) - Number(b.ts));
@@ -5106,6 +5114,8 @@
                     const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
                     const label = getLabel(seq[i]);
                     const color = getColor(seq[i]);
+                    const durationSec = ((end - start) / 1000).toFixed(1);
+                    const title = `${EVENT_LANES[typeKey].label}: ${label}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                     items.push({
                         id: itemId++,
                         group: typeKey,
@@ -5113,6 +5123,7 @@
                         start: new Date(start),
                         end: new Date(end),
                         type: 'range',
+                        title: title,
                         style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                     });
                 }
@@ -5125,8 +5136,6 @@
                 (e) => String(e.resolution || '?'),
                 (e) => displayResColor(e.resolution));
 
-            // VARIANT: each (resolution, bitrate) tuple gets its own
-            // swim lane. Lane key matches seenVariants.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
@@ -5136,6 +5145,8 @@
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const color = variantColor(m);
+                const durationSec = ((end - start) / 1000).toFixed(1);
+                const title = `Variant: ${variantLabel(m, res)}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                 items.push({
                     id: itemId++,
                     group: `VARIANT::${res}|${m}`,
@@ -5143,6 +5154,7 @@
                     start: new Date(start),
                     end: new Date(end),
                     type: 'range',
+                    title: title,
                     style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                 });
             }
@@ -5151,12 +5163,14 @@
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
+                const ts = Number(e.ts);
                 items.push({
                     id: itemId++,
                     group: e.type,
                     content: '',
-                    start: new Date(Number(e.ts)),
+                    start: new Date(ts),
                     type: 'point',
+                    title: `${cfg.label}\n${formatHoverTime(ts)}`,
                     style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
                 });
             }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -628,9 +628,21 @@
             border-left: none !important;
             border-right: none !important;
         }
-        /* Top-level section headers (PLAYER / SERVER) sit flush. */
+        /* Top-level section headers (PLAYER / SERVER) — flush left
+         * and compact since they're just dividers. */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
+            height: 24px !important;
+            min-height: 24px !important;
+            max-height: 24px !important;
+        }
+        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0 {
+            height: 24px !important;
+            min-height: 24px !important;
+            max-height: 24px !important;
+        }
+        .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
+            height: 24px !important;
         }
         .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
             padding-left: 0 !important;

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -966,6 +966,8 @@
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedVariantBySession = new Map();
+        // Two-sample debounce for VARIANT — see testing.html for details.
+        const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -4650,24 +4652,29 @@
                 }
             }
 
-            // VARIANT lane: dedup by (resolution, indicated bitrate) so
-            // multi-bitrate-per-resolution variants (e.g. H.264 + HEVC
-            // at 1080p) get distinct lanes. Bitrate is the manifest
-            // BANDWIDTH attribute on both clients (iOS indicatedBitrate,
-            // Android Format.bitrate), stable per rendition. Skip ticks
-            // where either resolution or bitrate is missing.
+            // VARIANT lane: dedup by (resolution, indicated bitrate)
+            // with a two-sample debounce. Resolution and bitrate come
+            // from independent observers and can be briefly mismatched
+            // mid-shift; require a candidate to repeat once before
+            // committing it to avoid phantom lanes.
             const variantRes = String(session.player_metrics_video_resolution || '').trim();
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
                 const variantKey = `${variantRes}|${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
-                if (prevVariant !== variantKey) {
+                const pending = pendingVariantBySession.get(String(key));
+                if (prevVariant === variantKey) {
+                    if (pending) pendingVariantBySession.delete(String(key));
+                } else if (pending && pending.key === variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
                     eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                     lastRecordedVariantBySession.set(String(key), variantKey);
+                    pendingVariantBySession.delete(String(key));
+                } else {
+                    pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
                 }
             }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -609,10 +609,11 @@
             overflow: visible !important;
         }
         .events-timeline-wrap .vis-label,
-        .events-timeline-wrap .vis-label.vis-nested-group {
+        .events-timeline-wrap .vis-label.vis-nested-group,
+        .events-timeline-wrap .vis-label[class*="vis-group-level"] {
             overflow: visible !important;
             white-space: nowrap !important;
-            padding-left: 4px !important;
+            padding-left: 8px !important;
             z-index: 10;
             position: relative;
             color: #1f2937;
@@ -626,6 +627,13 @@
             border-top: none !important;
             border-left: none !important;
             border-right: none !important;
+        }
+        /* Top-level section headers (PLAYER / SERVER) sit flush. */
+        .events-timeline-wrap .vis-label.vis-group-level-0 {
+            padding-left: 4px !important;
+        }
+        .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
+            padding-left: 0 !important;
         }
         .events-timeline-legend {
             display: none;
@@ -5068,8 +5076,7 @@
             const variantGroupIds = variantGroups.map((g) => g.id);
 
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: ['VARIANT_GROUP', ...playerLanes] },
-                { id: 'VARIANT_GROUP', content: 'VARIANT', nestedGroups: variantGroupIds.length ? variantGroupIds : null },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes] },
                 ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
                 { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4860,9 +4860,9 @@
         }
         function variantLabel(mbps, resolution) {
             const m = Number(mbps);
-            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)} Mbps` : '';
+            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)}Mbps` : '';
             const res = String(resolution || '').trim();
-            if (res && mbpsStr) return `${res} · ${mbpsStr}`;
+            if (res && mbpsStr) return `${res}:${mbpsStr}`;
             return res || mbpsStr || '—';
         }
         function manifestResolutionForBitrate(session, mbps) {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -954,6 +954,10 @@
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
+        // Per-session "follow live" flag — see testing.html for the
+        // full rationale. Skips the per-tick setWindow when the user
+        // has zoomed/panned away from the live edge.
+        const eventsTimelineFollowLive = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -5034,17 +5038,33 @@
                         orientation: { axis: 'top' },
                         height: heightPx,
                         start: liveStart,
-                        end: liveEnd
+                        end: liveEnd,
+                        // Match Chart.js zoom UX: plain wheel = page
+                        // scroll; Alt/Option + wheel = zoom; left-drag
+                        // = pan.
+                        zoomKey: 'altKey',
+                        horizontalScroll: false,
+                        zoomMin: 1000,
+                        zoomMax: 6 * 60 * 60 * 1000
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                eventsTimelineFollowLive.set(sessionId, true);
+                timeline.on('rangechanged', (props) => {
+                    if (!props || !props.byUser) return;
+                    const rightEdge = props.end.getTime();
+                    const driftMs = Math.abs(Date.now() - rightEdge);
+                    eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
+                });
                 requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
                 timeline.setOptions({ height: heightPx });
-                timeline.setWindow(liveStart, liveEnd, { animation: false });
+                if (eventsTimelineFollowLive.get(sessionId) !== false) {
+                    timeline.setWindow(liveStart, liveEnd, { animation: false });
+                }
             }
         }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1002,6 +1002,9 @@
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
+        // Per-session collapse state for the PLAYER / SERVER sections
+        // — see testing.html for full rationale.
+        const eventsTimelineSectionCollapsed = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -5060,6 +5063,19 @@
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
+            const existingTimeline = eventsTimelines.get(sessionId);
+            if (existingTimeline && existingTimeline.groupsData) {
+                const live = eventsTimelineSectionCollapsed.get(sessionId) || {};
+                const p = existingTimeline.groupsData.get('PLAYER_SECTION');
+                const s = existingTimeline.groupsData.get('SERVER_SECTION');
+                if (p) live.player = (p.showNested === false);
+                if (s) live.server = (s.showNested === false);
+                eventsTimelineSectionCollapsed.set(sessionId, live);
+            }
+            const sectionState = eventsTimelineSectionCollapsed.get(sessionId) || {};
+            const playerShowNested = !sectionState.player;
+            const serverShowNested = !sectionState.server;
+
             // VARIANT subgroups: one lane per (resolution, bitrate).
             // Multi-bitrate-per-resolution is a real ladder pattern.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
@@ -5084,10 +5100,10 @@
             const variantGroupIds = variantGroups.map((g) => g.id);
 
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes] },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes], showNested: playerShowNested },
                 ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
-                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
+                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes, showNested: serverShowNested },
                 ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
             ];
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4098,6 +4098,8 @@
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'loop_marker') return 'LOOP';
             if (eventType === 'playing') return 'PLAYING';
+            if (eventType === 'buffering_start') return 'BUFFERING';
+            if (eventType === 'rate_shift_up' || eventType === 'rate_shift_down') return 'SHIFT';
             return null;
         }
 
@@ -4624,7 +4626,9 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
-            'PLAYING':     { y: 5, color: '#16a34a', label: 'PLAYING' },
+            'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
+            'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
+            'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -4738,7 +4742,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 5.5,
+                                type: 'linear', min: 0.5, max: 7.5,
                                 title: {
                                     display: true,
                                     text: 'Events',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5259,9 +5259,8 @@
                         height: heightPx,
                         start: liveStart,
                         end: liveEnd,
-                        // Match the Chart.js charts' HH:MM:SS 24-hour
-                        // tick format; suppress the "Sat 25 April"
-                        // major-label strip.
+                        // Match Chart.js HH:MM:SS, fixed 60s spacing.
+                        timeAxis: { scale: 'second', step: 60 },
                         format: {
                             minorLabels: {
                                 millisecond: 'HH:mm:ss',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4097,6 +4097,7 @@
             if (eventType === 'stall_start' || eventType === 'segment_stall' || eventType === 'frozen') return 'STALL';
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'loop_marker') return 'LOOP';
+            if (eventType === 'playing') return 'PLAYING';
             return null;
         }
 
@@ -4623,6 +4624,7 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
+            'PLAYING':     { y: 5, color: '#16a34a', label: 'PLAYING' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -4736,7 +4738,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 4.5,
+                                type: 'linear', min: 0.5, max: 5.5,
                                 title: {
                                     display: true,
                                     text: 'Events',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -598,32 +598,27 @@
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
+        /* Float vis-timeline's left label panel over the chart so the
+         * time axis uses the full container width and aligns with the
+         * Chart.js charts; lane labels overlay on top of items. */
         .events-timeline-wrap .vis-left.vis-panel {
-            display: none !important;
+            position: absolute !important;
+            left: 0 !important;
+            top: 0 !important;
+            z-index: 5;
+            background: rgba(255, 255, 255, 0.85);
+            border-right: 1px solid rgba(0, 0, 0, 0.05);
+            pointer-events: none;
         }
         .events-timeline-wrap .vis-center.vis-panel {
             left: 0 !important;
             border-left: none !important;
         }
+        .events-timeline-wrap .vis-label {
+            background: transparent !important;
+        }
         .events-timeline-legend {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px 12px;
-            margin-bottom: 6px;
-            font-size: 10px;
-            font-family: 'Courier New', monospace;
-            color: #4b5563;
-        }
-        .events-timeline-legend .legend-item {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-        }
-        .events-timeline-legend .legend-swatch {
-            width: 10px;
-            height: 10px;
-            border-radius: 2px;
-            display: inline-block;
+            display: none;
         }
 
         .abrchar-panel {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4690,16 +4690,15 @@
                 }
             }
 
-            // PLAYERSTATE lane: sample player_metrics_state on each refresh
-            // tick and emit a marker on every transition. Derived purely
-            // from heartbeat data, so it works for both Apple (state_change
-            // events) and Android (heartbeat carries player_metrics_state).
+            // PLAYERSTATE: sample state + AVPlayer waiting reason
+            // (player_metrics_waiting_reason) for tooltip detail.
             const stateValue = String(session.player_metrics_state || '').trim();
+            const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
                 const prevState = lastRecordedPlayerStateBySession.get(String(key));
                 if (prevState !== stateValue) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue });
+                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                     lastRecordedPlayerStateBySession.set(String(key), stateValue);
@@ -4932,7 +4931,7 @@
 
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
 
             const datasets = Object.entries(EVENT_LANES).map(([laneKey, cfg]) => {
@@ -4941,7 +4940,7 @@
                     return lane === laneKey;
                 }).map((e) => ({
                     x: e.x, y: cfg.y, ts: e.ts,
-                    type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution
+                    type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution
                 }));
                 let colors = cfg.color;
                 if (laneKey === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
@@ -5000,7 +4999,11 @@
                                             : '';
                                         let extra = '';
                                         if (ctx && ctx.raw) {
-                                            if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
+                                            if (ctx.raw.state) {
+                                                extra = ctx.raw.reason
+                                                    ? `: ${ctx.raw.state} (${ctx.raw.reason})`
+                                                    : `: ${ctx.raw.state}`;
+                                            }
                                             else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
                                             else if (ctx.raw.type && EVENT_SUBTYPE_LABEL[ctx.raw.type]) extra = `: ${EVENT_SUBTYPE_LABEL[ctx.raw.type]}`;
                                         }
@@ -5173,8 +5176,13 @@
                 }
             }
 
+            // PLAYERSTATE label includes the AVPlayer waiting reason
+            // (when present) — e.g. "buffering (toMinimizeStalls)".
             pushRanges('PLAYERSTATE',
-                (e) => e.state || 'Unknown',
+                (e) => {
+                    const s = e.state || 'Unknown';
+                    return e.reason ? `${s} (${e.reason})` : s;
+                },
                 (e) => playerStateColor(e.state));
             pushRanges('DISPLAY_RES',
                 (e) => String(e.resolution || '?'),

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -941,6 +941,7 @@
         const bandwidthVariantsEnabledBySession = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
+        const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -4587,6 +4588,22 @@
                 }
             }
 
+            // PLAYERSTATE lane: sample player_metrics_state on each refresh
+            // tick and emit a marker on every transition. Derived purely
+            // from heartbeat data, so it works for both Apple (state_change
+            // events) and Android (heartbeat carries player_metrics_state).
+            const stateValue = String(session.player_metrics_state || '').trim();
+            if (stateValue) {
+                const prevState = lastRecordedPlayerStateBySession.get(String(key));
+                if (prevState !== stateValue) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                    lastRecordedPlayerStateBySession.set(String(key), stateValue);
+                }
+            }
+
             const series = bandwidthHistory.get(key) || [];
             if (!Number.isFinite(target)) {
                 const lastTarget = series.length > 0 ? series[series.length - 1].target : null;
@@ -4626,6 +4643,7 @@
         // #f59e0b/#6366f1/#115e59 etc.). Hot pink, deep purple, cyan, and lime
         // don't collide with any of the throughput/rendition/limit colors.
         const EVENT_LANES = {
+            'PLAYERSTATE': { y: 8, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
             'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
@@ -4634,6 +4652,18 @@
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
+        // Per-state colour for the PLAYERSTATE lane — each dot's colour
+        // tells you what the player thought it was doing at that tick.
+        const PLAYER_STATE_COLOR = {
+            'Playing':   '#16a34a',
+            'Buffering': '#f59e0b',
+            'Paused':    '#9333ea',
+            'Idle':      '#6b7280',
+            'Unknown':   '#d1d5db'
+        };
+        function playerStateColor(s) {
+            return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+        }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
         const legendHoverCallbacks = {
@@ -4671,18 +4701,24 @@
 
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
 
-            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
-                label: cfg.label,
-                data: chartEvents.filter((e) => e.type === type).map((e) => ({ x: e.x, y: cfg.y, ts: e.ts })),
-                backgroundColor: cfg.color,
-                borderColor: cfg.color,
-                pointRadius: 5,
-                pointHoverRadius: 7,
-                showLine: false,
-            }));
+            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
+                const points = chartEvents.filter((e) => e.type === type)
+                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state }));
+                const isPlayerState = type === 'PLAYERSTATE';
+                const colors = isPlayerState ? points.map(p => playerStateColor(p.state)) : cfg.color;
+                return {
+                    label: cfg.label,
+                    data: points,
+                    backgroundColor: colors,
+                    borderColor: colors,
+                    pointRadius: 5,
+                    pointHoverRadius: 7,
+                    showLine: false,
+                };
+            });
 
             let chart = eventsCharts.get(sessionId);
             if (chart && chart.canvas !== canvas) {
@@ -4721,7 +4757,8 @@
                                         const offset = Number.isFinite(ts) && startMs > 0
                                             ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
                                             : '';
-                                        return `${ctx.dataset.label}${offset}`;
+                                        const state = ctx && ctx.raw && ctx.raw.state ? `: ${ctx.raw.state}` : '';
+                                        return `${ctx.dataset.label}${state}${offset}`;
                                     }
                                 }
                             },
@@ -4742,7 +4779,7 @@
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 7.5,
+                                type: 'linear', min: 0.5, max: 8.5,
                                 title: {
                                     display: true,
                                     text: 'Events',

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -581,7 +581,6 @@
             margin-bottom: 0 !important;
         }
         .events-timeline-wrap {
-            min-height: 240px;
             margin-bottom: 12px;
             position: relative;
         }
@@ -5027,11 +5026,10 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Auto-grow with no maxHeight cap so all lanes
-                        // are visible; vis-timeline's internal scroll
-                        // hides the top rows when capped.
+                        // Auto-grow with no min/max so all lanes are
+                        // visible; vis-timeline scrolls internally and
+                        // hides top rows whenever a constraint kicks in.
                         height: 'auto',
-                        minHeight: '240px',
                         start: liveStart,
                         end: liveEnd
                     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5027,9 +5027,11 @@
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
+                        // Auto-grow with no maxHeight cap so all lanes
+                        // are visible; vis-timeline's internal scroll
+                        // hides the top rows when capped.
                         height: 'auto',
                         minHeight: '240px',
-                        maxHeight: '700px',
                         start: liveStart,
                         end: liveEnd
                     }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4248,6 +4248,16 @@
         }
 
         function readChartViewport(chartRef) {
+            if (!chartRef) return null;
+            // vis-timeline branch (see testing.html for rationale).
+            if (chartRef.$isVisTimeline && typeof chartRef.getWindow === 'function') {
+                const win = chartRef.getWindow();
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return null;
+                const min = (win.start.getTime() - startMs) / 1000;
+                const max = (win.end.getTime() - startMs) / 1000;
+                return normalizeChartViewport(min, max);
+            }
             const xScale = chartRef?.scales?.x;
             if (!xScale) return null;
             return normalizeChartViewport(xScale.min, xScale.max);
@@ -4255,6 +4265,16 @@
 
         function applyChartViewport(chartRef, viewport) {
             if (!chartRef || !viewport) return;
+            if (chartRef.$isVisTimeline && typeof chartRef.setWindow === 'function') {
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return;
+                chartRef.setWindow(
+                    new Date(startMs + viewport.min * 1000),
+                    new Date(startMs + viewport.max * 1000),
+                    { animation: false }
+                );
+                return;
+            }
             if (typeof chartRef.zoomScale === 'function') {
                 // Use the plugin API so the zoom state is stored inside the plugin and
                 // survives future chart.update() calls (direct options writes get overridden
@@ -4279,7 +4299,8 @@
                 eventsCharts.get(key),
                 bandwidthCharts.get(key),
                 bufferDepthCharts.get(key),
-                videoFpsCharts.get(key)
+                videoFpsCharts.get(key),
+                eventsTimelines.get(key)
             ].filter((chartRef) => !!chartRef);
         }
 
@@ -5050,11 +5071,18 @@
                 );
                 eventsTimelines.set(sessionId, timeline);
                 eventsTimelineFollowLive.set(sessionId, true);
+                // Tag for the cross-chart viewport sync; anchor seconds-
+                // from-windowStart so vis-timeline ranges convert to the
+                // 0–600 units the Chart.js charts use.
+                timeline.$isVisTimeline = true;
+                timeline.$windowStartMs = liveStart.getTime();
+                applyStoredChartViewport(sessionId, timeline);
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
                     const rightEdge = props.end.getTime();
                     const driftMs = Math.abs(Date.now() - rightEdge);
                     eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
+                    syncChartViewportAcrossSession(sessionId, timeline);
                 });
                 requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
@@ -5062,6 +5090,7 @@
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
                 timeline.setOptions({ height: heightPx });
+                timeline.$windowStartMs = liveStart.getTime();
                 if (eventsTimelineFollowLive.get(sessionId) !== false) {
                     timeline.setWindow(liveStart, liveEnd, { animation: false });
                 }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -598,6 +598,33 @@
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
+        .events-timeline-wrap .vis-left.vis-panel {
+            display: none !important;
+        }
+        .events-timeline-wrap .vis-center.vis-panel {
+            left: 0 !important;
+            border-left: none !important;
+        }
+        .events-timeline-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px 12px;
+            margin-bottom: 6px;
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+            color: #4b5563;
+        }
+        .events-timeline-legend .legend-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .events-timeline-legend .legend-swatch {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+            display: inline-block;
+        }
 
         .abrchar-panel {
             margin-bottom: 12px;
@@ -4987,6 +5014,13 @@
             if (!container) {
                 console.warn('[events-timeline] container .events-timeline not in DOM for session', sessionId);
                 return;
+            }
+            const legendEl = card.querySelector('.events-timeline-legend');
+            if (legendEl) {
+                const baseLegend = Object.entries(EVENT_LANES)
+                    .map(([type, cfg]) => `<span class="legend-item"><span class="legend-swatch" style="background:${cfg.color}"></span>${cfg.label}</span>`)
+                    .join('');
+                legendEl.innerHTML = baseLegend;
             }
 
             const nowMs = Date.now();

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -621,9 +621,21 @@ maybe a histogram of b
             border-right: none !important;
         }
         /* Top-level section headers (PLAYER / SERVER) sit at the
-         * leftmost edge — no indent. */
+         * leftmost edge — no indent — and stay compact since they
+         * have no items themselves; they're just visual dividers. */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
+            height: 24px !important;
+            min-height: 24px !important;
+            max-height: 24px !important;
+        }
+        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0 {
+            height: 24px !important;
+            min-height: 24px !important;
+            max-height: 24px !important;
+        }
+        .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
+            height: 24px !important;
         }
         /* vis-timeline applies the per-level indent via inline style
          * on the inner label cell — override that too. */

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2302,18 +2302,21 @@ maybe a histogram of b
                 }
             }
 
-            // VARIANT lane: sample player_metrics_video_bitrate_mbps on
-            // each refresh and emit a marker on every change. Dedup by
-            // BITRATE ONLY (rounded to 0.1 Mbps) — resolution can briefly
-            // be empty/null between samples on some clients, which would
-            // create spurious "new variant" entries with the same bitrate
-            // but different resolution strings. Resolution travels along
-            // for labelling only.
-            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
-                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
-                const variantRes = String(session.player_metrics_video_resolution || '').trim();
-                const variantKey = `${variantMbps}`;
+            // VARIANT lane: dedup by RESOLUTION, not bitrate.
+            // player_metrics_video_bitrate_mbps reports the actual
+            // segment bitrate which fluctuates with scene complexity
+            // even within one rendition (a high-motion 1080p segment
+            // can be 3x the bitrate of a low-motion 1080p segment).
+            // Resolution is stable per rendition, so it's the correct
+            // identity for an ABR variant. Skip ticks where resolution
+            // is missing rather than dedupe against an empty value
+            // (would briefly drop the active variant from the lane).
+            const variantRes = String(session.player_metrics_video_resolution || '').trim();
+            if (variantRes) {
+                const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+                const variantMbps = Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0
+                    ? Math.round(variantMbpsRaw * 10) / 10 : 0;
+                const variantKey = variantRes;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -2660,25 +2663,27 @@ maybe a histogram of b
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
-            // VARIANT subgroups: one lane per observed bitrate in the
-            // current window, ordered DESCENDING — highest at the top,
-            // lowest at the bottom — so the visual ladder matches how
-            // an ABR ladder is normally drawn. Lane key is bitrate
-            // alone; we keep the latest non-empty resolution for the
-            // label so a brief empty-resolution sample doesn't spawn
-            // a phantom lane.
+            // VARIANT subgroups: one lane per observed RESOLUTION in
+            // the current window. Lane key is resolution because each
+            // rendition has a unique resolution; bitrate fluctuates per
+            // segment within one rendition and would split into phantom
+            // lanes. Bitrate is kept (latest seen for that resolution)
+            // for sorting and labelling.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            const seenVariants = new Map(); // key (mbps) -> {mbps, resolution}
+            const seenVariants = new Map(); // key (resolution) -> {mbps, resolution}
             for (const v of variantEvents) {
+                const res = String(v.resolution || '').trim();
+                if (!res) continue;
                 const m = Number(v.mbps);
-                const k = `${m}`;
-                const existing = seenVariants.get(k);
+                const existing = seenVariants.get(res);
                 if (!existing) {
-                    seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
-                } else if (v.resolution && !existing.resolution) {
-                    existing.resolution = v.resolution;
+                    seenVariants.set(res, { mbps: m, resolution: res });
+                } else if (Number.isFinite(m) && m > 0) {
+                    existing.mbps = m; // keep the most recent bitrate for that resolution
                 }
             }
+            // Sort by bitrate DESCENDING (highest at top), so the visual
+            // ladder matches how ABR ladders are normally drawn.
             const variantOrder = Array.from(seenVariants.entries())
                 .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
@@ -2725,21 +2730,23 @@ maybe a histogram of b
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each bitrate gets its own swim lane. Lane key
-            // matches seenVariants — bitrate-only, so the segment goes
-            // into the right row regardless of any flicker on the
-            // resolution string.
+            // VARIANT: each resolution gets its own swim lane. Lane key
+            // matches seenVariants — resolution. Colour is bucketed by
+            // the segment's bitrate so high-motion (high-bitrate) and
+            // low-motion (low-bitrate) segments within one rendition
+            // are visible as colour shifts inside the same row.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
+                const res = String(v.resolution || '').trim();
+                if (!res) continue;
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const m = Number(v.mbps);
-                const k = `${m}`;
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${k}`,
+                    group: `VARIANT::${res}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -724,6 +724,13 @@ maybe a histogram of b
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedVariantBySession = new Map();
+        // Two-sample debounce for VARIANT: holds the most recent
+        // unconfirmed (res, bitrate) candidate. Only when the same
+        // tuple shows up twice in a row do we commit it as a variant
+        // event — single-sample mismatches between the resolution
+        // observer and the bitrate observer no longer create phantom
+        // lanes (e.g. "3840x2160 @ 3.5 Mbps" mid-upshift).
+        const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -2331,24 +2338,32 @@ maybe a histogram of b
             // VARIANT lane: dedup by (resolution, indicated bitrate).
             // ABR ladders can legitimately have multiple variants at the
             // same resolution but different bitrates (e.g. H.264 + HEVC
-            // at 1080p, or two quality presets), so resolution alone
-            // collapses real variants together. The bitrate is the
-            // manifest BANDWIDTH attribute (player_metrics_video_bitrate_mbps
-            // is iOS indicatedBitrate / Android Format.bitrate, both stable
-            // per rendition), so this is safe to use as identity now.
-            // Skip ticks where either is missing.
+            // at 1080p), so resolution alone collapses real variants.
+            // Two-sample debounce filters out transition skew —
+            // resolution and bitrate come from independent observers
+            // and can be briefly mismatched mid-shift, which would
+            // otherwise create phantom lanes like "3840x2160 @ 3.5 Mbps".
             const variantRes = String(session.player_metrics_video_resolution || '').trim();
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
                 const variantKey = `${variantRes}|${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
-                if (prevVariant !== variantKey) {
+                const pending = pendingVariantBySession.get(String(key));
+                if (prevVariant === variantKey) {
+                    // Already-committed variant — clear any stale pending.
+                    if (pending) pendingVariantBySession.delete(String(key));
+                } else if (pending && pending.key === variantKey) {
+                    // Two consecutive matching samples — commit.
                     const eventSeries = bandwidthEventHistory.get(key) || [];
                     eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                     lastRecordedVariantBySession.set(String(key), variantKey);
+                    pendingVariantBySession.delete(String(key));
+                } else {
+                    // First-seen candidate — hold it for one sample.
+                    pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
                 }
             }
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -743,12 +743,6 @@ maybe a histogram of b
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
-        // Per-session "follow live" flag. True = right edge tracks "now"
-        // every tick. Flips to false the moment the user zooms or pans
-        // manually, so the zoom state isn't clobbered by the per-second
-        // setWindow call. Re-enabled when the user pans/zooms back to a
-        // window whose right edge is within 5s of "now".
-        const eventsTimelineFollowLive = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -2982,7 +2976,6 @@ maybe a histogram of b
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
-                eventsTimelineFollowLive.set(sessionId, true);
                 // Tag for the cross-chart viewport sync helpers, anchor
                 // the seconds-from-windowStart frame to liveStart so
                 // vis-timeline ranges convert consistently to the 0–600
@@ -2992,16 +2985,25 @@ maybe a histogram of b
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
                 timeline.$container = container;
-                // If another chart in this session already has a stored
-                // viewport, apply it so the timeline starts in sync.
                 applyStoredChartViewport(sessionId, timeline);
-                // Detect user pan/zoom: rangechanged with byUser=true.
+                // After a user-driven range change (zoom or pan): if
+                // the chart is NOT paused, re-snap the right edge to
+                // "now" while preserving whatever zoom width the user
+                // landed on. This matches the Chart.js charts'
+                // live-mode behaviour — they auto-track live edge
+                // unless the explicit pause button is engaged. When
+                // paused, accept the user's range as-is.
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
-                    const rightEdge = props.end.getTime();
-                    const driftMs = Math.abs(Date.now() - rightEdge);
-                    eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
                     syncChartViewportAcrossSession(sessionId, timeline);
+                    if (isChartPaused(sessionId)) return;
+                    const width = props.end.getTime() - props.start.getTime();
+                    const nowMsLocal = Date.now();
+                    timeline.setWindow(
+                        new Date(nowMsLocal - width),
+                        new Date(nowMsLocal),
+                        { animation: false }
+                    );
                 });
                 // Container width is sometimes 0 on first paint (parent
                 // ScrollView not yet laid out, session card just inserted,
@@ -3030,14 +3032,20 @@ maybe a histogram of b
                 // Re-apply height each render — group count changes as
                 // variant lanes appear/disappear.
                 timeline.setOptions({ height: heightPx });
-                // Update the windowStart anchor for viewport conversions
-                // so they stay valid as "now" advances.
                 timeline.$windowStartMs = liveStart.getTime();
-                // Only slide back to "now" if the user hasn't manually
-                // panned/zoomed away. Otherwise we'd clobber their
-                // zoom state every render tick.
-                if (eventsTimelineFollowLive.get(sessionId) !== false) {
-                    timeline.setWindow(liveStart, liveEnd, { animation: false });
+                // Live-edge tracking: unless the user has explicitly
+                // paused the chart, slide the visible window so its
+                // right edge stays pinned to "now". Preserve whatever
+                // zoom width the user has set — only the position
+                // moves, not the width.
+                if (!isChartPaused(sessionId)) {
+                    const win = timeline.getWindow();
+                    const width = win.end.getTime() - win.start.getTime();
+                    timeline.setWindow(
+                        new Date(nowMs - width),
+                        new Date(nowMs),
+                        { animation: false }
+                    );
                 }
             }
         }

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2379,17 +2379,20 @@ maybe a histogram of b
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
-        // Per-state colour for the PLAYERSTATE lane — each dot's colour
-        // tells you what the player thought it was doing at that tick.
+        // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
+        // because clients emit a mix of casings ("Playing" on Apple,
+        // "playing" on Android-test/Roku/web) — playerStateColor()
+        // normalises before lookup so all map to the same colour.
         const PLAYER_STATE_COLOR = {
-            'Playing':   '#16a34a',
-            'Buffering': '#f59e0b',
-            'Paused':    '#9333ea',
-            'Idle':      '#6b7280',
-            'Unknown':   '#d1d5db'
+            'playing':   '#16a34a', // green
+            'buffering': '#f59e0b', // amber
+            'paused':    '#9333ea', // purple
+            'idle':      '#6b7280', // gray
+            'ended':     '#1f2937', // near-black
+            'unknown':   '#d1d5db'  // light gray
         };
         function playerStateColor(s) {
-            return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+            return PLAYER_STATE_COLOR[String(s || '').trim().toLowerCase()] || '#d1d5db';
         }
         // Variant colour buckets — lower bitrate = redder, higher = greener.
         // Drives the colour of segments / dots on the VARIANT swim lane so

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -598,10 +598,11 @@ maybe a histogram of b
             overflow: visible !important;
         }
         .events-timeline-wrap .vis-label,
-        .events-timeline-wrap .vis-label.vis-nested-group {
+        .events-timeline-wrap .vis-label.vis-nested-group,
+        .events-timeline-wrap .vis-label[class*="vis-group-level"] {
             overflow: visible !important;
             white-space: nowrap !important;
-            padding-left: 4px !important;
+            padding-left: 8px !important;
             z-index: 10;
             position: relative;
             color: #1f2937;
@@ -618,6 +619,16 @@ maybe a histogram of b
             border-top: none !important;
             border-left: none !important;
             border-right: none !important;
+        }
+        /* Top-level section headers (PLAYER / SERVER) sit at the
+         * leftmost edge — no indent. */
+        .events-timeline-wrap .vis-label.vis-group-level-0 {
+            padding-left: 4px !important;
+        }
+        /* vis-timeline applies the per-level indent via inline style
+         * on the inner label cell — override that too. */
+        .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
+            padding-left: 0 !important;
         }
         .events-timeline-legend {
             display: none;
@@ -2846,8 +2857,7 @@ maybe a histogram of b
             const variantGroupIds = variantGroups.map((g) => g.id);
 
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: ['VARIANT_GROUP', ...playerLanes] },
-                { id: 'VARIANT_GROUP', content: 'VARIANT', nestedGroups: variantGroupIds.length ? variantGroupIds : null },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes] },
                 ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
                 { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -3108,6 +3108,18 @@ maybe a histogram of b
                         { animation: false }
                     );
                 });
+                // Click toggles pause (matches Chart.js
+                // installChartClickPauseHandler). Skip clicks on the
+                // group label / collapse arrow (those expand/collapse
+                // sections) and skip Alt-clicks (Alt is the zoom
+                // modifier). vis-timeline already distinguishes click
+                // from drag — `click` only fires on a real click.
+                timeline.on('click', (props) => {
+                    if (!props) return;
+                    if (props.event && props.event.altKey) return;
+                    if (props.what === 'group-label') return;
+                    toggleChartPause(sessionId);
+                });
                 // Container width is sometimes 0 on first paint (parent
                 // ScrollView not yet laid out, session card just inserted,
                 // etc). A single requestAnimationFrame isn't reliable —

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2759,6 +2759,13 @@ maybe a histogram of b
                 });
             }
 
+            // Live-edge window: same 10-minute span as the other charts,
+            // right edge anchored to "now" so events scroll left as time
+            // advances. Updated on every render so the view tracks live.
+            const liveWindowMs = 10 * 60 * 1000;
+            const liveStart = new Date(nowMs - liveWindowMs);
+            const liveEnd = new Date(nowMs);
+
             let timeline = eventsTimelines.get(sessionId);
             if (!timeline) {
                 timeline = new vis.Timeline(
@@ -2779,10 +2786,8 @@ maybe a histogram of b
                         height: 'auto',
                         minHeight: '240px',
                         maxHeight: '700px',
-                        // Default visible window = last 10 minutes through now.
-                        // No min/max so panning forward/back works freely.
-                        start: new Date(nowMs - 600 * 1000),
-                        end: new Date(nowMs)
+                        start: liveStart,
+                        end: liveEnd
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
@@ -2794,6 +2799,11 @@ maybe a histogram of b
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
+                // Slide the visible window so "now" stays pinned to the
+                // right edge — matches the bitrate / buffer chart
+                // live-edge behaviour. animation:false avoids per-tick
+                // jitter.
+                timeline.setWindow(liveStart, liveEnd, { animation: false });
             }
         }
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1927,6 +1927,7 @@ maybe a histogram of b
             if (eventType === 'video_start_time') return 'START_TIME';
             if (eventType === 'rate_shift_up') return 'SHIFT_UP';
             if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
+            if (eventType === 'timejump') return 'TIMEJUMP';
             return null;
         }
 
@@ -2463,19 +2464,20 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'VARIANT':       { y: 16, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES':   { y: 15, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE':   { y: 14, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':       { y: 13, color: '#16a34a', label: 'PLAYING' },
-            'FIRST_FRAME':   { y: 12, color: '#14b8a6', label: 'FIRST FRAME' },
-            'START_TIME':    { y: 11, color: '#15803d', label: 'START TIME' },
-            'BUFFERING':     { y: 10, color: '#f59e0b', label: 'BUFFERING' },
-            'STALL':         { y: 9,  color: '#000000', label: 'STALL' },
-            'FROZEN':        { y: 8,  color: '#4c1d95', label: 'FROZEN' },
-            'SEGMENT_STALL': { y: 7,  color: '#c2410c', label: 'SEGMENT STALL' },
-            'SHIFT_UP':      { y: 6,  color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':    { y: 5,  color: '#ef4444', label: 'SHIFT DOWN' },
-            'ERROR':         { y: 4,  color: '#e11d48', label: 'ERROR' },
+            'VARIANT':       { y: 17, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES':   { y: 16, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE':   { y: 15, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':       { y: 14, color: '#16a34a', label: 'PLAYING' },
+            'FIRST_FRAME':   { y: 13, color: '#14b8a6', label: 'FIRST FRAME' },
+            'START_TIME':    { y: 12, color: '#15803d', label: 'START TIME' },
+            'BUFFERING':     { y: 11, color: '#f59e0b', label: 'BUFFERING' },
+            'STALL':         { y: 10, color: '#000000', label: 'STALL' },
+            'FROZEN':        { y: 9,  color: '#4c1d95', label: 'FROZEN' },
+            'SEGMENT_STALL': { y: 8,  color: '#c2410c', label: 'SEGMENT STALL' },
+            'SHIFT_UP':      { y: 7,  color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':    { y: 6,  color: '#ef4444', label: 'SHIFT DOWN' },
+            'ERROR':         { y: 5,  color: '#e11d48', label: 'ERROR' },
+            'TIMEJUMP':      { y: 4,  color: '#d97706', label: 'TIMEJUMP' },
             'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
@@ -2733,7 +2735,12 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 16.5,
+                                type: 'linear', min: 0.5, max: 17.5,
+                                // Force a fixed Y-axis width so this chart's
+                                // X-axis lines up vertically with the bandwidth /
+                                // buffer / fps charts below (they all use the
+                                // same afterFit width).
+                                afterFit: (axis) => { axis.width = 90; },
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,
@@ -3479,6 +3486,7 @@ maybe a histogram of b
                             y: {
                                 min: 0,
                                 max: maxY,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',
@@ -3618,6 +3626,7 @@ maybe a histogram of b
                             y: {
                                 min: 0,
                                 max: maxBufferDepth,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',
@@ -3917,6 +3926,7 @@ maybe a histogram of b
                             y: {
                                 min: 0,
                                 max: maxFps,
+                                afterFit: (axis) => { axis.width = 90; },
                                 grid: { color: '#e5e7eb' },
                                 ticks: {
                                     color: '#6b7280',

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -636,6 +636,31 @@ maybe a histogram of b
         .events-timeline-wrap .vis-time-axis .vis-text {
             padding: 0 4px !important;
         }
+        /* Hide vis-timeline's calendar-anchored tick labels — we draw
+         * our own right-edge-anchored ones via addCustomTime markers
+         * so the user sees timestamps like 13:34:41 (one minute back
+         * from "now") instead of 13:34:00 (clock-snapped). The grid
+         * lines stay so the chart still has visual structure. */
+        .events-timeline-wrap .vis-time-axis .vis-text.vis-minor {
+            visibility: hidden !important;
+        }
+        /* Style our right-edge-anchored tick markers like the default
+         * grid lines plus a small floating timestamp label. */
+        .events-timeline-wrap .vis-custom-time {
+            background-color: rgba(0, 0, 0, 0.15) !important;
+            width: 1px !important;
+            cursor: default !important;
+        }
+        .events-timeline-wrap .vis-custom-time .vis-custom-time-marker {
+            background: rgba(255, 255, 255, 0.92) !important;
+            border: 1px solid rgba(0, 0, 0, 0.08) !important;
+            border-radius: 2px !important;
+            color: #4b5563 !important;
+            font-family: 'Courier New', monospace !important;
+            font-size: 10px !important;
+            padding: 0 3px !important;
+            top: 2px !important;
+        }
         /* vis-timeline applies the per-level indent via inline style
          * on the inner label cell — override that too. */
         .events-timeline-wrap .vis-labelset .vis-label .vis-inner {
@@ -3220,6 +3245,51 @@ maybe a histogram of b
                         { animation: false }
                     );
                 }
+            }
+
+            // Right-edge-anchored tick LABELS — placed at the
+            // timestamps of the actual events in the visible window
+            // (deduped to 1-second resolution to keep the marker
+            // count manageable). vis-timeline's default minor labels
+            // are hidden via CSS; these custom-time markers replace
+            // them so the user sees real event timestamps like
+            // "13:34:41" instead of clock-snapped "13:34:00".
+            refreshEventTickMarkers(timeline, events, nowMs - liveWindowMs, nowMs);
+        }
+
+        // Add / update / remove vis-timeline custom-time markers so
+        // there's exactly one per unique event-second in the visible
+        // window. Each marker draws a vertical line and a floating
+        // HH:MM:SS label.
+        function refreshEventTickMarkers(timeline, events, windowStartMs, windowEndMs) {
+            if (!timeline.$tickIds) timeline.$tickIds = new Set();
+            const fmt = (ms) => {
+                const d = new Date(ms);
+                return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
+            };
+            const desired = new Map(); // id -> ts
+            for (const e of (events || [])) {
+                const ts = Number(e.ts);
+                if (!Number.isFinite(ts) || ts < windowStartMs || ts > windowEndMs) continue;
+                const sec = Math.floor(ts / 1000) * 1000;
+                const id = `event-tick-${sec}`;
+                if (!desired.has(id)) desired.set(id, sec);
+            }
+            // Remove markers that no longer correspond to a visible event.
+            for (const id of Array.from(timeline.$tickIds)) {
+                if (!desired.has(id)) {
+                    try { timeline.removeCustomTime(id); } catch (e) {}
+                    timeline.$tickIds.delete(id);
+                }
+            }
+            // Add markers for new events.
+            for (const [id, t] of desired) {
+                if (timeline.$tickIds.has(id)) continue;
+                try {
+                    timeline.addCustomTime(new Date(t), id);
+                    timeline.$tickIds.add(id);
+                    try { timeline.setCustomTimeMarker(fmt(t), id, false); } catch (e) {}
+                } catch (e) {}
             }
         }
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -583,26 +583,21 @@ maybe a histogram of b
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
-        /* Float vis-timeline's left label panel on top of the chart's
-         * leftmost column instead of reserving space for it. The chart
-         * area uses the full container width — its time axis lines up
-         * vertically with the Chart.js bandwidth/buffer/fps charts —
-         * and the lane labels overlay on top of the items. */
+        /* Lock vis-timeline's left label panel to a fixed 90px width
+         * so it matches the Chart.js charts' Y-axis width (also 90px
+         * via afterFit). Time axis on this chart now lines up
+         * vertically with the bandwidth/buffer/fps charts below.
+         * Long labels truncate with ellipsis — the legend strip above
+         * (rendered when needed) gives the full names. */
+        .events-timeline-wrap .vis-labelset,
         .events-timeline-wrap .vis-left.vis-panel {
-            position: absolute !important;
-            left: 0 !important;
-            top: 0 !important;
-            z-index: 5;
-            background: rgba(255, 255, 255, 0.85);
-            border-right: 1px solid rgba(0, 0, 0, 0.05);
-            pointer-events: none;
-        }
-        .events-timeline-wrap .vis-center.vis-panel {
-            left: 0 !important;
-            border-left: none !important;
+            width: 90px !important;
+            max-width: 90px !important;
         }
         .events-timeline-wrap .vis-label {
-            background: transparent !important;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2765,6 +2765,18 @@ maybe a histogram of b
             const liveStart = new Date(nowMs - liveWindowMs);
             const liveEnd = new Date(nowMs);
 
+            // Compute explicit height from the actual lane count.
+            // vis-timeline's height:'auto' is unreliable when the
+            // container has no intrinsic height (its internal panels
+            // are absolutely positioned, so the wrap can't measure
+            // them). Each group row is ~30px; section parent rows
+            // add their own ~30px. Add headroom for the time axis.
+            const ROW_HEIGHT_PX = 30;
+            const AXIS_AND_PADDING_PX = 60;
+            const computedHeight = groups.length * ROW_HEIGHT_PX + AXIS_AND_PADDING_PX;
+            const heightPx = `${computedHeight}px`;
+            container.style.height = heightPx;
+
             let timeline = eventsTimelines.get(sessionId);
             if (!timeline) {
                 timeline = new vis.Timeline(
@@ -2778,24 +2790,20 @@ maybe a histogram of b
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Auto-grow to fit all groups. No min/max
-                        // constraints — they cause vis-timeline to scroll
-                        // internally and hide the top lanes. Let the
-                        // outer page scroll when the chart gets tall.
-                        height: 'auto',
+                        height: heightPx,
                         start: liveStart,
                         end: liveEnd
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
-                // Container width is sometimes 0 on first paint (ScrollView /
-                // collapsed parent); force a redraw next frame so the
-                // timeline measures its real width.
                 requestAnimationFrame(() => timeline.redraw());
-                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
+                // Re-apply height each render — group count changes as
+                // variant lanes appear/disappear.
+                timeline.setOptions({ height: heightPx });
                 // Slide the visible window so "now" stays pinned to the
                 // right edge — matches the bitrate / buffer chart
                 // live-edge behaviour. animation:false avoids per-tick

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -583,6 +583,37 @@ maybe a histogram of b
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
+        /* Hide vis-timeline's built-in left label panel so the chart
+         * area uses the full container width and lines up vertically
+         * with the Chart.js bandwidth/buffer/fps charts below. Lane
+         * legend is rendered as a separate strip above the chart. */
+        .events-timeline-wrap .vis-left.vis-panel {
+            display: none !important;
+        }
+        .events-timeline-wrap .vis-center.vis-panel {
+            left: 0 !important;
+            border-left: none !important;
+        }
+        .events-timeline-legend {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px 12px;
+            margin-bottom: 6px;
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+            color: #4b5563;
+        }
+        .events-timeline-legend .legend-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .events-timeline-legend .legend-swatch {
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+            display: inline-block;
+        }
         .chart-paused-badge {
             display: none;
             position: absolute;
@@ -2747,6 +2778,17 @@ maybe a histogram of b
             if (!container) {
                 console.warn('[events-timeline] container .events-timeline not in DOM for session', sessionId);
                 return;
+            }
+            // Render the legend strip above the chart. We hide vis-
+            // timeline's left label panel via CSS so the chart area
+            // lines up with the Chart.js charts; the legend gives back
+            // the lane → colour mapping.
+            const legendEl = card.querySelector('.events-timeline-legend');
+            if (legendEl) {
+                const baseLegend = Object.entries(EVENT_LANES)
+                    .map(([type, cfg]) => `<span class="legend-item"><span class="legend-swatch" style="background:${cfg.color}"></span>${cfg.label}</span>`)
+                    .join('');
+                legendEl.innerHTML = baseLegend;
             }
 
             const nowMs = Date.now();

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -566,16 +566,14 @@ maybe a histogram of b
             position: relative;
         }
         .events-timeline-wrap {
-            height: 240px;
+            min-height: 240px;
             margin-bottom: 12px;
             position: relative;
         }
         .events-timeline-wrap .events-timeline {
-            height: 100%;
             background: #fff;
             border: 1px solid #e5e7eb;
             border-radius: 4px;
-            overflow: hidden;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {
@@ -2774,6 +2772,13 @@ maybe a histogram of b
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
+                        // Auto-grow to fit all groups (variant lanes are
+                        // added dynamically as the player walks the
+                        // ladder), but bounded so a runaway lane count
+                        // doesn't take over the whole page.
+                        height: 'auto',
+                        minHeight: '240px',
+                        maxHeight: '700px',
                         // Default visible window = last 10 minutes through now.
                         // No min/max so panning forward/back works freely.
                         start: new Date(nowMs - 600 * 1000),

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -611,6 +611,13 @@ maybe a histogram of b
                 0 0 6px rgba(255, 255, 255, 0.85),
                 1px 0 0 rgba(255, 255, 255, 0.75),
                 -1px 0 0 rgba(255, 255, 255, 0.75);
+            /* Neutralise vis-timeline's default label borders (which
+             * inherit currentColor and were rendering as red in this
+             * theme). Subtle gray bottom border keeps row separation. */
+            border-color: rgba(0, 0, 0, 0.06) !important;
+            border-top: none !important;
+            border-left: none !important;
+            border-right: none !important;
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1864,6 +1864,7 @@ maybe a histogram of b
             if (!eventType) return null;
             if (eventType === 'stall_start' || eventType === 'segment_stall' || eventType === 'frozen') return 'STALL';
             if (eventType === 'restart') return 'RESTART';
+            if (eventType === 'playing') return 'PLAYING';
             return null;
         }
 
@@ -2305,6 +2306,7 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
+            'PLAYING':     { y: 5, color: '#16a34a', label: 'PLAYING' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -2479,7 +2481,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 4.5,
+                                type: 'linear', min: 0.5, max: 5.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -621,21 +621,28 @@ maybe a histogram of b
             border-right: none !important;
         }
         /* Top-level section headers (PLAYER / SERVER) sit at the
-         * leftmost edge — no indent — and stay compact since they
-         * have no items themselves; they're just visual dividers. */
+         * leftmost edge — no indent — and are compacted to a single
+         * label-height row since they have no items themselves. */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
-            height: 24px !important;
-            min-height: 24px !important;
-            max-height: 24px !important;
+            height: 18px !important;
+            min-height: 18px !important;
+            max-height: 18px !important;
+            line-height: 18px !important;
         }
-        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0 {
-            height: 24px !important;
-            min-height: 24px !important;
-            max-height: 24px !important;
-        }
+        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0,
         .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
-            height: 24px !important;
+            height: 18px !important;
+            min-height: 18px !important;
+            max-height: 18px !important;
+        }
+        /* Slim down the time-axis bar — vis-timeline's default leaves
+         * a lot of vertical padding above and below the tick text. */
+        .events-timeline-wrap .vis-time-axis {
+            font-size: 10px;
+        }
+        .events-timeline-wrap .vis-time-axis .vis-text {
+            padding: 0 4px !important;
         }
         /* vis-timeline applies the per-level indent via inline style
          * on the inner label cell — override that too. */
@@ -2969,17 +2976,15 @@ maybe a histogram of b
             const liveStart = new Date(nowMs - liveWindowMs);
             const liveEnd = new Date(nowMs);
 
-            // Compute explicit height from the actual lane count.
-            // vis-timeline's height:'auto' is unreliable when the
-            // container has no intrinsic height (its internal panels
-            // are absolutely positioned, so the wrap can't measure
-            // them). Each group row is ~30px; section parent rows
-            // add their own ~30px. Add headroom for the time axis.
-            const ROW_HEIGHT_PX = 30;
-            const AXIS_AND_PADDING_PX = 60;
-            const computedHeight = groups.length * ROW_HEIGHT_PX + AXIS_AND_PADDING_PX;
-            const heightPx = `${computedHeight}px`;
-            container.style.height = heightPx;
+            // Let vis-timeline size itself to its actual content
+            // (rows + items + axis). Earlier we hand-computed the
+            // height to work around an empty-container collapse, but
+            // the resulting estimate over-allocated — vis-timeline's
+            // real row height is smaller than our 30px bucket and
+            // the unused vertical space showed as dead space at the
+            // top of the chart area. Wrap has min-height to prevent
+            // the initial render-before-data collapse.
+            container.style.removeProperty('height');
 
             // If the session card was rebuilt (innerHTML rewrite, etc.)
             // the cached timeline points at an orphaned div that's no
@@ -3004,7 +3009,7 @@ maybe a histogram of b
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        height: heightPx,
+                        height: 'auto',
                         start: liveStart,
                         end: liveEnd,
                         // Match the Chart.js bitrate chart's HH:MM:SS
@@ -3102,13 +3107,10 @@ maybe a histogram of b
                 } else {
                     requestAnimationFrame(() => timeline.redraw());
                 }
-                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
-                // Re-apply height each render — group count changes as
-                // variant lanes appear/disappear.
-                timeline.setOptions({ height: heightPx });
                 timeline.$windowStartMs = liveStart.getTime();
                 // Live-edge tracking: unless the user has explicitly
                 // paused the chart, slide the visible window so its

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2504,23 +2504,49 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'VARIANT':       { y: 17, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES':   { y: 16, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE':   { y: 15, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':       { y: 14, color: '#16a34a', label: 'PLAYING' },
-            'FIRST_FRAME':   { y: 13, color: '#14b8a6', label: 'FIRST FRAME' },
-            'START_TIME':    { y: 12, color: '#15803d', label: 'START TIME' },
-            'BUFFERING':     { y: 11, color: '#f59e0b', label: 'BUFFERING' },
-            'STALL':         { y: 10, color: '#000000', label: 'STALL' },
-            'FROZEN':        { y: 9,  color: '#4c1d95', label: 'FROZEN' },
-            'SEGMENT_STALL': { y: 8,  color: '#c2410c', label: 'SEGMENT STALL' },
-            'SHIFT_UP':      { y: 7,  color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':    { y: 6,  color: '#ef4444', label: 'SHIFT DOWN' },
-            'ERROR':         { y: 5,  color: '#e11d48', label: 'ERROR' },
-            'TIMEJUMP':      { y: 4,  color: '#d97706', label: 'TIMEJUMP' },
-            'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
-            'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
-            'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
+            'VARIANT':     { y: 8, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 7, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE': { y: 6, color: '#6b7280', label: 'PLAYERSTATE' },
+            'BUFFERING':   { y: 5, color: '#f59e0b', label: 'BUFFERING' },
+            'PLAYBACK':    { y: 4, color: '#16a34a', label: 'PLAYBACK' },
+            'IMPAIRMENT':  { y: 3, color: '#000000', label: 'IMPAIRMENT' },
+            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
+            'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
+        };
+        // Subtype → lane mapping. Each event-source string from
+        // parseBandwidthChartEventType resolves to the lane it
+        // appears in. Subtype tooltip labels and per-point colours
+        // live alongside.
+        const EVENT_SUBTYPE_LANE = {
+            'PLAYING': 'PLAYBACK', 'FIRST_FRAME': 'PLAYBACK', 'START_TIME': 'PLAYBACK',
+            'RESTART': 'PLAYBACK', 'TIMEJUMP': 'PLAYBACK',
+            'SHIFT_UP': 'PLAYBACK', 'SHIFT_DOWN': 'PLAYBACK',
+            'STALL': 'IMPAIRMENT', 'FROZEN': 'IMPAIRMENT',
+            'SEGMENT_STALL': 'IMPAIRMENT', 'ERROR': 'IMPAIRMENT',
+            'BUFFERING': 'BUFFERING',
+            'LOOP_PLAYER': 'LOOP_PLAYER', 'LOOP_SERVER': 'LOOP_SERVER'
+        };
+        const EVENT_SUBTYPE_COLOR = {
+            'PLAYING':       '#16a34a',
+            'FIRST_FRAME':   '#14b8a6',
+            'START_TIME':    '#15803d',
+            'RESTART':       '#a855f7',
+            'TIMEJUMP':      '#d97706',
+            'SHIFT_UP':      '#3b82f6',
+            'SHIFT_DOWN':    '#ef4444',
+            'STALL':         '#000000',
+            'FROZEN':        '#4c1d95',
+            'SEGMENT_STALL': '#c2410c',
+            'ERROR':         '#e11d48',
+            'BUFFERING':     '#f59e0b'
+        };
+        const EVENT_SUBTYPE_LABEL = {
+            'PLAYING': 'PLAYING', 'FIRST_FRAME': 'FIRST FRAME', 'START_TIME': 'START TIME',
+            'RESTART': 'RESTART', 'TIMEJUMP': 'TIMEJUMP',
+            'SHIFT_UP': 'SHIFT UP', 'SHIFT_DOWN': 'SHIFT DOWN',
+            'STALL': 'STALL', 'FROZEN': 'FROZEN',
+            'SEGMENT_STALL': 'SEGMENT STALL', 'ERROR': 'ERROR',
+            'BUFFERING': 'BUFFERING'
         };
         // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
         // because clients emit a mix of casings ("Playing" on Apple,
@@ -2698,13 +2724,25 @@ maybe a histogram of b
                 .filter((e) => Number(e.ts) >= windowStart)
                 .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
-            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
-                const points = chartEvents.filter((e) => e.type === type)
-                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state, mbps: e.mbps, resolution: e.resolution }));
+            const datasets = Object.entries(EVENT_LANES).map(([laneKey, cfg]) => {
+                // An event's lane comes either from a 1:1 mapping
+                // (PLAYERSTATE / VARIANT / DISPLAY_RES / LOOP_*) or
+                // via EVENT_SUBTYPE_LANE for the merged PLAYBACK /
+                // IMPAIRMENT / BUFFERING lanes.
+                const points = chartEvents.filter((e) => {
+                    const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                    return lane === laneKey;
+                }).map((e) => ({
+                    x: e.x, y: cfg.y, ts: e.ts,
+                    type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution
+                }));
                 let colors = cfg.color;
-                if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
-                else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
-                else if (type === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
+                if (laneKey === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
+                else if (laneKey === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
+                else if (laneKey === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
+                else if (laneKey === 'PLAYBACK' || laneKey === 'IMPAIRMENT') {
+                    colors = points.map(p => EVENT_SUBTYPE_COLOR[p.type] || cfg.color);
+                }
                 return {
                     label: cfg.label,
                     data: points,
@@ -2750,11 +2788,13 @@ maybe a histogram of b
                                             ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
                                             : '';
                                         let extra = '';
+                                        let label = ctx.dataset.label;
                                         if (ctx && ctx.raw) {
                                             if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
                                             else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
+                                            else if (ctx.raw.type && EVENT_SUBTYPE_LABEL[ctx.raw.type]) extra = `: ${EVENT_SUBTYPE_LABEL[ctx.raw.type]}`;
                                         }
-                                        return `${ctx.dataset.label}${extra}${offset}`;
+                                        return `${label}${extra}${offset}`;
                                     }
                                 }
                             },
@@ -2775,7 +2815,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 17.5,
+                                type: 'linear', min: 0.5, max: 8.5,
                                 // Force a fixed Y-axis width so this chart's
                                 // X-axis lines up vertically with the bandwidth /
                                 // buffer / fps charts below (they all use the
@@ -2972,17 +3012,20 @@ maybe a histogram of b
 
             for (const e of events) {
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
-                const cfg = EVENT_LANES[e.type];
+                const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                const cfg = EVENT_LANES[lane];
                 if (!cfg) continue;
+                const color = EVENT_SUBTYPE_COLOR[e.type] || cfg.color;
+                const subLabel = EVENT_SUBTYPE_LABEL[e.type] || e.type;
                 const ts = Number(e.ts);
                 items.push({
                     id: itemId++,
-                    group: e.type,
+                    group: lane,
                     content: '',
                     start: new Date(ts),
                     type: 'point',
-                    title: `${cfg.label}\n${formatHoverTime(ts)}`,
-                    style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
+                    title: `${subLabel}\n${formatHoverTime(ts)}`,
+                    style: `background-color: ${color}; border-color: ${color};`
                 });
             }
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2579,13 +2579,18 @@ maybe a histogram of b
         // to flow through the dashboard event capture (currently only
         // *_start variants reach parseBandwidthChartEventType).
         function renderEventsTimelineChart(sessionId, windowStart, eventSeries) {
-            if (typeof vis === 'undefined' || !vis.Timeline) return;
+            if (typeof vis === 'undefined' || !vis.Timeline) {
+                console.warn('[events-timeline] vis-timeline not loaded');
+                return;
+            }
             const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
             if (!card) return;
             const container = card.querySelector('.events-timeline');
-            if (!container) return;
+            if (!container) {
+                console.warn('[events-timeline] container .events-timeline not in DOM for session', sessionId);
+                return;
+            }
 
-            const windowEndMs = windowStart + 600 * 1000;
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
@@ -2637,18 +2642,19 @@ maybe a histogram of b
                     new vis.DataSet(groups),
                     {
                         stack: false,
-                        showCurrentTime: false,
+                        showCurrentTime: true,
                         zoomable: true,
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        min: new Date(windowStart - 60000),
-                        max: new Date(windowEndMs + 60000),
-                        start: new Date(windowStart),
-                        end: new Date(windowEndMs)
+                        // Default visible window = last 10 minutes through now.
+                        // No min/max so panning forward/back works freely.
+                        start: new Date(nowMs - 600 * 1000),
+                        end: new Date(nowMs)
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2000,6 +2000,18 @@ maybe a histogram of b
         }
 
         function readChartViewport(chartRef) {
+            if (!chartRef) return null;
+            // vis-timeline branch: marker `$isVisTimeline` set when we
+            // construct it. Window is Date objects; convert to the
+            // seconds-from-windowStart convention the Chart.js charts use.
+            if (chartRef.$isVisTimeline && typeof chartRef.getWindow === 'function') {
+                const win = chartRef.getWindow();
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return null;
+                const min = (win.start.getTime() - startMs) / 1000;
+                const max = (win.end.getTime() - startMs) / 1000;
+                return normalizeChartViewport(min, max);
+            }
             const xScale = chartRef?.scales?.x;
             if (!xScale) return null;
             return normalizeChartViewport(xScale.min, xScale.max);
@@ -2007,6 +2019,16 @@ maybe a histogram of b
 
         function applyChartViewport(chartRef, viewport) {
             if (!chartRef || !viewport) return;
+            if (chartRef.$isVisTimeline && typeof chartRef.setWindow === 'function') {
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return;
+                chartRef.setWindow(
+                    new Date(startMs + viewport.min * 1000),
+                    new Date(startMs + viewport.max * 1000),
+                    { animation: false }
+                );
+                return;
+            }
             if (typeof chartRef.zoomScale === 'function') {
                 chartRef.zoomScale('x', { min: viewport.min, max: viewport.max }, 'none');
             } else if (chartRef.options?.scales?.x) {
@@ -2028,7 +2050,8 @@ maybe a histogram of b
                 eventsCharts.get(key),
                 bandwidthCharts.get(key),
                 bufferDepthCharts.get(key),
-                videoFpsCharts.get(key)
+                videoFpsCharts.get(key),
+                eventsTimelines.get(key)
             ].filter((chartRef) => !!chartRef);
         }
 
@@ -2816,15 +2839,26 @@ maybe a histogram of b
                 );
                 eventsTimelines.set(sessionId, timeline);
                 eventsTimelineFollowLive.set(sessionId, true);
+                // Tag for the cross-chart viewport sync helpers, and
+                // anchor the seconds-from-windowStart frame to liveStart
+                // so vis-timeline ranges convert consistently to the
+                // 0–600 units the Chart.js charts use.
+                timeline.$isVisTimeline = true;
+                timeline.$windowStartMs = liveStart.getTime();
+                // If another chart in this session already has a stored
+                // viewport, apply it so the timeline starts in sync.
+                applyStoredChartViewport(sessionId, timeline);
                 // Detect user pan/zoom: rangechanged with byUser=true.
                 // Stop auto-following live so the user's zoom state
                 // sticks across the per-second render. Re-arm follow
-                // when the user pans/zooms back to within 5s of "now".
+                // when they pan back to within 5s of "now". Broadcast
+                // their viewport to every other chart in this session.
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
                     const rightEdge = props.end.getTime();
                     const driftMs = Math.abs(Date.now() - rightEdge);
                     eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
+                    syncChartViewportAcrossSession(sessionId, timeline);
                 });
                 requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
@@ -2834,6 +2868,9 @@ maybe a histogram of b
                 // Re-apply height each render — group count changes as
                 // variant lanes appear/disappear.
                 timeline.setOptions({ height: heightPx });
+                // Update the windowStart anchor for viewport conversions
+                // so they stay valid as "now" advances.
+                timeline.$windowStartMs = liveStart.getTime();
                 // Only slide back to "now" if the user hasn't manually
                 // panned/zoomed away. Otherwise we'd clobber their
                 // zoom state every render tick.

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2303,13 +2303,17 @@ maybe a histogram of b
             }
 
             // VARIANT lane: sample player_metrics_video_bitrate_mbps on
-            // each refresh and emit a marker on every change. Quantise
-            // to one decimal so micro-fluctuations don't flood the lane.
+            // each refresh and emit a marker on every change. Dedup by
+            // BITRATE ONLY (rounded to 0.1 Mbps) — resolution can briefly
+            // be empty/null between samples on some clients, which would
+            // create spurious "new variant" entries with the same bitrate
+            // but different resolution strings. Resolution travels along
+            // for labelling only.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
                 const variantRes = String(session.player_metrics_video_resolution || '').trim();
-                const variantKey = `${variantMbps}|${variantRes}`;
+                const variantKey = `${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -2319,6 +2323,7 @@ maybe a histogram of b
                     lastRecordedVariantBySession.set(String(key), variantKey);
                 }
             }
+
 
             const series = bandwidthHistory.get(key) || [];
             const lastLimit = series.length ? Number(series[series.length - 1].target) : NaN;
@@ -2655,16 +2660,24 @@ maybe a histogram of b
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
-            // VARIANT subgroups: one lane per observed variant key in the
-            // current window, ordered by bitrate DESCENDING — highest at
-            // the top, lowest at the bottom — so the visual ladder
-            // matches how an ABR ladder is normally drawn.
+            // VARIANT subgroups: one lane per observed bitrate in the
+            // current window, ordered DESCENDING — highest at the top,
+            // lowest at the bottom — so the visual ladder matches how
+            // an ABR ladder is normally drawn. Lane key is bitrate
+            // alone; we keep the latest non-empty resolution for the
+            // label so a brief empty-resolution sample doesn't spawn
+            // a phantom lane.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            const seenVariants = new Map(); // key -> {mbps, resolution}
+            const seenVariants = new Map(); // key (mbps) -> {mbps, resolution}
             for (const v of variantEvents) {
                 const m = Number(v.mbps);
-                const k = `${m}|${v.resolution || ''}`;
-                if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+                const k = `${m}`;
+                const existing = seenVariants.get(k);
+                if (!existing) {
+                    seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+                } else if (v.resolution && !existing.resolution) {
+                    existing.resolution = v.resolution;
+                }
             }
             const variantOrder = Array.from(seenVariants.entries())
                 .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
@@ -2712,17 +2725,17 @@ maybe a histogram of b
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each variant gets its own swim lane. Render each
-            // active span in the lane that matches its variant key.
-            // With variants ordered highest-bitrate-at-top, an upshift
-            // visually walks UP the ladder and a downshift walks DOWN.
+            // VARIANT: each bitrate gets its own swim lane. Lane key
+            // matches seenVariants — bitrate-only, so the segment goes
+            // into the right row regardless of any flicker on the
+            // resolution string.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const m = Number(v.mbps);
-                const k = `${m}|${v.resolution || ''}`;
+                const k = `${m}`;
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -711,6 +711,12 @@ maybe a histogram of b
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
+        // Per-session "follow live" flag. True = right edge tracks "now"
+        // every tick. Flips to false the moment the user zooms or pans
+        // manually, so the zoom state isn't clobbered by the per-second
+        // setWindow call. Re-enabled when the user pans/zooms back to a
+        // window whose right edge is within 5s of "now".
+        const eventsTimelineFollowLive = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -2792,10 +2798,34 @@ maybe a histogram of b
                         orientation: { axis: 'top' },
                         height: heightPx,
                         start: liveStart,
-                        end: liveEnd
+                        end: liveEnd,
+                        // Match the Chart.js charts' zoom UX:
+                        //   plain wheel = page scroll (do not intercept)
+                        //   Alt/Option + wheel = zoom in/out
+                        // Pan is left-drag on the timeline (vis-timeline
+                        // doesn't support right-drag natively; close enough
+                        // to the Chart.js right-drag-pan behaviour).
+                        zoomKey: 'altKey',
+                        horizontalScroll: false,
+                        // Reasonable zoom bounds: 1s lower (heavy zoom in)
+                        // to 6h upper (back-out enough to see longer
+                        // sessions if user pans backward).
+                        zoomMin: 1000,
+                        zoomMax: 6 * 60 * 60 * 1000
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                eventsTimelineFollowLive.set(sessionId, true);
+                // Detect user pan/zoom: rangechanged with byUser=true.
+                // Stop auto-following live so the user's zoom state
+                // sticks across the per-second render. Re-arm follow
+                // when the user pans/zooms back to within 5s of "now".
+                timeline.on('rangechanged', (props) => {
+                    if (!props || !props.byUser) return;
+                    const rightEdge = props.end.getTime();
+                    const driftMs = Math.abs(Date.now() - rightEdge);
+                    eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
+                });
                 requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
@@ -2804,11 +2834,12 @@ maybe a histogram of b
                 // Re-apply height each render — group count changes as
                 // variant lanes appear/disappear.
                 timeline.setOptions({ height: heightPx });
-                // Slide the visible window so "now" stays pinned to the
-                // right edge — matches the bitrate / buffer chart
-                // live-edge behaviour. animation:false avoids per-tick
-                // jitter.
-                timeline.setWindow(liveStart, liveEnd, { animation: false });
+                // Only slide back to "now" if the user hasn't manually
+                // panned/zoomed away. Otherwise we'd clobber their
+                // zoom state every render tick.
+                if (eventsTimelineFollowLive.get(sessionId) !== false) {
+                    timeline.setWindow(liveStart, liveEnd, { animation: false });
+                }
             }
         }
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -583,21 +583,34 @@ maybe a histogram of b
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
-        /* Lock vis-timeline's left label panel to a fixed 90px width
-         * so it matches the Chart.js charts' Y-axis width (also 90px
-         * via afterFit). Time axis on this chart now lines up
-         * vertically with the bandwidth/buffer/fps charts below.
-         * Long labels truncate with ellipsis — the legend strip above
-         * (rendered when needed) gives the full names. */
+        /* Keep the left label panel pinned to 90px (matches the
+         * Chart.js charts' Y-axis width via afterFit), so the chart
+         * area's left edge lines up vertically with the
+         * bandwidth/buffer/fps charts. Labels are allowed to overflow
+         * to the right INTO the chart area on top of the swim lane
+         * items — text-shadow halo keeps them readable. The
+         * nested-group indent (PLAYER / SERVER section nesting) is
+         * neutralised so child labels start at the leftmost column. */
         .events-timeline-wrap .vis-labelset,
         .events-timeline-wrap .vis-left.vis-panel {
             width: 90px !important;
             max-width: 90px !important;
+            overflow: visible !important;
         }
-        .events-timeline-wrap .vis-label {
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
+        .events-timeline-wrap .vis-label,
+        .events-timeline-wrap .vis-label.vis-nested-group {
+            overflow: visible !important;
+            white-space: nowrap !important;
+            padding-left: 4px !important;
+            z-index: 10;
+            position: relative;
+            color: #1f2937;
+            font-weight: 600;
+            text-shadow:
+                0 0 3px rgba(255, 255, 255, 0.95),
+                0 0 6px rgba(255, 255, 255, 0.85),
+                1px 0 0 rgba(255, 255, 255, 0.75),
+                -1px 0 0 rgba(255, 255, 255, 0.75);
         }
         .events-timeline-legend {
             display: none;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -720,6 +720,7 @@ maybe a histogram of b
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
+        const lastRecordedVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -2301,6 +2302,24 @@ maybe a histogram of b
                 }
             }
 
+            // VARIANT lane: sample player_metrics_video_bitrate_mbps on
+            // each refresh and emit a marker on every change. Quantise
+            // to one decimal so micro-fluctuations don't flood the lane.
+            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
+                const variantRes = String(session.player_metrics_video_resolution || '').trim();
+                const variantKey = `${variantMbps}|${variantRes}`;
+                const prevVariant = lastRecordedVariantBySession.get(String(key));
+                if (prevVariant !== variantKey) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                    lastRecordedVariantBySession.set(String(key), variantKey);
+                }
+            }
+
             const series = bandwidthHistory.get(key) || [];
             const lastLimit = series.length ? Number(series[series.length - 1].target) : NaN;
             let target = Number.isFinite(bandwidthTarget) ? bandwidthTarget : (Number.isFinite(lastLimit) ? lastLimit : 0);
@@ -2349,6 +2368,7 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
+            'VARIANT':     { y: 10, color: '#16a34a', label: 'VARIANT' },
             'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
@@ -2370,6 +2390,26 @@ maybe a histogram of b
         };
         function playerStateColor(s) {
             return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+        }
+        // Variant colour buckets — lower bitrate = redder, higher = greener.
+        // Drives the colour of segments / dots on the VARIANT swim lane so
+        // an upshift/downshift is visually obvious before reading the label.
+        function variantColor(mbps) {
+            const m = Number(mbps);
+            if (!Number.isFinite(m) || m <= 0) return '#9ca3af';
+            if (m < 1)  return '#dc2626'; // red
+            if (m < 2)  return '#ea580c'; // orange
+            if (m < 4)  return '#f59e0b'; // amber
+            if (m < 8)  return '#84cc16'; // lime
+            if (m < 16) return '#16a34a'; // green
+            return '#10b981';             // emerald
+        }
+        function variantLabel(mbps, resolution) {
+            const m = Number(mbps);
+            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)} Mbps` : '';
+            const res = String(resolution || '').trim();
+            if (res && mbpsStr) return `${res} · ${mbpsStr}`;
+            return res || mbpsStr || '—';
         }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
@@ -2474,13 +2514,14 @@ maybe a histogram of b
             if (isChartPaused(sessionId)) return;
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
             const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
                 const points = chartEvents.filter((e) => e.type === type)
-                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state }));
-                const isPlayerState = type === 'PLAYERSTATE';
-                const colors = isPlayerState ? points.map(p => playerStateColor(p.state)) : cfg.color;
+                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state, mbps: e.mbps, resolution: e.resolution }));
+                let colors = cfg.color;
+                if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
+                else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
                 return {
                     label: cfg.label,
                     data: points,
@@ -2525,8 +2566,12 @@ maybe a histogram of b
                                         const offset = Number.isFinite(ts) && startMs > 0
                                             ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
                                             : '';
-                                        const state = ctx && ctx.raw && ctx.raw.state ? `: ${ctx.raw.state}` : '';
-                                        return `${ctx.dataset.label}${state}${offset}`;
+                                        let extra = '';
+                                        if (ctx && ctx.raw) {
+                                            if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
+                                            else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
+                                        }
+                                        return `${ctx.dataset.label}${extra}${offset}`;
                                     }
                                 }
                             },
@@ -2547,7 +2592,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 9.5,
+                                type: 'linear', min: 0.5, max: 10.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,
@@ -2600,34 +2645,53 @@ maybe a histogram of b
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
-            const groups = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
-                id: type,
-                content: cfg.label
-            }));
+            // Two top-level sections so server-originated events (loop
+            // wrap notifications, etc.) don't visually mix with player-side
+            // events. Lane order within each section follows EVENT_LANES.
+            const SERVER_LANES = new Set(['LOOP_SERVER']);
+            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k));
+            const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
+            const groups = [
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: playerLanes },
+                ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
+                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
+                ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
+            ];
 
             const items = [];
             let itemId = 0;
 
-            const stateEvents = events.filter((e) => e.type === 'PLAYERSTATE')
-                .sort((a, b) => Number(a.ts) - Number(b.ts));
-            for (let i = 0; i < stateEvents.length; i++) {
-                const start = Number(stateEvents[i].ts);
-                const end = i + 1 < stateEvents.length ? Number(stateEvents[i + 1].ts) : nowMs;
-                const state = stateEvents[i].state || 'Unknown';
-                const color = playerStateColor(state);
-                items.push({
-                    id: itemId++,
-                    group: 'PLAYERSTATE',
-                    content: state,
-                    start: new Date(start),
-                    end: new Date(end),
-                    type: 'range',
-                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
-                });
+            // Helper to render an event-series sequence as continuous
+            // ranges (one segment per stable value, transition on change).
+            function pushRanges(typeKey, getLabel, getColor) {
+                const seq = events.filter((e) => e.type === typeKey)
+                    .sort((a, b) => Number(a.ts) - Number(b.ts));
+                for (let i = 0; i < seq.length; i++) {
+                    const start = Number(seq[i].ts);
+                    const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
+                    const label = getLabel(seq[i]);
+                    const color = getColor(seq[i]);
+                    items.push({
+                        id: itemId++,
+                        group: typeKey,
+                        content: label,
+                        start: new Date(start),
+                        end: new Date(end),
+                        type: 'range',
+                        style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                    });
+                }
             }
 
+            pushRanges('PLAYERSTATE',
+                (e) => e.state || 'Unknown',
+                (e) => playerStateColor(e.state));
+            pushRanges('VARIANT',
+                (e) => variantLabel(e.mbps, e.resolution),
+                (e) => variantColor(e.mbps));
+
             for (const e of events) {
-                if (e.type === 'PLAYERSTATE') continue;
+                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
                 items.push({
@@ -2660,6 +2724,10 @@ maybe a histogram of b
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                // Container width is sometimes 0 on first paint (ScrollView /
+                // collapsed parent); force a redraw next frame so the
+                // timeline measures its real width.
+                requestAnimationFrame(() => timeline.redraw());
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups');
             } else {
                 timeline.setItems(new vis.DataSet(items));

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -565,11 +565,17 @@ maybe a histogram of b
         .chart-wrap {
             position: relative;
         }
+        .events-timeline-wrap {
+            height: 240px;
+            margin-bottom: 12px;
+            position: relative;
+        }
         .events-timeline-wrap .events-timeline {
-            height: 220px;
+            height: 100%;
             background: #fff;
             border: 1px solid #e5e7eb;
             border-radius: 4px;
+            overflow: hidden;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1865,6 +1865,8 @@ maybe a histogram of b
             if (eventType === 'stall_start' || eventType === 'segment_stall' || eventType === 'frozen') return 'STALL';
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'playing') return 'PLAYING';
+            if (eventType === 'buffering_start') return 'BUFFERING';
+            if (eventType === 'rate_shift_up' || eventType === 'rate_shift_down') return 'SHIFT';
             return null;
         }
 
@@ -2306,7 +2308,9 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'PLAYING':     { y: 5, color: '#16a34a', label: 'PLAYING' },
+            'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
+            'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
+            'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -2481,7 +2485,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 5.5,
+                                type: 'linear', min: 0.5, max: 7.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1916,10 +1916,15 @@ maybe a histogram of b
         function parseBandwidthChartEventType(rawEventType) {
             const eventType = String(rawEventType || '').trim().toLowerCase();
             if (!eventType) return null;
-            if (eventType === 'stall_start' || eventType === 'segment_stall' || eventType === 'frozen') return 'STALL';
+            if (eventType === 'stall_start') return 'STALL';
+            if (eventType === 'frozen') return 'FROZEN';
+            if (eventType === 'segment_stall') return 'SEGMENT_STALL';
+            if (eventType === 'error') return 'ERROR';
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'playing') return 'PLAYING';
             if (eventType === 'buffering_start') return 'BUFFERING';
+            if (eventType === 'video_first_frame') return 'FIRST_FRAME';
+            if (eventType === 'video_start_time') return 'START_TIME';
             if (eventType === 'rate_shift_up') return 'SHIFT_UP';
             if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
             return null;
@@ -2458,17 +2463,22 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'VARIANT':     { y: 11, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES': { y: 10, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
-            'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
-            'SHIFT_UP':    { y: 6, color: '#3b82f6', label: 'SHIFT UP' },
-            'SHIFT_DOWN':  { y: 5, color: '#ef4444', label: 'SHIFT DOWN' },
-            'STALL':       { y: 4, color: '#000000', label: 'STALL' },
-            'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
-            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
-            'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
+            'VARIANT':       { y: 16, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES':   { y: 15, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE':   { y: 14, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':       { y: 13, color: '#16a34a', label: 'PLAYING' },
+            'FIRST_FRAME':   { y: 12, color: '#14b8a6', label: 'FIRST FRAME' },
+            'START_TIME':    { y: 11, color: '#15803d', label: 'START TIME' },
+            'BUFFERING':     { y: 10, color: '#f59e0b', label: 'BUFFERING' },
+            'STALL':         { y: 9,  color: '#000000', label: 'STALL' },
+            'FROZEN':        { y: 8,  color: '#4c1d95', label: 'FROZEN' },
+            'SEGMENT_STALL': { y: 7,  color: '#c2410c', label: 'SEGMENT STALL' },
+            'SHIFT_UP':      { y: 6,  color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':    { y: 5,  color: '#ef4444', label: 'SHIFT DOWN' },
+            'ERROR':         { y: 4,  color: '#e11d48', label: 'ERROR' },
+            'RESTART':       { y: 3,  color: '#a855f7', label: 'RESTART' },
+            'LOOP_PLAYER':   { y: 2,  color: '#06b6d4', label: 'LOOP PLAYER' },
+            'LOOP_SERVER':   { y: 1,  color: '#84cc16', label: 'LOOP SERVER' }
         };
         // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
         // because clients emit a mix of casings ("Playing" on Apple,
@@ -2723,7 +2733,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 11.5,
+                                type: 'linear', min: 0.5, max: 16.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -583,36 +583,29 @@ maybe a histogram of b
             font-size: 10px;
             font-family: 'Courier New', monospace;
         }
-        /* Hide vis-timeline's built-in left label panel so the chart
-         * area uses the full container width and lines up vertically
-         * with the Chart.js bandwidth/buffer/fps charts below. Lane
-         * legend is rendered as a separate strip above the chart. */
+        /* Float vis-timeline's left label panel on top of the chart's
+         * leftmost column instead of reserving space for it. The chart
+         * area uses the full container width — its time axis lines up
+         * vertically with the Chart.js bandwidth/buffer/fps charts —
+         * and the lane labels overlay on top of the items. */
         .events-timeline-wrap .vis-left.vis-panel {
-            display: none !important;
+            position: absolute !important;
+            left: 0 !important;
+            top: 0 !important;
+            z-index: 5;
+            background: rgba(255, 255, 255, 0.85);
+            border-right: 1px solid rgba(0, 0, 0, 0.05);
+            pointer-events: none;
         }
         .events-timeline-wrap .vis-center.vis-panel {
             left: 0 !important;
             border-left: none !important;
         }
+        .events-timeline-wrap .vis-label {
+            background: transparent !important;
+        }
         .events-timeline-legend {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 6px 12px;
-            margin-bottom: 6px;
-            font-size: 10px;
-            font-family: 'Courier New', monospace;
-            color: #4b5563;
-        }
-        .events-timeline-legend .legend-item {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-        }
-        .events-timeline-legend .legend-swatch {
-            width: 10px;
-            height: 10px;
-            border-radius: 2px;
-            display: inline-block;
+            display: none;
         }
         .chart-paused-badge {
             display: none;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2649,10 +2649,31 @@ maybe a histogram of b
             // wrap notifications, etc.) don't visually mix with player-side
             // events. Lane order within each section follows EVENT_LANES.
             const SERVER_LANES = new Set(['LOOP_SERVER']);
-            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k));
+            const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
+
+            // VARIANT subgroups: one lane per observed variant key in the
+            // current window, ordered by bitrate ascending (so the lowest
+            // sits at the bottom of the VARIANT band, like an ABR ladder).
+            const variantEvents = events.filter((e) => e.type === 'VARIANT');
+            const seenVariants = new Map(); // key -> {mbps, resolution}
+            for (const v of variantEvents) {
+                const m = Number(v.mbps);
+                const k = `${m}|${v.resolution || ''}`;
+                if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
+            }
+            const variantOrder = Array.from(seenVariants.entries())
+                .sort((a, b) => Number(a[1].mbps) - Number(b[1].mbps));
+            const variantGroups = variantOrder.map(([k, v]) => ({
+                id: `VARIANT::${k}`,
+                content: variantLabel(v.mbps, v.resolution)
+            }));
+            const variantGroupIds = variantGroups.map((g) => g.id);
+
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: playerLanes },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: ['VARIANT_GROUP', ...playerLanes] },
+                { id: 'VARIANT_GROUP', content: 'VARIANT', nestedGroups: variantGroupIds.length ? variantGroupIds : null },
+                ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
                 { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
                 ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
@@ -2686,9 +2707,28 @@ maybe a histogram of b
             pushRanges('PLAYERSTATE',
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
-            pushRanges('VARIANT',
-                (e) => variantLabel(e.mbps, e.resolution),
-                (e) => variantColor(e.mbps));
+
+            // VARIANT: each variant gets its own swim lane. Render each
+            // active span in the lane that matches its variant key, so an
+            // upshift visually walks UP the ladder.
+            const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
+            for (let i = 0; i < variantSeq.length; i++) {
+                const v = variantSeq[i];
+                const start = Number(v.ts);
+                const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
+                const m = Number(v.mbps);
+                const k = `${m}|${v.resolution || ''}`;
+                const color = variantColor(m);
+                items.push({
+                    id: itemId++,
+                    group: `VARIANT::${k}`,
+                    content: '',
+                    start: new Date(start),
+                    end: new Date(end),
+                    type: 'range',
+                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                });
+            }
 
             for (const e of events) {
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2554,7 +2554,8 @@ maybe a histogram of b
         // normalises before lookup so all map to the same colour.
         const PLAYER_STATE_COLOR = {
             'playing':   '#16a34a', // green
-            'buffering': '#f59e0b', // amber
+            'buffering': '#f59e0b', // amber — expected refill (pre-roll, post-seek)
+            'stalled':   '#dc2626', // red — unexpected mid-play rebuffer
             'paused':    '#9333ea', // purple
             'idle':      '#6b7280', // gray
             'ended':     '#1f2937', // near-black

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -568,11 +568,17 @@ maybe a histogram of b
         .events-timeline-wrap {
             margin-bottom: 12px;
             position: relative;
+            /* Reserve right padding equal to the FPS chart's right-side
+             * Y-axis (Dropped/s) so the events-timeline plot area's
+             * right edge aligns with the four Chart.js charts below. */
+            padding-right: 60px;
         }
         .events-timeline-wrap .events-timeline {
-            background: #fff;
-            border: 1px solid #e5e7eb;
-            border-radius: 4px;
+            /* Match the surrounding .collapsible-section background
+             * (#fafafa) — Chart.js canvases below are transparent so
+             * they show the same #fafafa, and a pure-white events-
+             * timeline stood out. */
+            background: #fafafa;
         }
         .events-timeline .vis-item.vis-box,
         .events-timeline .vis-item.vis-point {
@@ -615,10 +621,24 @@ maybe a histogram of b
             /* Neutralise vis-timeline's default label borders (which
              * inherit currentColor and were rendering as red in this
              * theme). Subtle gray bottom border keeps row separation. */
-            border-color: rgba(0, 0, 0, 0.06) !important;
+            border-color: #e5e7eb !important;
             border-top: none !important;
             border-left: none !important;
             border-right: none !important;
+        }
+        /* Match the Chart.js grid colour (#e5e7eb) for the row
+         * separators inside the items panel — they were drawn in
+         * the vis-timeline default red/black and clashed with the
+         * gray grid in the four charts below. */
+        .events-timeline-wrap .vis-foreground .vis-group,
+        .events-timeline-wrap .vis-panel.vis-background .vis-group,
+        .events-timeline-wrap .vis-panel.vis-background .vis-horizontal {
+            border-color: #e5e7eb !important;
+        }
+        /* Slim grey border around the entire timeline matches the
+         * Chart.js charts' gridline tone. */
+        .events-timeline-wrap .vis-timeline {
+            border-color: #e5e7eb !important;
         }
         /* Top-level section headers (PLAYER / SERVER) sit at the
          * leftmost edge — no indent. Don't override row height here:
@@ -644,22 +664,31 @@ maybe a histogram of b
         .events-timeline-wrap .vis-time-axis .vis-text.vis-minor {
             visibility: hidden !important;
         }
+        /* Hide vis-timeline's own calendar-snapped vertical grid lines —
+         * they slide left independently as time advances and clash with
+         * our right-edge-anchored custom-time markers. Only our markers
+         * should draw vertical lines. */
+        .events-timeline-wrap .vis-time-axis .vis-grid.vis-minor,
+        .events-timeline-wrap .vis-time-axis .vis-grid.vis-major,
+        .events-timeline-wrap .vis-panel.vis-background .vis-vertical {
+            border-color: transparent !important;
+        }
         /* Style our right-edge-anchored tick markers like the default
          * grid lines plus a small floating timestamp label. */
         .events-timeline-wrap .vis-custom-time {
-            background-color: rgba(0, 0, 0, 0.15) !important;
+            background-color: #e5e7eb !important;
             width: 1px !important;
             cursor: default !important;
         }
         .events-timeline-wrap .vis-custom-time .vis-custom-time-marker {
-            background: rgba(255, 255, 255, 0.92) !important;
-            border: 1px solid rgba(0, 0, 0, 0.08) !important;
-            border-radius: 2px !important;
+            background: transparent !important;
+            border: none !important;
             color: #4b5563 !important;
             font-family: 'Courier New', monospace !important;
             font-size: 10px !important;
             padding: 0 3px !important;
-            top: 2px !important;
+            top: auto !important;
+            bottom: 2px !important;
         }
         /* vis-timeline applies the per-level indent via inline style
          * on the inner label cell — override that too. */
@@ -797,6 +826,12 @@ maybe a histogram of b
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
+        // Width reserved on the RIGHT side of every chart's plot area
+        // so the four Chart.js charts (bandwidth, buffer, fps, events
+        // scatter) and the vis-timeline events-timeline above all end
+        // at the same X coordinate. Sized to fit the FPS chart's
+        // right-side "Dropped/s" Y-axis (numeric ticks + rotated title).
+        const RIGHT_AXIS_PAD_PX = 60;
         // Per-session collapse state for the PLAYER / SERVER section
         // headers. setGroups replaces the entire groups dataset on
         // every render, which would otherwise reset the user's
@@ -2834,11 +2869,13 @@ maybe a histogram of b
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
                         scales: {
                             x: {
                                 type: 'linear', min: 0, max: 600,
                                 ticks: {
                                     maxTicksLimit: 8,
+                                    align: 'inner',
                                     callback: (value) => {
                                         const startMs = Number(chart && chart.$windowStartMs) || 0;
                                         return formatBitrateChartAbsoluteTick(startMs, Number(value));
@@ -3247,44 +3284,53 @@ maybe a histogram of b
                 }
             }
 
-            // Right-edge-anchored tick LABELS — placed at the
-            // timestamps of the actual events in the visible window
-            // (deduped to 1-second resolution to keep the marker
-            // count manageable). vis-timeline's default minor labels
-            // are hidden via CSS; these custom-time markers replace
-            // them so the user sees real event timestamps like
-            // "13:34:41" instead of clock-snapped "13:34:00".
-            refreshEventTickMarkers(timeline, events, nowMs - liveWindowMs, nowMs);
+            // Right-edge-anchored tick markers placed at the same
+            // wall-clock times as the Chart.js charts' axis ticks
+            // (every 100s for the 10-min window). Items keep their
+            // exact timestamp positions regardless of where these
+            // tick lines fall.
+            //
+            // When the chart is paused, anchor the ticks to the
+            // visible window's right edge (frozen in time) so the
+            // tick lines stay on top of the events that were visible
+            // when the user paused — not slide right with wall-clock
+            // time while the events stay frozen.
+            const tickAnchorMs = isChartPaused(sessionId)
+                ? timeline.getWindow().end.getTime()
+                : nowMs;
+            refreshLiveTickMarkers(timeline, tickAnchorMs, liveWindowMs);
         }
 
-        // Add / update / remove vis-timeline custom-time markers so
-        // there's exactly one per unique event-second in the visible
-        // window. Each marker draws a vertical line and a floating
-        // HH:MM:SS label.
-        function refreshEventTickMarkers(timeline, events, windowStartMs, windowEndMs) {
+        // Add vis-timeline custom-time markers at fixed intervals
+        // back from "now" — matches the Chart.js charts' tick spacing
+        // so HH:MM:SS labels line up vertically across events-timeline
+        // / bandwidth / buffer / fps charts. We rebuild every render
+        // (remove all, add fresh) because vis-timeline's setCustomTime
+        // updates internal state but the DOM line element does not
+        // always reposition — leaving labels that move while the
+        // vertical lines stay put.
+        function refreshLiveTickMarkers(timeline, nowMs, windowMs) {
+            // 100s interval matches Chart.js's auto-pick for the
+            // [0, 600] (seconds) range with maxTicksLimit:8 → ticks
+            // every 100s = 7 visible labels in the 10-min window.
+            const TICK_INTERVAL_MS = 100000;
+            const tickCount = Math.floor(windowMs / TICK_INTERVAL_MS) + 1;
             if (!timeline.$tickIds) timeline.$tickIds = new Set();
             const fmt = (ms) => {
                 const d = new Date(ms);
                 return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
             };
-            const desired = new Map(); // id -> ts
-            for (const e of (events || [])) {
-                const ts = Number(e.ts);
-                if (!Number.isFinite(ts) || ts < windowStartMs || ts > windowEndMs) continue;
-                const sec = Math.floor(ts / 1000) * 1000;
-                const id = `event-tick-${sec}`;
-                if (!desired.has(id)) desired.set(id, sec);
-            }
-            // Remove markers that no longer correspond to a visible event.
+            // Drop every existing tick marker; the DOM line for a
+            // setCustomTime'd marker doesn't always re-render at the
+            // new x even though its label does.
             for (const id of Array.from(timeline.$tickIds)) {
-                if (!desired.has(id)) {
-                    try { timeline.removeCustomTime(id); } catch (e) {}
-                    timeline.$tickIds.delete(id);
-                }
+                try { timeline.removeCustomTime(id); } catch (e) {}
             }
-            // Add markers for new events.
-            for (const [id, t] of desired) {
-                if (timeline.$tickIds.has(id)) continue;
+            timeline.$tickIds.clear();
+            // Re-add at the current wall-clock anchored positions.
+            for (let i = 0; i < tickCount; i++) {
+                const id = `live-tick-${i}`;
+                const t = nowMs - i * TICK_INTERVAL_MS;
                 try {
                     timeline.addCustomTime(new Date(t), id);
                     timeline.$tickIds.add(id);
@@ -3352,7 +3398,17 @@ maybe a histogram of b
                 }))
                 .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
             renderEventsChart(sessionId, windowStart, eventSeries);
-            renderEventsTimelineChart(sessionId, windowStart, eventSeries);
+            // Hide the per-session events swim-lane in compare mode —
+            // it shows events for ONE session only, which is confusing
+            // alongside the multi-session line charts below.
+            const compareActiveForTimeline = getCompareGroupIds().length >= 2;
+            const eventsTimelineWrap = card.querySelector('.events-timeline-wrap');
+            if (eventsTimelineWrap) {
+                eventsTimelineWrap.style.display = compareActiveForTimeline ? 'none' : '';
+            }
+            if (!compareActiveForTimeline) {
+                renderEventsTimelineChart(sessionId, windowStart, eventSeries);
+            }
             const shaperRateData = points.map(point => ({ x: point.x, y: point.shaperRate }));
             const shaperAvgData = points.map(point => ({ x: point.x, y: point.shaperAvg }));
             const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));
@@ -3726,6 +3782,12 @@ maybe a histogram of b
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
+                        // Reserve right padding equal to the FPS chart's
+                        // right-side Y-axis (Dropped/s) width so all four
+                        // charts' plot areas share the same right edge,
+                        // and so vertical tick lines line up across all
+                        // charts and the events-timeline above.
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
                         scales: {
                             x: {
                                 type: 'linear',
@@ -3736,6 +3798,7 @@ maybe a histogram of b
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 },
                                     maxTicksLimit: 8,
+                                    align: 'inner',
                                     callback: (value) => {
                                         const startMs = Number(chart?.$windowStartMs || windowStart);
                                         return formatBitrateChartAbsoluteTick(startMs, Number(value));
@@ -3753,7 +3816,7 @@ maybe a histogram of b
                                 },
                                 title: {
                                     display: true,
-                                    text: 'Mbps',
+                                    text: 'Bitrate (Mbps)',
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 }
                                 }
@@ -3866,6 +3929,9 @@ maybe a histogram of b
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
+                        // Match FPS chart's right Y-axis width — see
+                        // bandwidth chart for full rationale.
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
                         scales: {
                             x: {
                                 type: 'linear',
@@ -3876,6 +3942,7 @@ maybe a histogram of b
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 },
                                     maxTicksLimit: 8,
+                                    align: 'inner',
                                     callback: (value) => {
                                         const startMs = Number(bufferChart?.$windowStartMs || windowStart);
                                         return formatBitrateChartAbsoluteTick(startMs, Number(value));
@@ -3981,7 +4048,7 @@ maybe a histogram of b
             const droppedFpsValues = droppedFpsDataRaw.map((point) => Number(point.y)).filter((value) => Number.isFinite(value) && value >= 0);
             const fpsSmoothedData = [];
             let smooth = null;
-            const smoothingAlpha = 0.15;
+            const smoothingAlpha = 0.4;
             for (const point of fpsData) {
                 const y = Number(point.y);
                 if (!Number.isFinite(y) || y < 0) {
@@ -4176,6 +4243,7 @@ maybe a histogram of b
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 },
                                     maxTicksLimit: 8,
+                                    align: 'inner',
                                     callback: (value) => {
                                         const startMs = Number(fpsChart?.$windowStartMs || windowStart);
                                         return formatBitrateChartAbsoluteTick(startMs, Number(value));
@@ -4202,6 +4270,10 @@ maybe a histogram of b
                                 position: 'right',
                                 min: 0,
                                 max: maxDroppedFps,
+                                // Pin width to RIGHT_AXIS_PAD_PX so all
+                                // four chart plot areas (and the events-
+                                // timeline above) end at the same X.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
                                 grid: { drawOnChartArea: false },
                                 ticks: {
                                     color: '#9a3412',

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -772,6 +772,15 @@ maybe a histogram of b
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
         const eventsTimelines = new Map();
+        // Per-session collapse state for the PLAYER / SERVER section
+        // headers. setGroups replaces the entire groups dataset on
+        // every render, which would otherwise reset the user's
+        // collapse choice to default (expanded) every tick. We read
+        // the live state from the timeline before each rebuild and
+        // mirror it here so the choice survives across renders AND
+        // across full timeline re-creations (e.g. orphan-detection
+        // rebuilds when the session card is regenerated).
+        const eventsTimelineSectionCollapsed = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -2842,6 +2851,22 @@ maybe a histogram of b
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
+            // Sync our collapse-state mirror from the live timeline
+            // BEFORE we rebuild the groups array — captures any user
+            // toggle that happened since the last render.
+            const existingTimeline = eventsTimelines.get(sessionId);
+            if (existingTimeline && existingTimeline.groupsData) {
+                const live = eventsTimelineSectionCollapsed.get(sessionId) || {};
+                const p = existingTimeline.groupsData.get('PLAYER_SECTION');
+                const s = existingTimeline.groupsData.get('SERVER_SECTION');
+                if (p) live.player = (p.showNested === false);
+                if (s) live.server = (s.showNested === false);
+                eventsTimelineSectionCollapsed.set(sessionId, live);
+            }
+            const sectionState = eventsTimelineSectionCollapsed.get(sessionId) || {};
+            const playerShowNested = !sectionState.player; // default true (expanded)
+            const serverShowNested = !sectionState.server;
+
             // VARIANT subgroups: one lane per observed (resolution,
             // bitrate) tuple. Multi-bitrate-per-resolution variants are
             // a real ABR ladder pattern (e.g. H.264 + HEVC at 1080p),
@@ -2868,10 +2893,10 @@ maybe a histogram of b
             const variantGroupIds = variantGroups.map((g) => g.id);
 
             const groups = [
-                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes] },
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes], showNested: playerShowNested },
                 ...variantGroups,
                 ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
-                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes },
+                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes, showNested: serverShowNested },
                 ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
             ];
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2384,17 +2384,19 @@ maybe a histogram of b
                 }
             }
 
-            // PLAYERSTATE lane: sample player_metrics_state on each refresh
-            // tick and emit a marker on every transition. Derived purely
-            // from heartbeat data, so it works for both Apple (state_change
-            // events) and Android (state_change isn't emitted but the
-            // heartbeat still carries player_metrics_state).
+            // PLAYERSTATE lane: sample player_metrics_state on each
+            // refresh tick and emit a marker on every transition. Also
+            // captures the AVFoundation reasonForWaitingToPlay
+            // (player_metrics_waiting_reason) so the tooltip can
+            // disambiguate buffering causes (toMinimizeStalls vs
+            // evaluatingBufferingRate vs noItemToPlay etc.).
             const stateValue = String(session.player_metrics_state || '').trim();
+            const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
                 const prevState = lastRecordedPlayerStateBySession.get(String(key));
                 if (prevState !== stateValue) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue });
+                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                     lastRecordedPlayerStateBySession.set(String(key), stateValue);
@@ -2723,7 +2725,7 @@ maybe a histogram of b
             if (isChartPaused(sessionId)) return;
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
             const datasets = Object.entries(EVENT_LANES).map(([laneKey, cfg]) => {
                 // An event's lane comes either from a 1:1 mapping
@@ -2735,7 +2737,7 @@ maybe a histogram of b
                     return lane === laneKey;
                 }).map((e) => ({
                     x: e.x, y: cfg.y, ts: e.ts,
-                    type: e.type, state: e.state, mbps: e.mbps, resolution: e.resolution
+                    type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution
                 }));
                 let colors = cfg.color;
                 if (laneKey === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
@@ -2791,7 +2793,11 @@ maybe a histogram of b
                                         let extra = '';
                                         let label = ctx.dataset.label;
                                         if (ctx && ctx.raw) {
-                                            if (ctx.raw.state) extra = `: ${ctx.raw.state}`;
+                                            if (ctx.raw.state) {
+                                                extra = ctx.raw.reason
+                                                    ? `: ${ctx.raw.state} (${ctx.raw.reason})`
+                                                    : `: ${ctx.raw.state}`;
+                                            }
                                             else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
                                             else if (ctx.raw.type && EVENT_SUBTYPE_LABEL[ctx.raw.type]) extra = `: ${EVENT_SUBTYPE_LABEL[ctx.raw.type]}`;
                                         }
@@ -2979,8 +2985,14 @@ maybe a histogram of b
                 }
             }
 
+            // PLAYERSTATE label includes the AVPlayer waiting reason
+            // (when present) so the user can disambiguate buffering
+            // causes — e.g. "buffering (toMinimizeStalls)".
             pushRanges('PLAYERSTATE',
-                (e) => e.state || 'Unknown',
+                (e) => {
+                    const s = e.state || 'Unknown';
+                    return e.reason ? `${s} (${e.reason})` : s;
+                },
                 (e) => playerStateColor(e.state));
             pushRanges('DISPLAY_RES',
                 (e) => String(e.resolution || '?'),

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2302,21 +2302,20 @@ maybe a histogram of b
                 }
             }
 
-            // VARIANT lane: dedup by RESOLUTION, not bitrate.
-            // player_metrics_video_bitrate_mbps reports the actual
-            // segment bitrate which fluctuates with scene complexity
-            // even within one rendition (a high-motion 1080p segment
-            // can be 3x the bitrate of a low-motion 1080p segment).
-            // Resolution is stable per rendition, so it's the correct
-            // identity for an ABR variant. Skip ticks where resolution
-            // is missing rather than dedupe against an empty value
-            // (would briefly drop the active variant from the lane).
+            // VARIANT lane: dedup by (resolution, indicated bitrate).
+            // ABR ladders can legitimately have multiple variants at the
+            // same resolution but different bitrates (e.g. H.264 + HEVC
+            // at 1080p, or two quality presets), so resolution alone
+            // collapses real variants together. The bitrate is the
+            // manifest BANDWIDTH attribute (player_metrics_video_bitrate_mbps
+            // is iOS indicatedBitrate / Android Format.bitrate, both stable
+            // per rendition), so this is safe to use as identity now.
+            // Skip ticks where either is missing.
             const variantRes = String(session.player_metrics_video_resolution || '').trim();
-            if (variantRes) {
-                const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-                const variantMbps = Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0
-                    ? Math.round(variantMbpsRaw * 10) / 10 : 0;
-                const variantKey = variantRes;
+            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+            if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
+                const variantKey = `${variantRes}|${variantMbps}`;
                 const prevVariant = lastRecordedVariantBySession.get(String(key));
                 if (prevVariant !== variantKey) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
@@ -2663,27 +2662,23 @@ maybe a histogram of b
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
-            // VARIANT subgroups: one lane per observed RESOLUTION in
-            // the current window. Lane key is resolution because each
-            // rendition has a unique resolution; bitrate fluctuates per
-            // segment within one rendition and would split into phantom
-            // lanes. Bitrate is kept (latest seen for that resolution)
-            // for sorting and labelling.
+            // VARIANT subgroups: one lane per observed (resolution,
+            // bitrate) tuple. Multi-bitrate-per-resolution variants are
+            // a real ABR ladder pattern (e.g. H.264 + HEVC at 1080p),
+            // so each gets its own row. Sorted by bitrate DESCENDING,
+            // so the visual ladder runs highest at the top, lowest at
+            // the bottom.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            const seenVariants = new Map(); // key (resolution) -> {mbps, resolution}
+            const seenVariants = new Map(); // key (res|mbps) -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();
-                if (!res) continue;
                 const m = Number(v.mbps);
-                const existing = seenVariants.get(res);
-                if (!existing) {
-                    seenVariants.set(res, { mbps: m, resolution: res });
-                } else if (Number.isFinite(m) && m > 0) {
-                    existing.mbps = m; // keep the most recent bitrate for that resolution
+                if (!res || !Number.isFinite(m) || m <= 0) continue;
+                const k = `${res}|${m}`;
+                if (!seenVariants.has(k)) {
+                    seenVariants.set(k, { mbps: m, resolution: res });
                 }
             }
-            // Sort by bitrate DESCENDING (highest at top), so the visual
-            // ladder matches how ABR ladders are normally drawn.
             const variantOrder = Array.from(seenVariants.entries())
                 .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
@@ -2730,23 +2725,20 @@ maybe a histogram of b
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
 
-            // VARIANT: each resolution gets its own swim lane. Lane key
-            // matches seenVariants — resolution. Colour is bucketed by
-            // the segment's bitrate so high-motion (high-bitrate) and
-            // low-motion (low-bitrate) segments within one rendition
-            // are visible as colour shifts inside the same row.
+            // VARIANT: each (resolution, bitrate) tuple gets its own
+            // swim lane. Lane key matches seenVariants.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];
                 const res = String(v.resolution || '').trim();
-                if (!res) continue;
+                const m = Number(v.mbps);
+                if (!res || !Number.isFinite(m) || m <= 0) continue;
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
-                const m = Number(v.mbps);
                 const color = variantColor(m);
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${res}`,
+                    group: `VARIANT::${res}|${m}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2781,11 +2781,12 @@ maybe a histogram of b
                         orientation: { axis: 'top' },
                         // Auto-grow to fit all groups (variant lanes are
                         // added dynamically as the player walks the
-                        // ladder), but bounded so a runaway lane count
-                        // doesn't take over the whole page.
+                        // ladder). No maxHeight cap — capping causes
+                        // vis-timeline to scroll internally and hide
+                        // the top lanes; let the page itself scroll
+                        // when the lane count gets large.
                         height: 'auto',
                         minHeight: '240px',
-                        maxHeight: '700px',
                         start: liveStart,
                         end: liveEnd
                     }

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -565,6 +565,21 @@ maybe a histogram of b
         .chart-wrap {
             position: relative;
         }
+        .events-timeline-wrap .events-timeline {
+            height: 220px;
+            background: #fff;
+            border: 1px solid #e5e7eb;
+            border-radius: 4px;
+        }
+        .events-timeline .vis-item.vis-box,
+        .events-timeline .vis-item.vis-point {
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+        }
+        .events-timeline .vis-label {
+            font-size: 10px;
+            font-family: 'Courier New', monospace;
+        }
         .chart-paused-badge {
             display: none;
             position: absolute;
@@ -692,6 +707,7 @@ maybe a histogram of b
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
+        const eventsTimelines = new Map();
         const chartViewportBySession = new Map();
         const chartPausedBySession = new Map();
         const bandwidthVisibility = new Map();
@@ -2554,6 +2570,91 @@ maybe a histogram of b
             }
         }
 
+        // Real swim-lane chart using vis-timeline. Stacked above the
+        // Chart.js scatter approximation so we can compare. PLAYERSTATE
+        // becomes a continuous coloured ribbon (one segment per state
+        // span). Other lanes remain point markers since their underlying
+        // events are point-in-time. BUFFERING and STALL stay as points
+        // for now — pairing start/end into ranges needs the *_end events
+        // to flow through the dashboard event capture (currently only
+        // *_start variants reach parseBandwidthChartEventType).
+        function renderEventsTimelineChart(sessionId, windowStart, eventSeries) {
+            if (typeof vis === 'undefined' || !vis.Timeline) return;
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            const container = card.querySelector('.events-timeline');
+            if (!container) return;
+
+            const windowEndMs = windowStart + 600 * 1000;
+            const nowMs = Date.now();
+            const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
+
+            const groups = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
+                id: type,
+                content: cfg.label
+            }));
+
+            const items = [];
+            let itemId = 0;
+
+            const stateEvents = events.filter((e) => e.type === 'PLAYERSTATE')
+                .sort((a, b) => Number(a.ts) - Number(b.ts));
+            for (let i = 0; i < stateEvents.length; i++) {
+                const start = Number(stateEvents[i].ts);
+                const end = i + 1 < stateEvents.length ? Number(stateEvents[i + 1].ts) : nowMs;
+                const state = stateEvents[i].state || 'Unknown';
+                const color = playerStateColor(state);
+                items.push({
+                    id: itemId++,
+                    group: 'PLAYERSTATE',
+                    content: state,
+                    start: new Date(start),
+                    end: new Date(end),
+                    type: 'range',
+                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                });
+            }
+
+            for (const e of events) {
+                if (e.type === 'PLAYERSTATE') continue;
+                const cfg = EVENT_LANES[e.type];
+                if (!cfg) continue;
+                items.push({
+                    id: itemId++,
+                    group: e.type,
+                    content: '',
+                    start: new Date(Number(e.ts)),
+                    type: 'point',
+                    style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
+                });
+            }
+
+            let timeline = eventsTimelines.get(sessionId);
+            if (!timeline) {
+                timeline = new vis.Timeline(
+                    container,
+                    new vis.DataSet(items),
+                    new vis.DataSet(groups),
+                    {
+                        stack: false,
+                        showCurrentTime: false,
+                        zoomable: true,
+                        moveable: true,
+                        margin: { item: 4 },
+                        orientation: { axis: 'top' },
+                        min: new Date(windowStart - 60000),
+                        max: new Date(windowEndMs + 60000),
+                        start: new Date(windowStart),
+                        end: new Date(windowEndMs)
+                    }
+                );
+                eventsTimelines.set(sessionId, timeline);
+            } else {
+                timeline.setItems(new vis.DataSet(items));
+                timeline.setGroups(new vis.DataSet(groups));
+            }
+        }
+
         document.addEventListener('testing-session:charts-resize', (event) => {
             const sessionId = event.detail && event.detail.sessionId;
             if (!sessionId) return;
@@ -2613,6 +2714,7 @@ maybe a histogram of b
                 }))
                 .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
             renderEventsChart(sessionId, windowStart, eventSeries);
+            renderEventsTimelineChart(sessionId, windowStart, eventSeries);
             const shaperRateData = points.map(point => ({ x: point.x, y: point.shaperRate }));
             const shaperAvgData = points.map(point => ({ x: point.x, y: point.shaperAvg }));
             const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2849,10 +2849,6 @@ maybe a histogram of b
                 // viewport, apply it so the timeline starts in sync.
                 applyStoredChartViewport(sessionId, timeline);
                 // Detect user pan/zoom: rangechanged with byUser=true.
-                // Stop auto-following live so the user's zoom state
-                // sticks across the per-second render. Re-arm follow
-                // when they pan back to within 5s of "now". Broadcast
-                // their viewport to every other chart in this session.
                 timeline.on('rangechanged', (props) => {
                     if (!props || !props.byUser) return;
                     const rightEdge = props.end.getTime();
@@ -2860,7 +2856,26 @@ maybe a histogram of b
                     eventsTimelineFollowLive.set(sessionId, driftMs < 5000);
                     syncChartViewportAcrossSession(sessionId, timeline);
                 });
-                requestAnimationFrame(() => timeline.redraw());
+                // Container width is sometimes 0 on first paint (parent
+                // ScrollView not yet laid out, session card just inserted,
+                // etc). A single requestAnimationFrame isn't reliable —
+                // the next frame can still report width 0. Use a
+                // ResizeObserver that fires redraw() the moment the
+                // container actually has dimensions, then disconnects.
+                if (typeof ResizeObserver !== 'undefined') {
+                    const ro = new ResizeObserver((entries) => {
+                        for (const entry of entries) {
+                            if (entry.contentRect.width > 0) {
+                                timeline.redraw();
+                                ro.disconnect();
+                                return;
+                            }
+                        }
+                    });
+                    ro.observe(container);
+                } else {
+                    requestAnimationFrame(() => timeline.redraw());
+                }
                 console.log('[events-timeline] created for session', sessionId, 'with', items.length, 'items,', groups.length, 'groups, height', heightPx);
             } else {
                 timeline.setItems(new vis.DataSet(items));

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2578,9 +2578,9 @@ maybe a histogram of b
         }
         function variantLabel(mbps, resolution) {
             const m = Number(mbps);
-            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)} Mbps` : '';
+            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)}Mbps` : '';
             const res = String(resolution || '').trim();
-            if (res && mbpsStr) return `${res} · ${mbpsStr}`;
+            if (res && mbpsStr) return `${res}:${mbpsStr}`;
             return res || mbpsStr || '—';
         }
         // Look up the manifest variant whose BANDWIDTH best matches the

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -621,20 +621,12 @@ maybe a histogram of b
             border-right: none !important;
         }
         /* Top-level section headers (PLAYER / SERVER) sit at the
-         * leftmost edge — no indent — and are compacted to a single
-         * label-height row since they have no items themselves. */
+         * leftmost edge — no indent. Don't override row height here:
+         * vis-timeline computes label-row and chart-row positions
+         * together and any CSS-only height override drifts the two
+         * out of alignment. Live with the auto height. */
         .events-timeline-wrap .vis-label.vis-group-level-0 {
             padding-left: 4px !important;
-            height: 18px !important;
-            min-height: 18px !important;
-            max-height: 18px !important;
-            line-height: 18px !important;
-        }
-        .events-timeline-wrap .vis-foreground .vis-group.vis-group-level-0,
-        .events-timeline-wrap .vis-background .vis-group.vis-group-level-0 {
-            height: 18px !important;
-            min-height: 18px !important;
-            max-height: 18px !important;
         }
         /* Slim down the time-axis bar — vis-timeline's default leaves
          * a lot of vertical padding above and below the tick text. */
@@ -2978,17 +2970,15 @@ maybe a histogram of b
 
             // Compute explicit height. vis-timeline's height:'auto'
             // collapses to 0 because the wrap has no intrinsic height
-            // (its internal panels are absolutely positioned). Use
-            // measured row sizes — section headers are 18px (set via
-            // CSS), regular lanes are 22px under our slim styling,
-            // axis + padding ≈ 32px. Counts every group in the array
-            // including the section parents.
-            const SECTION_ROW_PX = 18;
-            const LANE_ROW_PX = 22;
-            const AXIS_PAD_PX = 32;
-            const sectionRows = groups.filter((g) => Array.isArray(g.nestedGroups)).length;
-            const laneRows = groups.length - sectionRows;
-            const computedHeight = (sectionRows * SECTION_ROW_PX) + (laneRows * LANE_ROW_PX) + AXIS_PAD_PX;
+            // (its internal panels are absolutely positioned). Use a
+            // uniform per-row estimate — section headers and lane
+            // rows share the same auto height now that we no longer
+            // CSS-override section-header heights (which broke
+            // label-to-lane alignment). Slight over-estimate is
+            // safer than under (under-estimate hides top rows).
+            const ROW_PX = 28;
+            const AXIS_PAD_PX = 50;
+            const computedHeight = (groups.length * ROW_PX) + AXIS_PAD_PX;
             const heightPx = `${computedHeight}px`;
             container.style.height = heightPx;
 

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2656,8 +2656,9 @@ maybe a histogram of b
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
 
             // VARIANT subgroups: one lane per observed variant key in the
-            // current window, ordered by bitrate ascending (so the lowest
-            // sits at the bottom of the VARIANT band, like an ABR ladder).
+            // current window, ordered by bitrate DESCENDING — highest at
+            // the top, lowest at the bottom — so the visual ladder
+            // matches how an ABR ladder is normally drawn.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
             const seenVariants = new Map(); // key -> {mbps, resolution}
             for (const v of variantEvents) {
@@ -2666,7 +2667,7 @@ maybe a histogram of b
                 if (!seenVariants.has(k)) seenVariants.set(k, { mbps: m, resolution: v.resolution || '' });
             }
             const variantOrder = Array.from(seenVariants.entries())
-                .sort((a, b) => Number(a[1].mbps) - Number(b[1].mbps));
+                .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
             const variantGroups = variantOrder.map(([k, v]) => ({
                 id: `VARIANT::${k}`,
                 content: variantLabel(v.mbps, v.resolution)
@@ -2712,8 +2713,9 @@ maybe a histogram of b
                 (e) => playerStateColor(e.state));
 
             // VARIANT: each variant gets its own swim lane. Render each
-            // active span in the lane that matches its variant key, so an
-            // upshift visually walks UP the ladder.
+            // active span in the lane that matches its variant key.
+            // With variants ordered highest-bitrate-at-top, an upshift
+            // visually walks UP the ladder and a downshift walks DOWN.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
             for (let i = 0; i < variantSeq.length; i++) {
                 const v = variantSeq[i];

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2976,15 +2976,21 @@ maybe a histogram of b
             const liveStart = new Date(nowMs - liveWindowMs);
             const liveEnd = new Date(nowMs);
 
-            // Let vis-timeline size itself to its actual content
-            // (rows + items + axis). Earlier we hand-computed the
-            // height to work around an empty-container collapse, but
-            // the resulting estimate over-allocated — vis-timeline's
-            // real row height is smaller than our 30px bucket and
-            // the unused vertical space showed as dead space at the
-            // top of the chart area. Wrap has min-height to prevent
-            // the initial render-before-data collapse.
-            container.style.removeProperty('height');
+            // Compute explicit height. vis-timeline's height:'auto'
+            // collapses to 0 because the wrap has no intrinsic height
+            // (its internal panels are absolutely positioned). Use
+            // measured row sizes — section headers are 18px (set via
+            // CSS), regular lanes are 22px under our slim styling,
+            // axis + padding ≈ 32px. Counts every group in the array
+            // including the section parents.
+            const SECTION_ROW_PX = 18;
+            const LANE_ROW_PX = 22;
+            const AXIS_PAD_PX = 32;
+            const sectionRows = groups.filter((g) => Array.isArray(g.nestedGroups)).length;
+            const laneRows = groups.length - sectionRows;
+            const computedHeight = (sectionRows * SECTION_ROW_PX) + (laneRows * LANE_ROW_PX) + AXIS_PAD_PX;
+            const heightPx = `${computedHeight}px`;
+            container.style.height = heightPx;
 
             // If the session card was rebuilt (innerHTML rewrite, etc.)
             // the cached timeline points at an orphaned div that's no
@@ -3009,7 +3015,7 @@ maybe a histogram of b
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        height: 'auto',
+                        height: heightPx,
                         start: liveStart,
                         end: liveEnd,
                         // Match the Chart.js bitrate chart's HH:MM:SS
@@ -3111,6 +3117,9 @@ maybe a histogram of b
             } else {
                 timeline.setItems(new vis.DataSet(items));
                 timeline.setGroups(new vis.DataSet(groups));
+                // Re-apply height each render — group count changes as
+                // variant lanes appear/disappear.
+                timeline.setOptions({ height: heightPx });
                 timeline.$windowStartMs = liveStart.getTime();
                 // Live-edge tracking: unless the user has explicitly
                 // paused the chart, slide the visible window so its

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2879,6 +2879,16 @@ maybe a histogram of b
             const items = [];
             let itemId = 0;
 
+            // Format absolute times for hover tooltips (matches the
+            // bitrate chart's HH:MM:SS).
+            function formatHoverTime(ms) {
+                const d = new Date(ms);
+                const hh = String(d.getHours()).padStart(2, '0');
+                const mm = String(d.getMinutes()).padStart(2, '0');
+                const ss = String(d.getSeconds()).padStart(2, '0');
+                return `${hh}:${mm}:${ss}`;
+            }
+
             // Helper to render an event-series sequence as continuous
             // ranges (one segment per stable value, transition on change).
             function pushRanges(typeKey, getLabel, getColor) {
@@ -2889,6 +2899,8 @@ maybe a histogram of b
                     const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
                     const label = getLabel(seq[i]);
                     const color = getColor(seq[i]);
+                    const durationSec = ((end - start) / 1000).toFixed(1);
+                    const title = `${EVENT_LANES[typeKey].label}: ${label}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                     items.push({
                         id: itemId++,
                         group: typeKey,
@@ -2896,6 +2908,7 @@ maybe a histogram of b
                         start: new Date(start),
                         end: new Date(end),
                         type: 'range',
+                        title: title,
                         style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                     });
                 }
@@ -2919,6 +2932,8 @@ maybe a histogram of b
                 const start = Number(v.ts);
                 const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
                 const color = variantColor(m);
+                const durationSec = ((end - start) / 1000).toFixed(1);
+                const title = `Variant: ${variantLabel(m, res)}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                 items.push({
                     id: itemId++,
                     group: `VARIANT::${res}|${m}`,
@@ -2926,6 +2941,7 @@ maybe a histogram of b
                     start: new Date(start),
                     end: new Date(end),
                     type: 'range',
+                    title: title,
                     style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                 });
             }
@@ -2934,12 +2950,14 @@ maybe a histogram of b
                 if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
+                const ts = Number(e.ts);
                 items.push({
                     id: itemId++,
                     group: e.type,
                     content: '',
-                    start: new Date(Number(e.ts)),
+                    start: new Date(ts),
                     type: 'point',
+                    title: `${cfg.label}\n${formatHoverTime(ts)}`,
                     style: `background-color: ${cfg.color}; border-color: ${cfg.color};`
                 });
             }

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2977,6 +2977,36 @@ maybe a histogram of b
                         height: heightPx,
                         start: liveStart,
                         end: liveEnd,
+                        // Match the Chart.js bitrate chart's HH:MM:SS
+                        // 24-hour tick format (formatBitrateChartAbsoluteTick).
+                        // Suppress vis-timeline's "Sat 25 April" major-label
+                        // strip — the Chart.js charts don't show a date row,
+                        // and the timestamps below are unambiguous in the
+                        // live-edge window we render.
+                        format: {
+                            minorLabels: {
+                                millisecond: 'HH:mm:ss',
+                                second: 'HH:mm:ss',
+                                minute: 'HH:mm:ss',
+                                hour: 'HH:mm:ss',
+                                weekday: 'HH:mm:ss',
+                                day: 'HH:mm:ss',
+                                week: 'HH:mm:ss',
+                                month: 'HH:mm:ss',
+                                year: 'HH:mm:ss'
+                            },
+                            majorLabels: {
+                                millisecond: '',
+                                second: '',
+                                minute: '',
+                                hour: '',
+                                weekday: '',
+                                day: '',
+                                week: '',
+                                month: '',
+                                year: ''
+                            }
+                        },
                         // Match the Chart.js charts' zoom UX:
                         //   plain wheel = page scroll (do not intercept)
                         //   Alt/Option + wheel = zoom in/out

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -566,7 +566,6 @@ maybe a histogram of b
             position: relative;
         }
         .events-timeline-wrap {
-            min-height: 240px;
             margin-bottom: 12px;
             position: relative;
         }
@@ -2779,14 +2778,11 @@ maybe a histogram of b
                         moveable: true,
                         margin: { item: 4 },
                         orientation: { axis: 'top' },
-                        // Auto-grow to fit all groups (variant lanes are
-                        // added dynamically as the player walks the
-                        // ladder). No maxHeight cap — capping causes
-                        // vis-timeline to scroll internally and hide
-                        // the top lanes; let the page itself scroll
-                        // when the lane count gets large.
+                        // Auto-grow to fit all groups. No min/max
+                        // constraints — they cause vis-timeline to scroll
+                        // internally and hide the top lanes. Let the
+                        // outer page scroll when the chart gets tall.
                         height: 'auto',
-                        minHeight: '240px',
                         start: liveStart,
                         end: liveEnd
                     }

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1867,7 +1867,8 @@ maybe a histogram of b
             if (eventType === 'restart') return 'RESTART';
             if (eventType === 'playing') return 'PLAYING';
             if (eventType === 'buffering_start') return 'BUFFERING';
-            if (eventType === 'rate_shift_up' || eventType === 'rate_shift_down') return 'SHIFT';
+            if (eventType === 'rate_shift_up') return 'SHIFT_UP';
+            if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
             return null;
         }
 
@@ -2326,10 +2327,11 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'PLAYERSTATE': { y: 8, color: '#6b7280', label: 'PLAYERSTATE' },
-            'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
-            'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
-            'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
+            'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
+            'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
+            'SHIFT_UP':    { y: 6, color: '#3b82f6', label: 'SHIFT UP' },
+            'SHIFT_DOWN':  { y: 5, color: '#ef4444', label: 'SHIFT DOWN' },
             'STALL':       { y: 4, color: '#000000', label: 'STALL' },
             'RESTART':     { y: 3, color: '#a855f7', label: 'RESTART' },
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
@@ -2523,7 +2525,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 8.5,
+                                type: 'linear', min: 0.5, max: 9.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2506,13 +2506,11 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'VARIANT':     { y: 8, color: '#16a34a', label: 'VARIANT' },
-            'DISPLAY_RES': { y: 7, color: '#0ea5e9', label: 'DISPLAY RES' },
-            'PLAYERSTATE': { y: 6, color: '#6b7280', label: 'PLAYERSTATE' },
-            'BUFFERING':   { y: 5, color: '#f59e0b', label: 'BUFFERING' },
-            'PLAYBACK':    { y: 4, color: '#16a34a', label: 'PLAYBACK' },
-            'IMPAIRMENT':  { y: 3, color: '#000000', label: 'IMPAIRMENT' },
-            'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
+            'VARIANT':     { y: 6, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 5, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE': { y: 4, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYBACK':    { y: 3, color: '#16a34a', label: 'PLAYBACK' },
+            'IMPAIRMENT':  { y: 2, color: '#000000', label: 'IMPAIRMENT' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
         // Subtype → lane mapping. Each event-source string from
@@ -2525,8 +2523,12 @@ maybe a histogram of b
             'SHIFT_UP': 'PLAYBACK', 'SHIFT_DOWN': 'PLAYBACK',
             'STALL': 'IMPAIRMENT', 'FROZEN': 'IMPAIRMENT',
             'SEGMENT_STALL': 'IMPAIRMENT', 'ERROR': 'IMPAIRMENT',
-            'BUFFERING': 'BUFFERING',
-            'LOOP_PLAYER': 'LOOP_PLAYER', 'LOOP_SERVER': 'LOOP_SERVER'
+            // BUFFERING events still flow on the wire but have no lane
+            // here — buffering is already visible on the PLAYERSTATE
+            // ribbon and the dedicated lane was redundant. LOOP_PLAYER
+            // is omitted while the player-side loop counter is broken
+            // (always 0); LOOP_SERVER is the only meaningful loop lane.
+            'LOOP_SERVER': 'LOOP_SERVER'
         };
         const EVENT_SUBTYPE_COLOR = {
             'PLAYING':       '#16a34a',
@@ -2822,7 +2824,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 8.5,
+                                type: 'linear', min: 0.5, max: 6.5,
                                 // Force a fixed Y-axis width so this chart's
                                 // X-axis lines up vertically with the bandwidth /
                                 // buffer / fps charts below (they all use the

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -697,6 +697,7 @@ maybe a histogram of b
         const bandwidthVisibility = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
+        const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -2260,6 +2261,23 @@ maybe a histogram of b
                 }
             }
 
+            // PLAYERSTATE lane: sample player_metrics_state on each refresh
+            // tick and emit a marker on every transition. Derived purely
+            // from heartbeat data, so it works for both Apple (state_change
+            // events) and Android (state_change isn't emitted but the
+            // heartbeat still carries player_metrics_state).
+            const stateValue = String(session.player_metrics_state || '').trim();
+            if (stateValue) {
+                const prevState = lastRecordedPlayerStateBySession.get(String(key));
+                if (prevState !== stateValue) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                    lastRecordedPlayerStateBySession.set(String(key), stateValue);
+                }
+            }
+
             const series = bandwidthHistory.get(key) || [];
             const lastLimit = series.length ? Number(series[series.length - 1].target) : NaN;
             let target = Number.isFinite(bandwidthTarget) ? bandwidthTarget : (Number.isFinite(lastLimit) ? lastLimit : 0);
@@ -2308,6 +2326,7 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
+            'PLAYERSTATE': { y: 8, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 7, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 6, color: '#f59e0b', label: 'BUFFERING' },
             'SHIFT':       { y: 5, color: '#3b82f6', label: 'SHIFT' },
@@ -2316,6 +2335,18 @@ maybe a histogram of b
             'LOOP_PLAYER': { y: 2, color: '#06b6d4', label: 'LOOP PLAYER' },
             'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
         };
+        // Per-state colour for the PLAYERSTATE lane — each dot's colour
+        // tells you what the player thought it was doing at that tick.
+        const PLAYER_STATE_COLOR = {
+            'Playing':   '#16a34a',
+            'Buffering': '#f59e0b',
+            'Paused':    '#9333ea',
+            'Idle':      '#6b7280',
+            'Unknown':   '#d1d5db'
+        };
+        function playerStateColor(s) {
+            return PLAYER_STATE_COLOR[String(s || '').trim()] || '#6b7280';
+        }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
         let legendHoverMetricKind = null;
@@ -2419,17 +2450,23 @@ maybe a histogram of b
             if (isChartPaused(sessionId)) return;
             const chartEvents = (eventSeries || [])
                 .filter((e) => Number(e.ts) >= windowStart)
-                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, ts: Number(e.ts) }))
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, ts: Number(e.ts) }))
                 .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
-            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => ({
-                label: cfg.label,
-                data: chartEvents.filter((e) => e.type === type).map((e) => ({ x: e.x, y: cfg.y, ts: e.ts })),
-                backgroundColor: cfg.color,
-                borderColor: cfg.color,
-                pointRadius: 5,
-                pointHoverRadius: 7,
-                showLine: false,
-            }));
+            const datasets = Object.entries(EVENT_LANES).map(([type, cfg]) => {
+                const points = chartEvents.filter((e) => e.type === type)
+                    .map((e) => ({ x: e.x, y: cfg.y, ts: e.ts, state: e.state }));
+                const isPlayerState = type === 'PLAYERSTATE';
+                const colors = isPlayerState ? points.map(p => playerStateColor(p.state)) : cfg.color;
+                return {
+                    label: cfg.label,
+                    data: points,
+                    backgroundColor: colors,
+                    borderColor: colors,
+                    pointRadius: 5,
+                    pointHoverRadius: 7,
+                    showLine: false,
+                };
+            });
             let chart = eventsCharts.get(sessionId);
             if (chart && chart.canvas !== canvas) {
                 chart.destroy();
@@ -2464,7 +2501,8 @@ maybe a histogram of b
                                         const offset = Number.isFinite(ts) && startMs > 0
                                             ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
                                             : '';
-                                        return `${ctx.dataset.label}${offset}`;
+                                        const state = ctx && ctx.raw && ctx.raw.state ? `: ${ctx.raw.state}` : '';
+                                        return `${ctx.dataset.label}${state}${offset}`;
                                     }
                                 }
                             },
@@ -2485,7 +2523,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 7.5,
+                                type: 'linear', min: 0.5, max: 8.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -724,12 +724,8 @@ maybe a histogram of b
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedVariantBySession = new Map();
-        // Two-sample debounce for VARIANT: holds the most recent
-        // unconfirmed (res, bitrate) candidate. Only when the same
-        // tuple shows up twice in a row do we commit it as a variant
-        // event — single-sample mismatches between the resolution
-        // observer and the bitrate observer no longer create phantom
-        // lanes (e.g. "3840x2160 @ 3.5 Mbps" mid-upshift).
+        const lastRecordedDisplayResBySession = new Map();
+        // Two-sample debounce belt for VARIANT.
         const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
@@ -2335,35 +2331,57 @@ maybe a histogram of b
                 }
             }
 
-            // VARIANT lane: dedup by (resolution, indicated bitrate).
-            // ABR ladders can legitimately have multiple variants at the
-            // same resolution but different bitrates (e.g. H.264 + HEVC
-            // at 1080p), so resolution alone collapses real variants.
-            // Two-sample debounce filters out transition skew —
-            // resolution and bitrate come from independent observers
-            // and can be briefly mismatched mid-shift, which would
-            // otherwise create phantom lanes like "3840x2160 @ 3.5 Mbps".
-            const variantRes = String(session.player_metrics_video_resolution || '').trim();
+            // VARIANT lane: bitrate is the leading-edge fetch-time
+            // signal (accessLog updates when a segment download
+            // completes). Resolution is the lagging render-time signal
+            // (presentation-size updates when the new frame is shown).
+            // To avoid phantom (new-resolution, old-bitrate) or
+            // (new-bitrate, old-resolution) entries during the shift
+            // window, drive resolution from the manifest BANDWIDTH
+            // lookup keyed off the bitrate. Fall back to the player's
+            // reported resolution only when no manifest match exists.
+            // Two-sample debounce remains as a belt for sessions
+            // without manifest data.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
-            if (variantRes && Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
-                const variantKey = `${variantRes}|${variantMbps}`;
-                const prevVariant = lastRecordedVariantBySession.get(String(key));
-                const pending = pendingVariantBySession.get(String(key));
-                if (prevVariant === variantKey) {
-                    // Already-committed variant — clear any stale pending.
-                    if (pending) pendingVariantBySession.delete(String(key));
-                } else if (pending && pending.key === variantKey) {
-                    // Two consecutive matching samples — commit.
+                const reportedRes = String(session.player_metrics_video_resolution || '').trim();
+                const manifestRes = manifestResolutionForBitrate(session, variantMbps);
+                const variantRes = manifestRes || reportedRes;
+                if (variantRes) {
+                    const variantKey = `${variantRes}|${variantMbps}`;
+                    const prevVariant = lastRecordedVariantBySession.get(String(key));
+                    const pending = pendingVariantBySession.get(String(key));
+                    if (prevVariant === variantKey) {
+                        if (pending) pendingVariantBySession.delete(String(key));
+                    } else if (manifestRes || (pending && pending.key === variantKey)) {
+                        // Manifest-validated changes commit immediately;
+                        // pure-player fallback still requires two samples.
+                        const eventSeries = bandwidthEventHistory.get(key) || [];
+                        eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                        const eventCutoff = now - windowMs;
+                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                        lastRecordedVariantBySession.set(String(key), variantKey);
+                        pendingVariantBySession.delete(String(key));
+                    } else {
+                        pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
+                    }
+                }
+            }
+
+            // DISPLAY_RES lane: the player's actually-presented frame
+            // resolution (player_metrics_video_resolution). Distinct
+            // from VARIANT — gap between VARIANT shifting and
+            // DISPLAY_RES shifting is the fetch-to-render lag.
+            const displayRes = String(session.player_metrics_video_resolution || '').trim();
+            if (displayRes) {
+                const prevDisplayRes = lastRecordedDisplayResBySession.get(String(key));
+                if (prevDisplayRes !== displayRes) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedVariantBySession.set(String(key), variantKey);
-                    pendingVariantBySession.delete(String(key));
-                } else {
-                    // First-seen candidate — hold it for one sample.
-                    pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
+                    lastRecordedDisplayResBySession.set(String(key), displayRes);
                 }
             }
 
@@ -2416,7 +2434,8 @@ maybe a histogram of b
         // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
         // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
         const EVENT_LANES = {
-            'VARIANT':     { y: 10, color: '#16a34a', label: 'VARIANT' },
+            'VARIANT':     { y: 11, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 10, color: '#0ea5e9', label: 'DISPLAY RES' },
             'PLAYERSTATE': { y: 9, color: '#6b7280', label: 'PLAYERSTATE' },
             'PLAYING':     { y: 8, color: '#16a34a', label: 'PLAYING' },
             'BUFFERING':   { y: 7, color: '#f59e0b', label: 'BUFFERING' },
@@ -2461,6 +2480,42 @@ maybe a histogram of b
             const res = String(resolution || '').trim();
             if (res && mbpsStr) return `${res} · ${mbpsStr}`;
             return res || mbpsStr || '—';
+        }
+        // Look up the manifest variant whose BANDWIDTH best matches the
+        // bitrate the player just reported. Used to drive VARIANT's
+        // resolution from the bitrate (which leads the
+        // presentation-size update by the segment's decode/render delay)
+        // — eliminates phantom (new-resolution, old-bitrate) lanes.
+        function manifestResolutionForBitrate(session, mbps) {
+            const variants = Array.isArray(session?.manifest_variants) ? session.manifest_variants : [];
+            if (!variants.length) return null;
+            let best = null;
+            let bestDelta = Infinity;
+            for (const v of variants) {
+                const vMbps = Number(v?.bandwidth || 0) / 1_000_000;
+                if (!Number.isFinite(vMbps) || vMbps <= 0) continue;
+                const delta = Math.abs(vMbps - mbps);
+                const tol = Math.max(0.5, vMbps * 0.05);
+                if (delta < tol && delta < bestDelta) {
+                    bestDelta = delta;
+                    best = String(v.resolution || '').trim() || null;
+                }
+            }
+            return best;
+        }
+        // DISPLAY RES lane colour scheme — bucketed by frame height so a
+        // 4K presentation reads as green/emerald and a 360p reads as red.
+        function displayResColor(res) {
+            const m = /(\d+)\s*[xX]\s*(\d+)/.exec(String(res || ''));
+            if (!m) return '#9ca3af';
+            const h = Number(m[2]);
+            if (!Number.isFinite(h) || h <= 0) return '#9ca3af';
+            if (h <= 360)  return '#dc2626';
+            if (h <= 540)  return '#ea580c';
+            if (h <= 720)  return '#f59e0b';
+            if (h <= 1080) return '#84cc16';
+            if (h <= 1440) return '#16a34a';
+            return '#10b981';
         }
         let legendHoverIndex = null;
         let legendHoverChartId = null;
@@ -2573,6 +2628,7 @@ maybe a histogram of b
                 let colors = cfg.color;
                 if (type === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
                 else if (type === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
+                else if (type === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
                 return {
                     label: cfg.label,
                     data: points,
@@ -2643,7 +2699,7 @@ maybe a histogram of b
                                 grid: { color: 'rgba(0,0,0,0.05)' }
                             },
                             y: {
-                                type: 'linear', min: 0.5, max: 10.5,
+                                type: 'linear', min: 0.5, max: 11.5,
                                 title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
                                 ticks: {
                                     stepSize: 1,
@@ -2765,6 +2821,9 @@ maybe a histogram of b
             pushRanges('PLAYERSTATE',
                 (e) => e.state || 'Unknown',
                 (e) => playerStateColor(e.state));
+            pushRanges('DISPLAY_RES',
+                (e) => String(e.resolution || '?'),
+                (e) => displayResColor(e.resolution));
 
             // VARIANT: each (resolution, bitrate) tuple gets its own
             // swim lane. Lane key matches seenVariants.
@@ -2789,7 +2848,7 @@ maybe a histogram of b
             }
 
             for (const e of events) {
-                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT') continue;
+                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
                 const cfg = EVENT_LANES[e.type];
                 if (!cfg) continue;
                 items.push({

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -3077,11 +3077,11 @@ maybe a histogram of b
                         start: liveStart,
                         end: liveEnd,
                         // Match the Chart.js bitrate chart's HH:MM:SS
-                        // 24-hour tick format (formatBitrateChartAbsoluteTick).
-                        // Suppress vis-timeline's "Sat 25 April" major-label
-                        // strip — the Chart.js charts don't show a date row,
-                        // and the timestamps below are unambiguous in the
-                        // live-edge window we render.
+                        // 24-hour tick format. Suppress the date strip.
+                        // timeAxis.scale='second' + step=60 forces a
+                        // tick every 60 seconds at consistent spacing,
+                        // matching the bitrate chart's tick density.
+                        timeAxis: { scale: 'second', step: 60 },
                         format: {
                             minorLabels: {
                                 millisecond: 'HH:mm:ss',

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2806,7 +2806,17 @@ maybe a histogram of b
             const heightPx = `${computedHeight}px`;
             container.style.height = heightPx;
 
+            // If the session card was rebuilt (innerHTML rewrite, etc.)
+            // the cached timeline points at an orphaned div that's no
+            // longer in the DOM. Detect that and recreate against the
+            // new container — same defence the Chart.js code does
+            // (`if (chart.canvas !== canvas) destroy + recreate`).
             let timeline = eventsTimelines.get(sessionId);
+            if (timeline && timeline.$container !== container) {
+                timeline.destroy();
+                eventsTimelines.delete(sessionId);
+                timeline = null;
+            }
             if (!timeline) {
                 timeline = new vis.Timeline(
                     container,
@@ -2839,12 +2849,15 @@ maybe a histogram of b
                 );
                 eventsTimelines.set(sessionId, timeline);
                 eventsTimelineFollowLive.set(sessionId, true);
-                // Tag for the cross-chart viewport sync helpers, and
-                // anchor the seconds-from-windowStart frame to liveStart
-                // so vis-timeline ranges convert consistently to the
-                // 0–600 units the Chart.js charts use.
+                // Tag for the cross-chart viewport sync helpers, anchor
+                // the seconds-from-windowStart frame to liveStart so
+                // vis-timeline ranges convert consistently to the 0–600
+                // units the Chart.js charts use, and remember the DOM
+                // container so a session-card rebuild is detected on
+                // the next render.
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
+                timeline.$container = container;
                 // If another chart in this session already has a stored
                 // viewport, apply it so the timeline starts in sync.
                 applyStoredChartViewport(sessionId, timeline);

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1367,7 +1367,7 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 
 func isSignificantPlayerEvent(event string) bool {
 	switch strings.ToLower(strings.TrimSpace(event)) {
-	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing", "buffering_start", "buffering_end", "rate_shift_up", "rate_shift_down":
+	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing", "buffering_start", "buffering_end", "rate_shift_up", "rate_shift_down", "video_first_frame", "video_start_time":
 		return true
 	}
 	return false

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1367,7 +1367,7 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 
 func isSignificantPlayerEvent(event string) bool {
 	switch strings.ToLower(strings.TrimSpace(event)) {
-	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing":
+	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing", "buffering_start", "buffering_end", "rate_shift_up", "rate_shift_down":
 		return true
 	}
 	return false

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1367,7 +1367,7 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 
 func isSignificantPlayerEvent(event string) bool {
 	switch strings.ToLower(strings.TrimSpace(event)) {
-	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing", "buffering_start", "buffering_end", "rate_shift_up", "rate_shift_down", "video_first_frame", "video_start_time":
+	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing", "buffering_start", "buffering_end", "rate_shift_up", "rate_shift_down", "video_first_frame", "video_start_time", "timejump":
 		return true
 	}
 	return false

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1367,7 +1367,7 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 
 func isSignificantPlayerEvent(event string) bool {
 	switch strings.ToLower(strings.TrimSpace(event)) {
-	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker":
+	case "stall_start", "stall_end", "segment_stall", "restart", "frozen", "error", "loop_marker", "playing":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- New `playing` event fires from both Apple and Android players the moment a new piece of content starts loading, distinct from the existing `video_first_frame` (first decoded frame) and `video_start_time` (playhead ≥ 0.1s) events. SSE consumers get a session-start signal at content-select time rather than at first-frame time.
- Apple (`PlaybackViewModel.startPlaybackNow`): fired right after `player.play()` with `player_metrics_content_url`, `player_metrics_content_name`, `player_metrics_codec_fallback`.
- Android (`PlaybackMetrics.onPlaybackStarted`): fired at the end of the per-playback reset with `player_metrics_content_url` from the existing url provider.
- go-proxy (`isSignificantPlayerEvent`): `"playing"` added to the broadcast list so the existing `/api/sessions/stream` SSE picks it up alongside stall/restart/error.

Naming: lowercase `playing` to match the existing event-name convention (`heartbeat`, `restart`, `stall_start`, `video_first_frame`, …); the user wrote `PLAYING` for emphasis but the wire shape stays consistent.

Closes #240

## Test plan

- [x] `./gradlew assembleDebug` — builds clean.
- [x] `go vet ./... && go build ./...` in `go-proxy/` — clean.
- [ ] Install Apple TV and Android TV builds; pick a content item; verify `POST /api/session/{id}/metrics` arrives with `player_metrics_last_event=playing` and the content-url extras populated.
- [ ] Open the SSE stream (`/api/sessions/stream`); verify a `playing` event fires per content selection, not just per first-frame.
- [ ] Switch content while playing; verify a fresh `playing` event fires for the new URL (and `video_first_frame` follows once the new stream renders).