### PR TITLE
chore(dashboard): reduce brush minimum / default span from 60s to 30s

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -54,7 +54,7 @@
     // Default and minimum brush span. Tighter than this and the time
     // axis gets too granular to be useful; this is also the default
     // initial span when a session first opens.
-    const networkWaterfallMinBrushMs = 1 * 60 * 1000;
+    const networkWaterfallMinBrushMs = 30 * 1000;
     const networkLogAutoRefreshTimers = new Map();
     const networkLogFetchInFlight = new Set();
     const networkLogAutoRefreshMs = 1500;


### PR DESCRIPTION
Per-row bars are still legible at 30 s, and on a slow LL-HLS session 30 s captures roughly the last variant switch + a few segment fetches — useful resolution for short-window debugging without forcing the user to drag wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)