### PR TITLE
feat(go-proxy): ATS-style transfer timeouts

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -845,14 +845,14 @@
                                 </div>
                             </div>
                             <div class="range-row">
-                                <label>Active timeout (ms)</label>
-                                <input type="range" min="0" max="30000" step="100" data-field="transfer_active_timeout_ms" value="${Number.isFinite(Number(session.transfer_active_timeout_ms)) && Number(session.transfer_active_timeout_ms) >= 0 ? Number(session.transfer_active_timeout_ms) : 0}">
-                                <span class="range-value">${Number.isFinite(Number(session.transfer_active_timeout_ms)) && Number(session.transfer_active_timeout_ms) >= 0 ? Number(session.transfer_active_timeout_ms) : 0}</span>
+                                <label>Active timeout (s)</label>
+                                <input type="range" min="0" max="30" step="1" data-field="transfer_active_timeout_seconds" value="${Number.isFinite(Number(session.transfer_active_timeout_seconds)) && Number(session.transfer_active_timeout_seconds) >= 0 ? Number(session.transfer_active_timeout_seconds) : 0}">
+                                <span class="range-value">${Number.isFinite(Number(session.transfer_active_timeout_seconds)) && Number(session.transfer_active_timeout_seconds) >= 0 ? Number(session.transfer_active_timeout_seconds) : 0}</span>
                             </div>
                             <div class="range-row">
-                                <label>Idle timeout (ms)</label>
-                                <input type="range" min="0" max="30000" step="100" data-field="transfer_idle_timeout_ms" value="${Number.isFinite(Number(session.transfer_idle_timeout_ms)) && Number(session.transfer_idle_timeout_ms) >= 0 ? Number(session.transfer_idle_timeout_ms) : 0}">
-                                <span class="range-value">${Number.isFinite(Number(session.transfer_idle_timeout_ms)) && Number(session.transfer_idle_timeout_ms) >= 0 ? Number(session.transfer_idle_timeout_ms) : 0}</span>
+                                <label>Idle timeout (s)</label>
+                                <input type="range" min="0" max="30" step="1" data-field="transfer_idle_timeout_seconds" value="${Number.isFinite(Number(session.transfer_idle_timeout_seconds)) && Number(session.transfer_idle_timeout_seconds) >= 0 ? Number(session.transfer_idle_timeout_seconds) : 0}">
+                                <span class="range-value">${Number.isFinite(Number(session.transfer_idle_timeout_seconds)) && Number(session.transfer_idle_timeout_seconds) >= 0 ? Number(session.transfer_idle_timeout_seconds) : 0}</span>
                             </div>
                             <div class="session-item">
                                 <span class="label">Fault Counters</span>
@@ -1136,8 +1136,8 @@
             .map(input => input.value);
         
         // Transfer timeout settings
-        const transferActiveTimeoutMs = getRangeValue('transfer_active_timeout_ms');
-        const transferIdleTimeoutMs = getRangeValue('transfer_idle_timeout_ms');
+        const transferActiveTimeoutSeconds = getRangeValue('transfer_active_timeout_seconds');
+        const transferIdleTimeoutSeconds = getRangeValue('transfer_idle_timeout_seconds');
         const transferAppliesSegments = !!card.querySelector('input[data-field="transfer_timeout_applies_segments"]')?.checked;
         const transferAppliesManifests = !!card.querySelector('input[data-field="transfer_timeout_applies_manifests"]')?.checked;
         const transferAppliesMaster = !!card.querySelector('input[data-field="transfer_timeout_applies_master"]')?.checked;
@@ -1196,8 +1196,8 @@
             transport_fault_on_seconds: getRangeValue('transport_consecutive_failures'),
             transport_fault_off_seconds: getRangeValue('transport_failure_frequency'),
             // Transfer timeouts
-            transfer_active_timeout_ms: transferActiveTimeoutMs,
-            transfer_idle_timeout_ms: transferIdleTimeoutMs,
+            transfer_active_timeout_seconds: transferActiveTimeoutSeconds,
+            transfer_idle_timeout_seconds: transferIdleTimeoutSeconds,
             transfer_timeout_applies_segments: transferAppliesSegments,
             transfer_timeout_applies_manifests: transferAppliesManifests,
             transfer_timeout_applies_master: transferAppliesMaster,

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -535,6 +535,7 @@
 
         const sessionDetailsOpen = resolveSectionDefault(options, 'session-details', false);
         const faultInjectionOpen = resolveSectionDefault(options, 'fault-injection', true);
+        const serverTimeoutsOpen = resolveSectionDefault(options, 'server-timeouts', false);
         const networkShapingOpen = resolveSectionDefault(options, 'network-shaping', true);
         const bitrateChartOpen = resolveSectionDefault(options, 'bitrate-chart', false);
         const playerMetricsOpen = resolveSectionDefault(options, 'player-metrics', false);
@@ -827,6 +828,40 @@
                     </div>
                 </div>
 
+                <!-- Collapsible Server Timeouts -->
+                <div class="collapsible-section" data-section="server-timeouts" data-default-open="${serverTimeoutsOpen}">
+                    <div class="collapsible-header" data-toggle="server-timeouts">
+                        <span class="collapsible-icon">${serverTimeoutsOpen ? '▼' : '▶'}</span>
+                        <span class="collapsible-title">Server Timeouts</span>
+                    </div>
+                    <div class="collapsible-content" data-content="server-timeouts" style="display: ${serverTimeoutsOpen ? 'block' : 'none'};">
+                        <div class="fault-injection-section">
+                            <div class="fault-control-row">
+                                <label>Apply To</label>
+                                <div class="checkbox-group">
+                                    <label><input type="checkbox" data-field="transfer_timeout_applies_segments" ${getBool(session, 'transfer_timeout_applies_segments') ? 'checked' : ''}>Segments</label>
+                                    <label><input type="checkbox" data-field="transfer_timeout_applies_manifests" ${getBool(session, 'transfer_timeout_applies_manifests') ? 'checked' : ''}>Media manifests</label>
+                                    <label><input type="checkbox" data-field="transfer_timeout_applies_master" ${getBool(session, 'transfer_timeout_applies_master') ? 'checked' : ''}>Master manifest</label>
+                                </div>
+                            </div>
+                            <div class="range-row">
+                                <label>Active timeout (ms)</label>
+                                <input type="range" min="0" max="30000" step="100" data-field="transfer_active_timeout_ms" value="${Number.isFinite(Number(session.transfer_active_timeout_ms)) && Number(session.transfer_active_timeout_ms) >= 0 ? Number(session.transfer_active_timeout_ms) : 0}">
+                                <span class="range-value">${Number.isFinite(Number(session.transfer_active_timeout_ms)) && Number(session.transfer_active_timeout_ms) >= 0 ? Number(session.transfer_active_timeout_ms) : 0}</span>
+                            </div>
+                            <div class="range-row">
+                                <label>Idle timeout (ms)</label>
+                                <input type="range" min="0" max="30000" step="100" data-field="transfer_idle_timeout_ms" value="${Number.isFinite(Number(session.transfer_idle_timeout_ms)) && Number(session.transfer_idle_timeout_ms) >= 0 ? Number(session.transfer_idle_timeout_ms) : 0}">
+                                <span class="range-value">${Number.isFinite(Number(session.transfer_idle_timeout_ms)) && Number(session.transfer_idle_timeout_ms) >= 0 ? Number(session.transfer_idle_timeout_ms) : 0}</span>
+                            </div>
+                            <div class="session-item">
+                                <span class="label">Fault Counters</span>
+                                <span class="value" data-field="transfer_timeout_counters">Active ${Number(session.fault_count_transfer_active_timeout) || 0} · Idle ${Number(session.fault_count_transfer_idle_timeout) || 0}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Collapsible Network Shaping Section -->
                 <div class="collapsible-section" data-section="network-shaping" data-default-open="${networkShapingOpen}" data-net-shaping>
                     <div class="collapsible-header" data-toggle="network-shaping">
@@ -1099,6 +1134,13 @@
         const segmentChecks = Array.from(card.querySelectorAll('input[data-field="segment_failure_urls"]:checked'))
             .map(input => input.value);
         
+        // Transfer timeout settings
+        const transferActiveTimeoutMs = getRangeValue('transfer_active_timeout_ms');
+        const transferIdleTimeoutMs = getRangeValue('transfer_idle_timeout_ms');
+        const transferAppliesSegments = !!card.querySelector('input[data-field="transfer_timeout_applies_segments"]')?.checked;
+        const transferAppliesManifests = !!card.querySelector('input[data-field="transfer_timeout_applies_manifests"]')?.checked;
+        const transferAppliesMaster = !!card.querySelector('input[data-field="transfer_timeout_applies_master"]')?.checked;
+
         // Content manipulation settings
         const contentStripCodecs = !!card.querySelector('input[data-field="content_strip_codecs"]')?.checked;
         const contentStripAvgBandwidth = !!card.querySelector('input[data-field="content_strip_average_bandwidth"]')?.checked;
@@ -1152,6 +1194,12 @@
             transport_frequency_seconds: getRangeValue('transport_failure_frequency'),
             transport_fault_on_seconds: getRangeValue('transport_consecutive_failures'),
             transport_fault_off_seconds: getRangeValue('transport_failure_frequency'),
+            // Transfer timeouts
+            transfer_active_timeout_ms: transferActiveTimeoutMs,
+            transfer_idle_timeout_ms: transferIdleTimeoutMs,
+            transfer_timeout_applies_segments: transferAppliesSegments,
+            transfer_timeout_applies_manifests: transferAppliesManifests,
+            transfer_timeout_applies_master: transferAppliesMaster,
             // Content manipulation
             content_strip_codecs: contentStripCodecs,
             content_strip_average_bandwidth: contentStripAvgBandwidth,

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -2907,8 +2907,8 @@
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
-            syncRange('transfer_active_timeout_ms', session.transfer_active_timeout_ms, 0);
-            syncRange('transfer_idle_timeout_ms', session.transfer_idle_timeout_ms, 0);
+            syncRange('transfer_active_timeout_seconds', session.transfer_active_timeout_seconds, 0);
+            syncRange('transfer_idle_timeout_seconds', session.transfer_idle_timeout_seconds, 0);
             const syncTransferCheckbox = (field, value) => {
                 const input = card.querySelector(`input[data-field="${field}"]`);
                 if (input) input.checked = !!value;
@@ -3138,8 +3138,8 @@
                 'master_manifest_failure_frequency',
                 'transport_consecutive_failures',
                 'transport_failure_frequency',
-                'transfer_active_timeout_ms',
-                'transfer_idle_timeout_ms'
+                'transfer_active_timeout_seconds',
+                'transfer_idle_timeout_seconds'
             ].includes(field);
         }
 

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -2783,6 +2783,15 @@
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
+            syncRange('transfer_active_timeout_ms', session.transfer_active_timeout_ms, 0);
+            syncRange('transfer_idle_timeout_ms', session.transfer_idle_timeout_ms, 0);
+            const syncTransferCheckbox = (field, value) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (input) input.checked = !!value;
+            };
+            syncTransferCheckbox('transfer_timeout_applies_segments', session.transfer_timeout_applies_segments);
+            syncTransferCheckbox('transfer_timeout_applies_manifests', session.transfer_timeout_applies_manifests);
+            syncTransferCheckbox('transfer_timeout_applies_master', session.transfer_timeout_applies_master);
         }
 
         function syncServerFaultData(card, session) {
@@ -2796,6 +2805,12 @@
                 const dropPackets = Number(session.transport_fault_drop_packets || 0);
                 const rejectPackets = Number(session.transport_fault_reject_packets || 0);
                 countersEl.textContent = `Drop ${dropPackets} pkts · Reject ${rejectPackets} pkts`;
+            }
+            const transferCountersEl = card.querySelector('[data-field="transfer_timeout_counters"]');
+            if (transferCountersEl) {
+                const activeCount = Number(session.fault_count_transfer_active_timeout || 0);
+                const idleCount = Number(session.fault_count_transfer_idle_timeout || 0);
+                transferCountersEl.textContent = `Active ${activeCount} · Idle ${idleCount}`;
             }
         }
 
@@ -2998,7 +3013,9 @@
                 'master_manifest_consecutive_failures',
                 'master_manifest_failure_frequency',
                 'transport_consecutive_failures',
-                'transport_failure_frequency'
+                'transport_failure_frequency',
+                'transfer_active_timeout_ms',
+                'transfer_idle_timeout_ms'
             ].includes(field);
         }
 
@@ -3663,6 +3680,16 @@
                 }
                 if (event.target.dataset.field === 'content_allowed_variants' || event.target.dataset.field === 'content_strip_codecs') {
                     sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs']);
+                    return;
+                }
+                if (event.target.dataset.field === 'transfer_timeout_applies_segments' ||
+                    event.target.dataset.field === 'transfer_timeout_applies_manifests' ||
+                    event.target.dataset.field === 'transfer_timeout_applies_master') {
+                    sendSessionPatch(card, [
+                        'transfer_timeout_applies_segments',
+                        'transfer_timeout_applies_manifests',
+                        'transfer_timeout_applies_master'
+                    ]);
                     return;
                 }
                 if (event.target.dataset.field && event.target.dataset.field.startsWith('shaping_')) {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1386,6 +1386,15 @@ maybe a histogram of b
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
+            syncRange('transfer_active_timeout_ms', session.transfer_active_timeout_ms, 0);
+            syncRange('transfer_idle_timeout_ms', session.transfer_idle_timeout_ms, 0);
+            const syncTransferCheckbox = (field, value) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (input) input.checked = !!value;
+            };
+            syncTransferCheckbox('transfer_timeout_applies_segments', session.transfer_timeout_applies_segments);
+            syncTransferCheckbox('transfer_timeout_applies_manifests', session.transfer_timeout_applies_manifests);
+            syncTransferCheckbox('transfer_timeout_applies_master', session.transfer_timeout_applies_master);
         }
 
         function syncServerFaultData(card, session) {
@@ -1399,6 +1408,12 @@ maybe a histogram of b
                 const dropPackets = Number(session.transport_fault_drop_packets || 0);
                 const rejectPackets = Number(session.transport_fault_reject_packets || 0);
                 countersEl.textContent = `Drop ${dropPackets} pkts · Reject ${rejectPackets} pkts`;
+            }
+            const transferCountersEl = card.querySelector('[data-field="transfer_timeout_counters"]');
+            if (transferCountersEl) {
+                const activeCount = Number(session.fault_count_transfer_active_timeout || 0);
+                const idleCount = Number(session.fault_count_transfer_idle_timeout || 0);
+                transferCountersEl.textContent = `Active ${activeCount} · Idle ${idleCount}`;
             }
         }
         function formatDate(value) {
@@ -3598,7 +3613,9 @@ maybe a histogram of b
                 'master_manifest_consecutive_failures',
                 'master_manifest_failure_frequency',
                 'transport_consecutive_failures',
-                'transport_failure_frequency'
+                'transport_failure_frequency',
+                'transfer_active_timeout_ms',
+                'transfer_idle_timeout_ms'
             ].includes(field);
         }
 
@@ -3981,6 +3998,16 @@ maybe a histogram of b
             }
             if (target.dataset.field === 'content_allowed_variants' || target.dataset.field === 'content_strip_codecs' || target.dataset.field === 'content_live_offset') {
                 sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_live_offset']);
+                return;
+            }
+            if (target.dataset.field === 'transfer_timeout_applies_segments' ||
+                target.dataset.field === 'transfer_timeout_applies_manifests' ||
+                target.dataset.field === 'transfer_timeout_applies_master') {
+                sendSessionPatch(card, [
+                    'transfer_timeout_applies_segments',
+                    'transfer_timeout_applies_manifests',
+                    'transfer_timeout_applies_master'
+                ]);
                 return;
             }
             if (target.dataset.field === 'shaping_step_enabled') {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1540,8 +1540,8 @@ maybe a histogram of b
                 const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
                 if (valueEl) valueEl.textContent = transportFrequencyInput.value;
             }
-            syncRange('transfer_active_timeout_ms', session.transfer_active_timeout_ms, 0);
-            syncRange('transfer_idle_timeout_ms', session.transfer_idle_timeout_ms, 0);
+            syncRange('transfer_active_timeout_seconds', session.transfer_active_timeout_seconds, 0);
+            syncRange('transfer_idle_timeout_seconds', session.transfer_idle_timeout_seconds, 0);
             const syncTransferCheckbox = (field, value) => {
                 const input = card.querySelector(`input[data-field="${field}"]`);
                 if (input) input.checked = !!value;
@@ -4475,8 +4475,8 @@ maybe a histogram of b
                 'master_manifest_failure_frequency',
                 'transport_consecutive_failures',
                 'transport_failure_frequency',
-                'transfer_active_timeout_ms',
-                'transfer_idle_timeout_ms'
+                'transfer_active_timeout_seconds',
+                'transfer_idle_timeout_seconds'
             ].includes(field);
         }
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3502,37 +3502,38 @@ func transferTimeoutsFor(session SessionData, isSegment, isManifest, isMasterMan
 	return
 }
 
-// idleReader wraps an upstream response body; if no bytes are read for the
-// configured idle timeout, it cancels the request context (which closes the
-// connection mid-transfer) and records that the idle timer fired.
-type idleReader struct {
-	r        io.ReadCloser
+// idleWriter wraps the downstream io.Writer (proxy → client). If no
+// successful Write completes for the configured idle window, it cancels
+// the request context (which closes the connection mid-transfer) and
+// records that the idle timer fired. This catches a stalled client that
+// has stopped draining bytes — TCP back-pressure surfaces here.
+type idleWriter struct {
+	w        io.Writer
 	cancel   context.CancelFunc
 	timeout  time.Duration
 	timer    *time.Timer
 	timedOut atomic.Bool
 }
 
-func newIdleReader(r io.ReadCloser, timeout time.Duration, cancel context.CancelFunc) *idleReader {
-	ir := &idleReader{r: r, cancel: cancel, timeout: timeout}
-	ir.timer = time.AfterFunc(timeout, func() {
-		ir.timedOut.Store(true)
+func newIdleWriter(w io.Writer, timeout time.Duration, cancel context.CancelFunc) *idleWriter {
+	iw := &idleWriter{w: w, cancel: cancel, timeout: timeout}
+	iw.timer = time.AfterFunc(timeout, func() {
+		iw.timedOut.Store(true)
 		cancel()
 	})
-	return ir
+	return iw
 }
 
-func (ir *idleReader) Read(p []byte) (int, error) {
-	n, err := ir.r.Read(p)
+func (iw *idleWriter) Write(p []byte) (int, error) {
+	n, err := iw.w.Write(p)
 	if n > 0 {
-		ir.timer.Reset(ir.timeout)
+		iw.timer.Reset(iw.timeout)
 	}
 	return n, err
 }
 
-func (ir *idleReader) Close() error {
-	ir.timer.Stop()
-	return ir.r.Close()
+func (iw *idleWriter) Stop() {
+	iw.timer.Stop()
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
@@ -4057,11 +4058,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
-	var idleBody *idleReader
-	if idleTimeout > 0 {
-		idleBody = newIdleReader(resp.Body, idleTimeout, proxyCancel)
-		resp.Body = idleBody
-	}
+	// idleW wraps the downstream writer below so the timer measures gaps
+	// in proxy-to-client writes (i.e. it fires when the player stops
+	// draining bytes), not gaps in origin-to-proxy reads.
+	var idleW *idleWriter
 	if resp.StatusCode >= 400 {
 		log.Printf(
 			"PROXY upstream_status status=%d url=%s filename=%s request_kind=%s session_id=%s player_id=%s external_port=%s",
@@ -4094,10 +4094,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("ERROR: Failed to read master playlist body: %v", err)
-			if idleBody != nil && idleBody.timedOut.Load() {
-				bumpFaultCounter(sessionData, "transfer_idle_timeout")
-				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
-			} else if errors.Is(err, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
 			}
@@ -4121,7 +4118,12 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[GO-PROXY][CONTENT] Applied content manipulation to master playlist session_id=%s", getString(sessionData, "session_id"))
 	} else {
 		w.WriteHeader(resp.StatusCode)
-		writer := bufio.NewWriter(w)
+		var downstream io.Writer = w
+		if idleTimeout > 0 {
+			idleW = newIdleWriter(w, idleTimeout, proxyCancel)
+			downstream = idleW
+		}
+		writer := bufio.NewWriter(downstream)
 		if isSegment {
 			log.Printf(
 				"[GO-PROXY][REQUEST][SEGMENT] response status=%d content_type=%s content_length=%s accept_ranges=%s content_range=%s url=%s session_id=%s external_port=%s",
@@ -4138,6 +4140,9 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		var copyErr error
 		bytesOut, copyErr = io.Copy(writer, resp.Body)
 		flushErr := writer.Flush()
+		if idleW != nil {
+			idleW.Stop()
+		}
 		if copyErr != nil || flushErr != nil {
 			writeErr := copyErr
 			if writeErr == nil {
@@ -4145,7 +4150,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 			log.Printf("[GO-PROXY][ABANDONED] client disconnected mid-transfer url=%s bytes_sent=%d content_length=%s request_kind=%s session_id=%s external_port=%s err=%v",
 				upstreamURL, bytesOut, resp.Header.Get("Content-Length"), requestKind, getString(sessionData, "session_id"), externalPort, writeErr)
-			if idleBody != nil && idleBody.timedOut.Load() {
+			if idleW != nil && idleW.timedOut.Load() {
 				bumpFaultCounter(sessionData, "transfer_idle_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
 			} else if errors.Is(copyErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3477,6 +3477,64 @@ func transportModeFromConsecutiveUnits(units string) string {
 	return "failures_per_seconds"
 }
 
+// transferTimeoutsFor returns the active and idle transfer-timeout durations
+// configured for this session, gated by the per-request-kind apply flags.
+// Returns 0 for either value when disabled or when the kind isn't selected.
+func transferTimeoutsFor(session SessionData, isSegment, isManifest, isMasterManifest bool) (active, idle time.Duration) {
+	var applies bool
+	switch {
+	case isMasterManifest:
+		applies = getBool(session, "transfer_timeout_applies_master")
+	case isManifest:
+		applies = getBool(session, "transfer_timeout_applies_manifests")
+	case isSegment:
+		applies = getBool(session, "transfer_timeout_applies_segments")
+	}
+	if !applies {
+		return 0, 0
+	}
+	if v := getInt(session, "transfer_active_timeout_ms"); v > 0 {
+		active = time.Duration(v) * time.Millisecond
+	}
+	if v := getInt(session, "transfer_idle_timeout_ms"); v > 0 {
+		idle = time.Duration(v) * time.Millisecond
+	}
+	return
+}
+
+// idleReader wraps an upstream response body; if no bytes are read for the
+// configured idle timeout, it cancels the request context (which closes the
+// connection mid-transfer) and records that the idle timer fired.
+type idleReader struct {
+	r        io.ReadCloser
+	cancel   context.CancelFunc
+	timeout  time.Duration
+	timer    *time.Timer
+	timedOut atomic.Bool
+}
+
+func newIdleReader(r io.ReadCloser, timeout time.Duration, cancel context.CancelFunc) *idleReader {
+	ir := &idleReader{r: r, cancel: cancel, timeout: timeout}
+	ir.timer = time.AfterFunc(timeout, func() {
+		ir.timedOut.Store(true)
+		cancel()
+	})
+	return ir
+}
+
+func (ir *idleReader) Read(p []byte) (int, error) {
+	n, err := ir.r.Read(p)
+	if n > 0 {
+		ir.timer.Reset(ir.timeout)
+	}
+	return n, err
+}
+
+func (ir *idleReader) Close() error {
+	ir.timer.Stop()
+	return ir.r.Close()
+}
+
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
@@ -3638,6 +3696,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"fault_count_request_body_hang":            0,
 			"fault_count_request_body_reset":           0,
 			"fault_count_request_body_delayed":         0,
+			"transfer_active_timeout_ms":               0,
+			"transfer_idle_timeout_ms":                 0,
+			"transfer_timeout_applies_segments":        true,
+			"transfer_timeout_applies_manifests":       false,
+			"transfer_timeout_applies_master":          false,
+			"fault_count_transfer_active_timeout":      0,
+			"fault_count_transfer_idle_timeout":        0,
 			"x_forwarded_port":                         assignedInternalPort,
 			"x_forwarded_port_external":                assignedExternalPort,
 			"loop_count_server":                        0,
@@ -3943,7 +4008,19 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	proxyReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, upstreamURL, nil)
+	activeTimeout, idleTimeout := transferTimeoutsFor(sessionData, isSegment, isManifest, isMasterManifest)
+	proxyCtx := r.Context()
+	var proxyCancel context.CancelFunc
+	if activeTimeout > 0 {
+		proxyCtx, proxyCancel = context.WithTimeout(proxyCtx, activeTimeout)
+	} else if idleTimeout > 0 {
+		proxyCtx, proxyCancel = context.WithCancel(proxyCtx)
+	} else {
+		proxyCancel = func() {}
+	}
+	defer proxyCancel()
+
+	proxyReq, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)
 		// Log network entry for error
@@ -3958,12 +4035,16 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	if ifRange := r.Header.Get("If-Range"); ifRange != "" {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
-	resp, netEntry, err := a.doRequestWithTracing(r.Context(), proxyReq)
+	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
 	if err != nil {
 		// Set status before writing header
 		if errors.Is(err, context.DeadlineExceeded) {
 			netEntry.Status = http.StatusGatewayTimeout
 			w.WriteHeader(http.StatusGatewayTimeout)
+			if activeTimeout > 0 {
+				bumpFaultCounter(sessionData, "transfer_active_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_pre_headers")
+			}
 		} else {
 			netEntry.Status = http.StatusBadGateway
 			w.WriteHeader(http.StatusBadGateway)
@@ -3976,6 +4057,11 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
+	var idleBody *idleReader
+	if idleTimeout > 0 {
+		idleBody = newIdleReader(resp.Body, idleTimeout, proxyCancel)
+		resp.Body = idleBody
+	}
 	if resp.StatusCode >= 400 {
 		log.Printf(
 			"PROXY upstream_status status=%d url=%s filename=%s request_kind=%s session_id=%s player_id=%s external_port=%s",
@@ -4008,6 +4094,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("ERROR: Failed to read master playlist body: %v", err)
+			if idleBody != nil && idleBody.timedOut.Load() {
+				bumpFaultCounter(sessionData, "transfer_idle_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+			} else if errors.Is(err, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
+				bumpFaultCounter(sessionData, "transfer_active_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+			}
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -4052,6 +4145,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 			log.Printf("[GO-PROXY][ABANDONED] client disconnected mid-transfer url=%s bytes_sent=%d content_length=%s request_kind=%s session_id=%s external_port=%s err=%v",
 				upstreamURL, bytesOut, resp.Header.Get("Content-Length"), requestKind, getString(sessionData, "session_id"), externalPort, writeErr)
+			if idleBody != nil && idleBody.timedOut.Load() {
+				bumpFaultCounter(sessionData, "transfer_idle_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+			} else if errors.Is(copyErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
+				bumpFaultCounter(sessionData, "transfer_active_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+			}
 		}
 		if isManifest || isMasterManifest {
 			log.Printf("[GO-PROXY][MANIFEST] url=%s bytes_sent=%d upstream_content_length=%s status=%d session_id=%s external_port=%s",

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3493,11 +3493,11 @@ func transferTimeoutsFor(session SessionData, isSegment, isManifest, isMasterMan
 	if !applies {
 		return 0, 0
 	}
-	if v := getInt(session, "transfer_active_timeout_ms"); v > 0 {
-		active = time.Duration(v) * time.Millisecond
+	if v := getInt(session, "transfer_active_timeout_seconds"); v > 0 {
+		active = time.Duration(v) * time.Second
 	}
-	if v := getInt(session, "transfer_idle_timeout_ms"); v > 0 {
-		idle = time.Duration(v) * time.Millisecond
+	if v := getInt(session, "transfer_idle_timeout_seconds"); v > 0 {
+		idle = time.Duration(v) * time.Second
 	}
 	return
 }
@@ -3696,8 +3696,8 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"fault_count_request_body_hang":            0,
 			"fault_count_request_body_reset":           0,
 			"fault_count_request_body_delayed":         0,
-			"transfer_active_timeout_ms":               0,
-			"transfer_idle_timeout_ms":                 0,
+			"transfer_active_timeout_seconds":          0,
+			"transfer_idle_timeout_seconds":            0,
 			"transfer_timeout_applies_segments":        true,
 			"transfer_timeout_applies_manifests":       false,
 			"transfer_timeout_applies_master":          false,

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4111,11 +4111,28 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(modifiedBody)))
 		w.WriteHeader(resp.StatusCode)
-		writer := bufio.NewWriter(w)
-		_, _ = writer.Write(modifiedBody)
-		_ = writer.Flush()
+		var downstream io.Writer = w
+		if idleTimeout > 0 {
+			idleW = newIdleWriter(w, idleTimeout, proxyCancel)
+			downstream = idleW
+		}
+		writer := bufio.NewWriter(downstream)
+		_, writeErr := writer.Write(modifiedBody)
+		flushErr := writer.Flush()
+		if idleW != nil {
+			idleW.Stop()
+		}
 		bytesOut = int64(len(modifiedBody))
 		log.Printf("[GO-PROXY][CONTENT] Applied content manipulation to master playlist session_id=%s", getString(sessionData, "session_id"))
+		if writeErr != nil || flushErr != nil {
+			if idleW != nil && idleW.timedOut.Load() {
+				bumpFaultCounter(sessionData, "transfer_idle_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+			} else if errors.Is(writeErr, context.DeadlineExceeded) || errors.Is(flushErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
+				bumpFaultCounter(sessionData, "transfer_active_timeout")
+				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+			}
+		}
 	} else {
 		w.WriteHeader(resp.StatusCode)
 		var downstream io.Writer = w


### PR DESCRIPTION
## Summary
- New per-session **active** and **no-activity** transfer timeouts on `go-proxy`, mirroring ATS's `transaction_active_timeout` / `transaction_no_activity_timeout`.
- Each session has its own pair of values and selects which request kinds (segments / media manifests / master manifest) the limits apply to.
- Mid-body firings bump fault counters and emit `logFaultEvent` so the cause is visible alongside the effect.

## Implementation
- `go-proxy/cmd/server/main.go`:
  - `transferTimeoutsFor()` reads per-session config, gated by request kind.
  - Active timeout = `context.WithTimeout`; idle timeout = `idleReader` wrapping `resp.Body` with a `time.AfterFunc` that resets on each successful `Read` and cancels the request when it expires.
  - Errors classified after the fact: `DeadlineExceeded` ⇒ active, `idleReader.timedOut` ⇒ idle. Counters land in `fault_count_transfer_{active,idle}_timeout`.
- Dashboard:
  - New **Server Timeouts** collapsible section below **Fault Injection** in both `testing.html` and `testing-session.html`.
  - Two range sliders (0–30000 ms, step 100), three apply-to checkboxes, live counters.
  - `readSessionSettings`, `isFailureRangeField`, change handlers, and `syncServerFaultControls` / `syncServerFaultData` updated in both pages.

## Out of scope (per #248)
- Outbound (proxy → origin) timeouts — origin is in-container.
- HTTP/2 RST_STREAM specifics.
- Background-fill caching.

Closes #248.

## Test plan
- [ ] Open `http://jonathanoliver-ubuntu.local:21000/dashboard/testing-session.html?player_id=…` and confirm a **Server Timeouts** section appears below **Fault Injection** with two sliders + three checkboxes + counters.
- [ ] Move a slider; confirm the value persists across reloads (PATCH round-trips through `/api/session/{id}`).
- [ ] Set Idle = 500 ms with Apply → Segments. Trigger a stuck segment via go-proxy transport faults (`hang`). Confirm the segment fetch is killed mid-stream and `Active`/`Idle` counters increment.
- [ ] Cross-check `testing.html` shows the same section.
- [ ] Disable both timeouts (sliders to 0); confirm normal playback resumes with no spurious timeouts.

## Verified before opening PR
- `go build ./... && go vet ./... && go test -race ./...` clean.
- Deployed to `jonathanoliver-ubuntu.local:21000` via `make test-deploy-dev`.
- Session-create API returns the seven new fields with their defaults.
- PATCH round-trip via `/api/session/{id}` persists the values.
- No panics in container logs with timeouts disabled.