### PR TITLE
feat(androidtv): "Add a server" runs discovery inline

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.java
@@ -460,54 +460,49 @@ public class MainActivity extends AppCompatActivity {
      *  - Enter manually (always works as a fallback)
      */
      private void showAddServerMenu() {
-        String[] options = {
-            "Discover on this network…",
-            "Pair with code…",
-            "Enter host/port manually…"
-        };
-        new AlertDialog.Builder(this)
-            .setTitle("Add a server")
-            .setItems(options, (dialog, which) -> {
-                switch (which) {
-                    case 0: showDiscoverDialog(); break;
-                    case 1: showPairWithCodeDialog(); break;
-                    case 2: showManualEntryDialog(); break;
-                }
-            })
-            .setNegativeButton("Cancel", null)
-            .show();
-    }
-
-    private void showDiscoverDialog() {
+        // Kick off discovery immediately and surface results inline above
+        // pair-with-code / manual-entry. 95% of the time the TV is on the
+        // same network as the server and the user picks the first hit, so
+        // the previous "Discover on this network…" sub-dialog was an extra
+        // tap for the common case.
         statusText.setText(R.string.discovering);
         discoverButton.setEnabled(false);
         RendezvousService.discoverServers(this, (found, error) -> {
             discoverButton.setEnabled(true);
             if (error != null) {
-                Toast.makeText(this, "Discovery failed: " + error, Toast.LENGTH_LONG).show();
                 statusText.setText("Discovery failed: " + error);
-                return;
+            } else {
+                statusText.setText("");
             }
-            if (found.isEmpty()) {
-                new AlertDialog.Builder(this)
-                    .setTitle("Discover servers")
-                    .setMessage(R.string.no_servers_found)
-                    .setPositiveButton(android.R.string.ok, null)
-                    .show();
-                statusText.setText("No servers detected.");
-                return;
-            }
-            String[] labels = new String[found.size()];
-            for (int i = 0; i < found.size(); i++) {
-                RendezvousService.DiscoveredServer s = found.get(i);
-                labels[i] = s.label + "\n" + s.url;
-            }
-            new AlertDialog.Builder(this)
-                .setTitle("Detected servers (" + found.size() + ")")
-                .setItems(labels, (dialog, which) -> addDiscoveredServer(found.get(which)))
-                .setNegativeButton("Cancel", null)
-                .show();
+            showAddServerMenuWith(found != null ? found : new ArrayList<>());
         });
+    }
+
+    private void showAddServerMenuWith(List<RendezvousService.DiscoveredServer> discovered) {
+        final int n = discovered.size();
+        String[] options = new String[n + 2];
+        for (int i = 0; i < n; i++) {
+            RendezvousService.DiscoveredServer s = discovered.get(i);
+            options[i] = s.label + "\n" + s.url;
+        }
+        options[n] = "Pair with code…";
+        options[n + 1] = "Enter host/port manually…";
+        String title = n > 0
+            ? "Add a server (" + n + " found)"
+            : "Add a server (no servers detected)";
+        new AlertDialog.Builder(this)
+            .setTitle(title)
+            .setItems(options, (dialog, which) -> {
+                if (which < n) {
+                    addDiscoveredServer(discovered.get(which));
+                } else if (which == n) {
+                    showPairWithCodeDialog();
+                } else {
+                    showManualEntryDialog();
+                }
+            })
+            .setNegativeButton("Cancel", null)
+            .show();
     }
 
     /**

--- a/android/InfiniteStreamPlayer/app/src/main/res/layout/activity_main.xml
+++ b/android/InfiniteStreamPlayer/app/src/main/res/layout/activity_main.xml
@@ -155,9 +155,10 @@
 
             <com.google.android.material.button.MaterialButtonToggleGroup
                 android:id="@+id/server_toggle"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
+                android:orientation="vertical"
                 app:selectionRequired="true"
                 app:singleSelection="true" />
 


### PR DESCRIPTION
## Summary

`showAddServerMenu()` previously showed three siblings — Discover / Pair / Manual — forcing an extra tap to reach the discovery list. Replace with a single inline flow: tap "Add a server", the rendezvous announce probe runs immediately, the dialog lists discovered servers at the top and pair-with-code / manual-entry as fallbacks.

95% of the time the TV is on the same network as the server, so the common path collapses to two taps: "Add a server" → first hit.

Mirrors `AddServerSheet.swift` on iOS (per the iOS-as-parity reference).

Closes #246

## Test plan

- [x] `./gradlew assembleDebug` — clean.
- [ ] On the Google TV Streamer with a discoverable server: tap "Add a server" → verify the dialog title says "Add a server (N found)" and the first row(s) are the discovered server(s); selecting one adds it as expected.
- [ ] No-server case (rendezvous unreachable / no announce): tap "Add a server" → verify dialog title says "Add a server (no servers detected)", only Pair / Manual options listed, status line shows the error.
- [ ] Existing pair-with-code and manual-entry flows work unchanged from the new menu's bottom two rows.