### PR TITLE
feat(go-proxy): HAR shows downstream timings + player URL (#272)

### DIFF
--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -93,12 +93,14 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 				BytesIn:       e.BytesIn,
 				BytesOut:      e.BytesOut,
 				ContentType:   e.ContentType,
+				ClientWaitMs:  e.ClientWaitMs,
+				TransferMs:    e.TransferMs,
+				TotalMs:       e.TotalMs,
+				UpstreamURL:   e.UpstreamURL,
 				DNSMs:         e.DNSMs,
 				ConnectMs:     e.ConnectMs,
 				TLSMs:         e.TLSMs,
 				TTFBMs:        e.TTFBMs,
-				TransferMs:    e.TransferMs,
-				TotalMs:       e.TotalMs,
 				Faulted:       e.Faulted,
 				FaultType:     e.FaultType,
 				FaultAction:   e.FaultAction,
@@ -301,10 +303,16 @@ func writeIncidentFile(sessionID, playerID, reason, source string, doc har.HAR) 
 		return IncidentFileInfo{}, err
 	}
 
+	// Filename pattern: `proxy_<player_id>_<session_id>__<ts>.har`. The
+	// `proxy_` prefix signals "go-proxy's view" — future client-side
+	// HARs (issue #282) will use `client_`. The trailing __<ts> keeps
+	// successive incidents from the same player/session pair from
+	// overwriting each other (one play can produce multiple HARs:
+	// freeze, then user_retry, then segment_stall).
 	ts := now.Format("20060102T150405Z")
-	filename := fmt.Sprintf("%s__%s__%s.har",
+	filename := fmt.Sprintf("proxy_%s_%s__%s.har",
+		safeFilename(playerID),
 		safeFilename(sessionID),
-		safeFilename(reason),
 		ts,
 	)
 	full := filepath.Join(dir, filename)
@@ -418,15 +426,28 @@ func readIncidentMeta(path string) (IncidentFileInfo, error) {
 		}
 	}
 
-	// Filename fallback: {sessionID}__{reason}__{ts}.har
-	if info.SessionID == "" || info.Reason == "" {
-		parts := strings.SplitN(strings.TrimSuffix(info.Filename, ".har"), "__", 3)
-		if len(parts) >= 2 {
-			if info.SessionID == "" {
-				info.SessionID = parts[0]
+	// Filename fallback: `proxy_<playerID>_<sessionID>__<ts>.har`. We
+	// only use this when the JSON parse failed and the in-document
+	// _extensions.session block isn't available — best effort.
+	if info.SessionID == "" || info.PlayerID == "" {
+		stem := strings.TrimSuffix(info.Filename, ".har")
+		// Trim the optional `proxy_` / `client_` prefix.
+		stem = strings.TrimPrefix(stem, "proxy_")
+		stem = strings.TrimPrefix(stem, "client_")
+		// Drop the `__<ts>` suffix.
+		if idx := strings.LastIndex(stem, "__"); idx >= 0 {
+			stem = stem[:idx]
+		}
+		// Remaining: `<playerID>_<sessionID>`. Split on the LAST `_`:
+		// everything before is playerID, everything after is sessionID.
+		// Correct as long as sessionID has no `_` (it's UUID-shaped in
+		// practice, `[a-z0-9-]+`); playerID may contain `_`.
+		if idx := strings.LastIndex(stem, "_"); idx >= 0 {
+			if info.PlayerID == "" {
+				info.PlayerID = stem[:idx]
 			}
-			if info.Reason == "" {
-				info.Reason = parts[1]
+			if info.SessionID == "" {
+				info.SessionID = stem[idx+1:]
 			}
 		}
 	}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -95,10 +95,17 @@ type tcStatsCache struct {
 
 
 // NetworkLogEntry represents a single network request/response in the session
+//
+// The URL field stores the *player-facing* URL (what the client requested
+// from go-proxy) so HAR entries reflect the player's view. The
+// UpstreamURL field carries the URL the proxy used to reach the origin —
+// useful forensics ("did the proxy rewrite the variant?") that lands
+// under HAR's _extensions.upstream.url.
 type NetworkLogEntry struct {
 	Timestamp   time.Time `json:"timestamp"`
 	Method      string    `json:"method"`
 	URL         string    `json:"url"`
+	UpstreamURL string    `json:"upstream_url,omitempty"`
 	Path        string    `json:"path"`
 	RequestKind string    `json:"request_kind"` // "segment", "manifest", "master_manifest"
 	Status      int       `json:"status"`
@@ -106,13 +113,25 @@ type NetworkLogEntry struct {
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
 
-	// Timing phases (milliseconds)
+	// Timing phases (milliseconds).
+	//
+	// The DNSMs/ConnectMs/TLSMs/TTFBMs/TransferMs/TotalMs fields measure
+	// the *upstream* connection (proxy → origin) — captured by httptrace
+	// during doRequestWithTracing. They're useful for forensics ("was the
+	// origin slow?") but they are NOT what the player perceived.
 	DNSMs      float64 `json:"dns_ms"`
 	ConnectMs  float64 `json:"connect_ms"`
 	TLSMs      float64 `json:"tls_ms"`
-	TTFBMs     float64 `json:"ttfb_ms"`     // Time to first byte
-	TransferMs float64 `json:"transfer_ms"` // Downstream write+flush time to client
+	TTFBMs     float64 `json:"ttfb_ms"`     // Upstream time to first byte
+	TransferMs float64 `json:"transfer_ms"` // Downstream write+flush time to client (= client-perceived `receive`)
 	TotalMs    float64 `json:"total_ms"`
+
+	// ClientWaitMs is the time from when the proxy received the request
+	// to when it sent the first response byte back to the client. It IS
+	// what the player perceived as `wait` (HAR's TTFB), modulo the
+	// network RTT in both directions which we don't capture server-side
+	// (issue #283).
+	ClientWaitMs float64 `json:"client_wait_ms"`
 
 	// Fault injection metadata
 	Faulted       bool   `json:"faulted"`
@@ -3547,6 +3566,14 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Anchor the player's perceived timeline at the moment we received
+	// their request. ClientWaitMs (wait perceived by the player) is
+	// computed against this on every path, including faults.
+	requestReceivedAt := time.Now()
+	// playerURL is the URL the player asked for — used as the primary
+	// `URL` field on every NetworkLogEntry so HAR entries reflect what
+	// the player did, not the proxy → origin URL.
+	playerURL := r.URL.String()
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3857,14 +3884,20 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				updateSessionTraffic(sessionData, requestBytes, 0)
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
-				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
+				netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes, requestReceivedAt)
 				a.addNetworkLogEntry(sessionID, netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
 			}
 			resp, netEntry, err := a.doRequestWithTracing(r.Context(), proxyReq)
+			// doRequestWithTracing populates URL/Path from the upstream
+			// request — override with the player-facing values so HAR
+			// entries reflect what the player did, not the proxy → origin URL.
+			netEntry.URL = playerURL
+			netEntry.Path = r.URL.Path
 			if err != nil {
+				netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 				if errors.Is(err, context.DeadlineExceeded) {
 					actionTaken = "http_504_upstream_timeout"
 					w.WriteHeader(http.StatusGatewayTimeout)
@@ -3893,6 +3926,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			defer resp.Body.Close()
 			if resp.StatusCode >= 400 {
 				actionTaken = fmt.Sprintf("http_%d_upstream", resp.StatusCode)
+				netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 				w.WriteHeader(resp.StatusCode)
 				bumpFaultCounter(sessionData, failureType)
 				logFaultEvent(sessionData, externalPort, failureType, requestKind, actionTaken)
@@ -3914,6 +3948,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", contentType)
 			}
 			w.Header().Set("X-Session-ID", getString(sessionData, "session_number"))
+			netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 			w.WriteHeader(http.StatusOK)
 			bytesOut, transferMs, copyErr := streamToClientMeasured(w, resp.Body, true)
 			if copyErr != nil && !errors.Is(copyErr, io.EOF) {
@@ -3958,7 +3993,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			// and don't generate HTTP responses, so we log with 503 status
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
-			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+			netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, status, requestBytes, requestReceivedAt)
 			a.addNetworkLogEntry(sessionID, netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -4014,7 +4049,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		case "http_429_rate_limited":
 			status = http.StatusTooManyRequests
 		}
-		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+		netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, status, requestBytes, requestReceivedAt)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4036,7 +4071,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
-		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
+		netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes, requestReceivedAt)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4047,7 +4082,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
 	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
+	// doRequestWithTracing populates URL/Path from the upstream request —
+	// override with the player-facing values so HAR entries reflect what
+	// the player did, not the proxy → origin URL.
+	netEntry.URL = playerURL
+	netEntry.Path = r.URL.Path
 	if err != nil {
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		// Set status before writing header
 		if errors.Is(err, context.DeadlineExceeded) {
 			netEntry.Status = http.StatusGatewayTimeout
@@ -4083,6 +4124,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			getString(sessionData, "player_id"),
 			externalPort,
 		)
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		// Log network entry for upstream error
 		sessionID := getString(sessionData, "session_id")
@@ -4120,6 +4162,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(modifiedBody)))
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		var downstream io.Writer = w
 		if idleTimeout > 0 {
@@ -4127,8 +4170,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			downstream = idleW
 		}
 		writer := bufio.NewWriter(downstream)
+		transferStart := time.Now()
 		_, writeErr := writer.Write(modifiedBody)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = elapsedMs(transferStart)
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4144,6 +4189,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		var downstream io.Writer = w
 		if idleTimeout > 0 {
@@ -4165,8 +4211,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			)
 		}
 		var copyErr error
+		transferStart := time.Now()
 		bytesOut, copyErr = io.Copy(writer, resp.Body)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = elapsedMs(transferStart)
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -5019,6 +5067,11 @@ func mergeTotalTiming(entry *NetworkLogEntry) {
 	}
 }
 
+// elapsedMs returns time.Since(t0) in fractional milliseconds.
+func elapsedMs(t0 time.Time) float64 {
+	return float64(time.Since(t0).Microseconds()) / 1000.0
+}
+
 // streamToClientMeasured copies bytes from src to client response writer and measures
 // downstream write+flush time, which is where traffic shaping backpressure appears.
 func streamToClientMeasured(w http.ResponseWriter, src io.Reader, zeroFill bool) (int64, float64, error) {
@@ -5070,11 +5123,17 @@ func streamToClientMeasured(w http.ResponseWriter, src io.Reader, zeroFill bool)
 
 // doRequestWithTracing executes an HTTP request with timing trace and returns the response and timings
 func (a *App) doRequestWithTracing(ctx context.Context, req *http.Request) (*http.Response, *NetworkLogEntry, error) {
+	// Note: caller is expected to overwrite entry.URL / entry.Path with
+	// the *player-facing* URL after this returns; what we set here is the
+	// upstream URL. We populate UpstreamURL up front and copy it into URL
+	// as a safe default for callers that don't override.
+	upstreamURL := req.URL.String()
 	entry := &NetworkLogEntry{
-		Timestamp: time.Now(),
-		Method:    req.Method,
-		URL:       req.URL.String(),
-		Path:      req.URL.Path,
+		Timestamp:   time.Now(),
+		Method:      req.Method,
+		URL:         upstreamURL,
+		UpstreamURL: upstreamURL,
+		Path:        req.URL.Path,
 	}
 
 	var start, dnsStart, connectStart, tlsStart time.Time
@@ -5128,13 +5187,18 @@ func (a *App) doRequestWithTracing(ctx context.Context, req *http.Request) (*htt
 	return resp, entry, nil
 }
 
-// createFaultLogEntry creates a network log entry for a faulted request
-func createFaultLogEntry(url, requestKind, faultType, faultAction string, status int, bytesIn int64) NetworkLogEntry {
+// createFaultLogEntry creates a network log entry for a faulted request.
+// `playerURL` is what the player asked for; `upstreamURL` (optional, may be
+// empty if the proxy never reached the upstream) is the resolved upstream URL
+// used for forensics under HAR's _extensions.upstream.url.
+func createFaultLogEntry(playerURL, upstreamURL, requestKind, faultType, faultAction string, status int, bytesIn int64, requestReceivedAt time.Time) NetworkLogEntry {
+	wait := elapsedMs(requestReceivedAt)
 	return NetworkLogEntry{
 		Timestamp:     time.Now(),
 		Method:        "GET",
-		URL:           url,
-		Path:          extractPathFromURL(url),
+		URL:           playerURL,
+		UpstreamURL:   upstreamURL,
+		Path:          extractPathFromURL(playerURL),
 		RequestKind:   requestKind,
 		Status:        status,
 		BytesIn:       bytesIn,
@@ -5143,6 +5207,11 @@ func createFaultLogEntry(url, requestKind, faultType, faultAction string, status
 		FaultType:     faultType,
 		FaultAction:   faultAction,
 		FaultCategory: categorizeFaultType(faultType),
+		// Fault paths short-circuit before any body — wait time is the
+		// total latency from receiving the request to writing the
+		// response status line.
+		ClientWaitMs: wait,
+		TotalMs:      wait,
 	}
 }
 

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -136,21 +136,37 @@ type Timings struct {
 // Source is the minimal NetworkLogEntry shape the builder reads. Defining it
 // here as an interface-free struct keeps the har package decoupled from
 // main.go's full type — the caller copies fields in.
+//
+// Two timing perspectives are carried:
+//
+//   - DNSMs/ConnectMs/TLSMs/TTFBMs are the *upstream* timings (proxy →
+//     origin). They land under the entry's _extensions.upstream block
+//     for forensics ("was latency on our side or the origin's?").
+//
+//   - ClientWaitMs and TransferMs are the *downstream* (proxy → player)
+//     timings — what the player perceived. These map into HAR's
+//     standard timings.wait and timings.receive so a HAR viewer
+//     surfaces them by default.
 type Source struct {
-	Timestamp     time.Time
-	Method        string
-	URL           string
-	RequestKind   string
-	Status        int
-	BytesIn       int64
-	BytesOut      int64
-	ContentType   string
-	DNSMs         float64
-	ConnectMs     float64
-	TLSMs         float64
-	TTFBMs        float64
-	TransferMs    float64
-	TotalMs       float64
+	Timestamp    time.Time
+	Method       string
+	URL          string // player-facing URL
+	RequestKind  string
+	Status       int
+	BytesIn      int64
+	BytesOut     int64
+	ContentType  string
+	ClientWaitMs float64 // request received → first response byte sent to client
+	TransferMs   float64 // first response byte → response complete
+	TotalMs      float64
+
+	// Upstream context, surfaced via _extensions.upstream.
+	UpstreamURL string
+	DNSMs       float64
+	ConnectMs   float64
+	TLSMs       float64
+	TTFBMs      float64
+
 	Faulted       bool
 	FaultType     string
 	FaultAction   string
@@ -219,14 +235,23 @@ func Build(sources []Source, opts BuildOptions) HAR {
 func buildEntry(s Source) Entry {
 	startedDate := s.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	// Map *downstream* timings (proxy → player) into the standard HAR
+	// Timings block — that's what HAR viewers surface as the player's
+	// experience. Upstream timings live under _extensions.upstream below.
+	//
+	// HAR 1.2: -1 means "not applicable / not measured". DNS/Connect/SSL
+	// describe how the *client* reached its server; from go-proxy → player
+	// they're a keepalive HTTP transaction with no client-side connect
+	// to measure here, so they're -1. (Issue #283 will add real client
+	// RTT capture.)
 	timings := Timings{
 		Blocked: -1,
-		DNS:     msOrNeg(s.DNSMs),
-		Connect: msOrNeg(s.ConnectMs),
+		DNS:     -1,
+		Connect: -1,
 		Send:    -1,
-		Wait:    msOrNeg(s.TTFBMs),
+		Wait:    msOrNeg(s.ClientWaitMs),
 		Receive: msOrNeg(s.TransferMs),
-		SSL:     msOrNeg(s.TLSMs),
+		SSL:     -1,
 	}
 
 	statusText := statusTextFor(s.Status)
@@ -269,6 +294,25 @@ func buildEntry(s Source) Entry {
 	ext := map[string]interface{}{}
 	if s.RequestKind != "" {
 		ext["requestKind"] = s.RequestKind
+	}
+	// Upstream context — useful when an analyst wants to answer "was the
+	// wait the origin's fault or go-proxy's processing / fault-injection
+	// delay?", or "did the proxy rewrite the variant URL before fetching?".
+	// Includes the resolved upstream URL (often differs from the player's
+	// URL after proxy rewriting) and the upstream phase timings.
+	hasUpstream := s.UpstreamURL != "" && s.UpstreamURL != s.URL ||
+		s.DNSMs > 0 || s.ConnectMs > 0 || s.TLSMs > 0 || s.TTFBMs > 0
+	if hasUpstream {
+		upstream := map[string]interface{}{
+			"dns_ms":     s.DNSMs,
+			"connect_ms": s.ConnectMs,
+			"tls_ms":     s.TLSMs,
+			"ttfb_ms":    s.TTFBMs,
+		}
+		if s.UpstreamURL != "" && s.UpstreamURL != s.URL {
+			upstream["url"] = s.UpstreamURL
+		}
+		ext["upstream"] = upstream
 	}
 	if s.Faulted {
 		fault := map[string]interface{}{

--- a/go-proxy/internal/har/har_test.go
+++ b/go-proxy/internal/har/har_test.go
@@ -1,0 +1,319 @@
+package har
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuild_EmptySources(t *testing.T) {
+	doc := Build(nil, BuildOptions{SessionID: "sess-1", PlayerID: "player-a"})
+	if doc.Log.Version != HARVersion {
+		t.Errorf("version = %q, want %q", doc.Log.Version, HARVersion)
+	}
+	if doc.Log.Creator.Name != CreatorName {
+		t.Errorf("creator name = %q, want %q", doc.Log.Creator.Name, CreatorName)
+	}
+	if len(doc.Log.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(doc.Log.Entries))
+	}
+	// Session metadata always lands under _extensions.session.
+	sess, ok := doc.Log.Extensions["session"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected _extensions.session map, got %T", doc.Log.Extensions["session"])
+	}
+	if sess["session_id"] != "sess-1" || sess["player_id"] != "player-a" {
+		t.Errorf("session metadata wrong: %+v", sess)
+	}
+}
+
+func TestBuild_TimingMapping_DownstreamPerspective(t *testing.T) {
+	// HAR's standard timings.* surfaces *downstream* timings (proxy →
+	// player) so a viewer shows the player's experience by default.
+	// Upstream timings land under _extensions.upstream.
+	src := Source{
+		Timestamp:    time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+		Method:       "GET",
+		URL:          "https://example.test/segment.m4s",
+		ContentType:  "video/mp4",
+		Status:       200,
+		BytesIn:      1024 * 50,
+		BytesOut:     256,
+		ClientWaitMs: 65.0,  // request received → first response byte to client
+		TransferMs:   120.5, // body write+flush
+		TotalMs:      185.5,
+		// Upstream timings — should NOT appear in the standard Timings block.
+		DNSMs:     2.5,
+		ConnectMs: 8.1,
+		TLSMs:     12.0,
+		TTFBMs:    40.3,
+	}
+	doc := Build([]Source{src}, BuildOptions{SessionID: "s"})
+	if len(doc.Log.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(doc.Log.Entries))
+	}
+	e := doc.Log.Entries[0]
+	if e.Time != 185.5 {
+		t.Errorf("Time = %v, want 185.5", e.Time)
+	}
+	// Standard HAR Timings reflect downstream perspective only.
+	if e.Timings.Wait != 65.0 || e.Timings.Receive != 120.5 {
+		t.Errorf("downstream timings off: %+v", e.Timings)
+	}
+	// DNS / Connect / SSL describe the *client*'s connect to its server;
+	// from go-proxy → player they're a keepalive transaction with no
+	// client-side handshake to measure here, so they're -1.
+	if e.Timings.DNS != -1 || e.Timings.Connect != -1 || e.Timings.SSL != -1 {
+		t.Errorf("DNS/Connect/SSL should be -1 (downstream): %+v", e.Timings)
+	}
+	if e.Timings.Blocked != -1 || e.Timings.Send != -1 {
+		t.Errorf("Blocked/Send not defaulted to -1: %+v", e.Timings)
+	}
+	// Upstream timings live under _extensions.upstream.
+	upstream, ok := e.Extensions["upstream"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected _extensions.upstream, got %+v", e.Extensions)
+	}
+	if upstream["dns_ms"] != 2.5 || upstream["connect_ms"] != 8.1 ||
+		upstream["tls_ms"] != 12.0 || upstream["ttfb_ms"] != 40.3 {
+		t.Errorf("upstream block wrong: %+v", upstream)
+	}
+	if e.Request.Method != "GET" || e.Request.URL != src.URL {
+		t.Errorf("Request mapping off: %+v", e.Request)
+	}
+	if e.Response.Status != 200 || e.Response.StatusText != "OK" {
+		t.Errorf("Response status mapping off: %+v", e.Response)
+	}
+	if e.Response.Content.MimeType != "video/mp4" {
+		t.Errorf("Content.MimeType = %q, want video/mp4", e.Response.Content.MimeType)
+	}
+	if !strings.HasSuffix(e.StartedDateTime, "Z") {
+		t.Errorf("startedDateTime not UTC: %q", e.StartedDateTime)
+	}
+}
+
+func TestBuild_NoUpstreamExtensionWhenAllZero(t *testing.T) {
+	// Fault paths that never reach upstream should NOT emit
+	// _extensions.upstream — there's nothing to report.
+	src := Source{
+		URL:          "https://example.test/x",
+		Status:       502,
+		ClientWaitMs: 1.0,
+		// All upstream timings 0 (rejected before connect).
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if _, has := e.Extensions["upstream"]; has {
+		t.Errorf("upstream extension should be omitted when nothing measured: %+v", e.Extensions)
+	}
+}
+
+func TestBuild_UpstreamURLLandsInExtension(t *testing.T) {
+	// When the proxy rewrote the URL before fetching upstream
+	// (variant rewrite, mirror), the player URL and upstream URL
+	// differ — both should be visible.
+	src := Source{
+		URL:         "https://proxy.test/seg.m4s?player_id=p&play_id=1",
+		UpstreamURL: "https://origin.test/h264/720p/seg.m4s",
+		Status:      200,
+		TTFBMs:      10,
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.URL != src.URL {
+		t.Errorf("Request.URL should be the player URL, got %q", e.Request.URL)
+	}
+	upstream := e.Extensions["upstream"].(map[string]interface{})
+	if upstream["url"] != src.UpstreamURL {
+		t.Errorf("upstream.url = %v, want %q", upstream["url"], src.UpstreamURL)
+	}
+}
+
+func TestBuild_NoUpstreamURLWhenSameAsPlayerURL(t *testing.T) {
+	// If the proxy didn't rewrite, no point repeating the URL.
+	src := Source{
+		URL:         "https://example.test/seg.m4s",
+		UpstreamURL: "https://example.test/seg.m4s",
+		Status:      200,
+		TTFBMs:      10,
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	upstream := doc.Log.Entries[0].Extensions["upstream"].(map[string]interface{})
+	if _, has := upstream["url"]; has {
+		t.Errorf("upstream.url should be omitted when identical to player URL: %+v", upstream)
+	}
+}
+
+func TestBuild_NegativeTimingsCollapseToMinusOne(t *testing.T) {
+	// HAR 1.2: -1 means "not applicable / not measured".
+	doc := Build([]Source{{
+		URL:    "x",
+		Status: 0,
+		// All timings 0 (e.g. faulted before connect).
+	}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Timings.DNS != -1 || e.Timings.Connect != -1 || e.Timings.SSL != -1 ||
+		e.Timings.Wait != -1 || e.Timings.Receive != -1 {
+		t.Errorf("zero timings should map to -1: %+v", e.Timings)
+	}
+}
+
+func TestBuild_FaultExtension(t *testing.T) {
+	doc := Build([]Source{{
+		URL:           "https://example.test/seg.m4s",
+		Status:        404,
+		Faulted:       true,
+		FaultType:     "404",
+		FaultAction:   "respond",
+		FaultCategory: "http",
+		RequestKind:   "segment",
+	}}, BuildOptions{})
+	ext := doc.Log.Entries[0].Extensions
+	if ext == nil {
+		t.Fatal("expected entry _extensions")
+	}
+	if got := ext["requestKind"]; got != "segment" {
+		t.Errorf("requestKind = %v, want segment", got)
+	}
+	fault, ok := ext["fault"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("fault block missing or wrong type: %T", ext["fault"])
+	}
+	if fault["faulted"] != true || fault["type"] != "404" || fault["action"] != "respond" || fault["category"] != "http" {
+		t.Errorf("fault block wrong: %+v", fault)
+	}
+}
+
+func TestBuild_NoFaultNoExtension(t *testing.T) {
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	if ext := doc.Log.Entries[0].Extensions; ext != nil {
+		t.Errorf("expected no entry _extensions on a clean request, got %+v", ext)
+	}
+}
+
+func TestBuild_IncidentBlock(t *testing.T) {
+	now := time.Date(2026, 4, 28, 13, 30, 0, 0, time.UTC)
+	inc := &Incident{
+		Reason:    "frozen",
+		Source:    "player",
+		PlayerID:  "player-a",
+		SessionID: "sess-1",
+		Timestamp: now,
+		Metadata: map[string]interface{}{
+			"buffer_depth_s": 0.0,
+			"player_state":   "buffering",
+		},
+	}
+	doc := Build(nil, BuildOptions{
+		SessionID: "sess-1",
+		PlayerID:  "player-a",
+		Incident:  inc,
+	})
+	got, ok := doc.Log.Extensions["incident"].(*Incident)
+	if !ok {
+		t.Fatalf("incident block wrong type: %T", doc.Log.Extensions["incident"])
+	}
+	if got.Reason != "frozen" || got.Source != "player" {
+		t.Errorf("incident block wrong: %+v", got)
+	}
+}
+
+func TestBuild_DefaultsAppliedToRequest(t *testing.T) {
+	// Empty Method should default to GET; empty ContentType should default
+	// to application/octet-stream.
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.Method != "GET" {
+		t.Errorf("method default = %q, want GET", e.Request.Method)
+	}
+	if e.Response.Content.MimeType != "application/octet-stream" {
+		t.Errorf("mime default = %q, want application/octet-stream", e.Response.Content.MimeType)
+	}
+}
+
+func TestBuild_RoundTripsThroughJSON(t *testing.T) {
+	// A real HAR consumer (Chrome DevTools, Charles) parses the JSON
+	// shape — make sure ours marshals + unmarshals to the same shape.
+	doc := Build([]Source{
+		{URL: "https://example.test/a", Status: 200, BytesIn: 100, TotalMs: 5,
+			DNSMs: 1, ConnectMs: 1, TTFBMs: 1, TransferMs: 2},
+		{URL: "https://example.test/b", Status: 404, Faulted: true, FaultType: "404"},
+	}, BuildOptions{SessionID: "s", PlayerID: "p"})
+
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic map[string]interface{}
+	if err := json.Unmarshal(body, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Top-level shape: { log: { version, creator, entries } }
+	logRaw, ok := generic["log"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level log object, got %T", generic["log"])
+	}
+	if logRaw["version"] != "1.2" {
+		t.Errorf("version = %v, want 1.2", logRaw["version"])
+	}
+	entries, ok := logRaw["entries"].([]interface{})
+	if !ok || len(entries) != 2 {
+		t.Fatalf("entries = %v (count %d), want 2", logRaw["entries"], len(entries))
+	}
+	// Faulted entry should carry _extensions.fault even after JSON round-trip.
+	second := entries[1].(map[string]interface{})
+	ext := second["_extensions"].(map[string]interface{})
+	if ext["fault"] == nil {
+		t.Errorf("fault extension lost in round-trip: %+v", second)
+	}
+}
+
+func TestStatusTextFor(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{200, "OK"},
+		{206, "Partial Content"},
+		{301, "Moved Permanently"},
+		{404, "Not Found"},
+		{429, "Too Many Requests"},
+		{500, "Internal Server Error"},
+		{504, "Gateway Timeout"},
+		// Unknown specifics should fall through to bucketed text.
+		{418, "Client Error"},
+		{599, "Server Error"},
+		{0, ""},
+	}
+	for _, c := range cases {
+		if got := statusTextFor(c.status); got != c.want {
+			t.Errorf("statusTextFor(%d) = %q, want %q", c.status, got, c.want)
+		}
+	}
+}
+
+func TestMsOrNeg(t *testing.T) {
+	cases := []struct {
+		in, want float64
+	}{
+		{0, -1},
+		{-5, -1},
+		{0.001, 0.001},
+		{42, 42},
+	}
+	for _, c := range cases {
+		if got := msOrNeg(c.in); got != c.want {
+			t.Errorf("msOrNeg(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDefaultStr(t *testing.T) {
+	if got := defaultStr("", "GET"); got != "GET" {
+		t.Errorf("defaultStr(\"\", \"GET\") = %q, want GET", got)
+	}
+	if got := defaultStr("POST", "GET"); got != "POST" {
+		t.Errorf("defaultStr(\"POST\", ...) = %q, want POST", got)
+	}
+}


### PR DESCRIPTION
## Summary

Standard HAR \`timings.*\` and \`request.url\` now reflect what the **player** perceived, not what go-proxy saw upstream. Upstream context lands under each entry's \`_extensions.upstream\` block for forensics.

## Why

The HAR muddled two perspectives: \`request.url\` stored the *upstream* URL (post-variant-rewrite), and \`timings.dns/connect/ssl/wait\` measured the proxy → origin connection. A HAR consumer asking "what did my player experience?" got the wrong story.

## Changes

- **\`NetworkLogEntry\`** — adds \`ClientWaitMs\` (request received → first response byte sent) and \`UpstreamURL\`. \`URL\` now stores the player-facing URL.
- **\`handleProxy\`** — captures \`requestReceivedAt\` + \`playerURL\` once at the top; threaded through every entry-creation site.
- **\`createFaultLogEntry\`** — signature extended; all 4 call sites updated.
- **Both \`doRequestWithTracing\` callers** — override \`netEntry.URL = playerURL\` immediately after the call.
- **\`ClientWaitMs\`** — set via direct measurement (\`elapsedMs(requestReceivedAt)\`) just before each \`w.WriteHeader\` on success + upstream-failure branches.
- **\`TransferMs\`** — happy-path body writes now timed (was only measured on the segment-corruption path; normal traffic had \`TransferMs = 0\`).
- **HAR builder** — maps \`ClientWaitMs → timings.wait\`, \`TransferMs → timings.receive\`, \`dns/connect/ssl = -1\` (downstream is keepalive). Emits \`_extensions.upstream\` with \`url\` (when it differs from the player URL) and the four upstream phase timings.
- **Filename pattern** — \`proxy_<player_id>_<session_id>__<ts>.har\`. \`proxy_\` prefix reserves space for client-side HAR (#282); trailing \`__<ts>\` keeps successive incidents from the same session from overwriting.

## Test plan

- [x] \`go test ./go-proxy/internal/har/\` 14/14 PASS
- [x] \`pytest -m har\` 10/10 PASS against test-dev
- [x] Pre-commit Sonnet review v2 — first pass caught a critical bug (\`ClientWaitMs = TotalMs - TransferMs\` derivation only worked on the corruption path); v2 review clean
- [x] \`go build ./go-proxy/...\` clean
- [x] \`make test-deploy-dev\` deploys cleanly
- [ ] Manual: induce a freeze with auto-recovery enabled, save HAR, verify timings.wait reflects player wait (not upstream TTFB)

## Follow-up issues filed

- #279 — capture request/response headers + queryString
- #280 — \`play_id\` (streaming UUID) scoping
- #281 — incident context block (device/scenario/timing/recovery)
- #282 — client-side HAR via LocalHTTPProxy + OkHttp
- #283 — capture client↔proxy RTT via TCP_INFO (makes \`wait\` truly client-perceived)
- #284 — dashboard waterfall to consume \`client_wait_ms\`