### PR TITLE
fix(dashboard): buffer-depth chart Y-axis uses 60s as floor, not cap

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5142,9 +5142,11 @@
                 .map((point) => Number(point.y))
                 .filter((value) => Number.isFinite(value) && value >= 0);
             // Round up to the next 5-second step so the chart y-axis ticks
-            // land on 5, 10, 15, ..., 60. Cap at 60, floor at 5.
+            // land on 5, 10, 15, ..., 60+. Floor of 60 so the axis is
+            // consistent across sessions; expands beyond when the buffer
+            // genuinely goes deeper.
             const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
-            const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
+            const maxBufferDepth = Math.max(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
             let bufferChart = bufferDepthCharts.get(sessionId);
             if (bufferChart && bufferChart.canvas !== bufferCanvas) {
                 bufferChart.destroy();

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -3040,12 +3040,14 @@ maybe a histogram of b
             }
             // Compute max across ALL datasets (primary + any comparison
             // sessions) so grouped-session lines don't clip above the axis.
-            // Round up to the next 5s step, floor 5, cap 60.
+            // Round up to the next 5s step; floor at 60 so the axis stays
+            // consistent across sessions and expands beyond when the buffer
+            // genuinely goes deeper.
             const bufferValues = bufferDatasets.flatMap(ds => ds.data)
                 .map((point) => Number(point && point.y))
                 .filter((value) => Number.isFinite(value) && value >= 0);
             const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
-            const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
+            const maxBufferDepth = Math.max(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
             if (!bufferChart) {
                 bufferChart = new Chart(bufferCanvas, {
                     type: 'line',


### PR DESCRIPTION
## Summary

`testing.html:3048` and `testing-session.html:5147` computed the buffer-depth chart's Y-axis maximum as:

\`\`\`js
const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
\`\`\`

`Math.min(60, ...)` made 60s a **hard ceiling** — once the buffer reached ~60s the chart silently clipped further samples and a 90s buffer looked identical to a 60s buffer.

Flip to `Math.max(60, ...)` so 60s is a **floor** on the Y-axis maximum: the axis always shows at least 0–60s (consistent scale across sessions, easy cross-comparison) but expands when the buffer actually goes deeper. Both pages updated per the cross-compare-testing-pages convention; comment text adjusted to match.

Closes #242

## Test plan

- [ ] Reload `testing.html`; while buffer stays under 60s, verify the Y axis still tops out at 60 (consistent scale).
- [ ] Force a deep buffer (e.g. inject network shaping that lets the player run ahead, or a session whose live offset is large); verify the Y axis grows past 60 to fit the data instead of clipping at 60.
- [ ] Same checks on `testing-session.html`.