### PR TITLE
fix(go-proxy): default frequencyUnits to seconds when session has no Mode

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -7016,11 +7016,18 @@ func NewFailureHandler(prefix string, session SessionData) *FailureHandler {
 	if frequencyUnits == "" {
 		frequencyUnits = failureUnits
 	}
+	// Defaults match the dashboard's visible default Mode
+	// ("Failures / Seconds"), which maps to consecutiveUnits=requests
+	// and frequencyUnits=seconds. The dashboard only PATCHes Mode
+	// when the user actively changes it, so a session whose
+	// `<prefix>_failure_mode` field was never set still has empty
+	// units here. Defaulting to the same shape as the visible Mode
+	// avoids "rate limit doesn't fire as expected" on first use.
 	if consecutiveUnits == "" {
 		consecutiveUnits = "requests"
 	}
 	if frequencyUnits == "" {
-		frequencyUnits = "requests"
+		frequencyUnits = "seconds"
 	}
 	resetFailureType := session[prefix+"_reset_failure_type"]
 	if resetString, ok := resetFailureType.(string); ok {


### PR DESCRIPTION
Companion fix to #301. The dashboard's Mode dropdown displays "Failures / Seconds" as the visible default for a fresh session — but that default is only PATCHed to the server when the user actively changes the value. A session that never had Mode touched has empty `<prefix>_failure_mode` / `_consecutive_units` / `_frequency_units` on the server side, and `NewFailureHandler` then fell back to `frequencyUnits = "requests"`. So "1 per 5 seconds" silently ran as "1 per 5 requests".

Match `NewFailureHandler`'s empty-fallback to the dashboard's visible default: `consecutiveUnits=requests`, `frequencyUnits=seconds`. That's the shape `unitsFromMode("failures_per_seconds")` produces, so users get the time-based semantics they see in the UI without having to toggle Mode off and back to "save" it.

Sessions that explicitly chose another Mode (Seconds / Requests) have non-empty units and skip these fallbacks unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)