### PR TITLE
ci: add Claude GitHub App workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+# Triggers Claude in response to `@claude` mentions in issue / PR / review
+# comments. Auth: ANTHROPIC_API_KEY secret + the Claude GitHub App
+# (https://github.com/apps/claude) installed on the repo.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  claude:
+    # Skip runs that can't possibly contain a mention, to avoid burning
+    # Actions minutes (and API tokens) on every random comment.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/claude.yml` that runs `anthropics/claude-code-action@v1` when `@claude` is mentioned in issues, PR comments, or review comments.
- Permissions block scoped to `contents/issues/pull-requests: write`.
- Auth via `ANTHROPIC_API_KEY` repo secret.

Closes #249.

## Manual follow-ups (one-time)
- [ ] Install the Claude GitHub App on this repo: https://github.com/apps/claude
- [ ] Add `ANTHROPIC_API_KEY` to repo Actions secrets.

Both can be done in one shot from the Claude Code CLI: `/install-github-app` (requires repo admin).

## Test plan
- [ ] After merge + manual setup, comment `@claude say hi` on a throwaway issue and confirm the workflow runs and Claude replies.
- [ ] Confirm non-`@claude` comments do not trigger a workflow run (the `if:` filter should skip them).