### PR TITLE
fix(dashboard): don't reset Following Latest from IntersectionObserver's initial observe() report

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2157,9 +2157,19 @@
         sentinel.style.cssText = 'height:1px;width:1px;pointer-events:none;';
         sentinel.dataset.field = 'netwf_follow_sentinel';
         scrollHost.appendChild(sentinel);
+        // IntersectionObserver fires once on observe() to report the
+        // initial state. If the network log section is below the
+        // viewport at that moment (user hasn't scrolled to it yet) we'd
+        // get isIntersecting=false immediately and reset Following
+        // Latest before the user did anything. Only react to the
+        // sentinel leaving the viewport AFTER it has been visible at
+        // least once.
+        let hasBeenVisible = false;
         const io = new IntersectionObserver((entries) => {
             for (const entry of entries) {
-                if (!entry.isIntersecting && isNetworkLogFollowMode(sessionId)) {
+                if (entry.isIntersecting) {
+                    hasBeenVisible = true;
+                } else if (hasBeenVisible && isNetworkLogFollowMode(sessionId)) {
                     setNetworkLogFollowMode(sessionId, false);
                     updateNetworkLogFollowButton(card, sessionId);
                 }


### PR DESCRIPTION
User opens the page, sees Following Latest reset to off without having clicked anything.

`IntersectionObserver` fires once on `observe()` to report the initial state of the watched element. The follow-latest sentinel sits at the bottom of the network log section; if the user's initial scroll position has the section below the viewport (long page, fresh load), that initial fire reports `isIntersecting=false` and immediately disables Following Latest.

Fix: track `hasBeenVisible`. Only react to "no longer intersecting" **after** the sentinel has been visible at least once — i.e. require an actual transition from in-view to out-of-view, not just an initial out-of-view report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)