### PR TITLE
fix(go-proxy): move saveSessionByID inside the fault-decision lock

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4028,18 +4028,22 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// requests arriving in the same millisecond don't both pass the
 	// "1 per N seconds" filter and double-fire.
 	//
-	// The lock alone isn't enough: each goroutine has its own clone
-	// of sessionData (from the snap-clone in getSessionList above)
-	// taken BEFORE the lock — so without refreshing, two goroutines
-	// can both read segment_failure_recover_at = nil even when one
-	// of them just wrote a new value. Refresh the dedup-relevant
-	// fields from the latest snap inside the lock before deciding.
+	// The full atomic sequence is:
+	//   1. Refresh dedup state from the latest snap (defeats stale
+	//      clones).
+	//   2. Run HandleRequest (decides + writes to local clone).
+	//   3. Save back to the snap BEFORE unlocking, so the next
+	//      goroutine to take the lock sees this goroutine's writes
+	//      when it refreshes.
+	// The save MUST be inside the lock — if it's after the unlock,
+	// a second goroutine can acquire the lock and refresh from a
+	// snap that still doesn't have the first goroutine's writes,
+	// and the rule fires twice.
 	sessionStateMu.Lock()
 	refreshFailureStateFromLatest(a, sessionData, sessionNumber)
 	failureType := handler.HandleRequest(filename)
-	sessionStateMu.Unlock()
-
 	a.saveSessionByID(sessionNumber, sessionData)
+	sessionStateMu.Unlock()
 
 	if failureType != "none" {
 		log.Printf("FAILURE! Identifier: %s, %s, %s", sessionNumber, upstreamURL, failureType)


### PR DESCRIPTION
Final piece of the race fix that started in #295.

User reproduced a double-fault with "1 per 5s":
```
12:09:47.551  audio/segment_00036.m4s  404
12:09:48.567  audio/segment_00036.m4s  404   ← 1s later
```

#299 added `refreshFailureStateFromLatest` inside the lock, which closed the stale-clone window — but `saveSessionByID` was still happening **after** the lock release:

1. A locks
2. A refreshes from snap
3. A decides fault, writes `recover_at` on its clone
4. A unlocks ← snap NOT yet updated
5. A: `a.saveSessionByID()` ← snap finally updated
6. B locks (could happen between steps 4 and 5)
7. B refreshes from snap ← still no `recover_at`
8. B decides fault too

Window between 4 and 5 is small but non-zero, and at moderate request rates it bites.

Fix: pull `saveSessionByID` inside the lock so the next goroutine's refresh always sees this goroutine's writes. Lock ordering stays consistent (`sessionStateMu` → `sessionsMu`); `saveSessionByID` never takes `sessionStateMu`, no deadlock risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)