### PR TITLE
fix(go-proxy): refresh fault-decision state inside the lock to defeat stale-clone races

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4027,7 +4027,15 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// Serialise the failure-decision read-modify-write so video+audio
 	// requests arriving in the same millisecond don't both pass the
 	// "1 per N seconds" filter and double-fire.
+	//
+	// The lock alone isn't enough: each goroutine has its own clone
+	// of sessionData (from the snap-clone in getSessionList above)
+	// taken BEFORE the lock — so without refreshing, two goroutines
+	// can both read segment_failure_recover_at = nil even when one
+	// of them just wrote a new value. Refresh the dedup-relevant
+	// fields from the latest snap inside the lock before deciding.
 	sessionStateMu.Lock()
+	refreshFailureStateFromLatest(a, sessionData, sessionNumber)
 	failureType := handler.HandleRequest(filename)
 	sessionStateMu.Unlock()
 
@@ -6959,6 +6967,39 @@ type FailureHandler struct {
 	failureAt        interface{}
 	failureRecoverAt interface{}
 	resetFailureType interface{}
+}
+
+// refreshFailureStateFromLatest copies the fault-decision-relevant
+// fields from the latest published session snapshot onto the
+// per-request `dst` clone. Called inside `sessionStateMu` so the
+// snapshot and the read are consistent: every goroutine entering
+// the failure-decision critical section sees the same view of
+// `<prefix>_failure_at` / `<prefix>_failure_recover_at`,
+// regardless of when its outer clone was taken.
+func refreshFailureStateFromLatest(a *App, dst SessionData, sessionID string) {
+	if a == nil || dst == nil || sessionID == "" {
+		return
+	}
+	latest := a.getSessionList()
+	for _, s := range latest {
+		if getString(s, "session_id") != sessionID {
+			continue
+		}
+		// Counters and timestamps that gate the dedup. Order matters
+		// only in the sense that all of these need to come from the
+		// same snapshot.
+		for _, k := range []string{
+			"segments_count", "manifest_requests_count", "master_manifest_requests_count",
+			"segment_failure_at", "segment_failure_recover_at",
+			"manifest_failure_at", "manifest_failure_recover_at",
+			"master_manifest_failure_at", "master_manifest_failure_recover_at",
+		} {
+			if v, ok := s[k]; ok {
+				dst[k] = v
+			}
+		}
+		return
+	}
 }
 
 func NewFailureHandler(prefix string, session SessionData) *FailureHandler {


### PR DESCRIPTION
Follow-up to #295 and #298. Repro'd from a live testing session — \"1 per 5 s\" rule still firing twice within 500ms:

\`\`\`
12:03:51.796  GET 720p/segment_00033.m4s   404
12:03:52.280  GET 540p/segment_00033.m4s   404   ← only 484ms after #1
\`\`\`

## Root cause: stale-clone race, not a missing lock

\`handleProxy\` starts with \`sessionList := a.getSessionList()\` which deep-clones the published snapshot — each goroutine has its OWN copy of \`sessionData\`. Two goroutines arriving close together both clone before either has called \`saveSessionByID\`:

1. **Goroutine A** clones (\`segment_failure_recover_at = nil\`).
2. **Goroutine B** clones — still nil; A hasn't saved yet.
3. A acquires \`sessionStateMu\`, decides \"fire fault\", writes \`recover_at\` on its clone, unlocks, saves — snap now has \`recover_at\`.
4. B acquires the same mutex, runs \`HandleRequest\` on its **CLONE** — still nil — fires another fault.

The mutex prevents simultaneous *writes*, but does nothing about B reading from a snapshot that was already stale before B acquired the lock.

## Fix

Inside the lock, copy the dedup-relevant fields from the latest published snap onto the request's clone *before* running \`HandleRequest\`. Now the lock protects both the write and the \"latest known state\" read; B sees A's \`recover_at\` and the 1-per-N rule holds.

\`refreshFailureStateFromLatest\` covers all keys \`NewFailureHandler\` consumes:
- \`segments_count\` / \`manifest_requests_count\` / \`master_manifest_requests_count\`
- \`segment_failure_at\` / \`segment_failure_recover_at\`
- \`manifest_failure_at\` / \`manifest_failure_recover_at\`
- \`master_manifest_failure_at\` / \`master_manifest_failure_recover_at\`

## Test plan

- [x] \`go build ./go-proxy/cmd/server/\`.
- [x] Deploy to test-dev (\`make test-deploy-dev\`).
- [ ] Configure \"1 fault per 5 s\", load multi-variant content (audio + video) — verify exactly one 404 per 5 s window across all variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)