### PR TITLE
feat(har): full HAR stack — proxy snapshots, dashboard waterfall, incidents browser, player auto-capture

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -351,6 +351,7 @@ public final class PlaybackMetrics {
         Map<String, Object> extra = new HashMap<>();
         extra.put("player_metrics_error", message == null ? "" : message);
         sendEvent("error", extra);
+        requestHarSnapshot("player_error", 0, /* force= */ false);
     }
 
     /** Called when user triggers a restart (Restart Playback button, etc). */
@@ -360,6 +361,66 @@ public final class PlaybackMetrics {
         extra.put("player_metrics_restart_reason", reason);
         extra.put("player_restarts", playerRestarts);
         sendEvent("restart", extra);
+        // User-driven restarts should always produce a HAR — bypass the
+        // server-side per-player debounce window.
+        requestHarSnapshot(reason, 0, /* force= */ true);
+    }
+
+    /**
+     * Ask go-proxy to dump the current session timeline to disk as a HAR
+     * file. Issue #273. {@code force=true} bypasses the per-player
+     * 30s debounce — use it for user-driven Reload/Retry and per-attempt
+     * auto-recovery snapshots.
+     */
+    public void requestHarSnapshot(String reason, int attempt, boolean force) {
+        if (urlProvider.currentStreamUrl().isEmpty()) return;
+        final JSONObject metadata = new JSONObject();
+        try {
+            metadata.put("player_state", mapState());
+            metadata.put("auto_recovery_attempt", attempt);
+            metadata.put("player_restarts", playerRestarts);
+            long bufferedPositionMs = player.getBufferedPosition();
+            long currentPositionMs = player.getCurrentPosition();
+            metadata.put("buffer_depth_s",
+                roundSeconds(Math.max(0, bufferedPositionMs - currentPositionMs) / 1000.0));
+        } catch (Exception ignored) {
+        }
+        final JSONObject body = new JSONObject();
+        try {
+            body.put("reason", reason == null ? "manual" : reason);
+            body.put("source", "player");
+            body.put("force", force);
+            body.put("metadata", metadata);
+        } catch (Exception ignored) {
+            return;
+        }
+        networkExecutor.execute(() -> {
+            String sid = resolveSessionId();
+            if (sid == null || sid.isEmpty()) return;
+            postSnapshot(sid, body);
+        });
+    }
+
+    private void postSnapshot(String sid, JSONObject body) {
+        String base = baseUrlProvider.get();
+        if (base == null || base.isEmpty()) return;
+        HttpURLConnection conn = null;
+        try {
+            URL url = new URL(base + "/api/session/" + sid + "/har/snapshot");
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            conn.setReadTimeout(READ_TIMEOUT_MS);
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            }
+            conn.getResponseCode();
+        } catch (Exception ignored) {
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
     }
 
     private void maybeDetectFrozen() {
@@ -379,6 +440,7 @@ public final class PlaybackMetrics {
             if (frozenTicks >= FROZEN_THRESHOLD_TICKS && !frozenReported) {
                 frozenReported = true;
                 sendEvent("frozen", Collections.<String, Object>emptyMap());
+                requestHarSnapshot("frozen", 0, /* force= */ false);
             }
         } else {
             frozenTicks = 0;
@@ -397,6 +459,7 @@ public final class PlaybackMetrics {
         if (since >= SEGMENT_STALL_THRESHOLD_MS && !segmentStallReported) {
             segmentStallReported = true;
             sendEvent("segment_stall", Collections.<String, Object>emptyMap());
+            requestHarSnapshot("segment_stall", 0, /* force= */ false);
         }
     }
 

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -54,6 +54,31 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
 
     val playerId: String = UUID.randomUUID().toString()
 
+    /**
+     * `play_id` (issue #280) — a UUID regenerated at every fresh
+     * playback episode (loadStream / reload / retry / variant change).
+     * Threaded through every URL the player issues as `?play_id=...`
+     * so go-proxy can scope its NetworkLogEntry ring buffer per play.
+     * HAR snapshots filter to the most-recent play_id by default.
+     */
+    private var currentPlayId: String = UUID.randomUUID().toString()
+
+    private fun regeneratePlayId() {
+        currentPlayId = UUID.randomUUID().toString()
+    }
+
+    /** Replace any existing `play_id` query param with `currentPlayId`. */
+    private fun withPlayId(url: String): String {
+        if (url.isEmpty()) return url
+        val (base, query) = url.split("?", limit = 2).let {
+            if (it.size == 2) it[0] to it[1] else it[0] to ""
+        }
+        val params = if (query.isEmpty()) mutableListOf() else query.split("&").toMutableList()
+        params.removeAll { it.startsWith("play_id=") }
+        params.add("play_id=$currentPlayId")
+        return "$base?${params.joinToString("&")}"
+    }
+
     // Mutable so [recreatePlayer] can drop and rebuild them when the
     // current ExoPlayer instance gets wedged in a state its own retry
     // logic can't escape. Always non-null after init.
@@ -575,7 +600,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // injection). OFF → API/main nginx port (no proxy in front of the
         // stream). Same /go-live route in both cases.
         val port = if (s.localProxy) server.port else server.apiPort
-        val url = "http://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId"
+        // Fresh play_id at every loadStream boundary (issue #280) so
+        // go-proxy can scope its network log per play.
+        regeneratePlayId()
+        val url = "http://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId&play_id=$currentPlayId"
         _state.update { it.copy(currentUrl = url, statusText = url) }
         loadStream(url)
     }
@@ -628,9 +656,15 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     fun retry() {
         val url = _state.value.currentUrl
         if (url.isEmpty()) return
+        // A retry is a new playback episode — fresh play_id so the
+        // proxy's network log scopes the next round of requests
+        // separately from the one that just failed. Issue #280.
+        regeneratePlayId()
+        val refreshed = withPlayId(url)
+        _state.update { it.copy(currentUrl = refreshed, statusText = refreshed) }
         player.stop()
         player.clearMediaItems()
-        loadStream(url)
+        loadStream(refreshed)
     }
 
     /**

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -628,6 +628,8 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     fun retry() {
         val url = _state.value.currentUrl
         if (url.isEmpty()) return
+        // User-driven Retry deserves its own HAR — bypass per-player debounce.
+        metrics?.requestHarSnapshot("user_retry", 0, /* force= */ true)
         player.stop()
         player.clearMediaItems()
         loadStream(url)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -95,6 +95,13 @@ final class PlayerViewModel: ObservableObject {
     /// **not** rotate it — proxy session continuity matters.
     let playerId: String = UUID().uuidString
 
+    /// `play_id` (issue #280) — a UUID regenerated at every fresh
+    /// playback episode (loadStream / reload / retry / variant change).
+    /// Threaded through every URL the player issues as `?play_id=...`
+    /// so go-proxy can scope its NetworkLogEntry ring buffer per play.
+    /// HAR snapshots filter to the most-recent play_id by default.
+    private var currentPlayID: String = UUID().uuidString
+
     // MARK: - Private state
 
     private var codecRetries = 0
@@ -481,6 +488,8 @@ final class PlayerViewModel: ObservableObject {
 
     private func buildURLAndLoad() {
         guard let server = activeServer, !selectedContent.isEmpty else { return }
+        // Fresh play_id at every loadStream boundary — issue #280.
+        regeneratePlayID()
         var url = StreamURLBuilder.playbackURL(
             server: server,
             contentName: selectedContent,
@@ -499,7 +508,12 @@ final class PlayerViewModel: ObservableObject {
         } else {
             url = resolved
         }
-        guard let final = url else { return }
+        guard var final = url else { return }
+        // Append play_id last so it survives the player_id strip above
+        // for k3s-dev's content port. (For HAR scoping go-proxy reads
+        // play_id from URLs that hit it; the content port stripping
+        // only affects routes that don't reach go-proxy.)
+        final = appendPlayID(to: final)
         self.currentURL = final
         self.statusText = final.absoluteString
         loadStream(url: final)
@@ -510,6 +524,23 @@ final class PlayerViewModel: ObservableObject {
         components.queryItems = components.queryItems?.filter { $0.name != "player_id" }
         if components.queryItems?.isEmpty == true { components.queryItems = nil }
         return components.url ?? url
+    }
+
+    /// Replace any existing `play_id` query item with the current
+    /// `currentPlayID`. Issue #280.
+    private func appendPlayID(to url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "play_id" }
+        items.append(URLQueryItem(name: "play_id", value: currentPlayID))
+        components.queryItems = items
+        return components.url ?? url
+    }
+
+    /// Mint a fresh `play_id` UUID. Called at every new playback
+    /// episode boundary so go-proxy can scope its network log per play.
+    private func regeneratePlayID() {
+        currentPlayID = UUID().uuidString
     }
 
     private func loadStream(url: URL) {
@@ -773,7 +804,13 @@ final class PlayerViewModel: ObservableObject {
     /// the *same* URL on the *same* AVPlayer.
     func retry() {
         guard let url = currentURL else { return }
-        loadStream(url: url)
+        // A retry is a new playback episode — fresh play_id so the
+        // proxy's network log scopes the next round of requests
+        // separately from the one that just failed. Issue #280.
+        regeneratePlayID()
+        let refreshed = appendPlayID(to: url)
+        self.currentURL = refreshed
+        loadStream(url: refreshed)
     }
 
     /// Full tear-down + recreate. Replaces the AVPlayer instance,

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -773,6 +773,9 @@ final class PlayerViewModel: ObservableObject {
     /// the *same* URL on the *same* AVPlayer.
     func retry() {
         guard let url = currentURL else { return }
+        Task { [weak self] in
+            await self?.requestHARSnapshot(reason: "user_retry", force: true)
+        }
         loadStream(url: url)
     }
 
@@ -784,6 +787,9 @@ final class PlayerViewModel: ObservableObject {
     ///
     /// Same `playerId` (proxy session continuity), no catalogue refetch.
     func reload() {
+        Task { [weak self] in
+            await self?.requestHARSnapshot(reason: "user_reload", force: true)
+        }
         // Snapshot cumulative counters into diagnostics' "prior" buckets
         // so the new playback continues to add to the same dropped /
         // displayed totals — matches legacy behaviour.
@@ -1071,7 +1077,12 @@ extension PlayerViewModel {
                 self.log("Playback failure: \(value)")
                 Task { await self.sendPlayerMetrics(event: "error", extra: ["player_metrics_error": value]) }
                 if self.autoRecovery {
+                    // Per-attempt HAR is captured by scheduleAutoRecoveryRestart
+                    // when the timer fires (force=true). Don't double-capture
+                    // here.
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_failure")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "playback_failure") }
                 }
             }
             .store(in: &cancellables)
@@ -1091,7 +1102,11 @@ extension PlayerViewModel {
                 guard let self, frozen else { return }
                 Task { await self.sendPlayerMetrics(event: "frozen") }
                 if self.autoRecovery {
+                    // The recovery timer's per-attempt HAR (force=true)
+                    // captures the same incident a moment later.
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_frozen")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "frozen") }
                 }
             }
             .store(in: &cancellables)
@@ -1103,6 +1118,8 @@ extension PlayerViewModel {
                 Task { await self.sendPlayerMetrics(event: "segment_stall") }
                 if self.autoRecovery {
                     self.scheduleAutoRecoveryRestart(reason: "auto_recovery_segment_stall")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "segment_stall") }
                 }
             }
             .store(in: &cancellables)
@@ -1251,6 +1268,12 @@ extension PlayerViewModel {
                         "player_metrics_restart_reason": reason,
                         "player_restarts": self?.playerRestarts ?? 0
                     ])
+                }
+                // Each auto-recovery attempt deserves its own HAR — bypass
+                // the per-player debounce so back-to-back attempts inside
+                // the 30s window each produce a snapshot.
+                Task { [weak self] in
+                    await self?.requestHARSnapshot(reason: reason, attempt: attempt, force: true)
                 }
                 self.scheduleAutoRecoverySuccessCheck()
             }
@@ -1434,6 +1457,43 @@ extension PlayerViewModel {
             compact["player_metrics_network_bitrate_mbps"] = NSNull()
         }
         return compact
+    }
+
+    /// Tell go-proxy to dump the current session timeline to disk as a HAR
+    /// file. Called from auto-recovery / freeze / Reload sites — server
+    /// debounces by player_id (default 30s). Issue #273.
+    fileprivate func requestHARSnapshot(reason: String, attempt: Int = 0, force: Bool = false) async {
+        guard let baseURL = metricsBaseURL() else { return }
+        guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }
+        let url = baseURL
+            .appendingPathComponent("api/session")
+            .appendingPathComponent(sessionId)
+            .appendingPathComponent("har/snapshot")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyPlayerHeaders(to: &request)
+        var metadata: [String: Any] = [
+            "player_state": diagnostics.state,
+            "buffer_depth_s": diagnostics.bufferDepth as Any,
+            "stall_count": diagnostics.stallCount,
+            "auto_recovery_attempt": attempt,
+            "player_restarts": playerRestarts
+        ]
+        if !diagnostics.lastError.isEmpty { metadata["last_error"] = diagnostics.lastError }
+        if !diagnostics.lastFailure.isEmpty { metadata["last_failure"] = diagnostics.lastFailure }
+        let body: [String: Any] = [
+            "reason": reason,
+            "source": "player",
+            "force": force,
+            "metadata": metadata
+        ]
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            _ = try await URLSession.shared.data(for: request)
+        } catch {
+            log("HAR snapshot request failed: \(error.localizedDescription)")
+        }
     }
 
     fileprivate func patchSessionMetrics(sessionId: String, baseURL: URL, payload: [String: Any]) async {

--- a/content/dashboard/incidents.html
+++ b/content/dashboard/incidents.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Incidents - InfiniteStream</title>
+    <link rel="stylesheet" href="/shared-styles.css">
+    <style>
+        .incidents-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 14px;
+        }
+        .incidents-table th,
+        .incidents-table td {
+            text-align: left;
+            padding: 10px 12px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+        }
+        .incidents-table th {
+            background: var(--surface-2, #f7f7f9);
+            font-weight: 600;
+            color: var(--text-secondary);
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+        .incidents-table tbody tr:hover {
+            background: var(--surface-hover, rgba(0, 0, 0, 0.03));
+        }
+        .reason-pill {
+            display: inline-block;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 500;
+            background: var(--surface-2, #eee);
+            color: var(--text-primary);
+        }
+        .reason-frozen { background: #fde8e8; color: #b91c1c; }
+        .reason-segment_stall { background: #fef3c7; color: #92400e; }
+        .reason-playback_failure { background: #fde8e8; color: #b91c1c; }
+        .reason-player_error { background: #fde8e8; color: #b91c1c; }
+        .reason-user_retry,
+        .reason-user_reload { background: #dbeafe; color: #1e40af; }
+        .reason-manual { background: #e5e7eb; color: #374151; }
+        .reason-auto_recovery_frozen,
+        .reason-auto_recovery_segment_stall,
+        .reason-auto_recovery_failure,
+        .reason-auto_recovery_zero_buffer { background: #fef3c7; color: #92400e; }
+
+        .source-pill {
+            display: inline-block;
+            padding: 1px 6px;
+            border-radius: 3px;
+            font-size: 11px;
+            background: var(--surface-2, #f3f4f6);
+            color: var(--text-secondary);
+        }
+
+        .filters {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+        .filters input,
+        .filters select {
+            padding: 6px 10px;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            font-size: 14px;
+            background: var(--surface);
+            color: var(--text-primary);
+        }
+        .filters label {
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+        .filter-meta {
+            margin-left: auto;
+            font-size: 13px;
+            color: var(--text-secondary);
+        }
+        .mono {
+            font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+            font-size: 12px;
+        }
+        .session-id {
+            color: var(--text-secondary);
+            font-size: 11px;
+        }
+        .no-data {
+            text-align: center;
+            padding: 60px 20px;
+            color: var(--text-secondary);
+        }
+        .no-data-icon {
+            font-size: 48px;
+            margin-bottom: 12px;
+            opacity: 0.5;
+        }
+    </style>
+</head>
+<body data-ism-active-page="incidents">
+    <div class="ism-content-wide">
+        <div class="card">
+            <div class="card-header">
+                <div class="header-actions">
+                    <h1>🚨 Incidents</h1>
+                    <div class="header-actions-right">
+                        <button id="refreshBtn" class="btn btn-secondary">Refresh</button>
+                    </div>
+                </div>
+                <p>HAR snapshots captured by go-proxy when a player reported a freeze, auto-recovery attempt, or user-tapped Reload — or when someone hit "Save HAR" on a session. Drop a downloaded file into Chrome DevTools → Network → Import HAR.</p>
+            </div>
+            <div class="card-body">
+                <div class="filters">
+                    <label>Player ID
+                        <input type="text" id="filterPlayer" placeholder="any" size="20">
+                    </label>
+                    <label>Reason
+                        <select id="filterReason"><option value="">all</option></select>
+                    </label>
+                    <label>Source
+                        <select id="filterSource">
+                            <option value="">all</option>
+                            <option value="player">player</option>
+                            <option value="dashboard">dashboard</option>
+                            <option value="rest">rest</option>
+                        </select>
+                    </label>
+                    <span class="filter-meta" id="countLabel">—</span>
+                </div>
+
+                <div id="loading" class="text-center text-secondary" style="padding: 40px;">
+                    <div class="spinner"></div>
+                    <div style="margin-top: 12px;">Loading incidents…</div>
+                </div>
+
+                <div id="emptyState" class="no-data" style="display: none;">
+                    <div class="no-data-icon">📭</div>
+                    <h2>No incidents captured yet</h2>
+                    <p>Open a testing session, induce a fault, and the freeze/recovery path will write a HAR here. Or hit <strong>Save HAR</strong> in the Network Log of a testing session.</p>
+                </div>
+
+                <div id="tableWrap" style="display: none;">
+                    <table class="incidents-table">
+                        <thead>
+                            <tr>
+                                <th>When</th>
+                                <th>Reason</th>
+                                <th>Player</th>
+                                <th>Session</th>
+                                <th>Source</th>
+                                <th>Size</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody id="rows"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="/shared/shared-nav.js"></script>
+    <script>
+        const escapeHTML = (s) => {
+            if (s === null || s === undefined) return '';
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
+
+        const fmtSize = (n) => {
+            if (!n && n !== 0) return '—';
+            if (n < 1024) return `${n} B`;
+            if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+            return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+        };
+        const fmtAge = (iso) => {
+            if (!iso) return '—';
+            const d = new Date(iso);
+            const ms = Date.now() - d.getTime();
+            const s = Math.floor(ms / 1000);
+            if (s < 60) return `${s}s ago`;
+            if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+            if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+            return `${Math.floor(s / 86400)}d ago`;
+        };
+        const fmtDate = (iso) => iso ? new Date(iso).toLocaleString() : '—';
+        const reasonClass = (reason) => `reason-pill reason-${(reason || 'unknown').replace(/[^a-z0-9_]/gi, '_')}`;
+
+        let allIncidents = [];
+
+        async function loadIncidents() {
+            const loading = document.getElementById('loading');
+            const tableWrap = document.getElementById('tableWrap');
+            const emptyState = document.getElementById('emptyState');
+            loading.style.display = '';
+            tableWrap.style.display = 'none';
+            emptyState.style.display = 'none';
+            try {
+                const r = await fetch('/api/incidents');
+                const data = await r.json();
+                allIncidents = Array.isArray(data.incidents) ? data.incidents : [];
+                populateReasonFilter();
+                render();
+            } catch (e) {
+                loading.innerHTML = `<div style="color: var(--danger, #b91c1c);">Failed to load: ${escapeHTML(e.message)}</div>`;
+                return;
+            }
+            loading.style.display = 'none';
+        }
+
+        function populateReasonFilter() {
+            const sel = document.getElementById('filterReason');
+            const reasons = [...new Set(allIncidents.map(i => i.reason).filter(Boolean))].sort();
+            const current = sel.value;
+            sel.innerHTML = '<option value="">all</option>' +
+                reasons.map(r => `<option value="${escapeHTML(r)}">${escapeHTML(r)}</option>`).join('');
+            if (reasons.includes(current)) sel.value = current;
+        }
+
+        function render() {
+            const tableWrap = document.getElementById('tableWrap');
+            const emptyState = document.getElementById('emptyState');
+            const rows = document.getElementById('rows');
+            const playerFilter = document.getElementById('filterPlayer').value.trim().toLowerCase();
+            const reasonFilter = document.getElementById('filterReason').value;
+            const sourceFilter = document.getElementById('filterSource').value;
+
+            const filtered = allIncidents.filter(i => {
+                if (playerFilter && !(i.player_id || '').toLowerCase().includes(playerFilter)) return false;
+                if (reasonFilter && i.reason !== reasonFilter) return false;
+                if (sourceFilter && i.source !== sourceFilter) return false;
+                return true;
+            });
+
+            document.getElementById('countLabel').textContent =
+                filtered.length === allIncidents.length
+                    ? `${filtered.length} incident${filtered.length === 1 ? '' : 's'}`
+                    : `${filtered.length} of ${allIncidents.length}`;
+
+            if (filtered.length === 0) {
+                tableWrap.style.display = 'none';
+                emptyState.style.display = '';
+                return;
+            }
+            emptyState.style.display = 'none';
+            tableWrap.style.display = '';
+            rows.innerHTML = filtered.map(i => {
+                // i.path is server-controlled (it's the filesystem path of the
+                // saved HAR), but treat it as untrusted and escape into both
+                // URL and attribute contexts.
+                const pathSegments = String(i.path || '').split('/').map(encodeURIComponent).join('/');
+                const downloadHref = `/api/incidents/${pathSegments}`;
+                const reasonRaw = i.reason || '—';
+                const reasonHTML = `<span class="${reasonClass(i.reason)}">${escapeHTML(reasonRaw)}</span>`;
+                const sourceHTML = i.source
+                    ? `<span class="source-pill">${escapeHTML(i.source)}</span>`
+                    : '<span class="source-pill">—</span>';
+                const player = i.player_id
+                    ? escapeHTML(i.player_id)
+                    : '<span class="text-secondary">—</span>';
+                const sessionShort = i.session_id ? escapeHTML(i.session_id.slice(0, 12)) : '—';
+                const fullSession = escapeHTML(i.session_id || '');
+                const time = escapeHTML(fmtDate(i.created_at));
+                const age = escapeHTML(fmtAge(i.created_at));
+                const filenameAttr = escapeHTML(i.filename || 'incident.har');
+                const hrefAttr = escapeHTML(downloadHref);
+                return `
+                    <tr>
+                        <td>
+                            <div>${time}</div>
+                            <div class="session-id">${age}</div>
+                        </td>
+                        <td>${reasonHTML}</td>
+                        <td class="mono">${player}</td>
+                        <td class="mono" title="${fullSession}">${sessionShort}</td>
+                        <td>${sourceHTML}</td>
+                        <td>${fmtSize(i.size_bytes)}</td>
+                        <td>
+                            <a href="${hrefAttr}" download="${filenameAttr}" class="btn btn-mini btn-secondary">Download</a>
+                        </td>
+                    </tr>
+                `;
+            }).join('');
+        }
+
+        document.getElementById('refreshBtn').addEventListener('click', loadIncidents);
+        document.getElementById('filterPlayer').addEventListener('input', render);
+        document.getElementById('filterReason').addEventListener('change', render);
+        document.getElementById('filterSource').addEventListener('change', render);
+
+        // Honor ?player_id= in URL for deep-links from testing-session.html.
+        const params = new URLSearchParams(window.location.search);
+        const initialPlayer = params.get('player_id');
+        if (initialPlayer) document.getElementById('filterPlayer').value = initialPlayer;
+
+        loadIncidents();
+        // Auto-refresh every 10s while page is visible.
+        setInterval(() => {
+            if (document.visibilityState === 'visible') loadIncidents();
+        }, 10000);
+    </script>
+</body>
+</html>

--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -523,13 +523,479 @@
     margin-bottom: 10px;
     padding: 0;
     overflow: hidden;
+    font-size: 11px;
+}
+
+/* Native scroll on the wrapper. The list of rows is the height of the
+ * data; the wrapper clips it. New entries appended at the bottom
+ * don't pull the user's scroll position around. Max-height fits the
+ * sticky 22px axis row plus 20 data rows (axis stays visible while
+ * the rows below scroll). */
+.network-log-waterfall-scroll {
+    width: 100%;
+    max-height: 462px; /* 22 (axis) + 20 * 22 (rows) */
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .network-log-waterfall {
     position: relative;
     width: 100%;
-    min-height: 280px;
-    height: 320px;
+}
+
+/* Summary row: at-a-glance stats for the visible HAR window. Sits
+ * above the overview so the user sees totals, span, and trouble
+ * counts before they even scroll. Click on a stat-pill to filter? —
+ * a future enhancement; for now it's read-only. */
+.netwf-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: #f1f5f9;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 11px;
+    color: #475569;
+}
+
+.netwf-summary-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #e2e8f0;
+    color: #334155;
+    font-weight: 600;
+    line-height: 16px;
+    white-space: nowrap;
+}
+
+.netwf-summary-pill .count { font-variant-numeric: tabular-nums; }
+.netwf-summary-pill.span { background: #ddd6fe; color: #4c1d95; }
+.netwf-summary-pill.total { background: #cbd5e1; color: #1e293b; }
+.netwf-summary-pill.success { background: #d1fae5; color: #065f46; }
+.netwf-summary-pill.partial { background: #ccfbf1; color: #134e4a; }
+.netwf-summary-pill.client-error { background: #fef3c7; color: #92400e; }
+.netwf-summary-pill.server-error { background: #fee2e2; color: #991b1b; }
+.netwf-summary-pill.faulted { background: #fecaca; color: #7f1d1d; }
+.netwf-summary-pill.timeout { background: #fed7aa; color: #9a3412; }
+.netwf-summary-pill.disconnect { background: #fbcfe8; color: #831843; }
+.netwf-summary-pill.retry { background: #e0e7ff; color: #3730a3; }
+.netwf-summary-pill.zero { opacity: 0.45; }
+
+/* Time labels above the overview — give the user a wall-clock sense
+ * of the full session's span. Different ticks than the brush axis
+ * below (which zooms with the user's selection). */
+.netwf-overview-axis {
+    position: relative;
+    height: 18px;
+    background: #f8fafc;
+    border-bottom: 1px solid #eef2f7;
+    overflow: hidden;
+    font-size: 10px;
+    color: #64748b;
+    font-weight: 600;
+}
+
+/* Overview strip: shows the full session at small scale. The brush
+ * (selection rectangle) on top is the user's window into the
+ * waterfall below. Drag the body to pan, drag a handle to resize
+ * (zoom). Inspired by Chrome DevTools' Network overview. */
+.netwf-overview {
+    position: relative;
+    height: 36px;
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    cursor: crosshair;
+    user-select: none;
+    overflow: hidden;
+}
+
+.netwf-overview-bars {
+    position: absolute;
+    inset: 4px 0;
+    pointer-events: none;
+}
+
+.netwf-overview-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background: rgba(52, 211, 153, 0.65);
+    min-width: 1px;
+}
+
+/* Same status / fault palette as the main waterfall rows so the user
+ * can scan the overview and spot trouble at a glance. Higher z-index
+ * on errors so they're visible even when adjacent successful ticks
+ * cover them. */
+.netwf-overview-tick.status-206 { background: rgba(20, 184, 166, 0.75); }
+.netwf-overview-tick.status-3xx { background: rgba(96, 165, 250, 0.75); }
+.netwf-overview-tick.status-4xx { background: rgba(245, 158, 11, 0.85); z-index: 1; }
+.netwf-overview-tick.status-5xx { background: rgba(239, 68, 68, 0.9); z-index: 2; }
+.netwf-overview-tick.fault-timeout { background: rgba(217, 119, 6, 0.95); z-index: 3; }
+.netwf-overview-tick.fault-incomplete { background: rgba(190, 24, 93, 0.95); z-index: 3; }
+.netwf-overview-tick.is-faulted { background: rgba(185, 28, 28, 0.95); z-index: 4; }
+
+.netwf-brush {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    background: rgba(33, 150, 243, 0.10);
+    border-left: 2px solid #2196F3;
+    border-right: 2px solid #2196F3;
+    cursor: grab;
+    box-sizing: border-box;
+}
+
+.netwf-brush.dragging {
+    cursor: grabbing;
+}
+
+.netwf-brush-handle {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 6px;
+    background: rgba(33, 150, 243, 0.35);
+    cursor: ew-resize;
+}
+
+.netwf-brush-handle.left { left: -3px; }
+.netwf-brush-handle.right { right: -3px; }
+
+/* Global-axis waterfall: each row's bar is positioned within the
+ * brush's time window. Bars on the same horizontal pixel = requests
+ * happening at the same wall-clock instant. Phase segments inside
+ * the bar render dns/connect/tls/wait/receive to scale. */
+.netwf-row {
+    display: flex;
+    align-items: center;
+    height: 22px;
+    border-bottom: 1px solid #eef2f7;
+    border-left: 3px solid transparent;
+    line-height: 22px;
+    box-sizing: border-box;
+}
+
+/* Status / fault tinting. Left-border accent + faint row background
+ * so the colour is visible without overpowering the bars. Faulted +
+ * timeout entries get the strongest signal because they're the
+ * thing the user is hunting. */
+.netwf-row.status-2xx { border-left-color: #34d399; }
+/* 206 Partial Content — distinct from a normal 200 because the
+ * player asked for a byte range. Teal so it stands apart from the
+ * green of full 2xx responses. */
+.netwf-row.status-206 { border-left-color: #14b8a6; background: #f0fdfa; }
+.netwf-row.status-3xx { border-left-color: #60a5fa; }
+.netwf-row.status-4xx { border-left-color: #f59e0b; background: #fffbeb; }
+.netwf-row.status-5xx { border-left-color: #ef4444; background: #fef2f2; }
+
+/* Retry / re-attempt accent — colour the row label so the ↻ glyph
+ * (rendered inline by the JS, after the timestamp) reads at a
+ * glance. The ! fault prefix sits next to it for the same reason. */
+.netwf-row.is-retry .netwf-row-label {
+    color: #be185d;
+}
+
+.netwf-row.is-faulted {
+    background: #fee2e2;
+    border-left-color: #b91c1c;
+}
+
+.netwf-row.fault-timeout {
+    background: #fef3c7;
+    border-left-color: #d97706;
+}
+
+.netwf-row.fault-incomplete {
+    background: #fce7f3;
+    border-left-color: #be185d;
+}
+
+/* Column-cell layout. Widths live in CSS variables on the waterfall
+ * host so a single drag on a header resizer reflows every row + the
+ * axis row in lockstep. Defaults below are the same widths the
+ * single-label version used; users can drag from there. */
+.network-log-waterfall {
+    --netwf-col-time: 116px; /* fits HH:MM:SS.mmm with padding */
+    --netwf-col-flags: 28px;
+    --netwf-col-method: 44px;
+    --netwf-col-path: 200px;
+    --netwf-col-bytes: 64px;
+    --netwf-col-mbps: 72px;
+    --netwf-col-status: 56px;
+}
+
+.netwf-cell {
+    position: relative;
+    padding: 0 6px;
+    border-right: 1px solid #e2e8f0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-size: 11px;
+    color: #334155;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+}
+
+.netwf-cell.time   { flex: 0 0 var(--netwf-col-time); }
+.netwf-cell.flags  { flex: 0 0 var(--netwf-col-flags); text-align: center; padding: 0; font-weight: 700; }
+.netwf-cell.method { flex: 0 0 var(--netwf-col-method); }
+.netwf-cell.path   { flex: 0 0 var(--netwf-col-path); }
+.netwf-cell.bytes  { flex: 0 0 var(--netwf-col-bytes); text-align: right; font-variant-numeric: tabular-nums; }
+.netwf-cell.mbps   { flex: 0 0 var(--netwf-col-mbps); text-align: right; font-variant-numeric: tabular-nums; }
+.netwf-cell.status {
+    flex: 0 0 var(--netwf-col-status);
+    text-align: center;
+    font-weight: 600;
+    color: #475569;
+}
+
+.netwf-row.status-2xx .netwf-cell.status { color: #065f46; background: #d1fae5; }
+.netwf-row.status-206 .netwf-cell.status { color: #134e4a; background: #ccfbf1; }
+.netwf-row.status-3xx .netwf-cell.status { color: #1e3a8a; background: #dbeafe; }
+.netwf-row.status-4xx .netwf-cell.status { color: #92400e; background: #fef3c7; }
+.netwf-row.status-5xx .netwf-cell.status { color: #991b1b; background: #fee2e2; }
+.netwf-row.is-faulted .netwf-cell.status,
+.netwf-row.fault-timeout .netwf-cell.status,
+.netwf-row.fault-incomplete .netwf-cell.status {
+    color: #7f1d1d;
+    background: #fecaca;
+}
+
+/* Drag handle on the right edge of header cells. Picks up pointer
+ * events; the body cells underneath ignore them. */
+.netwf-cell-resizer {
+    position: absolute;
+    top: 0;
+    right: -3px;
+    bottom: 0;
+    width: 6px;
+    cursor: col-resize;
+    z-index: 5;
+}
+
+.netwf-cell-resizer:hover,
+.netwf-cell-resizer.dragging {
+    background: rgba(33, 150, 243, 0.35);
+}
+
+/* Header (axis) cells inherit the same widths but render with the
+ * existing axis-row look. Each header cell is the only place that
+ * carries a resizer — drag affects all body rows via the shared CSS
+ * vars. */
+.netwf-axis .netwf-cell {
+    background: #f8fafc;
+    color: #64748b;
+    font-weight: 600;
+    line-height: 22px;
+}
+
+.netwf-row.status-4xx .netwf-row-label { color: #92400e; }
+.netwf-row.status-5xx .netwf-row-label { color: #991b1b; }
+.netwf-row.is-faulted .netwf-row-label { color: #7f1d1d; font-weight: 600; }
+.netwf-row.fault-timeout .netwf-row-label { color: #92400e; font-weight: 600; }
+.netwf-row.fault-incomplete .netwf-row-label { color: #831843; font-weight: 600; }
+
+/* Bar overlay when transfer didn't complete — diagonal hatch over
+ * the receive segment so it's visually clear bytes are missing. */
+.netwf-row-bar.is-incomplete .netwf-row-phase.transfer {
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(190, 24, 93, 0.85) 0,
+        rgba(190, 24, 93, 0.85) 4px,
+        rgba(252, 231, 243, 0.85) 4px,
+        rgba(252, 231, 243, 0.85) 8px
+    );
+}
+
+/* Hover tooltip — floating panel that follows the cursor with full
+ * forensics for the row under the pointer. Pointer-events: none so
+ * the tooltip doesn't capture hover and ping-pong on/off. */
+.netwf-tooltip {
+    position: fixed;
+    z-index: 10000;
+    pointer-events: none;
+    background: #0f172a;
+    color: #e2e8f0;
+    border-radius: 6px;
+    padding: 10px 12px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.32);
+    font-size: 11px;
+    line-height: 1.45;
+    max-width: 480px;
+    min-width: 280px;
+    display: none;
+}
+
+.netwf-tooltip.visible {
+    display: block;
+}
+
+.netwf-tooltip-head {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    font-weight: 600;
+    margin-bottom: 4px;
+    color: #f1f5f9;
+    word-break: break-all;
+}
+
+.netwf-tooltip-meta {
+    display: grid;
+    grid-template-columns: max-content auto;
+    column-gap: 12px;
+    row-gap: 2px;
+    margin-bottom: 6px;
+    color: #cbd5e1;
+}
+
+.netwf-tooltip-meta dt { color: #94a3b8; }
+.netwf-tooltip-meta dd { margin: 0; color: #f1f5f9; }
+
+.netwf-tooltip-phases {
+    margin: 6px 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 6px;
+    display: grid;
+    grid-template-columns: 12px max-content auto;
+    column-gap: 8px;
+    row-gap: 2px;
+    align-items: center;
+}
+
+.netwf-tooltip-phase-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+}
+.netwf-tooltip-phase-swatch.dns { background: #8e8cd8; }
+.netwf-tooltip-phase-swatch.connect { background: #f59e0b; }
+.netwf-tooltip-phase-swatch.tls { background: #b084eb; }
+.netwf-tooltip-phase-swatch.wait { background: #7dd3fc; }
+.netwf-tooltip-phase-swatch.transfer { background: #34d399; }
+
+.netwf-tooltip-phase-name { color: #cbd5e1; }
+.netwf-tooltip-phase-value { color: #f1f5f9; font-variant-numeric: tabular-nums; }
+
+.netwf-tooltip-fault {
+    border-top: 1px solid rgba(248, 113, 113, 0.4);
+    padding-top: 6px;
+    margin-top: 6px;
+    color: #fca5a5;
+}
+
+.netwf-tooltip-url {
+    border-top: 1px solid rgba(148, 163, 184, 0.25);
+    padding-top: 6px;
+    margin-top: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    color: #94a3b8;
+    word-break: break-all;
+}
+
+.netwf-row-track {
+    flex: 1 1 auto;
+    position: relative;
+    height: 22px;
+    background-image: repeating-linear-gradient(
+        to right,
+        rgba(148, 163, 184, 0.10) 0,
+        rgba(148, 163, 184, 0.10) 1px,
+        transparent 1px,
+        transparent 40px
+    );
+}
+
+.netwf-row-bar {
+    position: absolute;
+    top: 6px;
+    height: 9px;
+    display: flex;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+    min-width: 2px;
+}
+
+.netwf-row-phase {
+    height: 100%;
+    min-width: 1px;
+}
+.netwf-row-phase.dns { background: #8e8cd8; }
+.netwf-row-phase.connect { background: #f59e0b; }
+.netwf-row-phase.tls { background: #b084eb; }
+.netwf-row-phase.wait { background: #7dd3fc; }
+.netwf-row-phase.transfer { background: #34d399; }
+
+.netwf-row-duration {
+    position: absolute;
+    top: 4px;
+    height: 14px;
+    line-height: 14px;
+    font-size: 10px;
+    color: #475569;
+    white-space: nowrap;
+    pointer-events: none;
+    padding: 0 4px;
+}
+
+.netwf-axis {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    height: 22px;
+    line-height: 22px;
+    background: #f8fafc;
+    border-bottom: 1px solid #e2e8f0;
+    font-size: 10px;
+    color: #64748b;
+    font-weight: 600;
+    box-sizing: border-box;
+}
+
+/* The column cells (.netwf-cell) cover the left columns now — the
+ * axis row has no separate label spacer. The flex track to the right
+ * of the cells is the time-axis scale. */
+
+.netwf-axis-scale {
+    flex: 1 1 auto;
+    position: relative;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.netwf-axis-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: rgba(148, 163, 184, 0.45);
+}
+
+.netwf-axis-tick-label {
+    position: absolute;
+    top: 4px;
+    transform: translateX(-50%);
+    line-height: 14px;
+    white-space: nowrap;
+    color: #64748b;
+    font-weight: 600;
+    background: #f8fafc;
+    padding: 0 3px;
+}
+
+.netwf-axis-summary {
+    position: absolute;
+    right: 8px;
+    top: 4px;
+    line-height: 14px;
+    color: #475569;
+    font-weight: 600;
+    background: #f8fafc;
+    padding: 0 3px;
 }
 
 .network-log-waterfall-empty {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1072,7 +1072,7 @@
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save current network timeline as a HAR file (Phase 1 of issue #272)">Save HAR</button>
-                                <a href="/api/incidents" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="List saved HAR snapshots (raw JSON)">Incidents</a>
+                                <a href="/dashboard/incidents.html" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="Browse saved HAR snapshots">Incidents</a>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-first">First</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-fit">Fit</button>

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -42,10 +42,7 @@
         { value: 'failures_per_packets', text: 'Packets / Seconds' }
     ];
     const networkLogEntriesBySession = new Map();
-    const networkWaterfallTimelines = new Map();
-    const networkWaterfallViewBySession = new Map();
     const networkWaterfallFollowModeBySession = new Map();
-    const networkWaterfallFullRangeBySession = new Map();
     const networkWaterfallRenderSignatureBySession = new Map();
     const networkWaterfallRowSignaturesBySession = new Map();
     const networkWaterfallRowsBySession = new Map();
@@ -1938,439 +1935,6 @@
         return ordered.filter((row) => (row.timestamp + row.duration) >= cutoff);
     }
 
-    function ensureWaterfallSelectionBox(state) {
-        if (!state || !state.host) return null;
-        let box = state.host.querySelector('.waterfall-selection-box');
-        if (!box) {
-            box = document.createElement('div');
-            box.className = 'waterfall-selection-box';
-            box.style.display = 'none';
-            state.host.appendChild(box);
-        }
-        return box;
-    }
-
-    function getWaterfallCenterPanel(state) {
-        if (!state || !state.host) return null;
-        return state.host.querySelector('.vis-panel.vis-center');
-    }
-
-    function pixelToTimelineMs(state, clientX, panelRect) {
-        if (!state || !state.timeline || !panelRect || panelRect.width <= 0) return NaN;
-        const x = Math.max(0, Math.min(panelRect.width, clientX - panelRect.left));
-        const currentWindow = state.timeline.getWindow();
-        if (!currentWindow || !currentWindow.start || !currentWindow.end) return NaN;
-        const startMs = new Date(currentWindow.start).getTime();
-        const endMs = new Date(currentWindow.end).getTime();
-        if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return NaN;
-        return startMs + (x / panelRect.width) * (endMs - startMs);
-    }
-
-    function beginWaterfallSelection(state, key, event) {
-        if (!state || !state.timeline || !state.host) return;
-        if (event.button !== 0 || !event.shiftKey) return;
-        const center = getWaterfallCenterPanel(state);
-        if (!center || !center.contains(event.target)) return;
-        const rect = center.getBoundingClientRect();
-        const hostRect = state.host.getBoundingClientRect();
-        if (!rect || rect.width <= 0) return;
-        const startMs = pixelToTimelineMs(state, event.clientX, rect);
-        if (!Number.isFinite(startMs)) return;
-        const startX = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
-        const leftOffset = Math.max(0, rect.left - hostRect.left);
-        const selection = ensureWaterfallSelectionBox(state);
-        if (!selection) return;
-        event.preventDefault();
-        state.host.classList.add('is-selecting');
-        selection.style.display = 'block';
-        selection.style.left = `${leftOffset + startX}px`;
-        selection.style.width = '0px';
-        state.drag = {
-            key,
-            startMs,
-            endMs: startMs,
-            startX,
-            endX: startX,
-            leftOffset
-        };
-    }
-
-    function updateWaterfallSelection(state, event) {
-        if (!state || !state.drag || !state.host) return;
-        const center = getWaterfallCenterPanel(state);
-        if (!center) return;
-        const rect = center.getBoundingClientRect();
-        if (!rect || rect.width <= 0) return;
-        const endMs = pixelToTimelineMs(state, event.clientX, rect);
-        if (!Number.isFinite(endMs)) return;
-        const endX = Math.max(0, Math.min(rect.width, event.clientX - rect.left));
-        const selection = ensureWaterfallSelectionBox(state);
-        if (!selection) return;
-        state.drag.endMs = endMs;
-        state.drag.endX = endX;
-        const left = Math.min(state.drag.startX, endX);
-        const width = Math.max(1, Math.abs(endX - state.drag.startX));
-        selection.style.left = `${state.drag.leftOffset + left}px`;
-        selection.style.width = `${width}px`;
-    }
-
-    function finishWaterfallSelection(state) {
-        if (!state || !state.drag || !state.timeline || !state.host) return;
-        const drag = state.drag;
-        state.drag = null;
-        const selection = ensureWaterfallSelectionBox(state);
-        if (selection) {
-            selection.style.display = 'none';
-            selection.style.width = '0px';
-        }
-        state.host.classList.remove('is-selecting');
-        const pixelDelta = Math.abs((drag.endX || drag.startX) - drag.startX);
-        const startMs = Math.min(drag.startMs, drag.endMs);
-        const endMs = Math.max(drag.startMs, drag.endMs);
-        if (pixelDelta < 4 || !Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs - startMs < 20) return;
-        state.timeline.setWindow(new Date(startMs), new Date(endMs), { animation: false });
-        networkWaterfallViewBySession.set(drag.key, { startMs, endMs });
-        setNetworkLogFollowMode(drag.key, false);
-        updateNetworkLogFollowButton(null, drag.key);
-    }
-
-    function resetWaterfallView(state, key) {
-        if (!state || !state.timeline) return;
-        const fullRange = networkWaterfallFullRangeBySession.get(key);
-        if (!fullRange || !Number.isFinite(fullRange.startMs) || !Number.isFinite(fullRange.endMs) || fullRange.endMs <= fullRange.startMs) return;
-        networkWaterfallViewBySession.delete(key);
-        state.timeline.setWindow(new Date(fullRange.startMs), new Date(fullRange.endMs), { animation: false });
-        state.timeline.redraw();
-    }
-
-    function jumpWaterfallView(sessionId, direction) {
-        const key = String(sessionId || '');
-        if (!key) return;
-        const state = networkWaterfallTimelines.get(key);
-        const fullRange = networkWaterfallFullRangeBySession.get(key);
-        if (!state || !state.timeline || !fullRange) return;
-        if (!Number.isFinite(fullRange.startMs) || !Number.isFinite(fullRange.endMs) || fullRange.endMs <= fullRange.startMs) return;
-
-        // Re-enable auto-pan: user explicitly asked for a coordinated view.
-        state.autoPan = true;
-
-        if (direction === 'fit') {
-            resetWaterfallView(state, key);
-            return;
-        }
-
-        const win = state.timeline.getWindow();
-        const currentStart = new Date(win.start).getTime();
-        const currentEnd = new Date(win.end).getTime();
-        const spanMs = Math.max(100, currentEnd - currentStart);
-
-        let nextStart = fullRange.startMs;
-        let nextEnd = Math.min(fullRange.endMs, nextStart + spanMs);
-        if (direction === 'last') {
-            nextEnd = fullRange.endMs;
-            nextStart = Math.max(fullRange.startMs, nextEnd - spanMs);
-        }
-        state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
-        networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
-        state.timeline.redraw();
-    }
-
-    function bindWaterfallSelectionHandlers(state, key) {
-        if (!state || !state.host || state.selectionHandlersBound) return;
-        state.selectionHandlersBound = true;
-        const onMouseDown = (event) => beginWaterfallSelection(state, key, event);
-        const onMouseMove = (event) => updateWaterfallSelection(state, event);
-        const onMouseUp = () => finishWaterfallSelection(state);
-        const onDoubleClick = (event) => {
-            const center = getWaterfallCenterPanel(state);
-            if (!center || !center.contains(event.target)) return;
-            resetWaterfallView(state, key);
-        };
-        state.host.addEventListener('mousedown', onMouseDown);
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
-        state.host.addEventListener('dblclick', onDoubleClick);
-        state.cleanupSelectionHandlers = () => {
-            state.host.removeEventListener('mousedown', onMouseDown);
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-            state.host.removeEventListener('dblclick', onDoubleClick);
-        };
-    }
-
-    function ensureWaterfallTimeline(card, sessionId) {
-        const field = card.querySelector('[data-field="network_log_waterfall"]');
-        if (!field || !hasVisTimeline()) return null;
-        const key = String(sessionId);
-        let state = networkWaterfallTimelines.get(key) || null;
-
-        if (state && state.host !== field) {
-            if (state.timeline && typeof state.timeline.destroy === 'function') {
-                state.timeline.destroy();
-            }
-            if (state.cleanupSelectionHandlers) {
-                state.cleanupSelectionHandlers();
-            }
-            state = null;
-        }
-
-        if (!state) {
-            const groups = new window.vis.DataSet();
-            const items = new window.vis.DataSet();
-            const options = {
-                stack: false,
-                zoomable: true,
-                moveable: true,
-                horizontalScroll: true,
-                verticalScroll: true,
-                showCurrentTime: false,
-                selectable: false,
-                showMajorLabels: false,
-                showMinorLabels: true,
-                orientation: { axis: 'top', item: 'bottom' },
-                groupHeightMode: 'fixed',
-                margin: {
-                    axis: 0,
-                    item: {
-                        horizontal: 0,
-                        vertical: 0
-                    }
-                },
-                minHeight: '240px',
-                maxHeight: '360px',
-                tooltip: {
-                    followMouse: true,
-                    overflowMethod: 'flip'
-                },
-                format: {
-                    minorLabels: {
-                        millisecond: 'HH:mm:ss.SSS',
-                        second: 'HH:mm:ss',
-                        minute: 'HH:mm',
-                        hour: 'HH:mm'
-                    },
-                    majorLabels: {
-                        millisecond: 'YYYY-MM-DD',
-                        second: 'YYYY-MM-DD',
-                        minute: 'YYYY-MM-DD',
-                        hour: 'YYYY-MM-DD'
-                    }
-                }
-            };
-            const timeline = new window.vis.Timeline(field, items, groups, options);
-            timeline.on('rangechanged', (props) => {
-                if (!props || !props.start || !props.end || props.byUser !== true) return;
-                const startMs = new Date(props.start).getTime();
-                const endMs = new Date(props.end).getTime();
-                if (Number.isFinite(startMs) && Number.isFinite(endMs) && endMs > startMs) {
-                    networkWaterfallViewBySession.set(key, { startMs, endMs });
-                    setNetworkLogFollowMode(key, false);
-                    updateNetworkLogFollowButton(null, key);
-                    // User took manual control — stop auto-panning until
-                    // they hit Fit / First / Last (issue #286).
-                    state.autoPan = false;
-                }
-            });
-            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: isFollowScrollMode(key) };
-            bindWaterfallSelectionHandlers(state, key);
-            attachWaterfallAutoPan(state, key);
-            networkWaterfallTimelines.set(key, state);
-        }
-        return state;
-    }
-
-    // attachWaterfallAutoPan listens for scroll on the entries list and
-    // pans the visible time window to match the rows the user is looking
-    // at. Issue #286.
-    //
-    // We listen to BOTH:
-    //   1. DOM `scroll` on `.vis-content` — fires when vis-timeline uses
-    //      native scrollbars.
-    //   2. `wheel` on the host — vis-timeline drives vertical scroll via
-    //      transforms in some configurations and the DOM scroll event
-    //      doesn't fire. The wheel handler covers that case.
-    function attachWaterfallAutoPan(state, key) {
-        if (!state || !state.host || state.autoPanBound) return;
-        const setupOnce = () => {
-            if (!state.host) return false;
-            const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
-            const center = state.host.querySelector('.vis-panel.vis-center .vis-content');
-            if (!left && !center) return false;
-            let rafId = null;
-            const schedule = () => {
-                if (!state.autoPan) return;
-                if (!isFollowScrollMode(key)) return;
-                if (rafId) return;
-                rafId = window.requestAnimationFrame(() => {
-                    rafId = null;
-                    applyWaterfallAutoPan(state, key);
-                });
-            };
-            if (left) left.addEventListener('scroll', schedule, { passive: true });
-            if (center && center !== left) center.addEventListener('scroll', schedule, { passive: true });
-            // Wheel events fire even when vis-timeline does
-            // transform-based scrolling. Schedule on the next frame so
-            // we read the post-scroll position.
-            state.host.addEventListener('wheel', (event) => {
-                // User-initiated scroll while Following Latest is on
-                // means they want to step away from the live tail —
-                // auto-disable Following Latest and let track-by-scroll
-                // pin the time window to whatever they're looking at.
-                if (isNetworkLogFollowMode(key)) {
-                    setNetworkLogFollowMode(key, false);
-                    const card = state.host.closest('.session-card');
-                    updateNetworkLogFollowButton(card, key);
-                }
-                schedule();
-            }, { passive: true });
-            state.autoPanBound = true;
-            return true;
-        };
-        // vis-timeline builds its DOM async — retry a few frames if the
-        // .vis-content nodes aren't there yet.
-        let attempts = 0;
-        const retry = () => {
-            if (setupOnce()) return;
-            attempts += 1;
-            if (attempts < 20) window.requestAnimationFrame(retry);
-        };
-        window.requestAnimationFrame(retry);
-    }
-
-    // restoreScrollAnchor finds the .vis-group element that corresponds
-    // to the anchor's rowIdx after a re-render and scrolls vis-timeline
-    // so that group sits at the same offset within the viewport as it
-    // did before the re-render. Issue #286 follow-up.
-    function restoreScrollAnchor(state, anchor) {
-        if (!state || !state.host || !anchor) return;
-        const center = state.host.querySelector('.vis-panel.vis-center');
-        if (!center) return;
-        const targetGroupId = String(anchor.rowIdx + 1);
-        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
-        let target = null;
-        for (const el of groupEls) {
-            if ((el.getAttribute('data-id') || el.dataset.id) === targetGroupId) {
-                target = el;
-                break;
-            }
-        }
-        if (!target) return;
-        const centerRect = center.getBoundingClientRect();
-        const targetRect = target.getBoundingClientRect();
-        const desiredOffsetTop = centerRect.top + anchor.offsetWithinGroup;
-        const delta = targetRect.top - desiredOffsetTop;
-        if (Math.abs(delta) < 1) return;
-        // Try vis-timeline's internal scroll surfaces in priority order;
-        // any one of them that's writable will scroll the panel.
-        const surfaces = [
-            state.timeline?.body?.dom?.shadow,
-            state.timeline?.body?.dom?.center,
-            state.host.querySelector('.vis-panel.vis-left .vis-content'),
-            state.host.querySelector('.vis-panel.vis-center .vis-content'),
-        ].filter(Boolean);
-        for (const s of surfaces) {
-            if (typeof s.scrollTop === 'number') {
-                const before = s.scrollTop;
-                s.scrollTop = before + delta;
-                // If it changed, we found the right surface.
-                if (s.scrollTop !== before) return;
-            }
-        }
-    }
-
-    // applyWaterfallAutoPan computes the time range covered by the
-    // entries list's currently-visible rows and pans the waterfall to it.
-    //
-    // vis-timeline virtualizes vertical scroll via CSS transforms, not
-    // native scroll, so .vis-content's scrollTop/scrollHeight don't
-    // reflect the actual scroll state. Instead we walk the rendered
-    // .vis-group DOM elements and check which ones intersect the
-    // center panel's viewport rect.
-    function applyWaterfallAutoPan(state, key) {
-        if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
-        if (!state.host) return;
-        if (!state.autoPan) return;
-
-        const center = state.host.querySelector('.vis-panel.vis-center');
-        if (!center) return;
-        const centerRect = center.getBoundingClientRect();
-        if (centerRect.height <= 0) return;
-
-        const rowCount = state.rows.length;
-        let firstVisibleIdx = -1;
-        let lastVisibleIdx = -1;
-
-        // Strategy 1: walk rendered .vis-group elements and take the
-        // ones whose bounding rect intersects the center viewport.
-        // Works if vis-timeline doesn't apply transforms that make all
-        // groups share the same on-screen rect.
-        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
-        let sampleHeight = 0;
-        groupEls.forEach((el) => {
-            const groupIdAttr = el.getAttribute('data-id') || el.dataset.id;
-            const groupId = parseInt(groupIdAttr, 10);
-            if (!Number.isFinite(groupId)) return;
-            const rowIdx = groupId - 1;
-            if (rowIdx < 0 || rowIdx >= rowCount) return;
-            const r = el.getBoundingClientRect();
-            if (r.height > 0 && sampleHeight === 0) sampleHeight = r.height;
-            if (r.height <= 0) return;
-            if (r.bottom > centerRect.top && r.top < centerRect.bottom) {
-                if (firstVisibleIdx === -1 || rowIdx < firstVisibleIdx) firstVisibleIdx = rowIdx;
-                if (lastVisibleIdx === -1 || rowIdx > lastVisibleIdx) lastVisibleIdx = rowIdx;
-            }
-        });
-
-        // Strategy 2: if intersection found nothing (or found ALL rows
-        // due to vis-timeline's transform-based virtualization), fall
-        // back to "row-height × viewport ÷ pin to last N". Works for
-        // the common Following Latest workflow. The sampled height
-        // comes from the first .vis-group we saw above; if no groups
-        // are rendered at all, we use a 22px default.
-        const sawAllRows = (lastVisibleIdx - firstVisibleIdx + 1) === rowCount;
-        const sawNoRows = firstVisibleIdx === -1;
-        if (sawNoRows || sawAllRows) {
-            const rowHeight = sampleHeight > 0 ? sampleHeight : 22;
-            const visibleRowCount = Math.max(1, Math.min(rowCount, Math.floor(centerRect.height / rowHeight)));
-            // When the entries list is following the latest entries
-            // (Following Latest is the default), the visible rows are
-            // the most recent — pin to the last N. This matches what
-            // the user sees on the left.
-            if (isNetworkLogFollowMode(key)) {
-                firstVisibleIdx = Math.max(0, rowCount - visibleRowCount);
-                lastVisibleIdx = rowCount - 1;
-            } else {
-                // Not following — without reliable scroll position we
-                // pick the FIRST N rows (top-of-list). Will be wrong
-                // when user has scrolled past the top, but that case
-                // doesn't appear common today.
-                firstVisibleIdx = 0;
-                lastVisibleIdx = Math.min(rowCount - 1, visibleRowCount - 1);
-            }
-        }
-
-        const startRow = state.rows[firstVisibleIdx];
-        const endRow = state.rows[lastVisibleIdx];
-        if (!startRow || !endRow) return;
-        const startTs = startRow.timestamp;
-        const endTs = endRow.timestamp + Math.max(50, endRow.duration);
-        if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
-
-        // Tight padding (1%) so adjacent bars peek in at the edges
-        // without swamping short bursts. Minimum 25ms so a single
-        // sub-millisecond bar doesn't render at zero width.
-        const padding = Math.max(25, (endTs - startTs) * 0.01);
-        const fullRange = networkWaterfallFullRangeBySession.get(key);
-        let nextStart = startTs - padding;
-        let nextEnd = endTs + padding;
-        if (fullRange) {
-            if (nextStart < fullRange.startMs) nextStart = fullRange.startMs;
-            if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
-        }
-        if (nextEnd <= nextStart) return;
-        state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
-        networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
-    }
 
     // Global-axis waterfall with a brushable overview pane (issue
     // #291). The overview shows the full session at small scale; the
@@ -2850,44 +2414,46 @@
     }
 
     function attachWaterfallColumnResizer(chartHost, resizer) {
-        let drag = null;
+        // Document-level mousemove/mouseup listeners are scoped to a
+        // single drag — added on mousedown, removed on mouseup. This
+        // avoids the "every axis rebuild adds another pair to document"
+        // leak the older keep-alive form would create.
         resizer.addEventListener('mousedown', (e) => {
             const col = resizer.dataset.col;
             if (!col) return;
             const cell = resizer.parentElement;
             const startPx = cell.getBoundingClientRect().width;
-            drag = {
+            const drag = {
                 col,
                 startX: e.clientX,
                 startPx,
                 minPx: parseInt(resizer.dataset.minPx, 10) || 30,
                 cssVar: `--netwf-col-${col}`
             };
+            const onMove = (ev) => {
+                const next = Math.max(drag.minPx, drag.startPx + (ev.clientX - drag.startX));
+                chartHost.style.setProperty(drag.cssVar, `${Math.round(next)}px`);
+            };
+            const onUp = () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+                resizer.classList.remove('dragging');
+                document.body.style.cursor = '';
+                // Persist the new width so it survives session-card
+                // re-renders and page reloads.
+                try {
+                    const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
+                    stored[drag.col] = chartHost.style.getPropertyValue(`--netwf-col-${drag.col}`);
+                    localStorage.setItem('netwf-cols-v2', JSON.stringify(stored));
+                } catch (_) { /* no-op */ }
+            };
             resizer.classList.add('dragging');
             document.body.style.cursor = 'col-resize';
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
             e.preventDefault();
             e.stopPropagation();
         });
-        const onMove = (e) => {
-            if (!drag) return;
-            const next = Math.max(drag.minPx, drag.startPx + (e.clientX - drag.startX));
-            chartHost.style.setProperty(drag.cssVar, `${Math.round(next)}px`);
-        };
-        const onUp = () => {
-            if (!drag) return;
-            // Persist the new width so it survives session-card re-renders
-            // and page reloads.
-            try {
-                const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
-                stored[drag.col] = chartHost.style.getPropertyValue(`--netwf-col-${drag.col}`);
-                localStorage.setItem('netwf-cols-v2', JSON.stringify(stored));
-            } catch (_) { /* no-op */ }
-            drag = null;
-            resizer.classList.remove('dragging');
-            document.body.style.cursor = '';
-        };
-        document.addEventListener('mousemove', onMove);
-        document.addEventListener('mouseup', onUp);
     }
 
     // Re-apply persisted column widths to a chart host on first

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2195,34 +2195,57 @@
         const centerRect = center.getBoundingClientRect();
         if (centerRect.height <= 0) return;
 
-        // Walk the rendered group elements. Each .vis-group has
-        // data-id matching the groupId we assigned (groupId = rowIdx + 1
-        // in updateNetworkWaterfall).
-        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        const rowCount = state.rows.length;
         let firstVisibleIdx = -1;
         let lastVisibleIdx = -1;
+
+        // Strategy 1: walk rendered .vis-group elements and take the
+        // ones whose bounding rect intersects the center viewport.
+        // Works if vis-timeline doesn't apply transforms that make all
+        // groups share the same on-screen rect.
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let sampleHeight = 0;
         groupEls.forEach((el) => {
             const groupIdAttr = el.getAttribute('data-id') || el.dataset.id;
             const groupId = parseInt(groupIdAttr, 10);
             if (!Number.isFinite(groupId)) return;
             const rowIdx = groupId - 1;
-            if (rowIdx < 0 || rowIdx >= state.rows.length) return;
+            if (rowIdx < 0 || rowIdx >= rowCount) return;
             const r = el.getBoundingClientRect();
+            if (r.height > 0 && sampleHeight === 0) sampleHeight = r.height;
             if (r.height <= 0) return;
-            // Group at least partially visible if it overlaps the
-            // center panel's viewport rect.
             if (r.bottom > centerRect.top && r.top < centerRect.bottom) {
                 if (firstVisibleIdx === -1 || rowIdx < firstVisibleIdx) firstVisibleIdx = rowIdx;
                 if (lastVisibleIdx === -1 || rowIdx > lastVisibleIdx) lastVisibleIdx = rowIdx;
             }
         });
 
-        // Fallback: if we couldn't read group elements (race, custom
-        // virtualization), pan to cover all rows. Better than leaving a
-        // mostly-blank timeline.
-        if (firstVisibleIdx === -1 || lastVisibleIdx === -1) {
-            firstVisibleIdx = 0;
-            lastVisibleIdx = state.rows.length - 1;
+        // Strategy 2: if intersection found nothing (or found ALL rows
+        // due to vis-timeline's transform-based virtualization), fall
+        // back to "row-height × viewport ÷ pin to last N". Works for
+        // the common Following Latest workflow. The sampled height
+        // comes from the first .vis-group we saw above; if no groups
+        // are rendered at all, we use a 22px default.
+        const sawAllRows = (lastVisibleIdx - firstVisibleIdx + 1) === rowCount;
+        const sawNoRows = firstVisibleIdx === -1;
+        if (sawNoRows || sawAllRows) {
+            const rowHeight = sampleHeight > 0 ? sampleHeight : 22;
+            const visibleRowCount = Math.max(1, Math.min(rowCount, Math.floor(centerRect.height / rowHeight)));
+            // When the entries list is following the latest entries
+            // (Following Latest is the default), the visible rows are
+            // the most recent — pin to the last N. This matches what
+            // the user sees on the left.
+            if (isNetworkLogFollowMode(key)) {
+                firstVisibleIdx = Math.max(0, rowCount - visibleRowCount);
+                lastVisibleIdx = rowCount - 1;
+            } else {
+                // Not following — without reliable scroll position we
+                // pick the FIRST N rows (top-of-list). Will be wrong
+                // when user has scrolled past the top, but that case
+                // doesn't appear common today.
+                firstVisibleIdx = 0;
+                lastVisibleIdx = Math.min(rowCount - 1, visibleRowCount - 1);
+            }
         }
 
         const startRow = state.rows[firstVisibleIdx];

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -45,17 +45,25 @@
     const networkWaterfallTimelines = new Map();
     const networkWaterfallViewBySession = new Map();
     const networkWaterfallFollowModeBySession = new Map();
-    // Follow Scroll: pan the waterfall's time window to match the rows
-    // visible in the entries list as the user scrolls. Default true.
-    // Issue #286.
-    const networkWaterfallFollowScrollBySession = new Map();
     const networkWaterfallFullRangeBySession = new Map();
     const networkWaterfallRenderSignatureBySession = new Map();
-    const networkWaterfallRollingWindowMs = 5 * 60 * 1000;
+    const networkWaterfallRowSignaturesBySession = new Map();
+    const networkWaterfallRowsBySession = new Map();
+    // Per-session brush state: { startMs, endMs, follow }. `follow=true`
+    // means the brush sticks to the right edge as new entries arrive
+    // (Following Latest). Drag-pan flips it to false.
+    const networkWaterfallBrushBySession = new Map();
+    const networkWaterfallRollingWindowMs = 10 * 60 * 1000;
+    // Default and minimum brush span. Tighter than this and the time
+    // axis gets too granular to be useful; this is also the default
+    // initial span when a session first opens.
+    const networkWaterfallMinBrushMs = 1 * 60 * 1000;
     const networkLogAutoRefreshTimers = new Map();
     const networkLogFetchInFlight = new Set();
     const networkLogAutoRefreshMs = 1500;
-    const networkLogDeveloperEnabled = new URLSearchParams(window.location.search).get('developer') === '1';
+    // Network log used to be developer-only; now enabled for everyone.
+    // The constant stays as `true` so the runtime gates still compile.
+    const networkLogDeveloperEnabled = true;
 
     function formatDate(value) {
         if (!value) return '—';
@@ -1063,7 +1071,6 @@
                 </div>
                 ` : ''}
 
-                ${developerMode ? `
                 <!-- Collapsible Network Log -->
                 <div class="collapsible-section" data-section="network-log" data-default-open="false">
                     <div class="collapsible-header" data-toggle="network-log">
@@ -1076,36 +1083,34 @@
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save the current network timeline as a HAR file: downloads to your machine and adds it to the Incidents list">Download HAR</button>
-                                <a href="/api/incidents" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="List saved HAR snapshots (raw JSON)">Incidents</a>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-first">First</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-fit">Fit</button>
+                                <a href="/dashboard/incidents.html" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="Browse saved HAR snapshots">Incidents</a>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-follow">Following Latest</button>
-                                <label class="network-log-filter" title="Pan the waterfall's time window to match the entries currently visible in the list above">
-                                    <input type="checkbox" data-field="follow-scroll" checked>
-                                    Follow Scroll
-                                </label>
-                                <label class="network-log-filter">
-                                    <input type="checkbox" data-filter="show-faulted" checked>
-                                    Show Faults
-                                </label>
-                                <label class="network-log-filter">
-                                    <input type="checkbox" data-filter="show-successful" checked>
-                                    Show Successful
+                                <label class="network-log-filter" title="When checked, only faulted / non-success entries appear in the list.">
+                                    <input type="checkbox" data-filter="hide-successful">
+                                    Hide Successful
                                 </label>
                             </div>
                             <div class="network-log-warning">
-                                Transfer timings and derived Mbps are approximate.
-                                They are most reliable when the network is slow and transfers are large (especially video segments).
+                                Transfer timings and derived Mbps are approximate, and measured <strong>downstream</strong> — from when go-proxy starts writing the response back to the client device until the last byte is flushed (proxy → player). They do <strong>not</strong> include the upstream fetch from go-proxy to go-live. The numbers are most reliable when the network is slow and transfers are large (especially video segments); short responses transfer in &lt;1 ms and round to noise.
                             </div>
                             <div class="network-log-waterfall-wrap">
-                                <div class="network-log-waterfall" data-field="network_log_waterfall"></div>
+                                <div class="netwf-summary" data-field="netwf_summary"></div>
+                                <div class="netwf-overview-axis" data-field="netwf_overview_axis"></div>
+                                <div class="netwf-overview" data-field="netwf_overview">
+                                    <div class="netwf-overview-bars" data-field="netwf_overview_bars"></div>
+                                    <div class="netwf-brush" data-field="netwf_brush" style="left:0%;width:100%;">
+                                        <div class="netwf-brush-handle left" data-field="netwf_brush_handle_left"></div>
+                                        <div class="netwf-brush-handle right" data-field="netwf_brush_handle_right"></div>
+                                    </div>
+                                </div>
+                                <div class="network-log-waterfall-scroll" data-field="network_log_waterfall_scroll">
+                                    <div class="network-log-waterfall" data-field="network_log_waterfall"></div>
+                                </div>
                                 <div class="network-log-waterfall-empty" data-field="network_log_waterfall_empty" style="display:none;">No requests to plot yet.</div>
                             </div>
                         </div>
                     </div>
                 </div>
-                ` : ''}
 
             </div>
         `;
@@ -1366,12 +1371,6 @@
             const cb = e.target;
             if (!cb || cb.type !== 'checkbox' || !cb.dataset.field) return;
             const field = cb.dataset.field;
-            if (field === 'follow-scroll') {
-                const card = cb.closest('.session-card');
-                const sessionId = card ? String(card.dataset.sessionId || '') : '';
-                if (sessionId) setFollowScrollMode(sessionId, !!cb.checked);
-                return;
-            }
             if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls') return;
             const group = cb.closest('.checkbox-group');
             if (!group) return;
@@ -1405,7 +1404,21 @@
                         setNetworkLogFollowMode(sessionId, nextFollow);
                         updateNetworkLogFollowButton(card, sessionId);
                         if (nextFollow) {
-                            jumpWaterfallView(sessionId, 'last');
+                            // Snap to the live point immediately —
+                            // refresh the entry list, re-render so the
+                            // brush hits the right edge, then make sure
+                            // the row list is scrolled to the bottom
+                            // even after layout settles.
+                            updateNetworkLog(sessionId);
+                            const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
+                            if (scrollHost) {
+                                scrollHost.scrollTop = scrollHost.scrollHeight;
+                                window.requestAnimationFrame(() => {
+                                    scrollHost.scrollTop = scrollHost.scrollHeight;
+                                });
+                            }
+                        } else if (card) {
+                            applyNetworkLogFilters(card);
                         }
                     }
                     return;
@@ -1414,50 +1427,43 @@
                     const card = actionButton.closest('.session-card');
                     const sessionId = card ? String(card.dataset.sessionId || '') : '';
                     if (!sessionId) return;
-                    const reason = window.prompt('Snapshot reason (e.g. manual, freeze, restart):', 'manual') || 'manual';
                     actionButton.disabled = true;
                     fetch(`/api/session/${encodeURIComponent(sessionId)}/har/snapshot`, {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ reason, source: 'dashboard' })
+                        body: JSON.stringify({ reason: 'manual', source: 'dashboard' })
                     })
                         .then(r => r.json())
-                        .then(data => {
+                        .then(async (data) => {
                             if (data && data.incident && data.incident.path) {
-                                // Trigger a direct download — server already
-                                // wrote the file to /incidents/, we just
-                                // route the browser at it via a hidden <a>.
+                                // Fetch the just-saved file as a blob and
+                                // trigger the download from a blob: URL.
+                                // Linking to /api/incidents/... directly
+                                // triggers Chrome's "insecure download"
+                                // block on plain-HTTP origins (mixed-
+                                // content download). A blob URL is
+                                // local-origin, so it isn't blocked.
+                                const fileResp = await fetch(`/api/incidents/${data.incident.path}`);
+                                if (!fileResp.ok) {
+                                    throw new Error(`HAR fetch ${fileResp.status}`);
+                                }
+                                const blob = await fileResp.blob();
+                                const url = URL.createObjectURL(blob);
                                 const a = document.createElement('a');
-                                a.href = `/api/incidents/${data.incident.path}`;
+                                a.href = url;
                                 a.download = data.incident.filename || 'incident.har';
                                 a.style.display = 'none';
                                 document.body.appendChild(a);
                                 a.click();
                                 document.body.removeChild(a);
+                                // Defer revoke so the click has time to start.
+                                setTimeout(() => URL.revokeObjectURL(url), 1000);
                             } else if (data && data.error) {
                                 window.alert(`HAR save failed: ${data.error}`);
                             }
                         })
                         .catch(err => window.alert(`HAR save failed: ${err}`))
                         .finally(() => { actionButton.disabled = false; });
-                    return;
-                }
-                if (action === 'network-log-jump-first' || action === 'network-log-jump-last' || action === 'network-log-jump-fit') {
-                    const card = actionButton.closest('.session-card');
-                    const sessionId = card ? card.dataset.sessionId : '';
-                    if (sessionId) {
-                        if (action === 'network-log-jump-first') {
-                            setNetworkLogFollowMode(sessionId, false);
-                            updateNetworkLogFollowButton(card, sessionId);
-                            jumpWaterfallView(sessionId, 'first');
-                        } else if (action === 'network-log-jump-last') {
-                            jumpWaterfallView(sessionId, 'last');
-                        } else {
-                            setNetworkLogFollowMode(sessionId, false);
-                            updateNetworkLogFollowButton(card, sessionId);
-                            jumpWaterfallView(sessionId, 'fit');
-                        }
-                    }
                     return;
                 }
             }
@@ -1548,13 +1554,8 @@
             return;
         }
         resumeNetworkLogAutoRefreshForVisiblePanels();
-        window.addEventListener('resize', () => {
-            networkWaterfallTimelines.forEach((state) => {
-                if (state && state.timeline && typeof state.timeline.redraw === 'function') {
-                    state.timeline.redraw();
-                }
-            });
-        });
+        // Native waterfall layouts re-flow on the next refresh tick;
+        // no explicit redraw needed on window resize.
         document.addEventListener('visibilitychange', () => {
             if (document.hidden) {
                 stopAllNetworkLogAutoRefresh();
@@ -1596,28 +1597,10 @@
 
     function isNetworkLogFollowMode(sessionId) {
         const key = String(sessionId || '');
-        // Default OFF — the user expects the list to "just sit there"
-        // until they explicitly opt into auto-scroll.
-        return networkWaterfallFollowModeBySession.get(key) === true;
-    }
-
-    // Follow Scroll mode: when on, the waterfall's time window
-    // auto-pans to match the rows currently visible in the entries
-    // list. Default true so the feature is on out-of-the-box. Issue #286.
-    function isFollowScrollMode(sessionId) {
-        const key = String(sessionId || '');
-        return networkWaterfallFollowScrollBySession.get(key) !== false;
-    }
-
-    function setFollowScrollMode(sessionId, enabled) {
-        const key = String(sessionId || '');
-        if (!key) return;
-        networkWaterfallFollowScrollBySession.set(key, !!enabled);
-        const state = networkWaterfallTimelines.get(key);
-        if (state) {
-            state.autoPan = !!enabled;
-            if (enabled) applyWaterfallAutoPan(state, key);
-        }
+        // Default ON — with the brushable overview, the user can pan
+        // away whenever they want; the live tail is the more useful
+        // initial state.
+        return networkWaterfallFollowModeBySession.get(key) !== false;
     }
 
     function setNetworkLogFollowMode(sessionId, enabled) {
@@ -1636,12 +1619,6 @@
         button.setAttribute('aria-pressed', following ? 'true' : 'false');
         button.classList.toggle('btn-primary', following);
         button.classList.toggle('btn-secondary', !following);
-        // Keep the Follow Scroll checkbox in sync with the per-session
-        // map across re-renders (the HTML template defaults to checked).
-        const followScrollCb = hostCard.querySelector('input[data-field="follow-scroll"]');
-        if (followScrollCb) {
-            followScrollCb.checked = isFollowScrollMode(sessionId);
-        }
     }
 
     function scrollWaterfallToLatestRow(state) {
@@ -1735,6 +1712,26 @@
         return `${mbps.toFixed(2)} Mbps`;
     }
 
+    // Fixed-precision formatters for the row table. Decimal count is
+    // constant across rows so a column scans cleanly (e.g. "5.00",
+    // "12.30", "145.00" rather than "5", "12.3", "145").
+    function formatKBNumber(bytes) {
+        const n = Number(bytes || 0);
+        if (!Number.isFinite(n) || n <= 0) return '—';
+        return (n / 1024).toFixed(1);
+    }
+
+    function formatMbpsNumber(bytes, transferMs) {
+        const bytesNum = Number(bytes || 0);
+        const msNum = Number(transferMs || 0);
+        if (!Number.isFinite(bytesNum) || !Number.isFinite(msNum) || bytesNum <= 0 || msNum <= 0) {
+            return '—';
+        }
+        const mbps = (bytesNum * 8) / (msNum * 1000);
+        if (!Number.isFinite(mbps) || mbps <= 0) return '—';
+        return mbps.toFixed(2);
+    }
+
     function escapeHtml(value) {
         return String(value || '')
             .replace(/&/g, '&amp;')
@@ -1764,12 +1761,36 @@
 
     function getFilteredNetworkEntries(card, sessionId) {
         const entries = networkLogEntriesBySession.get(String(sessionId)) || [];
-        const showFaulted = card.querySelector('[data-filter="show-faulted"]')?.checked ?? true;
-        const showSuccessful = card.querySelector('[data-filter="show-successful"]')?.checked ?? true;
-        return entries.filter((entry) => {
-            const faulted = !!entry.faulted;
-            return (faulted && showFaulted) || (!faulted && showSuccessful);
-        });
+        // Faults are always shown. "Hide Successful" defaults off, so
+        // by default we show everything; tick it to focus on problems.
+        const hideSuccessful = card.querySelector('[data-filter="hide-successful"]')?.checked ?? false;
+        return entries.filter((entry) => entry.faulted || !hideSuccessful);
+    }
+
+    // Derive segment duration from the URL conventions used by go-live:
+    //   /go-live/<content>/2s/...    -> 2s segments
+    //   /go-live/<content>/6s/...    -> 6s segments
+    //   /go-live/<content>/ll/...    -> LL partials (~200ms part target;
+    //                                    use 1s as a conservative
+    //                                    "normal cadence")
+    //   playlist_<N>s_<variant>.m3u8 -> N seconds (also matches DASH-side)
+    // Anything we can't classify falls back to the 6s default.
+    function waterfallSegmentDurationMsFor(row) {
+        const url = String(row.entry.url || row.entry.path || row.pathDisplay || '').toLowerCase();
+        if (!url) return 6000;
+        const lowLatency = /(^|[/_])ll([/_.]|$)/.test(url);
+        if (lowLatency) return 1000;
+        const m = url.match(/(?:[/_])(\d{1,2})s(?:[/_])/);
+        if (m) {
+            const secs = parseInt(m[1], 10);
+            if (secs > 0 && secs <= 30) return secs * 1000;
+        }
+        const m2 = url.match(/playlist_(\d{1,2})s[_-]/);
+        if (m2) {
+            const secs = parseInt(m2[1], 10);
+            if (secs > 0 && secs <= 30) return secs * 1000;
+        }
+        return 6000;
     }
 
     function buildWaterfallRows(entries) {
@@ -1883,6 +1904,35 @@
         });
         const ordered = rows.filter((row) => row.timestamp > 0).sort((a, b) => a.timestamp - b.timestamp);
         if (!ordered.length) return ordered;
+        // Tag re-requests: same URL+method seen earlier in the session.
+        // `attempt` / `totalAttempts` give chronological context; the
+        // narrower `is_retry` flag fires only when the gap from the
+        // previous fetch is suspiciously short — faster than a normal
+        // HLS playlist refresh / segment refetch cadence. The cutoff
+        // is *half the segment duration* parsed from the URL path
+        // (.../2s/..., .../6s/..., .../ll/..., or playlist_2s_...).
+        // Routine periodic refetches won't get flagged; rapid retries
+        // after a failure will.
+        const attemptByKey = new Map();
+        const lastTimeByKey = new Map();
+        for (const row of ordered) {
+            const k = `${row.entry.method || 'GET'} ${row.entry.url || row.entry.path || ''}`;
+            const next = (attemptByKey.get(k) || 0) + 1;
+            attemptByKey.set(k, next);
+            row.attempt = next;
+            const prevTs = lastTimeByKey.get(k);
+            row.segment_duration_ms = waterfallSegmentDurationMsFor(row);
+            const threshold = row.segment_duration_ms / 2;
+            row.retry_threshold_ms = threshold;
+            row.is_retry = next > 1 && prevTs !== undefined && (row.timestamp - prevTs) < threshold;
+            row.gap_from_prev_ms = prevTs !== undefined ? row.timestamp - prevTs : null;
+            lastTimeByKey.set(k, row.timestamp);
+            row.totalAttempts = 0; // filled in below
+        }
+        for (const row of ordered) {
+            const k = `${row.entry.method || 'GET'} ${row.entry.url || row.entry.path || ''}`;
+            row.totalAttempts = attemptByKey.get(k) || 1;
+        }
         const newestTimestamp = ordered[ordered.length - 1].timestamp;
         const cutoff = newestTimestamp - networkWaterfallRollingWindowMs;
         return ordered.filter((row) => (row.timestamp + row.duration) >= cutoff);
@@ -2322,224 +2372,747 @@
         networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
 
+    // Global-axis waterfall with a brushable overview pane (issue
+    // #291). The overview shows the full session at small scale; the
+    // user drags the brush to pick a time window, and the bars in the
+    // main view position themselves within that window. Chrome
+    // DevTools' Network panel pattern.
     function updateNetworkWaterfall(card, sessionId) {
         const key = String(sessionId);
         const chartHost = card.querySelector('[data-field="network_log_waterfall"]');
+        const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
         const emptyHost = card.querySelector('[data-field="network_log_waterfall_empty"]');
+        const overviewEl = card.querySelector('[data-field="netwf_overview"]');
+        const overviewBars = card.querySelector('[data-field="netwf_overview_bars"]');
+        const brushEl = card.querySelector('[data-field="netwf_brush"]');
         if (!chartHost || !emptyHost) return;
-
-        if (!hasVisTimeline()) {
-            emptyHost.textContent = 'vis-timeline not loaded; waterfall unavailable.';
-            emptyHost.style.display = 'block';
-            return;
-        }
+        applyPersistedWaterfallColumns(chartHost);
 
         const rows = buildWaterfallRows(getFilteredNetworkEntries(card, key));
         if (!rows.length) {
             emptyHost.textContent = 'No requests to plot yet.';
             emptyHost.style.display = 'block';
-            const state = networkWaterfallTimelines.get(key);
-            networkWaterfallFullRangeBySession.delete(key);
+            chartHost.replaceChildren();
+            if (overviewBars) overviewBars.replaceChildren();
             networkWaterfallRenderSignatureBySession.delete(key);
-            if (state && state.items && state.groups) {
-                state.items.clear();
-                state.groups.clear();
-                if (state.timeline && typeof state.timeline.redraw === 'function') {
-                    state.timeline.redraw();
-                }
-            }
+            networkWaterfallRowsBySession.delete(key);
             return;
         }
         emptyHost.style.display = 'none';
 
-        const state = ensureWaterfallTimeline(card, key);
-        if (!state) return;
+        // Full session range (the overview always shows this).
+        const dataStartMs = rows[0].timestamp;
+        const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+        const fullSpan = Math.max(50, dataEndMs - dataStartMs);
 
-        const dataStartMs = Math.min(...rows.map((row) => row.timestamp));
-        const dataEndMs = Math.max(...rows.map((row) => row.timestamp + row.duration));
-        const firstRow = rows[0];
-        const lastRow = rows[rows.length - 1];
-        const renderSignature = [
-            rows.length,
-            Math.round(dataStartMs),
-            Math.round(dataEndMs),
-            firstRow ? `${firstRow.filename}|${firstRow.entry.status || ''}|${Math.round(firstRow.duration)}` : '',
-            lastRow ? `${lastRow.filename}|${lastRow.entry.status || ''}|${Math.round(lastRow.duration)}` : ''
-        ].join('|');
-        const previousSignature = networkWaterfallRenderSignatureBySession.get(key);
-        if (previousSignature === renderSignature) {
-            updateNetworkLogFollowButton(card, key);
-            if (isNetworkLogFollowMode(key)) {
-                scrollWaterfallToLatestRow(state);
-            }
-            return;
+        // Brush state — Following Latest = stick to the right edge.
+        // Default: zoom to the most recent 2 minutes (or full session
+        // if shorter). 2 min is also the floor we enforce on user
+        // resize so bars stay scannable.
+        let brush = networkWaterfallBrushBySession.get(key);
+        if (!brush) {
+            const initialSpan = Math.min(fullSpan, networkWaterfallMinBrushMs);
+            brush = { startMs: dataEndMs - initialSpan, endMs: dataEndMs, follow: true };
+            networkWaterfallBrushBySession.set(key, brush);
         }
-        networkWaterfallRenderSignatureBySession.set(key, renderSignature);
-        const toTime = (timestampMs) => new Date(Math.max(0, Math.round(timestampMs)));
-        const groups = [];
-        const items = [];
+        // Sync brush.follow with the Follow Latest button. Clicking
+        // the button re-engages right-edge stickiness even if the user
+        // had previously dragged the brush.
+        brush.follow = isNetworkLogFollowMode(key);
+        if (brush.follow) {
+            const span = brush.endMs - brush.startMs;
+            brush.endMs = dataEndMs;
+            brush.startMs = Math.max(dataStartMs, brush.endMs - span);
+        }
+        // Clamp to data range and enforce the minimum brush width.
+        if (brush.endMs > dataEndMs) brush.endMs = dataEndMs;
+        if (brush.startMs < dataStartMs) brush.startMs = dataStartMs;
+        if (brush.endMs - brush.startMs < networkWaterfallMinBrushMs) {
+            // Try to expand left first; if there's not enough history,
+            // accept whatever we can fit (full session shorter than
+            // the minimum is fine — the floor only applies when the
+            // user could have a wider view).
+            brush.startMs = Math.max(dataStartMs, brush.endMs - networkWaterfallMinBrushMs);
+        }
 
-        rows.forEach((row, idx) => {
-            const groupId = idx + 1;
-            const method = row.entry.method || 'GET';
-            const status = row.entry.status || '—';
-            const labelClass = row.entry.faulted ? 'waterfall-rowtext is-faulted' : 'waterfall-rowtext';
-            const requestStartMs = row.timestamp;
-            const bytesOut = Number(row.entry.bytes_out || 0);
-            const bytesLabel = bytesOut > 0 ? formatBytes(bytesOut) : '—';
-            const mbpsLabel = formatMbpsFromBytesAndMs(bytesOut, row.transfer);
-            const variantLabel = row.variantLabel || '—';
-            const filenameLower = String(row.filename || '').toLowerCase();
-            let segmentLabel = '—';
-            const segmentMatch = filenameLower.match(/segment[_-](\d+)/);
-            if (segmentMatch) {
-                segmentLabel = segmentMatch[1];
-            } else if (filenameLower.includes('init.')) {
-                segmentLabel = 'init';
-            } else if (filenameLower.includes('playlist')) {
-                segmentLabel = 'playlist';
-            } else if (filenameLower.includes('master')) {
-                segmentLabel = 'master';
-            } else if (row.filename) {
-                segmentLabel = row.filename;
-            }
-            const labelText = [
-                formatColumn(method, 6),
-                formatColumn(row.pathDisplay, 54),
-                formatColumn(variantLabel, 10),
-                formatColumn(segmentLabel, 10),
-                formatColumn(status, 6, true),
-                formatColumn(bytesLabel, 10, true),
-                formatColumn(mbpsLabel, 10, true)
-            ].join(' ');
+        // Summary row: total + categorical counts. Read at a glance
+        // before the user starts panning the brush.
+        const summaryEl = card.querySelector('[data-field="netwf_summary"]');
+        if (summaryEl) {
+            renderWaterfallSummary(summaryEl, rows, dataStartMs, dataEndMs);
+        }
 
-            groups.push({
-                id: groupId,
-                content: `<span class="${labelClass}" title="${escapeHtml(row.entry.url || row.entry.path || '')}">${escapeHtml(labelText)}</span>`
-            });
+        // Time labels above the overview pane — full session range,
+        // independent of the brush. So the user sees both the
+        // big-picture wall clock (this row) and the zoomed-in
+        // wall clock (the row above the bars below).
+        const overviewAxis = card.querySelector('[data-field="netwf_overview_axis"]');
+        if (overviewAxis) {
+            renderWaterfallAxisTicks(overviewAxis, dataStartMs, dataEndMs);
+        }
 
-            const phases = [
-                { key: 'dns', value: row.dns, label: 'DNS' },
-                { key: 'connect', value: row.connect, label: 'Connect' },
-                { key: 'tls', value: row.tls, label: 'TLS' },
-                { key: 'wait', value: row.wait, label: 'Wait' },
-                { key: 'transfer', value: row.transfer, label: 'Receive' }
-            ];
-
-            let cursor = requestStartMs;
-            phases.forEach((phase) => {
-                if (phase.value <= 0) return;
-                const phaseStart = cursor;
-                const phaseEnd = cursor + phase.value;
-                items.push({
-                    id: `${groupId}-${phase.key}`,
-                    group: groupId,
-                    start: toTime(phaseStart),
-                    end: toTime(phaseEnd),
-                    className: `waterfall-phase waterfall-${phase.key}`,
-                    title: [
-                        `${method} ${row.filename}`,
-                        `Status: ${status}`,
-                        `${phase.label}: ${formatMilliseconds(phase.value)}`,
-                        `Total: ${formatMilliseconds(row.duration)}`,
-                        row.entry.url || row.entry.path || ''
-                    ].join('\n')
-                });
-                cursor = phaseEnd;
-            });
-        });
-
-        // Anchor preservation: when Following Latest is OFF, capture the
-        // topmost visible group's row index + pixel offset BEFORE the
-        // re-render so we can restore the user's view after the
-        // groups/items DataSet is replaced. Without this, vis-timeline's
-        // re-render snaps the scroll position to top and the user's view
-        // jumps every time new entries arrive.
-        let scrollAnchor = null;
-        if (!isNetworkLogFollowMode(key) && state.host) {
-            const center = state.host.querySelector('.vis-panel.vis-center');
-            const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
-            if (center && groupEls.length > 0) {
-                const centerRect = center.getBoundingClientRect();
-                for (const el of groupEls) {
-                    const r = el.getBoundingClientRect();
-                    if (r.height <= 0) continue;
-                    if (r.bottom > centerRect.top) {
-                        const groupId = parseInt(el.getAttribute('data-id') || el.dataset.id, 10);
-                        if (Number.isFinite(groupId)) {
-                            scrollAnchor = {
-                                rowIdx: groupId - 1,
-                                offsetWithinGroup: centerRect.top - r.top,
-                            };
-                        }
-                        break;
-                    }
-                }
+        // Render overview ticks (one per row, positioned by absolute
+        // time). Re-render is cheap; we redraw on every refresh.
+        // Apply the same status/fault classes the main rows use so
+        // bad requests stand out on the strip too.
+        if (overviewBars) {
+            overviewBars.replaceChildren();
+            for (const row of rows) {
+                const left = ((row.timestamp - dataStartMs) / fullSpan) * 100;
+                const width = Math.max(0.05, (Math.max(50, row.duration) / fullSpan) * 100);
+                const tick = document.createElement('div');
+                tick.className = 'netwf-overview-tick' + waterfallRowStatusClasses(row);
+                tick.style.left = `${left.toFixed(3)}%`;
+                tick.style.width = `${width.toFixed(3)}%`;
+                overviewBars.appendChild(tick);
             }
         }
 
-        state.groups.clear();
-        state.items.clear();
-        state.groups.add(groups);
-        state.items.add(items);
-        // Stash the rows so the auto-pan handler (issue #286) can map
-        // entries-list scroll position to a time window.
-        state.rows = rows;
+        // Position the brush to match its current state.
+        if (brushEl) {
+            const left = ((brush.startMs - dataStartMs) / fullSpan) * 100;
+            const width = ((brush.endMs - brush.startMs) / fullSpan) * 100;
+            brushEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
+            brushEl.style.width = `${Math.max(0.5, width).toFixed(3)}%`;
+        }
 
-        const fullStartMs = dataStartMs;
-        const latestTransferEndMs = dataEndMs;
-        const rightPadMs = 1000;
-        const fullEndMs = latestTransferEndMs + rightPadMs;
-        networkWaterfallFullRangeBySession.set(key, { startMs: fullStartMs, endMs: fullEndMs });
-        state.timeline.setOptions({
-            // Clamp user pan/zoom to the session's full data range so the
-            // viewer can't drift into empty space outside the session.
-            min: toTime(fullStartMs),
-            max: toTime(fullEndMs),
-            zoomMax: Math.max(1000, fullEndMs - fullStartMs),
-            zoomMin: 100 // Don't let users zoom-in tighter than 100ms.
+        // Lazy-attach brush drag handlers (one set per overview).
+        if (overviewEl && !overviewEl.dataset.netwfBound) {
+            overviewEl.dataset.netwfBound = '1';
+            attachBrushHandlers(card, overviewEl, brushEl);
+        }
+
+        // Filter the row list to requests that overlap the brush
+        // window. The overview above keeps showing the full session;
+        // the list below shows only what the user has selected.
+        const visibleRows = rows.filter((row) => {
+            const reqEnd = row.timestamp + Math.max(50, row.duration);
+            return reqEnd >= brush.startMs && row.timestamp <= brush.endMs;
         });
-        const storedView = networkWaterfallViewBySession.get(key);
-        const following = isNetworkLogFollowMode(key);
+
+        // Sticky axis row at the top of the list — column headers (with
+        // drag-to-resize handles) on the left, tick marks across the
+        // brush window on the right. One axis row in DOM, rebuilt only
+        // when its content changes.
+        let axisEl = chartHost.firstElementChild;
+        if (!axisEl || !axisEl.classList.contains('netwf-axis')) {
+            axisEl = buildWaterfallAxisRow(chartHost);
+            if (chartHost.firstElementChild) {
+                chartHost.insertBefore(axisEl, chartHost.firstElementChild);
+            } else {
+                chartHost.appendChild(axisEl);
+            }
+        }
+        // Update the time-cell header text with current count.
+        const timeHdr = axisEl.querySelector('.netwf-cell.time');
+        if (timeHdr) timeHdr.textContent = `${visibleRows.length}/${rows.length}`;
+        const axisScale = axisEl.querySelector('[data-field="netwf_axis_scale"]');
+        if (axisScale) {
+            renderWaterfallAxisTicks(axisScale, brush.startMs, brush.endMs);
+        }
+
+        // Diff-based DOM updates for the row list. Native scroll keeps
+        // its position when only existing rows update / new ones
+        // append. Note: the axis row sits at index 0, so data rows
+        // start at child index 1.
+        const sigs = visibleRows.map(buildRowSignature);
+        const oldSigs = networkWaterfallRowSignaturesBySession.get(key) || [];
+        const winKey = `${Math.round(brush.startMs)}-${Math.round(brush.endMs)}`;
+        const winChanged = chartHost.dataset.netwfWin !== winKey;
+
+        // Trim removed rows (filter shrunk OR ring buffer evicted).
+        while (chartHost.children.length - 1 > visibleRows.length) {
+            chartHost.removeChild(chartHost.lastElementChild);
+        }
+        visibleRows.forEach((row, idx) => {
+            const domIdx = idx + 1; // axis is at index 0
+            const existing = chartHost.children[domIdx];
+            if (existing && !winChanged && oldSigs[idx] === sigs[idx]) return;
+            const rowEl = buildWaterfallRowEl(row, idx, brush.startMs, brush.endMs);
+            if (existing) {
+                chartHost.replaceChild(rowEl, existing);
+            } else {
+                chartHost.appendChild(rowEl);
+            }
+        });
+        chartHost.dataset.netwfWin = winKey;
+        networkWaterfallRowSignaturesBySession.set(key, sigs);
+        // Keep the unfiltered rows on the session so the brush handler
+        // knows the full data range.
+        networkWaterfallRowsBySession.set(key, rows);
+        networkWaterfallRenderSignatureBySession.set(key, sigs.length + ':' + (sigs[sigs.length - 1] || ''));
+
+        if (scrollHost && isNetworkLogFollowMode(key)) {
+            scrollHost.scrollTop = scrollHost.scrollHeight;
+        }
         updateNetworkLogFollowButton(card, key);
-        if (following) {
-            const spanFromStored = (storedView && Number.isFinite(storedView.startMs) && Number.isFinite(storedView.endMs))
-                ? (storedView.endMs - storedView.startMs)
-                : (fullEndMs - fullStartMs);
-            const spanMs = Math.max(20, Math.min(spanFromStored, Math.max(20, fullEndMs - fullStartMs)));
-            const followEnd = fullEndMs;
-            const followStart = Math.max(fullStartMs, followEnd - spanMs);
-            state.timeline.setWindow(toTime(followStart), toTime(followEnd), { animation: false });
-            networkWaterfallViewBySession.set(key, { startMs: followStart, endMs: followEnd });
-        } else if (storedView && Number.isFinite(storedView.startMs) && Number.isFinite(storedView.endMs)) {
-            const clampedStart = Math.max(fullStartMs, Math.min(fullEndMs, storedView.startMs));
-            const clampedEnd = Math.max(clampedStart + 20, Math.min(fullEndMs, storedView.endMs));
-            state.timeline.setWindow(toTime(clampedStart), toTime(clampedEnd), { animation: false });
-        } else {
-            state.timeline.setWindow(toTime(fullStartMs), toTime(fullEndMs), { animation: false });
+
+        // Lazy-attach scroll listener — scrolling away from the bottom
+        // disables Following Latest.
+        if (scrollHost && !scrollHost.dataset.netwfBound) {
+            scrollHost.dataset.netwfBound = '1';
+            scrollHost.addEventListener('scroll', () => {
+                const c = scrollHost.closest('.session-card');
+                const sid = c ? String(c.dataset.sessionId || '') : '';
+                if (!sid) return;
+                if (isNetworkLogFollowMode(sid) && scrollHost.scrollTop + scrollHost.clientHeight < scrollHost.scrollHeight - 4) {
+                    setNetworkLogFollowMode(sid, false);
+                    updateNetworkLogFollowButton(c, sid);
+                }
+            }, { passive: true });
         }
-        state.timeline.redraw();
-        if (following) {
-            scrollWaterfallToLatestRow(state);
-        } else if (scrollAnchor) {
-            // Re-render snapped vis-timeline's scroll to top — restore
-            // the user's view by scrolling the same row back into the
-            // same vertical offset within the viewport.
-            window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => restoreScrollAnchor(state, scrollAnchor));
-            });
-        }
-        // After the initial render, drive the time window from the
-        // currently-visible rows when Follow Scroll is on. The setWindow
-        // calls above bracket the data range; auto-pan tightens to just
-        // what the user is looking at. Two rAFs let vis-timeline lay out
-        // its panels (the second one is when scrollHeight is final).
-        if (isFollowScrollMode(key) && state.autoPan) {
-            window.requestAnimationFrame(() => {
-                window.requestAnimationFrame(() => applyWaterfallAutoPan(state, key));
-            });
+
+        // Lazy-attach hover tooltip handlers on the chart host.
+        if (chartHost && !chartHost.dataset.netwfTipBound) {
+            chartHost.dataset.netwfTipBound = '1';
+            attachWaterfallHoverTooltip(chartHost);
         }
     }
+
+    let netwfTooltipEl = null;
+    function ensureNetwfTooltip() {
+        if (netwfTooltipEl && document.body.contains(netwfTooltipEl)) return netwfTooltipEl;
+        netwfTooltipEl = document.createElement('div');
+        netwfTooltipEl.className = 'netwf-tooltip';
+        document.body.appendChild(netwfTooltipEl);
+        return netwfTooltipEl;
+    }
+
+    function attachWaterfallHoverTooltip(chartHost) {
+        let activeRowEl = null;
+        const onMove = (event) => {
+            const rowEl = event.target.closest('.netwf-row');
+            if (!rowEl || !chartHost.contains(rowEl) || !rowEl.__netwfRow) {
+                hideTip();
+                return;
+            }
+            if (rowEl !== activeRowEl) {
+                activeRowEl = rowEl;
+                renderTipFor(rowEl.__netwfRow);
+            }
+            positionTip(event.clientX, event.clientY);
+        };
+        const onLeave = () => hideTip();
+        chartHost.addEventListener('mousemove', onMove);
+        chartHost.addEventListener('mouseleave', onLeave);
+    }
+
+    function renderTipFor(row) {
+        const tip = ensureNetwfTooltip();
+        const entry = row.entry || {};
+        const status = entry.status ? String(entry.status) : '—';
+        const method = entry.method || 'GET';
+        const bytesOut = Number(entry.bytes_out || 0);
+        const bytesLabel = bytesOut > 0 ? formatBytes(bytesOut) : '—';
+        const mbpsLabel = formatMbpsFromBytesAndMs(bytesOut, row.transfer);
+        const startedAt = new Date(row.timestamp);
+        const startedLabel = `${String(startedAt.getHours()).padStart(2,'0')}:${String(startedAt.getMinutes()).padStart(2,'0')}:${String(startedAt.getSeconds()).padStart(2,'0')}.${String(startedAt.getMilliseconds()).padStart(3,'0')}`;
+
+        const phases = [
+            { key: 'dns', name: 'DNS', value: row.dns },
+            { key: 'connect', name: 'Connect', value: row.connect },
+            { key: 'tls', name: 'TLS', value: row.tls },
+            { key: 'wait', name: 'Wait (TTFB)', value: row.wait },
+            { key: 'transfer', name: 'Receive', value: row.transfer }
+        ].filter((p) => p.value > 0);
+
+        const phaseRows = phases.map((p) =>
+            `<div class="netwf-tooltip-phase-swatch ${p.key}"></div>`
+            + `<div class="netwf-tooltip-phase-name">${escapeHtml(p.name)}</div>`
+            + `<div class="netwf-tooltip-phase-value">${escapeHtml(formatMilliseconds(p.value))}</div>`
+        ).join('');
+
+        const variant = row.variantLabel ? row.variantLabel : '—';
+        const filename = row.filename || '—';
+        const faultBlock = entry.faulted
+            ? `<div class="netwf-tooltip-fault"><strong>FAULT</strong>: ${escapeHtml(entry.fault_type || 'unknown')}${entry.fault_action ? ` · ${escapeHtml(entry.fault_action)}` : ''}</div>`
+            : '';
+        const url = entry.url || entry.path || '';
+
+        const attemptStr = row.totalAttempts > 1
+            ? `${row.attempt} of ${row.totalAttempts}`
+                + (row.gap_from_prev_ms !== null && row.gap_from_prev_ms !== undefined
+                    ? ` · ${formatMilliseconds(row.gap_from_prev_ms)} since previous`
+                    : '')
+                + (row.is_retry
+                    ? ` (quick retry · cutoff ${formatMilliseconds(row.retry_threshold_ms || 0)})`
+                    : '')
+            : '1';
+        const reqRange = entry.request_range || '';
+        const respRange = entry.response_content_range || '';
+        const rangeStr = reqRange || respRange
+            ? `${reqRange ? `req: ${reqRange}` : ''}${reqRange && respRange ? ' · ' : ''}${respRange ? `resp: ${respRange}` : ''}`
+            : '';
+
+        tip.innerHTML = `
+            <div class="netwf-tooltip-head">${escapeHtml(method)} ${escapeHtml(filename)}</div>
+            <dl class="netwf-tooltip-meta">
+                <dt>Status</dt><dd>${escapeHtml(status)}${status === '206' ? ' (Partial Content)' : ''}</dd>
+                <dt>Total</dt><dd>${escapeHtml(formatMilliseconds(row.duration))}</dd>
+                <dt>Bytes</dt><dd>${escapeHtml(bytesLabel)} @ ${escapeHtml(mbpsLabel)}</dd>
+                <dt>Variant</dt><dd>${escapeHtml(variant)}</dd>
+                <dt>Started</dt><dd>${escapeHtml(startedLabel)}</dd>
+                <dt>Attempt</dt><dd>${escapeHtml(attemptStr)}</dd>
+                ${rangeStr ? `<dt>Range</dt><dd>${escapeHtml(rangeStr)}</dd>` : ''}
+            </dl>
+            <div class="netwf-tooltip-phases">${phaseRows || '<div></div><div class="netwf-tooltip-phase-name">no phase data</div><div></div>'}</div>
+            ${faultBlock}
+            ${url ? `<div class="netwf-tooltip-url">${escapeHtml(url)}</div>` : ''}
+        `;
+        tip.classList.add('visible');
+    }
+
+    function positionTip(clientX, clientY) {
+        const tip = ensureNetwfTooltip();
+        if (!tip.classList.contains('visible')) return;
+        const margin = 12;
+        // Read after innerHTML has been set so dimensions reflect content.
+        const rect = tip.getBoundingClientRect();
+        let left = clientX + 14;
+        let top = clientY + 14;
+        if (left + rect.width + margin > window.innerWidth) {
+            left = clientX - rect.width - 14;
+        }
+        if (top + rect.height + margin > window.innerHeight) {
+            top = clientY - rect.height - 14;
+        }
+        if (left < margin) left = margin;
+        if (top < margin) top = margin;
+        tip.style.left = `${left}px`;
+        tip.style.top = `${top}px`;
+    }
+
+    function hideTip() {
+        if (netwfTooltipEl) netwfTooltipEl.classList.remove('visible');
+    }
+
+    function buildRowSignature(row) {
+        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}`;
+    }
+
+    function waterfallRowStatusClasses(row) {
+        const cls = [];
+        const status = Number(row.entry.status) || 0;
+        if (status === 206) cls.push(' status-206');
+        else if (status >= 200 && status < 300) cls.push(' status-2xx');
+        else if (status >= 300 && status < 400) cls.push(' status-3xx');
+        else if (status >= 400 && status < 500) cls.push(' status-4xx');
+        else if (status >= 500) cls.push(' status-5xx');
+
+        const ft = String(row.entry.fault_type || '').toLowerCase();
+        if (ft.includes('timeout')) cls.push(' fault-timeout');
+        else if (ft.includes('corrupt') || ft.includes('partial') || isWaterfallRowIncomplete(row)) cls.push(' fault-incomplete');
+        else if (row.entry.faulted) cls.push(' is-faulted');
+
+        if (row.is_retry) cls.push(' is-retry');
+        return cls.join('');
+    }
+
+    function isWaterfallRowIncomplete(row) {
+        const ft = String(row.entry.fault_type || '').toLowerCase();
+        if (ft.includes('timeout') || ft.includes('corrupt') || ft.includes('partial') || ft.includes('abandon')) return true;
+        // Heuristic: faulted with bytes-out smaller than expected. We
+        // don't always know "expected", but a faulted entry with a
+        // 2xx status implies the proxy injected a partial/incomplete
+        // response.
+        const status = Number(row.entry.status) || 0;
+        if (row.entry.faulted && status >= 200 && status < 300) return true;
+        return false;
+    }
+
+    function buildWaterfallRowEl(row, idx, winStart, winEnd) {
+        const el = document.createElement('div');
+        el.className = 'netwf-row' + waterfallRowStatusClasses(row);
+        el.dataset.rowIdx = String(idx);
+        // Stash the row data on the DOM node so the hover tooltip can
+        // build a rich expansion without re-querying the session map.
+        el.__netwfRow = row;
+
+        // Column cells. Widths come from CSS vars on the chart host —
+        // resizing a header reflows every row in sync.
+        const ts = new Date(row.timestamp);
+        const tsLabel = `${String(ts.getHours()).padStart(2,'0')}:${String(ts.getMinutes()).padStart(2,'0')}:${String(ts.getSeconds()).padStart(2,'0')}.${String(ts.getMilliseconds()).padStart(3,'0')}`;
+        const method = row.entry.method || 'GET';
+        const bytesOut = Number(row.entry.bytes_out || 0);
+        const bytesLabel = formatKBNumber(bytesOut);
+        const mbpsLabel = formatMbpsNumber(bytesOut, row.transfer);
+        const path = row.pathDisplay || row.filename || '';
+        const flags = (row.is_retry ? '↻' : '') + (row.entry.faulted ? '!' : '');
+        const statusCode = Number(row.entry.status) || 0;
+
+        const cells = [
+            { col: 'time', text: tsLabel },
+            { col: 'flags', text: flags, color: row.is_retry ? '#be185d' : (row.entry.faulted ? '#7f1d1d' : '') },
+            { col: 'method', text: method },
+            { col: 'path', text: path, title: row.entry.url || row.entry.path || '' },
+            { col: 'bytes', text: bytesLabel },
+            { col: 'mbps', text: mbpsLabel },
+            { col: 'status', text: statusCode > 0 ? String(statusCode) : '—' }
+        ];
+        for (const c of cells) {
+            const cellEl = document.createElement('div');
+            cellEl.className = `netwf-cell ${c.col}`;
+            cellEl.textContent = c.text;
+            if (c.title) cellEl.title = c.title;
+            if (c.color) cellEl.style.color = c.color;
+            el.appendChild(cellEl);
+        }
+
+        const trackEl = document.createElement('div');
+        trackEl.className = 'netwf-row-track';
+
+        const winSpan = Math.max(50, winEnd - winStart);
+        const reqStart = row.timestamp;
+        const reqEnd = row.timestamp + Math.max(50, row.duration);
+        // Off-screen rows (entirely outside the brush): render an
+        // empty track so vertical alignment with the URL list stays
+        // correct.
+        if (reqEnd >= winStart && reqStart <= winEnd) {
+            const left = ((reqStart - winStart) / winSpan) * 100;
+            const width = ((reqEnd - reqStart) / winSpan) * 100;
+            const barEl = document.createElement('div');
+            barEl.className = 'netwf-row-bar' + (isWaterfallRowIncomplete(row) ? ' is-incomplete' : '');
+            barEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
+            barEl.style.width = `${Math.max(0.2, width).toFixed(3)}%`;
+            // No native title — custom hover tooltip handles details.
+            const phases = [
+                { key: 'dns', value: row.dns },
+                { key: 'connect', value: row.connect },
+                { key: 'tls', value: row.tls },
+                { key: 'wait', value: row.wait },
+                { key: 'transfer', value: row.transfer }
+            ];
+            const total = phases.reduce((sum, p) => sum + Math.max(0, p.value), 0);
+            for (const phase of phases) {
+                if (phase.value <= 0) continue;
+                const seg = document.createElement('div');
+                seg.className = `netwf-row-phase ${phase.key}`;
+                seg.style.flex = `${phase.value / total} 0 0`;
+                barEl.appendChild(seg);
+            }
+            trackEl.appendChild(barEl);
+
+            // Duration text just past the right edge of the bar. If
+            // the bar is too far right to fit text after it, anchor
+            // the text just before the bar's right edge instead.
+            const right = Math.max(0, left) + Math.max(0.2, width);
+            const durEl = document.createElement('div');
+            durEl.className = 'netwf-row-duration';
+            durEl.textContent = formatMilliseconds(row.duration);
+            if (right < 90) {
+                durEl.style.left = `calc(${right.toFixed(3)}% + 6px)`;
+            } else {
+                durEl.style.right = `${(100 - right + 0.5).toFixed(3)}%`;
+            }
+            trackEl.appendChild(durEl);
+        }
+
+        el.appendChild(trackEl);
+        return el;
+    }
+
+    // Header column definitions — `key` matches CSS variable name
+    // (`--netwf-col-${key}`) and the cell class. `min` is the smallest
+    // pixel width we'll let the user drag the column to.
+    const NETWF_COLUMNS = [
+        { key: 'time',   label: 'Time',     min: 60 },
+        { key: 'flags',  label: '',         min: 16 },
+        { key: 'method', label: 'Method',   min: 30 },
+        { key: 'path',   label: 'Path',     min: 60 },
+        // Single-unit columns: header carries the unit, cells carry
+        // tabular-aligned numbers. Bytes always rendered in KB,
+        // throughput always in Mbps — easier to scan than mixed units.
+        { key: 'bytes',  label: 'KB',       min: 50 },
+        { key: 'mbps',   label: 'Mbps',     min: 50 },
+        { key: 'status', label: 'Status',   min: 40 }
+    ];
+
+    function buildWaterfallAxisRow(chartHost) {
+        const axisEl = document.createElement('div');
+        axisEl.className = 'netwf-axis';
+        for (const col of NETWF_COLUMNS) {
+            const cell = document.createElement('div');
+            cell.className = `netwf-cell ${col.key}`;
+            cell.textContent = col.label;
+            const resizer = document.createElement('div');
+            resizer.className = 'netwf-cell-resizer';
+            resizer.dataset.col = col.key;
+            resizer.dataset.minPx = String(col.min);
+            cell.appendChild(resizer);
+            attachWaterfallColumnResizer(chartHost, resizer);
+            axisEl.appendChild(cell);
+        }
+        const scale = document.createElement('div');
+        scale.className = 'netwf-axis-scale';
+        scale.dataset.field = 'netwf_axis_scale';
+        axisEl.appendChild(scale);
+        return axisEl;
+    }
+
+    function attachWaterfallColumnResizer(chartHost, resizer) {
+        let drag = null;
+        resizer.addEventListener('mousedown', (e) => {
+            const col = resizer.dataset.col;
+            if (!col) return;
+            const cell = resizer.parentElement;
+            const startPx = cell.getBoundingClientRect().width;
+            drag = {
+                col,
+                startX: e.clientX,
+                startPx,
+                minPx: parseInt(resizer.dataset.minPx, 10) || 30,
+                cssVar: `--netwf-col-${col}`
+            };
+            resizer.classList.add('dragging');
+            document.body.style.cursor = 'col-resize';
+            e.preventDefault();
+            e.stopPropagation();
+        });
+        const onMove = (e) => {
+            if (!drag) return;
+            const next = Math.max(drag.minPx, drag.startPx + (e.clientX - drag.startX));
+            chartHost.style.setProperty(drag.cssVar, `${Math.round(next)}px`);
+        };
+        const onUp = () => {
+            if (!drag) return;
+            // Persist the new width so it survives session-card re-renders
+            // and page reloads.
+            try {
+                const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
+                stored[drag.col] = chartHost.style.getPropertyValue(`--netwf-col-${drag.col}`);
+                localStorage.setItem('netwf-cols-v2', JSON.stringify(stored));
+            } catch (_) { /* no-op */ }
+            drag = null;
+            resizer.classList.remove('dragging');
+            document.body.style.cursor = '';
+        };
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    }
+
+    // Re-apply persisted column widths to a chart host on first
+    // render so user preferences survive page reloads.
+    function applyPersistedWaterfallColumns(chartHost) {
+        if (!chartHost || chartHost.dataset.netwfColsApplied) return;
+        chartHost.dataset.netwfColsApplied = '1';
+        try {
+            const stored = JSON.parse(localStorage.getItem('netwf-cols-v2') || '{}');
+            for (const col of NETWF_COLUMNS) {
+                const v = stored[col.key];
+                if (v) chartHost.style.setProperty(`--netwf-col-${col.key}`, v);
+            }
+        } catch (_) { /* no-op */ }
+    }
+
+    function renderWaterfallAxisTicks(host, winStart, winEnd) {
+        host.replaceChildren();
+        const span = winEnd - winStart;
+        if (span <= 0) return;
+        const targetTickCount = 6;
+        const niceMs = pickNiceTickIntervalMs(span / targetTickCount);
+        const firstTick = Math.ceil(winStart / niceMs) * niceMs;
+        for (let t = firstTick; t <= winEnd; t += niceMs) {
+            const left = ((t - winStart) / span) * 100;
+            if (left < 0 || left > 100) continue;
+            const tick = document.createElement('div');
+            tick.className = 'netwf-axis-tick';
+            tick.style.left = `${left.toFixed(3)}%`;
+            host.appendChild(tick);
+            const label = document.createElement('div');
+            label.className = 'netwf-axis-tick-label';
+            label.style.left = `${left.toFixed(3)}%`;
+            label.textContent = formatAxisTickLabel(t);
+            host.appendChild(label);
+        }
+        // Right-aligned summary: brush span (zoom level).
+        const summary = document.createElement('div');
+        summary.className = 'netwf-axis-summary';
+        summary.textContent = `Δ ${formatMilliseconds(span)}`;
+        host.appendChild(summary);
+    }
+
+    function renderWaterfallSummary(host, rows, dataStartMs, dataEndMs) {
+        const counts = {
+            total: rows.length,
+            success: 0,
+            partial: 0,
+            client: 0,
+            server: 0,
+            faulted: 0,
+            timeout: 0,
+            disconnect: 0,
+            retry: 0
+        };
+        for (const row of rows) {
+            const status = Number(row.entry.status) || 0;
+            if (status === 206) counts.partial += 1;
+            else if (status >= 200 && status < 300) counts.success += 1;
+            else if (status >= 400 && status < 500) counts.client += 1;
+            else if (status >= 500) counts.server += 1;
+
+            const ft = String(row.entry.fault_type || '').toLowerCase();
+            if (ft.includes('timeout')) counts.timeout += 1;
+            else if (ft.includes('client_disconnect') || ft === 'client_disconnect') counts.disconnect += 1;
+            else if (row.entry.faulted) counts.faulted += 1;
+
+            if (row.is_retry) counts.retry += 1;
+        }
+        const span = Math.max(0, dataEndMs - dataStartMs);
+        const pill = (cls, label, count) => {
+            const zero = count === 0 ? ' zero' : '';
+            return `<span class="netwf-summary-pill ${cls}${zero}"><span class="count">${count}</span> ${escapeHtml(label)}</span>`;
+        };
+        host.innerHTML = [
+            `<span class="netwf-summary-pill total"><span class="count">${counts.total}</span> requests</span>`,
+            `<span class="netwf-summary-pill span">${escapeHtml(formatMilliseconds(span))} span</span>`,
+            pill('success', '2xx', counts.success),
+            pill('partial', '206', counts.partial),
+            pill('client-error', '4xx', counts.client),
+            pill('server-error', '5xx', counts.server),
+            pill('faulted', 'faulted', counts.faulted),
+            pill('timeout', 'timeouts', counts.timeout),
+            pill('disconnect', 'disconnects', counts.disconnect),
+            pill('retry', 'retries', counts.retry)
+        ].join('');
+    }
+
+    function pickNiceTickIntervalMs(roughMs) {
+        const candidates = [10, 25, 50, 100, 200, 250, 500, 1000, 2000, 5000, 10000, 15000, 30000, 60000, 120000, 300000];
+        for (const c of candidates) if (c >= roughMs) return c;
+        return Math.ceil(roughMs / 60000) * 60000;
+    }
+
+    function formatAxisTickLabel(absMs) {
+        const d = new Date(absMs);
+        const hh = String(d.getHours()).padStart(2, '0');
+        const mm = String(d.getMinutes()).padStart(2, '0');
+        const ss = String(d.getSeconds()).padStart(2, '0');
+        return `${hh}:${mm}:${ss}`;
+    }
+
+    // Brush drag/resize handlers. The brush is positioned in % of the
+    // overview's width, so we convert px deltas to % via the
+    // overview's bounding rect. Drag-pan or drag-resize disables
+    // Following Latest so the user's selection stays put.
+    function attachBrushHandlers(card, overviewEl, brushEl) {
+        if (!overviewEl) return;
+        const sessionId = String(card.dataset.sessionId || '');
+        if (!sessionId) return;
+
+        let drag = null;
+
+        const startDrag = (event, mode) => {
+            const rect = overviewEl.getBoundingClientRect();
+            if (rect.width <= 0) return;
+            const rows = networkWaterfallRowsBySession.get(sessionId) || [];
+            if (!rows.length) return;
+            const dataStartMs = rows[0].timestamp;
+            const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+            const fullSpan = Math.max(50, dataEndMs - dataStartMs);
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            drag = {
+                mode,
+                rect,
+                fullSpan,
+                dataStartMs,
+                dataEndMs,
+                startBrushStart: brush.startMs,
+                startBrushEnd: brush.endMs,
+                pointerStartX: event.clientX
+            };
+            brushEl?.classList.add('dragging');
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        const onPointerMove = (event) => {
+            if (!drag) return;
+            const dxPx = event.clientX - drag.pointerStartX;
+            const dxMs = (dxPx / drag.rect.width) * drag.fullSpan;
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            if (drag.mode === 'pan') {
+                let newStart = drag.startBrushStart + dxMs;
+                let newEnd = drag.startBrushEnd + dxMs;
+                const span = newEnd - newStart;
+                if (newStart < drag.dataStartMs) { newStart = drag.dataStartMs; newEnd = newStart + span; }
+                if (newEnd > drag.dataEndMs) { newEnd = drag.dataEndMs; newStart = newEnd - span; }
+                brush.startMs = newStart;
+                brush.endMs = newEnd;
+            } else if (drag.mode === 'resize-left') {
+                let newStart = drag.startBrushStart + dxMs;
+                if (newStart < drag.dataStartMs) newStart = drag.dataStartMs;
+                // Enforce the minimum brush width — never let the user
+                // drag the left handle within networkWaterfallMinBrushMs
+                // of the right edge.
+                if (newStart > brush.endMs - networkWaterfallMinBrushMs) {
+                    newStart = brush.endMs - networkWaterfallMinBrushMs;
+                }
+                brush.startMs = newStart;
+            } else if (drag.mode === 'resize-right') {
+                let newEnd = drag.startBrushEnd + dxMs;
+                if (newEnd > drag.dataEndMs) newEnd = drag.dataEndMs;
+                if (newEnd < brush.startMs + networkWaterfallMinBrushMs) {
+                    newEnd = brush.startMs + networkWaterfallMinBrushMs;
+                }
+                brush.endMs = newEnd;
+            }
+            brush.follow = false;
+            // Disable Following Latest so the user's pick sticks.
+            if (isNetworkLogFollowMode(sessionId)) {
+                setNetworkLogFollowMode(sessionId, false);
+                updateNetworkLogFollowButton(card, sessionId);
+            }
+            updateNetworkWaterfall(card, sessionId);
+        };
+
+        const onPointerUp = () => {
+            if (!drag) return;
+            drag = null;
+            brushEl?.classList.remove('dragging');
+        };
+
+        // Brush body = pan. Handles = resize. Click on bare overview
+        // jumps the brush centre to the click point.
+        if (brushEl) {
+            brushEl.addEventListener('mousedown', (e) => {
+                if (e.target.classList.contains('netwf-brush-handle')) return;
+                startDrag(e, 'pan');
+            });
+            const leftHandle = brushEl.querySelector('.netwf-brush-handle.left');
+            const rightHandle = brushEl.querySelector('.netwf-brush-handle.right');
+            if (leftHandle) leftHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-left'));
+            if (rightHandle) rightHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-right'));
+        }
+        overviewEl.addEventListener('mousedown', (e) => {
+            if (e.target !== overviewEl && !e.target.classList.contains('netwf-overview-bars')) return;
+            const rect = overviewEl.getBoundingClientRect();
+            const rows = networkWaterfallRowsBySession.get(sessionId) || [];
+            if (!rows.length || rect.width <= 0) return;
+            const dataStartMs = rows[0].timestamp;
+            const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+            const fullSpan = Math.max(50, dataEndMs - dataStartMs);
+            const fracX = (e.clientX - rect.left) / rect.width;
+            const targetMs = dataStartMs + fracX * fullSpan;
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (!brush) return;
+            const span = brush.endMs - brush.startMs;
+            brush.startMs = Math.max(dataStartMs, targetMs - span / 2);
+            brush.endMs = Math.min(dataEndMs, brush.startMs + span);
+            brush.startMs = brush.endMs - span;
+            brush.follow = false;
+            if (isNetworkLogFollowMode(sessionId)) {
+                setNetworkLogFollowMode(sessionId, false);
+                updateNetworkLogFollowButton(card, sessionId);
+            }
+            updateNetworkWaterfall(card, sessionId);
+        });
+
+        document.addEventListener('mousemove', onPointerMove);
+        document.addEventListener('mouseup', onPointerUp);
+    }
+
 
     function updateNetworkLog(sessionId, options = {}) {
         if (!networkLogDeveloperEnabled) return;

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1802,16 +1802,29 @@
 
         const rows = entries.slice().map((entry, index) => {
             const timestamp = Date.parse(entry.timestamp || '') || 0;
+            // Upstream-perspective phases (proxy → origin) — surfaced in the
+            // tooltip for forensics but not part of the player-perceived bar.
             const dns = Number(entry.dns_ms || 0);
             const connect = Number(entry.connect_ms || 0);
             const tls = Number(entry.tls_ms || 0);
             const ttfb = Number(entry.ttfb_ms || 0);
             const total = Number(entry.total_ms || 0);
             const transferRaw = Number(entry.transfer_ms || 0);
+            // Player-perceived wait — request received → first response byte
+            // sent. Falls back to the legacy upstream-derived value for
+            // entries written before the downstream-timings change (#272).
+            const clientWaitRaw = Number(entry.client_wait_ms || 0);
             const handshake = dns + connect + tls;
-            const wait = Math.max(0, ttfb - handshake);
+            const wait = clientWaitRaw > 0
+                ? clientWaitRaw
+                : Math.max(0, ttfb - handshake);
             const transfer = transferRaw > 0 ? transferRaw : Math.max(0, total - ttfb);
-            const duration = Math.max(0, dns + connect + tls + wait + transfer);
+            // The bar represents the player's view: just wait + transfer.
+            // The upstream handshake phases are out-of-band (proxy ↔ origin)
+            // and don't count toward what the player saw.
+            const duration = clientWaitRaw > 0
+                ? Math.max(0, wait + transfer)
+                : Math.max(0, dns + connect + tls + wait + transfer);
             const parsed = parsePathAndVariant(entry);
             const prefix = entry.faulted ? '!' : '';
             return {
@@ -1950,6 +1963,9 @@
         if (!state || !state.timeline || !fullRange) return;
         if (!Number.isFinite(fullRange.startMs) || !Number.isFinite(fullRange.endMs) || fullRange.endMs <= fullRange.startMs) return;
 
+        // Re-enable auto-pan: user explicitly asked for a coordinated view.
+        state.autoPan = true;
+
         if (direction === 'fit') {
             resetWaterfallView(state, key);
             return;
@@ -2062,13 +2078,96 @@
                     networkWaterfallViewBySession.set(key, { startMs, endMs });
                     setNetworkLogFollowMode(key, false);
                     updateNetworkLogFollowButton(null, key);
+                    // User took manual control — stop auto-panning until
+                    // they hit Fit / First / Last (issue #286).
+                    state.autoPan = false;
                 }
             });
-            state = { host: field, timeline, groups, items, drag: null };
+            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: true };
             bindWaterfallSelectionHandlers(state, key);
+            attachWaterfallAutoPan(state, key);
             networkWaterfallTimelines.set(key, state);
         }
         return state;
+    }
+
+    // attachWaterfallAutoPan listens to scroll events on the entries list
+    // (vis-timeline's left + center panels share scrollTop) and pans the
+    // visible time window to match the rows the user is looking at. Issue #286.
+    function attachWaterfallAutoPan(state, key) {
+        if (!state || !state.host || state.autoPanBound) return;
+        const setupOnce = () => {
+            if (!state.host) return false;
+            const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
+            const center = state.host.querySelector('.vis-panel.vis-center .vis-content');
+            if (!left && !center) return false;
+            let rafId = null;
+            const onScroll = () => {
+                if (!state.autoPan) return;
+                if (rafId) return;
+                rafId = window.requestAnimationFrame(() => {
+                    rafId = null;
+                    applyWaterfallAutoPan(state, key);
+                });
+            };
+            if (left) left.addEventListener('scroll', onScroll, { passive: true });
+            if (center && center !== left) center.addEventListener('scroll', onScroll, { passive: true });
+            state.autoPanBound = true;
+            return true;
+        };
+        // vis-timeline builds its DOM async — retry a few frames if the
+        // .vis-content nodes aren't there yet.
+        let attempts = 0;
+        const retry = () => {
+            if (setupOnce()) return;
+            attempts += 1;
+            if (attempts < 20) window.requestAnimationFrame(retry);
+        };
+        window.requestAnimationFrame(retry);
+    }
+
+    // applyWaterfallAutoPan computes the time range covered by the
+    // entries list's currently-visible rows and pans the waterfall to it.
+    function applyWaterfallAutoPan(state, key) {
+        if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
+        if (!state.host) return;
+        // Re-check autoPan: the user may have done Alt+scroll/right-drag
+        // between the scroll event and this rAF firing — `onScroll`
+        // already gates new schedules but a previously-queued rAF would
+        // otherwise override the manual pan.
+        if (!state.autoPan) return;
+        const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
+        if (!left) return;
+        const scrollTop = left.scrollTop;
+        const clientH = left.clientHeight;
+        const scrollH = left.scrollHeight;
+        if (scrollH <= clientH) return;
+        const rowCount = state.rows.length;
+        const rowHeight = scrollH / rowCount;
+        if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
+        const startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
+        const endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        if (endIdx < startIdx) return;
+        const startTs = state.rows[startIdx].timestamp;
+        const endRow = state.rows[endIdx];
+        const endTs = endRow.timestamp + Math.max(50, endRow.duration);
+        if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
+        // Pad 5% on each side so adjacent bars peek in at the edges.
+        const padding = Math.max(50, (endTs - startTs) * 0.05);
+        const fullRange = networkWaterfallFullRangeBySession.get(key);
+        let nextStart = startTs - padding;
+        let nextEnd = endTs + padding;
+        if (fullRange) {
+            // Don't pan past the session's data bounds.
+            if (nextStart < fullRange.startMs) nextStart = fullRange.startMs;
+            if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
+        }
+        if (nextEnd <= nextStart) return;
+        // Suppress the rangechanged user-flag for our own setWindow call —
+        // vis-timeline doesn't fire byUser=true when we drive setWindow,
+        // so this is mostly belt-and-suspenders.
+        state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
+        networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
 
     function updateNetworkWaterfall(card, sessionId) {
@@ -2202,6 +2301,9 @@
         state.items.clear();
         state.groups.add(groups);
         state.items.add(items);
+        // Stash the rows so the auto-pan handler (issue #286) can map
+        // entries-list scroll position to a time window.
+        state.rows = rows;
 
         const fullStartMs = dataStartMs;
         const latestTransferEndMs = dataEndMs;
@@ -2209,9 +2311,12 @@
         const fullEndMs = latestTransferEndMs + rightPadMs;
         networkWaterfallFullRangeBySession.set(key, { startMs: fullStartMs, endMs: fullEndMs });
         state.timeline.setOptions({
+            // Clamp user pan/zoom to the session's full data range so the
+            // viewer can't drift into empty space outside the session.
             min: toTime(fullStartMs),
             max: toTime(fullEndMs),
-            zoomMax: Math.max(1000, fullEndMs - fullStartMs)
+            zoomMax: Math.max(1000, fullEndMs - fullStartMs),
+            zoomMin: 100 // Don't let users zoom-in tighter than 100ms.
         });
         const storedView = networkWaterfallViewBySession.get(key);
         const following = isNetworkLogFollowMode(key);

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1350,9 +1350,6 @@
                 const sessionId = card ? String(card.dataset.sessionId || '') : '';
                 if (!sessionId) return;
                 if (isOpen) {
-                    if (!hasNetworkLogFollowModeState(sessionId)) {
-                        setNetworkLogFollowMode(sessionId, true);
-                    }
                     updateNetworkLogFollowButton(card, sessionId);
                     startNetworkLogAutoRefresh(sessionId, card);
                 } else {
@@ -1514,9 +1511,6 @@
                         const card = sectionEl ? sectionEl.closest('.session-card') : null;
                         const sessionId = card ? card.dataset.sessionId : null;
                         if (sessionId && window.TestingSessionUI) {
-                            if (!hasNetworkLogFollowModeState(sessionId)) {
-                                setNetworkLogFollowMode(sessionId, true);
-                            }
                             updateNetworkLogFollowButton(card, sessionId);
                             startNetworkLogAutoRefresh(sessionId, card);
                         }
@@ -1602,7 +1596,9 @@
 
     function isNetworkLogFollowMode(sessionId) {
         const key = String(sessionId || '');
-        return networkWaterfallFollowModeBySession.get(key) !== false;
+        // Default OFF — the user expects the list to "just sit there"
+        // until they explicitly opt into auto-scroll.
+        return networkWaterfallFollowModeBySession.get(key) === true;
     }
 
     // Follow Scroll mode: when on, the waterfall's time window
@@ -1622,12 +1618,6 @@
             state.autoPan = !!enabled;
             if (enabled) applyWaterfallAutoPan(state, key);
         }
-    }
-
-    function hasNetworkLogFollowModeState(sessionId) {
-        const key = String(sessionId || '');
-        if (!key) return false;
-        return networkWaterfallFollowModeBySession.has(key);
     }
 
     function setNetworkLogFollowMode(sessionId, enabled) {

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2179,39 +2179,59 @@
 
     // applyWaterfallAutoPan computes the time range covered by the
     // entries list's currently-visible rows and pans the waterfall to it.
+    //
+    // vis-timeline virtualizes vertical scroll via CSS transforms, not
+    // native scroll, so .vis-content's scrollTop/scrollHeight don't
+    // reflect the actual scroll state. Instead we walk the rendered
+    // .vis-group DOM elements and check which ones intersect the
+    // center panel's viewport rect.
     function applyWaterfallAutoPan(state, key) {
         if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
         if (!state.host) return;
-        // Re-check autoPan: the user may have done Alt+scroll/right-drag
-        // between the scroll event and this rAF firing.
         if (!state.autoPan) return;
-        const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
-        if (!left) return;
-        const scrollTop = left.scrollTop;
-        const clientH = left.clientHeight;
-        const scrollH = left.scrollHeight;
-        const rowCount = state.rows.length;
 
-        // When the entries list isn't tall enough to scroll (scrollH ==
-        // clientH), every row is "visible" — pan to cover all of them.
-        // Previously this branch returned early, leaving the time
-        // window at the last Fit/setOptions value (often the full
-        // session range), which made the timeline mostly blank.
-        let startIdx, endIdx;
-        if (scrollH <= clientH || scrollTop <= 0 && clientH >= scrollH) {
-            startIdx = 0;
-            endIdx = rowCount - 1;
-        } else {
-            const rowHeight = scrollH / rowCount;
-            if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
-            startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
-            endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        const center = state.host.querySelector('.vis-panel.vis-center');
+        if (!center) return;
+        const centerRect = center.getBoundingClientRect();
+        if (centerRect.height <= 0) return;
+
+        // Walk the rendered group elements. Each .vis-group has
+        // data-id matching the groupId we assigned (groupId = rowIdx + 1
+        // in updateNetworkWaterfall).
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let firstVisibleIdx = -1;
+        let lastVisibleIdx = -1;
+        groupEls.forEach((el) => {
+            const groupIdAttr = el.getAttribute('data-id') || el.dataset.id;
+            const groupId = parseInt(groupIdAttr, 10);
+            if (!Number.isFinite(groupId)) return;
+            const rowIdx = groupId - 1;
+            if (rowIdx < 0 || rowIdx >= state.rows.length) return;
+            const r = el.getBoundingClientRect();
+            if (r.height <= 0) return;
+            // Group at least partially visible if it overlaps the
+            // center panel's viewport rect.
+            if (r.bottom > centerRect.top && r.top < centerRect.bottom) {
+                if (firstVisibleIdx === -1 || rowIdx < firstVisibleIdx) firstVisibleIdx = rowIdx;
+                if (lastVisibleIdx === -1 || rowIdx > lastVisibleIdx) lastVisibleIdx = rowIdx;
+            }
+        });
+
+        // Fallback: if we couldn't read group elements (race, custom
+        // virtualization), pan to cover all rows. Better than leaving a
+        // mostly-blank timeline.
+        if (firstVisibleIdx === -1 || lastVisibleIdx === -1) {
+            firstVisibleIdx = 0;
+            lastVisibleIdx = state.rows.length - 1;
         }
-        if (endIdx < startIdx) return;
-        const startTs = state.rows[startIdx].timestamp;
-        const endRow = state.rows[endIdx];
+
+        const startRow = state.rows[firstVisibleIdx];
+        const endRow = state.rows[lastVisibleIdx];
+        if (!startRow || !endRow) return;
+        const startTs = startRow.timestamp;
         const endTs = endRow.timestamp + Math.max(50, endRow.duration);
         if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
+
         // Tight padding (1%) so adjacent bars peek in at the edges
         // without swamping short bursts. Minimum 25ms so a single
         // sub-millisecond bar doesn't render at zero width.
@@ -2220,7 +2240,6 @@
         let nextStart = startTs - padding;
         let nextEnd = endTs + padding;
         if (fullRange) {
-            // Don't pan past the session's data bounds.
             if (nextStart < fullRange.startMs) nextStart = fullRange.startMs;
             if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
         }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2130,9 +2130,16 @@
         return state;
     }
 
-    // attachWaterfallAutoPan listens to scroll events on the entries list
-    // (vis-timeline's left + center panels share scrollTop) and pans the
-    // visible time window to match the rows the user is looking at. Issue #286.
+    // attachWaterfallAutoPan listens for scroll on the entries list and
+    // pans the visible time window to match the rows the user is looking
+    // at. Issue #286.
+    //
+    // We listen to BOTH:
+    //   1. DOM `scroll` on `.vis-content` — fires when vis-timeline uses
+    //      native scrollbars.
+    //   2. `wheel` on the host — vis-timeline drives vertical scroll via
+    //      transforms in some configurations and the DOM scroll event
+    //      doesn't fire. The wheel handler covers that case.
     function attachWaterfallAutoPan(state, key) {
         if (!state || !state.host || state.autoPanBound) return;
         const setupOnce = () => {
@@ -2141,7 +2148,7 @@
             const center = state.host.querySelector('.vis-panel.vis-center .vis-content');
             if (!left && !center) return false;
             let rafId = null;
-            const onScroll = () => {
+            const schedule = () => {
                 if (!state.autoPan) return;
                 if (!isFollowScrollMode(key)) return;
                 if (rafId) return;
@@ -2150,8 +2157,12 @@
                     applyWaterfallAutoPan(state, key);
                 });
             };
-            if (left) left.addEventListener('scroll', onScroll, { passive: true });
-            if (center && center !== left) center.addEventListener('scroll', onScroll, { passive: true });
+            if (left) left.addEventListener('scroll', schedule, { passive: true });
+            if (center && center !== left) center.addEventListener('scroll', schedule, { passive: true });
+            // Wheel events fire even when vis-timeline does
+            // transform-based scrolling. Schedule on the next frame so
+            // we read the post-scroll position.
+            state.host.addEventListener('wheel', schedule, { passive: true });
             state.autoPanBound = true;
             return true;
         };
@@ -2172,28 +2183,39 @@
         if (!state || !state.timeline || !Array.isArray(state.rows) || state.rows.length === 0) return;
         if (!state.host) return;
         // Re-check autoPan: the user may have done Alt+scroll/right-drag
-        // between the scroll event and this rAF firing — `onScroll`
-        // already gates new schedules but a previously-queued rAF would
-        // otherwise override the manual pan.
+        // between the scroll event and this rAF firing.
         if (!state.autoPan) return;
         const left = state.host.querySelector('.vis-panel.vis-left .vis-content');
         if (!left) return;
         const scrollTop = left.scrollTop;
         const clientH = left.clientHeight;
         const scrollH = left.scrollHeight;
-        if (scrollH <= clientH) return;
         const rowCount = state.rows.length;
-        const rowHeight = scrollH / rowCount;
-        if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
-        const startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
-        const endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+
+        // When the entries list isn't tall enough to scroll (scrollH ==
+        // clientH), every row is "visible" — pan to cover all of them.
+        // Previously this branch returned early, leaving the time
+        // window at the last Fit/setOptions value (often the full
+        // session range), which made the timeline mostly blank.
+        let startIdx, endIdx;
+        if (scrollH <= clientH || scrollTop <= 0 && clientH >= scrollH) {
+            startIdx = 0;
+            endIdx = rowCount - 1;
+        } else {
+            const rowHeight = scrollH / rowCount;
+            if (!Number.isFinite(rowHeight) || rowHeight <= 0) return;
+            startIdx = Math.max(0, Math.floor(scrollTop / rowHeight));
+            endIdx = Math.min(rowCount - 1, Math.ceil((scrollTop + clientH) / rowHeight) - 1);
+        }
         if (endIdx < startIdx) return;
         const startTs = state.rows[startIdx].timestamp;
         const endRow = state.rows[endIdx];
         const endTs = endRow.timestamp + Math.max(50, endRow.duration);
         if (!Number.isFinite(startTs) || !Number.isFinite(endTs) || endTs <= startTs) return;
-        // Pad 5% on each side so adjacent bars peek in at the edges.
-        const padding = Math.max(50, (endTs - startTs) * 0.05);
+        // Tight padding (1%) so adjacent bars peek in at the edges
+        // without swamping short bursts. Minimum 25ms so a single
+        // sub-millisecond bar doesn't render at zero width.
+        const padding = Math.max(25, (endTs - startTs) * 0.01);
         const fullRange = networkWaterfallFullRangeBySession.get(key);
         let nextStart = startTs - padding;
         let nextEnd = endTs + padding;
@@ -2203,9 +2225,6 @@
             if (nextEnd > fullRange.endMs) nextEnd = fullRange.endMs;
         }
         if (nextEnd <= nextStart) return;
-        // Suppress the rangechanged user-flag for our own setWindow call —
-        // vis-timeline doesn't fire byUser=true when we drive setWindow,
-        // so this is mostly belt-and-suspenders.
         state.timeline.setWindow(new Date(nextStart), new Date(nextEnd), { animation: false });
         networkWaterfallViewBySession.set(key, { startMs: nextStart, endMs: nextEnd });
     }
@@ -2380,6 +2399,16 @@
         state.timeline.redraw();
         if (following) {
             scrollWaterfallToLatestRow(state);
+        }
+        // After the initial render, drive the time window from the
+        // currently-visible rows when Follow Scroll is on. The setWindow
+        // calls above bracket the data range; auto-pan tightens to just
+        // what the user is looking at. Two rAFs let vis-timeline lay out
+        // its panels (the second one is when scrollHeight is final).
+        if (isFollowScrollMode(key) && state.autoPan) {
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => applyWaterfallAutoPan(state, key));
+            });
         }
     }
 

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -45,6 +45,10 @@
     const networkWaterfallTimelines = new Map();
     const networkWaterfallViewBySession = new Map();
     const networkWaterfallFollowModeBySession = new Map();
+    // Follow Scroll: pan the waterfall's time window to match the rows
+    // visible in the entries list as the user scrolls. Default true.
+    // Issue #286.
+    const networkWaterfallFollowScrollBySession = new Map();
     const networkWaterfallFullRangeBySession = new Map();
     const networkWaterfallRenderSignatureBySession = new Map();
     const networkWaterfallRollingWindowMs = 5 * 60 * 1000;
@@ -1077,6 +1081,10 @@
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-fit">Fit</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-follow">Following Latest</button>
+                                <label class="network-log-filter" title="Pan the waterfall's time window to match the entries currently visible in the list above">
+                                    <input type="checkbox" data-field="follow-scroll" checked>
+                                    Follow Scroll
+                                </label>
                                 <label class="network-log-filter">
                                     <input type="checkbox" data-filter="show-faulted" checked>
                                     Show Faults
@@ -1361,6 +1369,12 @@
             const cb = e.target;
             if (!cb || cb.type !== 'checkbox' || !cb.dataset.field) return;
             const field = cb.dataset.field;
+            if (field === 'follow-scroll') {
+                const card = cb.closest('.session-card');
+                const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                if (sessionId) setFollowScrollMode(sessionId, !!cb.checked);
+                return;
+            }
             if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls') return;
             const group = cb.closest('.checkbox-group');
             if (!group) return;
@@ -1582,6 +1596,25 @@
         return networkWaterfallFollowModeBySession.get(key) !== false;
     }
 
+    // Follow Scroll mode: when on, the waterfall's time window
+    // auto-pans to match the rows currently visible in the entries
+    // list. Default true so the feature is on out-of-the-box. Issue #286.
+    function isFollowScrollMode(sessionId) {
+        const key = String(sessionId || '');
+        return networkWaterfallFollowScrollBySession.get(key) !== false;
+    }
+
+    function setFollowScrollMode(sessionId, enabled) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        networkWaterfallFollowScrollBySession.set(key, !!enabled);
+        const state = networkWaterfallTimelines.get(key);
+        if (state) {
+            state.autoPan = !!enabled;
+            if (enabled) applyWaterfallAutoPan(state, key);
+        }
+    }
+
     function hasNetworkLogFollowModeState(sessionId) {
         const key = String(sessionId || '');
         if (!key) return false;
@@ -1604,6 +1637,12 @@
         button.setAttribute('aria-pressed', following ? 'true' : 'false');
         button.classList.toggle('btn-primary', following);
         button.classList.toggle('btn-secondary', !following);
+        // Keep the Follow Scroll checkbox in sync with the per-session
+        // map across re-renders (the HTML template defaults to checked).
+        const followScrollCb = hostCard.querySelector('input[data-field="follow-scroll"]');
+        if (followScrollCb) {
+            followScrollCb.checked = isFollowScrollMode(sessionId);
+        }
     }
 
     function scrollWaterfallToLatestRow(state) {
@@ -2083,7 +2122,7 @@
                     state.autoPan = false;
                 }
             });
-            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: true };
+            state = { host: field, timeline, groups, items, drag: null, rows: [], autoPan: isFollowScrollMode(key) };
             bindWaterfallSelectionHandlers(state, key);
             attachWaterfallAutoPan(state, key);
             networkWaterfallTimelines.set(key, state);
@@ -2104,6 +2143,7 @@
             let rafId = null;
             const onScroll = () => {
                 if (!state.autoPan) return;
+                if (!isFollowScrollMode(key)) return;
                 if (rafId) return;
                 rafId = window.requestAnimationFrame(() => {
                     rafId = null;

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1075,7 +1075,7 @@
                         <div class="network-log-section">
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
-                                <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save current network timeline as a HAR file (Phase 1 of issue #272)">Save HAR</button>
+                                <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save the current network timeline as a HAR file: downloads to your machine and adds it to the Incidents list">Download HAR</button>
                                 <a href="/api/incidents" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="List saved HAR snapshots (raw JSON)">Incidents</a>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-first">First</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="network-log-jump-last">Last</button>
@@ -1427,7 +1427,16 @@
                         .then(r => r.json())
                         .then(data => {
                             if (data && data.incident && data.incident.path) {
-                                window.alert(`HAR saved: ${data.incident.filename}\n\nDownload via /api/incidents/${data.incident.path}`);
+                                // Trigger a direct download — server already
+                                // wrote the file to /incidents/, we just
+                                // route the browser at it via a hidden <a>.
+                                const a = document.createElement('a');
+                                a.href = `/api/incidents/${data.incident.path}`;
+                                a.download = data.incident.filename || 'incident.har';
+                                a.style.display = 'none';
+                                document.body.appendChild(a);
+                                a.click();
+                                document.body.removeChild(a);
                             } else if (data && data.error) {
                                 window.alert(`HAR save failed: ${data.error}`);
                             }
@@ -2162,7 +2171,18 @@
             // Wheel events fire even when vis-timeline does
             // transform-based scrolling. Schedule on the next frame so
             // we read the post-scroll position.
-            state.host.addEventListener('wheel', schedule, { passive: true });
+            state.host.addEventListener('wheel', (event) => {
+                // User-initiated scroll while Following Latest is on
+                // means they want to step away from the live tail —
+                // auto-disable Following Latest and let track-by-scroll
+                // pin the time window to whatever they're looking at.
+                if (isNetworkLogFollowMode(key)) {
+                    setNetworkLogFollowMode(key, false);
+                    const card = state.host.closest('.session-card');
+                    updateNetworkLogFollowButton(card, key);
+                }
+                schedule();
+            }, { passive: true });
             state.autoPanBound = true;
             return true;
         };
@@ -2175,6 +2195,47 @@
             if (attempts < 20) window.requestAnimationFrame(retry);
         };
         window.requestAnimationFrame(retry);
+    }
+
+    // restoreScrollAnchor finds the .vis-group element that corresponds
+    // to the anchor's rowIdx after a re-render and scrolls vis-timeline
+    // so that group sits at the same offset within the viewport as it
+    // did before the re-render. Issue #286 follow-up.
+    function restoreScrollAnchor(state, anchor) {
+        if (!state || !state.host || !anchor) return;
+        const center = state.host.querySelector('.vis-panel.vis-center');
+        if (!center) return;
+        const targetGroupId = String(anchor.rowIdx + 1);
+        const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+        let target = null;
+        for (const el of groupEls) {
+            if ((el.getAttribute('data-id') || el.dataset.id) === targetGroupId) {
+                target = el;
+                break;
+            }
+        }
+        if (!target) return;
+        const centerRect = center.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+        const desiredOffsetTop = centerRect.top + anchor.offsetWithinGroup;
+        const delta = targetRect.top - desiredOffsetTop;
+        if (Math.abs(delta) < 1) return;
+        // Try vis-timeline's internal scroll surfaces in priority order;
+        // any one of them that's writable will scroll the panel.
+        const surfaces = [
+            state.timeline?.body?.dom?.shadow,
+            state.timeline?.body?.dom?.center,
+            state.host.querySelector('.vis-panel.vis-left .vis-content'),
+            state.host.querySelector('.vis-panel.vis-center .vis-content'),
+        ].filter(Boolean);
+        for (const s of surfaces) {
+            if (typeof s.scrollTop === 'number') {
+                const before = s.scrollTop;
+                s.scrollTop = before + delta;
+                // If it changed, we found the right surface.
+                if (s.scrollTop !== before) return;
+            }
+        }
     }
 
     // applyWaterfallAutoPan computes the time range covered by the
@@ -2398,6 +2459,35 @@
             });
         });
 
+        // Anchor preservation: when Following Latest is OFF, capture the
+        // topmost visible group's row index + pixel offset BEFORE the
+        // re-render so we can restore the user's view after the
+        // groups/items DataSet is replaced. Without this, vis-timeline's
+        // re-render snaps the scroll position to top and the user's view
+        // jumps every time new entries arrive.
+        let scrollAnchor = null;
+        if (!isNetworkLogFollowMode(key) && state.host) {
+            const center = state.host.querySelector('.vis-panel.vis-center');
+            const groupEls = state.host.querySelectorAll('.vis-foreground .vis-group');
+            if (center && groupEls.length > 0) {
+                const centerRect = center.getBoundingClientRect();
+                for (const el of groupEls) {
+                    const r = el.getBoundingClientRect();
+                    if (r.height <= 0) continue;
+                    if (r.bottom > centerRect.top) {
+                        const groupId = parseInt(el.getAttribute('data-id') || el.dataset.id, 10);
+                        if (Number.isFinite(groupId)) {
+                            scrollAnchor = {
+                                rowIdx: groupId - 1,
+                                offsetWithinGroup: centerRect.top - r.top,
+                            };
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         state.groups.clear();
         state.items.clear();
         state.groups.add(groups);
@@ -2441,6 +2531,13 @@
         state.timeline.redraw();
         if (following) {
             scrollWaterfallToLatestRow(state);
+        } else if (scrollAnchor) {
+            // Re-render snapped vis-timeline's scroll to top — restore
+            // the user's view by scrolling the same row back into the
+            // same vertical offset within the viewport.
+            window.requestAnimationFrame(() => {
+                window.requestAnimationFrame(() => restoreScrollAnchor(state, scrollAnchor));
+            });
         }
         // After the initial render, drive the time window from the
         // currently-visible rows when Follow Scroll is on. The setWindow

--- a/content/shared/shared-nav.js
+++ b/content/shared/shared-nav.js
@@ -21,6 +21,7 @@
             { id: 'playback', icon: '▶️', text: 'Playback', href: '/dashboard/playback.html' },
             { id: 'test-playback', icon: '🧭', text: 'Testing Playback', href: '/dashboard/testing-session.html?nav=1' },
             { id: 'testing', icon: '🧪', text: 'Testing Monitor', href: '/dashboard/testing.html' },
+            { id: 'incidents', icon: '🚨', text: 'Incidents', href: '/dashboard/incidents.html' },
             { id: 'quartet', icon: '🎬', text: 'Quartet', href: '/dashboard/quartet.html', alpha: true },
             { id: 'segment-duration', icon: '⏱️', text: 'Live Offset', href: '/dashboard/segment-duration-comparison.html', alpha: true }
         ],

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -259,6 +259,18 @@ server {
         add_header Expires "0" always;
     }
 
+    # HAR incidents — list (/api/incidents) and download
+    # (/api/incidents/<YYYY-MM-DD>/<file>.har). Proxied to go-proxy.
+    location ~ ^/api/incidents {
+        proxy_pass http://go_proxy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Port $server_port;
+        add_header Access-Control-Allow-Origin * always;
+        # No no-cache here — HAR files are content-addressable by name.
+    }
+
     # API: Byteranges generation (Go upload service)
     location ~ ^/api/content/.*/generate-byteranges$ {
         proxy_pass http://go_upload_service;

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -223,6 +223,35 @@ server {
         add_header Expires "0" always;
     }
 
+    # HAR snapshot listing + download (issue #272 phase 2). Covers both
+    # `/api/incidents` (list, JSON) and `/api/incidents/{date}/{file}` (download).
+    location ~ ^/api/incidents {
+        proxy_pass http://go_proxy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Port $server_port;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+
+    # Per-player live timeline (issue #272 phase 1). The trailing `.har`
+    # is intentionally part of the path so curl-on-CLI gets a sensible
+    # filename via Content-Disposition.
+    location ~ ^/api/sessions/[^/]+/timeline\.har$ {
+        proxy_pass http://go_proxy;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Port $server_port;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+
     location ~ ^/api/failure-settings/ {
         proxy_pass http://go_proxy;
         proxy_set_header Host $host;

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -85,24 +85,27 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		sources = make([]har.Source, 0, len(entries))
 		for _, e := range entries {
 			sources = append(sources, har.Source{
-				Timestamp:     e.Timestamp,
-				Method:        e.Method,
-				URL:           e.URL,
-				RequestKind:   e.RequestKind,
-				Status:        e.Status,
-				BytesIn:       e.BytesIn,
-				BytesOut:      e.BytesOut,
-				ContentType:   e.ContentType,
-				DNSMs:         e.DNSMs,
-				ConnectMs:     e.ConnectMs,
-				TLSMs:         e.TLSMs,
-				TTFBMs:        e.TTFBMs,
-				TransferMs:    e.TransferMs,
-				TotalMs:       e.TotalMs,
-				Faulted:       e.Faulted,
-				FaultType:     e.FaultType,
-				FaultAction:   e.FaultAction,
-				FaultCategory: e.FaultCategory,
+				Timestamp:       e.Timestamp,
+				Method:          e.Method,
+				URL:             e.URL,
+				RequestKind:     e.RequestKind,
+				Status:          e.Status,
+				BytesIn:         e.BytesIn,
+				BytesOut:        e.BytesOut,
+				ContentType:     e.ContentType,
+				DNSMs:           e.DNSMs,
+				ConnectMs:       e.ConnectMs,
+				TLSMs:           e.TLSMs,
+				TTFBMs:          e.TTFBMs,
+				TransferMs:      e.TransferMs,
+				TotalMs:         e.TotalMs,
+				RequestHeaders:  toNameValueSlice(e.RequestHeaders),
+				ResponseHeaders: toNameValueSlice(e.ResponseHeaders),
+				QueryString:     toNameValueSlice(e.QueryString),
+				Faulted:         e.Faulted,
+				FaultType:       e.FaultType,
+				FaultAction:     e.FaultAction,
+				FaultCategory:   e.FaultCategory,
 			})
 		}
 	}
@@ -126,6 +129,20 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 	}
 
 	return har.Build(sources, opts)
+}
+
+// toNameValueSlice converts a []HeaderPair (main package's HTTP capture
+// type) to a []har.NameValue without sharing memory. Returns nil for an
+// empty slice so the HAR builder can apply its own defaults.
+func toNameValueSlice(in []HeaderPair) []har.NameValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]har.NameValue, len(in))
+	for i, p := range in {
+		out[i] = har.NameValue{Name: p.Name, Value: p.Value}
+	}
+	return out
 }
 
 // findSessionByID returns the session map matching session_id, or nil.

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -53,9 +53,11 @@ func resolveIncidentDir() string {
 
 // SnapshotRequest is the body for POST /api/session/{id}/har/snapshot.
 type SnapshotRequest struct {
-	Reason   string                 `json:"reason"`
-	Source   string                 `json:"source"` // "dashboard", "rest", "player"
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Reason          string                 `json:"reason"`
+	Source          string                 `json:"source"` // "dashboard", "rest", "player"
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	PlayID          string                 `json:"play_id,omitempty"`           // override the auto-detected most-recent play_id
+	IncludeAllPlays bool                   `json:"include_all_plays,omitempty"` // forensic mode — no scoping
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -70,20 +72,46 @@ type IncidentFileInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// HARBuildFilter controls play_id scoping in buildHARForSession.
+//
+//   - PlayID == "" and IncludeAllPlays == false: filter to the
+//     most-recent play_id in the ring buffer (default — matches what
+//     the player asks for at incident time).
+//   - PlayID != "": filter to that exact play_id.
+//   - IncludeAllPlays == true: no filter — every entry across every
+//     play is included (forensic mode).
+type HARBuildFilter struct {
+	PlayID          string
+	IncludeAllPlays bool
+}
+
 // buildHARForSession reads the session's network ring buffer and returns a HAR
 // document. Caller is expected to have already validated the session exists.
-func (a *App) buildHARForSession(session SessionData, incident *har.Incident) har.HAR {
+func (a *App) buildHARForSession(session SessionData, incident *har.Incident, filter HARBuildFilter) har.HAR {
 	sessionID := getString(session, "session_id")
 
 	a.networkLogsMu.RLock()
 	rb, exists := a.networkLogs[sessionID]
 	a.networkLogsMu.RUnlock()
 
+	// Resolve the play_id we'll filter on, unless the caller opts out.
+	resolvedPlayID := filter.PlayID
+	if !filter.IncludeAllPlays && resolvedPlayID == "" && exists {
+		resolvedPlayID = mostRecentPlayID(rb.GetAll())
+	}
+
 	var sources []har.Source
+	var playStartedAt time.Time
 	if exists {
 		entries := rb.GetAll()
 		sources = make([]har.Source, 0, len(entries))
 		for _, e := range entries {
+			if !filter.IncludeAllPlays && resolvedPlayID != "" && e.PlayID != resolvedPlayID {
+				continue
+			}
+			if playStartedAt.IsZero() || e.Timestamp.Before(playStartedAt) {
+				playStartedAt = e.Timestamp
+			}
 			sources = append(sources, har.Source{
 				Timestamp:     e.Timestamp,
 				Method:        e.Method,
@@ -123,9 +151,36 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		if incident.GroupID == "" {
 			incident.GroupID = opts.GroupID
 		}
+		// Surface play_id scope in the incident block so HAR consumers
+		// know what they're looking at without inspecting individual
+		// entries' URLs.
+		if incident.Metadata == nil {
+			incident.Metadata = map[string]interface{}{}
+		}
+		if resolvedPlayID != "" {
+			incident.Metadata["play_id"] = resolvedPlayID
+		}
+		if filter.IncludeAllPlays {
+			incident.Metadata["include_all_plays"] = true
+		}
+		if !playStartedAt.IsZero() {
+			incident.Metadata["play_started_at"] = playStartedAt.UTC().Format(time.RFC3339Nano)
+		}
 	}
 
 	return har.Build(sources, opts)
+}
+
+// mostRecentPlayID walks the ring buffer newest-first looking for the
+// last play_id seen. Empty string if no entry carried one (e.g., older
+// players that don't yet emit play_id query param).
+func mostRecentPlayID(entries []NetworkLogEntry) string {
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].PlayID != "" {
+			return entries[i].PlayID
+		}
+	}
+	return ""
 }
 
 // findSessionByID returns the session map matching session_id, or nil.
@@ -156,7 +211,13 @@ func (a *App) handleGetSessionTimelineHAR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	doc := a.buildHARForSession(session, nil)
+	// timeline.har accepts ?play_id=X (specific play) and
+	// ?include_all_plays=1 (forensic). Default: most-recent play_id.
+	filter := HARBuildFilter{
+		PlayID:          strings.TrimSpace(r.URL.Query().Get("play_id")),
+		IncludeAllPlays: strings.EqualFold(r.URL.Query().Get("include_all_plays"), "1") || strings.EqualFold(r.URL.Query().Get("include_all_plays"), "true"),
+	}
+	doc := a.buildHARForSession(session, nil, filter)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="timeline-%s.har"`, safeFilename(playerID)))
@@ -203,7 +264,10 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		Metadata:  req.Metadata,
 	}
 
-	doc := a.buildHARForSession(session, incident)
+	doc := a.buildHARForSession(session, incident, HARBuildFilter{
+		PlayID:          strings.TrimSpace(req.PlayID),
+		IncludeAllPlays: req.IncludeAllPlays,
+	})
 	playerID := getString(session, "player_id")
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -52,10 +52,89 @@ func resolveIncidentDir() string {
 }
 
 // SnapshotRequest is the body for POST /api/session/{id}/har/snapshot.
+//
+// Players send Device + Stream blocks alongside the freeform Metadata so
+// the server can fold them into the HAR's _extensions.context block
+// (issue #281).
 type SnapshotRequest struct {
 	Reason   string                 `json:"reason"`
 	Source   string                 `json:"source"` // "dashboard", "rest", "player"
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Device   *SnapshotDeviceMeta    `json:"device,omitempty"`
+	Stream   *SnapshotStreamMeta    `json:"stream,omitempty"`
+	PlayID   string                 `json:"play_id,omitempty"`
+}
+
+// SnapshotDeviceMeta is the device fingerprint a player sends with a
+// snapshot request. Mirrors har.DeviceContext on the wire.
+type SnapshotDeviceMeta struct {
+	Model       string `json:"model,omitempty"`
+	OSVersion   string `json:"os_version,omitempty"`
+	AppVersion  string `json:"app_version,omitempty"`
+	NetworkType string `json:"network_type,omitempty"`
+}
+
+// SnapshotStreamMeta describes what the player is playing.
+type SnapshotStreamMeta struct {
+	ContentID         string `json:"content_id,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Codec             string `json:"codec,omitempty"`
+	InitialVariantURL string `json:"initial_variant_url,omitempty"`
+}
+
+// recoveryChainStore tracks the ordered list of incident reasons a
+// player has hit during the current play. Keyed by playerID + ":" +
+// playID so a fresh play resets the chain. Issue #281.
+var (
+	recoveryChainMu    sync.Mutex
+	recoveryChainStore = map[string][]string{}
+)
+
+func recoveryChainKey(playerID, playID string) string {
+	if playerID == "" && playID == "" {
+		return ""
+	}
+	return playerID + ":" + playID
+}
+
+// recoveryChainSnapshot returns the current chain for (playerID, playID)
+// without modifying it. Used for forensic snapshots that should observe
+// without polluting the chain.
+func recoveryChainSnapshot(playerID, playID string) []string {
+	key := recoveryChainKey(playerID, playID)
+	if key == "" {
+		return nil
+	}
+	recoveryChainMu.Lock()
+	defer recoveryChainMu.Unlock()
+	chain := recoveryChainStore[key]
+	if len(chain) == 0 {
+		return nil
+	}
+	out := make([]string, len(chain))
+	copy(out, chain)
+	return out
+}
+
+// recordRecoveryReason appends `reason` to the chain for
+// (playerID, playID), capped at 32 entries to keep the HAR reasonable.
+// Returns the resulting chain.
+func recordRecoveryReason(playerID, playID, reason string) []string {
+	key := recoveryChainKey(playerID, playID)
+	if key == "" || reason == "" {
+		return nil
+	}
+	recoveryChainMu.Lock()
+	defer recoveryChainMu.Unlock()
+	chain := append(recoveryChainStore[key], reason)
+	const maxChain = 32
+	if len(chain) > maxChain {
+		chain = chain[len(chain)-maxChain:]
+	}
+	recoveryChainStore[key] = chain
+	out := make([]string, len(chain))
+	copy(out, chain)
+	return out
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -72,7 +151,8 @@ type IncidentFileInfo struct {
 
 // buildHARForSession reads the session's network ring buffer and returns a HAR
 // document. Caller is expected to have already validated the session exists.
-func (a *App) buildHARForSession(session SessionData, incident *har.Incident) har.HAR {
+// `context` is optional — when non-nil, it lands at log._extensions.context.
+func (a *App) buildHARForSession(session SessionData, incident *har.Incident, context *har.Context) har.HAR {
 	sessionID := getString(session, "session_id")
 
 	a.networkLogsMu.RLock()
@@ -112,6 +192,7 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 		PlayerID:  getString(session, "player_id"),
 		GroupID:   getString(session, "group_id"),
 		Incident:  incident,
+		Context:   context,
 	}
 	if incident != nil {
 		if incident.PlayerID == "" {
@@ -126,6 +207,111 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 	}
 
 	return har.Build(sources, opts)
+}
+
+// buildIncidentContext assembles the _extensions.context block for a
+// snapshot. Pulls device + stream from the player's request body,
+// scenario from the session record, timing from the network log's
+// earliest entry for the current play, and the recovery chain from
+// the in-memory store. Issue #281.
+func (a *App) buildIncidentContext(session SessionData, req *SnapshotRequest, playerID string) *har.Context {
+	if req == nil {
+		return nil
+	}
+	ctx := &har.Context{}
+
+	// Device + Stream — copied from request body.
+	if req.Device != nil {
+		ctx.Device = &har.DeviceContext{
+			Model:       req.Device.Model,
+			OSVersion:   req.Device.OSVersion,
+			AppVersion:  req.Device.AppVersion,
+			NetworkType: req.Device.NetworkType,
+		}
+	}
+	if req.Stream != nil {
+		ctx.Stream = &har.StreamContext{
+			ContentID:         req.Stream.ContentID,
+			Protocol:          req.Stream.Protocol,
+			Codec:             req.Stream.Codec,
+			InitialVariantURL: req.Stream.InitialVariantURL,
+		}
+	}
+
+	// Scenario — pull a sanitised view of the session's testing
+	// configuration. Avoid leaking everything in the session blob;
+	// pick the keys analysts actually care about.
+	scenario := &har.ScenarioContext{}
+	faultKeys := []string{
+		"segment_failure_type", "segment_failure_frequency", "segment_consecutive_failures",
+		"segment_failure_mode", "segment_failure_units", "segment_failure_urls",
+		"manifest_failure_type", "manifest_failure_frequency", "manifest_consecutive_failures",
+		"manifest_failure_mode", "manifest_failure_units", "manifest_failure_urls",
+		"master_manifest_failure_type", "master_manifest_failure_frequency",
+		"master_manifest_consecutive_failures", "master_manifest_failure_mode",
+		"transport_failure_type", "transport_consecutive_failures", "transport_failure_frequency",
+		"transport_failure_mode",
+	}
+	for _, k := range faultKeys {
+		if v, ok := session[k]; ok && v != nil && v != "" && v != "none" && v != 0 && v != 0.0 {
+			if scenario.FaultSettings == nil {
+				scenario.FaultSettings = map[string]interface{}{}
+			}
+			scenario.FaultSettings[k] = v
+		}
+	}
+	shapeKeys := []string{
+		"nftables_bandwidth_mbps", "nftables_delay_ms", "nftables_packet_loss",
+		"nftables_pattern_enabled", "nftables_pattern_steps",
+	}
+	for _, k := range shapeKeys {
+		v, ok := session[k]
+		if !ok || v == nil || v == "" {
+			continue
+		}
+		// Booleans are equal to 0 under interface comparison, so skip
+		// the v != 0 guard for bool fields — `false` is a meaningful
+		// "off" we want to surface for nftables_pattern_enabled.
+		if _, isBool := v.(bool); !isBool {
+			if v == 0 || v == 0.0 {
+				continue
+			}
+		}
+		if scenario.NftablesShape == nil {
+			scenario.NftablesShape = map[string]interface{}{}
+		}
+		scenario.NftablesShape[k] = v
+	}
+	if scenario.FaultSettings != nil || scenario.NftablesShape != nil {
+		ctx.Scenario = scenario
+	}
+
+	// Timing — when the player tells us play_started_at via Metadata
+	// (typically a "player_metrics_play_started_at" RFC3339 string)
+	// we surface it here. Once #280 (play_id scoping) lands, the
+	// server will derive this from the network log's earliest entry
+	// for the current play_id; until then, rely on the player's
+	// own snapshot.
+	playID := strings.TrimSpace(req.PlayID)
+	if playStartedAtRaw, ok := req.Metadata["play_started_at"].(string); ok && playStartedAtRaw != "" {
+		if playStartedAt, err := time.Parse(time.RFC3339Nano, playStartedAtRaw); err == nil {
+			ctx.Timing = &har.TimingContext{
+				PlayStartedAt:   playStartedAt.UTC().Format(time.RFC3339Nano),
+				IncidentOffsetS: time.Since(playStartedAt).Seconds(),
+			}
+		}
+	}
+
+	// Recovery chain — append the current reason and surface the
+	// resulting list. Forensic snapshots (source != "player") read
+	// without recording so they don't pollute the chain.
+	if req.Source == "player" {
+		ctx.RecoveryChain = recordRecoveryReason(playerID, playID, req.Reason)
+	} else {
+		ctx.RecoveryChain = recoveryChainSnapshot(playerID, playID)
+	}
+
+	return ctx
 }
 
 // findSessionByID returns the session map matching session_id, or nil.
@@ -156,7 +342,7 @@ func (a *App) handleGetSessionTimelineHAR(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	doc := a.buildHARForSession(session, nil)
+	doc := a.buildHARForSession(session, nil, nil)
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="timeline-%s.har"`, safeFilename(playerID)))
@@ -203,8 +389,9 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		Metadata:  req.Metadata,
 	}
 
-	doc := a.buildHARForSession(session, incident)
 	playerID := getString(session, "player_id")
+	context := a.buildIncidentContext(session, &req, playerID)
+	doc := a.buildHARForSession(session, incident, context)
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -93,12 +93,14 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident) ha
 				BytesIn:       e.BytesIn,
 				BytesOut:      e.BytesOut,
 				ContentType:   e.ContentType,
+				ClientWaitMs:  e.ClientWaitMs,
+				TransferMs:    e.TransferMs,
+				TotalMs:       e.TotalMs,
+				UpstreamURL:   e.UpstreamURL,
 				DNSMs:         e.DNSMs,
 				ConnectMs:     e.ConnectMs,
 				TLSMs:         e.TLSMs,
 				TTFBMs:        e.TTFBMs,
-				TransferMs:    e.TransferMs,
-				TotalMs:       e.TotalMs,
 				Faulted:       e.Faulted,
 				FaultType:     e.FaultType,
 				FaultAction:   e.FaultAction,
@@ -301,10 +303,16 @@ func writeIncidentFile(sessionID, playerID, reason, source string, doc har.HAR) 
 		return IncidentFileInfo{}, err
 	}
 
+	// Filename pattern: `proxy_<player_id>_<session_id>__<ts>.har`. The
+	// `proxy_` prefix signals "go-proxy's view" — future client-side
+	// HARs (issue #282) will use `client_`. The trailing __<ts> keeps
+	// successive incidents from the same player/session pair from
+	// overwriting each other (one play can produce multiple HARs:
+	// freeze, then user_retry, then segment_stall).
 	ts := now.Format("20060102T150405Z")
-	filename := fmt.Sprintf("%s__%s__%s.har",
+	filename := fmt.Sprintf("proxy_%s_%s__%s.har",
+		safeFilename(playerID),
 		safeFilename(sessionID),
-		safeFilename(reason),
 		ts,
 	)
 	full := filepath.Join(dir, filename)
@@ -418,15 +426,28 @@ func readIncidentMeta(path string) (IncidentFileInfo, error) {
 		}
 	}
 
-	// Filename fallback: {sessionID}__{reason}__{ts}.har
-	if info.SessionID == "" || info.Reason == "" {
-		parts := strings.SplitN(strings.TrimSuffix(info.Filename, ".har"), "__", 3)
-		if len(parts) >= 2 {
-			if info.SessionID == "" {
-				info.SessionID = parts[0]
+	// Filename fallback: `proxy_<playerID>_<sessionID>__<ts>.har`. We
+	// only use this when the JSON parse failed and the in-document
+	// _extensions.session block isn't available — best effort.
+	if info.SessionID == "" || info.PlayerID == "" {
+		stem := strings.TrimSuffix(info.Filename, ".har")
+		// Trim the optional `proxy_` / `client_` prefix.
+		stem = strings.TrimPrefix(stem, "proxy_")
+		stem = strings.TrimPrefix(stem, "client_")
+		// Drop the `__<ts>` suffix.
+		if idx := strings.LastIndex(stem, "__"); idx >= 0 {
+			stem = stem[:idx]
+		}
+		// Remaining: `<playerID>_<sessionID>`. Split on the LAST `_`:
+		// everything before is playerID, everything after is sessionID.
+		// Correct as long as sessionID has no `_` (it's UUID-shaped in
+		// practice, `[a-z0-9-]+`); playerID may contain `_`.
+		if idx := strings.LastIndex(stem, "_"); idx >= 0 {
+			if info.PlayerID == "" {
+				info.PlayerID = stem[:idx]
 			}
-			if info.Reason == "" {
-				info.Reason = parts[1]
+			if info.SessionID == "" {
+				info.SessionID = stem[idx+1:]
 			}
 		}
 	}

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -55,7 +55,35 @@ func resolveIncidentDir() string {
 type SnapshotRequest struct {
 	Reason   string                 `json:"reason"`
 	Source   string                 `json:"source"` // "dashboard", "rest", "player"
+	Force    bool                   `json:"force"`  // bypass per-player debounce
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// snapshotDebounceWindow is the minimum gap between auto-driven captures from
+// the same player. Manual (force=true) and dashboard captures bypass this.
+const snapshotDebounceWindow = 30 * time.Second
+
+var (
+	snapshotLastMu sync.Mutex
+	snapshotLastAt = map[string]time.Time{} // player_id -> last accepted capture
+)
+
+// snapshotShouldDebounce returns true if we should drop this capture because
+// the player triggered another one within the debounce window. Dashboard /
+// REST captures (source != "player") never debounce.
+func snapshotShouldDebounce(playerID, source string, force bool) bool {
+	if force || source != "player" || playerID == "" {
+		return false
+	}
+	snapshotLastMu.Lock()
+	defer snapshotLastMu.Unlock()
+	now := time.Now()
+	last, ok := snapshotLastAt[playerID]
+	if ok && now.Sub(last) < snapshotDebounceWindow {
+		return true
+	}
+	snapshotLastAt[playerID] = now
+	return false
 }
 
 // IncidentFileInfo describes a stored HAR file in listings.
@@ -195,6 +223,17 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	playerID := getString(session, "player_id")
+	if snapshotShouldDebounce(playerID, req.Source, req.Force) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		writeJSON(w, map[string]interface{}{
+			"status":           "debounced",
+			"debounce_window":  snapshotDebounceWindow.Seconds(),
+			"message":          "another snapshot was captured for this player within the debounce window",
+		})
+		return
+	}
+
 	incident := &har.Incident{
 		Reason:    req.Reason,
 		Source:    req.Source,
@@ -204,7 +243,6 @@ func (a *App) handlePostHARSnapshot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	doc := a.buildHARForSession(session, incident)
-	playerID := getString(session, "player_id")
 	info, err := writeIncidentFile(sessionID, playerID, req.Reason, req.Source, doc)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/go-proxy/cmd/server/headers_test.go
+++ b/go-proxy/cmd/server/headers_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestCapturedHeaders_FiltersSensitive(t *testing.T) {
+	h := http.Header{}
+	h.Set("User-Agent", "test")
+	h.Set("Range", "bytes=0-1023")
+	h.Set("Cookie", "session=secret")
+	h.Set("Authorization", "Bearer xyz")
+	h.Set("Set-Cookie", "abc=def")
+	h.Set("X-Amz-Security-Token", "stoken")
+	h.Set("Content-Type", "video/mp4")
+
+	out := capturedHeaders(h)
+	names := map[string]bool{}
+	for _, p := range out {
+		names[p.Name] = true
+	}
+	for _, banned := range []string{"Cookie", "Authorization", "Set-Cookie", "X-Amz-Security-Token"} {
+		if names[banned] {
+			t.Errorf("sensitive header %q leaked into capture: %+v", banned, out)
+		}
+	}
+	for _, expected := range []string{"User-Agent", "Range", "Content-Type"} {
+		if !names[expected] {
+			t.Errorf("expected header %q missing from capture: %+v", expected, out)
+		}
+	}
+}
+
+func TestCapturedHeaders_StableOrder(t *testing.T) {
+	// Map iteration order is non-deterministic in Go; capturedHeaders
+	// must sort so two runs of the same input produce identical HAR
+	// diffs.
+	h := http.Header{}
+	h.Set("Z-Header", "z")
+	h.Set("A-Header", "a")
+	h.Set("M-Header", "m")
+
+	a := capturedHeaders(h)
+	b := capturedHeaders(h)
+	if len(a) != len(b) {
+		t.Fatalf("captures of same input have different lengths")
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("position %d differs: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+	// Verify alphabetical.
+	if a[0].Name != "A-Header" || a[1].Name != "M-Header" || a[2].Name != "Z-Header" {
+		t.Errorf("not sorted: %+v", a)
+	}
+}
+
+func TestCapturedHeaders_PreservesRepeatedValues(t *testing.T) {
+	h := http.Header{}
+	h.Add("Accept", "video/mp4")
+	h.Add("Accept", "application/json")
+	out := capturedHeaders(h)
+	count := 0
+	for _, p := range out {
+		if p.Name == "Accept" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 Accept entries, got %d: %+v", count, out)
+	}
+}
+
+func TestCapturedHeaders_EmptyInput(t *testing.T) {
+	if got := capturedHeaders(http.Header{}); got != nil {
+		t.Errorf("empty input should return nil, got %+v", got)
+	}
+	if got := capturedHeaders(nil); got != nil {
+		t.Errorf("nil input should return nil, got %+v", got)
+	}
+}
+
+func TestCapturedQueryString_PreservesURLOrder(t *testing.T) {
+	u, err := url.Parse("https://example.test/playlist.m3u8?player_id=p1&play_id=42&codec=h264")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := capturedQueryString(u)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 params, got %d", len(out))
+	}
+	want := []struct{ name, value string }{
+		{"player_id", "p1"},
+		{"play_id", "42"},
+		{"codec", "h264"},
+	}
+	for i, w := range want {
+		if out[i].Name != w.name || out[i].Value != w.value {
+			t.Errorf("position %d: got %+v, want %s=%s", i, out[i], w.name, w.value)
+		}
+	}
+}
+
+func TestCapturedQueryString_DecodesPercent(t *testing.T) {
+	u, _ := url.Parse("https://example.test/x?path=%2Fhome%2Fuser&q=hello%20world")
+	out := capturedQueryString(u)
+	if out[0].Name != "path" || out[0].Value != "/home/user" {
+		t.Errorf("percent decode failed: %+v", out[0])
+	}
+	if out[1].Value != "hello world" {
+		t.Errorf("space decode failed: %+v", out[1])
+	}
+}
+
+func TestCapturedQueryString_NoQuery(t *testing.T) {
+	u, _ := url.Parse("https://example.test/x")
+	if got := capturedQueryString(u); got != nil {
+		t.Errorf("URL without query should yield nil, got %+v", got)
+	}
+}
+
+func TestCapturedQueryString_FlagOnlyParam(t *testing.T) {
+	// Bare param like `?debug` should appear with empty value.
+	u, _ := url.Parse("https://example.test/x?debug")
+	out := capturedQueryString(u)
+	if len(out) != 1 || out[0].Name != "debug" || out[0].Value != "" {
+		t.Errorf("flag-only param wrong: %+v", out)
+	}
+}
+
+func TestStampNetMeta_DoesntOverwriteExisting(t *testing.T) {
+	pre := []HeaderPair{{Name: "pre", Value: "v"}}
+	entry := NetworkLogEntry{
+		RequestHeaders: pre,
+	}
+	stampNetMeta(&entry, []HeaderPair{{Name: "new", Value: "v"}}, nil, nil)
+	if len(entry.RequestHeaders) != 1 || entry.RequestHeaders[0].Name != "pre" {
+		t.Errorf("stamp overwrote pre-set headers: %+v", entry.RequestHeaders)
+	}
+}
+
+func TestStampNetMeta_NilEntryIsSafe(t *testing.T) {
+	// Defensive — no panic.
+	stampNetMeta(nil, []HeaderPair{{Name: "x", Value: "y"}}, nil, nil)
+}
+
+func TestStampNetMeta_PopulatesFromCaptures(t *testing.T) {
+	entry := NetworkLogEntry{}
+	req := []HeaderPair{{Name: "User-Agent", Value: "t"}}
+	qs := []HeaderPair{{Name: "p", Value: "v"}}
+	resp := &http.Response{Header: http.Header{"Content-Type": []string{"text/plain"}}}
+	stampNetMeta(&entry, req, qs, resp)
+	if len(entry.RequestHeaders) != 1 || entry.RequestHeaders[0].Name != "User-Agent" {
+		t.Errorf("RequestHeaders not populated: %+v", entry.RequestHeaders)
+	}
+	if len(entry.QueryString) != 1 {
+		t.Errorf("QueryString not populated: %+v", entry.QueryString)
+	}
+	if len(entry.ResponseHeaders) != 1 || entry.ResponseHeaders[0].Name != "Content-Type" {
+		t.Errorf("ResponseHeaders not populated: %+v", entry.ResponseHeaders)
+	}
+}

--- a/go-proxy/cmd/server/incident_context_test.go
+++ b/go-proxy/cmd/server/incident_context_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"testing"
+)
+
+// Tests for the recovery chain store + buildIncidentContext (issue #281).
+
+func TestRecoveryChain_AppendAndSnapshot(t *testing.T) {
+	// Reset the store between tests by using unique keys.
+	playerID := "player-rc-1"
+	playID := "play-1"
+	chain := recordRecoveryReason(playerID, playID, "frozen")
+	if len(chain) != 1 || chain[0] != "frozen" {
+		t.Errorf("first reason: got %+v, want [frozen]", chain)
+	}
+	chain = recordRecoveryReason(playerID, playID, "user_retry")
+	if len(chain) != 2 || chain[1] != "user_retry" {
+		t.Errorf("second reason: got %+v, want [frozen, user_retry]", chain)
+	}
+	snap := recoveryChainSnapshot(playerID, playID)
+	if len(snap) != 2 {
+		t.Errorf("snapshot length = %d, want 2", len(snap))
+	}
+}
+
+func TestRecoveryChain_DifferentPlayIDsDoNotShare(t *testing.T) {
+	// A new play_id starts a fresh chain — old play's reasons stay
+	// in their own bucket.
+	playerID := "player-rc-2"
+	recordRecoveryReason(playerID, "play-A", "frozen")
+	recordRecoveryReason(playerID, "play-A", "user_retry")
+	chainB := recordRecoveryReason(playerID, "play-B", "segment_stall")
+	if len(chainB) != 1 || chainB[0] != "segment_stall" {
+		t.Errorf("play-B chain shouldn't include play-A reasons: %+v", chainB)
+	}
+	chainA := recoveryChainSnapshot(playerID, "play-A")
+	if len(chainA) != 2 {
+		t.Errorf("play-A chain mutated by play-B activity: %+v", chainA)
+	}
+}
+
+func TestRecoveryChain_EmptyKeyReturnsNil(t *testing.T) {
+	if got := recordRecoveryReason("", "", "frozen"); got != nil {
+		t.Errorf("empty (player, play) should return nil, got %+v", got)
+	}
+	if got := recoveryChainSnapshot("", ""); got != nil {
+		t.Errorf("empty (player, play) snapshot should return nil, got %+v", got)
+	}
+}
+
+func TestRecoveryChain_EmptyReasonNoOp(t *testing.T) {
+	playerID := "player-rc-3"
+	playID := "play-1"
+	recordRecoveryReason(playerID, playID, "frozen")
+	chain := recordRecoveryReason(playerID, playID, "")
+	// Empty reason should not add to the chain.
+	if len(chain) != 0 {
+		t.Errorf("empty reason returned non-empty chain: %+v", chain)
+	}
+	snap := recoveryChainSnapshot(playerID, playID)
+	if len(snap) != 1 {
+		t.Errorf("chain mutated by empty reason: %+v", snap)
+	}
+}
+
+func TestBuildIncidentContext_PopulatesDeviceAndStream(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p1"}
+	req := &SnapshotRequest{
+		Reason: "frozen",
+		Source: "player",
+		Device: &SnapshotDeviceMeta{
+			Model: "iPad Pro", OSVersion: "iOS 18", AppVersion: "1.0", NetworkType: "wifi",
+		},
+		Stream: &SnapshotStreamMeta{
+			ContentID: "movie", Protocol: "hls", Codec: "h264",
+		},
+	}
+	ctx := a.buildIncidentContext(session, req, "p1")
+	if ctx == nil || ctx.Device == nil || ctx.Stream == nil {
+		t.Fatalf("expected device + stream populated, got %+v", ctx)
+	}
+	if ctx.Device.Model != "iPad Pro" || ctx.Stream.ContentID != "movie" {
+		t.Errorf("device/stream copy wrong: device=%+v stream=%+v", ctx.Device, ctx.Stream)
+	}
+}
+
+func TestBuildIncidentContext_ScenarioFromSession(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{
+		"session_id":                    "s1",
+		"player_id":                     "p1",
+		"segment_failure_type":          "404",
+		"segment_consecutive_failures":  3,
+		"transport_failure_type":        "none",        // should be filtered out
+		"nftables_bandwidth_mbps":       5,
+		"unrelated_session_field":       "should-not-appear",
+	}
+	req := &SnapshotRequest{Reason: "manual", Source: "rest"}
+	ctx := a.buildIncidentContext(session, req, "p1")
+	if ctx.Scenario == nil {
+		t.Fatalf("expected scenario block")
+	}
+	if ctx.Scenario.FaultSettings["segment_failure_type"] != "404" {
+		t.Errorf("fault_settings missing segment_failure_type: %+v", ctx.Scenario.FaultSettings)
+	}
+	if _, leaked := ctx.Scenario.FaultSettings["transport_failure_type"]; leaked {
+		t.Errorf("'none' values should be filtered: %+v", ctx.Scenario.FaultSettings)
+	}
+	if _, leaked := ctx.Scenario.FaultSettings["unrelated_session_field"]; leaked {
+		t.Errorf("non-fault keys leaked: %+v", ctx.Scenario.FaultSettings)
+	}
+	if ctx.Scenario.NftablesShape["nftables_bandwidth_mbps"] != 5 {
+		t.Errorf("nftables_shape missing bandwidth: %+v", ctx.Scenario.NftablesShape)
+	}
+}
+
+func TestBuildIncidentContext_RecordsForPlayerSource(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p-rec-1"}
+	req := &SnapshotRequest{
+		Reason: "frozen",
+		Source: "player",
+		PlayID: "play-rec-1",
+	}
+	ctx := a.buildIncidentContext(session, req, "p-rec-1")
+	if len(ctx.RecoveryChain) != 1 || ctx.RecoveryChain[0] != "frozen" {
+		t.Errorf("first recovery_chain: got %+v, want [frozen]", ctx.RecoveryChain)
+	}
+	// A second snapshot appends.
+	req2 := &SnapshotRequest{Reason: "user_retry", Source: "player", PlayID: "play-rec-1"}
+	ctx2 := a.buildIncidentContext(session, req2, "p-rec-1")
+	if len(ctx2.RecoveryChain) != 2 || ctx2.RecoveryChain[1] != "user_retry" {
+		t.Errorf("second recovery_chain: got %+v, want [frozen, user_retry]", ctx2.RecoveryChain)
+	}
+}
+
+func TestBuildIncidentContext_DashboardSourceObservesWithoutRecording(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	session := SessionData{"session_id": "s1", "player_id": "p-obs-1"}
+	// Pre-populate via a player snapshot.
+	a.buildIncidentContext(session, &SnapshotRequest{
+		Reason: "frozen", Source: "player", PlayID: "play-obs-1",
+	}, "p-obs-1")
+	// Dashboard snapshot reads but doesn't append "manual".
+	ctx := a.buildIncidentContext(session, &SnapshotRequest{
+		Reason: "manual", Source: "dashboard", PlayID: "play-obs-1",
+	}, "p-obs-1")
+	if len(ctx.RecoveryChain) != 1 || ctx.RecoveryChain[0] != "frozen" {
+		t.Errorf("dashboard read should not record: %+v", ctx.RecoveryChain)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -94,6 +95,15 @@ type tcStatsCache struct {
 
 
 
+// HeaderPair is a single name/value pair, used to carry HTTP request /
+// response headers and query parameters in NetworkLogEntry. Mirrors the
+// HAR 1.2 NameValue shape so a HAR consumer can drop these straight into
+// request.headers / response.headers without conversion.
+type HeaderPair struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // NetworkLogEntry represents a single network request/response in the session
 type NetworkLogEntry struct {
 	Timestamp   time.Time `json:"timestamp"`
@@ -105,6 +115,13 @@ type NetworkLogEntry struct {
 	BytesIn     int64     `json:"bytes_in"`
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
+
+	// HTTP-level metadata captured per-request. Sensitive headers
+	// (Cookie / Authorization / Set-Cookie) are filtered before they
+	// land here — see capturedRequestHeaders / capturedResponseHeaders.
+	RequestHeaders  []HeaderPair `json:"request_headers,omitempty"`
+	ResponseHeaders []HeaderPair `json:"response_headers,omitempty"`
+	QueryString     []HeaderPair `json:"query_string,omitempty"`
 
 	// Timing phases (milliseconds)
 	DNSMs      float64 `json:"dns_ms"`
@@ -119,6 +136,91 @@ type NetworkLogEntry struct {
 	FaultType     string `json:"fault_type,omitempty"`
 	FaultAction   string `json:"fault_action,omitempty"`
 	FaultCategory string `json:"fault_category,omitempty"` // "http", "socket", "transport", "corruption"
+}
+
+// sensitiveHeaderNames are excluded from HAR captures regardless of source.
+// Lower-cased for canonical comparison.
+var sensitiveHeaderNames = map[string]bool{
+	"cookie":               true,
+	"set-cookie":           true,
+	"authorization":        true,
+	"proxy-authorization":  true,
+	"x-amz-security-token": true,
+}
+
+// capturedHeaders converts an http.Header map to a sorted []HeaderPair,
+// dropping sensitive entries. Stable ordering keeps HAR diffs readable.
+func capturedHeaders(h http.Header) []HeaderPair {
+	if len(h) == 0 {
+		return nil
+	}
+	out := make([]HeaderPair, 0, len(h))
+	for name, values := range h {
+		if sensitiveHeaderNames[strings.ToLower(name)] {
+			continue
+		}
+		for _, v := range values {
+			out = append(out, HeaderPair{Name: name, Value: v})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Value < out[j].Value
+	})
+	return out
+}
+
+// stampNetMeta attaches captured request headers, query string, and (if
+// available) response headers onto a NetworkLogEntry. Idempotent — won't
+// overwrite already-set fields, so callers can pre-populate any of them
+// at the entry-construction site.
+func stampNetMeta(entry *NetworkLogEntry, requestHeaders, queryString []HeaderPair, resp *http.Response) {
+	if entry == nil {
+		return
+	}
+	if entry.RequestHeaders == nil && len(requestHeaders) > 0 {
+		entry.RequestHeaders = requestHeaders
+	}
+	if entry.QueryString == nil && len(queryString) > 0 {
+		entry.QueryString = queryString
+	}
+	if entry.ResponseHeaders == nil && resp != nil {
+		entry.ResponseHeaders = capturedHeaders(resp.Header)
+	}
+}
+
+// capturedQueryString converts the URL's query into []HeaderPair preserving
+// the parameter order from the URL. Sensitive values aren't filtered here —
+// the dashboard already exposes player_id query params; if that ever changes
+// the privacy filter goes here.
+func capturedQueryString(u *url.URL) []HeaderPair {
+	if u == nil || u.RawQuery == "" {
+		return nil
+	}
+	pairs := strings.Split(u.RawQuery, "&")
+	out := make([]HeaderPair, 0, len(pairs))
+	for _, p := range pairs {
+		if p == "" {
+			continue
+		}
+		var name, value string
+		if eq := strings.IndexByte(p, '='); eq >= 0 {
+			name, value = p[:eq], p[eq+1:]
+		} else {
+			name = p
+		}
+		// URL-decode each side; ignore errors and keep the raw bytes.
+		if decoded, err := url.QueryUnescape(name); err == nil {
+			name = decoded
+		}
+		if decoded, err := url.QueryUnescape(value); err == nil {
+			value = decoded
+		}
+		out = append(out, HeaderPair{Name: name, Value: value})
+	}
+	return out
 }
 
 // NetworkLogRingBuffer maintains a bounded list of recent network entries
@@ -3547,6 +3649,12 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Snapshot the player's request headers + query string once for HAR
+	// capture (issue #279). Sensitive headers are filtered inside
+	// capturedHeaders. The parsed query is preserved in original URL
+	// order via capturedQueryString.
+	requestHeaders := capturedHeaders(r.Header)
+	queryString := capturedQueryString(r.URL)
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3858,6 +3966,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
 				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
+				stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 				a.addNetworkLogEntry(sessionID, netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3885,6 +3994,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
+				stampNetMeta(netEntry, requestHeaders, queryString, nil)
 				a.addNetworkLogEntry(sessionID, *netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3905,6 +4015,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
+				stampNetMeta(netEntry, requestHeaders, queryString, resp)
 				a.addNetworkLogEntry(sessionID, *netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
@@ -3937,6 +4048,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			netEntry.FaultType = failureType
 			netEntry.FaultAction = actionTaken
 			netEntry.FaultCategory = categorizeFaultType(failureType)
+			stampNetMeta(netEntry, requestHeaders, queryString, resp)
 			a.addNetworkLogEntry(sessionID, *netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -3959,6 +4071,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
 			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+			stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 			a.addNetworkLogEntry(sessionID, netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -4015,6 +4128,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusTooManyRequests
 		}
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+		stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4037,6 +4151,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
+		stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4064,6 +4179,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
+		stampNetMeta(netEntry, requestHeaders, queryString, nil)
 		a.addNetworkLogEntry(sessionID, *netEntry)
 		return
 	}
@@ -4088,6 +4204,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
+		stampNetMeta(netEntry, requestHeaders, queryString, resp)
 		a.addNetworkLogEntry(sessionID, *netEntry)
 		return
 	}
@@ -4207,6 +4324,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	netEntry.RequestKind = requestKind
 	netEntry.BytesIn = requestBytes
 	netEntry.BytesOut = bytesOut
+	stampNetMeta(netEntry, requestHeaders, queryString, resp)
 	a.addNetworkLogEntry(sessionID, *netEntry)
 	a.saveSessionByID(sessionNumber, sessionData)
 }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -95,10 +95,17 @@ type tcStatsCache struct {
 
 
 // NetworkLogEntry represents a single network request/response in the session
+//
+// The URL field stores the *player-facing* URL (what the client requested
+// from go-proxy) so HAR entries reflect the player's view. The
+// UpstreamURL field carries the URL the proxy used to reach the origin —
+// useful forensics ("did the proxy rewrite the variant?") that lands
+// under HAR's _extensions.upstream.url.
 type NetworkLogEntry struct {
 	Timestamp   time.Time `json:"timestamp"`
 	Method      string    `json:"method"`
 	URL         string    `json:"url"`
+	UpstreamURL string    `json:"upstream_url,omitempty"`
 	Path        string    `json:"path"`
 	RequestKind string    `json:"request_kind"` // "segment", "manifest", "master_manifest"
 	Status      int       `json:"status"`
@@ -106,13 +113,25 @@ type NetworkLogEntry struct {
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
 
-	// Timing phases (milliseconds)
+	// Timing phases (milliseconds).
+	//
+	// The DNSMs/ConnectMs/TLSMs/TTFBMs/TransferMs/TotalMs fields measure
+	// the *upstream* connection (proxy → origin) — captured by httptrace
+	// during doRequestWithTracing. They're useful for forensics ("was the
+	// origin slow?") but they are NOT what the player perceived.
 	DNSMs      float64 `json:"dns_ms"`
 	ConnectMs  float64 `json:"connect_ms"`
 	TLSMs      float64 `json:"tls_ms"`
-	TTFBMs     float64 `json:"ttfb_ms"`     // Time to first byte
-	TransferMs float64 `json:"transfer_ms"` // Downstream write+flush time to client
+	TTFBMs     float64 `json:"ttfb_ms"`     // Upstream time to first byte
+	TransferMs float64 `json:"transfer_ms"` // Downstream write+flush time to client (= client-perceived `receive`)
 	TotalMs    float64 `json:"total_ms"`
+
+	// ClientWaitMs is the time from when the proxy received the request
+	// to when it sent the first response byte back to the client. It IS
+	// what the player perceived as `wait` (HAR's TTFB), modulo the
+	// network RTT in both directions which we don't capture server-side
+	// (issue #283).
+	ClientWaitMs float64 `json:"client_wait_ms"`
 
 	// Fault injection metadata
 	Faulted       bool   `json:"faulted"`
@@ -3547,6 +3566,14 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Anchor the player's perceived timeline at the moment we received
+	// their request. ClientWaitMs (wait perceived by the player) is
+	// computed against this on every path, including faults.
+	requestReceivedAt := time.Now()
+	// playerURL is the URL the player asked for — used as the primary
+	// `URL` field on every NetworkLogEntry so HAR entries reflect what
+	// the player did, not the proxy → origin URL.
+	playerURL := r.URL.String()
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3857,14 +3884,20 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				updateSessionTraffic(sessionData, requestBytes, 0)
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
-				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
+				netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes, requestReceivedAt)
 				a.addNetworkLogEntry(sessionID, netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
 			}
 			resp, netEntry, err := a.doRequestWithTracing(r.Context(), proxyReq)
+			// doRequestWithTracing populates URL/Path from the upstream
+			// request — override with the player-facing values so HAR
+			// entries reflect what the player did, not the proxy → origin URL.
+			netEntry.URL = playerURL
+			netEntry.Path = r.URL.Path
 			if err != nil {
+				netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 				if errors.Is(err, context.DeadlineExceeded) {
 					actionTaken = "http_504_upstream_timeout"
 					w.WriteHeader(http.StatusGatewayTimeout)
@@ -3893,6 +3926,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			defer resp.Body.Close()
 			if resp.StatusCode >= 400 {
 				actionTaken = fmt.Sprintf("http_%d_upstream", resp.StatusCode)
+				netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 				w.WriteHeader(resp.StatusCode)
 				bumpFaultCounter(sessionData, failureType)
 				logFaultEvent(sessionData, externalPort, failureType, requestKind, actionTaken)
@@ -3914,6 +3948,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", contentType)
 			}
 			w.Header().Set("X-Session-ID", getString(sessionData, "session_number"))
+			netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 			w.WriteHeader(http.StatusOK)
 			bytesOut, transferMs, copyErr := streamToClientMeasured(w, resp.Body, true)
 			if copyErr != nil && !errors.Is(copyErr, io.EOF) {
@@ -3958,7 +3993,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			// and don't generate HTTP responses, so we log with 503 status
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
-			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+			netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, status, requestBytes, requestReceivedAt)
 			a.addNetworkLogEntry(sessionID, netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
@@ -4014,7 +4049,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		case "http_429_rate_limited":
 			status = http.StatusTooManyRequests
 		}
-		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
+		netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, status, requestBytes, requestReceivedAt)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4036,7 +4071,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
-		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
+		netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes, requestReceivedAt)
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
@@ -4047,7 +4082,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
 	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
+	// doRequestWithTracing populates URL/Path from the upstream request —
+	// override with the player-facing values so HAR entries reflect what
+	// the player did, not the proxy → origin URL.
+	netEntry.URL = playerURL
+	netEntry.Path = r.URL.Path
 	if err != nil {
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		// Set status before writing header
 		if errors.Is(err, context.DeadlineExceeded) {
 			netEntry.Status = http.StatusGatewayTimeout
@@ -4083,6 +4124,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			getString(sessionData, "player_id"),
 			externalPort,
 		)
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		// Log network entry for upstream error
 		sessionID := getString(sessionData, "session_id")
@@ -4120,6 +4162,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(modifiedBody)))
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		var downstream io.Writer = w
 		if idleTimeout > 0 {
@@ -4127,8 +4170,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			downstream = idleW
 		}
 		writer := bufio.NewWriter(downstream)
+		transferStart := time.Now()
 		_, writeErr := writer.Write(modifiedBody)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = elapsedMs(transferStart)
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4144,6 +4189,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
+		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)
 		w.WriteHeader(resp.StatusCode)
 		var downstream io.Writer = w
 		if idleTimeout > 0 {
@@ -4165,8 +4211,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			)
 		}
 		var copyErr error
+		transferStart := time.Now()
 		bytesOut, copyErr = io.Copy(writer, resp.Body)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = elapsedMs(transferStart)
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -5019,6 +5067,11 @@ func mergeTotalTiming(entry *NetworkLogEntry) {
 	}
 }
 
+// elapsedMs returns time.Since(t0) in fractional milliseconds.
+func elapsedMs(t0 time.Time) float64 {
+	return float64(time.Since(t0).Microseconds()) / 1000.0
+}
+
 // streamToClientMeasured copies bytes from src to client response writer and measures
 // downstream write+flush time, which is where traffic shaping backpressure appears.
 func streamToClientMeasured(w http.ResponseWriter, src io.Reader, zeroFill bool) (int64, float64, error) {
@@ -5070,11 +5123,17 @@ func streamToClientMeasured(w http.ResponseWriter, src io.Reader, zeroFill bool)
 
 // doRequestWithTracing executes an HTTP request with timing trace and returns the response and timings
 func (a *App) doRequestWithTracing(ctx context.Context, req *http.Request) (*http.Response, *NetworkLogEntry, error) {
+	// Note: caller is expected to overwrite entry.URL / entry.Path with
+	// the *player-facing* URL after this returns; what we set here is the
+	// upstream URL. We populate UpstreamURL up front and copy it into URL
+	// as a safe default for callers that don't override.
+	upstreamURL := req.URL.String()
 	entry := &NetworkLogEntry{
-		Timestamp: time.Now(),
-		Method:    req.Method,
-		URL:       req.URL.String(),
-		Path:      req.URL.Path,
+		Timestamp:   time.Now(),
+		Method:      req.Method,
+		URL:         upstreamURL,
+		UpstreamURL: upstreamURL,
+		Path:        req.URL.Path,
 	}
 
 	var start, dnsStart, connectStart, tlsStart time.Time
@@ -5128,13 +5187,18 @@ func (a *App) doRequestWithTracing(ctx context.Context, req *http.Request) (*htt
 	return resp, entry, nil
 }
 
-// createFaultLogEntry creates a network log entry for a faulted request
-func createFaultLogEntry(url, requestKind, faultType, faultAction string, status int, bytesIn int64) NetworkLogEntry {
+// createFaultLogEntry creates a network log entry for a faulted request.
+// `playerURL` is what the player asked for; `upstreamURL` (optional, may be
+// empty if the proxy never reached the upstream) is the resolved upstream URL
+// used for forensics under HAR's _extensions.upstream.url.
+func createFaultLogEntry(playerURL, upstreamURL, requestKind, faultType, faultAction string, status int, bytesIn int64, requestReceivedAt time.Time) NetworkLogEntry {
+	wait := elapsedMs(requestReceivedAt)
 	return NetworkLogEntry{
 		Timestamp:     time.Now(),
 		Method:        "GET",
-		URL:           url,
-		Path:          extractPathFromURL(url),
+		URL:           playerURL,
+		UpstreamURL:   upstreamURL,
+		Path:          extractPathFromURL(playerURL),
 		RequestKind:   requestKind,
 		Status:        status,
 		BytesIn:       bytesIn,
@@ -5143,6 +5207,11 @@ func createFaultLogEntry(url, requestKind, faultType, faultAction string, status
 		FaultType:     faultType,
 		FaultAction:   faultAction,
 		FaultCategory: categorizeFaultType(faultType),
+		// Fault paths short-circuit before any body — wait time is the
+		// total latency from receiving the request to writing the
+		// response status line.
+		ClientWaitMs: wait,
+		TotalMs:      wait,
 	}
 }
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -106,6 +106,14 @@ type NetworkLogEntry struct {
 	BytesOut    int64     `json:"bytes_out"`
 	ContentType string    `json:"content_type"`
 
+	// PlayID identifies the playback episode this request belongs to.
+	// The player generates a fresh UUID at every loadStream / reload
+	// and passes it as `?play_id=...` on every URL. HAR snapshots
+	// filter by the current play_id by default, so a freeze 8 minutes
+	// into a session shows just that play's network log instead of
+	// the whole ring buffer. Issue #280.
+	PlayID string `json:"play_id,omitempty"`
+
 	// Timing phases (milliseconds)
 	DNSMs      float64 `json:"dns_ms"`
 	ConnectMs  float64 `json:"connect_ms"`
@@ -3547,6 +3555,17 @@ func (iw *idleWriter) Stop() {
 }
 
 func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
+	// Extract the player's `play_id` query param (issue #280). Used to
+	// scope HAR snapshots to a single playback episode. Stamped onto
+	// every NetworkLogEntry created in this handler via the logEntry
+	// closure below.
+	playID := strings.TrimSpace(r.URL.Query().Get("play_id"))
+	logEntry := func(sessionID string, entry NetworkLogEntry) {
+		if entry.PlayID == "" {
+			entry.PlayID = playID
+		}
+		a.addNetworkLogEntry(sessionID, entry)
+	}
 	filename := strings.TrimPrefix(r.URL.Path, "/")
 	escapedPath := strings.TrimPrefix(r.URL.EscapedPath(), "/")
 	if filename == "" {
@@ -3858,7 +3877,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// Log network entry for fault
 				sessionID := getString(sessionData, "session_id")
 				netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, http.StatusBadGateway, requestBytes)
-				a.addNetworkLogEntry(sessionID, netEntry)
+				logEntry(sessionID,netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3885,7 +3904,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
-				a.addNetworkLogEntry(sessionID, *netEntry)
+				logEntry(sessionID,*netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3905,7 +3924,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				netEntry.FaultType = failureType
 				netEntry.FaultAction = actionTaken
 				netEntry.FaultCategory = categorizeFaultType(failureType)
-				a.addNetworkLogEntry(sessionID, *netEntry)
+				logEntry(sessionID,*netEntry)
 				sessionList[index] = sessionData
 				a.saveSessionList(sessionList)
 				return
@@ -3937,7 +3956,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			netEntry.FaultType = failureType
 			netEntry.FaultAction = actionTaken
 			netEntry.FaultCategory = categorizeFaultType(failureType)
-			a.addNetworkLogEntry(sessionID, *netEntry)
+			logEntry(sessionID,*netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
 			return
@@ -3959,7 +3978,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			sessionID := getString(sessionData, "session_id")
 			status := http.StatusServiceUnavailable
 			netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
-			a.addNetworkLogEntry(sessionID, netEntry)
+			logEntry(sessionID,netEntry)
 			sessionList[index] = sessionData
 			a.saveSessionList(sessionList)
 			return
@@ -4015,7 +4034,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			status = http.StatusTooManyRequests
 		}
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, failureType, actionTaken, status, requestBytes)
-		a.addNetworkLogEntry(sessionID, netEntry)
+		logEntry(sessionID,netEntry)
 		return
 	}
 
@@ -4037,7 +4056,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// Log network entry for error
 		sessionID := getString(sessionData, "session_id")
 		netEntry := createFaultLogEntry(upstreamURL, requestKind, "none", "http_502_request_failed", http.StatusBadGateway, requestBytes)
-		a.addNetworkLogEntry(sessionID, netEntry)
+		logEntry(sessionID,netEntry)
 		return
 	}
 	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
@@ -4064,7 +4083,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
-		a.addNetworkLogEntry(sessionID, *netEntry)
+		logEntry(sessionID,*netEntry)
 		return
 	}
 	defer resp.Body.Close()
@@ -4088,7 +4107,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionID := getString(sessionData, "session_id")
 		netEntry.RequestKind = requestKind
 		netEntry.BytesIn = requestBytes
-		a.addNetworkLogEntry(sessionID, *netEntry)
+		logEntry(sessionID,*netEntry)
 		return
 	}
 	copyUpstreamHeaders(w, resp)
@@ -4207,7 +4226,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	netEntry.RequestKind = requestKind
 	netEntry.BytesIn = requestBytes
 	netEntry.BytesOut = bytesOut
-	a.addNetworkLogEntry(sessionID, *netEntry)
+	logEntry(sessionID,*netEntry)
 	a.saveSessionByID(sessionNumber, sessionData)
 }
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -119,6 +119,14 @@ type NetworkLogEntry struct {
 	FaultType     string `json:"fault_type,omitempty"`
 	FaultAction   string `json:"fault_action,omitempty"`
 	FaultCategory string `json:"fault_category,omitempty"` // "http", "socket", "transport", "corruption"
+
+	// Range-request metadata. RequestRange is the client's `Range:`
+	// header (e.g. "bytes=0-1023"); ResponseContentRange is the
+	// origin's `Content-Range:` header (e.g. "bytes 0-1023/5242880").
+	// Useful for telling apart partial-content fetches and continuation
+	// requests in the dashboard.
+	RequestRange         string `json:"request_range,omitempty"`
+	ResponseContentRange string `json:"response_content_range,omitempty"`
 }
 
 // NetworkLogRingBuffer maintains a bounded list of recent network entries
@@ -4040,13 +4048,20 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		a.addNetworkLogEntry(sessionID, netEntry)
 		return
 	}
-	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
-		proxyReq.Header.Set("Range", rangeHeader)
+	clientRange := r.Header.Get("Range")
+	if clientRange != "" {
+		proxyReq.Header.Set("Range", clientRange)
 	}
 	if ifRange := r.Header.Get("If-Range"); ifRange != "" {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
 	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
+	if netEntry != nil {
+		netEntry.RequestRange = clientRange
+		if resp != nil {
+			netEntry.ResponseContentRange = resp.Header.Get("Content-Range")
+		}
+	}
 	if err != nil {
 		// Set status before writing header
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -4127,8 +4142,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			downstream = idleW
 		}
 		writer := bufio.NewWriter(downstream)
+		transferStart := time.Now()
 		_, writeErr := writer.Write(modifiedBody)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = float64(time.Since(transferStart).Microseconds()) / 1000.0
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4138,9 +4155,22 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			if idleW != nil && idleW.timedOut.Load() {
 				bumpFaultCounter(sessionData, "transfer_idle_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_idle_timeout"
+				netEntry.FaultAction = "transfer_idle_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_idle_timeout")
 			} else if errors.Is(writeErr, context.DeadlineExceeded) || errors.Is(flushErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_active_timeout"
+				netEntry.FaultAction = "transfer_active_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_active_timeout")
+			} else {
+				netEntry.Faulted = true
+				netEntry.FaultType = "client_disconnect"
+				netEntry.FaultAction = "transfer_abandoned"
+				netEntry.FaultCategory = "client_disconnect"
 			}
 		}
 	} else {
@@ -4165,8 +4195,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			)
 		}
 		var copyErr error
+		transferStart := time.Now()
 		bytesOut, copyErr = io.Copy(writer, resp.Body)
 		flushErr := writer.Flush()
+		netEntry.TransferMs = float64(time.Since(transferStart).Microseconds()) / 1000.0
 		if idleW != nil {
 			idleW.Stop()
 		}
@@ -4180,9 +4212,26 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			if idleW != nil && idleW.timedOut.Load() {
 				bumpFaultCounter(sessionData, "transfer_idle_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_idle_timeout", requestKind, "transfer_idle_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_idle_timeout"
+				netEntry.FaultAction = "transfer_idle_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_idle_timeout")
 			} else if errors.Is(copyErr, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
+				netEntry.Faulted = true
+				netEntry.FaultType = "transfer_active_timeout"
+				netEntry.FaultAction = "transfer_active_timeout_mid_body"
+				netEntry.FaultCategory = categorizeFaultType("transfer_active_timeout")
+			} else {
+				// Real client closed the socket mid-body (broken pipe,
+				// ECONNRESET, etc.). Not a deliberate fault — tag it
+				// so the dashboard can show "abandoned by client" in
+				// red without the user having to read the proxy log.
+				netEntry.Faulted = true
+				netEntry.FaultType = "client_disconnect"
+				netEntry.FaultAction = "transfer_abandoned"
+				netEntry.FaultCategory = "client_disconnect"
 			}
 		}
 		if isManifest || isMasterManifest {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4227,16 +4227,26 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		proxyReq.Header.Set("If-Range", ifRange)
 	}
 	resp, netEntry, err := a.doRequestWithTracing(proxyCtx, proxyReq)
+	// doRequestWithTracing always returns a non-nil entry — but if a
+	// future regression breaks that contract, fall back to a minimal
+	// stub here so the rest of handleProxy can deref freely without
+	// scattered nil-guards.
+	if netEntry == nil {
+		netEntry = &NetworkLogEntry{
+			Timestamp: time.Now(),
+			Method:    proxyReq.Method,
+			URL:       playerURL,
+			Path:      r.URL.Path,
+		}
+	}
 	// doRequestWithTracing populates URL/Path from the upstream request —
 	// override with the player-facing values so HAR entries reflect what
 	// the player did, not the proxy → origin URL.
-	if netEntry != nil {
-		netEntry.URL = playerURL
-		netEntry.Path = r.URL.Path
-		netEntry.RequestRange = clientRange
-		if resp != nil {
-			netEntry.ResponseContentRange = resp.Header.Get("Content-Range")
-		}
+	netEntry.URL = playerURL
+	netEntry.Path = r.URL.Path
+	netEntry.RequestRange = clientRange
+	if resp != nil {
+		netEntry.ResponseContentRange = resp.Header.Get("Content-Range")
 	}
 	if err != nil {
 		netEntry.ClientWaitMs = elapsedMs(requestReceivedAt)

--- a/go-proxy/cmd/server/play_id_test.go
+++ b/go-proxy/cmd/server/play_id_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/internal/har"
+)
+
+// Tests for the play_id capture + filter plumbing introduced for
+// issue #280.
+
+func TestMostRecentPlayID_PrefersNewest(t *testing.T) {
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now().Add(-3 * time.Second), PlayID: "old"},
+		{Timestamp: time.Now().Add(-2 * time.Second), PlayID: "middle"},
+		{Timestamp: time.Now().Add(-1 * time.Second), PlayID: "newest"},
+	}
+	if got := mostRecentPlayID(entries); got != "newest" {
+		t.Errorf("mostRecentPlayID = %q, want %q", got, "newest")
+	}
+}
+
+func TestMostRecentPlayID_SkipsEmpty(t *testing.T) {
+	// Older entries (pre-#280 players) may not carry play_id; the
+	// resolver should walk past them to find the newest play_id that
+	// actually exists.
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now().Add(-3 * time.Second), PlayID: "actual-play"},
+		{Timestamp: time.Now().Add(-2 * time.Second), PlayID: ""},
+		{Timestamp: time.Now().Add(-1 * time.Second), PlayID: ""},
+	}
+	if got := mostRecentPlayID(entries); got != "actual-play" {
+		t.Errorf("mostRecentPlayID with trailing-empties = %q, want %q", got, "actual-play")
+	}
+}
+
+func TestMostRecentPlayID_AllEmptyReturnsEmpty(t *testing.T) {
+	entries := []NetworkLogEntry{
+		{Timestamp: time.Now(), PlayID: ""},
+		{Timestamp: time.Now(), PlayID: ""},
+	}
+	if got := mostRecentPlayID(entries); got != "" {
+		t.Errorf("mostRecentPlayID with all-empty = %q, want empty string", got)
+	}
+}
+
+func TestMostRecentPlayID_EmptySlice(t *testing.T) {
+	if got := mostRecentPlayID(nil); got != "" {
+		t.Errorf("mostRecentPlayID(nil) = %q, want empty", got)
+	}
+	if got := mostRecentPlayID([]NetworkLogEntry{}); got != "" {
+		t.Errorf("mostRecentPlayID([]) = %q, want empty", got)
+	}
+}
+
+// buildHARForSession's filter logic is exercised by reading through a
+// mock NetworkLogRingBuffer. Set up an App with two plays in one
+// session and verify each filter mode picks the right entries.
+func TestBuildHARForSession_FiltersToMostRecentPlayByDefault(t *testing.T) {
+	a := &App{
+		networkLogs: map[string]*NetworkLogRingBuffer{},
+	}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	// Play A: 3 entries
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-30 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-29 * time.Second), URL: "/a/2", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-28 * time.Second), URL: "/a/3", PlayID: "play-a"})
+	// Play B: 2 entries (more recent)
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-5 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-4 * time.Second), URL: "/b/2", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+
+	session := SessionData{"session_id": "sess-1", "player_id": "p1"}
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("default filter (most-recent play) entry count = %d, want 2", got)
+	}
+	for _, e := range doc.Log.Entries {
+		if e.Request.URL == "/a/1" || e.Request.URL == "/a/2" || e.Request.URL == "/a/3" {
+			t.Errorf("default filter leaked play-a entries: %+v", e.Request.URL)
+		}
+	}
+}
+
+func TestBuildHARForSession_IncludeAllPlays(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-10 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-1 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{IncludeAllPlays: true})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("IncludeAllPlays entry count = %d, want 2 (both plays)", got)
+	}
+}
+
+func TestBuildHARForSession_ExplicitPlayIDOverride(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-10 * time.Second), URL: "/a/1", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-9 * time.Second), URL: "/a/2", PlayID: "play-a"})
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-1 * time.Second), URL: "/b/1", PlayID: "play-b"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	// Default (no PlayID, no IncludeAllPlays) → most recent = play-b → 1 entry
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	if got := len(doc.Log.Entries); got != 1 {
+		t.Errorf("default = play-b entry count = %d, want 1", got)
+	}
+
+	// Explicit override to play-a → 2 entries
+	doc = a.buildHARForSession(session, nil, HARBuildFilter{PlayID: "play-a"})
+	if got := len(doc.Log.Entries); got != 2 {
+		t.Errorf("explicit play-a entry count = %d, want 2", got)
+	}
+}
+
+func TestBuildHARForSession_IncidentMetadataCarriesPlayID(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	now := time.Now()
+	rb.Add(NetworkLogEntry{Timestamp: now.Add(-2 * time.Second), URL: "/x", PlayID: "play-zz"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	incident := &har.Incident{Reason: "manual"}
+	a.buildHARForSession(session, incident, HARBuildFilter{})
+	if incident.Metadata == nil {
+		t.Fatalf("expected metadata populated by builder")
+	}
+	if got := incident.Metadata["play_id"]; got != "play-zz" {
+		t.Errorf("metadata.play_id = %v, want play-zz", got)
+	}
+	if _, has := incident.Metadata["play_started_at"]; !has {
+		t.Errorf("metadata.play_started_at missing: %+v", incident.Metadata)
+	}
+}
+
+func TestBuildHARForSession_IncidentMetadataMarksIncludeAllPlays(t *testing.T) {
+	a := &App{networkLogs: map[string]*NetworkLogRingBuffer{}}
+	rb := NewNetworkLogRingBuffer(100)
+	rb.Add(NetworkLogEntry{Timestamp: time.Now(), URL: "/x", PlayID: "p1"})
+	rb.Add(NetworkLogEntry{Timestamp: time.Now(), URL: "/y", PlayID: "p2"})
+	a.networkLogs["sess-1"] = rb
+	session := SessionData{"session_id": "sess-1"}
+
+	incident := &har.Incident{Reason: "forensic"}
+	a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true})
+	if v, _ := incident.Metadata["include_all_plays"].(bool); !v {
+		t.Errorf("expected metadata.include_all_plays=true, got %+v", incident.Metadata)
+	}
+}

--- a/go-proxy/cmd/server/play_id_test.go
+++ b/go-proxy/cmd/server/play_id_test.go
@@ -73,7 +73,7 @@ func TestBuildHARForSession_FiltersToMostRecentPlayByDefault(t *testing.T) {
 	a.networkLogs["sess-1"] = rb
 
 	session := SessionData{"session_id": "sess-1", "player_id": "p1"}
-	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{}, nil)
 	if got := len(doc.Log.Entries); got != 2 {
 		t.Errorf("default filter (most-recent play) entry count = %d, want 2", got)
 	}
@@ -93,7 +93,7 @@ func TestBuildHARForSession_IncludeAllPlays(t *testing.T) {
 	a.networkLogs["sess-1"] = rb
 	session := SessionData{"session_id": "sess-1"}
 
-	doc := a.buildHARForSession(session, nil, HARBuildFilter{IncludeAllPlays: true})
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{IncludeAllPlays: true}, nil)
 	if got := len(doc.Log.Entries); got != 2 {
 		t.Errorf("IncludeAllPlays entry count = %d, want 2 (both plays)", got)
 	}
@@ -110,13 +110,13 @@ func TestBuildHARForSession_ExplicitPlayIDOverride(t *testing.T) {
 	session := SessionData{"session_id": "sess-1"}
 
 	// Default (no PlayID, no IncludeAllPlays) → most recent = play-b → 1 entry
-	doc := a.buildHARForSession(session, nil, HARBuildFilter{})
+	doc := a.buildHARForSession(session, nil, HARBuildFilter{}, nil)
 	if got := len(doc.Log.Entries); got != 1 {
 		t.Errorf("default = play-b entry count = %d, want 1", got)
 	}
 
 	// Explicit override to play-a → 2 entries
-	doc = a.buildHARForSession(session, nil, HARBuildFilter{PlayID: "play-a"})
+	doc = a.buildHARForSession(session, nil, HARBuildFilter{PlayID: "play-a"}, nil)
 	if got := len(doc.Log.Entries); got != 2 {
 		t.Errorf("explicit play-a entry count = %d, want 2", got)
 	}
@@ -131,7 +131,7 @@ func TestBuildHARForSession_IncidentMetadataCarriesPlayID(t *testing.T) {
 	session := SessionData{"session_id": "sess-1"}
 
 	incident := &har.Incident{Reason: "manual"}
-	a.buildHARForSession(session, incident, HARBuildFilter{})
+	a.buildHARForSession(session, incident, HARBuildFilter{}, nil)
 	if incident.Metadata == nil {
 		t.Fatalf("expected metadata populated by builder")
 	}
@@ -152,7 +152,7 @@ func TestBuildHARForSession_IncidentMetadataMarksIncludeAllPlays(t *testing.T) {
 	session := SessionData{"session_id": "sess-1"}
 
 	incident := &har.Incident{Reason: "forensic"}
-	a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true})
+	a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true}, nil)
 	if v, _ := incident.Metadata["include_all_plays"].(bool); !v {
 		t.Errorf("expected metadata.include_all_plays=true, got %+v", incident.Metadata)
 	}

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -136,21 +136,37 @@ type Timings struct {
 // Source is the minimal NetworkLogEntry shape the builder reads. Defining it
 // here as an interface-free struct keeps the har package decoupled from
 // main.go's full type — the caller copies fields in.
+//
+// Two timing perspectives are carried:
+//
+//   - DNSMs/ConnectMs/TLSMs/TTFBMs are the *upstream* timings (proxy →
+//     origin). They land under the entry's _extensions.upstream block
+//     for forensics ("was latency on our side or the origin's?").
+//
+//   - ClientWaitMs and TransferMs are the *downstream* (proxy → player)
+//     timings — what the player perceived. These map into HAR's
+//     standard timings.wait and timings.receive so a HAR viewer
+//     surfaces them by default.
 type Source struct {
-	Timestamp     time.Time
-	Method        string
-	URL           string
-	RequestKind   string
-	Status        int
-	BytesIn       int64
-	BytesOut      int64
-	ContentType   string
-	DNSMs         float64
-	ConnectMs     float64
-	TLSMs         float64
-	TTFBMs        float64
-	TransferMs    float64
-	TotalMs       float64
+	Timestamp    time.Time
+	Method       string
+	URL          string // player-facing URL
+	RequestKind  string
+	Status       int
+	BytesIn      int64
+	BytesOut     int64
+	ContentType  string
+	ClientWaitMs float64 // request received → first response byte sent to client
+	TransferMs   float64 // first response byte → response complete
+	TotalMs      float64
+
+	// Upstream context, surfaced via _extensions.upstream.
+	UpstreamURL string
+	DNSMs       float64
+	ConnectMs   float64
+	TLSMs       float64
+	TTFBMs      float64
+
 	Faulted       bool
 	FaultType     string
 	FaultAction   string
@@ -219,14 +235,23 @@ func Build(sources []Source, opts BuildOptions) HAR {
 func buildEntry(s Source) Entry {
 	startedDate := s.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z")
 
+	// Map *downstream* timings (proxy → player) into the standard HAR
+	// Timings block — that's what HAR viewers surface as the player's
+	// experience. Upstream timings live under _extensions.upstream below.
+	//
+	// HAR 1.2: -1 means "not applicable / not measured". DNS/Connect/SSL
+	// describe how the *client* reached its server; from go-proxy → player
+	// they're a keepalive HTTP transaction with no client-side connect
+	// to measure here, so they're -1. (Issue #283 will add real client
+	// RTT capture.)
 	timings := Timings{
 		Blocked: -1,
-		DNS:     msOrNeg(s.DNSMs),
-		Connect: msOrNeg(s.ConnectMs),
+		DNS:     -1,
+		Connect: -1,
 		Send:    -1,
-		Wait:    msOrNeg(s.TTFBMs),
+		Wait:    msOrNeg(s.ClientWaitMs),
 		Receive: msOrNeg(s.TransferMs),
-		SSL:     msOrNeg(s.TLSMs),
+		SSL:     -1,
 	}
 
 	statusText := statusTextFor(s.Status)
@@ -269,6 +294,25 @@ func buildEntry(s Source) Entry {
 	ext := map[string]interface{}{}
 	if s.RequestKind != "" {
 		ext["requestKind"] = s.RequestKind
+	}
+	// Upstream context — useful when an analyst wants to answer "was the
+	// wait the origin's fault or go-proxy's processing / fault-injection
+	// delay?", or "did the proxy rewrite the variant URL before fetching?".
+	// Includes the resolved upstream URL (often differs from the player's
+	// URL after proxy rewriting) and the upstream phase timings.
+	hasUpstream := s.UpstreamURL != "" && s.UpstreamURL != s.URL ||
+		s.DNSMs > 0 || s.ConnectMs > 0 || s.TLSMs > 0 || s.TTFBMs > 0
+	if hasUpstream {
+		upstream := map[string]interface{}{
+			"dns_ms":     s.DNSMs,
+			"connect_ms": s.ConnectMs,
+			"tls_ms":     s.TLSMs,
+			"ttfb_ms":    s.TTFBMs,
+		}
+		if s.UpstreamURL != "" && s.UpstreamURL != s.URL {
+			upstream["url"] = s.UpstreamURL
+		}
+		ext["upstream"] = upstream
 	}
 	if s.Faulted {
 		fault := map[string]interface{}{

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -151,6 +151,14 @@ type Source struct {
 	TTFBMs        float64
 	TransferMs    float64
 	TotalMs       float64
+
+	// HTTP-level metadata captured from the request and upstream
+	// response. Sensitive headers (Cookie / Authorization) are filtered
+	// at the proxy capture site before they reach here.
+	RequestHeaders  []NameValue
+	ResponseHeaders []NameValue
+	QueryString     []NameValue
+
 	Faulted       bool
 	FaultType     string
 	FaultAction   string
@@ -235,6 +243,19 @@ func buildEntry(s Source) Entry {
 		mimeType = "application/octet-stream"
 	}
 
+	requestHeaders := s.RequestHeaders
+	if requestHeaders == nil {
+		requestHeaders = []NameValue{}
+	}
+	responseHeaders := s.ResponseHeaders
+	if responseHeaders == nil {
+		responseHeaders = []NameValue{}
+	}
+	queryString := s.QueryString
+	if queryString == nil {
+		queryString = []NameValue{}
+	}
+
 	entry := Entry{
 		StartedDateTime: startedDate,
 		Time:            s.TotalMs,
@@ -243,8 +264,8 @@ func buildEntry(s Source) Entry {
 			URL:         s.URL,
 			HTTPVersion: "HTTP/1.1",
 			Cookies:     []NameValue{},
-			Headers:     []NameValue{},
-			QueryString: []NameValue{},
+			Headers:     requestHeaders,
+			QueryString: queryString,
 			HeadersSize: -1,
 			BodySize:    s.BytesOut,
 		},
@@ -253,7 +274,7 @@ func buildEntry(s Source) Entry {
 			StatusText:  statusText,
 			HTTPVersion: "HTTP/1.1",
 			Cookies:     []NameValue{},
-			Headers:     []NameValue{},
+			Headers:     responseHeaders,
 			Content: Content{
 				Size:     s.BytesIn,
 				MimeType: mimeType,

--- a/go-proxy/internal/har/har.go
+++ b/go-proxy/internal/har/har.go
@@ -168,12 +168,57 @@ type Incident struct {
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// Context is an analyst-friendly snapshot of *everything around* a HAR
+// at the moment it was captured (issue #281). Lands under
+// `_extensions.context` at the document level so an incident HAR is
+// self-contained — no cross-referencing of separate logs needed to
+// answer "what device, what stream, what test scenario, how far into
+// playback was this?".
+type Context struct {
+	Device        *DeviceContext         `json:"device,omitempty"`
+	Stream        *StreamContext         `json:"stream,omitempty"`
+	Scenario      *ScenarioContext       `json:"scenario,omitempty"`
+	Timing        *TimingContext         `json:"timing,omitempty"`
+	RecoveryChain []string               `json:"recovery_chain,omitempty"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
+}
+
+// DeviceContext is the player-supplied device fingerprint.
+type DeviceContext struct {
+	Model       string `json:"model,omitempty"`
+	OSVersion   string `json:"os_version,omitempty"`
+	AppVersion  string `json:"app_version,omitempty"`
+	NetworkType string `json:"network_type,omitempty"`
+}
+
+// StreamContext describes what the player is playing.
+type StreamContext struct {
+	ContentID         string `json:"content_id,omitempty"`
+	Protocol          string `json:"protocol,omitempty"` // "hls" or "dash"
+	Codec             string `json:"codec,omitempty"`
+	InitialVariantURL string `json:"initial_variant_url,omitempty"`
+}
+
+// ScenarioContext is a snapshot of the test conditions active when the
+// HAR was taken — server-side from the session record.
+type ScenarioContext struct {
+	FaultSettings map[string]interface{} `json:"fault_settings,omitempty"`
+	NftablesShape map[string]interface{} `json:"nftables_shape,omitempty"`
+}
+
+// TimingContext anchors the incident in playback time.
+type TimingContext struct {
+	PlayStartedAt    string  `json:"play_started_at,omitempty"`    // RFC3339, when the play began
+	IncidentOffsetS  float64 `json:"incident_offset_s,omitempty"`  // seconds since play_started_at
+}
+
 // BuildOptions controls extra metadata embedded at the HAR Log level.
 type BuildOptions struct {
 	SessionID string
 	PlayerID  string
 	GroupID   string
 	Incident  *Incident
+	Context   *Context
 }
 
 // Build constructs a HAR document from the given NetworkLogEntry sources.
@@ -209,11 +254,24 @@ func Build(sources []Source, opts BuildOptions) HAR {
 	if opts.Incident != nil {
 		ext["incident"] = opts.Incident
 	}
+	if opts.Context != nil && !opts.Context.isEmpty() {
+		ext["context"] = opts.Context
+	}
 	if len(ext) > 0 {
 		log.Extensions = ext
 	}
 
 	return HAR{Log: log}
+}
+
+// isEmpty reports whether the Context has nothing populated. Used to
+// avoid emitting an `_extensions.context: {}` block.
+func (c *Context) isEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return c.Device == nil && c.Stream == nil && c.Scenario == nil &&
+		c.Timing == nil && len(c.RecoveryChain) == 0 && len(c.Extra) == 0
 }
 
 func buildEntry(s Source) Entry {

--- a/go-proxy/internal/har/har_context_test.go
+++ b/go-proxy/internal/har/har_context_test.go
@@ -1,0 +1,153 @@
+package har
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Tests target the _extensions.context block introduced for issue #281.
+// Lives in its own file so it can land independently of other test files
+// (#278 har_test.go, #279 har_headers_test.go).
+
+func TestBuild_ContextDeviceSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Device: &DeviceContext{
+				Model:       "iPad Pro 12.9 (6th gen)",
+				OSVersion:   "iOS 18.2",
+				AppVersion:  "1.4.2-abc123",
+				NetworkType: "wifi",
+			},
+		},
+	})
+	ctx, ok := doc.Log.Extensions["context"].(*Context)
+	if !ok {
+		t.Fatalf("expected _extensions.context, got %T", doc.Log.Extensions["context"])
+	}
+	if ctx.Device.Model != "iPad Pro 12.9 (6th gen)" || ctx.Device.NetworkType != "wifi" {
+		t.Errorf("device block wrong: %+v", ctx.Device)
+	}
+}
+
+func TestBuild_ContextStreamSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Stream: &StreamContext{
+				ContentID:         "big-buck-bunny",
+				Protocol:          "hls",
+				Codec:             "h264",
+				InitialVariantURL: "https://example.test/1080p.m3u8",
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Stream.ContentID != "big-buck-bunny" || ctx.Stream.Protocol != "hls" {
+		t.Errorf("stream block wrong: %+v", ctx.Stream)
+	}
+}
+
+func TestBuild_ContextScenarioSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Scenario: &ScenarioContext{
+				FaultSettings: map[string]interface{}{
+					"segment_failure_type":      "404",
+					"segment_consecutive_failures": 3,
+				},
+				NftablesShape: map[string]interface{}{
+					"nftables_bandwidth_mbps": 5.0,
+					"nftables_delay_ms":       100,
+				},
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Scenario.FaultSettings["segment_failure_type"] != "404" {
+		t.Errorf("scenario.fault_settings wrong: %+v", ctx.Scenario.FaultSettings)
+	}
+	if ctx.Scenario.NftablesShape["nftables_bandwidth_mbps"] != 5.0 {
+		t.Errorf("scenario.nftables_shape wrong: %+v", ctx.Scenario.NftablesShape)
+	}
+}
+
+func TestBuild_ContextTimingSurface(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			Timing: &TimingContext{
+				PlayStartedAt:   "2026-04-29T12:00:00Z",
+				IncidentOffsetS: 47.3,
+			},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if ctx.Timing.PlayStartedAt != "2026-04-29T12:00:00Z" {
+		t.Errorf("timing.play_started_at wrong: %+v", ctx.Timing)
+	}
+	if ctx.Timing.IncidentOffsetS != 47.3 {
+		t.Errorf("timing.incident_offset_s = %v, want 47.3", ctx.Timing.IncidentOffsetS)
+	}
+}
+
+func TestBuild_ContextRecoveryChain(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		Context: &Context{
+			RecoveryChain: []string{"frozen", "user_retry", "segment_stall"},
+		},
+	})
+	ctx := doc.Log.Extensions["context"].(*Context)
+	if len(ctx.RecoveryChain) != 3 || ctx.RecoveryChain[1] != "user_retry" {
+		t.Errorf("recovery_chain wrong: %+v", ctx.RecoveryChain)
+	}
+}
+
+func TestBuild_EmptyContextOmitted(t *testing.T) {
+	// An entirely empty Context should NOT produce an
+	// `_extensions.context: {}` block — it'd just be noise.
+	doc := Build(nil, BuildOptions{
+		Context: &Context{},
+	})
+	if _, has := doc.Log.Extensions["context"]; has {
+		t.Errorf("empty context should not be emitted: %+v", doc.Log.Extensions)
+	}
+}
+
+func TestBuild_NilContextOmitted(t *testing.T) {
+	doc := Build(nil, BuildOptions{Context: nil})
+	if _, has := doc.Log.Extensions["context"]; has {
+		t.Errorf("nil context should not be emitted: %+v", doc.Log.Extensions)
+	}
+}
+
+func TestBuild_ContextRoundTripsThroughJSON(t *testing.T) {
+	doc := Build(nil, BuildOptions{
+		SessionID: "s",
+		Context: &Context{
+			Device: &DeviceContext{Model: "Apple TV 4K", OSVersion: "tvOS 18"},
+			Stream: &StreamContext{ContentID: "demo", Protocol: "hls"},
+			Scenario: &ScenarioContext{
+				FaultSettings: map[string]interface{}{"segment_failure_type": "timeout"},
+			},
+			RecoveryChain: []string{"frozen"},
+		},
+	})
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(body), `"recovery_chain":["frozen"]`) {
+		t.Errorf("recovery_chain not in JSON: %s", body)
+	}
+	// Round-trip the whole thing and confirm the context survives.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	logBlock := parsed["log"].(map[string]interface{})
+	ext := logBlock["_extensions"].(map[string]interface{})
+	ctx := ext["context"].(map[string]interface{})
+	device := ctx["device"].(map[string]interface{})
+	if device["model"] != "Apple TV 4K" {
+		t.Errorf("device.model lost in round-trip: %+v", device)
+	}
+}

--- a/go-proxy/internal/har/har_headers_test.go
+++ b/go-proxy/internal/har/har_headers_test.go
@@ -1,0 +1,133 @@
+package har
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// These tests target the request/response headers + queryString
+// plumbing added in issue #279. They live in a separate file from
+// har_test.go (PR #278) so the two PRs can land in any order.
+
+func TestBuild_RequestHeadersFlowThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s",
+		Status: 200,
+		RequestHeaders: []NameValue{
+			{Name: "User-Agent", Value: "InfiniteStreamPlayer/1.0"},
+			{Name: "Range", Value: "bytes=0-1023"},
+			{Name: "If-None-Match", Value: `"abc123"`},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	headers := doc.Log.Entries[0].Request.Headers
+	if len(headers) != 3 {
+		t.Fatalf("expected 3 request headers, got %d: %+v", len(headers), headers)
+	}
+	if headers[1].Name != "Range" || headers[1].Value != "bytes=0-1023" {
+		t.Errorf("Range header mapping wrong: %+v", headers[1])
+	}
+}
+
+func TestBuild_ResponseHeadersFlowThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s",
+		Status: 200,
+		ResponseHeaders: []NameValue{
+			{Name: "Content-Type", Value: "video/mp4"},
+			{Name: "Cache-Control", Value: "no-store"},
+			{Name: "Server", Value: "nginx"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	headers := doc.Log.Entries[0].Response.Headers
+	if len(headers) != 3 {
+		t.Fatalf("expected 3 response headers, got %d: %+v", len(headers), headers)
+	}
+}
+
+func TestBuild_QueryStringFlowsThrough(t *testing.T) {
+	src := Source{
+		URL:    "https://proxy.test/playlist.m3u8?player_id=p1&play_id=42",
+		Status: 200,
+		QueryString: []NameValue{
+			{Name: "player_id", Value: "p1"},
+			{Name: "play_id", Value: "42"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	qs := doc.Log.Entries[0].Request.QueryString
+	if len(qs) != 2 {
+		t.Fatalf("expected 2 query params, got %d: %+v", len(qs), qs)
+	}
+	if qs[0].Name != "player_id" || qs[0].Value != "p1" {
+		t.Errorf("first param wrong: %+v", qs[0])
+	}
+}
+
+func TestBuild_EmptyMetadataYieldsEmptyArrays(t *testing.T) {
+	// Per HAR 1.2 spec, request.headers/queryString and response.headers
+	// must be present (empty array, not null) so a HAR consumer can
+	// always iterate. Builder should produce []NameValue{} when the
+	// source has none.
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.Headers == nil {
+		t.Errorf("Request.Headers should be []NameValue{}, got nil")
+	}
+	if e.Request.QueryString == nil {
+		t.Errorf("Request.QueryString should be []NameValue{}, got nil")
+	}
+	if e.Response.Headers == nil {
+		t.Errorf("Response.Headers should be []NameValue{}, got nil")
+	}
+}
+
+func TestBuild_HeadersSurviveJSONRoundTrip(t *testing.T) {
+	// Real HAR consumers parse the JSON. Make sure our headers and
+	// query params reach the wire shape DevTools/Charles expect.
+	src := Source{
+		URL:    "https://proxy.test/seg.m4s?player_id=p1",
+		Status: 200,
+		RequestHeaders: []NameValue{
+			{Name: "User-Agent", Value: "test"},
+		},
+		ResponseHeaders: []NameValue{
+			{Name: "Content-Type", Value: "video/mp4"},
+		},
+		QueryString: []NameValue{
+			{Name: "player_id", Value: "p1"},
+		},
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	logBlock := parsed["log"].(map[string]interface{})
+	entries := logBlock["entries"].([]interface{})
+	entry := entries[0].(map[string]interface{})
+	request := entry["request"].(map[string]interface{})
+	response := entry["response"].(map[string]interface{})
+
+	reqHeaders := request["headers"].([]interface{})
+	if len(reqHeaders) != 1 {
+		t.Errorf("request.headers count = %d, want 1", len(reqHeaders))
+	}
+	respHeaders := response["headers"].([]interface{})
+	if len(respHeaders) != 1 {
+		t.Errorf("response.headers count = %d, want 1", len(respHeaders))
+	}
+	qs := request["queryString"].([]interface{})
+	if len(qs) != 1 {
+		t.Errorf("queryString count = %d, want 1", len(qs))
+	}
+	first := reqHeaders[0].(map[string]interface{})
+	if first["name"] != "User-Agent" || first["value"] != "test" {
+		t.Errorf("header round-trip lost data: %+v", first)
+	}
+}

--- a/go-proxy/internal/har/har_test.go
+++ b/go-proxy/internal/har/har_test.go
@@ -1,0 +1,319 @@
+package har
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuild_EmptySources(t *testing.T) {
+	doc := Build(nil, BuildOptions{SessionID: "sess-1", PlayerID: "player-a"})
+	if doc.Log.Version != HARVersion {
+		t.Errorf("version = %q, want %q", doc.Log.Version, HARVersion)
+	}
+	if doc.Log.Creator.Name != CreatorName {
+		t.Errorf("creator name = %q, want %q", doc.Log.Creator.Name, CreatorName)
+	}
+	if len(doc.Log.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(doc.Log.Entries))
+	}
+	// Session metadata always lands under _extensions.session.
+	sess, ok := doc.Log.Extensions["session"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected _extensions.session map, got %T", doc.Log.Extensions["session"])
+	}
+	if sess["session_id"] != "sess-1" || sess["player_id"] != "player-a" {
+		t.Errorf("session metadata wrong: %+v", sess)
+	}
+}
+
+func TestBuild_TimingMapping_DownstreamPerspective(t *testing.T) {
+	// HAR's standard timings.* surfaces *downstream* timings (proxy →
+	// player) so a viewer shows the player's experience by default.
+	// Upstream timings land under _extensions.upstream.
+	src := Source{
+		Timestamp:    time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+		Method:       "GET",
+		URL:          "https://example.test/segment.m4s",
+		ContentType:  "video/mp4",
+		Status:       200,
+		BytesIn:      1024 * 50,
+		BytesOut:     256,
+		ClientWaitMs: 65.0,  // request received → first response byte to client
+		TransferMs:   120.5, // body write+flush
+		TotalMs:      185.5,
+		// Upstream timings — should NOT appear in the standard Timings block.
+		DNSMs:     2.5,
+		ConnectMs: 8.1,
+		TLSMs:     12.0,
+		TTFBMs:    40.3,
+	}
+	doc := Build([]Source{src}, BuildOptions{SessionID: "s"})
+	if len(doc.Log.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(doc.Log.Entries))
+	}
+	e := doc.Log.Entries[0]
+	if e.Time != 185.5 {
+		t.Errorf("Time = %v, want 185.5", e.Time)
+	}
+	// Standard HAR Timings reflect downstream perspective only.
+	if e.Timings.Wait != 65.0 || e.Timings.Receive != 120.5 {
+		t.Errorf("downstream timings off: %+v", e.Timings)
+	}
+	// DNS / Connect / SSL describe the *client*'s connect to its server;
+	// from go-proxy → player they're a keepalive transaction with no
+	// client-side handshake to measure here, so they're -1.
+	if e.Timings.DNS != -1 || e.Timings.Connect != -1 || e.Timings.SSL != -1 {
+		t.Errorf("DNS/Connect/SSL should be -1 (downstream): %+v", e.Timings)
+	}
+	if e.Timings.Blocked != -1 || e.Timings.Send != -1 {
+		t.Errorf("Blocked/Send not defaulted to -1: %+v", e.Timings)
+	}
+	// Upstream timings live under _extensions.upstream.
+	upstream, ok := e.Extensions["upstream"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected _extensions.upstream, got %+v", e.Extensions)
+	}
+	if upstream["dns_ms"] != 2.5 || upstream["connect_ms"] != 8.1 ||
+		upstream["tls_ms"] != 12.0 || upstream["ttfb_ms"] != 40.3 {
+		t.Errorf("upstream block wrong: %+v", upstream)
+	}
+	if e.Request.Method != "GET" || e.Request.URL != src.URL {
+		t.Errorf("Request mapping off: %+v", e.Request)
+	}
+	if e.Response.Status != 200 || e.Response.StatusText != "OK" {
+		t.Errorf("Response status mapping off: %+v", e.Response)
+	}
+	if e.Response.Content.MimeType != "video/mp4" {
+		t.Errorf("Content.MimeType = %q, want video/mp4", e.Response.Content.MimeType)
+	}
+	if !strings.HasSuffix(e.StartedDateTime, "Z") {
+		t.Errorf("startedDateTime not UTC: %q", e.StartedDateTime)
+	}
+}
+
+func TestBuild_NoUpstreamExtensionWhenAllZero(t *testing.T) {
+	// Fault paths that never reach upstream should NOT emit
+	// _extensions.upstream — there's nothing to report.
+	src := Source{
+		URL:          "https://example.test/x",
+		Status:       502,
+		ClientWaitMs: 1.0,
+		// All upstream timings 0 (rejected before connect).
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if _, has := e.Extensions["upstream"]; has {
+		t.Errorf("upstream extension should be omitted when nothing measured: %+v", e.Extensions)
+	}
+}
+
+func TestBuild_UpstreamURLLandsInExtension(t *testing.T) {
+	// When the proxy rewrote the URL before fetching upstream
+	// (variant rewrite, mirror), the player URL and upstream URL
+	// differ — both should be visible.
+	src := Source{
+		URL:         "https://proxy.test/seg.m4s?player_id=p&play_id=1",
+		UpstreamURL: "https://origin.test/h264/720p/seg.m4s",
+		Status:      200,
+		TTFBMs:      10,
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.URL != src.URL {
+		t.Errorf("Request.URL should be the player URL, got %q", e.Request.URL)
+	}
+	upstream := e.Extensions["upstream"].(map[string]interface{})
+	if upstream["url"] != src.UpstreamURL {
+		t.Errorf("upstream.url = %v, want %q", upstream["url"], src.UpstreamURL)
+	}
+}
+
+func TestBuild_NoUpstreamURLWhenSameAsPlayerURL(t *testing.T) {
+	// If the proxy didn't rewrite, no point repeating the URL.
+	src := Source{
+		URL:         "https://example.test/seg.m4s",
+		UpstreamURL: "https://example.test/seg.m4s",
+		Status:      200,
+		TTFBMs:      10,
+	}
+	doc := Build([]Source{src}, BuildOptions{})
+	upstream := doc.Log.Entries[0].Extensions["upstream"].(map[string]interface{})
+	if _, has := upstream["url"]; has {
+		t.Errorf("upstream.url should be omitted when identical to player URL: %+v", upstream)
+	}
+}
+
+func TestBuild_NegativeTimingsCollapseToMinusOne(t *testing.T) {
+	// HAR 1.2: -1 means "not applicable / not measured".
+	doc := Build([]Source{{
+		URL:    "x",
+		Status: 0,
+		// All timings 0 (e.g. faulted before connect).
+	}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Timings.DNS != -1 || e.Timings.Connect != -1 || e.Timings.SSL != -1 ||
+		e.Timings.Wait != -1 || e.Timings.Receive != -1 {
+		t.Errorf("zero timings should map to -1: %+v", e.Timings)
+	}
+}
+
+func TestBuild_FaultExtension(t *testing.T) {
+	doc := Build([]Source{{
+		URL:           "https://example.test/seg.m4s",
+		Status:        404,
+		Faulted:       true,
+		FaultType:     "404",
+		FaultAction:   "respond",
+		FaultCategory: "http",
+		RequestKind:   "segment",
+	}}, BuildOptions{})
+	ext := doc.Log.Entries[0].Extensions
+	if ext == nil {
+		t.Fatal("expected entry _extensions")
+	}
+	if got := ext["requestKind"]; got != "segment" {
+		t.Errorf("requestKind = %v, want segment", got)
+	}
+	fault, ok := ext["fault"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("fault block missing or wrong type: %T", ext["fault"])
+	}
+	if fault["faulted"] != true || fault["type"] != "404" || fault["action"] != "respond" || fault["category"] != "http" {
+		t.Errorf("fault block wrong: %+v", fault)
+	}
+}
+
+func TestBuild_NoFaultNoExtension(t *testing.T) {
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	if ext := doc.Log.Entries[0].Extensions; ext != nil {
+		t.Errorf("expected no entry _extensions on a clean request, got %+v", ext)
+	}
+}
+
+func TestBuild_IncidentBlock(t *testing.T) {
+	now := time.Date(2026, 4, 28, 13, 30, 0, 0, time.UTC)
+	inc := &Incident{
+		Reason:    "frozen",
+		Source:    "player",
+		PlayerID:  "player-a",
+		SessionID: "sess-1",
+		Timestamp: now,
+		Metadata: map[string]interface{}{
+			"buffer_depth_s": 0.0,
+			"player_state":   "buffering",
+		},
+	}
+	doc := Build(nil, BuildOptions{
+		SessionID: "sess-1",
+		PlayerID:  "player-a",
+		Incident:  inc,
+	})
+	got, ok := doc.Log.Extensions["incident"].(*Incident)
+	if !ok {
+		t.Fatalf("incident block wrong type: %T", doc.Log.Extensions["incident"])
+	}
+	if got.Reason != "frozen" || got.Source != "player" {
+		t.Errorf("incident block wrong: %+v", got)
+	}
+}
+
+func TestBuild_DefaultsAppliedToRequest(t *testing.T) {
+	// Empty Method should default to GET; empty ContentType should default
+	// to application/octet-stream.
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.Method != "GET" {
+		t.Errorf("method default = %q, want GET", e.Request.Method)
+	}
+	if e.Response.Content.MimeType != "application/octet-stream" {
+		t.Errorf("mime default = %q, want application/octet-stream", e.Response.Content.MimeType)
+	}
+}
+
+func TestBuild_RoundTripsThroughJSON(t *testing.T) {
+	// A real HAR consumer (Chrome DevTools, Charles) parses the JSON
+	// shape — make sure ours marshals + unmarshals to the same shape.
+	doc := Build([]Source{
+		{URL: "https://example.test/a", Status: 200, BytesIn: 100, TotalMs: 5,
+			DNSMs: 1, ConnectMs: 1, TTFBMs: 1, TransferMs: 2},
+		{URL: "https://example.test/b", Status: 404, Faulted: true, FaultType: "404"},
+	}, BuildOptions{SessionID: "s", PlayerID: "p"})
+
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic map[string]interface{}
+	if err := json.Unmarshal(body, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Top-level shape: { log: { version, creator, entries } }
+	logRaw, ok := generic["log"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level log object, got %T", generic["log"])
+	}
+	if logRaw["version"] != "1.2" {
+		t.Errorf("version = %v, want 1.2", logRaw["version"])
+	}
+	entries, ok := logRaw["entries"].([]interface{})
+	if !ok || len(entries) != 2 {
+		t.Fatalf("entries = %v (count %d), want 2", logRaw["entries"], len(entries))
+	}
+	// Faulted entry should carry _extensions.fault even after JSON round-trip.
+	second := entries[1].(map[string]interface{})
+	ext := second["_extensions"].(map[string]interface{})
+	if ext["fault"] == nil {
+		t.Errorf("fault extension lost in round-trip: %+v", second)
+	}
+}
+
+func TestStatusTextFor(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{200, "OK"},
+		{206, "Partial Content"},
+		{301, "Moved Permanently"},
+		{404, "Not Found"},
+		{429, "Too Many Requests"},
+		{500, "Internal Server Error"},
+		{504, "Gateway Timeout"},
+		// Unknown specifics should fall through to bucketed text.
+		{418, "Client Error"},
+		{599, "Server Error"},
+		{0, ""},
+	}
+	for _, c := range cases {
+		if got := statusTextFor(c.status); got != c.want {
+			t.Errorf("statusTextFor(%d) = %q, want %q", c.status, got, c.want)
+		}
+	}
+}
+
+func TestMsOrNeg(t *testing.T) {
+	cases := []struct {
+		in, want float64
+	}{
+		{0, -1},
+		{-5, -1},
+		{0.001, 0.001},
+		{42, 42},
+	}
+	for _, c := range cases {
+		if got := msOrNeg(c.in); got != c.want {
+			t.Errorf("msOrNeg(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDefaultStr(t *testing.T) {
+	if got := defaultStr("", "GET"); got != "GET" {
+		t.Errorf("defaultStr(\"\", \"GET\") = %q, want GET", got)
+	}
+	if got := defaultStr("POST", "GET"); got != "POST" {
+		t.Errorf("defaultStr(\"POST\", ...) = %q, want POST", got)
+	}
+}

--- a/go-proxy/internal/har/har_test.go
+++ b/go-proxy/internal/har/har_test.go
@@ -1,0 +1,249 @@
+package har
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuild_EmptySources(t *testing.T) {
+	doc := Build(nil, BuildOptions{SessionID: "sess-1", PlayerID: "player-a"})
+	if doc.Log.Version != HARVersion {
+		t.Errorf("version = %q, want %q", doc.Log.Version, HARVersion)
+	}
+	if doc.Log.Creator.Name != CreatorName {
+		t.Errorf("creator name = %q, want %q", doc.Log.Creator.Name, CreatorName)
+	}
+	if len(doc.Log.Entries) != 0 {
+		t.Errorf("entries = %d, want 0", len(doc.Log.Entries))
+	}
+	// Session metadata always lands under _extensions.session.
+	sess, ok := doc.Log.Extensions["session"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected _extensions.session map, got %T", doc.Log.Extensions["session"])
+	}
+	if sess["session_id"] != "sess-1" || sess["player_id"] != "player-a" {
+		t.Errorf("session metadata wrong: %+v", sess)
+	}
+}
+
+func TestBuild_TimingMapping(t *testing.T) {
+	src := Source{
+		Timestamp:   time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
+		Method:      "GET",
+		URL:         "https://example.test/segment.m4s",
+		ContentType: "video/mp4",
+		Status:      200,
+		BytesIn:     1024 * 50,
+		BytesOut:    256,
+		DNSMs:       2.5,
+		ConnectMs:   8.1,
+		TLSMs:       12.0,
+		TTFBMs:      40.3,
+		TransferMs:  120.5,
+		TotalMs:     183.4,
+	}
+	doc := Build([]Source{src}, BuildOptions{SessionID: "s"})
+	if len(doc.Log.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(doc.Log.Entries))
+	}
+	e := doc.Log.Entries[0]
+	if e.Time != 183.4 {
+		t.Errorf("Time = %v, want 183.4", e.Time)
+	}
+	if e.Timings.DNS != 2.5 || e.Timings.Connect != 8.1 || e.Timings.SSL != 12.0 ||
+		e.Timings.Wait != 40.3 || e.Timings.Receive != 120.5 {
+		t.Errorf("Timings mapping off: %+v", e.Timings)
+	}
+	// HAR spec: blocked/send default to -1 ("not applicable").
+	if e.Timings.Blocked != -1 || e.Timings.Send != -1 {
+		t.Errorf("Blocked/Send not defaulted to -1: %+v", e.Timings)
+	}
+	if e.Request.Method != "GET" || e.Request.URL != src.URL {
+		t.Errorf("Request mapping off: %+v", e.Request)
+	}
+	if e.Response.Status != 200 || e.Response.StatusText != "OK" {
+		t.Errorf("Response status mapping off: %+v", e.Response)
+	}
+	if e.Response.Content.MimeType != "video/mp4" {
+		t.Errorf("Content.MimeType = %q, want video/mp4", e.Response.Content.MimeType)
+	}
+	// startedDateTime must be ISO8601 in UTC.
+	if !strings.HasSuffix(e.StartedDateTime, "Z") {
+		t.Errorf("startedDateTime not UTC: %q", e.StartedDateTime)
+	}
+}
+
+func TestBuild_NegativeTimingsCollapseToMinusOne(t *testing.T) {
+	// HAR 1.2: -1 means "not applicable / not measured".
+	doc := Build([]Source{{
+		URL:    "x",
+		Status: 0,
+		// All timings 0 (e.g. faulted before connect).
+	}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Timings.DNS != -1 || e.Timings.Connect != -1 || e.Timings.SSL != -1 ||
+		e.Timings.Wait != -1 || e.Timings.Receive != -1 {
+		t.Errorf("zero timings should map to -1: %+v", e.Timings)
+	}
+}
+
+func TestBuild_FaultExtension(t *testing.T) {
+	doc := Build([]Source{{
+		URL:           "https://example.test/seg.m4s",
+		Status:        404,
+		Faulted:       true,
+		FaultType:     "404",
+		FaultAction:   "respond",
+		FaultCategory: "http",
+		RequestKind:   "segment",
+	}}, BuildOptions{})
+	ext := doc.Log.Entries[0].Extensions
+	if ext == nil {
+		t.Fatal("expected entry _extensions")
+	}
+	if got := ext["requestKind"]; got != "segment" {
+		t.Errorf("requestKind = %v, want segment", got)
+	}
+	fault, ok := ext["fault"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("fault block missing or wrong type: %T", ext["fault"])
+	}
+	if fault["faulted"] != true || fault["type"] != "404" || fault["action"] != "respond" || fault["category"] != "http" {
+		t.Errorf("fault block wrong: %+v", fault)
+	}
+}
+
+func TestBuild_NoFaultNoExtension(t *testing.T) {
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	if ext := doc.Log.Entries[0].Extensions; ext != nil {
+		t.Errorf("expected no entry _extensions on a clean request, got %+v", ext)
+	}
+}
+
+func TestBuild_IncidentBlock(t *testing.T) {
+	now := time.Date(2026, 4, 28, 13, 30, 0, 0, time.UTC)
+	inc := &Incident{
+		Reason:    "frozen",
+		Source:    "player",
+		PlayerID:  "player-a",
+		SessionID: "sess-1",
+		Timestamp: now,
+		Metadata: map[string]interface{}{
+			"buffer_depth_s": 0.0,
+			"player_state":   "buffering",
+		},
+	}
+	doc := Build(nil, BuildOptions{
+		SessionID: "sess-1",
+		PlayerID:  "player-a",
+		Incident:  inc,
+	})
+	got, ok := doc.Log.Extensions["incident"].(*Incident)
+	if !ok {
+		t.Fatalf("incident block wrong type: %T", doc.Log.Extensions["incident"])
+	}
+	if got.Reason != "frozen" || got.Source != "player" {
+		t.Errorf("incident block wrong: %+v", got)
+	}
+}
+
+func TestBuild_DefaultsAppliedToRequest(t *testing.T) {
+	// Empty Method should default to GET; empty ContentType should default
+	// to application/octet-stream.
+	doc := Build([]Source{{URL: "x", Status: 200}}, BuildOptions{})
+	e := doc.Log.Entries[0]
+	if e.Request.Method != "GET" {
+		t.Errorf("method default = %q, want GET", e.Request.Method)
+	}
+	if e.Response.Content.MimeType != "application/octet-stream" {
+		t.Errorf("mime default = %q, want application/octet-stream", e.Response.Content.MimeType)
+	}
+}
+
+func TestBuild_RoundTripsThroughJSON(t *testing.T) {
+	// A real HAR consumer (Chrome DevTools, Charles) parses the JSON
+	// shape — make sure ours marshals + unmarshals to the same shape.
+	doc := Build([]Source{
+		{URL: "https://example.test/a", Status: 200, BytesIn: 100, TotalMs: 5,
+			DNSMs: 1, ConnectMs: 1, TTFBMs: 1, TransferMs: 2},
+		{URL: "https://example.test/b", Status: 404, Faulted: true, FaultType: "404"},
+	}, BuildOptions{SessionID: "s", PlayerID: "p"})
+
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var generic map[string]interface{}
+	if err := json.Unmarshal(body, &generic); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Top-level shape: { log: { version, creator, entries } }
+	logRaw, ok := generic["log"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected top-level log object, got %T", generic["log"])
+	}
+	if logRaw["version"] != "1.2" {
+		t.Errorf("version = %v, want 1.2", logRaw["version"])
+	}
+	entries, ok := logRaw["entries"].([]interface{})
+	if !ok || len(entries) != 2 {
+		t.Fatalf("entries = %v (count %d), want 2", logRaw["entries"], len(entries))
+	}
+	// Faulted entry should carry _extensions.fault even after JSON round-trip.
+	second := entries[1].(map[string]interface{})
+	ext := second["_extensions"].(map[string]interface{})
+	if ext["fault"] == nil {
+		t.Errorf("fault extension lost in round-trip: %+v", second)
+	}
+}
+
+func TestStatusTextFor(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{200, "OK"},
+		{206, "Partial Content"},
+		{301, "Moved Permanently"},
+		{404, "Not Found"},
+		{429, "Too Many Requests"},
+		{500, "Internal Server Error"},
+		{504, "Gateway Timeout"},
+		// Unknown specifics should fall through to bucketed text.
+		{418, "Client Error"},
+		{599, "Server Error"},
+		{0, ""},
+	}
+	for _, c := range cases {
+		if got := statusTextFor(c.status); got != c.want {
+			t.Errorf("statusTextFor(%d) = %q, want %q", c.status, got, c.want)
+		}
+	}
+}
+
+func TestMsOrNeg(t *testing.T) {
+	cases := []struct {
+		in, want float64
+	}{
+		{0, -1},
+		{-5, -1},
+		{0.001, 0.001},
+		{42, 42},
+	}
+	for _, c := range cases {
+		if got := msOrNeg(c.in); got != c.want {
+			t.Errorf("msOrNeg(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDefaultStr(t *testing.T) {
+	if got := defaultStr("", "GET"); got != "GET" {
+		t.Errorf("defaultStr(\"\", \"GET\") = %q, want GET", got)
+	}
+	if got := defaultStr("POST", "GET"); got != "POST" {
+		t.Errorf("defaultStr(\"POST\", ...) = %q, want POST", got)
+	}
+}


### PR DESCRIPTION
Single landing PR for the full HAR ('Player Error Characterization') stack. Supersedes #275, #276, #278, #285, #287, #288, #289, #290 — collapse-merging the integration branch as one commit per the user's preference.

## What's in here

### go-proxy server
- HAR builder package (`internal/har`) with W3C HAR 1.2 schema + `_extensions` for session, incident, context, upstream timings (#272, #285).
- HAR snapshot endpoints: `GET /api/sessions/{id}/timeline.har`, `POST /api/session/{id}/har/snapshot`, `GET /api/incidents`, `GET /api/incidents/{path}` (#272, #285).
- Downstream timings — `client_wait_ms` measured proxy→player; `transfer_ms` measured around `io.Copy + Flush` on every happy path (default + master-manifest-with-content-manipulation).
- Request/response headers + queryString captured per entry (#279/#288).
- `play_id` per-play scoping so HARs are per-stream-attempt not per-session lifetime (#280/#289).
- Incident context block (`_extensions.context`) carrying device, scenario, timing, recovery_chain (#281/#290).
- Range capture (`request_range` / `response_content_range`) on entries.
- Fault-tagging fixes: `transfer_idle_timeout` / `transfer_active_timeout` now flag the entry (not just bump counters); `client_disconnect` / `transfer_abandoned` tagging on broken-pipe / RST.
- Defensive nil-fallback in `handleProxy` so the entry deref never panics if `doRequestWithTracing`'s contract ever regresses.
- HAR builder unit tests (#278).

### Dashboard
- Native brushable waterfall replacing vis-timeline (#287, closes #291):
  - Overview strip + draggable brush (pan / resize / click-to-jump).
  - Two distinct time axes (full-session above overview; brush window above row list).
  - Per-row global-axis bars with phase segments (DNS / Connect / TLS / Wait / Receive).
  - Status / fault colour bands (2xx green, 206 teal, 3xx blue, 4xx amber, 5xx red, faulted/timeout/incomplete with diagonal hatch on the receive segment).
  - Dedicated Status column with status-family tinting.
  - Resizable column cells with `localStorage` persistence (`netwf-cols-v2`).
  - Summary pill row (totals + categorical counts).
  - Hover tooltip with method/status/total/bytes/Mbps/variant/started-at/per-phase breakdown/attempt N of M/range/fault info/URL.
  - Time-aware retry detection (gap < half segment duration parsed from URL; 2s / 6s / ll / playlist_Ns variants).
  - 1-min default + minimum brush; 10-min rolling window; 20-row default visible height.
  - Network log no longer gated by `?developer=1`; "Hide Successful" filter (default off); Following Latest default ON with immediate-snap behaviour; **Download HAR** uses blob: URL to bypass Chrome's HTTP-mixed-content download block.
- Incidents browser page (`/dashboard/incidents.html`, #276).
- Cleanup of dead vis-timeline scaffolding (~440 lines, #292): removed 12 functions and 3 maps. Resizer mousemove/mouseup listeners now scoped per-drag.

### Players
- iOS / iPadOS / tvOS: auto-snapshot HAR on freeze / segment-stall / recovery / reload; `play_id` regeneration (#273/#275).
- Android TV: same auto-snapshot + `play_id` plumbing via `PlaybackMetrics.requestHarSnapshot` (#273/#275).

### Nginx
- New `^/api/incidents` location proxying to go-proxy.

## Closes
- #272 Player error-characterization framework (umbrella)
- #273 Auto-snapshot HAR on player freeze / auto-recovery
- #279 HAR: capture request/response headers + queryString
- #280 HAR: scope snapshots to a single play via play_id
- #281 HAR: incident context block

## Superseded PRs (closed by this merge)
- #275 Player auto-snapshot
- #276 Recent Incidents page
- #278 HAR builder unit tests
- #285 Downstream timings + player URL
- #287 Native brushable waterfall + paired fixes
- #288 Headers + queryString
- #289 play_id scoping
- #290 Incident context

## Test plan
- [x] `make test-deploy-dev` — image builds, container starts.
- [x] `node -c content/dashboard/testing-session-ui.js` parses clean.
- [x] `go build ./go-proxy/cmd/server/` succeeds.
- [x] Dashboard loads, waterfall renders, brush drag works.
- [x] HAR snapshot via Download HAR button — blob download succeeds.
- [x] `/dashboard/incidents.html` lists snapshots, downloads file.
- [ ] Apple / Android players auto-snapshot on freeze (manual verification).