### PR TITLE
ci: bump claude-review --max-turns from 5 to 20

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,4 +41,4 @@ jobs:
             real boundaries, security issues (command injection, path traversal,
             etc.), and divergence from existing patterns. Do not flag stylistic
             nits unless they obscure intent.
-          claude_args: "--max-turns 5 --model claude-opus-4-7"
+          claude_args: "--max-turns 20 --model claude-opus-4-7"


### PR DESCRIPTION
## Summary
- `.github/workflows/claude-review.yml`: `--max-turns 5` → `--max-turns 20`.

## Why
The auto-review workflow ran on #258 but bailed with `Claude Code returned an error result: Reached maximum number of turns (5)` — never posted a review. Five turns is consumed reading the PR diff and opening changed files; there's no budget left to actually write the review.

20 covers typical PRs comfortably (read diff, open a handful of files with offsets, cross-reference, post inline comments) without inviting runaway cost on pathological PRs since the hard cap still applies.

## Test plan
- [ ] This PR's own auto-review run succeeds with the new budget.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)