### PR TITLE
feat(dashboard): native brushable waterfall + paired downstream timing fixes

### DIFF
--- a/content/dashboard/incidents.html
+++ b/content/dashboard/incidents.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Incidents - InfiniteStream</title>
+    <link rel="stylesheet" href="/shared-styles.css">
+    <style>
+        .incidents-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 14px;
+        }
+        .incidents-table th,
+        .incidents-table td {
+            text-align: left;
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+        .incidents-table th {
+            background: var(--surface-2, #f7f7f9);
+            font-weight: 600;
+            color: var(--text-secondary);
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+        .incidents-table tbody tr:hover {
+            background: var(--surface-hover, rgba(0, 0, 0, 0.03));
+        }
+        .reason-pill {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            background: var(--surface-2, #eee);
+            color: var(--text-primary);
+        }
+        .reason-frozen { background: #fde8e8; color: #b91c1c; }
+        .reason-segment_stall { background: #fef3c7; color: #92400e; }
+        .reason-playback_failure { background: #fde8e8; color: #b91c1c; }
+        .reason-player_error { background: #fde8e8; color: #b91c1c; }
+        .reason-user_retry,
+        .reason-user_reload { background: #dbeafe; color: #1e40af; }
+        .reason-manual { background: #e5e7eb; color: #374151; }
+        .reason-auto_recovery_frozen,
+        .reason-auto_recovery_segment_stall,
+        .reason-auto_recovery_failure,
+        .reason-auto_recovery_zero_buffer { background: #fef3c7; color: #92400e; }
+
+        .source-pill {
+            display: inline-block;
+            padding: 1px 6px;
+            border-radius: 3px;
+            font-size: 11px;
+            background: var(--surface-2, #f3f4f6);
+            color: var(--text-secondary);
+        }
+
+        .filters {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+        .filters input,
+        .filters select {
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            font-size: 14px;
+            background: var(--surface);
+            color: var(--text-primary);
+        }
+        .filters label {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+        .filter-meta {
+            margin-left: auto;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+        .mono {
+            font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+            font-size: 12px;
+        }
+        .session-id {
+            color: var(--text-secondary);
+            font-size: 11px;
+        }
+        .no-data {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-secondary);
+        }
+        .no-data-icon {
+            font-size: 48px;
+            margin-bottom: 12px;
+            opacity: 0.5;
+        }
+    </style>
+</head>
+<body data-ism-active-page="incidents">
+    <div class="ism-content-wide">
+        <div class="card">
+            <div class="card-header">
+                <div class="header-actions">
+                    <h1>🚨 Incidents</h1>
+                    <div class="header-actions-right">
+                        <button id="refreshBtn" class="btn btn-secondary">Refresh</button>
+                    </div>
+                </div>
+                <p>HAR snapshots captured by go-proxy when a player reported a freeze, auto-recovery attempt, or user-tapped Reload — or when someone hit "Save HAR" on a session. Drop a downloaded file into Chrome DevTools → Network → Import HAR.</p>
+            </div>
+            <div class="card-body">
+                <div class="filters">
+                    <label>Player ID
+                        <input type="text" id="filterPlayer" placeholder="any" size="20">
+                    </label>
+                    <label>Reason
+                        <select id="filterReason"><option value="">all</option></select>
+                    </label>
+                    <label>Source
+                        <select id="filterSource">
+                            <option value="">all</option>
+                            <option value="player">player</option>
+                            <option value="dashboard">dashboard</option>
+                            <option value="rest">rest</option>
+                        </select>
+                    </label>
+                    <span class="filter-meta" id="countLabel">—</span>
+                </div>
+
+                <div id="loading" class="text-center text-secondary" style="padding: 40px;">
+                    <div class="spinner"></div>
+                    <div style="margin-top: 12px;">Loading incidents…</div>
+                </div>
+
+                <div id="emptyState" class="no-data" style="display: none;">
+                    <div class="no-data-icon">📭</div>
+                    <h2>No incidents captured yet</h2>
+                    <p>Open a testing session, induce a fault, and the freeze/recovery path will write a HAR here. Or hit <strong>Save HAR</strong> in the Network Log of a testing session.</p>
+                </div>
+
+                <div id="tableWrap" style="display: none;">
+                    <table class="incidents-table">
+                        <thead>
+                            <tr>
+                                <th>When</th>
+                                <th>Reason</th>
+                                <th>Player</th>
+                                <th>Session</th>
+                                <th>Source</th>
+                                <th>Size</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="rows"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="/shared/shared-nav.js"></script>
+    <script>
+        const escapeHTML = (s) => {
+            if (s === null || s === undefined) return '';
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
+
+        const fmtSize = (n) => {
+            if (!n && n !== 0) return '—';
+            if (n < 1024) return `${n} B`;
+            if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+            return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+        };
+        const fmtAge = (iso) => {
+            if (!iso) return '—';
+            const d = new Date(iso);
+            const ms = Date.now() - d.getTime();
+            const s = Math.floor(ms / 1000);
+            if (s < 60) return `${s}s ago`;
+            if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+            if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+            return `${Math.floor(s / 86400)}d ago`;
+        };
+        const fmtDate = (iso) => iso ? new Date(iso).toLocaleString() : '—';
+        const reasonClass = (reason) => `reason-pill reason-${(reason || 'unknown').replace(/[^a-z0-9_]/gi, '_')}`;
+
+        let allIncidents = [];
+
+        async function loadIncidents() {
+            const loading = document.getElementById('loading');
+            const tableWrap = document.getElementById('tableWrap');
+            const emptyState = document.getElementById('emptyState');
+            loading.style.display = '';
+            tableWrap.style.display = 'none';
+            emptyState.style.display = 'none';
+            try {
+                const r = await fetch('/api/incidents');
+                const data = await r.json();
+                allIncidents = Array.isArray(data.incidents) ? data.incidents : [];
+                populateReasonFilter();
+                render();
+            } catch (e) {
+                loading.innerHTML = `<div style="color: var(--danger, #b91c1c);">Failed to load: ${escapeHTML(e.message)}</div>`;
+                return;
+            }
+            loading.style.display = 'none';
+        }
+
+        function populateReasonFilter() {
+            const sel = document.getElementById('filterReason');
+            const reasons = [...new Set(allIncidents.map(i => i.reason).filter(Boolean))].sort();
+            const current = sel.value;
+            sel.innerHTML = '<option value="">all</option>' +
+                reasons.map(r => `<option value="${escapeHTML(r)}">${escapeHTML(r)}</option>`).join('');
+            if (reasons.includes(current)) sel.value = current;
+        }
+
+        function render() {
+            const tableWrap = document.getElementById('tableWrap');
+            const emptyState = document.getElementById('emptyState');
+            const rows = document.getElementById('rows');
+            const playerFilter = document.getElementById('filterPlayer').value.trim().toLowerCase();
+            const reasonFilter = document.getElementById('filterReason').value;
+            const sourceFilter = document.getElementById('filterSource').value;
+
+            const filtered = allIncidents.filter(i => {
+                if (playerFilter && !(i.player_id || '').toLowerCase().includes(playerFilter)) return false;
+                if (reasonFilter && i.reason !== reasonFilter) return false;
+                if (sourceFilter && i.source !== sourceFilter) return false;
+                return true;
+            });
+
+            document.getElementById('countLabel').textContent =
+                filtered.length === allIncidents.length
+                    ? `${filtered.length} incident${filtered.length === 1 ? '' : 's'}`
+                    : `${filtered.length} of ${allIncidents.length}`;
+
+            if (filtered.length === 0) {
+                tableWrap.style.display = 'none';
+                emptyState.style.display = '';
+                return;
+            }
+            emptyState.style.display = 'none';
+            tableWrap.style.display = '';
+            rows.innerHTML = filtered.map(i => {
+                // i.path is server-controlled (it's the filesystem path of the
+                // saved HAR), but treat it as untrusted and escape into both
+                // URL and attribute contexts.
+                const pathSegments = String(i.path || '').split('/').map(encodeURIComponent).join('/');
+                const downloadHref = `/api/incidents/${pathSegments}`;
+                const reasonRaw = i.reason || '—';
+                const reasonHTML = `<span class="${reasonClass(i.reason)}">${escapeHTML(reasonRaw)}</span>`;
+                const sourceHTML = i.source
+                    ? `<span class="source-pill">${escapeHTML(i.source)}</span>`
+                    : '<span class="source-pill">—</span>';
+                const player = i.player_id
+                    ? escapeHTML(i.player_id)
+                    : '<span class="text-secondary">—</span>';
+                const sessionShort = i.session_id ? escapeHTML(i.session_id.slice(0, 12)) : '—';
+                const fullSession = escapeHTML(i.session_id || '');
+                const time = escapeHTML(fmtDate(i.created_at));
+                const age = escapeHTML(fmtAge(i.created_at));
+                const filenameAttr = escapeHTML(i.filename || 'incident.har');
+                const hrefAttr = escapeHTML(downloadHref);
+                return `
+                    <tr>
+                        <td>
+                            <div>${time}</div>
+                            <div class="session-id">${age}</div>
+                        </td>
+                        <td>${reasonHTML}</td>
+                        <td class="mono">${player}</td>
+                        <td class="mono" title="${fullSession}">${sessionShort}</td>
+                        <td>${sourceHTML}</td>
+                        <td>${fmtSize(i.size_bytes)}</td>
+                        <td>
+                            <a href="${hrefAttr}" download="${filenameAttr}" class="btn btn-mini btn-secondary">Download</a>
+                        </td>
+                    </tr>
+                `;
+            }).join('');
+        }
+
+        document.getElementById('refreshBtn').addEventListener('click', loadIncidents);
+        document.getElementById('filterPlayer').addEventListener('input', render);
+        document.getElementById('filterReason').addEventListener('change', render);
+        document.getElementById('filterSource').addEventListener('change', render);
+
+        // Honor ?player_id= in URL for deep-links from testing-session.html.
+        const params = new URLSearchParams(window.location.search);
+        const initialPlayer = params.get('player_id');
+        if (initialPlayer) document.getElementById('filterPlayer').value = initialPlayer;
+
+        loadIncidents();
+        // Auto-refresh every 10s while page is visible.
+        setInterval(() => {
+            if (document.visibilityState === 'visible') loadIncidents();
+        }, 10000);
+    </script>
+</body>
+</html>

--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -523,13 +523,479 @@
     margin-bottom: 10px;
     padding: 0;
     overflow: hidden;
+    font-size: 11px;
+}
+
+/* Native scroll on the wrapper. The list of rows is the height of the
+ * data; the wrapper clips it. New entries appended at the bottom
+ * don't pull the user's scroll position around. Max-height fits the
+ * sticky 22px axis row plus 20 data rows (axis stays visible while
+ * the rows below scroll). */
+.network-log-waterfall-scroll {
+    width: 100%;
+    max-height: 462px; /* 22 (axis) + 20 * 22 (rows) */
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .network-log-waterfall {
     position: relative;
     width: 100%;
-    min-height: 280px;
-    height: 320px;
+}
+
+/* Summary row: at-a-glance stats for the visible HAR window. Sits
+ * above the overview so the user sees totals, span, and trouble
+ * counts before they even scroll. Click on a stat-pill to filter? —
+ * a future enhancement; for now it's read-only. */
+.netwf-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: #f1f5f9;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 11px;
+    color: #475569;
+}
+
+.netwf-summary-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #e2e8f0;
+    color: #334155;
+    font-weight: 600;
+    line-height: 16px;
+    white-space: nowrap;
+}
+
+.netwf-summary-pill .count { font-variant-numeric: tabular-nums; }
+.netwf-summary-pill.span { background: #ddd6fe; color: #4c1d95; }
+.netwf-summary-pill.total { background: #cbd5e1; color: #1e293b; }
+.netwf-summary-pill.success { background: #d1fae5; color: #065f46; }
+.netwf-summary-pill.partial { background: #ccfbf1; color: #134e4a; }
+.netwf-summary-pill.client-error { background: #fef3c7; color: #92400e; }
+.netwf-summary-pill.server-error { background: #fee2e2; color: #991b1b; }
+.netwf-summary-pill.faulted { background: #fecaca; color: #7f1d1d; }
+.netwf-summary-pill.timeout { background: #fed7aa; color: #9a3412; }
+.netwf-summary-pill.disconnect { background: #fbcfe8; color: #831843; }
+.netwf-summary-pill.retry { background: #e0e7ff; color: #3730a3; }
+.netwf-summary-pill.zero { opacity: 0.45; }
+
+/* Time labels above the overview — give the user a wall-clock sense
+ * of the full session's span. Different ticks than the brush axis
+ * below (which zooms with the user's selection). */
+.netwf-overview-axis {
+    position: relative;
+    height: 18px;
+    background: #f8fafc;
+    border-bottom: 1px solid #eef2f7;
+    overflow: hidden;
+    font-size: 10px;
+    color: #64748b;
+    font-weight: 600;
+}
+
+/* Overview strip: shows the full session at small scale. The brush
+ * (selection rectangle) on top is the user's window into the
+ * waterfall below. Drag the body to pan, drag a handle to resize
+ * (zoom). Inspired by Chrome DevTools' Network overview. */
+.netwf-overview {
+    position: relative;
+    height: 36px;
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    cursor: crosshair;
+    user-select: none;
+    overflow: hidden;
+}
+
+.netwf-overview-bars {
+    position: absolute;
+    inset: 4px 0;
+    pointer-events: none;
+}
+
+.netwf-overview-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background: rgba(52, 211, 153, 0.65);
+    min-width: 1px;
+}
+
+/* Same status / fault palette as the main waterfall rows so the user
+ * can scan the overview and spot trouble at a glance. Higher z-index
+ * on errors so they're visible even when adjacent successful ticks
+ * cover them. */
+.netwf-overview-tick.status-206 { background: rgba(20, 184, 166, 0.75); }
+.netwf-overview-tick.status-3xx { background: rgba(96, 165, 250, 0.75); }
+.netwf-overview-tick.status-4xx { background: rgba(245, 158, 11, 0.85); z-index: 1; }
+.netwf-overview-tick.status-5xx { background: rgba(239, 68, 68, 0.9); z-index: 2; }
+.netwf-overview-tick.fault-timeout { background: rgba(217, 119, 6, 0.95); z-index: 3; }
+.netwf-overview-tick.fault-incomplete { background: rgba(190, 24, 93, 0.95); z-index: 3; }
+.netwf-overview-tick.is-faulted { background: rgba(185, 28, 28, 0.95); z-index: 4; }
+
+.netwf-brush {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background: rgba(33, 150, 243, 0.10);
+    border-left: 2px solid #2196F3;
+    border-right: 2px solid #2196F3;
+    cursor: grab;
+    box-sizing: border-box;
+}
+
+.netwf-brush.dragging {
+    cursor: grabbing;
+}
+
+.netwf-brush-handle {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background: rgba(33, 150, 243, 0.35);
+    cursor: ew-resize;
+}
+
+.netwf-brush-handle.left { left: -3px; }
+.netwf-brush-handle.right { right: -3px; }
+
+/* Global-axis waterfall: each row's bar is positioned within the
+ * brush's time window. Bars on the same horizontal pixel = requests
+ * happening at the same wall-clock instant. Phase segments inside
+ * the bar render dns/connect/tls/wait/receive to scale. */
+.netwf-row {
+    display: flex;
+    align-items: center;
+    height: 22px;
+    border-bottom: 1px solid #eef2f7;
+    border-left: 3px solid transparent;
+    line-height: 22px;
+    box-sizing: border-box;
+}
+
+/* Status / fault tinting. Left-border accent + faint row background
+ * so the colour is visible without overpowering the bars. Faulted +
+ * timeout entries get the strongest signal because they're the
+ * thing the user is hunting. */
+.netwf-row.status-2xx { border-left-color: #34d399; }
+/* 206 Partial Content — distinct from a normal 200 because the
+ * player asked for a byte range. Teal so it stands apart from the
+ * green of full 2xx responses. */
+.netwf-row.status-206 { border-left-color: #14b8a6; background: #f0fdfa; }
+.netwf-row.status-3xx { border-left-color: #60a5fa; }
+.netwf-row.status-4xx { border-left-color: #f59e0b; background: #fffbeb; }
+.netwf-row.status-5xx { border-left-color: #ef4444; background: #fef2f2; }
+
+/* Retry / re-attempt accent — colour the row label so the ↻ glyph
+ * (rendered inline by the JS, after the timestamp) reads at a
+ * glance. The ! fault prefix sits next to it for the same reason. */
+.netwf-row.is-retry .netwf-row-label {
+    color: #be185d;
+}
+
+.netwf-row.is-faulted {
+    background: #fee2e2;
+    border-left-color: #b91c1c;
+}
+
+.netwf-row.fault-timeout {
+    background: #fef3c7;
+    border-left-color: #d97706;
+}
+
+.netwf-row.fault-incomplete {
+    background: #fce7f3;
+    border-left-color: #be185d;
+}
+
+/* Column-cell layout. Widths live in CSS variables on the waterfall
+ * host so a single drag on a header resizer reflows every row + the
+ * axis row in lockstep. Defaults below are the same widths the
+ * single-label version used; users can drag from there. */
+.network-log-waterfall {
+    --netwf-col-time: 116px; /* fits HH:MM:SS.mmm with padding */
+    --netwf-col-flags: 28px;
+    --netwf-col-method: 44px;
+    --netwf-col-path: 200px;
+    --netwf-col-bytes: 64px;
+    --netwf-col-mbps: 72px;
+    --netwf-col-status: 56px;
+}
+
+.netwf-cell {
+    position: relative;
+    padding: 0 6px;
+    border-right: 1px solid #e2e8f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 11px;
+    color: #334155;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+}
+
+.netwf-cell.time   { flex: 0 0 var(--netwf-col-time); }
+.netwf-cell.flags  { flex: 0 0 var(--netwf-col-flags); text-align: center; padding: 0; font-weight: 700; }
+.netwf-cell.method { flex: 0 0 var(--netwf-col-method); }
+.netwf-cell.path   { flex: 0 0 var(--netwf-col-path); }
+.netwf-cell.bytes  { flex: 0 0 var(--netwf-col-bytes); text-align: right; font-variant-numeric: tabular-nums; }
+.netwf-cell.mbps   { flex: 0 0 var(--netwf-col-mbps); text-align: right; font-variant-numeric: tabular-nums; }
+.netwf-cell.status {
+    flex: 0 0 var(--netwf-col-status);
+    text-align: center;
+    font-weight: 600;
+    color: #475569;
+}
+
+.netwf-row.status-2xx .netwf-cell.status { color: #065f46; background: #d1fae5; }
+.netwf-row.status-206 .netwf-cell.status { color: #134e4a; background: #ccfbf1; }
+.netwf-row.status-3xx .netwf-cell.status { color: #1e3a8a; background: #dbeafe; }
+.netwf-row.status-4xx .netwf-cell.status { color: #92400e; background: #fef3c7; }
+.netwf-row.status-5xx .netwf-cell.status { color: #991b1b; background: #fee2e2; }
+.netwf-row.is-faulted .netwf-cell.status,
+.netwf-row.fault-timeout .netwf-cell.status,
+.netwf-row.fault-incomplete .netwf-cell.status {
+    color: #7f1d1d;
+    background: #fecaca;
+}
+
+/* Drag handle on the right edge of header cells. Picks up pointer
+ * events; the body cells underneath ignore them. */
+.netwf-cell-resizer {
+    position: absolute;
+    top: 0;
+    right: -3px;
+    bottom: 0;
+    width: 6px;
+    cursor: col-resize;
+    z-index: 5;
+}
+
+.netwf-cell-resizer:hover,
+.netwf-cell-resizer.dragging {
+    background: rgba(33, 150, 243, 0.35);
+}
+
+/* Header (axis) cells inherit the same widths but render with the
+ * existing axis-row look. Each header cell is the only place that
+ * carries a resizer — drag affects all body rows via the shared CSS
+ * vars. */
+.netwf-axis .netwf-cell {
+    background: #f8fafc;
+    color: #64748b;
+    font-weight: 600;
+    line-height: 22px;
+}
+
+.netwf-row.status-4xx .netwf-row-label { color: #92400e; }
+.netwf-row.status-5xx .netwf-row-label { color: #991b1b; }
+.netwf-row.is-faulted .netwf-row-label { color: #7f1d1d; font-weight: 600; }
+.netwf-row.fault-timeout .netwf-row-label { color: #92400e; font-weight: 600; }
+.netwf-row.fault-incomplete .netwf-row-label { color: #831843; font-weight: 600; }
+
+/* Bar overlay when transfer didn't complete — diagonal hatch over
+ * the receive segment so it's visually clear bytes are missing. */
+.netwf-row-bar.is-incomplete .netwf-row-phase.transfer {
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(190, 24, 93, 0.85) 0,
+        rgba(190, 24, 93, 0.85) 4px,
+        rgba(252, 231, 243, 0.85) 4px,
+        rgba(252, 231, 243, 0.85) 8px
+    );
+}
+
+/* Hover tooltip — floating panel that follows the cursor with full
+ * forensics for the row under the pointer. Pointer-events: none so
+ * the tooltip doesn't capture hover and ping-pong on/off. */
+.netwf-tooltip {
+    position: fixed;
+    z-index: 10000;
+    pointer-events: none;
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: 6px;
+    padding: 10px 12px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.32);
+    font-size: 11px;
+    line-height: 1.45;
+    max-width: 480px;
+    min-width: 280px;
+    display: none;
+}
+
+.netwf-tooltip.visible {
+    display: block;
+}
+
+.netwf-tooltip-head {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: #f1f5f9;
+    word-break: break-all;
+}
+
+.netwf-tooltip-meta {
+    display: grid;
+    grid-template-columns: max-content auto;
+    column-gap: 12px;
+    row-gap: 2px;
+    margin-bottom: 6px;
+    color: #cbd5e1;
+}
+
+.netwf-tooltip-meta dt { color: #94a3b8; }
+.netwf-tooltip-meta dd { margin: 0; color: #f1f5f9; }
+
+.netwf-tooltip-phases {
+    margin: 6px 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 6px;
+    display: grid;
+    grid-template-columns: 12px max-content auto;
+    column-gap: 8px;
+    row-gap: 2px;
+    align-items: center;
+}
+
+.netwf-tooltip-phase-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+}
+.netwf-tooltip-phase-swatch.dns { background: #8e8cd8; }
+.netwf-tooltip-phase-swatch.connect { background: #f59e0b; }
+.netwf-tooltip-phase-swatch.tls { background: #b084eb; }
+.netwf-tooltip-phase-swatch.wait { background: #7dd3fc; }
+.netwf-tooltip-phase-swatch.transfer { background: #34d399; }
+
+.netwf-tooltip-phase-name { color: #cbd5e1; }
+.netwf-tooltip-phase-value { color: #f1f5f9; font-variant-numeric: tabular-nums; }
+
+.netwf-tooltip-fault {
+    border-top: 1px solid rgba(248, 113, 113, 0.4);
+    padding-top: 6px;
+    margin-top: 6px;
+    color: #fca5a5;
+}
+
+.netwf-tooltip-url {
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 6px;
+    margin-top: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    color: #94a3b8;
+    word-break: break-all;
+}
+
+.netwf-row-track {
+    flex: 1 1 auto;
+    position: relative;
+    height: 22px;
+    background-image: repeating-linear-gradient(
+        to right,
+        rgba(148, 163, 184, 0.10) 0,
+        rgba(148, 163, 184, 0.10) 1px,
+        transparent 1px,
+        transparent 40px
+    );
+}
+
+.netwf-row-bar {
+    position: absolute;
+    top: 6px;
+    height: 9px;
+    display: flex;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+    min-width: 2px;
+}
+
+.netwf-row-phase {
+    height: 100%;
+    min-width: 1px;
+}
+.netwf-row-phase.dns { background: #8e8cd8; }
+.netwf-row-phase.connect { background: #f59e0b; }
+.netwf-row-phase.tls { background: #b084eb; }
+.netwf-row-phase.wait { background: #7dd3fc; }
+.netwf-row-phase.transfer { background: #34d399; }
+
+.netwf-row-duration {
+    position: absolute;
+    top: 4px;
+    height: 14px;
+    line-height: 14px;
+    font-size: 10px;
+    color: #475569;
+    white-space: nowrap;
+    pointer-events: none;
+    padding: 0 4px;
+}
+
+.netwf-axis {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    height: 22px;
+    line-height: 22px;
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 10px;
+    color: #64748b;
+    font-weight: 600;
+    box-sizing: border-box;
+}
+
+/* The column cells (.netwf-cell) cover the left columns now — the
+ * axis row has no separate label spacer. The flex track to the right
+ * of the cells is the time-axis scale. */
+
+.netwf-axis-scale {
+    flex: 1 1 auto;
+    position: relative;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.netwf-axis-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(148, 163, 184, 0.45);
+}
+
+.netwf-axis-tick-label {
+    position: absolute;
+    top: 4px;
+    transform: translateX(-50%);
+    line-height: 14px;
+    white-space: nowrap;
+    color: #64748b;
+    font-weight: 600;
+    background: #f8fafc;
+    padding: 0 3px;
+}
+
+.netwf-axis-summary {
+    position: absolute;
+    right: 8px;
+    top: 4px;
+    line-height: 14px;
+    color: #475569;
+    font-weight: 600;
+    background: #f8fafc;
+    padding: 0 3px;
 }
 
 .network-log-waterfall-empty {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2195,34 +2195,57 @@
         const centerRect = center.getBoundingClientRect();
         if (centerRect.height <= 0) return;
 
-        // Walk the rendered group elements. Each .vis-group has
-        // data-id matching the groupId we assigned (groupId = rowIdx + 1
-        // in updateNetworkWaterfall).
-        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        const rowCount = state.rows.length;
         let firstVisibleIdx = -1;
         let lastVisibleIdx = -1;
+
+        // Strategy 1: walk rendered .vis-group elements and take the
+        // ones whose bounding rect intersects the center viewport.
+        // Works if vis-timeline doesn't apply transforms that make all
+        // groups share the same on-screen rect.
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let sampleHeight = 0;
         groupEls.forEach((el) => {
             const groupIdAttr = el.getAttribute('data-id') || el.dataset.id;
             const groupId = parseInt(groupIdAttr, 10);
             if (!Number.isFinite(groupId)) return;
             const rowIdx = groupId - 1;
-            if (rowIdx < 0 || rowIdx >= state.rows.length) return;
+            if (rowIdx < 0 || rowIdx >= rowCount) return;
             const r = el.getBoundingClientRect();
+            if (r.height > 0 && sampleHeight === 0) sampleHeight = r.height;
             if (r.height <= 0) return;
-            // Group at least partially visible if it overlaps the
-            // center panel's viewport rect.
             if (r.bottom > centerRect.top && r.top < centerRect.bottom) {
                 if (firstVisibleIdx === -1 || rowIdx < firstVisibleIdx) firstVisibleIdx = rowIdx;
                 if (lastVisibleIdx === -1 || rowIdx > lastVisibleIdx) lastVisibleIdx = rowIdx;
             }
         });
 
-        // Fallback: if we couldn't read group elements (race, custom
-        // virtualization), pan to cover all rows. Better than leaving a
-        // mostly-blank timeline.
-        if (firstVisibleIdx === -1 || lastVisibleIdx === -1) {
-            firstVisibleIdx = 0;
-            lastVisibleIdx = state.rows.length - 1;
+        // Strategy 2: if intersection found nothing (or found ALL rows
+        // due to vis-timeline's transform-based virtualization), fall
+        // back to "row-height × viewport ÷ pin to last N". Works for
+        // the common Following Latest workflow. The sampled height
+        // comes from the first .vis-group we saw above; if no groups
+        // are rendered at all, we use a 22px default.
+        const sawAllRows = (lastVisibleIdx - firstVisibleIdx + 1) === rowCount;
+        const sawNoRows = firstVisibleIdx === -1;
+        if (sawNoRows || sawAllRows) {
+            const rowHeight = sampleHeight > 0 ? sampleHeight : 22;
+            const visibleRowCount = Math.max(1, Math.min(rowCount, Math.floor(centerRect.height / rowHeight)));
+            // When the entries list is following the latest entries
+            // (Following Latest is the default), the visible rows are
+            // the most recent — pin to the last N. This matches what
+            // the user sees on the left.
+            if (isNetworkLogFollowMode(key)) {
+                firstVisibleIdx = Math.max(0, rowCount - visibleRowCount);
+                lastVisibleIdx = rowCount - 1;
+            } else {
+                // Not following — without reliable scroll position we
+                // pick the FIRST N rows (top-of-list). Will be wrong
+                // when user has scrolled past the top, but that case
+                // doesn't appear common today.
+                firstVisibleIdx = 0;
+                lastVisibleIdx = Math.min(rowCount - 1, visibleRowCount - 1);
+            }
         }
 
         const startRow = state.rows[firstVisibleIdx];

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -45,17 +45,25 @@
     const networkWaterfallTimelines = new Map();
     const networkWaterfallViewBySession = new Map();
     const networkWaterfallFollowModeBySession = new Map();
-    // Follow Scroll: pan the waterfall's time window to match the rows
-    // visible in the entries list as the user scrolls. Default true.
-    // Issue #286.
-    const networkWaterfallFollowScrollBySession = new Map();
     const networkWaterfallFullRangeBySession = new Map();
     const networkWaterfallRenderSignatureBySession = new Map();
-    const networkWaterfallRollingWindowMs = 5 * 60 * 1000;
+    const networkWaterfallRowSignaturesBySession = new Map();
+    const networkWaterfallRowsBySession = new Map();
+    // Per-session brush state: { startMs, endMs, follow }. `follow=true`
+    // means the brush sticks to the right edge as new entries arrive
+    // (Following Latest). Drag-pan flips it to false.
+    const networkWaterfallBrushBySession = new Map();
+    const networkWaterfallRollingWindowMs = 10 * 60 * 1000;
+    // Default and minimum brush span. Tighter than this and the time
+    // axis gets too granular to be useful; this is also the default
+    // initial span when a session first opens.
+    const networkWaterfallMinBrushMs = 1 * 60 * 1000;
     const networkLogAutoRefreshTimers = new Map();
     const networkLogFetchInFlight = new Set();
     const networkLogAutoRefreshMs = 1500;
-    const networkLogDeveloperEnabled = new URLSearchParams(window.location.search).get('developer') === '1';
+    // Network log used to be developer-only; now enabled for everyone.
+    // The constant stays as `true` so the runtime gates still compile.
+    const networkLogDeveloperEnabled = true;
 
     function formatDate(value) {
         if (!value) return '—';
@@ -1063,7 +1071,6 @@
                 </div>
                 ` : ''}
 
-                ${developerMode ? `
                 <!-- Collapsible Network Log -->
                 <div class="collapsible-section" data-section="network-log" data-default-open="false">
                     <div class="collapsible-header" data-toggle="network-log">
@@ -1076,36 +1083,34 @@
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save the current network timeline as a HAR file: downloads to your machine and adds it to the Incidents list">Download HAR</button>
-                                <a href="/api/incidents" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="List saved HAR snapshots (raw JSON)">Incidents</a>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-first">First</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-fit">Fit</button>
+                                <a href="/dashboard/incidents.html" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="Browse saved HAR snapshots">Incidents</a>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-follow">Following Latest</button>
-                                <label class="network-log-filter" title="Pan the waterfall's time window to match the entries currently visible in the list above">
-                                    <input type="checkbox" data-field="follow-scroll" checked>
-                                    Follow Scroll
-                                </label>
-                                <label class="network-log-filter">
-                                    <input type="checkbox" data-filter="show-faulted" checked>
-                                    Show Faults
-                                </label>
-                                <label class="network-log-filter">
-                                    <input type="checkbox" data-filter="show-successful" checked>
-                                    Show Successful
+                                <label class="network-log-filter" title="When checked, only faulted / non-success entries appear in the list.">
+                                    <input type="checkbox" data-filter="hide-successful">
+                                    Hide Successful
                                 </label>
                             </div>
                             <div class="network-log-warning">
-                                Transfer timings and derived Mbps are approximate.
-                                They are most reliable when the network is slow and transfers are large (especially video segments).
+                                Transfer timings and derived Mbps are approximate, and measured <strong>downstream</strong> — from when go-proxy starts writing the response back to the client device until the last byte is flushed (proxy → player). They do <strong>not</strong> include the upstream fetch from go-proxy to go-live. The numbers are most reliable when the network is slow and transfers are large (especially video segments); short responses transfer in &lt;1 ms and round to noise.
                             </div>
                             <div class="network-log-waterfall-wrap">
-                                <div class="network-log-waterfall" data-field="network_log_waterfall"></div>
+                                <div class="netwf-summary" data-field="netwf_summary"></div>
+                                <div class="netwf-overview-axis" data-field="netwf_overview_axis"></div>
+                                <div class="netwf-overview" data-field="netwf_overview">
+                                    <div class="netwf-overview-bars" data-field="netwf_overview_bars"></div>
+                                    <div class="netwf-brush" data-field="netwf_brush" style="left:0%;width:100%;">
+                                        <div class="netwf-brush-handle left" data-field="netwf_brush_handle_left"></div>
+                                        <div class="netwf-brush-handle right" data-field="netwf_brush_handle_right"></div>
+                                    </div>
+                                </div>
+                                <div class="network-log-waterfall-scroll" data-field="network_log_waterfall_scroll">
+                                    <div class="network-log-waterfall" data-field="network_log_waterfall"></div>
+                                </div>
                                 <div class="network-log-waterfall-empty" data-field="network_log_waterfall_empty" style="display:none;">No requests to plot yet.</div>
                             </div>
                         </div>
                     </div>
                 </div>
-                ` : ''}
 
             </div>
         `;
@@ -1366,12 +1371,6 @@
             const cb = e.target;
             if (!cb || cb.type !== 'checkbox' || !cb.dataset.field) return;
             const field = cb.dataset.field;
-            if (field === 'follow-scroll') {
-                const card = cb.closest('.session-card');
-                const sessionId = card ? String(card.dataset.sessionId || '') : '';
-                if (sessionId) setFollowScrollMode(sessionId, !!cb.checked);
-                return;
-            }
             if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls') return;
             const group = cb.closest('.checkbox-group');
             if (!group) return;
@@ -1405,7 +1404,21 @@
                         setNetworkLogFollowMode(sessionId, nextFollow);
                         updateNetworkLogFollowButton(card, sessionId);
                         if (nextFollow) {
-                            jumpWaterfallView(sessionId, 'last');
+                            // Snap to the live point immediately —
+                            // refresh the entry list, re-render so the
+                            // brush hits the right edge, then make sure
+                            // the row list is scrolled to the bottom
+                            // even after layout settles.
+                            updateNetworkLog(sessionId);
+                            const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
+                            if (scrollHost) {
+                                scrollHost.scrollTop = scrollHost.scrollHeight;
+                                window.requestAnimationFrame(() => {
+                                    scrollHost.scrollTop = scrollHost.scrollHeight;
+                                });
+                            }
+                        } else if (card) {
+                            applyNetworkLogFilters(card);
                         }
                     }
                     return;
@@ -1414,50 +1427,43 @@
                     const card = actionButton.closest('.session-card');
                     const sessionId = card ? String(card.dataset.sessionId || '') : '';
                     if (!sessionId) return;
-                    const reason = window.prompt('Snapshot reason (e.g. manual, freeze, restart):', 'manual') || 'manual';
                     actionButton.disabled = true;
                     fetch(`/api/session/${encodeURIComponent(sessionId)}/har/snapshot`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ reason, source: 'dashboard' })
+                        body: JSON.stringify({ reason: 'manual', source: 'dashboard' })
                     })
                         .then(r => r.json())
-                        .then(data => {
+                        .then(async (data) => {
                             if (data && data.incident && data.incident.path) {
-                                // Trigger a direct download — server already
-                                // wrote the file to /incidents/, we just
-                                // route the browser at it via a hidden <a>.
+                                // Fetch the just-saved file as a blob and
+                                // trigger the download from a blob: URL.
+                                // Linking to /api/incidents/... directly
+                                // triggers Chrome's "insecure download"
+                                // block on plain-HTTP origins (mixed-
+                                // content download). A blob URL is
+                                // local-origin, so it isn't blocked.
+                                const fileResp = await fetch(`/api/incidents/${data.incident.path}`);
+                                if (!fileResp.ok) {
+                                    throw new Error(`HAR fetch ${fileResp.status}`);
+                                }
+                                const blob = await fileResp.blob();
+                                const url = URL.createObjectURL(blob);
                                 const a = document.createElement('a');
-                                a.href = `/api/incidents/${data.incident.path}`;
+                                a.href = url;
                                 a.download = data.incident.filename || 'incident.har';
                                 a.style.display = 'none';
                                 document.body.appendChild(a);
                                 a.click();
                                 document.body.removeChild(a);
+                                // Defer revoke so the click has time to start.
+                                setTimeout(() => URL.revokeObjectURL(url), 1000);
                             } else if (data && data.error) {
                                 window.alert(`HAR save failed: ${data.error}`);
                             }
                         })
                         .catch(err => window.alert(`HAR save failed: ${err}`))
                         .finally(() => { actionButton.disabled = false; });
-                    return;
-                }
-                if (action === 'network-log-jump-first' || action === 'network-log-jump-last' || action === 'network-log-jump-fit') {
-                    const card = actionButton.closest('.session-card');
-                    const sessionId = card ? card.dataset.sessionId : '';
-                    if (sessionId) {
-                        if (action === 'network-log-jump-first') {
-                            setNetworkLogFollowMode(sessionId, false);
-                            updateNetworkLogFollowButton(card, sessionId);
-                            jumpWaterfallView(sessionId, 'first');
-                        } else if (action === 'network-log-jump-last') {
-                            jumpWaterfallView(sessionId, 'last');
-                        } else {
-                            setNetworkLogFollowMode(sessionId, false);
-                            updateNetworkLogFollowButton(card, sessionId);
-                            jumpWaterfallView(sessionId, 'fit');
-                        }
-                    }
                     return;
                 }
             }
@@ -1548,13 +1554,8 @@
             return;
         }
         resumeNetworkLogAutoRefreshForVisiblePanels();
-        window.addEventListener('resize', () => {
-            networkWaterfallTimelines.forEach((state) => {
-                if (state && state.timeline && typeof state.timeline.redraw === 'function') {
-                    state.timeline.redraw();
-                }
-            });
-        });
+        // Native waterfall layouts re-flow on the next refresh tick;
+        // no explicit redraw needed on window resize.
         document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
                 stopAllNetworkLogAutoRefresh();
@@ -1596,28 +1597,10 @@
 
     function isNetworkLogFollowMode(sessionId) {
         const key = String(sessionId || '');
-        // Default OFF — the user expects the list to "just sit there"
-        // until they explicitly opt into auto-scroll.
-        return networkWaterfallFollowModeBySession.get(key) === true;
-    }
-
-    // Follow Scroll mode: when on, the waterfall's time window
-    // auto-pans to match the rows currently visible in the entries
-    // list. Default true so the feature is on out-of-the-box. Issue #286.
-    function isFollowScrollMode(sessionId) {
-        const key = String(sessionId || '');
-        return networkWaterfallFollowScrollBySession.get(key) !== false;
-    }
-
-    function setFollowScrollMode(sessionId, enabled) {
-        const key = String(sessionId || '');
-        if (!key) return;
-        networkWaterfallFollowScrollBySession.set(key, !!enabled);
-        const state = networkWaterfallTimelines.get(key);
-        if (state) {
-            state.autoPan = !!enabled;
-            if (enabled) applyWaterfallAutoPan(state, key);
-        }
+        // Default ON — with the brushable overview, the user can pan
+        // away whenever they want; the live tail is the more useful
+        // initial state.
+        return networkWaterfallFollowModeBySession.get(key) !== false;
     }
 
     function setNetworkLogFollowMode(sessionId, enabled) {
@@ -1636,12 +1619,6 @@
         button.setAttribute('aria-pressed', following ? 'true' : 'false');
         button.classList.toggle('btn-primary', following);
         button.classList.toggle('btn-secondary', !following);
-        // Keep the Follow Scroll checkbox in sync with the per-session
-        // map across re-renders (the HTML template defaults to checked).
-        const followScrollCb = hostCard.querySelector('input[data-field="follow-scroll"]');
-        if (followScrollCb) {
-            followScrollCb.checked = isFollowScrollMode(sessionId);
-        }
     }
 
     function scrollWaterfallToLatestRow(state) {
@@ -1735,6 +1712,26 @@
         return `${mbps.toFixed(2)} Mbps`;
     }
 
+    // Fixed-precision formatters for the row table. Decimal count is
+    // constant across rows so a column scans cleanly (e.g. "5.00",
+    // "12.30", "145.00" rather than "5", "12.3", "145").
+    function formatKBNumber(bytes) {
+        const n = Number(bytes || 0);
+        if (!Number.isFinite(n) || n <= 0) return '—';
+        return (n / 1024).toFixed(1);
+    }
+
+    function formatMbpsNumber(bytes, transferMs) {
+        const bytesNum = Number(bytes || 0);
+        const msNum = Number(transferMs || 0);
+        if (!Number.isFinite(bytesNum) || !Number.isFinite(msNum) || bytesNum <= 0 || msNum <= 0) {
+            return '—';
+        }
+        const mbps = (bytesNum * 8) / (msNum * 1000);
+        if (!Number.isFinite(mbps) || mbps <= 0) return '—';
+        return mbps.toFixed(2);
+    }
+
     function escapeHtml(value) {
         return String(value || '')
             .replace(/&/g, '&amp;')
@@ -1764,12 +1761,36 @@
 
     function getFilteredNetworkEntries(card, sessionId) {
         const entries = networkLogEntriesBySession.get(String(sessionId)) || [];
-        const showFaulted = card.querySelector('[data-filter="show-faulted"]')?.checked ?? true;
-        const showSuccessful = card.querySelector('[data-filter="show-successful"]')?.checked ?? true;
-        return entries.filter((entry) => {
-            const faulted = !!entry.faulted;
-            return (faulted && showFaulted) || (!faulted && showSuccessful);
-        });
+        // Faults are always shown. "Hide Successful" defaults off, so
+        // by default we show everything; tick it to focus on problems.
+        const hideSuccessful = card.querySelector('[data-filter="hide-successful"]')?.checked ?? false;
+        return entries.filter((entry) => entry.faulted || !hideSuccessful);
+    }
+
+    // Derive segment duration from the URL conventions used by go-live:
+    //   /go-live/<content>/2s/...    -> 2s segments
+    //   /go-live/<content>/6s/...    -> 6s segments
+    //   /go-live/<content>/ll/...    -> LL partials (~200ms part target;
+    //                                    use 1s as a conservative
+    //                                    "normal cadence")
+    //   playlist_<N>s_<variant>.m3u8 -> N seconds (also matches DASH-side)
+    // Anything we can't classify falls back to the 6s default.
+    function waterfallSegmentDurationMsFor(row) {
+        const url = String(row.entry.url || row.entry.path || row.pathDisplay || '').toLowerCase();
+        if (!url) return 6000;
+        const lowLatency = /(^|[/_])ll([/_.]|$)/.test(url);
+        if (lowLatency) return 1000;
+        const m = url.match(/(?:[/_])(\d{1,2})s(?:[/_])/);
+        if (m) {
+            const secs = parseInt(m[1], 10);
+            if (secs > 0 && secs <= 30) return secs * 1000;
+        }
+        const m2 = url.match(/playlist_(\d{1,2})s[_-]/);
+        if (m2) {
+            const secs = parseInt(m2[1], 10);
+            if (secs > 0 && secs <= 30) return secs * 1000;
+        }
+        return 6000;
     }
 
     function buildWaterfallRows(entries) {
@@ -1883,6 +1904,35 @@
         });
         const ordered = rows.filter((row) => row.timestamp > 0).sort((a, b) => a.timestamp - b.timestamp);
         if (!ordered.length) return ordered;
+        // Tag re-requests: same URL+method seen earlier in the session.
+        // `attempt` / `totalAttempts` give chronological context; the
+        // narrower `is_retry` flag fires only when the gap from the
+        // previous fetch is suspiciously short — faster than a normal
+        // HLS playlist refresh / segment refetch cadence. The cutoff
+        // is *half the segment duration* parsed from the URL path
+        // (.../2s/..., .../6s/..., .../ll/..., or playlist_2s_...).
+        // Routine periodic refetches won't get flagged; rapid retries
+        // after a failure will.
+        const attemptByKey = new Map();
+        const lastTimeByKey = new Map();
+        for (const row of ordered) {
+            const k = `${row.entry.method || 'GET'} ${row.entry.url || row.entry.path || ''}`;
+            const next = (attemptByKey.get(k) || 0) + 1;
+            attemptByKey.set(k, next);
+            row.attempt = next;
+            const prevTs = lastTimeByKey.get(k);
+            row.segment_duration_ms = waterfallSegmentDurationMsFor(row);
+            const threshold = row.segment_duration_ms / 2;
+            row.retry_threshold_ms = threshold;
+            row.is_retry = next > 1 && prevTs !== undefined && (row.timestamp - prevTs) < threshold;
+            row.gap_from_prev_ms = prevTs !== undefined ? row.timestamp - prevTs : null;
+            lastTimeByKey.set(k, row.timestamp);
+            row.totalAttempts = 0; // filled in below
+        }
+        for (const row of ordered) {
+            const k = `${row.entry.method || 'GET'} ${row.entry.url || row.entry.path || ''}`;
+            row.totalAttempts = attemptByKey.get(k) || 1;
+        }
         const newestTimestamp = ordered[ordered.length - 1].timestamp;
         const cutoff = newestTimestamp - networkWaterfallRollingWindowMs;
         return ordered.filter((row) => (row.timestamp + row.duration) >= cutoff);
@@ -2322,224 +2372,747 @@
         networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
 
+    // Global-axis waterfall with a brushable overview pane (issue
+    // #291). The overview shows the full session at small scale; the
+    // user drags the brush to pick a time window, and the bars in the
+    // main view position themselves within that window. Chrome
+    // DevTools' Network panel pattern.
     function updateNetworkWaterfall(card, sessionId) {
         const key = String(sessionId);
         const chartHost = card.querySelector('[data-field="network_log_waterfall"]');
+        const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
         const emptyHost = card.querySelector('[data-field="network_log_waterfall_empty"]');
+        const overviewEl = card.querySelector('[data-field="netwf_overview"]');
+        const overviewBars = card.querySelector('[data-field="netwf_overview_bars"]');
+        const brushEl = card.querySelector('[data-field="netwf_brush"]');
         if (!chartHost || !emptyHost) return;
-
-        if (!hasVisTimeline()) {
-            emptyHost.textContent = 'vis-timeline not loaded; waterfall unavailable.';
-            emptyHost.style.display = 'block';
-            return;
-        }
+        applyPersistedWaterfallColumns(chartHost);
 
         const rows = buildWaterfallRows(getFilteredNetworkEntries(card, key));
         if (!rows.length) {
             emptyHost.textContent = 'No requests to plot yet.';
             emptyHost.style.display = 'block';
-            const state = networkWaterfallTimelines.get(key);
-            networkWaterfallFullRangeBySession.delete(key);
+            chartHost.replaceChildren();
+            if (overviewBars) overviewBars.replaceChildren();
             networkWaterfallRenderSignatureBySession.delete(key);
-            if (state && state.items && state.groups) {
-                state.items.clear();
-                state.groups.clear();
-                if (state.timeline && typeof state.timeline.redraw === 'function') {
-                    state.timeline.redraw();
-                }
-            }
+            networkWaterfallRowsBySession.delete(key);
             return;
         }
         emptyHost.style.display = 'none';
 
-        const state = ensureWaterfallTimeline(card, key);
-        if (!state) return;
+        // Full session range (the overview always shows this).
+        const dataStartMs = rows[0].timestamp;
+        const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+        const fullSpan = Math.max(50, dataEndMs - dataStartMs);
 
-        const dataStartMs = Math.min(...rows.map((row) => row.timestamp));
-        const dataEndMs = Math.max(...rows.map((row) => row.timestamp + row.duration));
-        const firstRow = rows[0];
-        const lastRow = rows[rows.length - 1];
-        const renderSignature = [
-            rows.length,
-            Math.round(dataStartMs),
-            Math.round(dataEndMs),
-            firstRow ? `${firstRow.filename}|${firstRow.entry.status || ''}|${Math.round(firstRow.duration)}` : '',
-            lastRow ? `${lastRow.filename}|${lastRow.entry.status || ''}|${Math.round(lastRow.duration)}` : ''
-        ].join('|');
-        const previousSignature = networkWaterfallRenderSignatureBySession.get(key);
-        if (previousSignature === renderSignature) {
-            updateNetworkLogFollowButton(card, key);
-            if (isNetworkLogFollowMode(key)) {
-                scrollWaterfallToLatestRow(state);
-            }
-            return;
+        // Brush state — Following Latest = stick to the right edge.
+        // Default: zoom to the most recent 2 minutes (or full session
+        // if shorter). 2 min is also the floor we enforce on user
+        // resize so bars stay scannable.
+        let brush = networkWaterfallBrushBySession.get(key);
+        if (!brush) {
+            const initialSpan = Math.min(fullSpan, networkWaterfallMinBrushMs);
+            brush = { startMs: dataEndMs - initialSpan, endMs: dataEndMs, follow: true };
+            networkWaterfallBrushBySession.set(key, brush);
         }
-        networkWaterfallRenderSignatureBySession.set(key, renderSignature);
-        const toTime = (timestampMs) => new Date(Math.max(0, Math.round(timestampMs)));
-        const groups = [];
-        const items = [];
+        // Sync brush.follow with the Follow Latest button. Clicking
+        // the button re-engages right-edge stickiness even if the user
+        // had previously dragged the brush.
+        brush.follow = isNetworkLogFollowMode(key);
+        if (brush.follow) {
+            const span = brush.endMs - brush.startMs;
+            brush.endMs = dataEndMs;
+            brush.startMs = Math.max(dataStartMs, brush.endMs - span);
+        }
+        // Clamp to data range and enforce the minimum brush width.
+        if (brush.endMs > dataEndMs) brush.endMs = dataEndMs;
+        if (brush.startMs < dataStartMs) brush.startMs = dataStartMs;
+        if (brush.endMs - brush.startMs < networkWaterfallMinBrushMs) {
+            // Try to expand left first; if there's not enough history,
+            // accept whatever we can fit (full session shorter than
+            // the minimum is fine — the floor only applies when the
+            // user could have a wider view).
+            brush.startMs = Math.max(dataStartMs, brush.endMs - networkWaterfallMinBrushMs);
+        }
 
-        rows.forEach((row, idx) => {
-            const groupId = idx + 1;
-            const method = row.entry.method || 'GET';
-            const status = row.entry.status || '—';
-            const labelClass = row.entry.faulted ? 'waterfall-rowtext is-faulted' : 'waterfall-rowtext';
-            const requestStartMs = row.timestamp;
-            const bytesOut = Number(row.entry.bytes_out || 0);
-            const bytesLabel = bytesOut > 0 ? formatBytes(bytesOut) : '—';
-            const mbpsLabel = formatMbpsFromBytesAndMs(bytesOut, row.transfer);
-            const variantLabel = row.variantLabel || '—';
-            const filenameLower = String(row.filename || '').toLowerCase();
-            let segmentLabel = '—';
-            const segmentMatch = filenameLower.match(/segment[_-](\d+)/);
-            if (segmentMatch) {
-                segmentLabel = segmentMatch[1];
-            } else if (filenameLower.includes('init.')) {
-                segmentLabel = 'init';
-            } else if (filenameLower.includes('playlist')) {
-                segmentLabel = 'playlist';
-            } else if (filenameLower.includes('master')) {
-                segmentLabel = 'master';
-            } else if (row.filename) {
-                segmentLabel = row.filename;
-            }
-            const labelText = [
-                formatColumn(method, 6),
-                formatColumn(row.pathDisplay, 54),
-                formatColumn(variantLabel, 10),
-                formatColumn(segmentLabel, 10),
-                formatColumn(status, 6, true),
-                formatColumn(bytesLabel, 10, true),
-                formatColumn(mbpsLabel, 10, true)
-            ].join(' ');
+        // Summary row: total + categorical counts. Read at a glance
+        // before the user starts panning the brush.
+        const summaryEl = card.querySelector('[data-field="netwf_summary"]');
+        if (summaryEl) {
+            renderWaterfallSummary(summaryEl, rows, dataStartMs, dataEndMs);
+        }
 
-            groups.push({
-                id: groupId,
-                content: `<span class="${labelClass}" title="${escapeHtml(row.entry.url || row.entry.path || '')}">${escapeHtml(labelText)}</span>`
-            });
+        // Time labels above the overview pane — full session range,
+        // independent of the brush. So the user sees both the
+        // big-picture wall clock (this row) and the zoomed-in
+        // wall clock (the row above the bars below).
+        const overviewAxis = card.querySelector('[data-field="netwf_overview_axis"]');
+        if (overviewAxis) {
+            renderWaterfallAxisTicks(overviewAxis, dataStartMs, dataEndMs);
+        }
 
-            const phases = [
-                { key: 'dns', value: row.dns, label: 'DNS' },
-                { key: 'connect', value: row.connect, label: 'Connect' },
-                { key: 'tls', value: row.tls, label: 'TLS' },
-                { key: 'wait', value: row.wait, label: 'Wait' },
-                { key: 'transfer', value: row.transfer, label: 'Receive' }
-            ];
-
-            let cursor = requestStartMs;
-            phases.forEach((phase) => {
-                if (phase.value <= 0) return;
-                const phaseStart = cursor;
-                const phaseEnd = cursor + phase.value;
-                items.push({
-                    id: `${groupId}-${phase.key}`,
-                    group: groupId,
-                    start: toTime(phaseStart),
-                    end: toTime(phaseEnd),
-                    className: `waterfall-phase waterfall-${phase.key}`,
-                    title: [
-                        `${method} ${row.filename}`,
-                        `Status: ${status}`,
-                        `${phase.label}: ${formatMilliseconds(phase.value)}`,
-                        `Total: ${formatMilliseconds(row.duration)}`,
-                        row.entry.url || row.entry.path || ''
-                    ].join('\n')
-                });
-                cursor = phaseEnd;
-            });
-        });
-
-        // Anchor preservation: when Following Latest is OFF, capture the
-        // topmost visible group's row index + pixel offset BEFORE the
-        // re-render so we can restore the user's view after the
-        // groups/items DataSet is replaced. Without this, vis-timeline's
-        // re-render snaps the scroll position to top and the user's view
-        // jumps every time new entries arrive.
-        let scrollAnchor = null;
-        if (!isNetworkLogFollowMode(key) && state.host) {
-            const center = state.host.querySelector('.vis-panel.vis-center');
-            const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
-            if (center && groupEls.length > 0) {
-                const centerRect = center.getBoundingClientRect();
-                for (const el of groupEls) {
-                    const r = el.getBoundingClientRect();
-                    if (r.height <= 0) continue;
-                    if (r.bottom > centerRect.top) {
-                        const groupId = parseInt(el.getAttribute('data-id') || el.dataset.id, 10);
-                        if (Number.isFinite(groupId)) {
-                            scrollAnchor = {
-                                rowIdx: groupId - 1,
-                                offsetWithinGroup: centerRect.top - r.top,
-                            };
-                        }
-                        break;
-                    }
-                }
+        // Render overview ticks (one per row, positioned by absolute
+        // time). Re-render is cheap; we redraw on every refresh.
+        // Apply the same status/fault classes the main rows use so
+        // bad requests stand out on the strip too.
+        if (overviewBars) {
+            overviewBars.replaceChildren();
+            for (const row of rows) {
+                const left = ((row.timestamp - dataStartMs) / fullSpan) * 100;
+                const width = Math.max(0.05, (Math.max(50, row.duration) / fullSpan) * 100);
+                const tick = document.createElement('div');
+                tick.className = 'netwf-overview-tick' + waterfallRowStatusClasses(row);
+                tick.style.left = `${left.toFixed(3)}%`;
+                tick.style.width = `${width.toFixed(3)}%`;
+                overviewBars.appendChild(tick);
             }
         }
 
-        state.groups.clear();
-        state.items.clear();
-        state.groups.add(groups);
-        state.items.add(items);
-        // Stash the rows so the auto-pan handler (issue #286) can map
-        // entries-list scroll position to a time window.
-        state.rows = rows;
+        // Position the brush to match its current state.
+        if (brushEl) {
+            const left = ((brush.startMs - dataStartMs) / fullSpan) * 100;
+            const width = ((brush.endMs - brush.startMs) / fullSpan) * 100;
+            brushEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
+            brushEl.style.width = `${Math.max(0.5, width).toFixed(3)}%`;
+        }
 
-        const fullStartMs = dataStartMs;
-        const latestTransferEndMs = dataEndMs;
-        const rightPadMs = 1000;
-        const fullEndMs = latestTransferEndMs + rightPadMs;
-        networkWaterfallFullRangeBySession.set(key, { startMs: fullStartMs, endMs: fullEndMs });
-        state.timeline.setOptions({
-            // Clamp user pan/zoom to the session's full data range so the
-            // viewer can't drift into empty space outside the session.
-            min: toTime(fullStartMs),
-            max: toTime(fullEndMs),
-            zoomMax: Math.max(1000, fullEndMs - fullStartMs),
-            zoomMin: 100 // Don't let users zoom-in tighter than 100ms.
+        // Lazy-attach brush drag handlers (one set per overview).
+        if (overviewEl && !overviewEl.dataset.netwfBound) {
+            overviewEl.dataset.netwfBound = '1';
+            attachBrushHandlers(card, overviewEl, brushEl);
+        }
+
+        // Filter the row list to requests that overlap the brush
+        // window. The overview above keeps showing the full session;
+        // the list below shows only what the user has selected.
+        const visibleRows = rows.filter((row) => {
+            const reqEnd = row.timestamp + Math.max(50, row.duration);
+            return reqEnd >= brush.startMs && row.timestamp <= brush.endMs;
         });
-        const storedView = networkWaterfallViewBySession.get(key);
-        const following = isNetworkLogFollowMode(key);
+
+        // Sticky axis row at the top of the list — column headers (with
+        // drag-to-resize handles) on the left, tick marks across the
+        // brush window on the right. One axis row in DOM, rebuilt only
+        // when its content changes.
+        let axisEl = chartHost.firstElementChild;
+        if (!axisEl || !axisEl.classList.contains('netwf-axis')) {
+            axisEl = buildWaterfallAxisRow(chartHost);
+            if (chartHost.firstElementChild) {
+                chartHost.insertBefore(axisEl, chartHost.firstElementChild);
+            } else {
+                chartHost.appendChild(axisEl);
+            }
+        }
+        // Update the time-cell header text with current count.
+        const timeHdr = axisEl.querySelector('.netwf-cell.time');
+        if (timeHdr) timeHdr.textContent = `${visibleRows.length}/${rows.length}`;
+        const axisScale = axisEl.querySelector('[data-field="netwf_axis_scale"]');
+        if (axisScale) {
+            renderWaterfallAxisTicks(axisScale, brush.startMs, brush.endMs);
+        }
+
+        // Diff-based DOM updates for the row list. Native scroll keeps
+        // its position when only existing rows update / new ones
+        // append. Note: the axis row sits at index 0, so data rows
+        // start at child index 1.
+        const sigs = visibleRows.map(buildRowSignature);
+        const oldSigs = networkWaterfallRowSignaturesBySession.get(key) || [];
+        const winKey = `${Math.round(brush.startMs)}-${Math.round(brush.endMs)}`;
+        const winChanged = chartHost.dataset.netwfWin !== winKey;
+
+        // Trim removed rows (filter shrunk OR ring buffer evicted).
+        while (chartHost.children.length - 1 > visibleRows.length) {
+            chartHost.removeChild(chartHost.lastElementChild);
+        }
+        visibleRows.forEach((row, idx) => {
+            const domIdx = idx + 1; // axis is at index 0
+            const existing = chartHost.children[domIdx];
+            if (existing && !winChanged && oldSigs[idx] === sigs[idx]) return;
+            const rowEl = buildWaterfallRowEl(row, idx, brush.startMs, brush.endMs);
+            if (existing) {
+                chartHost.replaceChild(rowEl, existing);
+            } else {
+                chartHost.appendChild(rowEl);
+            }
+        });
+        chartHost.dataset.netwfWin = winKey;
+        networkWaterfallRowSignaturesBySession.set(key, sigs);
+        // Keep the unfiltered rows on the session so the brush handler
+        // knows the full data range.
+        networkWaterfallRowsBySession.set(key, rows);
+        networkWaterfallRenderSignatureBySession.set(key, sigs.length + ':' + (sigs[sigs.length - 1] || ''));
+
+        if (scrollHost && isNetworkLogFollowMode(key)) {
+            scrollHost.scrollTop = scrollHost.scrollHeight;
+        }
         updateNetworkLogFollowButton(card, key);
-        if (following) {
-            const spanFromStored = (storedView && Number.isFinite(storedView.startMs) && Number.isFinite(storedView.endMs))
-                ? (storedView.endMs - storedView.startMs)
-                : (fullEndMs - fullStartMs);
-            const spanMs = Math.max(20, Math.min(spanFromStored, Math.max(20, fullEndMs - fullStartMs)));
-            const followEnd = fullEndMs;
-            const followStart = Math.max(fullStartMs, followEnd - spanMs);
-            state.timeline.setWindow(toTime(followStart), toTime(followEnd), { animation: false });
-            networkWaterfallViewBySession.set(key, { startMs: followStart, endMs: followEnd });
-        } else if (storedView && Number.isFinite(storedView.startMs) && Number.isFinite(storedView.endMs)) {
-            const clampedStart = Math.max(fullStartMs, Math.min(fullEndMs, storedView.startMs));
-            const clampedEnd = Math.max(clampedStart + 20, Math.min(fullEndMs, storedView.endMs));
-            state.timeline.setWindow(toTime(clampedStart), toTime(clampedEnd), { animation: false });
-        } else {
-            state.timeline.setWindow(toTime(fullStartMs), toTime(fullEndMs), { animation: false });
+
+        // Lazy-attach scroll listener — scrolling away from the bottom
+        // disables Following Latest.
+        if (scrollHost && !scrollHost.dataset.netwfBound) {
+            scrollHost.dataset.netwfBound = '1';
+            scrollHost.addEventListener('scroll', () => {
+                const c = scrollHost.closest('.session-card');
+                const sid = c ? String(c.dataset.sessionId || '') : '';
+                if (!sid) return;
+                if (isNetworkLogFollowMode(sid) && scrollHost.scrollTop + scrollHost.clientHeight < scrollHost.scrollHeight - 4) {
+                    setNetworkLogFollowMode(sid, false);
+                    updateNetworkLogFollowButton(c, sid);
+                }
+            }, { passive: true });
         }
-        state.timeline.redraw();
-        if (following) {
-            scrollWaterfallToLatestRow(state);
-        } else if (scrollAnchor) {
-            // Re-render snapped vis-timeline's scroll to top — restore
-            // the user's view by scrolling the same row back into the
-            // same vertical offset within the viewport.
-            window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => restoreScrollAnchor(state, scrollAnchor));
-            });
-        }
-        // After the initial render, drive the time window from the
-        // currently-visible rows when Follow Scroll is on. The setWindow
-        // calls above bracket the data range; auto-pan tightens to just
-        // what the user is looking at. Two rAFs let vis-timeline lay out
-        // its panels (the second one is when scrollHeight is final).
-        if (isFollowScrollMode(key) && state.autoPan) {
-            window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => applyWaterfallAutoPan(state, key));
-            });
+
+        // Lazy-attach hover tooltip handlers on the chart host.
+        if (chartHost && !chartHost.dataset.netwfTipBound) {
+            chartHost.dataset.netwfTipBound = '1';
+            attachWaterfallHoverTooltip(chartHost);
         }
     }
+
+    let netwfTooltipEl = null;
+    function ensureNetwfTooltip() {
+        if (netwfTooltipEl && document.body.contains(netwfTooltipEl)) return netwfTooltipEl;
+        netwfTooltipEl = document.createElement('div');
+        netwfTooltipEl.className = 'netwf-tooltip';
+        document.body.appendChild(netwfTooltipEl);
+        return netwfTooltipEl;
+    }
+
+    function attachWaterfallHoverTooltip(chartHost) {
+        let activeRowEl = null;
+        const onMove = (event) => {
+            const rowEl = event.target.closest('.netwf-row');
+            if (!rowEl || !chartHost.contains(rowEl) || !rowEl.__netwfRow) {
+                hideTip();
+                return;
+            }
+            if (rowEl !== activeRowEl) {
+                activeRowEl = rowEl;
+                renderTipFor(rowEl.__netwfRow);
+            }
+            positionTip(event.clientX, event.clientY);
+        };
+        const onLeave = () => hideTip();
+        chartHost.addEventListener('mousemove', onMove);
+        chartHost.addEventListener('mouseleave', onLeave);
+    }
+
+    function renderTipFor(row) {
+        const tip = ensureNetwfTooltip();
+        const entry = row.entry || {};
+        const status = entry.status ? String(entry.status) : '—';
+        const method = entry.method || 'GET';
+        const bytesOut = Number(entry.bytes_out || 0);
+        const bytesLabel = bytesOut > 0 ? formatBytes(bytesOut) : '—';
+        const mbpsLabel = formatMbpsFromBytesAndMs(bytesOut, row.transfer);
+        const startedAt = new Date(row.timestamp);
+        const startedLabel = `${String(startedAt.getHours()).padStart(2,'0')}:${String(startedAt.getMinutes()).padStart(2,'0')}:${String(startedAt.getSeconds()).padStart(2,'0')}.${String(startedAt.getMilliseconds()).padStart(3,'0')}`;
+
+        const phases = [
+            { key: 'dns', name: 'DNS', value: row.dns },
+            { key: 'connect', name: 'Connect', value: row.connect },
+            { key: 'tls', name: 'TLS', value: row.tls },
+            { key: 'wait', name: 'Wait (TTFB)', value: row.wait },
+            { key: 'transfer', name: 'Receive', value: row.transfer }
+        ].filter((p) => p.value > 0);
+
+        const phaseRows = phases.map((p) =>
+            `<div class="netwf-tooltip-phase-swatch ${p.key}"></div>`
+            + `<div class="netwf-tooltip-phase-name">${escapeHtml(p.name)}</div>`
+            + `<div class="netwf-tooltip-phase-value">${escapeHtml(formatMilliseconds(p.value))}</div>`
+        ).join('');
+
+        const variant = row.variantLabel ? row.variantLabel : '—';
+        const filename = row.filename || '—';
+        const faultBlock = entry.faulted
+            ? `<div class="netwf-tooltip-fault"><strong>FAULT</strong>: ${escapeHtml(entry.fault_type || 'unknown')}${entry.fault_action ? ` · ${escapeHtml(entry.fault_action)}` : ''}</div>`
+            : '';
+        const url = entry.url || entry.path || '';
+
+        const attemptStr = row.totalAttempts > 1
+            ? `${row.attempt} of ${row.totalAttempts}`
+                + (row.gap_from_prev_ms !== null && row.gap_from_prev_ms !== undefined
+                    ? ` · ${formatMilliseconds(row.gap_from_prev_ms)} since previous`
+                    : '')
+                + (row.is_retry
+                    ? ` (quick retry · cutoff ${formatMilliseconds(row.retry_threshold_ms || 0)})`
+                    : '')
+            : '1';
+        const reqRange = entry.request_range || '';
+        const respRange = entry.response_content_range || '';
+        const rangeStr = reqRange || respRange
+            ? `${reqRange ? `req: ${reqRange}` : ''}${reqRange && respRange ? ' · ' : ''}${respRange ? `resp: ${respRange}` : ''}`
+            : '';
+
+        tip.innerHTML = `
+            <div class="netwf-tooltip-head">${escapeHtml(method)} ${escapeHtml(filename)}</div>
+            <dl class="netwf-tooltip-meta">
+                <dt>Status</dt><dd>${escapeHtml(status)}${status === '206' ? ' (Partial Content)' : ''}</dd>
+                <dt>Total</dt><dd>${escapeHtml(formatMilliseconds(row.duration))}</dd>
+                <dt>Bytes</dt><dd>${escapeHtml(bytesLabel)} @ ${escapeHtml(mbpsLabel)}</dd>
+                <dt>Variant</dt><dd>${escapeHtml(variant)}</dd>
+                <dt>Started</dt><dd>${escapeHtml(startedLabel)}</dd>
+                <dt>Attempt</dt><dd>${escapeHtml(attemptStr)}</dd>
+                ${rangeStr ? `<dt>Range</dt><dd>${escapeHtml(rangeStr)}</dd>` : ''}
+            </dl>
+            <div class="netwf-tooltip-phases">${phaseRows || '<div></div><div class="netwf-tooltip-phase-name">no phase data</div><div></div>'}</div>
+            ${faultBlock}
+            ${url ? `<div class="netwf-tooltip-url">${escapeHtml(url)}</div>` : ''}
+        `;
+        tip.classList.add('visible');
+    }
+
+    function positionTip(clientX, clientY) {
+        const tip = ensureNetwfTooltip();
+        if (!tip.classList.contains('visible')) return;
+        const margin = 12;
+        // Read after innerHTML has been set so dimensions reflect content.
+        const rect = tip.getBoundingClientRect();
+        let left = clientX + 14;
+        let top = clientY + 14;
+        if (left + rect.width + margin > window.innerWidth) {
+            left = clientX - rect.width - 14;
+        }
+        if (top + rect.height + margin > window.innerHeight) {
+            top = clientY - rect.height - 14;
+        }
+        if (left < margin) left = margin;
+        if (top < margin) top = margin;
+        tip.style.left = `${left}px`;
+        tip.style.top = `${top}px`;
+    }
+
+    function hideTip() {
+        if (netwfTooltipEl) netwfTooltipEl.classList.remove('visible');
+    }
+
+    function buildRowSignature(row) {
+        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}`;
+    }
+
+    function waterfallRowStatusClasses(row) {
+        const cls = [];
+        const status = Number(row.entry.status) || 0;
+        if (status === 206) cls.push(' status-206');
+        else if (status >= 200 && status < 300) cls.push(' status-2xx');
+        else if (status >= 300 && status < 400) cls.push(' status-3xx');
+        else if (status >= 400 && status < 500) cls.push(' status-4xx');
+        else if (status >= 500) cls.push(' status-5xx');
+
+        const ft = String(row.entry.fault_type || '').toLowerCase();
+        if (ft.includes('timeout')) cls.push(' fault-timeout');
+        else if (ft.includes('corrupt') || ft.includes('partial') || isWaterfallRowIncomplete(row)) cls.push(' fault-incomplete');
+        else if (row.entry.faulted) cls.push(' is-faulted');
+
+        if (row.is_retry) cls.push(' is-retry');
+        return cls.join('');
+    }
+
+    function isWaterfallRowIncomplete(row) {
+        const ft = String(row.entry.fault_type || '').toLowerCase();
+        if (ft.includes('timeout') || ft.includes('corrupt') || ft.includes('partial') || ft.includes('abandon')) return true;
+        // Heuristic: faulted with bytes-out smaller than expected. We
+        // don't always know "expected", but a faulted entry with a
+        // 2xx status implies the proxy injected a partial/incomplete
+        // response.
+        const status = Number(row.entry.status) || 0;
+        if (row.entry.faulted && status >= 200 && status < 300) return true;
+        return false;
+    }
+
+    function buildWaterfallRowEl(row, idx, winStart, winEnd) {
+        const el = document.createElement('div');
+        el.className = 'netwf-row' + waterfallRowStatusClasses(row);
+        el.dataset.rowIdx = String(idx);
+        // Stash the row data on the DOM node so the hover tooltip can
+        // build a rich expansion without re-querying the session map.
+        el.__netwfRow = row;
+
+        // Column cells. Widths come from CSS vars on the chart host —
+        // resizing a header reflows every row in sync.
+        const ts = new Date(row.timestamp);
+        const tsLabel = `${String(ts.getHours()).padStart(2,'0')}:${String(ts.getMinutes()).padStart(2,'0')}:${String(ts.getSeconds()).padStart(2,'0')}.${String(ts.getMilliseconds()).padStart(3,'0')}`;
+        const method = row.entry.method || 'GET';
+        const bytesOut = Number(row.entry.bytes_out || 0);
+        const bytesLabel = formatKBNumber(bytesOut);
+        const mbpsLabel = formatMbpsNumber(bytesOut, row.transfer);
+        const path = row.pathDisplay || row.filename || '';
+        const flags = (row.is_retry ? '↻' : '') + (row.entry.faulted ? '!' : '');
+        const statusCode = Number(row.entry.status) || 0;
+
+        const cells = [
+            { col: 'time', text: tsLabel },
+            { col: 'flags', text: flags, color: row.is_retry ? '#be185d' : (row.entry.faulted ? '#7f1d1d' : '') },
+            { col: 'method', text: method },
+            { col: 'path', text: path, title: row.entry.url || row.entry.path || '' },
+            { col: 'bytes', text: bytesLabel },
+            { col: 'mbps', text: mbpsLabel },
+            { col: 'status', text: statusCode > 0 ? String(statusCode) : '—' }
+        ];
+        for (const c of cells) {
+            const cellEl = document.createElement('div');
+            cellEl.className = `netwf-cell ${c.col}`;
+            cellEl.textContent = c.text;
+            if (c.title) cellEl.title = c.title;
+            if (c.color) cellEl.style.color = c.color;
+            el.appendChild(cellEl);
+        }
+
+        const trackEl = document.createElement('div');
+        trackEl.className = 'netwf-row-track';
+
+        const winSpan = Math.max(50, winEnd - winStart);
+        const reqStart = row.timestamp;
+        const reqEnd = row.timestamp + Math.max(50, row.duration);
+        // Off-screen rows (entirely outside the brush): render an
+        // empty track so vertical alignment with the URL list stays
+        // correct.
+        if (reqEnd >= winStart && reqStart <= winEnd) {
+            const left = ((reqStart - winStart) / winSpan) * 100;
+            const width = ((reqEnd - reqStart) / winSpan) * 100;
+            const barEl = document.createElement('div');
+            barEl.className = 'netwf-row-bar' + (isWaterfallRowIncomplete(row) ? ' is-incomplete' : '');
+            barEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
+            barEl.style.width = `${Math.max(0.2, width).toFixed(3)}%`;
+            // No native title — custom hover tooltip handles details.
+            const phases = [
+                { key: 'dns', value: row.dns },
+                { key: 'connect', value: row.connect },
+                { key: 'tls', value: row.tls },
+                { key: 'wait', value: row.wait },
+                { key: 'transfer', value: row.transfer }
+            ];
+            const total = phases.reduce((sum, p) => sum + Math.max(0, p.value), 0);
+            for (const phase of phases) {
+                if (phase.value <= 0) continue;
+                const seg = document.createElement('div');
+                seg.className = `netwf-row-phase ${phase.key}`;
+                seg.style.flex = `${phase.value / total} 0 0`;
+                barEl.appendChild(seg);
+            }
+            trackEl.appendChild(barEl);
+
+            // Duration text just past the right edge of the bar. If
+            // the bar is too far right to fit text after it, anchor
+            // the text just before the bar's right edge instead.
+            const right = Math.max(0, left) + Math.max(0.2, width);
+            const durEl = document.createElement('div');
+            durEl.className = 'netwf-row-duration';
+            durEl.textContent = formatMilliseconds(row.duration);
+            if (right < 90) {
+                durEl.style.left = `calc(${right.toFixed(3)}% + 6px)`;
+            } else {
+                durEl.style.right = `${(100 - right + 0.5).toFixed(3)}%`;
+            }
+            trackEl.appendChild(durEl);
+        }
+
+        el.appendChild(trackEl);
+        return el;
+    }
+
+    // Header column definitions — `key` matches CSS variable name
+    // (`--netwf-col-${key}`) and the cell class. `min` is the smallest
+    // pixel width we'll let the user drag the column to.
+    const NETWF_COLUMNS = [
+        { key: 'time',   label: 'Time',     min: 60 },
+        { key: 'flags',  label: '',         min: 16 },
+        { key: 'method', label: 'Method',   min: 30 },
+        { key: 'path',   label: 'Path',     min: 60 },
+        // Single-unit columns: header carries the unit, cells carry
+        // tabular-aligned numbers. Bytes always rendered in KB,
+        // throughput always in Mbps — easier to scan than mixed units.
+        { key: 'bytes',  label: 'KB',       min: 50 },
+        { key: 'mbps',   label: 'Mbps',     min: 50 },
+        { key: 'status', label: 'Status',   min: 40 }
+    ];
+
+    function buildWaterfallAxisRow(chartHost) {
+        const axisEl = document.createElement('div');
+        axisEl.className = 'netwf-axis';
+        for (const col of NETWF_COLUMNS) {
+            const cell = document.createElement('div');
+            cell.className = `netwf-cell ${col.key}`;
+            cell.textContent = col.label;
+            const resizer = document.createElement('div');
+            resizer.className = 'netwf-cell-resizer';
+            resizer.dataset.col = col.key;
+            resizer.dataset.minPx = String(col.min);
+            cell.appendChild(resizer);
+            attachWaterfallColumnResizer(chartHost, resizer);
+            axisEl.appendChild(cell);
+        }
+        const scale = document.createElement('div');
+        scale.className = 'netwf-axis-scale';
+        scale.dataset.field = 'netwf_axis_scale';
+        axisEl.appendChild(scale);
+        return axisEl;
+    }
+
+    function attachWaterfallColumnResizer(chartHost, resizer) {
+        let drag = null;
+        resizer.addEventListener('mousedown', (e) => {
+            const col = resizer.dataset.col;
+            if (!col) return;
+            const cell = resizer.parentElement;
+            const startPx = cell.getBoundingClientRect().width;
+            drag = {
+                col,
+                startX: e.clientX,
+                startPx,
+                minPx: parseInt(resizer.dataset.minPx, 10) || 30,
+                cssVar: `--netwf-col-${col}`
+            };
+            resizer.classList.add('dragging');
+            document.body.style.cursor = 'col-resize';
+            e.preventDefault();
+            e.stopPropagation();
+        });
+        const onMove = (e) => {
+            if (!drag) return;
+            const next = Math.max(drag.minPx, drag.startPx + (e.clientX - drag.startX));
+            chartHost.style.setProperty(drag.cssVar, `${Math.round(next)}px`);
+        };
+        const onUp = () => {
+            if (!drag) return;
+            // Persist the new width so it survives session-card re-renders
+            // and page reloads.
+            try {
+                const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
+                stored[drag.col] = chartHost.style.getPropertyValue(`--netwf-col-${drag.col}`);
+                localStorage.setItem('netwf-cols-v2', JSON.stringify(stored));
+            } catch (_) { /* no-op */ }
+            drag = null;
+            resizer.classList.remove('dragging');
+            document.body.style.cursor = '';
+        };
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    }
+
+    // Re-apply persisted column widths to a chart host on first
+    // render so user preferences survive page reloads.
+    function applyPersistedWaterfallColumns(chartHost) {
+        if (!chartHost || chartHost.dataset.netwfColsApplied) return;
+        chartHost.dataset.netwfColsApplied = '1';
+        try {
+            const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
+            for (const col of NETWF_COLUMNS) {
+                const v = stored[col.key];
+                if (v) chartHost.style.setProperty(`--netwf-col-${col.key}`, v);
+            }
+        } catch (_) { /* no-op */ }
+    }
+
+    function renderWaterfallAxisTicks(host, winStart, winEnd) {
+        host.replaceChildren();
+        const span = winEnd - winStart;
+        if (span <= 0) return;
+        const targetTickCount = 6;
+        const niceMs = pickNiceTickIntervalMs(span / targetTickCount);
+        const firstTick = Math.ceil(winStart / niceMs) * niceMs;
+        for (let t = firstTick; t <= winEnd; t += niceMs) {
+            const left = ((t - winStart) / span) * 100;
+            if (left < 0 || left > 100) continue;
+            const tick = document.createElement('div');
+            tick.className = 'netwf-axis-tick';
+            tick.style.left = `${left.toFixed(3)}%`;
+            host.appendChild(tick);
+            const label = document.createElement('div');
+            label.className = 'netwf-axis-tick-label';
+            label.style.left = `${left.toFixed(3)}%`;
+            label.textContent = formatAxisTickLabel(t);
+            host.appendChild(label);
+        }
+        // Right-aligned summary: brush span (zoom level).
+        const summary = document.createElement('div');
+        summary.className = 'netwf-axis-summary';
+        summary.textContent = `Δ ${formatMilliseconds(span)}`;
+        host.appendChild(summary);
+    }
+
+    function renderWaterfallSummary(host, rows, dataStartMs, dataEndMs) {
+        const counts = {
+            total: rows.length,
+            success: 0,
+            partial: 0,
+            client: 0,
+            server: 0,
+            faulted: 0,
+            timeout: 0,
+            disconnect: 0,
+            retry: 0
+        };
+        for (const row of rows) {
+            const status = Number(row.entry.status) || 0;
+            if (status === 206) counts.partial += 1;
+            else if (status >= 200 && status < 300) counts.success += 1;
+            else if (status >= 400 && status < 500) counts.client += 1;
+            else if (status >= 500) counts.server += 1;
+
+            const ft = String(row.entry.fault_type || '').toLowerCase();
+            if (ft.includes('timeout')) counts.timeout += 1;
+            else if (ft.includes('client_disconnect') || ft === 'client_disconnect') counts.disconnect += 1;
+            else if (row.entry.faulted) counts.faulted += 1;
+
+            if (row.is_retry) counts.retry += 1;
+        }
+        const span = Math.max(0, dataEndMs - dataStartMs);
+        const pill = (cls, label, count) => {
+            const zero = count === 0 ? ' zero' : '';
+            return `<span class="netwf-summary-pill ${cls}${zero}"><span class="count">${count}</span> ${escapeHtml(label)}</span>`;
+        };
+        host.innerHTML = [
+            `<span class="netwf-summary-pill total"><span class="count">${counts.total}</span> requests</span>`,
+            `<span class="netwf-summary-pill span">${escapeHtml(formatMilliseconds(span))} span</span>`,
+            pill('success', '2xx', counts.success),
+            pill('partial', '206', counts.partial),
+            pill('client-error', '4xx', counts.client),
+            pill('server-error', '5xx', counts.server),
+            pill('faulted', 'faulted', counts.faulted),
+            pill('timeout', 'timeouts', counts.timeout),
+            pill('disconnect', 'disconnects', counts.disconnect),
+            pill('retry', 'retries', counts.retry)
+        ].join('');
+    }
+
+    function pickNiceTickIntervalMs(roughMs) {
+        const candidates = [10, 25, 50, 100, 200, 250, 500, 1000, 2000, 5000, 10000, 15000, 30000, 60000, 120000, 300000];
+        for (const c of candidates) if (c >= roughMs) return c;
+        return Math.ceil(roughMs / 60000) * 60000;
+    }
+
+    function formatAxisTickLabel(absMs) {
+        const d = new Date(absMs);
+        const hh = String(d.getHours()).padStart(2, '0');
+        const mm = String(d.getMinutes()).padStart(2, '0');
+        const ss = String(d.getSeconds()).padStart(2, '0');
+        return `${hh}:${mm}:${ss}`;
+    }
+
+    // Brush drag/resize handlers. The brush is positioned in % of the
+    // overview's width, so we convert px deltas to % via the
+    // overview's bounding rect. Drag-pan or drag-resize disables
+    // Following Latest so the user's selection stays put.
+    function attachBrushHandlers(card, overviewEl, brushEl) {
+        if (!overviewEl) return;
+        const sessionId = String(card.dataset.sessionId || '');
+        if (!sessionId) return;
+
+        let drag = null;
+
+        const startDrag = (event, mode) => {
+            const rect = overviewEl.getBoundingClientRect();
+            if (rect.width <= 0) return;
+            const rows = networkWaterfallRowsBySession.get(sessionId) || [];
+            if (!rows.length) return;
+            const dataStartMs = rows[0].timestamp;
+            const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+            const fullSpan = Math.max(50, dataEndMs - dataStartMs);
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            drag = {
+                mode,
+                rect,
+                fullSpan,
+                dataStartMs,
+                dataEndMs,
+                startBrushStart: brush.startMs,
+                startBrushEnd: brush.endMs,
+                pointerStartX: event.clientX
+            };
+            brushEl?.classList.add('dragging');
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        const onPointerMove = (event) => {
+            if (!drag) return;
+            const dxPx = event.clientX - drag.pointerStartX;
+            const dxMs = (dxPx / drag.rect.width) * drag.fullSpan;
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            if (drag.mode === 'pan') {
+                let newStart = drag.startBrushStart + dxMs;
+                let newEnd = drag.startBrushEnd + dxMs;
+                const span = newEnd - newStart;
+                if (newStart < drag.dataStartMs) { newStart = drag.dataStartMs; newEnd = newStart + span; }
+                if (newEnd > drag.dataEndMs) { newEnd = drag.dataEndMs; newStart = newEnd - span; }
+                brush.startMs = newStart;
+                brush.endMs = newEnd;
+            } else if (drag.mode === 'resize-left') {
+                let newStart = drag.startBrushStart + dxMs;
+                if (newStart < drag.dataStartMs) newStart = drag.dataStartMs;
+                // Enforce the minimum brush width — never let the user
+                // drag the left handle within networkWaterfallMinBrushMs
+                // of the right edge.
+                if (newStart > brush.endMs - networkWaterfallMinBrushMs) {
+                    newStart = brush.endMs - networkWaterfallMinBrushMs;
+                }
+                brush.startMs = newStart;
+            } else if (drag.mode === 'resize-right') {
+                let newEnd = drag.startBrushEnd + dxMs;
+                if (newEnd > drag.dataEndMs) newEnd = drag.dataEndMs;
+                if (newEnd < brush.startMs + networkWaterfallMinBrushMs) {
+                    newEnd = brush.startMs + networkWaterfallMinBrushMs;
+                }
+                brush.endMs = newEnd;
+            }
+            brush.follow = false;
+            // Disable Following Latest so the user's pick sticks.
+            if (isNetworkLogFollowMode(sessionId)) {
+                setNetworkLogFollowMode(sessionId, false);
+                updateNetworkLogFollowButton(card, sessionId);
+            }
+            updateNetworkWaterfall(card, sessionId);
+        };
+
+        const onPointerUp = () => {
+            if (!drag) return;
+            drag = null;
+            brushEl?.classList.remove('dragging');
+        };
+
+        // Brush body = pan. Handles = resize. Click on bare overview
+        // jumps the brush centre to the click point.
+        if (brushEl) {
+            brushEl.addEventListener('mousedown', (e) => {
+                if (e.target.classList.contains('netwf-brush-handle')) return;
+                startDrag(e, 'pan');
+            });
+            const leftHandle = brushEl.querySelector('.netwf-brush-handle.left');
+            const rightHandle = brushEl.querySelector('.netwf-brush-handle.right');
+            if (leftHandle) leftHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-left'));
+            if (rightHandle) rightHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-right'));
+        }
+        overviewEl.addEventListener('mousedown', (e) => {
+            if (e.target !== overviewEl && !e.target.classList.contains('netwf-overview-bars')) return;
+            const rect = overviewEl.getBoundingClientRect();
+            const rows = networkWaterfallRowsBySession.get(sessionId) || [];
+            if (!rows.length || rect.width <= 0) return;
+            const dataStartMs = rows[0].timestamp;
+            const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+            const fullSpan = Math.max(50, dataEndMs - dataStartMs);
+            const fracX = (e.clientX - rect.left) / rect.width;
+            const targetMs = dataStartMs + fracX * fullSpan;
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            const span = brush.endMs - brush.startMs;
+            brush.startMs = Math.max(dataStartMs, targetMs - span / 2);
+            brush.endMs = Math.min(dataEndMs, brush.startMs + span);
+            brush.startMs = brush.endMs - span;
+            brush.follow = false;
+            if (isNetworkLogFollowMode(sessionId)) {
+                setNetworkLogFollowMode(sessionId, false);
+                updateNetworkLogFollowButton(card, sessionId);
+            }
+            updateNetworkWaterfall(card, sessionId);
+        });
+
+        document.addEventListener('mousemove', onPointerMove);
+        document.addEventListener('mouseup', onPointerUp);
+    }
+
 
     function updateNetworkLog(sessionId, options = {}) {
         if (!networkLogDeveloperEnabled) return;

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1802,16 +1802,29 @@
 
         const rows = entries.slice().map((entry, index) => {
             const timestamp = Date.parse(entry.timestamp || '') || 0;
+            // Upstream-perspective phases (proxy → origin) — surfaced in the
+            // tooltip for forensics but not part of the player-perceived bar.
             const dns = Number(entry.dns_ms || 0);
             const connect = Number(entry.connect_ms || 0);
             const tls = Number(entry.tls_ms || 0);
             const ttfb = Number(entry.ttfb_ms || 0);
             const total = Number(entry.total_ms || 0);
             const transferRaw = Number(entry.transfer_ms || 0);
+            // Player-perceived wait — request received → first response byte
+            // sent. Falls back to the legacy upstream-derived value for
+            // entries written before the downstream-timings change (#272).
+            const clientWaitRaw = Number(entry.client_wait_ms || 0);
             const handshake = dns + connect + tls;
-            const wait = Math.max(0, ttfb - handshake);
+            const wait = clientWaitRaw > 0
+                ? clientWaitRaw
+                : Math.max(0, ttfb - handshake);
             const transfer = transferRaw > 0 ? transferRaw : Math.max(0, total - ttfb);
-            const duration = Math.max(0, dns + connect + tls + wait + transfer);
+            // The bar represents the player's view: just wait + transfer.
+            // The upstream handshake phases are out-of-band (proxy ↔ origin)
+            // and don't count toward what the player saw.
+            const duration = clientWaitRaw > 0
+                ? Math.max(0, wait + transfer)
+                : Math.max(0, dns + connect + tls + wait + transfer);
             const parsed = parsePathAndVariant(entry);
             const prefix = entry.faulted ? '!' : '';
             return {
@@ -1950,6 +1963,9 @@
         if (!state || !state.timeline || !fullRange) return;
         if (!Number.isFinite(fullRange.startMs) || !Number.isFinite(fullRange.endMs) || fullRange.endMs <= fullRange.startMs) return;
 
+        // Re-enable auto-pan: user explicitly asked for a coordinated view.
+        state.autoPan = true;
+
         if (direction === 'fit') {
             resetWaterfallView(state, key);
             return;
@@ -2062,13 +2078,96 @@
                     networkWaterfallViewBySession.set(key, { startMs, endMs });
                     setNetworkLogFollowMode(key, false);
                     updateNetworkLogFollowButton(null, key);
+                    // User took manual control — stop auto-panning until
+                    // they hit Fit / First / Last (issue #286).
+                    state.autoPan = false;
                 }
             });
-            state = { host: field, timeline, groups, items, drag: null };
+            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: true };
             bindWaterfallSelectionHandlers(state, key);
+            attachWaterfallAutoPan(state, key);
             networkWaterfallTimelines.set(key, state);
         }
         return state;
+    }
+
+    // attachWaterfallAutoPan listens to scroll events on the entries list
+    // (vis-timeline's left + center panels share scrollTop) and pans the
+    // visible time window to match the rows the user is looking at. Issue #286.
+    function attachWaterfallAutoPan(state, key) {
+        if (!state || !state.host || state.autoPanBound) return;
+        const setupOnce = () => {
+            if (!state.host) return false;
+            const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
+            const center = state.host.querySelector('.vis-panel.vis-center .vis-content');
+            if (!left && !center) return false;
+            let rafId = null;
+            const onScroll = () => {
+                if (!state.autoPan) return;
+                if (rafId) return;
+                rafId = window.requestAnimationFrame(() => {
+                    rafId = null;
+                    applyWaterfallAutoPan(state, key);
+                });
+            };
+            if (left) left.addEventListener('scroll', onScroll, { passive: true });
+            if (center && center !== left) center.addEventListener('scroll', onScroll, { passive: true });
+            state.autoPanBound = true;
+            return true;
+        };
+        // vis-timeline builds its DOM async — retry a few frames if the
+        // .vis-content nodes aren't there yet.
+        let attempts = 0;
+        const retry = () => {
+            if (setupOnce()) return;
+            attempts += 1;
+            if (attempts < 20) window.requestAnimationFrame(retry);
+        };
+        window.requestAnimationFrame(retry);
+    }
+
+    // applyWaterfallAutoPan computes the time range covered by the
+    // entries list's currently-visible rows and pans the waterfall to it.
+    function applyWaterfallAutoPan(state, key) {
+        if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
+        if (!state.host) return;
+        // Re-check autoPan: the user may have done Alt+scroll/right-drag
+        // between the scroll event and this rAF firing — `onScroll`
+        // already gates new schedules but a previously-queued rAF would
+        // otherwise override the manual pan.
+        if (!state.autoPan) return;
+        const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
+        if (!left) return;
+        const scrollTop = left.scrollTop;
+        const clientH = left.clientHeight;
+        const scrollH = left.scrollHeight;
+        if (scrollH <= clientH) return;
+        const rowCount = state.rows.length;
+        const rowHeight = scrollH / rowCount;
+        if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
+        const startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
+        const endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        if (endIdx < startIdx) return;
+        const startTs = state.rows[startIdx].timestamp;
+        const endRow = state.rows[endIdx];
+        const endTs = endRow.timestamp + Math.max(50, endRow.duration);
+        if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
+        // Pad 5% on each side so adjacent bars peek in at the edges.
+        const padding = Math.max(50, (endTs - startTs) * 0.05);
+        const fullRange = networkWaterfallFullRangeBySession.get(key);
+        let nextStart = startTs - padding;
+        let nextEnd = endTs + padding;
+        if (fullRange) {
+            // Don't pan past the session's data bounds.
+            if (nextStart < fullRange.startMs) nextStart = fullRange.startMs;
+            if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
+        }
+        if (nextEnd <= nextStart) return;
+        // Suppress the rangechanged user-flag for our own setWindow call —
+        // vis-timeline doesn't fire byUser=true when we drive setWindow,
+        // so this is mostly belt-and-suspenders.
+        state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
+        networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
 
     function updateNetworkWaterfall(card, sessionId) {
@@ -2202,6 +2301,9 @@
         state.items.clear();
         state.groups.add(groups);
         state.items.add(items);
+        // Stash the rows so the auto-pan handler (issue #286) can map
+        // entries-list scroll position to a time window.
+        state.rows = rows;
 
         const fullStartMs = dataStartMs;
         const latestTransferEndMs = dataEndMs;
@@ -2209,9 +2311,12 @@
         const fullEndMs = latestTransferEndMs + rightPadMs;
         networkWaterfallFullRangeBySession.set(key, { startMs: fullStartMs, endMs: fullEndMs });
         state.timeline.setOptions({
+            // Clamp user pan/zoom to the session's full data range so the
+            // viewer can't drift into empty space outside the session.
             min: toTime(fullStartMs),
             max: toTime(fullEndMs),
-            zoomMax: Math.max(1000, fullEndMs - fullStartMs)
+            zoomMax: Math.max(1000, fullEndMs - fullStartMs),
+            zoomMin: 100 // Don't let users zoom-in tighter than 100ms.
         });
         const storedView = networkWaterfallViewBySession.get(key);
         const following = isNetworkLogFollowMode(key);

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1350,9 +1350,6 @@
                 const sessionId = card ? String(card.dataset.sessionId || '') : '';
                 if (!sessionId) return;
                 if (isOpen) {
-                    if (!hasNetworkLogFollowModeState(sessionId)) {
-                        setNetworkLogFollowMode(sessionId, true);
-                    }
                     updateNetworkLogFollowButton(card, sessionId);
                     startNetworkLogAutoRefresh(sessionId, card);
                 } else {
@@ -1514,9 +1511,6 @@
                         const card = sectionEl ? sectionEl.closest('.session-card') : null;
                         const sessionId = card ? card.dataset.sessionId : null;
                         if (sessionId && window.TestingSessionUI) {
-                            if (!hasNetworkLogFollowModeState(sessionId)) {
-                                setNetworkLogFollowMode(sessionId, true);
-                            }
                             updateNetworkLogFollowButton(card, sessionId);
                             startNetworkLogAutoRefresh(sessionId, card);
                         }
@@ -1602,7 +1596,9 @@
 
     function isNetworkLogFollowMode(sessionId) {
         const key = String(sessionId || '');
-        return networkWaterfallFollowModeBySession.get(key) !== false;
+        // Default OFF — the user expects the list to "just sit there"
+        // until they explicitly opt into auto-scroll.
+        return networkWaterfallFollowModeBySession.get(key) === true;
     }
 
     // Follow Scroll mode: when on, the waterfall's time window
@@ -1622,12 +1618,6 @@
             state.autoPan = !!enabled;
             if (enabled) applyWaterfallAutoPan(state, key);
         }
-    }
-
-    function hasNetworkLogFollowModeState(sessionId) {
-        const key = String(sessionId || '');
-        if (!key) return false;
-        return networkWaterfallFollowModeBySession.has(key);
     }
 
     function setNetworkLogFollowMode(sessionId, enabled) {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2179,39 +2179,59 @@
 
     // applyWaterfallAutoPan computes the time range covered by the
     // entries list's currently-visible rows and pans the waterfall to it.
+    //
+    // vis-timeline virtualizes vertical scroll via CSS transforms, not
+    // native scroll, so .vis-content's scrollTop/scrollHeight don't
+    // reflect the actual scroll state. Instead we walk the rendered
+    // .vis-group DOM elements and check which ones intersect the
+    // center panel's viewport rect.
     function applyWaterfallAutoPan(state, key) {
         if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
         if (!state.host) return;
-        // Re-check autoPan: the user may have done Alt+scroll/right-drag
-        // between the scroll event and this rAF firing.
         if (!state.autoPan) return;
-        const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
-        if (!left) return;
-        const scrollTop = left.scrollTop;
-        const clientH = left.clientHeight;
-        const scrollH = left.scrollHeight;
-        const rowCount = state.rows.length;
 
-        // When the entries list isn't tall enough to scroll (scrollH ==
-        // clientH), every row is "visible" — pan to cover all of them.
-        // Previously this branch returned early, leaving the time
-        // window at the last Fit/setOptions value (often the full
-        // session range), which made the timeline mostly blank.
-        let startIdx, endIdx;
-        if (scrollH <= clientH || scrollTop <= 0 && clientH >= scrollH) {
-            startIdx = 0;
-            endIdx = rowCount - 1;
-        } else {
-            const rowHeight = scrollH / rowCount;
-            if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
-            startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
-            endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        const center = state.host.querySelector('.vis-panel.vis-center');
+        if (!center) return;
+        const centerRect = center.getBoundingClientRect();
+        if (centerRect.height <= 0) return;
+
+        // Walk the rendered group elements. Each .vis-group has
+        // data-id matching the groupId we assigned (groupId = rowIdx + 1
+        // in updateNetworkWaterfall).
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let firstVisibleIdx = -1;
+        let lastVisibleIdx = -1;
+        groupEls.forEach((el) => {
+            const groupIdAttr = el.getAttribute('data-id') || el.dataset.id;
+            const groupId = parseInt(groupIdAttr, 10);
+            if (!Number.isFinite(groupId)) return;
+            const rowIdx = groupId - 1;
+            if (rowIdx < 0 || rowIdx >= state.rows.length) return;
+            const r = el.getBoundingClientRect();
+            if (r.height <= 0) return;
+            // Group at least partially visible if it overlaps the
+            // center panel's viewport rect.
+            if (r.bottom > centerRect.top && r.top < centerRect.bottom) {
+                if (firstVisibleIdx === -1 || rowIdx < firstVisibleIdx) firstVisibleIdx = rowIdx;
+                if (lastVisibleIdx === -1 || rowIdx > lastVisibleIdx) lastVisibleIdx = rowIdx;
+            }
+        });
+
+        // Fallback: if we couldn't read group elements (race, custom
+        // virtualization), pan to cover all rows. Better than leaving a
+        // mostly-blank timeline.
+        if (firstVisibleIdx === -1 || lastVisibleIdx === -1) {
+            firstVisibleIdx = 0;
+            lastVisibleIdx = state.rows.length - 1;
         }
-        if (endIdx < startIdx) return;
-        const startTs = state.rows[startIdx].timestamp;
-        const endRow = state.rows[endIdx];
+
+        const startRow = state.rows[firstVisibleIdx];
+        const endRow = state.rows[lastVisibleIdx];
+        if (!startRow || !endRow) return;
+        const startTs = startRow.timestamp;
         const endTs = endRow.timestamp + Math.max(50, endRow.duration);
         if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
+
         // Tight padding (1%) so adjacent bars peek in at the edges
         // without swamping short bursts. Minimum 25ms so a single
         // sub-millisecond bar doesn't render at zero width.
@@ -2220,7 +2240,6 @@
         let nextStart = startTs - padding;
         let nextEnd = endTs + padding;
         if (fullRange) {
-            // Don't pan past the session's data bounds.
             if (nextStart < fullRange.startMs) nextStart = fullRange.startMs;
             if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
         }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2130,9 +2130,16 @@
         return state;
     }
 
-    // attachWaterfallAutoPan listens to scroll events on the entries list
-    // (vis-timeline's left + center panels share scrollTop) and pans the
-    // visible time window to match the rows the user is looking at. Issue #286.
+    // attachWaterfallAutoPan listens for scroll on the entries list and
+    // pans the visible time window to match the rows the user is looking
+    // at. Issue #286.
+    //
+    // We listen to BOTH:
+    //   1. DOM `scroll` on `.vis-content` — fires when vis-timeline uses
+    //      native scrollbars.
+    //   2. `wheel` on the host — vis-timeline drives vertical scroll via
+    //      transforms in some configurations and the DOM scroll event
+    //      doesn't fire. The wheel handler covers that case.
     function attachWaterfallAutoPan(state, key) {
         if (!state || !state.host || state.autoPanBound) return;
         const setupOnce = () => {
@@ -2141,7 +2148,7 @@
             const center = state.host.querySelector('.vis-panel.vis-center .vis-content');
             if (!left && !center) return false;
             let rafId = null;
-            const onScroll = () => {
+            const schedule = () => {
                 if (!state.autoPan) return;
                 if (!isFollowScrollMode(key)) return;
                 if (rafId) return;
@@ -2150,8 +2157,12 @@
                     applyWaterfallAutoPan(state, key);
                 });
             };
-            if (left) left.addEventListener('scroll', onScroll, { passive: true });
-            if (center && center !== left) center.addEventListener('scroll', onScroll, { passive: true });
+            if (left) left.addEventListener('scroll', schedule, { passive: true });
+            if (center && center !== left) center.addEventListener('scroll', schedule, { passive: true });
+            // Wheel events fire even when vis-timeline does
+            // transform-based scrolling. Schedule on the next frame so
+            // we read the post-scroll position.
+            state.host.addEventListener('wheel', schedule, { passive: true });
             state.autoPanBound = true;
             return true;
         };
@@ -2172,28 +2183,39 @@
         if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
         if (!state.host) return;
         // Re-check autoPan: the user may have done Alt+scroll/right-drag
-        // between the scroll event and this rAF firing — `onScroll`
-        // already gates new schedules but a previously-queued rAF would
-        // otherwise override the manual pan.
+        // between the scroll event and this rAF firing.
         if (!state.autoPan) return;
         const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
         if (!left) return;
         const scrollTop = left.scrollTop;
         const clientH = left.clientHeight;
         const scrollH = left.scrollHeight;
-        if (scrollH <= clientH) return;
         const rowCount = state.rows.length;
-        const rowHeight = scrollH / rowCount;
-        if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
-        const startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
-        const endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+
+        // When the entries list isn't tall enough to scroll (scrollH ==
+        // clientH), every row is "visible" — pan to cover all of them.
+        // Previously this branch returned early, leaving the time
+        // window at the last Fit/setOptions value (often the full
+        // session range), which made the timeline mostly blank.
+        let startIdx, endIdx;
+        if (scrollH <= clientH || scrollTop <= 0 && clientH >= scrollH) {
+            startIdx = 0;
+            endIdx = rowCount - 1;
+        } else {
+            const rowHeight = scrollH / rowCount;
+            if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
+            startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
+            endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        }
         if (endIdx < startIdx) return;
         const startTs = state.rows[startIdx].timestamp;
         const endRow = state.rows[endIdx];
         const endTs = endRow.timestamp + Math.max(50, endRow.duration);
         if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
-        // Pad 5% on each side so adjacent bars peek in at the edges.
-        const padding = Math.max(50, (endTs - startTs) * 0.05);
+        // Tight padding (1%) so adjacent bars peek in at the edges
+        // without swamping short bursts. Minimum 25ms so a single
+        // sub-millisecond bar doesn't render at zero width.
+        const padding = Math.max(25, (endTs - startTs) * 0.01);
         const fullRange = networkWaterfallFullRangeBySession.get(key);
         let nextStart = startTs - padding;
         let nextEnd = endTs + padding;
@@ -2203,9 +2225,6 @@
             if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
         }
         if (nextEnd <= nextStart) return;
-        // Suppress the rangechanged user-flag for our own setWindow call —
-        // vis-timeline doesn't fire byUser=true when we drive setWindow,
-        // so this is mostly belt-and-suspenders.
         state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
         networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
@@ -2380,6 +2399,16 @@
         state.timeline.redraw();
         if (following) {
             scrollWaterfallToLatestRow(state);
+        }
+        // After the initial render, drive the time window from the
+        // currently-visible rows when Follow Scroll is on. The setWindow
+        // calls above bracket the data range; auto-pan tightens to just
+        // what the user is looking at. Two rAFs let vis-timeline lay out
+        // its panels (the second one is when scrollHeight is final).
+        if (isFollowScrollMode(key) && state.autoPan) {
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => applyWaterfallAutoPan(state, key));
+            });
         }
     }
 

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -45,6 +45,10 @@
     const networkWaterfallTimelines = new Map();
     const networkWaterfallViewBySession = new Map();
     const networkWaterfallFollowModeBySession = new Map();
+    // Follow Scroll: pan the waterfall's time window to match the rows
+    // visible in the entries list as the user scrolls. Default true.
+    // Issue #286.
+    const networkWaterfallFollowScrollBySession = new Map();
     const networkWaterfallFullRangeBySession = new Map();
     const networkWaterfallRenderSignatureBySession = new Map();
     const networkWaterfallRollingWindowMs = 5 * 60 * 1000;
@@ -1077,6 +1081,10 @@
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-fit">Fit</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-follow">Following Latest</button>
+                                <label class="network-log-filter" title="Pan the waterfall's time window to match the entries currently visible in the list above">
+                                    <input type="checkbox" data-field="follow-scroll" checked>
+                                    Follow Scroll
+                                </label>
                                 <label class="network-log-filter">
                                     <input type="checkbox" data-filter="show-faulted" checked>
                                     Show Faults
@@ -1361,6 +1369,12 @@
             const cb = e.target;
             if (!cb || cb.type !== 'checkbox' || !cb.dataset.field) return;
             const field = cb.dataset.field;
+            if (field === 'follow-scroll') {
+                const card = cb.closest('.session-card');
+                const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                if (sessionId) setFollowScrollMode(sessionId, !!cb.checked);
+                return;
+            }
             if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls') return;
             const group = cb.closest('.checkbox-group');
             if (!group) return;
@@ -1582,6 +1596,25 @@
         return networkWaterfallFollowModeBySession.get(key) !== false;
     }
 
+    // Follow Scroll mode: when on, the waterfall's time window
+    // auto-pans to match the rows currently visible in the entries
+    // list. Default true so the feature is on out-of-the-box. Issue #286.
+    function isFollowScrollMode(sessionId) {
+        const key = String(sessionId || '');
+        return networkWaterfallFollowScrollBySession.get(key) !== false;
+    }
+
+    function setFollowScrollMode(sessionId, enabled) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        networkWaterfallFollowScrollBySession.set(key, !!enabled);
+        const state = networkWaterfallTimelines.get(key);
+        if (state) {
+            state.autoPan = !!enabled;
+            if (enabled) applyWaterfallAutoPan(state, key);
+        }
+    }
+
     function hasNetworkLogFollowModeState(sessionId) {
         const key = String(sessionId || '');
         if (!key) return false;
@@ -1604,6 +1637,12 @@
         button.setAttribute('aria-pressed', following ? 'true' : 'false');
         button.classList.toggle('btn-primary', following);
         button.classList.toggle('btn-secondary', !following);
+        // Keep the Follow Scroll checkbox in sync with the per-session
+        // map across re-renders (the HTML template defaults to checked).
+        const followScrollCb = hostCard.querySelector('input[data-field="follow-scroll"]');
+        if (followScrollCb) {
+            followScrollCb.checked = isFollowScrollMode(sessionId);
+        }
     }
 
     function scrollWaterfallToLatestRow(state) {
@@ -2083,7 +2122,7 @@
                     state.autoPan = false;
                 }
             });
-            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: true };
+            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: isFollowScrollMode(key) };
             bindWaterfallSelectionHandlers(state, key);
             attachWaterfallAutoPan(state, key);
             networkWaterfallTimelines.set(key, state);
@@ -2104,6 +2143,7 @@
             let rafId = null;
             const onScroll = () => {
                 if (!state.autoPan) return;
+                if (!isFollowScrollMode(key)) return;
                 if (rafId) return;
                 rafId = window.requestAnimationFrame(() => {
                     rafId = null;

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1075,7 +1075,7 @@
                         <div class="network-log-section">
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save current network timeline as a HAR file (Phase 1 of issue #272)">Save HAR</button>
+                                <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save the current network timeline as a HAR file: downloads to your machine and adds it to the Incidents list">Download HAR</button>
                                 <a href="/api/incidents" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="List saved HAR snapshots (raw JSON)">Incidents</a>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-first">First</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
@@ -1427,7 +1427,16 @@
                         .then(r => r.json())
                         .then(data => {
                             if (data && data.incident && data.incident.path) {
-                                window.alert(`HAR saved: ${data.incident.filename}\n\nDownload via /api/incidents/${data.incident.path}`);
+                                // Trigger a direct download — server already
+                                // wrote the file to /incidents/, we just
+                                // route the browser at it via a hidden <a>.
+                                const a = document.createElement('a');
+                                a.href = `/api/incidents/${data.incident.path}`;
+                                a.download = data.incident.filename || 'incident.har';
+                                a.style.display = 'none';
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
                             } else if (data && data.error) {
                                 window.alert(`HAR save failed: ${data.error}`);
                             }
@@ -2162,7 +2171,18 @@
             // Wheel events fire even when vis-timeline does
             // transform-based scrolling. Schedule on the next frame so
             // we read the post-scroll position.
-            state.host.addEventListener('wheel', schedule, { passive: true });
+            state.host.addEventListener('wheel', (event) => {
+                // User-initiated scroll while Following Latest is on
+                // means they want to step away from the live tail —
+                // auto-disable Following Latest and let track-by-scroll
+                // pin the time window to whatever they're looking at.
+                if (isNetworkLogFollowMode(key)) {
+                    setNetworkLogFollowMode(key, false);
+                    const card = state.host.closest('.session-card');
+                    updateNetworkLogFollowButton(card, key);
+                }
+                schedule();
+            }, { passive: true });
             state.autoPanBound = true;
             return true;
         };
@@ -2175,6 +2195,47 @@
             if (attempts < 20) window.requestAnimationFrame(retry);
         };
         window.requestAnimationFrame(retry);
+    }
+
+    // restoreScrollAnchor finds the .vis-group element that corresponds
+    // to the anchor's rowIdx after a re-render and scrolls vis-timeline
+    // so that group sits at the same offset within the viewport as it
+    // did before the re-render. Issue #286 follow-up.
+    function restoreScrollAnchor(state, anchor) {
+        if (!state || !state.host || !anchor) return;
+        const center = state.host.querySelector('.vis-panel.vis-center');
+        if (!center) return;
+        const targetGroupId = String(anchor.rowIdx + 1);
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let target = null;
+        for (const el of groupEls) {
+            if ((el.getAttribute('data-id') || el.dataset.id) === targetGroupId) {
+                target = el;
+                break;
+            }
+        }
+        if (!target) return;
+        const centerRect = center.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        const desiredOffsetTop = centerRect.top + anchor.offsetWithinGroup;
+        const delta = targetRect.top - desiredOffsetTop;
+        if (Math.abs(delta) < 1) return;
+        // Try vis-timeline's internal scroll surfaces in priority order;
+        // any one of them that's writable will scroll the panel.
+        const surfaces = [
+            state.timeline?.body?.dom?.shadow,
+            state.timeline?.body?.dom?.center,
+            state.host.querySelector('.vis-panel.vis-left .vis-content'),
+            state.host.querySelector('.vis-panel.vis-center .vis-content'),
+        ].filter(Boolean);
+        for (const s of surfaces) {
+            if (typeof s.scrollTop === 'number') {
+                const before = s.scrollTop;
+                s.scrollTop = before + delta;
+                // If it changed, we found the right surface.
+                if (s.scrollTop !== before) return;
+            }
+        }
     }
 
     // applyWaterfallAutoPan computes the time range covered by the
@@ -2398,6 +2459,35 @@
             });
         });
 
+        // Anchor preservation: when Following Latest is OFF, capture the
+        // topmost visible group's row index + pixel offset BEFORE the
+        // re-render so we can restore the user's view after the
+        // groups/items DataSet is replaced. Without this, vis-timeline's
+        // re-render snaps the scroll position to top and the user's view
+        // jumps every time new entries arrive.
+        let scrollAnchor = null;
+        if (!isNetworkLogFollowMode(key) && state.host) {
+            const center = state.host.querySelector('.vis-panel.vis-center');
+            const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+            if (center && groupEls.length > 0) {
+                const centerRect = center.getBoundingClientRect();
+                for (const el of groupEls) {
+                    const r = el.getBoundingClientRect();
+                    if (r.height <= 0) continue;
+                    if (r.bottom > centerRect.top) {
+                        const groupId = parseInt(el.getAttribute('data-id') || el.dataset.id, 10);
+                        if (Number.isFinite(groupId)) {
+                            scrollAnchor = {
+                                rowIdx: groupId - 1,
+                                offsetWithinGroup: centerRect.top - r.top,
+                            };
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         state.groups.clear();
         state.items.clear();
         state.groups.add(groups);
@@ -2441,6 +2531,13 @@
         state.timeline.redraw();
         if (following) {
             scrollWaterfallToLatestRow(state);
+        } else if (scrollAnchor) {
+            // Re-render snapped vis-timeline's scroll to top — restore
+            // the user's view by scrolling the same row back into the
+            // same vertical offset within the viewport.
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => restoreScrollAnchor(state, scrollAnchor));
+            });
         }
         // After the initial render, drive the time window from the
         // currently-visible rows when Follow Scroll is on. The setWindow

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -259,6 +259,18 @@ server {
         add_header Expires "0" always;
     }
 
+    # HAR incidents — list (/api/incidents) and download
+    # (/api/incidents/<YYYY-MM-DD>/<file>.har). Proxied to go-proxy.
+    location ~ ^/api/incidents {
+        proxy_pass http://go_proxy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Port $server_port;
+        add_header Access-Control-Allow-Origin * always;
+        # No no-cache here — HAR files are content-addressable by name.
+    }
+
     # API: Byteranges generation (Go upload service)
     location ~ ^/api/content/.*/generate-byteranges$ {
         proxy_pass http://go_upload_service;

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -119,6 +119,14 @@ type NetworkLogEntry struct {
 	FaultType     string `json:"fault_type,omitempty"`
 	FaultAction   string `json:"fault_action,omitempty"`
 	FaultCategory string `json:"fault_category,omitempty"` // "http", "socket", "transport", "corruption"
+
+	// Range-request metadata. RequestRange is the client's `Range:`
+	// header (e.g. "bytes=0-1023"); ResponseContentRange is the
+	// origin's `Content-Range:` header (e.g. "bytes 0-1023/5242880").
+	// Useful for telling apart partial-content fetches and continuation
+	// requests in the dashboard.
+	RequestRange         string `json:"request_range,omitempty"`
+	ResponseContentRange string `json:"response_content_range,omitempty"`
 }
 
 // NetworkLogRingBuffer maintains a bounded list of recent network entries
@@ -4040,13 +4048,20 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
-	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
-		proxyReq.Header.Set("Range", rangeHeader)
+	clientRange := r.Header.Get("Range")
+	if clientRange != "" {
+		proxyReq.Header.Set("Range", clientRange)
 	}
 	if ifRange := r.Header.Get("If-Range"); ifRange != "" {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
 	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
+	if netEntry != nil {
+		netEntry.RequestRange = clientRange
+		if resp != nil {
+			netEntry.ResponseContentRange = resp.Header.Get("Content-Range")
+		}
+	}
 	if err != nil {
 		// Set status before writing header
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -4127,8 +4142,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			downstream = idleW
 		}
 		writer := bufio.NewWriter(downstream)
+		transferStart := time.Now()
 		_, writeErr := writer.Write(modifiedBody)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = float64(time.Since(transferStart).Microseconds()) / 1000.0
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4138,9 +4155,22 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			if idleW != nil && idleW.timedOut.Load() {
 				bumpFaultCounter(sessionData, "transfer_idle_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_idle_timeout"
+				netEntry.FaultAction = "transfer_idle_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_idle_timeout")
 			} else if errors.Is(writeErr, context.DeadlineExceeded) || errors.Is(flushErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_active_timeout"
+				netEntry.FaultAction = "transfer_active_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_active_timeout")
+			} else {
+				netEntry.Faulted = true
+				netEntry.FaultType = "client_disconnect"
+				netEntry.FaultAction = "transfer_abandoned"
+				netEntry.FaultCategory = "client_disconnect"
 			}
 		}
 	} else {
@@ -4165,8 +4195,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			)
 		}
 		var copyErr error
+		transferStart := time.Now()
 		bytesOut, copyErr = io.Copy(writer, resp.Body)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = float64(time.Since(transferStart).Microseconds()) / 1000.0
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4180,9 +4212,26 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			if idleW != nil && idleW.timedOut.Load() {
 				bumpFaultCounter(sessionData, "transfer_idle_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_idle_timeout"
+				netEntry.FaultAction = "transfer_idle_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_idle_timeout")
 			} else if errors.Is(copyErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_active_timeout"
+				netEntry.FaultAction = "transfer_active_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_active_timeout")
+			} else {
+				// Real client closed the socket mid-body (broken pipe,
+				// ECONNRESET, etc.). Not a deliberate fault — tag it
+				// so the dashboard can show "abandoned by client" in
+				// red without the user having to read the proxy log.
+				netEntry.Faulted = true
+				netEntry.FaultType = "client_disconnect"
+				netEntry.FaultAction = "transfer_abandoned"
+				netEntry.FaultCategory = "client_disconnect"
 			}
 		}
 		if isManifest || isMasterManifest {


### PR DESCRIPTION
Replaces the vis-timeline-based network log waterfall with a native HTML/CSS waterfall driven by browser scroll. The vis-timeline build fought us on every iteration — its transform-based vertical scroll made scroll preservation, time-axis tracking, and follow-latest behaviour all stack-of-cards on top of each other.

## Dashboard

- Brushable overview strip on top: drag the body to pan, drag a handle to resize (zoom), click bare overview to jump. Brush is the time window the row list shows.
- Two distinct time axes: `HH:MM:SS` ticks above the overview (full session), `HH:MM:SS` ticks above the row list (brush window).
- Per-row global-axis bars filtered to the brush window; phase segments (DNS / Connect / TLS / Wait / Receive) coloured to scale.
- **Status / fault colour bands**: 2xx green, 206 teal, 3xx blue, 4xx amber, 5xx red, faulted / timeout / incomplete in red / orange / pink with diagonal-hatch overlay on the receive segment when bytes are missing.
- Dedicated Status column with status-family tinting.
- **Resizable column cells** (drag header dividers; widths persisted to `localStorage` as `netwf-cols-v2`).
- **Summary pill row** with totals + categorical counts.
- **Hover tooltip** with method / status / total / bytes & Mbps / variant / started-at / per-phase breakdown / attempt N of M / range header / fault info / URL.
- **Time-aware retry detection**: refetch flagged only when the gap from previous fetch is < half the segment duration parsed from the URL (`2s` / `6s` / `ll` / `playlist_Ns` variants).
- **1-min default and minimum brush**; 10-min rolling window; 20-row default visible height.
- Network log no longer gated by `?developer=1`.
- "Hide Successful" filter (default off) replaces previous Show Faults / Show Successful pair.
- Following Latest is default ON; clicking re-snaps to live immediately (refetch + double-rAF scroll-to-bottom).
- Removed dead First / Last / Fit / Follow-Scroll plumbing.
- **Download HAR** no longer prompts; downloads via `blob:` URL so Chrome's HTTP-mixed-content download block doesn't fire.
- Cherry-picked the Incidents browser page (`incidents.html`) from #276 so the Incidents button opens a real list view.
- Timestamp prefix and ↻/! badges on each row label, status code in its own colour-tinted column.

## Server (paired)

- `TransferMs` measured on the happy path (default proxy + master-manifest content-manipulation paths). Was 0 for non-faulted — dashboard durations were stuck at <1 ms.
- `transfer_idle_timeout` / `transfer_active_timeout` now **tag the network log entry**, not just bump fault counters.
- `client_disconnect` / `transfer_abandoned` tagging when the client closes the socket mid-body (broken pipe / RST). Drives the new `fault-incomplete` row colour + diagonal-hatch overlay.
- `RequestRange` + `ResponseContentRange` captured on entries to surface byte-range / continuation requests in the tooltip.

## Nginx

- New `^/api/incidents` location proxying to `go-proxy`. The route was previously unreachable through the test-dev / Compose nginx, so the Download HAR file fetch and the Incidents page both 404'd.

Closes #291.