### PR TITLE
feat(har): incident context block — _extensions.context for self-contained HARs (#281)

### DIFF
--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -52,10 +52,89 @@ func resolveIncidentDir() string {
 }
 
 // SnapshotRequest is the body for POST /api/session/{id}/har/snapshot.
+//
+// Players send Device + Stream blocks alongside the freeform Metadata so
+// the server can fold them into the HAR's _extensions.context block
+// (issue #281).
 type SnapshotRequest struct {
 	Reason   string                 `json:"reason"`
 	Source   string                 `json:"source"` // "dashboard", "rest", "player"
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Device   *SnapshotDeviceMeta    `json:"device,omitempty"`
+	Stream   *SnapshotStreamMeta    `json:"stream,omitempty"`
+	PlayID   string                 `json:"play_id,omitempty"`
+}
+
+// SnapshotDeviceMeta is the device fingerprint a player sends with a
+// snapshot request. Mirrors har.DeviceContext on the wire.
+type SnapshotDeviceMeta struct {
+	Model       string `json:"model,omitempty"`
+	OSVersion   string `json:"os_version,omitempty"`
+	AppVersion  string `json:"app_version,omitempty"`
+	NetworkType string `json:"network_type,omitempty"`
+}
+
+// SnapshotStreamMeta describes what the player is playing.
+type SnapshotStreamMeta struct {
+	ContentID         string `json:"content_id,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Codec             string `json:"codec,omitempty"`
+	InitialVariantURL string `json:"initial_variant_url,omitempty"`
+}
+
+// recoveryChainStore tracks the ordered list of incident reasons a
+// player has hit during the current play. Keyed by playerID + ":" +
+// playID so a fresh play resets the chain. Issue #281.
+var (
+	recoveryChainMu    sync.Mutex
+	recoveryChainStore = map[string][]string{}
+)
+
+func recoveryChainKey(playerID, playID string) string {
+	if playerID == "" && playID == "" {
+		return ""
+	}
+	return playerID + ":" + playID
+}
+
+// recoveryChainSnapshot returns the current chain for (playerID, playID)
+// without modifying it. Used for forensic snapshots that should observe
+// without polluting the chain.
+func recoveryChainSnapshot(playerID, playID string) []string {
+	key := recoveryChainKey(playerID, playID)
+	if key == "" {
+		return nil
+	}
+	recoveryChainMu.Lock()
+	defer recoveryChainMu.Unlock()
+	chain := recoveryChainStore[key]
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]string, len(chain))
+	copy(out, chain)
+	return out
+}
+
+// recordRecoveryReason appends `reason` to the chain for
+// (playerID, playID), capped at 32 entries to keep the HAR reasonable.
+// Returns the resulting chain.
+func recordRecoveryReason(playerID, playID, reason string) []string {
+	key := recoveryChainKey(playerID, playID)
+	if key == "" || reason == "" {
+		return nil
+	}
+	recoveryChainMu.Lock()
+	defer recoveryChainMu.Unlock()
+	chain := append(recoveryChainStore[key], reason)
+	const maxChain = 32
+	if len(chain) > maxChain {
+		chain = chain[len(chain)-maxChain:]
+	}
+	recoveryChainStore[key] = chain
+	out := make([]string, len(chain))
+	copy(out, chain)
+	return out
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -72,7 +151,8 @@ type IncidentFileInfo struct {
 
 // buildHARForSession reads the session's network ring buffer and returns a HAR
 // document. Caller is expected to have already validated the session exists.
-func (a *App) buildHARForSession(session SessionData, incident *har.Incident) har.HAR {
+// `context` is optional — when non-nil, it lands at log._extensions.context.
+func (a *App) buildHARForSession(session SessionData, incident *har.Incident, context *har.Context) har.HAR {
 	sessionID := getString(session, "session_id")
 
 	a.networkLogsMu.RLock()
@@ -112,6 +192,7 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		PlayerID:  getString(session, "player_id"),
 		GroupID:   getString(session, "group_id"),
 		Incident:  incident,
+		Context:   context,
 	}
 	if incident != nil {
 		if incident.PlayerID == "" {
@@ -126,6 +207,111 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 	}
 
 	return har.Build(sources, opts)
+}
+
+// buildIncidentContext assembles the _extensions.context block for a
+// snapshot. Pulls device + stream from the player's request body,
+// scenario from the session record, timing from the network log's
+// earliest entry for the current play, and the recovery chain from
+// the in-memory store. Issue #281.
+func (a *App) buildIncidentContext(session SessionData, req *SnapshotRequest, playerID string) *har.Context {
+	if req == nil {
+		return nil
+	}
+	ctx := &har.Context{}
+
+	// Device + Stream — copied from request body.
+	if req.Device != nil {
+		ctx.Device = &har.DeviceContext{
+			Model:       req.Device.Model,
+			OSVersion:   req.Device.OSVersion,
+			AppVersion:  req.Device.AppVersion,
+			NetworkType: req.Device.NetworkType,
+		}
+	}
+	if req.Stream != nil {
+		ctx.Stream = &har.StreamContext{
+			ContentID:         req.Stream.ContentID,
+			Protocol:          req.Stream.Protocol,
+			Codec:             req.Stream.Codec,
+			InitialVariantURL: req.Stream.InitialVariantURL,
+		}
+	}
+
+	// Scenario — pull a sanitised view of the session's testing
+	// configuration. Avoid leaking everything in the session blob;
+	// pick the keys analysts actually care about.
+	scenario := &har.ScenarioContext{}
+	faultKeys := []string{
+		"segment_failure_type", "segment_failure_frequency", "segment_consecutive_failures",
+		"segment_failure_mode", "segment_failure_units", "segment_failure_urls",
+		"manifest_failure_type", "manifest_failure_frequency", "manifest_consecutive_failures",
+		"manifest_failure_mode", "manifest_failure_units", "manifest_failure_urls",
+		"master_manifest_failure_type", "master_manifest_failure_frequency",
+		"master_manifest_consecutive_failures", "master_manifest_failure_mode",
+		"transport_failure_type", "transport_consecutive_failures", "transport_failure_frequency",
+		"transport_failure_mode",
+	}
+	for _, k := range faultKeys {
+		if v, ok := session[k]; ok && v != nil && v != "" && v != "none" && v != 0 && v != 0.0 {
+			if scenario.FaultSettings == nil {
+				scenario.FaultSettings = map[string]interface{}{}
+			}
+			scenario.FaultSettings[k] = v
+		}
+	}
+	shapeKeys := []string{
+		"nftables_bandwidth_mbps", "nftables_delay_ms", "nftables_packet_loss",
+		"nftables_pattern_enabled", "nftables_pattern_steps",
+	}
+	for _, k := range shapeKeys {
+		v, ok := session[k]
+		if !ok || v == nil || v == "" {
+			continue
+		}
+		// Booleans are equal to 0 under interface comparison, so skip
+		// the v != 0 guard for bool fields — `false` is a meaningful
+		// "off" we want to surface for nftables_pattern_enabled.
+		if _, isBool := v.(bool); !isBool {
+			if v == 0 || v == 0.0 {
+				continue
+			}
+		}
+		if scenario.NftablesShape == nil {
+			scenario.NftablesShape = map[string]interface{}{}
+		}
+		scenario.NftablesShape[k] = v
+	}
+	if scenario.FaultSettings != nil || scenario.NftablesShape != nil {
+		ctx.Scenario = scenario
+	}
+
+	// Timing — when the player tells us play_started_at via Metadata
+	// (typically a "player_metrics_play_started_at" RFC3339 string)
+	// we surface it here. Once #280 (play_id scoping) lands, the
+	// server will derive this from the network log's earliest entry
+	// for the current play_id; until then, rely on the player's
+	// own snapshot.
+	playID := strings.TrimSpace(req.PlayID)
+	if playStartedAtRaw, ok := req.Metadata["play_started_at"].(string); ok && playStartedAtRaw != "" {
+		if playStartedAt, err := time.Parse(time.RFC3339Nano, playStartedAtRaw); err == nil {
+			ctx.Timing = &har.TimingContext{
+				PlayStartedAt:   playStartedAt.UTC().Format(time.RFC3339Nano),
+				IncidentOffsetS: time.Since(playStartedAt).Seconds(),
+			}
+		}
+	}
+
+	// Recovery chain — append the current reason and surface the
+	// resulting list. Forensic snapshots (source != "player") read
+	// without recording so they don't pollute the chain.
+	if req.Source == "player" {
+		ctx.RecoveryChain = recordRecoveryReason(playerID, playID, req.Reason)
+	} else {
+		ctx.RecoveryChain = recoveryChainSnapshot(playerID, playID)
+	}
+
+	return ctx
 }
 
 // findSessionByID returns the session map matching session_id, or nil.
@@ -156,7 +342,7 @@ func (a *App) handleGetSessionTimelineHAR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	doc := a.buildHARForSession(session, nil)
+	doc := a.buildHARForSession(session, nil, nil)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="timeline-%s.har"`, safeFilename(playerID)))
@@ -203,8 +389,9 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		Metadata:  req.Metadata,
 	}
 
-	doc := a.buildHARForSession(session, incident)
 	playerID := getString(session, "player_id")
+	context := a.buildIncidentContext(session, &req, playerID)
+	doc := a.buildHARForSession(session, incident, context)
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/go-proxy/cmd/server/incident_context_test.go
+++ b/go-proxy/cmd/server/incident_context_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"testing"
+)
+
+// Tests for the recovery chain store + buildIncidentContext (issue #281).
+
+func TestRecoveryChain_AppendAndSnapshot(t *testing.T) {
+	// Reset the store between tests by using unique keys.
+	playerID := "player-rc-1"
+	playID := "play-1"
+	chain := recordRecoveryReason(playerID, playID, "frozen")
+	if len(chain) != 1 || chain[0] != "frozen" {
+		t.Errorf("first reason: got %+v, want [frozen]", chain)
+	}
+	chain = recordRecoveryReason(playerID, playID, "user_retry")
+	if len(chain) != 2 || chain[1] != "user_retry" {
+		t.Errorf("second reason: got %+v, want [frozen, user_retry]", chain)
+	}
+	snap := recoveryChainSnapshot(playerID, playID)
+	if len(snap) != 2 {
+		t.Errorf("snapshot length = %d, want 2", len(snap))
+	}
+}
+
+func TestRecoveryChain_DifferentPlayIDsDoNotShare(t *testing.T) {
+	// A new play_id starts a fresh chain — old play's reasons stay
+	// in their own bucket.
+	playerID := "player-rc-2"
+	recordRecoveryReason(playerID, "play-A", "frozen")
+	recordRecoveryReason(playerID, "play-A", "user_retry")
+	chainB := recordRecoveryReason(playerID, "play-B", "segment_stall")
+	if len(chainB) != 1 || chainB[0] != "segment_stall" {
+		t.Errorf("play-B chain shouldn't include play-A reasons: %+v", chainB)
+	}
+	chainA := recoveryChainSnapshot(playerID, "play-A")
+	if len(chainA) != 2 {
+		t.Errorf("play-A chain mutated by play-B activity: %+v", chainA)
+	}
+}
+
+func TestRecoveryChain_EmptyKeyReturnsNil(t *testing.T) {
+	if got := recordRecoveryReason("", "", "frozen"); got != nil {
+		t.Errorf("empty (player, play) should return nil, got %+v", got)
+	}
+	if got := recoveryChainSnapshot("", ""); got != nil {
+		t.Errorf("empty (player, play) snapshot should return nil, got %+v", got)
+	}
+}
+
+func TestRecoveryChain_EmptyReasonNoOp(t *testing.T) {
+	playerID := "player-rc-3"
+	playID := "play-1"
+	recordRecoveryReason(playerID, playID, "frozen")
+	chain := recordRecoveryReason(playerID, playID, "")
+	// Empty reason should not add to the chain.
+	if len(chain) != 0 {
+		t.Errorf("empty reason returned non-empty chain: %+v", chain)
+	}
+	snap := recoveryChainSnapshot(playerID, playID)
+	if len(snap) != 1 {
+		t.Errorf("chain mutated by empty reason: %+v", snap)
+	}
+}
+
+func TestBuildIncidentContext_PopulatesDeviceAndStream(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p1"}
+	req := &SnapshotRequest{
+		Reason: "frozen",
+		Source: "player",
+		Device: &SnapshotDeviceMeta{
+			Model: "iPad Pro", OSVersion: "iOS 18", AppVersion: "1.0", NetworkType: "wifi",
+		},
+		Stream: &SnapshotStreamMeta{
+			ContentID: "movie", Protocol: "hls", Codec: "h264",
+		},
+	}
+	ctx := a.buildIncidentContext(session, req, "p1")
+	if ctx == nil || ctx.Device == nil || ctx.Stream == nil {
+		t.Fatalf("expected device + stream populated, got %+v", ctx)
+	}
+	if ctx.Device.Model != "iPad Pro" || ctx.Stream.ContentID != "movie" {
+		t.Errorf("device/stream copy wrong: device=%+v stream=%+v", ctx.Device, ctx.Stream)
+	}
+}
+
+func TestBuildIncidentContext_ScenarioFromSession(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{
+		"session_id":                    "s1",
+		"player_id":                     "p1",
+		"segment_failure_type":          "404",
+		"segment_consecutive_failures":  3,
+		"transport_failure_type":        "none",        // should be filtered out
+		"nftables_bandwidth_mbps":       5,
+		"unrelated_session_field":       "should-not-appear",
+	}
+	req := &SnapshotRequest{Reason: "manual", Source: "rest"}
+	ctx := a.buildIncidentContext(session, req, "p1")
+	if ctx.Scenario == nil {
+		t.Fatalf("expected scenario block")
+	}
+	if ctx.Scenario.FaultSettings["segment_failure_type"] != "404" {
+		t.Errorf("fault_settings missing segment_failure_type: %+v", ctx.Scenario.FaultSettings)
+	}
+	if _, leaked := ctx.Scenario.FaultSettings["transport_failure_type"]; leaked {
+		t.Errorf("'none' values should be filtered: %+v", ctx.Scenario.FaultSettings)
+	}
+	if _, leaked := ctx.Scenario.FaultSettings["unrelated_session_field"]; leaked {
+		t.Errorf("non-fault keys leaked: %+v", ctx.Scenario.FaultSettings)
+	}
+	if ctx.Scenario.NftablesShape["nftables_bandwidth_mbps"] != 5 {
+		t.Errorf("nftables_shape missing bandwidth: %+v", ctx.Scenario.NftablesShape)
+	}
+}
+
+func TestBuildIncidentContext_RecordsForPlayerSource(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p-rec-1"}
+	req := &SnapshotRequest{
+		Reason: "frozen",
+		Source: "player",
+		PlayID: "play-rec-1",
+	}
+	ctx := a.buildIncidentContext(session, req, "p-rec-1")
+	if len(ctx.RecoveryChain) != 1 || ctx.RecoveryChain[0] != "frozen" {
+		t.Errorf("first recovery_chain: got %+v, want [frozen]", ctx.RecoveryChain)
+	}
+	// A second snapshot appends.
+	req2 := &SnapshotRequest{Reason: "user_retry", Source: "player", PlayID: "play-rec-1"}
+	ctx2 := a.buildIncidentContext(session, req2, "p-rec-1")
+	if len(ctx2.RecoveryChain) != 2 || ctx2.RecoveryChain[1] != "user_retry" {
+		t.Errorf("second recovery_chain: got %+v, want [frozen, user_retry]", ctx2.RecoveryChain)
+	}
+}
+
+func TestBuildIncidentContext_DashboardSourceObservesWithoutRecording(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p-obs-1"}
+	// Pre-populate via a player snapshot.
+	a.buildIncidentContext(session, &SnapshotRequest{
+		Reason: "frozen", Source: "player", PlayID: "play-obs-1",
+	}, "p-obs-1")
+	// Dashboard snapshot reads but doesn't append "manual".
+	ctx := a.buildIncidentContext(session, &SnapshotRequest{
+		Reason: "manual", Source: "dashboard", PlayID: "play-obs-1",
+	}, "p-obs-1")
+	if len(ctx.RecoveryChain) != 1 || ctx.RecoveryChain[0] != "frozen" {
+		t.Errorf("dashboard read should not record: %+v", ctx.RecoveryChain)
+	}
+}

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -168,12 +168,57 @@ type Incident struct {
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// Context is an analyst-friendly snapshot of *everything around* a HAR
+// at the moment it was captured (issue #281). Lands under
+// `_extensions.context` at the document level so an incident HAR is
+// self-contained — no cross-referencing of separate logs needed to
+// answer "what device, what stream, what test scenario, how far into
+// playback was this?".
+type Context struct {
+	Device        *DeviceContext         `json:"device,omitempty"`
+	Stream        *StreamContext         `json:"stream,omitempty"`
+	Scenario      *ScenarioContext       `json:"scenario,omitempty"`
+	Timing        *TimingContext         `json:"timing,omitempty"`
+	RecoveryChain []string               `json:"recovery_chain,omitempty"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
+}
+
+// DeviceContext is the player-supplied device fingerprint.
+type DeviceContext struct {
+	Model       string `json:"model,omitempty"`
+	OSVersion   string `json:"os_version,omitempty"`
+	AppVersion  string `json:"app_version,omitempty"`
+	NetworkType string `json:"network_type,omitempty"`
+}
+
+// StreamContext describes what the player is playing.
+type StreamContext struct {
+	ContentID         string `json:"content_id,omitempty"`
+	Protocol          string `json:"protocol,omitempty"` // "hls" or "dash"
+	Codec             string `json:"codec,omitempty"`
+	InitialVariantURL string `json:"initial_variant_url,omitempty"`
+}
+
+// ScenarioContext is a snapshot of the test conditions active when the
+// HAR was taken — server-side from the session record.
+type ScenarioContext struct {
+	FaultSettings map[string]interface{} `json:"fault_settings,omitempty"`
+	NftablesShape map[string]interface{} `json:"nftables_shape,omitempty"`
+}
+
+// TimingContext anchors the incident in playback time.
+type TimingContext struct {
+	PlayStartedAt    string  `json:"play_started_at,omitempty"`    // RFC3339, when the play began
+	IncidentOffsetS  float64 `json:"incident_offset_s,omitempty"`  // seconds since play_started_at
+}
+
 // BuildOptions controls extra metadata embedded at the HAR Log level.
 type BuildOptions struct {
 	SessionID string
 	PlayerID  string
 	GroupID   string
 	Incident  *Incident
+	Context   *Context
 }
 
 // Build constructs a HAR document from the given NetworkLogEntry sources.
@@ -209,11 +254,24 @@ func Build(sources []Source, opts BuildOptions) HAR {
 	if opts.Incident != nil {
 		ext["incident"] = opts.Incident
 	}
+	if opts.Context != nil && !opts.Context.isEmpty() {
+		ext["context"] = opts.Context
+	}
 	if len(ext) > 0 {
 		log.Extensions = ext
 	}
 
 	return HAR{Log: log}
+}
+
+// isEmpty reports whether the Context has nothing populated. Used to
+// avoid emitting an `_extensions.context: {}` block.
+func (c *Context) isEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return c.Device == nil && c.Stream == nil && c.Scenario == nil &&
+		c.Timing == nil && len(c.RecoveryChain) == 0 && len(c.Extra) == 0
 }
 
 func buildEntry(s Source) Entry {

--- a/go-proxy/internal/har/har_context_test.go
+++ b/go-proxy/internal/har/har_context_test.go
@@ -1,0 +1,153 @@
+package har
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Tests target the _extensions.context block introduced for issue #281.
+// Lives in its own file so it can land independently of other test files
+// (#278 har_test.go, #279 har_headers_test.go).
+
+func TestBuild_ContextDeviceSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Device: &DeviceContext{
+				Model:       "iPad Pro 12.9 (6th gen)",
+				OSVersion:   "iOS 18.2",
+				AppVersion:  "1.4.2-abc123",
+				NetworkType: "wifi",
+			},
+		},
+	})
+	ctx, ok := doc.Log.Extensions["context"].(*Context)
+	if !ok {
+		t.Fatalf("expected _extensions.context, got %T", doc.Log.Extensions["context"])
+	}
+	if ctx.Device.Model != "iPad Pro 12.9 (6th gen)" || ctx.Device.NetworkType != "wifi" {
+		t.Errorf("device block wrong: %+v", ctx.Device)
+	}
+}
+
+func TestBuild_ContextStreamSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Stream: &StreamContext{
+				ContentID:         "big-buck-bunny",
+				Protocol:          "hls",
+				Codec:             "h264",
+				InitialVariantURL: "https://example.test/1080p.m3u8",
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Stream.ContentID != "big-buck-bunny" || ctx.Stream.Protocol != "hls" {
+		t.Errorf("stream block wrong: %+v", ctx.Stream)
+	}
+}
+
+func TestBuild_ContextScenarioSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Scenario: &ScenarioContext{
+				FaultSettings: map[string]interface{}{
+					"segment_failure_type":      "404",
+					"segment_consecutive_failures": 3,
+				},
+				NftablesShape: map[string]interface{}{
+					"nftables_bandwidth_mbps": 5.0,
+					"nftables_delay_ms":       100,
+				},
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Scenario.FaultSettings["segment_failure_type"] != "404" {
+		t.Errorf("scenario.fault_settings wrong: %+v", ctx.Scenario.FaultSettings)
+	}
+	if ctx.Scenario.NftablesShape["nftables_bandwidth_mbps"] != 5.0 {
+		t.Errorf("scenario.nftables_shape wrong: %+v", ctx.Scenario.NftablesShape)
+	}
+}
+
+func TestBuild_ContextTimingSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Timing: &TimingContext{
+				PlayStartedAt:   "2026-04-29T12:00:00Z",
+				IncidentOffsetS: 47.3,
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Timing.PlayStartedAt != "2026-04-29T12:00:00Z" {
+		t.Errorf("timing.play_started_at wrong: %+v", ctx.Timing)
+	}
+	if ctx.Timing.IncidentOffsetS != 47.3 {
+		t.Errorf("timing.incident_offset_s = %v, want 47.3", ctx.Timing.IncidentOffsetS)
+	}
+}
+
+func TestBuild_ContextRecoveryChain(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			RecoveryChain: []string{"frozen", "user_retry", "segment_stall"},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if len(ctx.RecoveryChain) != 3 || ctx.RecoveryChain[1] != "user_retry" {
+		t.Errorf("recovery_chain wrong: %+v", ctx.RecoveryChain)
+	}
+}
+
+func TestBuild_EmptyContextOmitted(t *testing.T) {
+	// An entirely empty Context should NOT produce an
+	// `_extensions.context: {}` block — it'd just be noise.
+	doc := Build(nil, BuildOptions{
+		Context: &Context{},
+	})
+	if _, has := doc.Log.Extensions["context"]; has {
+		t.Errorf("empty context should not be emitted: %+v", doc.Log.Extensions)
+	}
+}
+
+func TestBuild_NilContextOmitted(t *testing.T) {
+	doc := Build(nil, BuildOptions{Context: nil})
+	if _, has := doc.Log.Extensions["context"]; has {
+		t.Errorf("nil context should not be emitted: %+v", doc.Log.Extensions)
+	}
+}
+
+func TestBuild_ContextRoundTripsThroughJSON(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		SessionID: "s",
+		Context: &Context{
+			Device: &DeviceContext{Model: "Apple TV 4K", OSVersion: "tvOS 18"},
+			Stream: &StreamContext{ContentID: "demo", Protocol: "hls"},
+			Scenario: &ScenarioContext{
+				FaultSettings: map[string]interface{}{"segment_failure_type": "timeout"},
+			},
+			RecoveryChain: []string{"frozen"},
+		},
+	})
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"recovery_chain":["frozen"]`) {
+		t.Errorf("recovery_chain not in JSON: %s", body)
+	}
+	// Round-trip the whole thing and confirm the context survives.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	logBlock := parsed["log"].(map[string]interface{})
+	ext := logBlock["_extensions"].(map[string]interface{})
+	ctx := ext["context"].(map[string]interface{})
+	device := ctx["device"].(map[string]interface{})
+	if device["model"] != "Apple TV 4K" {
+		t.Errorf("device.model lost in round-trip: %+v", device)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a document-level \`_extensions.context\` block so an incident HAR is self-contained — no cross-referencing of separate logs to answer "what device, what stream, what test scenario, how far into playback was this?".

\`\`\`json
{
  "_extensions": {
    "context": {
      "device":   { "model": "...", "os_version": "...", "app_version": "...", "network_type": "wifi" },
      "stream":   { "content_id": "...", "protocol": "hls", "codec": "h264", "initial_variant_url": "..." },
      "scenario": { "fault_settings": { "segment_failure_type": "404" }, "nftables_shape": { "nftables_bandwidth_mbps": 5 } },
      "timing":   { "play_started_at": "2026-04-29T12:00:00Z", "incident_offset_s": 47.3 },
      "recovery_chain": ["frozen", "user_retry", "segment_stall"]
    }
  }
}
\`\`\`

## Sources

- **device + stream** — POSTed by the player in \`SnapshotRequest.Device\` / \`.Stream\`. Apple/Android wiring deferred to a follow-up (depends on PR #275's auto-snapshot path).
- **scenario** — server-side, picked from session record via an allowlist of fault/shape keys. Defense-in-depth against leaking session secrets.
- **timing** — derived from \`metadata.play_started_at\` (RFC3339) when the player provides it. Once #280 (play_id) lands the server can also infer this from the network log.
- **recovery_chain** — in-memory store keyed by \`(player_id, play_id)\`, capped at 32 reasons. \`source="player"\` appends; \`source="dashboard"\` / \`source="rest"\` observe-only.

## Tests (16 new)

- 8 in \`internal/har\`: each sub-block plumbs through \`Build\`; empty context omitted; JSON round-trip preserves shape
- 8 in \`cmd/server\`: recovery chain append/snapshot, fresh play_id starts a new chain, \`source="player"\` records (others read-only), scenario allowlist filters defaults

## Test plan

- [x] \`go test ./...\` 16 new + existing pass
- [x] Pre-commit Sonnet review — caught two dead allowlist entries (\`nftables_pattern\`, \`nftables_shape\` don't exist as session keys); replaced with \`nftables_pattern_enabled\` and \`nftables_pattern_steps\` plus a bool-aware filter so \`false\` values still surface
- [ ] Manual: hit Download HAR after this lands, open in DevTools, verify \`_extensions.context.scenario\` reflects the active fault settings