### PR TITLE
chore(dashboard): double the network log inner-scroll height (40 rows)

### DIFF
--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -535,7 +535,7 @@
  * wheel handler that enforces this behaviour. */
 .network-log-waterfall-scroll {
     width: 100%;
-    max-height: 462px; /* ~22 (axis) + 20 * 22 (rows) — same fit as before */
+    max-height: 902px; /* ~22 (axis) + 40 * 22 (rows) — 2× the previous depth */
     overflow-y: auto;
     overflow-x: hidden;
 }


### PR DESCRIPTION
Bumped `max-height` on `.network-log-waterfall-scroll` from 462 px (20 rows) to 902 px (40 rows). Wheel-scrolls-the-page semantics and the Alt-wheel-scrolls-inner-list affordance unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)