### PR TITLE
feat(dashboard): cross-client wall-clock offset chart (#259)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -2,11 +2,13 @@ package com.infinitestream.player;
 
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.OptIn;
 import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.Player;
+import androidx.media3.common.Timeline;
 import androidx.media3.common.VideoSize;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.ExoPlayer;
@@ -56,6 +58,7 @@ final class PlaybackMetrics {
         String currentStreamUrl();
     }
 
+    private static final String TAG = "InfiniteStream";
     private static final long HEARTBEAT_INTERVAL_MS = 1000;
     private static final long SESSION_LOOKUP_INTERVAL_MS = 30_000;
     private static final int CONNECT_TIMEOUT_MS = 3000;
@@ -113,6 +116,7 @@ final class PlaybackMetrics {
     private final Runnable heartbeatRunnable = new Runnable() {
         @Override
         public void run() {
+            logOffsetHeartbeat();
             sendEvent("heartbeat", Collections.<String, Object>emptyMap());
             maybeReportVideoStart();
             maybeDetectFrozen();
@@ -122,6 +126,52 @@ final class PlaybackMetrics {
             }
         }
     };
+
+    /**
+     * Greppable 1 Hz heartbeat for cross-platform live-offset observation.
+     * Field names match iOS PlaybackDiagnostics.playbackSnapshot() so a single
+     * grep across logs covers all clients.
+     *
+     * <p>{@code pdt} is the encoded wall-clock at the playhead, derived from
+     * the timeline window's {@code windowStartTimeMs} (HLS PROGRAM-DATE-TIME)
+     * plus {@code currentPosition}. {@code trueOff} is host-now − pdt — a
+     * ground-truth live offset that survives stalls and HOLD-BACK changes
+     * that fool ExoPlayer's own {@link Player#getCurrentLiveOffset()}.
+     */
+    private void logOffsetHeartbeat() {
+        long nowMs = System.currentTimeMillis();
+        long posMs = player.getCurrentPosition();
+        long bufferedMs = player.getBufferedPosition();
+        double bufferDepthS = Math.max(0, bufferedMs - posMs) / 1000.0;
+        long liveOffsetMs = player.getCurrentLiveOffset();
+        String liveOff = liveOffsetMs == C.TIME_UNSET
+            ? "nil"
+            : String.format(Locale.US, "%.1fs", liveOffsetMs / 1000.0);
+
+        Long pdtMs = null;
+        Timeline timeline = player.getCurrentTimeline();
+        if (!timeline.isEmpty()) {
+            int windowIndex = player.getCurrentMediaItemIndex();
+            if (windowIndex >= 0 && windowIndex < timeline.getWindowCount()) {
+                Timeline.Window window = new Timeline.Window();
+                timeline.getWindow(windowIndex, window);
+                if (window.windowStartTimeMs != C.TIME_UNSET) {
+                    pdtMs = window.windowStartTimeMs + posMs;
+                }
+            }
+        }
+        String pdt = pdtMs == null ? "nil" : iso8601.format(new Date(pdtMs));
+        String trueOff = pdtMs == null
+            ? "nil"
+            : String.format(Locale.US, "%.2fs", (nowMs - pdtMs) / 1000.0);
+        String wall = iso8601.format(new Date(nowMs));
+        String pos = String.format(Locale.US, "%.2fs", posMs / 1000.0);
+        String buf = String.format(Locale.US, "%.1fs", bufferDepthS);
+
+        Log.i(TAG, String.format(Locale.US,
+            "[OFFSET] state=%s wall=%s pdt=%s trueOff=%s pos=%s liveOff=%s bufDepth=%s",
+            mapState(), wall, pdt, trueOff, pos, liveOff, buf));
+    }
 
     PlaybackMetrics(ExoPlayer player,
                     PlayerView playerView,
@@ -401,6 +451,28 @@ final class PlaybackMetrics {
             long liveOffsetMs = player.getCurrentLiveOffset();
             if (liveOffsetMs != C.TIME_UNSET) {
                 p.put("player_metrics_live_offset_s", roundSeconds(liveOffsetMs / 1000.0));
+            }
+
+            // Encoded wall-clock at the playhead (epoch ms) — derived from the
+            // HLS timeline window's PROGRAM-DATE-TIME (windowStartTimeMs)
+            // plus currentPosition. Pairs with the receiver's clock to compute
+            // a ground-truth live offset.
+            Timeline tl = player.getCurrentTimeline();
+            if (!tl.isEmpty()) {
+                int windowIndex = player.getCurrentMediaItemIndex();
+                if (windowIndex >= 0 && windowIndex < tl.getWindowCount()) {
+                    Timeline.Window window = new Timeline.Window();
+                    tl.getWindow(windowIndex, window);
+                    if (window.windowStartTimeMs != C.TIME_UNSET) {
+                        long pdtMs = window.windowStartTimeMs + currentPositionMs;
+                        p.put("player_metrics_playhead_wallclock_ms", pdtMs);
+                        // Client-side fallback for receivers that can't pair
+                        // with a server-stamped received_at. Biased by client
+                        // clock skew vs. server clock.
+                        p.put("player_metrics_true_offset_s",
+                            roundSeconds((System.currentTimeMillis() - pdtMs) / 1000.0));
+                    }
+                }
             }
 
             VideoSize vs = player.getVideoSize();

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -46,6 +46,11 @@ final class PlaybackDiagnostics: ObservableObject {
     @Published var bufferDepth: Double?
     @Published var seekableEnd: Double?
     @Published var liveOffset: Double?
+    /// Wall-clock time encoded into the manifest at the playhead position
+    /// (AVPlayerItem.currentDate() — derived from EXT-X-PROGRAM-DATE-TIME).
+    /// Pairs with `Date()` at sample time to give ground-truth live offset
+    /// independent of the player's seekable-window estimate.
+    @Published var playheadWallClock: Date?
     @Published var windowDuration: Double?
     @Published var windowSlack: Double?
     @Published var displayWidth: Double?
@@ -93,6 +98,7 @@ final class PlaybackDiagnostics: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private weak var player: AVPlayer?
     private var lastBufferSampleAt: Date?
+    private var lastOffsetLogAt: Date?
     private var lastPlayerSampleAt: Date?
     private var stallStartAt: Date?
     /// Set when AVPlayerItemPlaybackStalled fires (an unexpected
@@ -262,6 +268,7 @@ final class PlaybackDiagnostics: ObservableObject {
         bufferDepth = nil
         seekableEnd = nil
         liveOffset = nil
+        playheadWallClock = nil
         displayWidth = nil
         displayHeight = nil
         videoWidth = nil
@@ -472,6 +479,7 @@ final class PlaybackDiagnostics: ObservableObject {
             self.updateItemState()
             self.checkFrozenState()
             self.periodicVariantSummary()
+            self.maybeLogOffsetHeartbeat()
         }
     }
 
@@ -541,6 +549,10 @@ final class PlaybackDiagnostics: ObservableObject {
                 lastBufferSampleAt = now
             }
         }
+        // Encoded wall-clock at the playhead, sourced from EXT-X-PROGRAM-DATE-TIME
+        // via AVFoundation. Stays valid through stalls and HOLD-BACK shifts that
+        // would mislead a seekableEnd-based offset.
+        playheadWallClock = item.currentDate()
         if let liveRange = item.seekableTimeRanges.last?.timeRangeValue {
             let liveEdge = liveRange.start.seconds + liveRange.duration.seconds
             let window = liveRange.duration.seconds
@@ -918,8 +930,31 @@ final class PlaybackDiagnostics: ObservableObject {
         let obsMbps = (observedBitrate ?? 0) / 1_000_000
         let liveStr = liveOffset.map { String(format: "%.1fs", $0) } ?? "nil"
         let slackStr = windowSlack.map { String(format: "%.1fs", $0) } ?? "nil"
-        let winStr = windowDuration.map { String(format: "%.1fs", $0) } ?? "nil"
-        return "variant=\(variant) seg=\(segStr)/max=\(maxStr) netBuf=\(depthStr) empty=\(bufEmpty) full=\(bufFull) keepUp=\(keepUp) ranges=[\(ranges)] liveOff=\(liveStr) window=\(winStr) slack=\(slackStr) ind=\(String(format: "%.1fMbps", indMbps)) obs=\(String(format: "%.1fMbps", obsMbps))"
+        let bufStr = bufferDepth.map { String(format: "%.1fs", $0) } ?? "nil"
+        let posStr = String(format: "%.2fs", liveTime)
+        let now = Date()
+        let wallStr = Self.snapshotISO8601.string(from: now)
+        let pdt = playheadWallClock
+        let pdtStr = pdt.map { Self.snapshotISO8601.string(from: $0) } ?? "nil"
+        let trueOffStr = pdt.map { String(format: "%.2fs", now.timeIntervalSince($0)) } ?? "nil"
+        return "wall=\(wallStr) pdt=\(pdtStr) trueOff=\(trueOffStr) pos=\(posStr) liveOff=\(liveStr) bufDepth=\(bufStr) variant=\(variant) seg=\(segStr)/max=\(maxStr) netBuf=\(depthStr) empty=\(bufEmpty) full=\(bufFull) keepUp=\(keepUp) ranges=[\(ranges)] slack=\(slackStr) ind=\(String(format: "%.1fMbps", indMbps)) obs=\(String(format: "%.1fMbps", obsMbps))"
+    }
+
+    private static let snapshotISO8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    // Greppable 1 Hz heartbeat for live-offset observation across throttling,
+    // errors, and stalls. Tag `[OFFSET]` is shared with Android logcat so a
+    // single grep across logs covers all clients.
+    private func maybeLogOffsetHeartbeat() {
+        guard player?.currentItem != nil else { return }
+        let now = Date()
+        if let last = lastOffsetLogAt, now.timeIntervalSince(last) < 1.0 { return }
+        lastOffsetLogAt = now
+        print("[OFFSET] state=\(state) \(playbackSnapshot())")
     }
 
     // AVPlayer's access log URIs are per-variant playlists, not per-segment,

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackViewModel.swift
@@ -1032,6 +1032,19 @@ final class PlaybackViewModel: ObservableObject {
             "player_metrics_seekable_end_s": diagnostics.seekableEnd.map { roundSeconds($0) },
             "player_metrics_live_edge_s": diagnostics.seekableEnd.map { roundSeconds($0) },
             "player_metrics_live_offset_s": diagnostics.liveOffset.map { roundSeconds($0) },
+            // Encoded wall-clock at the playhead (epoch ms) — sourced from
+            // EXT-X-PROGRAM-DATE-TIME via AVPlayerItem.currentDate(). Pairs
+            // with the receiving side's clock to compute a ground-truth live
+            // offset that survives stalls and HOLD-BACK shifts.
+            "player_metrics_playhead_wallclock_ms": diagnostics.playheadWallClock.map {
+                Int64(($0.timeIntervalSince1970 * 1000).rounded())
+            },
+            // Client-side trueOffset = client_now - playhead_wallclock. Used
+            // when the server's received_at stamp isn't available; biased by
+            // client clock skew but useful as a fallback.
+            "player_metrics_true_offset_s": diagnostics.playheadWallClock.map {
+                roundSeconds(Date().timeIntervalSince($0))
+            },
             "player_metrics_display_resolution": formatResolution(width: diagnostics.displayWidth, height: diagnostics.displayHeight),
             "player_metrics_video_resolution": formatResolution(width: diagnostics.videoWidth, height: diagnostics.videoHeight),
             "player_metrics_video_first_frame_time_s": videoFirstFrameSeconds,

--- a/content/dashboard/playback.html
+++ b/content/dashboard/playback.html
@@ -318,7 +318,7 @@
                 <div class="stats-item"><span class="label">Current Time</span><span class="value" id="statTime">0.00s</span></div>
                 <div class="stats-item"><span class="label">Buffered End</span><span class="value" id="statBufferedEnd">--</span></div>
                 <div class="stats-item"><span class="label">Buffer Depth</span><span class="value" id="statBufferDepth">--</span></div>
-                <div class="stats-item"><span class="label">Live Offset</span><span class="value" id="statLiveOffset">--</span></div>
+                <div class="stats-item"><span class="label">Wall-Clock Offset</span><span class="value" id="statLiveOffset">--</span></div>
                 <div class="stats-item"><span class="label">URL</span><span class="value" id="statUrl">--</span></div>
             </div>
         </div>
@@ -494,7 +494,16 @@
                     playerState.type = 'native';
                     return;
                 }
-                const hls = new Hls({ liveSyncDurationCount: 3, autoLevelEnabled: true });
+                // Let the manifest's EXT-X-SERVER-CONTROL drive the live
+                // offset (HOLD-BACK on 2s/6s, PART-HOLD-BACK on LL) and
+                // EXT-X-START drive the initial seek (now emitted into
+                // the variant by go-live so hls.js doesn't park at the
+                // oldest segment). lowLatencyMode is only useful on LL.
+                const isLL = !/(_2s|_6s)\.m3u8/.test(url);
+                const hls = new Hls({
+                    lowLatencyMode: isLL,
+                    autoLevelEnabled: true
+                });
                 hls.loadSource(url);
                 hls.attachMedia(video);
                 playerState.instance = hls;
@@ -677,22 +686,97 @@
             setGlobalMuted(nextMuted);
         }
 
+        let lastOffsetLogAt = 0;
+
+        // Pull a Date stamped onto the current playhead — derived from
+        // EXT-X-PROGRAM-DATE-TIME (or DASH availabilityStartTime). Each engine
+        // exposes its own API; native HTML5 video has none.
+        function getPlayheadDate() {
+            if (playerState.type === 'shaka' && playerState.instance) {
+                try {
+                    const d = playerState.instance.getPlayheadTimeAsDate();
+                    return d instanceof Date && !isNaN(d.getTime()) ? d : null;
+                } catch (_) { return null; }
+            }
+            if (playerState.type === 'hlsjs' && playerState.instance) {
+                const d = playerState.instance.playingDate;
+                return d instanceof Date && !isNaN(d.getTime()) ? d : null;
+            }
+            return null;
+        }
+
+        // Engine-reported live offset. Falls back to seekable.end - currentTime.
+        function getLiveOffsetSeconds(currentTime) {
+            if (playerState.type === 'hlsjs' && playerState.instance) {
+                const lat = playerState.instance.latency;
+                if (typeof lat === 'number' && isFinite(lat)) return lat;
+            }
+            if (playerState.type === 'shaka' && playerState.instance) {
+                try {
+                    const stats = playerState.instance.getStats();
+                    const lat = stats && stats.liveLatency;
+                    if (typeof lat === 'number' && isFinite(lat)) return lat;
+                } catch (_) {}
+            }
+            const seekable = video.seekable;
+            if (seekable && seekable.length > 0) {
+                return Math.max(0, seekable.end(seekable.length - 1) - currentTime);
+            }
+            return null;
+        }
+
+        function fmtSec(v) { return v == null ? 'nil' : `${v.toFixed(2)}s`; }
+        function fmtIso(d) { return d == null ? 'nil' : d.toISOString(); }
+
         function updateStats() {
             const buffered = video.buffered;
             const current = video.currentTime || 0;
             let bufferedEnd = '--';
             let bufferDepth = '--';
+            let bufferDepthValue = null;
             if (buffered && buffered.length > 0) {
                 const end = buffered.end(buffered.length - 1);
                 bufferedEnd = `${end.toFixed(2)}s`;
-                bufferDepth = `${Math.max(0, end - current).toFixed(2)}s`;
+                bufferDepthValue = Math.max(0, end - current);
+                bufferDepth = `${bufferDepthValue.toFixed(2)}s`;
             }
+
+            const now = new Date();
+            const pdt = getPlayheadDate();
+            const trueOffSec = pdt ? (now.getTime() - pdt.getTime()) / 1000 : null;
+            const liveOffSec = getLiveOffsetSeconds(current);
+
+            const seekable = video.seekable;
+            let winStart = null;
+            let winDurSec = null;
+            if (seekable && seekable.length > 0) {
+                const seekStart = seekable.start(0);
+                const seekEnd = seekable.end(seekable.length - 1);
+                winDurSec = seekEnd - seekStart;
+                if (pdt) {
+                    winStart = new Date(pdt.getTime() - (current - seekStart) * 1000);
+                }
+            }
+
+            const state = video.paused ? 'paused' : (video.muted ? 'playing-muted' : 'playing');
             document.getElementById('statState').textContent = video.paused ? 'Paused' : (video.muted ? 'Playing (Muted)' : 'Playing');
             document.getElementById('statTime').textContent = `${current.toFixed(2)}s`;
             document.getElementById('statBufferedEnd').textContent = bufferedEnd;
             document.getElementById('statBufferDepth').textContent = bufferDepth;
-            document.getElementById('statLiveOffset').textContent = '--';
+            document.getElementById('statLiveOffset').textContent = trueOffSec != null ? `${trueOffSec.toFixed(2)}s` : (liveOffSec != null ? `${liveOffSec.toFixed(2)}s` : '--');
             update4kBadge();
+
+            // Greppable 1 Hz heartbeat. Tag matches iOS/Android logcat so a
+            // single grep across logs covers all clients.
+            if (now.getTime() - lastOffsetLogAt >= 1000) {
+                lastOffsetLogAt = now.getTime();
+                console.log(
+                    `[OFFSET] state=${state} engine=${playerState.type || 'none'} ` +
+                    `wall=${fmtIso(now)} pdt=${fmtIso(pdt)} trueOff=${fmtSec(trueOffSec)} ` +
+                    `pos=${fmtSec(current)} liveOff=${fmtSec(liveOffSec)} ` +
+                    `bufDepth=${fmtSec(bufferDepthValue)} winStart=${fmtIso(winStart)} winDur=${fmtSec(winDurSec)}`
+                );
+            }
         }
 
         function createPlayerId() {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -612,6 +612,7 @@
                             <div class="session-item"><span class="label">Seekable End</span><span class="value" data-field="player_metrics_seekable_end_s">${formatSeconds(session.player_metrics_seekable_end_s)}</span></div>
                             <div class="session-item"><span class="label">Live Edge</span><span class="value" data-field="player_metrics_live_edge_s">${formatSeconds(session.player_metrics_live_edge_s)}</span></div>
                             <div class="session-item"><span class="label">Live Offset</span><span class="value" data-field="player_metrics_live_offset_s">${formatSeconds(session.player_metrics_live_offset_s)}</span></div>
+                            <div class="session-item"><span class="label">Wall-Clock Offset</span><span class="value" data-field="player_metrics_true_offset_s">${formatSeconds(session.player_metrics_true_offset_s)}</span></div>
                             <div class="session-item"><span class="label">Display Resolution</span><span class="value" data-field="player_metrics_display_resolution">${session.player_metrics_display_resolution ?? '—'}</span></div>
                             <div class="session-item"><span class="label">Video Resolution</span><span class="value" data-field="player_metrics_video_resolution">${session.player_metrics_video_resolution ?? '—'}</span></div>
                             <div class="session-item"><span class="label">First Frame Time</span><span class="value" data-field="player_metrics_video_first_frame_time_s">${formatSeconds(session.player_metrics_video_first_frame_time_s)}</span></div>
@@ -815,6 +816,9 @@
                                                 <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="6" ${String(session.content_live_offset) === '6' ? 'checked' : ''}> 6s</label>
                                                 <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="18" ${String(session.content_live_offset) === '18' ? 'checked' : ''}> 18s</label>
                                                 <label><input type="radio" name="content_live_offset_${sessionId}" data-field="content_live_offset" value="24" ${String(session.content_live_offset) === '24' ? 'checked' : ''}> 24s</label>
+                                            </div>
+                                            <div class="content-tab-note" style="margin-top:4px">
+                                                Drives both the player's <strong>start time</strong> (<code>EXT-X-START:TIME-OFFSET</code>, master and variant) and its steady-state <strong>HOLD-BACK</strong> on 2s/6s variants. <code>PART-HOLD-BACK</code> on the LL variant is left untouched since it's a sub-second LL timing parameter, not a window-scale offset. Values below the spec minimum (3× target duration) may be rejected by AVPlayer.
                                             </div>
                                         </div>
                                         <div class="content-tab-note">

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1558,6 +1558,22 @@
             const liveOffset = (seekableEnd !== null)
                 ? toMetricSeconds(Math.max(0, seekableEnd - current))
                 : null;
+            // Encoded wall-clock at the playhead (epoch ms). Sourced from the
+            // active engine — Shaka's getPlayheadTimeAsDate() or HLS.js's
+            // playingDate, both of which surface EXT-X-PROGRAM-DATE-TIME from
+            // the manifest. Native HTML5 video has no equivalent, so this stays
+            // null for those engines.
+            let playheadWallclockMs = null;
+            try {
+                if (typeof shakaPlayer !== 'undefined' && shakaPlayer && typeof shakaPlayer.getPlayheadTimeAsDate === 'function') {
+                    const d = shakaPlayer.getPlayheadTimeAsDate();
+                    if (d instanceof Date && !isNaN(d.getTime())) playheadWallclockMs = d.getTime();
+                }
+                if (playheadWallclockMs === null && typeof hlsInstance !== 'undefined' && hlsInstance && hlsInstance.playingDate instanceof Date) {
+                    const d = hlsInstance.playingDate;
+                    if (!isNaN(d.getTime())) playheadWallclockMs = d.getTime();
+                }
+            } catch (_) {}
             const quality = video.getVideoPlaybackQuality ? video.getVideoPlaybackQuality() : null;
             const totalFrames = quality ? Number(quality.totalVideoFrames || 0) : null;
             const droppedFrames = quality ? Number(quality.droppedVideoFrames || 0) : null;
@@ -1580,6 +1596,10 @@
                 player_metrics_seekable_end_s: seekableEnd,
                 player_metrics_live_edge_s: seekableEnd,
                 player_metrics_live_offset_s: liveOffset,
+                player_metrics_playhead_wallclock_ms: playheadWallclockMs,
+                player_metrics_true_offset_s: playheadWallclockMs != null
+                    ? toMetricSeconds((Date.now() - playheadWallclockMs) / 1000)
+                    : null,
                 player_metrics_display_resolution: displayResolution,
                 player_metrics_video_resolution: videoResolution,
                 player_metrics_video_first_frame_time_s: toMetricSeconds(videoFirstFrameS),
@@ -2402,7 +2422,19 @@
                 });
             } else if (playerType === 'hlsjs') {
                 if (Hls.isSupported()) {
-                    hlsInstance = new Hls({ enableWorker: true, lowLatencyMode: false });
+                    // Let the manifest drive everything: HOLD-BACK /
+                    // PART-HOLD-BACK from EXT-X-SERVER-CONTROL set the
+                    // steady-state target, EXT-X-START sets the initial
+                    // seek (now emitted into the variant by go-live, so
+                    // hls.js no longer parks at the oldest segment).
+                    // lowLatencyMode is only useful on LL (where partial
+                    // segments exist); on 2s/6s it just enables a fetch
+                    // path that has nothing to fetch.
+                    const isLL = (derived.segment || '').toUpperCase() === 'LL';
+                    hlsInstance = new Hls({
+                        enableWorker: true,
+                        lowLatencyMode: isLL
+                    });
                     hlsInstance.on(Hls.Events.ERROR, (evt, data) => {
                         log(`HLS ERROR: ${data.type} ${data.details}`);
                         const hlsHttp = extractHlsHttpFailure(data);
@@ -4192,6 +4224,7 @@
             setText('[data-field="player_metrics_seekable_end_s"]', formatSeconds(session.player_metrics_seekable_end_s));
             setText('[data-field="player_metrics_live_edge_s"]', formatSeconds(session.player_metrics_live_edge_s));
             setText('[data-field="player_metrics_live_offset_s"]', formatSeconds(session.player_metrics_live_offset_s));
+            setText('[data-field="player_metrics_true_offset_s"]', formatSeconds(session.player_metrics_true_offset_s));
             setText('[data-field="player_metrics_display_resolution"]', session.player_metrics_display_resolution || '—');
             setText('[data-field="player_metrics_video_resolution"]', session.player_metrics_video_resolution || '—');
             setText('[data-field="player_metrics_video_first_frame_time_s"]', formatSeconds(session.player_metrics_video_first_frame_time_s));
@@ -4631,6 +4664,39 @@
                     bufferDepth = Math.max(0, Math.round(depth * 100) / 100);
                 }
             }
+            // Wall-clock offset = (clock authority) − encoded PDT at playhead.
+            // Preference order (best → worst):
+            //   1. server_received_at_ms − playhead_wallclock_ms
+            //      (server stamps on POST receipt; eliminates client clock skew)
+            //   2. player_metrics_true_offset_s
+            //      (client computed it on its own clock; biased by client skew)
+            //   3. dashboard's Date.now() − local preview's PDT
+            //      (no client report at all yet; uses the preview's own engine)
+            let wallClockOffset = null;
+            const reportedPdtMs = Number(session.player_metrics_playhead_wallclock_ms);
+            const serverReceivedAtMs = Number(session.server_received_at_ms);
+            const reportedTrueOff = Number(session.player_metrics_true_offset_s);
+            if (Number.isFinite(reportedPdtMs) && reportedPdtMs > 0
+                && Number.isFinite(serverReceivedAtMs) && serverReceivedAtMs > 0) {
+                wallClockOffset = Math.round((serverReceivedAtMs - reportedPdtMs) / 10) / 100;
+            } else if (Number.isFinite(reportedTrueOff)) {
+                wallClockOffset = reportedTrueOff;
+            } else {
+                let localPdtMs = null;
+                try {
+                    if (typeof shakaPlayer !== 'undefined' && shakaPlayer && typeof shakaPlayer.getPlayheadTimeAsDate === 'function') {
+                        const d = shakaPlayer.getPlayheadTimeAsDate();
+                        if (d instanceof Date && !isNaN(d.getTime())) localPdtMs = d.getTime();
+                    }
+                    if (localPdtMs === null && typeof hlsInstance !== 'undefined' && hlsInstance && hlsInstance.playingDate instanceof Date) {
+                        const d = hlsInstance.playingDate;
+                        if (!isNaN(d.getTime())) localPdtMs = d.getTime();
+                    }
+                } catch (_) {}
+                if (localPdtMs !== null) {
+                    wallClockOffset = Math.round((now - localPdtMs) / 10) / 100;
+                }
+            }
             const playerEstimate = Number(playerEstimatedMbps || 0);
             const currentRendition = Number(currentRenditionMbps || 0);
             const framesDisplayed = Number.isFinite(Number(session.player_metrics_frames_displayed))
@@ -4822,6 +4888,7 @@
                 segmentDrain,
                 fullSegmentNetworkBitrate,
                 bufferDepth,
+                wallClockOffset,
                 playerEstimate,
                 currentRendition,
                 framesDisplayed,
@@ -5519,6 +5586,7 @@
                     segmentDrain: point.segmentDrain,
                     fullSegmentNetworkBitrate: point.fullSegmentNetworkBitrate,
                     bufferDepth: point.bufferDepth,
+                    wallClockOffset: point.wallClockOffset,
                     playerEstimate: point.playerEstimate,
                     currentRendition: point.currentRendition,
                     framesDisplayed: point.framesDisplayed,
@@ -5544,6 +5612,7 @@
             const segmentDrainData = points.map(point => ({ x: point.x, y: point.segmentDrain }));
             const fullSegmentNetworkBitrateData = points.map(point => ({ x: point.x, y: point.fullSegmentNetworkBitrate }));
             const bufferDepthData = points.map(point => ({ x: point.x, y: Number.isFinite(point.bufferDepth) ? point.bufferDepth : null }));
+            const wallClockOffsetData = points.map(point => ({ x: point.x, y: Number.isFinite(point.wallClockOffset) ? point.wallClockOffset : null }));
             const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null, atMs: point.metricsAtMs || null }));
             const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null, atMs: point.metricsAtMs || null }));
             const estimateData = points.map(point => ({ x: point.x, y: point.playerEstimate || null }));
@@ -5876,22 +5945,40 @@
                 bufferChart = null;
                 bufferDepthCharts.delete(sessionId);
             }
+            // Wall-clock offset shares this chart on a right-side axis. The two
+            // metrics are related — buffer drains tend to coincide with offset
+            // jumps — so plotting them together makes correlation immediate.
+            const wallClockValues = wallClockOffsetData
+                .map((point) => Number(point.y))
+                .filter((value) => Number.isFinite(value));
+            const maxWallClockRaw = Math.max(5, ...wallClockValues, 0);
+            const maxWallClock = Math.min(120, Math.ceil(maxWallClockRaw / 5) * 5);
+            const bufferDatasets = [
+                {
+                    label: 'Buffer Depth',
+                    data: bufferDepthData,
+                    borderColor: '#2563eb',
+                    backgroundColor: 'rgba(37,99,235,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    yAxisID: 'y'
+                },
+                {
+                    label: 'Wall-Clock Offset',
+                    data: wallClockOffsetData,
+                    borderColor: '#0d9488',
+                    backgroundColor: 'rgba(13,148,136,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    yAxisID: 'y1'
+                }
+            ];
             if (!bufferChart) {
                 bufferChart = new Chart(bufferCanvas, {
                     type: 'line',
-                    data: {
-                        datasets: [
-                            {
-                                label: 'Buffer Depth',
-                                data: bufferDepthData,
-                                borderColor: '#2563eb',
-                                backgroundColor: 'rgba(37,99,235,0.12)',
-                                borderWidth: 2,
-                                pointRadius: 0,
-                                tension: 0.2
-                            }
-                        ]
-                    },
+                    data: { datasets: bufferDatasets },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
@@ -5938,6 +6025,7 @@
                                 }
                             },
                             y: {
+                                position: 'left',
                                 min: 0,
                                 max: maxBufferDepth,
                                 afterFit: (axis) => { axis.width = 90; },
@@ -5949,6 +6037,22 @@
                                 title: {
                                     display: true,
                                     text: 'Buffer Depth (s)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            y1: {
+                                position: 'right',
+                                min: 0,
+                                max: maxWallClock,
+                                grid: { drawOnChartArea: false },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Wall-Clock Offset (s)',
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 }
                                 }
@@ -5966,9 +6070,10 @@
                 }
                 bufferDepthCharts.set(sessionId, bufferChart);
             } else {
-                bufferChart.data.datasets[0].data = bufferDepthData;
+                bufferChart.data.datasets = bufferDatasets;
                 bufferChart.$windowStartMs = windowStart;
                 bufferChart.options.scales.y.max = maxBufferDepth;
+                bufferChart.options.scales.y1.max = maxWallClock;
                 applyLegendHover(bufferChart);
                 bufferChart.update('none');
             }

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1701,6 +1701,7 @@ maybe a histogram of b
             setText('[data-field="player_metrics_seekable_end_s"]', formatSeconds(session.player_metrics_seekable_end_s));
             setText('[data-field="player_metrics_live_edge_s"]', formatSeconds(session.player_metrics_live_edge_s));
             setText('[data-field="player_metrics_live_offset_s"]', formatSeconds(session.player_metrics_live_offset_s));
+            setText('[data-field="player_metrics_true_offset_s"]', formatSeconds(session.player_metrics_true_offset_s));
             setText('[data-field="player_metrics_display_resolution"]', session.player_metrics_display_resolution || '—');
             setText('[data-field="player_metrics_video_resolution"]', session.player_metrics_video_resolution || '—');
             setText('[data-field="player_metrics_video_first_frame_time_s"]', formatSeconds(session.player_metrics_video_first_frame_time_s));
@@ -2365,6 +2366,23 @@ maybe a histogram of b
             const bufferDepth = Number.isFinite(Number(session.player_metrics_buffer_depth_s))
                 ? Number(session.player_metrics_buffer_depth_s)
                 : null;
+            // Wall-clock offset = (clock authority) − encoded PDT (epoch ms).
+            // Preference order:
+            //   1. server_received_at_ms − playhead_wallclock_ms (no client skew)
+            //   2. player_metrics_true_offset_s (client computed; biased by skew)
+            //   3. Date.now() − playhead_wallclock_ms (browser's clock as authority)
+            let wallClockOffset = null;
+            const reportedPdtMs = Number(session.player_metrics_playhead_wallclock_ms);
+            const serverReceivedAtMs = Number(session.server_received_at_ms);
+            const reportedTrueOff = Number(session.player_metrics_true_offset_s);
+            if (Number.isFinite(reportedPdtMs) && reportedPdtMs > 0
+                && Number.isFinite(serverReceivedAtMs) && serverReceivedAtMs > 0) {
+                wallClockOffset = Math.round((serverReceivedAtMs - reportedPdtMs) / 10) / 100;
+            } else if (Number.isFinite(reportedTrueOff)) {
+                wallClockOffset = reportedTrueOff;
+            } else if (Number.isFinite(reportedPdtMs) && reportedPdtMs > 0) {
+                wallClockOffset = Math.round((Date.now() - reportedPdtMs) / 10) / 100;
+            }
             const measuredVideoBitrate = Number(session.player_metrics_video_bitrate_mbps);
             const inferredVideoBitrate = inferSessionNativeRenditionMbps(session);
             const currentRendition = (Number.isFinite(measuredVideoBitrate) && measuredVideoBitrate > 0)
@@ -2531,6 +2549,7 @@ maybe a histogram of b
                 transferComplete,
                 metricsAtMs,
                 bufferDepth,
+                wallClockOffset,
                 playerEstimate,
                 playerWireBitrate,
                 currentRendition,
@@ -3392,6 +3411,7 @@ maybe a histogram of b
                     transferComplete: point.transferComplete,
                     metricsAtMs: point.metricsAtMs,
                     bufferDepth: point.bufferDepth,
+                    wallClockOffset: point.wallClockOffset,
                     playerEstimate: point.playerEstimate,
                     playerWireBitrate: point.playerWireBitrate,
                     currentRendition: point.currentRendition,
@@ -3425,6 +3445,7 @@ maybe a histogram of b
             const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));
             const transferCompleteData = points.map(point => ({ x: point.x, y: point.transferComplete }));
             const bufferDepthData = points.map(point => ({ x: point.x, y: Number.isFinite(point.bufferDepth) ? point.bufferDepth : null }));
+            const wallClockOffsetData = points.map(point => ({ x: point.x, y: Number.isFinite(point.wallClockOffset) ? point.wallClockOffset : null }));
             const estimateData = points.map(point => ({ x: point.x, y: point.playerEstimate || null }));
             const playerWireBitrateData = points.map(point => ({
                 x: point.x,
@@ -3877,7 +3898,22 @@ maybe a histogram of b
                     backgroundColor: 'rgba(37,99,235,0.12)',
                     borderWidth: 2,
                     pointRadius: 0,
-                    tension: 0.2
+                    tension: 0.2,
+                    yAxisID: 'y'
+                },
+                {
+                    // Wall-clock offset shares this chart on a right-side axis.
+                    // The two metrics are related — buffer drains tend to
+                    // coincide with offset jumps — so plotting them together
+                    // makes correlation immediate.
+                    label: compareActive ? `Wall-Clock (S${sessionId})` : 'Wall-Clock Offset',
+                    data: wallClockOffsetData,
+                    borderColor: '#0d9488',
+                    backgroundColor: 'rgba(13,148,136,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    yAxisID: 'y1'
                 }
             ];
             if (compareGroupIds.length >= 2) {
@@ -3885,28 +3921,50 @@ maybe a histogram of b
                 otherIds.forEach((sid) => {
                     const ci = sessionColorIndex(sid, compareGroupIds);
                     const color = SESSION_COLORS[ci];
-                    const otherSeries = (bandwidthHistory.get(sid) || [])
+                    const otherBufferSeries = (bandwidthHistory.get(sid) || [])
                         .filter(p => p.ts >= windowStart)
                         .map(p => ({ x: (p.ts - windowStart) / 1000, y: Number.isFinite(p.bufferDepth) ? p.bufferDepth : null }));
+                    const otherWallSeries = (bandwidthHistory.get(sid) || [])
+                        .filter(p => p.ts >= windowStart)
+                        .map(p => ({ x: (p.ts - windowStart) / 1000, y: Number.isFinite(p.wallClockOffset) ? p.wallClockOffset : null }));
                     bufferDatasets.push({
                         label: `Buffer (S${sid})`,
-                        data: otherSeries,
+                        data: otherBufferSeries,
                         borderColor: color.main,
                         borderWidth: 1.5,
                         pointRadius: 0,
                         tension: 0.2,
-                        borderDash: [4, 3]
+                        borderDash: [4, 3],
+                        yAxisID: 'y'
+                    });
+                    bufferDatasets.push({
+                        label: `Wall-Clock (S${sid})`,
+                        data: otherWallSeries,
+                        borderColor: color.light,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [2, 4],
+                        yAxisID: 'y1'
                     });
                 });
             }
-            // Compute max across ALL datasets (primary + any comparison
-            // sessions) so grouped-session lines don't clip above the axis.
-            // Round up to the next 5s step, floor 5, cap 60.
-            const bufferValues = bufferDatasets.flatMap(ds => ds.data)
+            // Buffer-depth bound (left axis): cap 60.
+            const bufferValues = bufferDatasets
+                .filter(ds => ds.yAxisID === 'y')
+                .flatMap(ds => ds.data)
                 .map((point) => Number(point && point.y))
                 .filter((value) => Number.isFinite(value) && value >= 0);
             const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
             const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
+            // Wall-clock bound (right axis): cap 120.
+            const wallValues = bufferDatasets
+                .filter(ds => ds.yAxisID === 'y1')
+                .flatMap(ds => ds.data)
+                .map((point) => Number(point && point.y))
+                .filter((value) => Number.isFinite(value));
+            const maxWallClockRaw = Math.max(5, ...wallValues, 0);
+            const maxWallClock = Math.min(120, Math.ceil(maxWallClockRaw / 5) * 5);
             if (!bufferChart) {
                 bufferChart = new Chart(bufferCanvas, {
                     type: 'line',
@@ -3961,6 +4019,7 @@ maybe a histogram of b
                                 }
                             },
                             y: {
+                                position: 'left',
                                 min: 0,
                                 max: maxBufferDepth,
                                 afterFit: (axis) => { axis.width = 90; },
@@ -3972,6 +4031,22 @@ maybe a histogram of b
                                 title: {
                                     display: true,
                                     text: 'Buffer Depth (s)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            y1: {
+                                position: 'right',
+                                min: 0,
+                                max: maxWallClock,
+                                grid: { drawOnChartArea: false },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Wall-Clock Offset (s)',
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 }
                                 }
@@ -3998,6 +4073,7 @@ maybe a histogram of b
                 bufferChart.data.datasets = bufferDatasets;
                 bufferChart.$windowStartMs = windowStart;
                 bufferChart.options.scales.y.max = maxBufferDepth;
+                bufferChart.options.scales.y1.max = maxWallClock;
                 applyLegendHover(bufferChart);
                 bufferChart.update('none');
             }

--- a/go-live/pkg/generator/range_hls.go
+++ b/go-live/pkg/generator/range_hls.go
@@ -204,6 +204,13 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 	targetDurationSecs := int(math.Ceil(maxSegDuration))
 	liveHoldBack := 3.0 * float64(targetDurationSecs)
 	sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f\n", liveHoldBack))
+	// EXT-X-START in the variant matters because hls.js (and some other
+	// players) only honor TIME-OFFSET in the *media* playlist; the master
+	// inheritance is widely under-implemented. Without this, hls.js parks at
+	// the oldest segment in the sliding window and never seeks to live —
+	// the player ends up ~MAX_LIVE_WINDOW_DURATION seconds behind real time.
+	// Match HOLD-BACK so the seek target and steady-state target agree.
+	sb.WriteString(fmt.Sprintf("#EXT-X-START:TIME-OFFSET=-%.3f,PRECISE=YES\n", liveHoldBack))
 	sb.WriteString(fmt.Sprintf("#EXT-X-PROGRAM-DATE-TIME:%s\n", pdt.Format("2006-01-02T15:04:05.000Z")))
 
 	if segmentMap != "" {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1357,6 +1357,12 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 		metricsOnly[key] = value
 	}
 	metricsOnly["session_id"] = id
+	// Stamp the moment we received this metrics payload, on the server's
+	// own clock. Pairs with player_metrics_playhead_wallclock_ms (the
+	// encoder's PDT at the playhead) so the dashboard can compute a
+	// ground-truth live offset that's independent of the client's clock:
+	//   trueOffsetMs = server_received_at_ms - playhead_wallclock_ms
+	metricsOnly["server_received_at_ms"] = time.Now().UnixMilli()
 	a.saveSessionByID(id, metricsOnly)
 	if isSignificantPlayerEvent(getString(metricsOnly, "player_metrics_last_event")) {
 		a.flushSessionsBroadcast()
@@ -4232,7 +4238,19 @@ func (a *App) applyContentManipulation(body []byte, session SessionData, content
 
 	// Handle HLS master playlists
 	if strings.Contains(strings.ToLower(contentType), "mpegurl") || strings.Contains(strings.ToLower(contentType), "m3u8") {
-		return manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, liveOffset, allowedVariants)
+		result, err := manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, overstateBandwidth, liveOffset, allowedVariants)
+		if err != nil {
+			return nil, err
+		}
+		// Variant playlists carry HOLD-BACK / PART-HOLD-BACK and their own
+		// EXT-X-START tag (not all players honor master-level inheritance —
+		// notably hls.js, which would otherwise park at the oldest segment).
+		// Master EXT-X-START is rewritten inside manipulateHLSMaster; this
+		// pass handles the variant side. No-op on master playlists.
+		if liveOffset > 0 {
+			result = rewriteVariantLiveOffsetTags(result, liveOffset)
+		}
+		return result, nil
 	}
 
 	// Handle DASH manifests
@@ -4369,6 +4387,54 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 	}
 
 	return buf.Bytes(), nil
+}
+
+// rewriteVariantLiveOffsetTags updates HOLD-BACK inside EXT-X-SERVER-CONTROL
+// lines and TIME-OFFSET inside EXT-X-START lines of a media (variant)
+// playlist. PART-HOLD-BACK is intentionally left alone: it's a sub-second
+// timing parameter (>= 3× partial duration, ~0.6s on our LL playlist), not a
+// window-scale offset, so applying the user's content_live_offset value
+// (typically 6–24s) to it would push LL clients to a deep offset and defeat
+// the LL use case. Other attributes (CAN-SKIP-UNTIL, PRECISE, etc.) are
+// preserved. No clamping: the user is testing spec-violating values too
+// (HLS spec requires HOLD-BACK >= 3× target duration; AVPlayer rejects below
+// that with -12646), so we surface the chosen value verbatim.
+// Master-playlist EXT-X-START is rewritten elsewhere — see manipulateHLSMaster.
+var (
+	serverControlLineRE = regexp.MustCompile(`(?m)^#EXT-X-SERVER-CONTROL:.*$`)
+	extXStartLineRE     = regexp.MustCompile(`(?m)^#EXT-X-START:.*$`)
+)
+
+func rewriteVariantLiveOffsetTags(body []byte, liveOffsetSecs int) []byte {
+	// Master playlists carry #EXT-X-STREAM-INF and have no HOLD-BACK; their
+	// EXT-X-START is already rewritten by manipulateHLSMaster. Skip cleanly
+	// here so we don't double-write (same value, but hidden coupling).
+	if bytes.Contains(body, []byte("#EXT-X-STREAM-INF")) {
+		return body
+	}
+	holdBackValue := fmt.Sprintf("%d.000", liveOffsetSecs)
+	timeOffsetValue := fmt.Sprintf("-%d.000", liveOffsetSecs)
+	body = serverControlLineRE.ReplaceAllFunc(body, func(line []byte) []byte {
+		const prefix = "#EXT-X-SERVER-CONTROL:"
+		attrs := strings.Split(strings.TrimPrefix(string(line), prefix), ",")
+		for i, a := range attrs {
+			if strings.HasPrefix(strings.TrimSpace(a), "HOLD-BACK=") {
+				attrs[i] = "HOLD-BACK=" + holdBackValue
+			}
+		}
+		return []byte(prefix + strings.Join(attrs, ","))
+	})
+	body = extXStartLineRE.ReplaceAllFunc(body, func(line []byte) []byte {
+		const prefix = "#EXT-X-START:"
+		attrs := strings.Split(strings.TrimPrefix(string(line), prefix), ",")
+		for i, a := range attrs {
+			if strings.HasPrefix(strings.TrimSpace(a), "TIME-OFFSET=") {
+				attrs[i] = "TIME-OFFSET=" + timeOffsetValue
+			}
+		}
+		return []byte(prefix + strings.Join(attrs, ","))
+	})
+	return body
 }
 
 // manipulateDASHManifest modifies a DASH manifest


### PR DESCRIPTION
## Summary

Closes #259. Adds end-to-end *Wall-Clock Offset* observability across iOS / tvOS, Android TV, and the web preview, plus the manifest-level fixes needed for it to be meaningful.

## What changed

**Per-client emission**
- iOS / tvOS: `AVPlayerItem.currentDate()` → new `player_metrics_playhead_wallclock_ms` and `player_metrics_true_offset_s`.
- Android: `Timeline.Window.windowStartTimeMs + currentPosition` → same fields.
- Web (testing-session.html preview, playback.html): Shaka `getPlayheadTimeAsDate()` / hls.js `playingDate`.
- Each platform also emits a 1 Hz `[OFFSET]` log line with `wall pdt trueOff pos liveOff bufDepth` so a single grep across iOS Console / adb logcat / DevTools covers every client.

**Server (go-proxy)**
- Stamps `server_received_at_ms` on every metrics POST so the dashboard computes drift independent of client clock skew.
- New `rewriteVariantLiveOffsetTags` rewrites `HOLD-BACK` and variant-level `EXT-X-START:TIME-OFFSET` based on `content_live_offset`. `PART-HOLD-BACK` left untouched (sub-second LL timing parameter, not window-scale).
- Master-playlist guard so the variant rewriter doesn't double-write `EXT-X-START` already touched by `manipulateHLSMaster`.

**Manifest (go-live)**
- `range_hls.go` now emits `EXT-X-START:TIME-OFFSET=-HOLD-BACK,PRECISE=YES` into 2s/6s variant playlists. hls.js doesn't honor master-level inheritance and would otherwise park at the oldest segment of the sliding window — root cause of the original 180s offset bug.

**Dashboard (testing-session.html, testing.html)**
- New "Wall-Clock Offset" trace overlaid on the existing buffer-depth chart on a right Y axis. Compare-mode in `testing.html` overlays both metrics for grouped sessions (buffer dashed, wall-clock dotted in `color.light`).
- New "Wall-Clock Offset" row in the metrics panel (sourced from `player_metrics_true_offset_s`).
- Preference order for the chart's clock authority: `server_received_at − pdt` → client-computed `true_offset_s` → `Date.now() − pdt`.
- hls.js config simplified: no hardcoded `liveSyncDuration`, no `liveDurationInfinity` (was a workaround for "park at oldest", now fixed properly upstream). `lowLatencyMode` keyed off variant (true on LL).

**UI hint**
- Live Offset control now annotated: drives `EXT-X-START` (master + variant) and `HOLD-BACK` (2s/6s); leaves `PART-HOLD-BACK` alone.

## Test plan
- [x] iOS/tvOS build succeeds.
- [x] Android build + install succeeds; `adb logcat -s InfiniteStream` shows `[OFFSET]` heartbeat at 1 Hz.
- [x] go-proxy builds clean, `go vet` clean.
- [x] testing-session.html, testing.html, testing-session-ui.js, playback.html parse cleanly.
- [x] Verified live: 6s variant playlist now ships `EXT-X-START:TIME-OFFSET=-21.000` matching `HOLD-BACK=21.000`.
- [x] Verified live: LL variant still ships `PART-HOLD-BACK=3.0` (not rewritten).
- [x] iOS, Android, hls.js wall-clock offset all settle at HOLD-BACK ± few seconds in steady state on test-deploy-dev.
- [ ] Verify on Apple TV via real device after merge (no regression to existing playback path).

## Out of scope (tracked separately)
- Roku emitter — deferred (no native PDT API; needs a manifest parser).
- Post-stall recovery policy decision — #263.