### PR TITLE
ci: bump claude-review --max-turns from 20 to 40

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,4 +41,4 @@ jobs:
             real boundaries, security issues (command injection, path traversal,
             etc.), and divergence from existing patterns. Do not flag stylistic
             nits unless they obscure intent.
-          claude_args: "--max-turns 20 --model claude-opus-4-7"
+          claude_args: "--max-turns 40 --model claude-opus-4-7"


### PR DESCRIPTION
## Summary
- PR #264 (~600-line wall-clock offset chart change) exhausted the 20-turn budget mid-review.
- Bump to 40 to handle larger multi-file PRs without running out before posting findings.

## Test plan
- [ ] Merge first, then re-trigger the auto-review on PR #264 (push or label toggle) and confirm it completes.