### PR TITLE
feat(dashboard): network log grows to fit all rows; no inner scrollbar

### DIFF
--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -526,15 +526,13 @@
     font-size: 11px;
 }
 
-/* Native scroll on the wrapper. The list of rows is the height of the
- * data; the wrapper clips it. New entries appended at the bottom
- * don't pull the user's scroll position around. Max-height fits the
- * sticky 22px axis row plus 20 data rows (axis stays visible while
- * the rows below scroll). */
+/* Wrapper grows with its content — no inner scroll cap. The page
+ * itself scrolls when the list runs past the viewport, and the
+ * sticky axis row pins to the page-viewport top while the user
+ * scans down. New entries appended at the bottom don't pull the
+ * page's scroll position around. */
 .network-log-waterfall-scroll {
     width: 100%;
-    max-height: 462px; /* 22 (axis) + 20 * 22 (rows) */
-    overflow-y: auto;
     overflow-x: hidden;
 }
 

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1407,13 +1407,21 @@
                             // the row list is scrolled to the bottom
                             // even after layout settles.
                             updateNetworkLog(sessionId);
-                            const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
-                            if (scrollHost) {
-                                scrollHost.scrollTop = scrollHost.scrollHeight;
-                                window.requestAnimationFrame(() => {
-                                    scrollHost.scrollTop = scrollHost.scrollHeight;
-                                });
-                            }
+                            // Section has no internal scroll — the page
+                            // scrolls instead. Bring the last row into
+                            // view across two rAFs so the new entries
+                            // (which may not be in the DOM yet) are
+                            // covered.
+                            const chartHost = card.querySelector('[data-field="network_log_waterfall"]');
+                            const snapToLast = () => {
+                                const rows = chartHost ? chartHost.children : null;
+                                const last = rows && rows[rows.length - 1];
+                                if (last) last.scrollIntoView({ block: 'end', behavior: 'auto' });
+                            };
+                            window.requestAnimationFrame(() => {
+                                snapToLast();
+                                window.requestAnimationFrame(snapToLast);
+                            });
                         } else if (card) {
                             applyNetworkLogFilters(card);
                         }
@@ -2106,24 +2114,26 @@
         networkWaterfallRowsBySession.set(key, rows);
         networkWaterfallRenderSignatureBySession.set(key, sigs.length + ':' + (sigs[sigs.length - 1] || ''));
 
-        if (scrollHost && isNetworkLogFollowMode(key)) {
-            scrollHost.scrollTop = scrollHost.scrollHeight;
+        // Following Latest: bring the last row into view via the page
+        // scroll. The waterfall has no internal scroll cap — the
+        // section grows with the data — so we use the bottom row's
+        // own scrollIntoView instead of `scrollTop = scrollHeight`.
+        if (isNetworkLogFollowMode(key)) {
+            const rowEls = chartHost.children;
+            const lastRow = rowEls[rowEls.length - 1];
+            if (lastRow) {
+                lastRow.scrollIntoView({ block: 'end', behavior: 'auto' });
+            }
         }
         updateNetworkLogFollowButton(card, key);
 
-        // Lazy-attach scroll listener — scrolling away from the bottom
-        // disables Following Latest.
-        if (scrollHost && !scrollHost.dataset.netwfBound) {
-            scrollHost.dataset.netwfBound = '1';
-            scrollHost.addEventListener('scroll', () => {
-                const c = scrollHost.closest('.session-card');
-                const sid = c ? String(c.dataset.sessionId || '') : '';
-                if (!sid) return;
-                if (isNetworkLogFollowMode(sid) && scrollHost.scrollTop + scrollHost.clientHeight < scrollHost.scrollHeight - 4) {
-                    setNetworkLogFollowMode(sid, false);
-                    updateNetworkLogFollowButton(c, sid);
-                }
-            }, { passive: true });
+        // Lazy-attach an IntersectionObserver on the last-row sentinel
+        // so when the user scrolls the page away from the live tail
+        // (the bottom of the row list leaves the viewport) we
+        // auto-disable Following Latest. One observer per chart host.
+        if (chartHost && !chartHost.dataset.netwfFollowObserved) {
+            chartHost.dataset.netwfFollowObserved = '1';
+            attachWaterfallFollowObserver(card, chartHost);
         }
 
         // Lazy-attach hover tooltip handlers on the chart host.
@@ -2131,6 +2141,31 @@
             chartHost.dataset.netwfTipBound = '1';
             attachWaterfallHoverTooltip(chartHost);
         }
+    }
+
+    function attachWaterfallFollowObserver(card, chartHost) {
+        if (typeof window.IntersectionObserver !== 'function') return;
+        const sessionId = String(card.dataset.sessionId || '');
+        if (!sessionId) return;
+        const scrollHost = chartHost.parentElement;
+        if (!scrollHost) return;
+        // A 1px sentinel placed *after* the chart host (sibling, not
+        // child) so the row-update trim loop in updateNetworkWaterfall
+        // doesn't remove it. When the sentinel is off-screen, the
+        // user has scrolled away from the live tail.
+        const sentinel = document.createElement('div');
+        sentinel.style.cssText = 'height:1px;width:1px;pointer-events:none;';
+        sentinel.dataset.field = 'netwf_follow_sentinel';
+        scrollHost.appendChild(sentinel);
+        const io = new IntersectionObserver((entries) => {
+            for (const entry of entries) {
+                if (!entry.isIntersecting && isNetworkLogFollowMode(sessionId)) {
+                    setNetworkLogFollowMode(sessionId, false);
+                    updateNetworkLogFollowButton(card, sessionId);
+                }
+            }
+        }, { threshold: 0 });
+        io.observe(sentinel);
     }
 
     let netwfTooltipEl = null;


### PR DESCRIPTION
The network log section no longer caps its height — the list grows with the data and the **page** scroll is what moves the user through it. The sticky axis row pins to the page-viewport top, so column headers stay visible while scanning.

## Why

Previously the row list was clipped to 20 rows + axis (\`max-height: 462px\`) with its own internal scrollbar. With more requests on screen, scanning the list meant one scrollbar nested inside another (the page's) — awkward, and one of those problems where you scroll past the section's bottom and the page doesn't catch up.

## Changes

- **CSS** — drop \`max-height\` and \`overflow-y\` on \`.network-log-waterfall-scroll\`. The wrapper now flows naturally.
- **Following Latest snap** — switched from \`scrollHost.scrollTop = scrollHost.scrollHeight\` (no-op when there's no internal scroll) to \`lastRow.scrollIntoView({block: 'end'})\`, which uses whatever scroll surface contains the row (the page).
- **\"Stepped away from live tail\" detection** — replaced the \`scroll\` listener on the wrapper with an \`IntersectionObserver\` watching a 1-px sentinel placed *after* the chart host (sibling, not child, so the row-update trim loop doesn't accidentally delete it). When the sentinel leaves the viewport, Following Latest auto-disables.
- **Follow-Latest button click** likewise switched to \`scrollIntoView\`, double-rAF-deferred so it covers the case where new entries are still being added to the DOM.

## Test plan

- [x] Compile / syntax (\`node -c\`).
- [x] Deploy to test-dev.
- [x] Dashboard renders with no inner scrollbar.
- [ ] Page-scroll past the network log section — sticky axis pins to page-viewport top.
- [ ] Click \"Following Latest\" — page scrolls so the bottom of the list is in view.
- [ ] Manually scroll the page so the bottom of the list leaves the viewport — Following Latest auto-disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)