### PR TITLE
feat(har): capture request/response headers + queryString (#279)

### DIFF
--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -85,24 +85,27 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		sources = make([]har.Source, 0, len(entries))
 		for _, e := range entries {
 			sources = append(sources, har.Source{
-				Timestamp:     e.Timestamp,
-				Method:        e.Method,
-				URL:           e.URL,
-				RequestKind:   e.RequestKind,
-				Status:        e.Status,
-				BytesIn:       e.BytesIn,
-				BytesOut:      e.BytesOut,
-				ContentType:   e.ContentType,
-				DNSMs:         e.DNSMs,
-				ConnectMs:     e.ConnectMs,
-				TLSMs:         e.TLSMs,
-				TTFBMs:        e.TTFBMs,
-				TransferMs:    e.TransferMs,
-				TotalMs:       e.TotalMs,
-				Faulted:       e.Faulted,
-				FaultType:     e.FaultType,
-				FaultAction:   e.FaultAction,
-				FaultCategory: e.FaultCategory,
+				Timestamp:       e.Timestamp,
+				Method:          e.Method,
+				URL:             e.URL,
+				RequestKind:     e.RequestKind,
+				Status:          e.Status,
+				BytesIn:         e.BytesIn,
+				BytesOut:        e.BytesOut,
+				ContentType:     e.ContentType,
+				DNSMs:           e.DNSMs,
+				ConnectMs:       e.ConnectMs,
+				TLSMs:           e.TLSMs,
+				TTFBMs:          e.TTFBMs,
+				TransferMs:      e.TransferMs,
+				TotalMs:         e.TotalMs,
+				RequestHeaders:  toNameValueSlice(e.RequestHeaders),
+				ResponseHeaders: toNameValueSlice(e.ResponseHeaders),
+				QueryString:     toNameValueSlice(e.QueryString),
+				Faulted:         e.Faulted,
+				FaultType:       e.FaultType,
+				FaultAction:     e.FaultAction,
+				FaultCategory:   e.FaultCategory,
 			})
 		}
 	}
@@ -126,6 +129,20 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 	}
 
 	return har.Build(sources, opts)
+}
+
+// toNameValueSlice converts a []HeaderPair (main package's HTTP capture
+// type) to a []har.NameValue without sharing memory. Returns nil for an
+// empty slice so the HAR builder can apply its own defaults.
+func toNameValueSlice(in []HeaderPair) []har.NameValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]har.NameValue, len(in))
+	for i, p := range in {
+		out[i] = har.NameValue{Name: p.Name, Value: p.Value}
+	}
+	return out
 }
 
 // findSessionByID returns the session map matching session_id, or nil.

--- a/go-proxy/cmd/server/headers_test.go
+++ b/go-proxy/cmd/server/headers_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestCapturedHeaders_FiltersSensitive(t *testing.T) {
+	h := http.Header{}
+	h.Set("User-Agent", "test")
+	h.Set("Range", "bytes=0-1023")
+	h.Set("Cookie", "session=secret")
+	h.Set("Authorization", "Bearer xyz")
+	h.Set("Set-Cookie", "abc=def")
+	h.Set("X-Amz-Security-Token", "stoken")
+	h.Set("Content-Type", "video/mp4")
+
+	out := capturedHeaders(h)
+	names := map[string]bool{}
+	for _, p := range out {
+		names[p.Name] = true
+	}
+	for _, banned := range []string{"Cookie", "Authorization", "Set-Cookie", "X-Amz-Security-Token"} {
+		if names[banned] {
+			t.Errorf("sensitive header %q leaked into capture: %+v", banned, out)
+		}
+	}
+	for _, expected := range []string{"User-Agent", "Range", "Content-Type"} {
+		if !names[expected] {
+			t.Errorf("expected header %q missing from capture: %+v", expected, out)
+		}
+	}
+}
+
+func TestCapturedHeaders_StableOrder(t *testing.T) {
+	// Map iteration order is non-deterministic in Go; capturedHeaders
+	// must sort so two runs of the same input produce identical HAR
+	// diffs.
+	h := http.Header{}
+	h.Set("Z-Header", "z")
+	h.Set("A-Header", "a")
+	h.Set("M-Header", "m")
+
+	a := capturedHeaders(h)
+	b := capturedHeaders(h)
+	if len(a) != len(b) {
+		t.Fatalf("captures of same input have different lengths")
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("position %d differs: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+	// Verify alphabetical.
+	if a[0].Name != "A-Header" || a[1].Name != "M-Header" || a[2].Name != "Z-Header" {
+		t.Errorf("not sorted: %+v", a)
+	}
+}
+
+func TestCapturedHeaders_PreservesRepeatedValues(t *testing.T) {
+	h := http.Header{}
+	h.Add("Accept", "video/mp4")
+	h.Add("Accept", "application/json")
+	out := capturedHeaders(h)
+	count := 0
+	for _, p := range out {
+		if p.Name == "Accept" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 Accept entries, got %d: %+v", count, out)
+	}
+}
+
+func TestCapturedHeaders_EmptyInput(t *testing.T) {
+	if got := capturedHeaders(http.Header{}); got != nil {
+		t.Errorf("empty input should return nil, got %+v", got)
+	}
+	if got := capturedHeaders(nil); got != nil {
+		t.Errorf("nil input should return nil, got %+v", got)
+	}
+}
+
+func TestCapturedQueryString_PreservesURLOrder(t *testing.T) {
+	u, err := url.Parse("https://example.test/playlist.m3u8?player_id=p1&play_id=42&codec=h264")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := capturedQueryString(u)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 params, got %d", len(out))
+	}
+	want := []struct{ name, value string }{
+		{"player_id", "p1"},
+		{"play_id", "42"},
+		{"codec", "h264"},
+	}
+	for i, w := range want {
+		if out[i].Name != w.name || out[i].Value != w.value {
+			t.Errorf("position %d: got %+v, want %s=%s", i, out[i], w.name, w.value)
+		}
+	}
+}
+
+func TestCapturedQueryString_DecodesPercent(t *testing.T) {
+	u, _ := url.Parse("https://example.test/x?path=%2Fhome%2Fuser&q=hello%20world")
+	out := capturedQueryString(u)
+	if out[0].Name != "path" || out[0].Value != "/home/user" {
+		t.Errorf("percent decode failed: %+v", out[0])
+	}
+	if out[1].Value != "hello world" {
+		t.Errorf("space decode failed: %+v", out[1])
+	}
+}
+
+func TestCapturedQueryString_NoQuery(t *testing.T) {
+	u, _ := url.Parse("https://example.test/x")
+	if got := capturedQueryString(u); got != nil {
+		t.Errorf("URL without query should yield nil, got %+v", got)
+	}
+}
+
+func TestCapturedQueryString_FlagOnlyParam(t *testing.T) {
+	// Bare param like `?debug` should appear with empty value.
+	u, _ := url.Parse("https://example.test/x?debug")
+	out := capturedQueryString(u)
+	if len(out) != 1 || out[0].Name != "debug" || out[0].Value != "" {
+		t.Errorf("flag-only param wrong: %+v", out)
+	}
+}
+
+func TestStampNetMeta_DoesntOverwriteExisting(t *testing.T) {
+	pre := []HeaderPair{{Name: "pre", Value: "v"}}
+	entry := NetworkLogEntry{
+		RequestHeaders: pre,
+	}
+	stampNetMeta(&entry, []HeaderPair{{Name: "new", Value: "v"}}, nil, nil)
+	if len(entry.RequestHeaders) != 1 || entry.RequestHeaders[0].Name != "pre" {
+		t.Errorf("stamp overwrote pre-set headers: %+v", entry.RequestHeaders)
+	}
+}
+
+func TestStampNetMeta_NilEntryIsSafe(t *testing.T) {
+	// Defensive — no panic.
+	stampNetMeta(nil, []HeaderPair{{Name: "x", Value: "y"}}, nil, nil)
+}
+
+func TestStampNetMeta_PopulatesFromCaptures(t *testing.T) {
+	entry := NetworkLogEntry{}
+	req := []HeaderPair{{Name: "User-Agent", Value: "t"}}
+	qs := []HeaderPair{{Name: "p", Value: "v"}}
+	resp := &http.Response{Header: http.Header{"Content-Type": []string{"text/plain"}}}
+	stampNetMeta(&entry, req, qs, resp)
+	if len(entry.RequestHeaders) != 1 || entry.RequestHeaders[0].Name != "User-Agent" {
+		t.Errorf("RequestHeaders not populated: %+v", entry.RequestHeaders)
+	}
+	if len(entry.QueryString) != 1 {
+		t.Errorf("QueryString not populated: %+v", entry.QueryString)
+	}
+	if len(entry.ResponseHeaders) != 1 || entry.ResponseHeaders[0].Name != "Content-Type" {
+		t.Errorf("ResponseHeaders not populated: %+v", entry.ResponseHeaders)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,6 +95,15 @@ type tcStatsCache struct {
 
 
 
+// HeaderPair is a single name/value pair, used to carry HTTP request /
+// response headers and query parameters in NetworkLogEntry. Mirrors the
+// HAR 1.2 NameValue shape so a HAR consumer can drop these straight into
+// request.headers / response.headers without conversion.
+type HeaderPair struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // NetworkLogEntry represents a single network request/response in the session
 type NetworkLogEntry struct {
 	Timestamp   time.Time `json:"timestamp"`
@@ -105,6 +115,13 @@ type NetworkLogEntry struct {
 	BytesIn     int64     `json:"bytes_in"`
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
+
+	// HTTP-level metadata captured per-request. Sensitive headers
+	// (Cookie / Authorization / Set-Cookie) are filtered before they
+	// land here — see capturedRequestHeaders / capturedResponseHeaders.
+	RequestHeaders  []HeaderPair `json:"request_headers,omitempty"`
+	ResponseHeaders []HeaderPair `json:"response_headers,omitempty"`
+	QueryString     []HeaderPair `json:"query_string,omitempty"`
 
 	// Timing phases (milliseconds)
 	DNSMs      float64 `json:"dns_ms"`
@@ -119,6 +136,91 @@ type NetworkLogEntry struct {
 	FaultType     string `json:"fault_type,omitempty"`
 	FaultAction   string `json:"fault_action,omitempty"`
 	FaultCategory string `json:"fault_category,omitempty"` // "http", "socket", "transport", "corruption"
+}
+
+// sensitiveHeaderNames are excluded from HAR captures regardless of source.
+// Lower-cased for canonical comparison.
+var sensitiveHeaderNames = map[string]bool{
+	"cookie":               true,
+	"set-cookie":           true,
+	"authorization":        true,
+	"proxy-authorization":  true,
+	"x-amz-security-token": true,
+}
+
+// capturedHeaders converts an http.Header map to a sorted []HeaderPair,
+// dropping sensitive entries. Stable ordering keeps HAR diffs readable.
+func capturedHeaders(h http.Header) []HeaderPair {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make([]HeaderPair, 0, len(h))
+	for name, values := range h {
+		if sensitiveHeaderNames[strings.ToLower(name)] {
+			continue
+		}
+		for _, v := range values {
+			out = append(out, HeaderPair{Name: name, Value: v})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Value < out[j].Value
+	})
+	return out
+}
+
+// stampNetMeta attaches captured request headers, query string, and (if
+// available) response headers onto a NetworkLogEntry. Idempotent — won't
+// overwrite already-set fields, so callers can pre-populate any of them
+// at the entry-construction site.
+func stampNetMeta(entry *NetworkLogEntry, requestHeaders, queryString []HeaderPair, resp *http.Response) {
+	if entry == nil {
+		return
+	}
+	if entry.RequestHeaders == nil && len(requestHeaders) > 0 {
+		entry.RequestHeaders = requestHeaders
+	}
+	if entry.QueryString == nil && len(queryString) > 0 {
+		entry.QueryString = queryString
+	}
+	if entry.ResponseHeaders == nil && resp != nil {
+		entry.ResponseHeaders = capturedHeaders(resp.Header)
+	}
+}
+
+// capturedQueryString converts the URL's query into []HeaderPair preserving
+// the parameter order from the URL. Sensitive values aren't filtered here —
+// the dashboard already exposes player_id query params; if that ever changes
+// the privacy filter goes here.
+func capturedQueryString(u *url.URL) []HeaderPair {
+	if u == nil || u.RawQuery == "" {
+		return nil
+	}
+	pairs := strings.Split(u.RawQuery, "&")
+	out := make([]HeaderPair, 0, len(pairs))
+	for _, p := range pairs {
+		if p == "" {
+			continue
+		}
+		var name, value string
+		if eq := strings.IndexByte(p, '='); eq >= 0 {
+			name, value = p[:eq], p[eq+1:]
+		} else {
+			name = p
+		}
+		// URL-decode each side; ignore errors and keep the raw bytes.
+		if decoded, err := url.QueryUnescape(name); err == nil {
+			name = decoded
+		}
+		if decoded, err := url.QueryUnescape(value); err == nil {
+			value = decoded
+		}
+		out = append(out, HeaderPair{Name: name, Value: value})
+	}
+	return out
 }
 
 // NetworkLogRingBuffer maintains a bounded list of recent network entries
@@ -3547,6 +3649,12 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Snapshot the player's request headers + query string once for HAR
+	// capture (issue #279). Sensitive headers are filtered inside
+	// capturedHeaders. The parsed query is preserved in original URL
+	// order via capturedQueryString.
+	requestHeaders := capturedHeaders(r.Header)
+	queryString := capturedQueryString(r.URL)
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3858,6 +3966,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
 				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
+				stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 				a.addNetworkLogEntry(sessionID, netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3885,6 +3994,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
+				stampNetMeta(netEntry, requestHeaders, queryString, nil)
 				a.addNetworkLogEntry(sessionID, *netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3905,6 +4015,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
+				stampNetMeta(netEntry, requestHeaders, queryString, resp)
 				a.addNetworkLogEntry(sessionID, *netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3937,6 +4048,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			netEntry.FaultType = failureType
 			netEntry.FaultAction = actionTaken
 			netEntry.FaultCategory = categorizeFaultType(failureType)
+			stampNetMeta(netEntry, requestHeaders, queryString, resp)
 			a.addNetworkLogEntry(sessionID, *netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -3959,6 +4071,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
 			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+			stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 			a.addNetworkLogEntry(sessionID, netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -4015,6 +4128,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusTooManyRequests
 		}
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+		stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4037,6 +4151,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
+		stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4064,6 +4179,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
+		stampNetMeta(netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, *netEntry)
 		return
 	}
@@ -4088,6 +4204,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
+		stampNetMeta(netEntry, requestHeaders, queryString, resp)
 		a.addNetworkLogEntry(sessionID, *netEntry)
 		return
 	}
@@ -4207,6 +4324,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	netEntry.RequestKind = requestKind
 	netEntry.BytesIn = requestBytes
 	netEntry.BytesOut = bytesOut
+	stampNetMeta(netEntry, requestHeaders, queryString, resp)
 	a.addNetworkLogEntry(sessionID, *netEntry)
 	a.saveSessionByID(sessionNumber, sessionData)
 }

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -151,6 +151,14 @@ type Source struct {
 	TTFBMs        float64
 	TransferMs    float64
 	TotalMs       float64
+
+	// HTTP-level metadata captured from the request and upstream
+	// response. Sensitive headers (Cookie / Authorization) are filtered
+	// at the proxy capture site before they reach here.
+	RequestHeaders  []NameValue
+	ResponseHeaders []NameValue
+	QueryString     []NameValue
+
 	Faulted       bool
 	FaultType     string
 	FaultAction   string
@@ -235,6 +243,19 @@ func buildEntry(s Source) Entry {
 		mimeType = "application/octet-stream"
 	}
 
+	requestHeaders := s.RequestHeaders
+	if requestHeaders == nil {
+		requestHeaders = []NameValue{}
+	}
+	responseHeaders := s.ResponseHeaders
+	if responseHeaders == nil {
+		responseHeaders = []NameValue{}
+	}
+	queryString := s.QueryString
+	if queryString == nil {
+		queryString = []NameValue{}
+	}
+
 	entry := Entry{
 		StartedDateTime: startedDate,
 		Time:            s.TotalMs,
@@ -243,8 +264,8 @@ func buildEntry(s Source) Entry {
 			URL:         s.URL,
 			HTTPVersion: "HTTP/1.1",
 			Cookies:     []NameValue{},
-			Headers:     []NameValue{},
-			QueryString: []NameValue{},
+			Headers:     requestHeaders,
+			QueryString: queryString,
 			HeadersSize: -1,
 			BodySize:    s.BytesOut,
 		},
@@ -253,7 +274,7 @@ func buildEntry(s Source) Entry {
 			StatusText:  statusText,
 			HTTPVersion: "HTTP/1.1",
 			Cookies:     []NameValue{},
-			Headers:     []NameValue{},
+			Headers:     responseHeaders,
 			Content: Content{
 				Size:     s.BytesIn,
 				MimeType: mimeType,

--- a/go-proxy/internal/har/har_headers_test.go
+++ b/go-proxy/internal/har/har_headers_test.go
@@ -1,0 +1,133 @@
+package har
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// These tests target the request/response headers + queryString
+// plumbing added in issue #279. They live in a separate file from
+// har_test.go (PR #278) so the two PRs can land in any order.
+
+func TestBuild_RequestHeadersFlowThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s",
+		Status: 200,
+		RequestHeaders: []NameValue{
+			{Name: "User-Agent", Value: "InfiniteStreamPlayer/1.0"},
+			{Name: "Range", Value: "bytes=0-1023"},
+			{Name: "If-None-Match", Value: `"abc123"`},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	headers := doc.Log.Entries[0].Request.Headers
+	if len(headers) != 3 {
+		t.Fatalf("expected 3 request headers, got %d: %+v", len(headers), headers)
+	}
+	if headers[1].Name != "Range" || headers[1].Value != "bytes=0-1023" {
+		t.Errorf("Range header mapping wrong: %+v", headers[1])
+	}
+}
+
+func TestBuild_ResponseHeadersFlowThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s",
+		Status: 200,
+		ResponseHeaders: []NameValue{
+			{Name: "Content-Type", Value: "video/mp4"},
+			{Name: "Cache-Control", Value: "no-store"},
+			{Name: "Server", Value: "nginx"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	headers := doc.Log.Entries[0].Response.Headers
+	if len(headers) != 3 {
+		t.Fatalf("expected 3 response headers, got %d: %+v", len(headers), headers)
+	}
+}
+
+func TestBuild_QueryStringFlowsThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/playlist.m3u8?player_id=p1&play_id=42",
+		Status: 200,
+		QueryString: []NameValue{
+			{Name: "player_id", Value: "p1"},
+			{Name: "play_id", Value: "42"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	qs := doc.Log.Entries[0].Request.QueryString
+	if len(qs) != 2 {
+		t.Fatalf("expected 2 query params, got %d: %+v", len(qs), qs)
+	}
+	if qs[0].Name != "player_id" || qs[0].Value != "p1" {
+		t.Errorf("first param wrong: %+v", qs[0])
+	}
+}
+
+func TestBuild_EmptyMetadataYieldsEmptyArrays(t *testing.T) {
+	// Per HAR 1.2 spec, request.headers/queryString and response.headers
+	// must be present (empty array, not null) so a HAR consumer can
+	// always iterate. Builder should produce []NameValue{} when the
+	// source has none.
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.Headers == nil {
+		t.Errorf("Request.Headers should be []NameValue{}, got nil")
+	}
+	if e.Request.QueryString == nil {
+		t.Errorf("Request.QueryString should be []NameValue{}, got nil")
+	}
+	if e.Response.Headers == nil {
+		t.Errorf("Response.Headers should be []NameValue{}, got nil")
+	}
+}
+
+func TestBuild_HeadersSurviveJSONRoundTrip(t *testing.T) {
+	// Real HAR consumers parse the JSON. Make sure our headers and
+	// query params reach the wire shape DevTools/Charles expect.
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s?player_id=p1",
+		Status: 200,
+		RequestHeaders: []NameValue{
+			{Name: "User-Agent", Value: "test"},
+		},
+		ResponseHeaders: []NameValue{
+			{Name: "Content-Type", Value: "video/mp4"},
+		},
+		QueryString: []NameValue{
+			{Name: "player_id", Value: "p1"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	logBlock := parsed["log"].(map[string]interface{})
+	entries := logBlock["entries"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+	request := entry["request"].(map[string]interface{})
+	response := entry["response"].(map[string]interface{})
+
+	reqHeaders := request["headers"].([]interface{})
+	if len(reqHeaders) != 1 {
+		t.Errorf("request.headers count = %d, want 1", len(reqHeaders))
+	}
+	respHeaders := response["headers"].([]interface{})
+	if len(respHeaders) != 1 {
+		t.Errorf("response.headers count = %d, want 1", len(respHeaders))
+	}
+	qs := request["queryString"].([]interface{})
+	if len(qs) != 1 {
+		t.Errorf("queryString count = %d, want 1", len(qs))
+	}
+	first := reqHeaders[0].(map[string]interface{})
+	if first["name"] != "User-Agent" || first["value"] != "test" {
+		t.Errorf("header round-trip lost data: %+v", first)
+	}
+}


### PR DESCRIPTION
## Summary

Populates HAR \`request.headers\`, \`request.queryString\`, and \`response.headers\` per request — fields that were always empty arrays before. After this PR, opening a HAR in Chrome DevTools / Charles immediately shows what kind of request was made (User-Agent, Range, If-None-Match) and what came back (Content-Type, Cache-Control, Server).

## Changes

- **\`NetworkLogEntry\`** (\`go-proxy/cmd/server/main.go\`) — adds \`HeaderPair\` type and three new fields: \`RequestHeaders\`, \`ResponseHeaders\`, \`QueryString\`.
- **Capture helpers**:
  - \`capturedHeaders(http.Header) []HeaderPair\` — filters Cookie / Set-Cookie / Authorization / Proxy-Authorization / X-Amz-Security-Token; sorts for deterministic HAR diffs.
  - \`capturedQueryString(*url.URL) []HeaderPair\` — preserves URL parameter order; percent-decodes name and value.
  - \`stampNetMeta(*NetworkLogEntry, ...)\` — idempotent attach helper.
- **\`handleProxy\`** captures request headers + query string once at the top, then 10 \`stampNetMeta\` calls cover every \`addNetworkLogEntry\` site (success path, upstream error paths, all four \`createFaultLogEntry\` paths, the segment-corruption branches).
- **HAR builder** (\`go-proxy/internal/har/har.go\`) — adds the three fields to \`Source\`, populates the standard HAR \`Request\`/\`Response\` slots in \`buildEntry\`. Empty sources still produce \`[]NameValue{}\` (HAR 1.2 spec requires the arrays to be present, not null).
- **16 new unit tests** (5 in \`internal/har\`, 11 in \`cmd/server\`) covering plumbing, privacy filter, stable ordering, percent-decode, flag-only params, JSON round-trip.

## Test plan

- [x] \`go test ./go-proxy/...\` 16 new tests + all existing pass
- [x] \`go build ./go-proxy/...\` clean
- [x] Pre-commit Sonnet review v1 — clean
- [x] Lives in \`integration/har-stack\` for end-to-end testing alongside the rest of the HAR stack
- [ ] Manual: download a HAR via Save HAR after this lands; open in Chrome DevTools → Network → Import HAR; confirm Request/Response Headers panes are populated and queryString shows query parameters