### PR TITLE
fix(dashboard): heartbeat persistent-state lanes so VARIANT/DISPLAY_RES/PLAYERSTATE survive 10-min stable runs

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1061,10 +1061,6 @@
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
-        const lastRecordedVariantBySession = new Map();
-        const lastRecordedDisplayResBySession = new Map();
-        // Two-sample debounce for VARIANT — see testing.html for details.
-        const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -4756,11 +4752,12 @@
 
             // VARIANT lane: bitrate is the leading-edge fetch-time
             // signal; resolution lags. Drive resolution from the
-            // manifest BANDWIDTH lookup keyed off the bitrate. Fall
-            // back to player's reported resolution only when there's
-            // no manifest match. Manifest-validated changes commit
-            // immediately; the pure-player fallback path still uses
-            // the two-sample debounce as a belt.
+            // manifest BANDWIDTH lookup keyed off the bitrate, falling
+            // back to the player's reported resolution only when no
+            // manifest match exists. The session payload is heartbeat-
+            // style — every poll carries the current values — so push
+            // unconditionally and let the renderer coalesce same-value
+            // runs into single ranges.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
@@ -4768,21 +4765,10 @@
                 const manifestRes = manifestResolutionForBitrate(session, variantMbps);
                 const variantRes = manifestRes || reportedRes;
                 if (variantRes) {
-                    const variantKey = `${variantRes}|${variantMbps}`;
-                    const prevVariant = lastRecordedVariantBySession.get(String(key));
-                    const pending = pendingVariantBySession.get(String(key));
-                    if (prevVariant === variantKey) {
-                        if (pending) pendingVariantBySession.delete(String(key));
-                    } else if (manifestRes || (pending && pending.key === variantKey)) {
-                        const eventSeries = bandwidthEventHistory.get(key) || [];
-                        eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
-                        const eventCutoff = now - windowMs;
-                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                        lastRecordedVariantBySession.set(String(key), variantKey);
-                        pendingVariantBySession.delete(String(key));
-                    } else {
-                        pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
-                    }
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                 }
             }
 
@@ -4791,14 +4777,10 @@
             // render lag.
             const displayRes = String(session.player_metrics_video_resolution || '').trim();
             if (displayRes) {
-                const prevDisplayRes = lastRecordedDisplayResBySession.get(String(key));
-                if (prevDisplayRes !== displayRes) {
-                    const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
-                    const eventCutoff = now - windowMs;
-                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedDisplayResBySession.set(String(key), displayRes);
-                }
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
 
             const series = bandwidthHistory.get(key) || [];
@@ -5142,15 +5124,6 @@
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
-            // DISPLAY_RES uses the same push-on-change pattern as
-            // VARIANT, so its colored ribbon also drains away after a
-            // long stable run. Synthesize a carry-over at windowStart
-            // when the current value isn't represented in-window.
-            const currentDisplayRes = lastRecordedDisplayResBySession.get(String(sessionId));
-            if (currentDisplayRes && !events.some((e) => e.type === 'DISPLAY_RES' && String(e.resolution || '').trim() === currentDisplayRes)) {
-                events.unshift({ ts: windowStart, type: 'DISPLAY_RES', resolution: currentDisplayRes });
-            }
-
             const SERVER_LANES = new Set(['LOOP_SERVER']);
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
@@ -5171,19 +5144,6 @@
             // VARIANT subgroups: one lane per (resolution, bitrate).
             // Multi-bitrate-per-resolution is a real ladder pattern.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            // VARIANT events only push on a *change*, so a session that
-            // has been on a single variant for longer than windowMs has
-            // no in-window events. Synthesize a carry-over event at
-            // windowStart from the always-current map so the lane and
-            // its colored ribbon both survive the rolling cutoff.
-            const currentVariantKey = lastRecordedVariantBySession.get(String(sessionId));
-            if (currentVariantKey && !variantEvents.some((e) => `${String(e.resolution || '').trim()}|${Number(e.mbps)}` === currentVariantKey)) {
-                const [curRes, curMbpsStr] = String(currentVariantKey).split('|');
-                const curMbps = Number(curMbpsStr);
-                if (curRes && Number.isFinite(curMbps) && curMbps > 0) {
-                    variantEvents.unshift({ ts: windowStart, type: 'VARIANT', mbps: curMbps, resolution: curRes });
-                }
-            }
             const seenVariants = new Map(); // res|mbps -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();
@@ -5223,14 +5183,20 @@
                 return `${hh}:${mm}:${ss}`;
             }
 
+            // Heartbeat-style writers emit one event per poll even when
+            // nothing changed; coalesce consecutive same-label entries
+            // into a single range.
             function pushRanges(typeKey, getLabel, getColor) {
                 const seq = events.filter((e) => e.type === typeKey)
                     .sort((a, b) => Number(a.ts) - Number(b.ts));
-                for (let i = 0; i < seq.length; i++) {
+                let i = 0;
+                while (i < seq.length) {
                     const start = Number(seq[i].ts);
-                    const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
                     const label = getLabel(seq[i]);
                     const color = getColor(seq[i]);
+                    let j = i + 1;
+                    while (j < seq.length && getLabel(seq[j]) === label) j++;
+                    const end = j < seq.length ? Number(seq[j].ts) : nowMs;
                     const durationSec = ((end - start) / 1000).toFixed(1);
                     const title = `${EVENT_LANES[typeKey].label}: ${label}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                     items.push({
@@ -5243,6 +5209,7 @@
                         title: title,
                         style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                     });
+                    i = j;
                 }
             }
 
@@ -5258,20 +5225,32 @@
                 (e) => String(e.resolution || '?'),
                 (e) => displayResColor(e.resolution));
 
+            // Heartbeat-style emission means consecutive same-key
+            // VARIANT entries coalesce into a single range.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
-            for (let i = 0; i < variantSeq.length; i++) {
-                const v = variantSeq[i];
+            let vi = 0;
+            while (vi < variantSeq.length) {
+                const v = variantSeq[vi];
                 const res = String(v.resolution || '').trim();
                 const m = Number(v.mbps);
-                if (!res || !Number.isFinite(m) || m <= 0) continue;
+                if (!res || !Number.isFinite(m) || m <= 0) { vi++; continue; }
+                const k = `${res}|${m}`;
+                let vj = vi + 1;
+                while (vj < variantSeq.length) {
+                    const nv = variantSeq[vj];
+                    const nres = String(nv.resolution || '').trim();
+                    const nm = Number(nv.mbps);
+                    if (`${nres}|${nm}` !== k) break;
+                    vj++;
+                }
                 const start = Number(v.ts);
-                const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
+                const end = vj < variantSeq.length ? Number(variantSeq[vj].ts) : nowMs;
                 const color = variantColor(m);
                 const durationSec = ((end - start) / 1000).toFixed(1);
                 const title = `Variant: ${variantLabel(m, res)}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${res}|${m}`,
+                    group: `VARIANT::${k}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),
@@ -5279,6 +5258,7 @@
                     title: title,
                     style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                 });
+                vi = vj;
             }
 
             for (const e of events) {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1060,7 +1060,6 @@
         const bandwidthVariantsEnabledBySession = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
-        const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -4735,19 +4734,15 @@
                 }
             }
 
-            // PLAYERSTATE: sample state + AVPlayer waiting reason
-            // (player_metrics_waiting_reason) for tooltip detail.
+            // PLAYERSTATE: sample state + AVPlayer waiting reason every
+            // poll; the renderer coalesces same-label runs.
             const stateValue = String(session.player_metrics_state || '').trim();
             const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
-                const prevState = lastRecordedPlayerStateBySession.get(String(key));
-                if (prevState !== stateValue) {
-                    const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
-                    const eventCutoff = now - windowMs;
-                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedPlayerStateBySession.set(String(key), stateValue);
-                }
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
 
             // VARIANT lane: bitrate is the leading-edge fetch-time

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -5142,6 +5142,15 @@
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
+            // DISPLAY_RES uses the same push-on-change pattern as
+            // VARIANT, so its colored ribbon also drains away after a
+            // long stable run. Synthesize a carry-over at windowStart
+            // when the current value isn't represented in-window.
+            const currentDisplayRes = lastRecordedDisplayResBySession.get(String(sessionId));
+            if (currentDisplayRes && !events.some((e) => e.type === 'DISPLAY_RES' && String(e.resolution || '').trim() === currentDisplayRes)) {
+                events.unshift({ ts: windowStart, type: 'DISPLAY_RES', resolution: currentDisplayRes });
+            }
+
             const SERVER_LANES = new Set(['LOOP_SERVER']);
             const playerLanes = Object.keys(EVENT_LANES).filter((k) => !SERVER_LANES.has(k) && k !== 'VARIANT');
             const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
@@ -5162,6 +5171,19 @@
             // VARIANT subgroups: one lane per (resolution, bitrate).
             // Multi-bitrate-per-resolution is a real ladder pattern.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
+            // VARIANT events only push on a *change*, so a session that
+            // has been on a single variant for longer than windowMs has
+            // no in-window events. Synthesize a carry-over event at
+            // windowStart from the always-current map so the lane and
+            // its colored ribbon both survive the rolling cutoff.
+            const currentVariantKey = lastRecordedVariantBySession.get(String(sessionId));
+            if (currentVariantKey && !variantEvents.some((e) => `${String(e.resolution || '').trim()}|${Number(e.mbps)}` === currentVariantKey)) {
+                const [curRes, curMbpsStr] = String(currentVariantKey).split('|');
+                const curMbps = Number(curMbpsStr);
+                if (curRes && Number.isFinite(curMbps) && curMbps > 0) {
+                    variantEvents.unshift({ ts: windowStart, type: 'VARIANT', mbps: curMbps, resolution: curRes });
+                }
+            }
             const seenVariants = new Map(); // res|mbps -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -846,7 +846,6 @@ maybe a histogram of b
         const bandwidthVisibility = new Map();
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
-        const lastRecordedPlayerStateBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -2440,23 +2439,20 @@ maybe a histogram of b
                 }
             }
 
-            // PLAYERSTATE lane: sample player_metrics_state on each
-            // refresh tick and emit a marker on every transition. Also
-            // captures the AVFoundation reasonForWaitingToPlay
-            // (player_metrics_waiting_reason) so the tooltip can
-            // disambiguate buffering causes (toMinimizeStalls vs
-            // evaluatingBufferingRate vs noItemToPlay etc.).
+            // PLAYERSTATE lane: sample player_metrics_state every poll
+            // and let the renderer coalesce same-label runs. The
+            // AVFoundation reasonForWaitingToPlay
+            // (player_metrics_waiting_reason) is part of the rendered
+            // label so reason transitions within a state (e.g.
+            // toMinimizeStalls vs evaluatingBufferingRate) split into
+            // distinct ranges.
             const stateValue = String(session.player_metrics_state || '').trim();
             const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
-                const prevState = lastRecordedPlayerStateBySession.get(String(key));
-                if (prevState !== stateValue) {
-                    const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
-                    const eventCutoff = now - windowMs;
-                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedPlayerStateBySession.set(String(key), stateValue);
-                }
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
 
             // VARIANT lane: bitrate is the leading-edge fetch-time

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -847,10 +847,6 @@ maybe a histogram of b
         const bitrateAxisMaxBySession = new Map();
         const lastRecordedPlayerEventBySession = new Map();
         const lastRecordedPlayerStateBySession = new Map();
-        const lastRecordedVariantBySession = new Map();
-        const lastRecordedDisplayResBySession = new Map();
-        // Two-sample debounce belt for VARIANT.
-        const pendingVariantBySession = new Map();
         const lastRecordedLoopCountBySession = new Map();
         const lastRecordedServerLoopCountBySession = new Map();
         const lastRecordedLoopEventStampBySession = new Map();
@@ -2467,13 +2463,14 @@ maybe a histogram of b
             // signal (accessLog updates when a segment download
             // completes). Resolution is the lagging render-time signal
             // (presentation-size updates when the new frame is shown).
-            // To avoid phantom (new-resolution, old-bitrate) or
-            // (new-bitrate, old-resolution) entries during the shift
-            // window, drive resolution from the manifest BANDWIDTH
-            // lookup keyed off the bitrate. Fall back to the player's
-            // reported resolution only when no manifest match exists.
-            // Two-sample debounce remains as a belt for sessions
-            // without manifest data.
+            // To avoid phantom (new-resolution, old-bitrate) entries
+            // during the shift window, drive resolution from the
+            // manifest BANDWIDTH lookup keyed off the bitrate, falling
+            // back to the player's reported resolution only when no
+            // manifest match exists. The session payload is heartbeat-
+            // style — every poll carries the current values — so push
+            // unconditionally and let the renderer coalesce same-value
+            // runs into single ranges.
             const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
             if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
                 const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
@@ -2481,23 +2478,10 @@ maybe a histogram of b
                 const manifestRes = manifestResolutionForBitrate(session, variantMbps);
                 const variantRes = manifestRes || reportedRes;
                 if (variantRes) {
-                    const variantKey = `${variantRes}|${variantMbps}`;
-                    const prevVariant = lastRecordedVariantBySession.get(String(key));
-                    const pending = pendingVariantBySession.get(String(key));
-                    if (prevVariant === variantKey) {
-                        if (pending) pendingVariantBySession.delete(String(key));
-                    } else if (manifestRes || (pending && pending.key === variantKey)) {
-                        // Manifest-validated changes commit immediately;
-                        // pure-player fallback still requires two samples.
-                        const eventSeries = bandwidthEventHistory.get(key) || [];
-                        eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
-                        const eventCutoff = now - windowMs;
-                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                        lastRecordedVariantBySession.set(String(key), variantKey);
-                        pendingVariantBySession.delete(String(key));
-                    } else {
-                        pendingVariantBySession.set(String(key), { key: variantKey, mbps: variantMbps, resolution: variantRes });
-                    }
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                 }
             }
 
@@ -2507,14 +2491,10 @@ maybe a histogram of b
             // DISPLAY_RES shifting is the fetch-to-render lag.
             const displayRes = String(session.player_metrics_video_resolution || '').trim();
             if (displayRes) {
-                const prevDisplayRes = lastRecordedDisplayResBySession.get(String(key));
-                if (prevDisplayRes !== displayRes) {
-                    const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
-                    const eventCutoff = now - windowMs;
-                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
-                    lastRecordedDisplayResBySession.set(String(key), displayRes);
-                }
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
 
 
@@ -2955,15 +2935,6 @@ maybe a histogram of b
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
-            // DISPLAY_RES uses the same push-on-change pattern as
-            // VARIANT, so its colored ribbon also drains away after a
-            // long stable run. Synthesize a carry-over at windowStart
-            // when the current value isn't represented in-window.
-            const currentDisplayRes = lastRecordedDisplayResBySession.get(String(sessionId));
-            if (currentDisplayRes && !events.some((e) => e.type === 'DISPLAY_RES' && String(e.resolution || '').trim() === currentDisplayRes)) {
-                events.unshift({ ts: windowStart, type: 'DISPLAY_RES', resolution: currentDisplayRes });
-            }
-
             // Two top-level sections so server-originated events (loop
             // wrap notifications, etc.) don't visually mix with player-side
             // events. Lane order within each section follows EVENT_LANES.
@@ -2994,19 +2965,6 @@ maybe a histogram of b
             // so the visual ladder runs highest at the top, lowest at
             // the bottom.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
-            // VARIANT events only push on a *change*, so a session that
-            // has been on a single variant for longer than windowMs has
-            // no in-window events. Synthesize a carry-over event at
-            // windowStart from the always-current map so the lane and
-            // its colored ribbon both survive the rolling cutoff.
-            const currentVariantKey = lastRecordedVariantBySession.get(String(sessionId));
-            if (currentVariantKey && !variantEvents.some((e) => `${String(e.resolution || '').trim()}|${Number(e.mbps)}` === currentVariantKey)) {
-                const [curRes, curMbpsStr] = String(currentVariantKey).split('|');
-                const curMbps = Number(curMbpsStr);
-                if (curRes && Number.isFinite(curMbps) && curMbps > 0) {
-                    variantEvents.unshift({ ts: windowStart, type: 'VARIANT', mbps: curMbps, resolution: curRes });
-                }
-            }
             const seenVariants = new Map(); // key (res|mbps) -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();
@@ -3047,15 +3005,21 @@ maybe a histogram of b
             }
 
             // Helper to render an event-series sequence as continuous
-            // ranges (one segment per stable value, transition on change).
+            // ranges (one segment per stable value, transition on
+            // change). Heartbeat-style writers emit one event per poll
+            // even when nothing changed, so consecutive same-label
+            // entries are coalesced into a single range.
             function pushRanges(typeKey, getLabel, getColor) {
                 const seq = events.filter((e) => e.type === typeKey)
                     .sort((a, b) => Number(a.ts) - Number(b.ts));
-                for (let i = 0; i < seq.length; i++) {
+                let i = 0;
+                while (i < seq.length) {
                     const start = Number(seq[i].ts);
-                    const end = i + 1 < seq.length ? Number(seq[i + 1].ts) : nowMs;
                     const label = getLabel(seq[i]);
                     const color = getColor(seq[i]);
+                    let j = i + 1;
+                    while (j < seq.length && getLabel(seq[j]) === label) j++;
+                    const end = j < seq.length ? Number(seq[j].ts) : nowMs;
                     const durationSec = ((end - start) / 1000).toFixed(1);
                     const title = `${EVENT_LANES[typeKey].label}: ${label}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                     items.push({
@@ -3068,6 +3032,7 @@ maybe a histogram of b
                         title: title,
                         style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                     });
+                    i = j;
                 }
             }
 
@@ -3085,21 +3050,33 @@ maybe a histogram of b
                 (e) => displayResColor(e.resolution));
 
             // VARIANT: each (resolution, bitrate) tuple gets its own
-            // swim lane. Lane key matches seenVariants.
+            // swim lane. Lane key matches seenVariants. Heartbeat-style
+            // emission means consecutive same-key entries coalesce into
+            // a single range.
             const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
-            for (let i = 0; i < variantSeq.length; i++) {
-                const v = variantSeq[i];
+            let vi = 0;
+            while (vi < variantSeq.length) {
+                const v = variantSeq[vi];
                 const res = String(v.resolution || '').trim();
                 const m = Number(v.mbps);
-                if (!res || !Number.isFinite(m) || m <= 0) continue;
+                if (!res || !Number.isFinite(m) || m <= 0) { vi++; continue; }
+                const k = `${res}|${m}`;
+                let vj = vi + 1;
+                while (vj < variantSeq.length) {
+                    const nv = variantSeq[vj];
+                    const nres = String(nv.resolution || '').trim();
+                    const nm = Number(nv.mbps);
+                    if (`${nres}|${nm}` !== k) break;
+                    vj++;
+                }
                 const start = Number(v.ts);
-                const end = i + 1 < variantSeq.length ? Number(variantSeq[i + 1].ts) : nowMs;
+                const end = vj < variantSeq.length ? Number(variantSeq[vj].ts) : nowMs;
                 const color = variantColor(m);
                 const durationSec = ((end - start) / 1000).toFixed(1);
                 const title = `Variant: ${variantLabel(m, res)}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
                 items.push({
                     id: itemId++,
-                    group: `VARIANT::${res}|${m}`,
+                    group: `VARIANT::${k}`,
                     content: '',
                     start: new Date(start),
                     end: new Date(end),
@@ -3107,6 +3084,7 @@ maybe a histogram of b
                     title: title,
                     style: `background-color: ${color}; border-color: ${color}; color: #fff;`
                 });
+                vi = vj;
             }
 
             for (const e of events) {

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2955,6 +2955,15 @@ maybe a histogram of b
             const nowMs = Date.now();
             const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
 
+            // DISPLAY_RES uses the same push-on-change pattern as
+            // VARIANT, so its colored ribbon also drains away after a
+            // long stable run. Synthesize a carry-over at windowStart
+            // when the current value isn't represented in-window.
+            const currentDisplayRes = lastRecordedDisplayResBySession.get(String(sessionId));
+            if (currentDisplayRes && !events.some((e) => e.type === 'DISPLAY_RES' && String(e.resolution || '').trim() === currentDisplayRes)) {
+                events.unshift({ ts: windowStart, type: 'DISPLAY_RES', resolution: currentDisplayRes });
+            }
+
             // Two top-level sections so server-originated events (loop
             // wrap notifications, etc.) don't visually mix with player-side
             // events. Lane order within each section follows EVENT_LANES.
@@ -2985,6 +2994,19 @@ maybe a histogram of b
             // so the visual ladder runs highest at the top, lowest at
             // the bottom.
             const variantEvents = events.filter((e) => e.type === 'VARIANT');
+            // VARIANT events only push on a *change*, so a session that
+            // has been on a single variant for longer than windowMs has
+            // no in-window events. Synthesize a carry-over event at
+            // windowStart from the always-current map so the lane and
+            // its colored ribbon both survive the rolling cutoff.
+            const currentVariantKey = lastRecordedVariantBySession.get(String(sessionId));
+            if (currentVariantKey && !variantEvents.some((e) => `${String(e.resolution || '').trim()}|${Number(e.mbps)}` === currentVariantKey)) {
+                const [curRes, curMbpsStr] = String(currentVariantKey).split('|');
+                const curMbps = Number(curMbpsStr);
+                if (curRes && Number.isFinite(curMbps) && curMbps > 0) {
+                    variantEvents.unshift({ ts: windowStart, type: 'VARIANT', mbps: curMbps, resolution: curRes });
+                }
+            }
             const seenVariants = new Map(); // key (res|mbps) -> {mbps, resolution}
             for (const v of variantEvents) {
                 const res = String(v.resolution || '').trim();


### PR DESCRIPTION
## Summary
- Push `VARIANT`, `DISPLAY_RES`, and `PLAYERSTATE` events on every session poll (heartbeat-style) instead of only on change. The rolling 10-min event window now stays populated regardless of how long the player sits on a stable variant / resolution / state.
- Coalesce consecutive same-label entries into single ranges at render time so heartbeat emission doesn't produce hundreds of micro-ranges.
- Drop the now-redundant state machinery: `lastRecordedVariantBySession`, `lastRecordedDisplayResBySession`, `lastRecordedPlayerStateBySession`, `pendingVariantBySession`, plus the two-sample debounce branching.

Mirrored across `testing.html` and `testing-session.html`.

## Why
Issue #254 traced the disappearing VARIANT lane to push-on-change emission outliving its single event. DISPLAY_RES and PLAYERSTATE share the same root cause — including the long-stall case where PLAYERSTATE should clearly show `stalled` for the duration but went blank past the 10-min mark. Since the iOS heartbeat (`PlaybackViewModel.swift:832`) and the dashboard's session poll both already carry the current state every tick, simply emitting an event per poll fixes the bug at the source — no renderer-side synthesis indirection needed.

## Behavior changes
- **Persistent-state lanes always reflect current value.** Verified on a long-stable session and a long-stall session.
- **Range boundaries pixel-identical to before.** Coalesce-end equals next-range-start (the first poll observing the new value), no gap or overlap.
- **PLAYERSTATE waiting-reason granularity improved** as a side effect — the renderer's coalesce key includes the AVPlayer `reasonForWaitingToPlay`, so reason transitions within a state (e.g. `buffering toMinimizeStalls` → `buffering evaluatingBufferingRate`) now split into distinct adjacent ranges. Previously they collapsed to the first observed reason.
- **Two-sample debounce removed** for sessions without manifest data. A one-sample noise blip would now produce a ~1s cosmetic range. Negligible — manifest data is the dominant case in normal operation.
- **Out of scope (correctly):** transient point-event lanes (PLAYBACK, IMPAIRMENT, LOOP_SERVER) do not heartbeat; being empty during a stable run is the correct outcome.

## Test plan
- [x] Long-stable session (>10 min on a single variant): VARIANT, DISPLAY_RES, and PLAYERSTATE all remain visible with a single coalesced range.
- [x] Force a variant change: transitions paint cleanly with no boundary gap.
- [x] Long stall (>10 min): PLAYERSTATE shows continuous `stalled` with waiting reason in the tooltip.
- [x] Verified against `dashboard/testing.html` and `dashboard/testing-session.html`.

Closes #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)