### PR TITLE
fix(go-proxy): make Frequency = cycle length, not gap-after-recovery

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -7076,6 +7076,9 @@ func (h *FailureHandler) handleFailureCount(count int, now time.Time) {
 			return
 		}
 		if h.failureFrequency > 0 {
+			// Mixed-units case (counts overall, seconds on-window).
+			// Schedule next fault `freq` requests from now — the on-
+			// window cost in counts is unknown so we don't subtract.
 			h.failureAt = count + h.failureFrequency
 			h.failureType = "none"
 			h.failureRecoverAt = nil
@@ -7096,7 +7099,15 @@ func (h *FailureHandler) handleFailureCount(count int, now time.Time) {
 		return
 	}
 	if h.failureFrequency > 0 {
-		h.failureAt = count + h.failureFrequency
+		// Frequency = full cycle length (fault start → next fault
+		// start). Subtract the on-window in counts so the gap after
+		// recovery makes the cycle exactly `freq` requests. Clamp ≥0
+		// in case the user set freq < consec.
+		gap := h.failureFrequency - h.consecutive
+		if gap < 0 {
+			gap = 0
+		}
+		h.failureAt = count + gap
 		h.failureType = "none"
 		h.failureRecoverAt = nil
 		return
@@ -7129,7 +7140,15 @@ func (h *FailureHandler) handleFailureTime(count int, now time.Time) {
 			return
 		}
 		if h.failureFrequency > 0 {
-			h.failureAt = now.Add(time.Duration(h.failureFrequency) * time.Second).Format("2006-01-02T15:04:05.000")
+			// Frequency = full cycle length (fault start → next fault
+			// start). Subtract the on-window so the gap after recovery
+			// makes the cycle exactly `freq` seconds. Clamp ≥0 in case
+			// the user set freq < consec (would mean continuous fault).
+			gapSec := h.failureFrequency - h.consecutive
+			if gapSec < 0 {
+				gapSec = 0
+			}
+			h.failureAt = now.Add(time.Duration(gapSec) * time.Second).Format("2006-01-02T15:04:05.000")
 			h.failureType = "none"
 			h.failureRecoverAt = nil
 			return
@@ -7149,6 +7168,9 @@ func (h *FailureHandler) handleFailureTime(count int, now time.Time) {
 		return
 	}
 	if h.failureFrequency > 0 {
+		// Mixed-units case: fault on-window is counts but the gap
+		// scheduling is in seconds. Keep the existing semantics —
+		// next fault scheduled `freq` seconds from recovery wallclock.
 		h.failureAt = now.Add(time.Duration(h.failureFrequency) * time.Second).Format("2006-01-02T15:04:05.000")
 		h.failureType = "none"
 		h.failureRecoverAt = nil


### PR DESCRIPTION
User configured "1 fault per 5 seconds" / "1 per 5 requests" and saw faults at **6-second / 6-request** intervals. The previous semantics interpreted `frequency` as "quiet time after recovery", so the real cycle was `consecutive + frequency`.

## Fix

Aligned the math so `frequency` is the **full cycle length** (fault start → next fault start):

- Time-on / time-gap path: `failureAt = recovery_now + (freq - consec) sec`
- Count-on / count-gap path: `failureAt = recovery_count + (freq - consec)`
- Mixed-units paths left as-is (semantics ambiguous when on-window and gap are different units)
- Clamp at zero so `freq < consec` doesn't go negative.

## Result with `consecutive=1, frequency=5`

| Mode | Before | After |
|---|---|---|
| Seconds (time/time) | 1s fault + 5s gap = 6s cycle | 1s fault + 4s gap = **5s cycle** |
| Requests (count/count) | 1 fault + 5 quiet = 6 req cycle | 1 fault + 4 quiet = **5 req cycle** |

Also dropped the temporary `FAULT_DBG` diagnostic logs — locks and saves are confirmed working from #295/#298/#299/#300; no need for the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)