### PR TITLE
feat(player): auto-snapshot HAR on freeze / auto-recovery / reload (#273)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -351,6 +351,7 @@ public final class PlaybackMetrics {
         Map<String, Object> extra = new HashMap<>();
         extra.put("player_metrics_error", message == null ? "" : message);
         sendEvent("error", extra);
+        requestHarSnapshot("player_error", 0, /* force= */ false);
     }
 
     /** Called when user triggers a restart (Restart Playback button, etc). */
@@ -360,6 +361,66 @@ public final class PlaybackMetrics {
         extra.put("player_metrics_restart_reason", reason);
         extra.put("player_restarts", playerRestarts);
         sendEvent("restart", extra);
+        // User-driven restarts should always produce a HAR — bypass the
+        // server-side per-player debounce window.
+        requestHarSnapshot(reason, 0, /* force= */ true);
+    }
+
+    /**
+     * Ask go-proxy to dump the current session timeline to disk as a HAR
+     * file. Issue #273. {@code force=true} bypasses the per-player
+     * 30s debounce — use it for user-driven Reload/Retry and per-attempt
+     * auto-recovery snapshots.
+     */
+    public void requestHarSnapshot(String reason, int attempt, boolean force) {
+        if (urlProvider.currentStreamUrl().isEmpty()) return;
+        final JSONObject metadata = new JSONObject();
+        try {
+            metadata.put("player_state", mapState());
+            metadata.put("auto_recovery_attempt", attempt);
+            metadata.put("player_restarts", playerRestarts);
+            long bufferedPositionMs = player.getBufferedPosition();
+            long currentPositionMs = player.getCurrentPosition();
+            metadata.put("buffer_depth_s",
+                roundSeconds(Math.max(0, bufferedPositionMs - currentPositionMs) / 1000.0));
+        } catch (Exception ignored) {
+        }
+        final JSONObject body = new JSONObject();
+        try {
+            body.put("reason", reason == null ? "manual" : reason);
+            body.put("source", "player");
+            body.put("force", force);
+            body.put("metadata", metadata);
+        } catch (Exception ignored) {
+            return;
+        }
+        networkExecutor.execute(() -> {
+            String sid = resolveSessionId();
+            if (sid == null || sid.isEmpty()) return;
+            postSnapshot(sid, body);
+        });
+    }
+
+    private void postSnapshot(String sid, JSONObject body) {
+        String base = baseUrlProvider.get();
+        if (base == null || base.isEmpty()) return;
+        HttpURLConnection conn = null;
+        try {
+            URL url = new URL(base + "/api/session/" + sid + "/har/snapshot");
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            }
+            conn.getResponseCode();
+        } catch (Exception ignored) {
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
     }
 
     private void maybeDetectFrozen() {
@@ -379,6 +440,7 @@ public final class PlaybackMetrics {
             if (frozenTicks >= FROZEN_THRESHOLD_TICKS && !frozenReported) {
                 frozenReported = true;
                 sendEvent("frozen", Collections.<String, Object>emptyMap());
+                requestHarSnapshot("frozen", 0, /* force= */ false);
             }
         } else {
             frozenTicks = 0;
@@ -397,6 +459,7 @@ public final class PlaybackMetrics {
         if (since >= SEGMENT_STALL_THRESHOLD_MS && !segmentStallReported) {
             segmentStallReported = true;
             sendEvent("segment_stall", Collections.<String, Object>emptyMap());
+            requestHarSnapshot("segment_stall", 0, /* force= */ false);
         }
     }
 

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -628,6 +628,8 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     fun retry() {
         val url = _state.value.currentUrl
         if (url.isEmpty()) return
+        // User-driven Retry deserves its own HAR — bypass per-player debounce.
+        metrics?.requestHarSnapshot("user_retry", 0, /* force= */ true)
         player.stop()
         player.clearMediaItems()
         loadStream(url)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -773,6 +773,9 @@ final class PlayerViewModel: ObservableObject {
     /// the *same* URL on the *same* AVPlayer.
     func retry() {
         guard let url = currentURL else { return }
+        Task { [weak self] in
+            await self?.requestHARSnapshot(reason: "user_retry", force: true)
+        }
         loadStream(url: url)
     }
 
@@ -784,6 +787,9 @@ final class PlayerViewModel: ObservableObject {
     ///
     /// Same `playerId` (proxy session continuity), no catalogue refetch.
     func reload() {
+        Task { [weak self] in
+            await self?.requestHARSnapshot(reason: "user_reload", force: true)
+        }
         // Snapshot cumulative counters into diagnostics' "prior" buckets
         // so the new playback continues to add to the same dropped /
         // displayed totals — matches legacy behaviour.
@@ -1071,7 +1077,12 @@ extension PlayerViewModel {
                 self.log("Playback failure: \(value)")
                 Task { await self.sendPlayerMetrics(event: "error", extra: ["player_metrics_error": value]) }
                 if self.autoRecovery {
+                    // Per-attempt HAR is captured by scheduleAutoRecoveryRestart
+                    // when the timer fires (force=true). Don't double-capture
+                    // here.
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_failure")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "playback_failure") }
                 }
             }
             .store(in: &cancellables)
@@ -1091,7 +1102,11 @@ extension PlayerViewModel {
                 guard let self, frozen else { return }
                 Task { await self.sendPlayerMetrics(event: "frozen") }
                 if self.autoRecovery {
+                    // The recovery timer's per-attempt HAR (force=true)
+                    // captures the same incident a moment later.
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_frozen")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "frozen") }
                 }
             }
             .store(in: &cancellables)
@@ -1103,6 +1118,8 @@ extension PlayerViewModel {
                 Task { await self.sendPlayerMetrics(event: "segment_stall") }
                 if self.autoRecovery {
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_segment_stall")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "segment_stall") }
                 }
             }
             .store(in: &cancellables)
@@ -1251,6 +1268,12 @@ extension PlayerViewModel {
                         "player_metrics_restart_reason": reason,
                         "player_restarts": self?.playerRestarts ?? 0
                     ])
+                }
+                // Each auto-recovery attempt deserves its own HAR — bypass
+                // the per-player debounce so back-to-back attempts inside
+                // the 30s window each produce a snapshot.
+                Task { [weak self] in
+                    await self?.requestHARSnapshot(reason: reason, attempt: attempt, force: true)
                 }
                 self.scheduleAutoRecoverySuccessCheck()
             }
@@ -1434,6 +1457,43 @@ extension PlayerViewModel {
             compact["player_metrics_network_bitrate_mbps"] = NSNull()
         }
         return compact
+    }
+
+    /// Tell go-proxy to dump the current session timeline to disk as a HAR
+    /// file. Called from auto-recovery / freeze / Reload sites — server
+    /// debounces by player_id (default 30s). Issue #273.
+    fileprivate func requestHARSnapshot(reason: String, attempt: Int = 0, force: Bool = false) async {
+        guard let baseURL = metricsBaseURL() else { return }
+        guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }
+        let url = baseURL
+            .appendingPathComponent("api/session")
+            .appendingPathComponent(sessionId)
+            .appendingPathComponent("har/snapshot")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyPlayerHeaders(to: &request)
+        var metadata: [String: Any] = [
+            "player_state": diagnostics.state,
+            "buffer_depth_s": diagnostics.bufferDepth as Any,
+            "stall_count": diagnostics.stallCount,
+            "auto_recovery_attempt": attempt,
+            "player_restarts": playerRestarts
+        ]
+        if !diagnostics.lastError.isEmpty { metadata["last_error"] = diagnostics.lastError }
+        if !diagnostics.lastFailure.isEmpty { metadata["last_failure"] = diagnostics.lastFailure }
+        let body: [String: Any] = [
+            "reason": reason,
+            "source": "player",
+            "force": force,
+            "metadata": metadata
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            _ = try await URLSession.shared.data(for: request)
+        } catch {
+            log("HAR snapshot request failed: \(error.localizedDescription)")
+        }
     }
 
     fileprivate func patchSessionMetrics(sessionId: String, baseURL: URL, payload: [String: Any]) async {

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -55,7 +55,35 @@ func resolveIncidentDir() string {
 type SnapshotRequest struct {
 	Reason   string                 `json:"reason"`
 	Source   string                 `json:"source"` // "dashboard", "rest", "player"
+	Force    bool                   `json:"force"`  // bypass per-player debounce
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// snapshotDebounceWindow is the minimum gap between auto-driven captures from
+// the same player. Manual (force=true) and dashboard captures bypass this.
+const snapshotDebounceWindow = 30 * time.Second
+
+var (
+	snapshotLastMu sync.Mutex
+	snapshotLastAt = map[string]time.Time{} // player_id -> last accepted capture
+)
+
+// snapshotShouldDebounce returns true if we should drop this capture because
+// the player triggered another one within the debounce window. Dashboard /
+// REST captures (source != "player") never debounce.
+func snapshotShouldDebounce(playerID, source string, force bool) bool {
+	if force || source != "player" || playerID == "" {
+		return false
+	}
+	snapshotLastMu.Lock()
+	defer snapshotLastMu.Unlock()
+	now := time.Now()
+	last, ok := snapshotLastAt[playerID]
+	if ok && now.Sub(last) < snapshotDebounceWindow {
+		return true
+	}
+	snapshotLastAt[playerID] = now
+	return false
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -195,6 +223,17 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	playerID := getString(session, "player_id")
+	if snapshotShouldDebounce(playerID, req.Source, req.Force) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		writeJSON(w, map[string]interface{}{
+			"status":           "debounced",
+			"debounce_window":  snapshotDebounceWindow.Seconds(),
+			"message":          "another snapshot was captured for this player within the debounce window",
+		})
+		return
+	}
+
 	incident := &har.Incident{
 		Reason:    req.Reason,
 		Source:    req.Source,
@@ -204,7 +243,6 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	doc := a.buildHARForSession(session, incident)
-	playerID := getString(session, "player_id")
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Stacked on #274 — depends on the HAR builder + endpoints landing first.

## Summary

Production complement to #272. Players now ask the proxy to dump a HAR file the moment they detect bad state. Each incident becomes a self-contained, devtools-readable artifact.

**Triggers** (Apple + Android, with parity):
- Freeze detection (\`PlaybackDiagnostics.frozenDetected\`, segment-stall)
- Auto-recovery timer fire — each attempt with \`force=true\` so back-to-back attempts inside the debounce window each produce a HAR
- User-tapped Retry / Reload (\`force=true\`)
- Apple \`\$lastFailure\` sink (when auto-recovery is OFF — otherwise per-attempt HAR covers it)
- Android \`onPlayerError\`

**Server** (go-proxy):
- New \`force\` field on \`POST /api/session/{id}/har/snapshot\` body
- Per-player 30s debounce when \`source == "player"\` and \`force != true\` — dashboard / REST captures never debounce
- Returns 429 + \`{status: "debounced"}\` when suppressed

Each request carries \`metadata: { player_state, buffer_depth_s, auto_recovery_attempt, player_restarts, last_error, last_failure }\` which lands in the HAR's \`_extensions.incident\` block.

## Test plan

- [x] iOS sim build clean
- [x] tvOS sim build clean
- [x] Android \`./gradlew assembleDebug\` clean
- [x] \`go build ./go-proxy/...\` clean
- [x] \`make test-deploy-dev\` deploys, endpoints respond
- [x] Pre-commit Sonnet review — addressed double-snapshot on freeze+auto-recovery and missing \`\$lastFailure\` trigger
- [ ] Manual: enable auto-recovery on iPad, induce freeze via go-proxy fault injection, verify per-attempt HAR files appear under \`/incidents/\`
- [ ] Manual: tap Reload on Android TV, verify HAR is created with \`source=player\` and \`force=true\`
- [ ] Verify 429 response when player triggers two snapshots <30s apart with \`force=false\`