### PR TITLE
fix(makefile): deploy-androidtv preserves app data across redeploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,13 +274,21 @@ deploy-iphone:
 		"$(IPHONE_BUNDLE_ID)"
 
 deploy-androidtv:
-	$(ANDROID_SDK_HOME)/platform-tools/adb uninstall com.infinitestream.player 2>/dev/null || true
+	# Don't `adb uninstall` first — gradlew installDebug performs an
+	# in-place upgrade that preserves SharedPreferences (server list,
+	# selected protocol/segment/codec, etc.) since the local debug
+	# keystore signature is stable across rebuilds. Use
+	# `make uninstall-androidtv` if a real reset is needed (e.g. after
+	# a signature change).
 	cd $(ANDROIDTV_DIR) && \
 		JAVA_HOME="$(JAVA_HOME_ANDROID)" \
 		ANDROID_HOME="$(ANDROID_SDK_HOME)" \
 		PATH="$(ANDROID_SDK_HOME)/platform-tools:$$PATH" \
 		./gradlew installDebug
 	$(ANDROID_SDK_HOME)/platform-tools/adb shell am start -n com.infinitestream.player/.MainActivity
+
+uninstall-androidtv:
+	$(ANDROID_SDK_HOME)/platform-tools/adb uninstall com.infinitestream.player 2>/dev/null || true
 
 # ── Synthetic test pattern ─────────────────────────────────────────────
 # Generate a 4K mezzanine file from FFmpeg's `testsrc` source (colour


### PR DESCRIPTION
## Summary

`make deploy-androidtv` ran `adb uninstall com.infinitestream.player` before every `gradlew installDebug`, which deleted the app's data dir and wiped SharedPreferences — every redeploy forced re-discovery of servers.

`gradlew installDebug` alone does an in-place upgrade that preserves app data because debug builds reuse the stable local debug keystore on every rebuild (signatures match). The uninstall step was unnecessary and counter-productive.

- Drop the uninstall from `deploy-androidtv`.
- Add `uninstall-androidtv` as a separate target for the rare case (manual keystore change, signature mismatch) where a real reset is needed.

Closes #244

## Test plan

- [ ] On the Google TV Streamer with a known server list, run `make deploy-androidtv`; verify app launches with the existing servers still present (no re-discovery needed).
- [ ] Repeat once more to confirm a second redeploy also preserves them.
- [ ] If a future build hits a signature mismatch (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`), run `make uninstall-androidtv` then `make deploy-androidtv`.