### PR TITLE
feat(har): play_id scoping — HAR snapshots per-play not per-session (#280)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -54,6 +54,31 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
 
     val playerId: String = UUID.randomUUID().toString()
 
+    /**
+     * `play_id` (issue #280) — a UUID regenerated at every fresh
+     * playback episode (loadStream / reload / retry / variant change).
+     * Threaded through every URL the player issues as `?play_id=...`
+     * so go-proxy can scope its NetworkLogEntry ring buffer per play.
+     * HAR snapshots filter to the most-recent play_id by default.
+     */
+    private var currentPlayId: String = UUID.randomUUID().toString()
+
+    private fun regeneratePlayId() {
+        currentPlayId = UUID.randomUUID().toString()
+    }
+
+    /** Replace any existing `play_id` query param with `currentPlayId`. */
+    private fun withPlayId(url: String): String {
+        if (url.isEmpty()) return url
+        val (base, query) = url.split("?", limit = 2).let {
+            if (it.size == 2) it[0] to it[1] else it[0] to ""
+        }
+        val params = if (query.isEmpty()) mutableListOf() else query.split("&").toMutableList()
+        params.removeAll { it.startsWith("play_id=") }
+        params.add("play_id=$currentPlayId")
+        return "$base?${params.joinToString("&")}"
+    }
+
     // Mutable so [recreatePlayer] can drop and rebuild them when the
     // current ExoPlayer instance gets wedged in a state its own retry
     // logic can't escape. Always non-null after init.
@@ -575,7 +600,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // injection). OFF → API/main nginx port (no proxy in front of the
         // stream). Same /go-live route in both cases.
         val port = if (s.localProxy) server.port else server.apiPort
-        val url = "http://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId"
+        // Fresh play_id at every loadStream boundary (issue #280) so
+        // go-proxy can scope its network log per play.
+        regeneratePlayId()
+        val url = "http://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId&play_id=$currentPlayId"
         _state.update { it.copy(currentUrl = url, statusText = url) }
         loadStream(url)
     }
@@ -628,9 +656,15 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     fun retry() {
         val url = _state.value.currentUrl
         if (url.isEmpty()) return
+        // A retry is a new playback episode — fresh play_id so the
+        // proxy's network log scopes the next round of requests
+        // separately from the one that just failed. Issue #280.
+        regeneratePlayId()
+        val refreshed = withPlayId(url)
+        _state.update { it.copy(currentUrl = refreshed, statusText = refreshed) }
         player.stop()
         player.clearMediaItems()
-        loadStream(url)
+        loadStream(refreshed)
     }
 
     /**

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -95,6 +95,13 @@ final class PlayerViewModel: ObservableObject {
     /// **not** rotate it — proxy session continuity matters.
     let playerId: String = UUID().uuidString
 
+    /// `play_id` (issue #280) — a UUID regenerated at every fresh
+    /// playback episode (loadStream / reload / retry / variant change).
+    /// Threaded through every URL the player issues as `?play_id=...`
+    /// so go-proxy can scope its NetworkLogEntry ring buffer per play.
+    /// HAR snapshots filter to the most-recent play_id by default.
+    private var currentPlayID: String = UUID().uuidString
+
     // MARK: - Private state
 
     private var codecRetries = 0
@@ -481,6 +488,8 @@ final class PlayerViewModel: ObservableObject {
 
     private func buildURLAndLoad() {
         guard let server = activeServer, !selectedContent.isEmpty else { return }
+        // Fresh play_id at every loadStream boundary — issue #280.
+        regeneratePlayID()
         var url = StreamURLBuilder.playbackURL(
             server: server,
             contentName: selectedContent,
@@ -499,7 +508,12 @@ final class PlayerViewModel: ObservableObject {
         } else {
             url = resolved
         }
-        guard let final = url else { return }
+        guard var final = url else { return }
+        // Append play_id last so it survives the player_id strip above
+        // for k3s-dev's content port. (For HAR scoping go-proxy reads
+        // play_id from URLs that hit it; the content port stripping
+        // only affects routes that don't reach go-proxy.)
+        final = appendPlayID(to: final)
         self.currentURL = final
         self.statusText = final.absoluteString
         loadStream(url: final)
@@ -510,6 +524,23 @@ final class PlayerViewModel: ObservableObject {
         components.queryItems = components.queryItems?.filter { $0.name != "player_id" }
         if components.queryItems?.isEmpty == true { components.queryItems = nil }
         return components.url ?? url
+    }
+
+    /// Replace any existing `play_id` query item with the current
+    /// `currentPlayID`. Issue #280.
+    private func appendPlayID(to url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "play_id" }
+        items.append(URLQueryItem(name: "play_id", value: currentPlayID))
+        components.queryItems = items
+        return components.url ?? url
+    }
+
+    /// Mint a fresh `play_id` UUID. Called at every new playback
+    /// episode boundary so go-proxy can scope its network log per play.
+    private func regeneratePlayID() {
+        currentPlayID = UUID().uuidString
     }
 
     private func loadStream(url: URL) {
@@ -773,7 +804,13 @@ final class PlayerViewModel: ObservableObject {
     /// the *same* URL on the *same* AVPlayer.
     func retry() {
         guard let url = currentURL else { return }
-        loadStream(url: url)
+        // A retry is a new playback episode — fresh play_id so the
+        // proxy's network log scopes the next round of requests
+        // separately from the one that just failed. Issue #280.
+        regeneratePlayID()
+        let refreshed = appendPlayID(to: url)
+        self.currentURL = refreshed
+        loadStream(url: refreshed)
     }
 
     /// Full tear-down + recreate. Replaces the AVPlayer instance,

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -53,9 +53,11 @@ func resolveIncidentDir() string {
 
 // SnapshotRequest is the body for POST /api/session/{id}/har/snapshot.
 type SnapshotRequest struct {
-	Reason   string                 `json:"reason"`
-	Source   string                 `json:"source"` // "dashboard", "rest", "player"
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Reason          string                 `json:"reason"`
+	Source          string                 `json:"source"` // "dashboard", "rest", "player"
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	PlayID          string                 `json:"play_id,omitempty"`           // override the auto-detected most-recent play_id
+	IncludeAllPlays bool                   `json:"include_all_plays,omitempty"` // forensic mode — no scoping
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -70,20 +72,46 @@ type IncidentFileInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// HARBuildFilter controls play_id scoping in buildHARForSession.
+//
+//   - PlayID == "" and IncludeAllPlays == false: filter to the
+//     most-recent play_id in the ring buffer (default — matches what
+//     the player asks for at incident time).
+//   - PlayID != "": filter to that exact play_id.
+//   - IncludeAllPlays == true: no filter — every entry across every
+//     play is included (forensic mode).
+type HARBuildFilter struct {
+	PlayID          string
+	IncludeAllPlays bool
+}
+
 // buildHARForSession reads the session's network ring buffer and returns a HAR
 // document. Caller is expected to have already validated the session exists.
-func (a *App) buildHARForSession(session SessionData, incident *har.Incident) har.HAR {
+func (a *App) buildHARForSession(session SessionData, incident *har.Incident, filter HARBuildFilter) har.HAR {
 	sessionID := getString(session, "session_id")
 
 	a.networkLogsMu.RLock()
 	rb, exists := a.networkLogs[sessionID]
 	a.networkLogsMu.RUnlock()
 
+	// Resolve the play_id we'll filter on, unless the caller opts out.
+	resolvedPlayID := filter.PlayID
+	if !filter.IncludeAllPlays && resolvedPlayID == "" && exists {
+		resolvedPlayID = mostRecentPlayID(rb.GetAll())
+	}
+
 	var sources []har.Source
+	var playStartedAt time.Time
 	if exists {
 		entries := rb.GetAll()
 		sources = make([]har.Source, 0, len(entries))
 		for _, e := range entries {
+			if !filter.IncludeAllPlays && resolvedPlayID != "" && e.PlayID != resolvedPlayID {
+				continue
+			}
+			if playStartedAt.IsZero() || e.Timestamp.Before(playStartedAt) {
+				playStartedAt = e.Timestamp
+			}
 			sources = append(sources, har.Source{
 				Timestamp:     e.Timestamp,
 				Method:        e.Method,
@@ -123,9 +151,36 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		if incident.GroupID == "" {
 			incident.GroupID = opts.GroupID
 		}
+		// Surface play_id scope in the incident block so HAR consumers
+		// know what they're looking at without inspecting individual
+		// entries' URLs.
+		if incident.Metadata == nil {
+			incident.Metadata = map[string]interface{}{}
+		}
+		if resolvedPlayID != "" {
+			incident.Metadata["play_id"] = resolvedPlayID
+		}
+		if filter.IncludeAllPlays {
+			incident.Metadata["include_all_plays"] = true
+		}
+		if !playStartedAt.IsZero() {
+			incident.Metadata["play_started_at"] = playStartedAt.UTC().Format(time.RFC3339Nano)
+		}
 	}
 
 	return har.Build(sources, opts)
+}
+
+// mostRecentPlayID walks the ring buffer newest-first looking for the
+// last play_id seen. Empty string if no entry carried one (e.g., older
+// players that don't yet emit play_id query param).
+func mostRecentPlayID(entries []NetworkLogEntry) string {
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].PlayID != "" {
+			return entries[i].PlayID
+		}
+	}
+	return ""
 }
 
 // findSessionByID returns the session map matching session_id, or nil.
@@ -156,7 +211,13 @@ func (a *App) handleGetSessionTimelineHAR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	doc := a.buildHARForSession(session, nil)
+	// timeline.har accepts ?play_id=X (specific play) and
+	// ?include_all_plays=1 (forensic). Default: most-recent play_id.
+	filter := HARBuildFilter{
+		PlayID:          strings.TrimSpace(r.URL.Query().Get("play_id")),
+		IncludeAllPlays: strings.EqualFold(r.URL.Query().Get("include_all_plays"), "1") || strings.EqualFold(r.URL.Query().Get("include_all_plays"), "true"),
+	}
+	doc := a.buildHARForSession(session, nil, filter)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="timeline-%s.har"`, safeFilename(playerID)))
@@ -203,7 +264,10 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		Metadata:  req.Metadata,
 	}
 
-	doc := a.buildHARForSession(session, incident)
+	doc := a.buildHARForSession(session, incident, HARBuildFilter{
+		PlayID:          strings.TrimSpace(req.PlayID),
+		IncludeAllPlays: req.IncludeAllPlays,
+	})
 	playerID := getString(session, "player_id")
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -106,6 +106,14 @@ type NetworkLogEntry struct {
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
 
+	// PlayID identifies the playback episode this request belongs to.
+	// The player generates a fresh UUID at every loadStream / reload
+	// and passes it as `?play_id=...` on every URL. HAR snapshots
+	// filter by the current play_id by default, so a freeze 8 minutes
+	// into a session shows just that play's network log instead of
+	// the whole ring buffer. Issue #280.
+	PlayID string `json:"play_id,omitempty"`
+
 	// Timing phases (milliseconds)
 	DNSMs      float64 `json:"dns_ms"`
 	ConnectMs  float64 `json:"connect_ms"`
@@ -3547,6 +3555,17 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Extract the player's `play_id` query param (issue #280). Used to
+	// scope HAR snapshots to a single playback episode. Stamped onto
+	// every NetworkLogEntry created in this handler via the logEntry
+	// closure below.
+	playID := strings.TrimSpace(r.URL.Query().Get("play_id"))
+	logEntry := func(sessionID string, entry NetworkLogEntry) {
+		if entry.PlayID == "" {
+			entry.PlayID = playID
+		}
+		a.addNetworkLogEntry(sessionID, entry)
+	}
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3858,7 +3877,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
 				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
-				a.addNetworkLogEntry(sessionID, netEntry)
+				logEntry(sessionID,netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3885,7 +3904,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
-				a.addNetworkLogEntry(sessionID, *netEntry)
+				logEntry(sessionID,*netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3905,7 +3924,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
-				a.addNetworkLogEntry(sessionID, *netEntry)
+				logEntry(sessionID,*netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3937,7 +3956,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			netEntry.FaultType = failureType
 			netEntry.FaultAction = actionTaken
 			netEntry.FaultCategory = categorizeFaultType(failureType)
-			a.addNetworkLogEntry(sessionID, *netEntry)
+			logEntry(sessionID,*netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
 			return
@@ -3959,7 +3978,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
 			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
-			a.addNetworkLogEntry(sessionID, netEntry)
+			logEntry(sessionID,netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
 			return
@@ -4015,7 +4034,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusTooManyRequests
 		}
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
-		a.addNetworkLogEntry(sessionID, netEntry)
+		logEntry(sessionID,netEntry)
 		return
 	}
 
@@ -4037,7 +4056,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
-		a.addNetworkLogEntry(sessionID, netEntry)
+		logEntry(sessionID,netEntry)
 		return
 	}
 	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
@@ -4064,7 +4083,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
-		a.addNetworkLogEntry(sessionID, *netEntry)
+		logEntry(sessionID,*netEntry)
 		return
 	}
 	defer resp.Body.Close()
@@ -4088,7 +4107,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
-		a.addNetworkLogEntry(sessionID, *netEntry)
+		logEntry(sessionID,*netEntry)
 		return
 	}
 	copyUpstreamHeaders(w, resp)
@@ -4207,7 +4226,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	netEntry.RequestKind = requestKind
 	netEntry.BytesIn = requestBytes
 	netEntry.BytesOut = bytesOut
-	a.addNetworkLogEntry(sessionID, *netEntry)
+	logEntry(sessionID,*netEntry)
 	a.saveSessionByID(sessionNumber, sessionData)
 }
 

--- a/go-proxy/cmd/server/play_id_test.go
+++ b/go-proxy/cmd/server/play_id_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/internal/har"
+)
+
+// Tests for the play_id capture + filter plumbing introduced for
+// issue #280.
+
+func TestMostRecentPlayID_PrefersNewest(t *testing.T) {
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now().Add(-3 * time.Second), PlayID: "old"},
+		{Timestamp: time.Now().Add(-2 * time.Second), PlayID: "middle"},
+		{Timestamp: time.Now().Add(-1 * time.Second), PlayID: "newest"},
+	}
+	if got := mostRecentPlayID(entries); got != "newest" {
+		t.Errorf("mostRecentPlayID = %q, want %q", got, "newest")
+	}
+}
+
+func TestMostRecentPlayID_SkipsEmpty(t *testing.T) {
+	// Older entries (pre-#280 players) may not carry play_id; the
+	// resolver should walk past them to find the newest play_id that
+	// actually exists.
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now().Add(-3 * time.Second), PlayID: "actual-play"},
+		{Timestamp: time.Now().Add(-2 * time.Second), PlayID: ""},
+		{Timestamp: time.Now().Add(-1 * time.Second), PlayID: ""},
+	}
+	if got := mostRecentPlayID(entries); got != "actual-play" {
+		t.Errorf("mostRecentPlayID with trailing-empties = %q, want %q", got, "actual-play")
+	}
+}
+
+func TestMostRecentPlayID_AllEmptyReturnsEmpty(t *testing.T) {
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now(), PlayID: ""},
+		{Timestamp: time.Now(), PlayID: ""},
+	}
+	if got := mostRecentPlayID(entries); got != "" {
+		t.Errorf("mostRecentPlayID with all-empty = %q, want empty string", got)
+	}
+}
+
+func TestMostRecentPlayID_EmptySlice(t *testing.T) {
+	if got := mostRecentPlayID(nil); got != "" {
+		t.Errorf("mostRecentPlayID(nil) = %q, want empty", got)
+	}
+	if got := mostRecentPlayID([]NetworkLogEntry{}); got != "" {
+		t.Errorf("mostRecentPlayID([]) = %q, want empty", got)
+	}
+}
+
+// buildHARForSession's filter logic is exercised by reading through a
+// mock NetworkLogRingBuffer. Set up an App with two plays in one
+// session and verify each filter mode picks the right entries.
+func TestBuildHARForSession_FiltersToMostRecentPlayByDefault(t *testing.T) {
+	a := &App{
+		networkLogs: map[string]*NetworkLogRingBuffer{},
+	}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	// Play A: 3 entries
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-30 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-29 * time.Second), URL: "/a/2", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-28 * time.Second), URL: "/a/3", PlayID: "play-a"})
+	// Play B: 2 entries (more recent)
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-5 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-4 * time.Second), URL: "/b/2", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+
+	session := SessionData{"session_id": "sess-1", "player_id": "p1"}
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("default filter (most-recent play) entry count = %d, want 2", got)
+	}
+	for _, e := range doc.Log.Entries {
+		if e.Request.URL == "/a/1" || e.Request.URL == "/a/2" || e.Request.URL == "/a/3" {
+			t.Errorf("default filter leaked play-a entries: %+v", e.Request.URL)
+		}
+	}
+}
+
+func TestBuildHARForSession_IncludeAllPlays(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-10 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-1 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{IncludeAllPlays: true})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("IncludeAllPlays entry count = %d, want 2 (both plays)", got)
+	}
+}
+
+func TestBuildHARForSession_ExplicitPlayIDOverride(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-10 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-9 * time.Second), URL: "/a/2", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-1 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	// Default (no PlayID, no IncludeAllPlays) → most recent = play-b → 1 entry
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	if got := len(doc.Log.Entries); got != 1 {
+		t.Errorf("default = play-b entry count = %d, want 1", got)
+	}
+
+	// Explicit override to play-a → 2 entries
+	doc = a.buildHARForSession(session, nil, HARBuildFilter{PlayID: "play-a"})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("explicit play-a entry count = %d, want 2", got)
+	}
+}
+
+func TestBuildHARForSession_IncidentMetadataCarriesPlayID(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-2 * time.Second), URL: "/x", PlayID: "play-zz"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	incident := &har.Incident{Reason: "manual"}
+	a.buildHARForSession(session, incident, HARBuildFilter{})
+	if incident.Metadata == nil {
+		t.Fatalf("expected metadata populated by builder")
+	}
+	if got := incident.Metadata["play_id"]; got != "play-zz" {
+		t.Errorf("metadata.play_id = %v, want play-zz", got)
+	}
+	if _, has := incident.Metadata["play_started_at"]; !has {
+		t.Errorf("metadata.play_started_at missing: %+v", incident.Metadata)
+	}
+}
+
+func TestBuildHARForSession_IncidentMetadataMarksIncludeAllPlays(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	rb.Add(NetworkLogEntry{Timestamp: time.Now(), URL: "/x", PlayID: "p1"})
+	rb.Add(NetworkLogEntry{Timestamp: time.Now(), URL: "/y", PlayID: "p2"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	incident := &har.Incident{Reason: "forensic"}
+	a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true})
+	if v, _ := incident.Metadata["include_all_plays"].(bool); !v {
+		t.Errorf("expected metadata.include_all_plays=true, got %+v", incident.Metadata)
+	}
+}


### PR DESCRIPTION
## Summary

The proxy's \`NetworkLogEntry\` ring buffer holds 5000 entries, so a session alive 10 minutes spans multiple plays. A HAR taken on a freeze 8 minutes in used to include the noise from earlier plays. This PR scopes each snapshot to one playback episode by default.

## Mechanism

- **Player** generates a fresh \`play_id\` UUID at every \`loadStream\` / \`reload\` / \`retry\` boundary (Apple + Android), passes it as \`?play_id=...\` on every URL.
- **go-proxy** reads \`play_id\` off the URL in \`handleProxy\` and stamps it onto every \`NetworkLogEntry\` via a \`logEntry\` closure (single point of capture).
- **\`HARBuildFilter\`** in \`buildHARForSession\`:
  - \`PlayID == ""\` + \`IncludeAllPlays == false\` → most-recent \`play_id\` (default)
  - \`PlayID != ""\` → that exact \`play_id\`
  - \`IncludeAllPlays == true\` → no filter (forensic mode)
- **\`SnapshotRequest\`** gains \`play_id\` and \`include_all_plays\` body fields; \`GET /api/sessions/{player_id}/timeline.har\` accepts matching query params.
- **\`Incident.Metadata\`** populated with \`play_id\`, \`play_started_at\`, and \`include_all_plays\` so HAR consumers see the scope without inspecting entries.

## Tests

9 new in \`cmd/server/play_id_test.go\`:
- \`mostRecentPlayID\` — prefers newest, skips empty, empty/empty-slice handling
- Default filter (most-recent), \`IncludeAllPlays\`, explicit \`PlayID\` override
- \`Incident.Metadata\` carries \`play_id\` + \`play_started_at\` + \`include_all_plays\`

## Build status

- \`go test ./...\` — all 9 new + existing pass
- \`go build ./...\` — clean
- iOS sim build — clean
- Android \`gradlew assembleDebug\` — clean

## Test plan

- [x] Unit tests
- [ ] Manual: open testing-session.html, induce a freeze, save HAR, verify the entries inside reference one play_id only
- [ ] Manual: hit Retry, induce another freeze, save another HAR — verify the play_ids differ
- [ ] Manual: \`POST .../har/snapshot\` with \`{"include_all_plays": true}\` — verify entries from both plays appear