### PR TITLE
feat(server): always-AAC transcode, wall-clock offset metrics, longer titles

### DIFF
--- a/generate_abr/create_abr_ladder.sh
+++ b/generate_abr/create_abr_ladder.sh
@@ -2175,13 +2175,15 @@ create_audio_mezzanine() {
     
     log "Extracting audio from mezzanine file..."
 
-    # Detect audio codec and channel count
+    # Detect audio codec, profile, and channel count.
     AUDIO_CODEC=$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name \
+                  -of default=noprint_wrappers=1:nokey=1 "$MEZZANINE" 2>/dev/null | head -1)
+    AUDIO_PROFILE=$(ffprobe -v error -select_streams a:0 -show_entries stream=profile \
                   -of default=noprint_wrappers=1:nokey=1 "$MEZZANINE" 2>/dev/null | head -1)
     AUDIO_CHANNELS=$(ffprobe -v error -select_streams a:0 -show_entries stream=channels \
                   -of default=noprint_wrappers=1:nokey=1 "$MEZZANINE" 2>/dev/null | head -1)
 
-    log "Source audio codec: $AUDIO_CODEC, channels: ${AUDIO_CHANNELS:-?}"
+    log "Source audio codec: $AUDIO_CODEC, profile: ${AUDIO_PROFILE:-?}, channels: ${AUDIO_CHANNELS:-?}"
 
     START_TIME=$(date +%s)
 
@@ -2202,52 +2204,29 @@ create_audio_mezzanine() {
         ENCODING_INFOS+=("Audio downmixed from ${AUDIO_CHANNELS}-channel to stereo")
     fi
 
-    # Transcode codecs that Shaka Packager doesn't support, OR force-downmix
-    # multichannel sources to stereo even when the codec is compatible.
-    # Shaka Packager supports: AAC, MP3, Opus, Vorbis
-    # Shaka Packager does NOT support: AC-3, DTS, PCM, etc.
-    if [[ "$needs_downmix" -eq 1 ]] || [[ "$AUDIO_CODEC" == "ac3" ]] || [[ "$AUDIO_CODEC" == "eac3" ]] || [[ "$AUDIO_CODEC" == "dts" ]] || [[ "$AUDIO_CODEC" == "truehd" ]] || [[ "$AUDIO_CODEC" =~ ^pcm ]]; then
-        log "Transcoding $AUDIO_CODEC to AAC (Shaka Packager doesn't support $AUDIO_CODEC)"
-        ENCODING_WARNINGS+=("Audio transcoded from ${AUDIO_CODEC} to AAC (Shaka Packager compatibility)")
-        
-        # Build audio filter with optional padding
-        if [ "$needs_padding" -eq 1 ]; then
-            # When padding: don't use -t, apply apad filter
-            ffmpeg -i "$MEZZANINE" \
-                   -vn -c:a aac -b:a 192k -ar 48000 -ac 2 \
-                   -af "apad=pad_dur=${AUDIO_PADDING_DURATION}" \
-                   -movflags empty_moov+default_base_moof -frag_duration 1000000 \
-                   "$TEMP_DIR/audio.mp4" \
-                   -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
-        else
-            # When not padding: no special filter needed
-            ffmpeg -i "$MEZZANINE" \
-                   -vn -c:a aac -b:a 192k -ar 48000 -ac 2 \
-                   -movflags empty_moov+default_base_moof -frag_duration 1000000 \
-                   "$TEMP_DIR/audio.mp4" \
-                   -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
-        fi
+    # Always transcode to AAC-LC 192k stereo 48kHz. Single canonical
+    # audio output for the whole catalogue, no codec/profile gating
+    # decisions, every master.m3u8 carries `CODECS="...,mp4a.40.2"`,
+    # every player on every platform decodes it. Trade is one extra
+    # audio re-encode per clip — cheap (audio is a few MB), worth the
+    # certainty across Apple AVPlayer / Android ExoPlayer / hls.js /
+    # Roku.
+    log "Transcoding audio (source codec: $AUDIO_CODEC, profile: ${AUDIO_PROFILE:-?}) → AAC-LC 192k stereo 48kHz"
+    ENCODING_INFOS+=("Audio transcoded to AAC-LC 192k stereo 48kHz (source: ${AUDIO_CODEC})")
+
+    if [ "$needs_padding" -eq 1 ]; then
+        ffmpeg -i "$MEZZANINE" \
+               -vn -c:a aac -b:a 192k -ar 48000 -ac 2 \
+               -af "apad=pad_dur=${AUDIO_PADDING_DURATION}" \
+               -movflags empty_moov+default_base_moof -frag_duration 1000000 \
+               "$TEMP_DIR/audio.mp4" \
+               -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
     else
-        # AAC, MP3, or other compatible codecs
-        if [ "$needs_padding" -eq 1 ]; then
-            # When padding: must transcode (can't use filters with -c copy)
-            log "Adding ${AUDIO_PADDING_DURATION}s padding to audio (requires transcode to AAC)"
-            ffmpeg -i "$MEZZANINE" \
-                   -vn -c:a aac -b:a 192k -ar 48000 -ac 2 \
-                   -af "apad=pad_dur=${AUDIO_PADDING_DURATION}" \
-                   -movflags empty_moov+default_base_moof -frag_duration 1000000 \
-                   "$TEMP_DIR/audio.mp4" \
-                   -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
-        else
-            # When not padding: stream copy for best quality/speed
-            log "Copying audio stream (codec: $AUDIO_CODEC)"
-            ENCODING_INFOS+=("Audio stream copied (codec: ${AUDIO_CODEC})")
-            ffmpeg -i "$MEZZANINE" \
-                   -vn -c:a copy \
-                   -movflags empty_moov+default_base_moof -frag_duration 1000000 \
-                   "$TEMP_DIR/audio.mp4" \
-                   -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
-        fi
+        ffmpeg -i "$MEZZANINE" \
+               -vn -c:a aac -b:a 192k -ar 48000 -ac 2 \
+               -movflags empty_moov+default_base_moof -frag_duration 1000000 \
+               "$TEMP_DIR/audio.mp4" \
+               -loglevel error -stats 2>&1 | tee -a "$LOG_FILE"
     fi
     
     END_TIME=$(date +%s)
@@ -2469,7 +2448,7 @@ EOF
     
     # Create master playlist
     local master_file="$output_dir/master.m3u8"
-    
+
     cat > "$master_file" << 'EOF'
 #EXTM3U
 #EXT-X-VERSION:7

--- a/generate_abr/create_hls_manifests.py
+++ b/generate_abr/create_hls_manifests.py
@@ -308,6 +308,19 @@ def generate_master_playlist(dash_info, output_dir, package_name):
         if audio_peak_bandwidth <= 0:
             audio_peak_bandwidth = audio_average_bandwidth
 
+    # Resolve the audio codec string for inclusion in every variant's
+    # CODECS attribute. Per Apple's HLS Authoring Spec, CODECS MUST
+    # list every codec needed to play the variant — both video AND
+    # audio. Default `mp4a.40.2` (AAC-LC) since `create_abr_ladder.sh`
+    # always transcodes to AAC-LC. Pipeline ALSO post-processes the
+    # audio init.mp4 to strip a 5-byte ASC's SBR-extension marker that
+    # ffmpeg's native AAC encoder writes — without that strip the
+    # mp4a.40.2 declaration mismatches what AVPlayer reads from the
+    # init segment and the master fails to start.
+    audio_codec_str = ""
+    if audio_reps:
+        audio_codec_str = audio_reps[0].get("codecs") or "mp4a.40.2"
+
     for video_rep in video_reps:
         video_bandwidth = int(video_rep.get("bandwidth", 0) or 0)
         codecs = video_rep["codecs"]
@@ -336,7 +349,10 @@ def generate_master_playlist(dash_info, output_dir, package_name):
         if width and height:
             stream_info += f",RESOLUTION={width}x{height}"
 
-        stream_info += f',CODECS="{codecs}"'
+        codec_list = [codecs]
+        if audio_codec_str:
+            codec_list.append(audio_codec_str)
+        stream_info += f',CODECS="{",".join(codec_list)}"'
 
         if audio_reps:
             stream_info += ',AUDIO="audio"'

--- a/go-upload/internal/util/strings.go
+++ b/go-upload/internal/util/strings.go
@@ -9,11 +9,21 @@ import (
 
 var sanitizePattern = regexp.MustCompile(`[^\w\-]+`)
 
+// Maximum sanitised name length. Sized so the resulting catalogue
+// directory (`<safe>_p200_<codec>_<YYYYMMDD>_<HHMMSS>`, ~25 chars of
+// suffix) stays well under modern filesystems' 255-byte filename
+// limit (ext4 / btrfs / APFS / NTFS). Older versions used 50, which
+// truncated descriptive titles like
+// "samsung_4k_demo_samsung_and_redbull_see_the_unexpected_hdr_uhd_4k_full_hd_2160p"
+// to "samsung_4k_demo_samsung_and_redbull_see_the_unexpe" — losing the
+// distinguishing tail.
+const maxSanitizedNameLen = 200
+
 func SanitizeName(name string) string {
 	trimmed := strings.TrimSpace(name)
 	safe := sanitizePattern.ReplaceAllString(trimmed, "_")
-	if len(safe) > 50 {
-		safe = safe[:50]
+	if len(safe) > maxSanitizedNameLen {
+		safe = safe[:maxSanitizedNameLen]
 	}
 	return safe
 }


### PR DESCRIPTION
## Summary

Cluster of server-side changes that landed alongside the Apple cinematic rework.

**generate_abr (encoder pipeline)**
- `create_abr_ladder.sh` always transcodes audio to AAC-LC stereo 48kHz regardless of source codec. Pass-through of source AAC was producing variants (HE-AAC, multichannel, non-48kHz) that some clients (Safari, hls.js) reject at manifest parse. MP3 sources also transcoded.
- `create_hls_manifests.py`: include `mp4a.40.2` in `master.m3u8` `CODECS` next to the video codec — Apple HLS Authoring Spec calls for explicit per-rendition codec strings.

**go-live**
- Stamp `EXT-X-PROGRAM-DATE-TIME` + `EXT-X-START:TIME-OFFSET` in the 2s and 6s segment variants (already present in the LL variant). Players use these to compute wall-clock offset from live edge, which the dashboard graphs.

**go-proxy**
- Stamp `server_received_at_ms` on every metrics event so the dashboard can plot client-vs-server clock drift.
- `rewriteVariantLiveOffsetTags` rewrites `EXT-X-SERVER-CONTROL` `HOLD-BACK` in the 2s/6s variants when the user passes a `live_offset_s` query param so each variant honours it.

**go-upload**
- Bump the filename sanitizer cap from 50 → 200 chars so titles like "Samsung Ride on Board 4K Demo - Best of Red Bull Storm Chase" stop getting truncated.

**dashboard**
- `playback.html`, `testing.html`, `testing-session.html`, `testing-session-ui.js`: add wall-clock offset chart traces (true offset, server-received-at delta) alongside the buffer depth graph so client buffer behaviour can be visually correlated with wall-clock drift on stalling streams.

**CI**
- `claude-review.yml`: bump `--max-turns` 5 → 20 (5 was timing out on PRs touching many files).

## Test plan

- [ ] Re-encode an AAC-stereo source: master.m3u8 lists `mp4a.40.2`; audio init.mp4 plays in Safari and hls.js.
- [ ] Re-encode an Opus / HE-AAC / multichannel / 44.1kHz source: every variant ends up AAC-LC stereo 48kHz; no client errors.
- [ ] Re-encode an MP3 source: result transcodes (same path).
- [ ] Upload a clip with a 100+ char title: filename ≤ 200 chars, no truncation.
- [ ] Open testing-session.html on a stalling stream: wall-clock offset trace appears on the buffer depth chart.
- [ ] Hit a 6s variant with `?live_offset_s=10`: manifest's `HOLD-BACK` reflects the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)