### PR TITLE
ci: claude-review on Sonnet 4.6, --max-turns 80

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,4 +41,10 @@ jobs:
             real boundaries, security issues (command injection, path traversal,
             etc.), and divergence from existing patterns. Do not flag stylistic
             nits unless they obscure intent.
-          claude_args: "--max-turns 40 --model claude-opus-4-7"
+          # Sonnet on a higher turn budget: routine PR review is the
+          # canonical Sonnet workload (logic / security / pattern
+          # checks), and Opus burns the Max-plan quota fast on big
+          # multi-platform PRs while still hitting --max-turns. Bumped
+          # from 40 → 80 after PRs touching iOS + tvOS + Android +
+          # go-proxy + dashboard ran the tank dry.
+          claude_args: "--max-turns 80 --model claude-sonnet-4-6"


### PR DESCRIPTION
## Summary

Auto-review failed on the recent multi-platform HAR PRs (#275, #276) with \`Reached maximum number of turns (40)\`. Two fixes:

- Switch model from Opus 4.7 → Sonnet 4.6. Routine PR review is the canonical Sonnet workload — Opus is overkill for logic/security/pattern checks and burns the Max-plan quota.
- Bump turn budget 40 → 80 so reviews of larger PRs finish.

Independent of the HAR feature stack — landing this first lets the auto-review re-run cleanly on the open PRs.

## Test plan

- [x] YAML diff is the two-line change above
- [ ] Merge → auto-review re-runs on the next push to any open PR (or trigger manually)