### PR TITLE
ci: Claude workflows on OAuth + auto PR review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,43 @@
+name: Claude PR Review
+
+# Auto-review every non-draft PR via anthropics/claude-code-action.
+# The `prompt:` field flips the action from "wait for @claude mention"
+# into automation mode, so it runs without manual invocation.
+# Auth: CLAUDE_CODE_OAUTH_TOKEN (Max plan) — same secret as claude.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for correctness, security, regressions,
+            and adherence to project conventions (see CLAUDE.md and AGENTS.md
+            in the repo root).
+
+            Post specific findings as inline review comments on the changed
+            lines. If you have no concerns, post a single approval comment
+            summarizing what the PR does and why it looks good.
+
+            Focus on: logic errors, race conditions, missing error handling at
+            real boundaries, security issues (command injection, path traversal,
+            etc.), and divergence from existing patterns. Do not flag stylistic
+            nits unless they obscure intent.
+          claude_args: "--max-turns 5 --model claude-opus-4-7"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,8 @@
 name: Claude Code
 
 # Triggers Claude in response to `@claude` mentions in issue / PR / review
-# comments. Auth: ANTHROPIC_API_KEY secret + the Claude GitHub App
-# (https://github.com/apps/claude) installed on the repo.
+# comments. Auth: CLAUDE_CODE_OAUTH_TOKEN secret (Max plan) + the Claude
+# GitHub App (https://github.com/apps/claude) installed on the repo.
 
 on:
   issue_comment:
@@ -36,4 +36,4 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- **Fix:** \`.github/workflows/claude.yml\` referenced a missing \`ANTHROPIC_API_KEY\` secret (the \`/install-github-app\` flow set up \`CLAUDE_CODE_OAUTH_TOKEN\` instead). Bot was probably broken on every \`@claude\` mention since #250 landed.
- **Add:** \`.github/workflows/claude-review.yml\` runs claude-code-action in automation mode (the \`prompt:\` field flips the action from \"wait for mention\" to \"auto-run\") on every non-draft PR. Skips PRs labeled \`skip-review\`.
- Both workflows now auth with \`CLAUDE_CODE_OAUTH_TOKEN\`, so all inference bills against the Max plan instead of the API console.

Closes #256.

## Test plan
- [ ] After merge, comment \`@claude say hi\` on a throwaway issue → bot responds (would have errored before).
- [ ] Open a non-draft PR → Claude posts review within ~30 s.
- [ ] Add the \`skip-review\` label and push a new commit → no new review fires.
- [ ] Open a draft PR → no review fires.

## Notes
- The auto-review check appears as **\"Claude PR Review\"** in the Checks tab. Its conclusion is *neutral* by default — to make it merge-blocking would need a custom step that parses findings into a \`failure\` check, or the managed Code Review SaaS.
- The OAuth token expires ~1 year after \`claude setup-token\`; rotate before then.