### PR TITLE
fix(go-proxy): serialise fault-decision so video+audio don't double-fire

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -357,6 +357,12 @@ type App struct {
 	transferCompleteMu           sync.Mutex
 	transferCompleteMbps         map[int]float64   // latest completed segment Mbps per port
 	transferCompleteAt           map[int]time.Time // when the drain completed
+	// failureDecisionMu serialises the read-modify-write inside
+	// RequestHandler.HandleRequest. Without it, concurrent segment
+	// requests (e.g. video + audio for the same sequence number) race
+	// on segments_count and segment_failure_at, so a single 1-per-Ns
+	// rule can fire twice in the same window.
+	failureDecisionMu        sync.Mutex
 }
 
 type ServerLoopState struct {
@@ -4004,7 +4010,12 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	handler := NewRequestHandler(isSegment, isManifest, isMasterManifest, sessionData)
+	// Serialise the failure-decision read-modify-write so video+audio
+	// requests arriving in the same millisecond don't both pass the
+	// "1 per N seconds" filter and double-fire.
+	a.failureDecisionMu.Lock()
 	failureType := handler.HandleRequest(filename)
+	a.failureDecisionMu.Unlock()
 
 	a.saveSessionByID(sessionNumber, sessionData)
 


### PR DESCRIPTION
## Bug

With \"1 fault per 8 s\" configured, two segments arriving within 1 ms of each other (1080p video + audio for the same sequence number) both received 404. Reproduced from a live testing session:

\`\`\`
11:52:34.190  GET 1080p/segment_00031.m4s  404
11:52:34.191  GET audio/segment_00031.m4s  404
\`\`\`

The rule should have fired exactly once per 8 s window — it fired twice in the same millisecond.

## Root cause

\`handleSegmentFailure\` does an unsynchronised read-modify-write on the session map:

1. Increments \`segments_count\`.
2. Asks the failure handler whether the new count crosses the per-N-seconds threshold.
3. Writes \`segment_failure_at\` / \`segment_failure_recover_at\` to mark the window.

Two goroutines racing on this both:
1. Read the same \`segments_count\`,
2. Compute the same \"+1\",
3. Both clear the freq window check,
4. Both write the failure timestamps (lost-update),
5. Both inject the fault.

The \`_failure_at\` / \`_failure_recover_at\` timestamps were the intended dedupe — first request writes them, second request sees them set — but neither write happens before the second read.

## Fix

Added \`failureDecisionMu sync.Mutex\` to \`App\` and wrapped \`handler.HandleRequest(filename)\` so the entire counter-update + threshold-check + timestamp-write block is atomic per process. Global rather than per-session because the cost is negligible (one mutex per request, no I/O held); per-session fanout would add complexity for marginal gain.

## Test plan

- [x] Compile (\`go build ./go-proxy/cmd/server/\`).
- [x] Deploy to test-dev (\`make test-deploy-dev\`).
- [ ] Repro: configure \"1 fault per 8 s\" with both video + audio segments selected, watch network log — should see exactly one 404 per 8 s window, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)