### PR TITLE
feat(players): add 911 button to Apple + Android players (#308)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -354,6 +354,19 @@ public final class PlaybackMetrics {
         requestHarSnapshot("player_error", 0, /* force= */ false);
     }
 
+    /**
+     * 911 button. Fires a "user_marked" metrics event; the server
+     * recognises that and writes a HAR snapshot to /api/incidents
+     * with reason="user_marked", so the user can review what was on
+     * the wire when they tapped. Posting via the metrics path (not
+     * /har/snapshot directly) keeps the marker visible on the
+     * dashboard's events swim lane too. buildPayload already stamps
+     * an event timestamp — no extras needed.
+     */
+    public void onUserMarked() {
+        sendEvent("user_marked", Collections.<String, Object>emptyMap());
+    }
+
     /** Called when user triggers a restart (Restart Playback button, etc). */
     public void onRestart(String reason) {
         playerRestarts = Math.max(0, playerRestarts) + 1;

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -685,6 +685,16 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
      *
      * Same player_id (proxy session continuity), no catalogue refetch.
      */
+    /**
+     * 911 button — marks "something interesting just happened" so the
+     * server fires a HAR snapshot of the current session timeline. The
+     * metrics POST also surfaces a marker on the dashboard's events
+     * swim lane. Doesn't touch playback — purely a forensic capture.
+     */
+    fun mark911() {
+        metrics?.onUserMarked()
+    }
+
     fun reload() {
         metrics?.onRestart("reload")
         metrics?.release()

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/PlaybackScreen.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/PlaybackScreen.kt
@@ -294,6 +294,8 @@ private fun HudBar(
                 RecoveryButton("Retry", onActivity) { vm.retry() }
                 Spacer(Modifier.width(Space.s2))
                 RecoveryButton("Reload", onActivity) { vm.reload() }
+                Spacer(Modifier.width(Space.s2))
+                RecoveryButton("911", onActivity) { vm.mark911() }
             }
         }
     }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackScreen.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackScreen.swift
@@ -21,6 +21,7 @@ struct PlaybackScreen: View {
                 player: vm.player,
                 onRetry: { vm.retry() },
                 onReload: { vm.reload() },
+                onMark911: { vm.mark911() },
                 onOpenSettings: { vm.setSettingsOpen(true) }
             )
             .id(vm.playerEpoch)
@@ -34,6 +35,7 @@ struct PlaybackScreen: View {
                     Spacer()
                     iconButton(systemName: "arrow.clockwise") { vm.retry() }
                     iconButton(systemName: "arrow.triangle.2.circlepath") { vm.reload() }
+                    iconButton(systemName: "exclamationmark.triangle.fill") { vm.mark911() }
                     iconButton(systemName: "gearshape") { vm.setSettingsOpen(true) }
                 }
                 .padding(Space.s4)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerView.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerView.swift
@@ -15,6 +15,7 @@ struct PlayerView: UIViewControllerRepresentable {
     let player: AVPlayer
     var onRetry: (() -> Void)? = nil
     var onReload: (() -> Void)? = nil
+    var onMark911: (() -> Void)? = nil
     var onOpenSettings: (() -> Void)? = nil
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
@@ -49,6 +50,15 @@ struct PlayerView: UIViewControllerRepresentable {
                 title: "Reload",
                 image: UIImage(systemName: "arrow.triangle.2.circlepath")
             ) { _ in onReload() })
+        }
+        if let onMark911 {
+            // 911 — capture a HAR snapshot of the moment for forensic
+            // review later. Sits right of Reload to match the iOS
+            // overlay layout.
+            actions.append(UIAction(
+                title: "911",
+                image: UIImage(systemName: "exclamationmark.triangle.fill")
+            ) { _ in onMark911() })
         }
         if let onOpenSettings {
             actions.append(UIAction(

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -823,6 +823,19 @@ final class PlayerViewModel: ObservableObject {
     /// Right tool after a server restart.
     ///
     /// Same `playerId` (proxy session continuity), no catalogue refetch.
+    /// 911 button — marks "something interesting just happened" so a
+    /// HAR snapshot of the current session timeline lands on the
+    /// server's incidents directory. The metrics POST also surfaces
+    /// the marker on the dashboard's events swim lane. Doesn't touch
+    /// playback — purely a forensic capture.
+    func mark911() {
+        Task { [weak self] in
+            await self?.sendPlayerMetrics(event: "user_marked", extra: [
+                "player_metrics_user_marked_at": Self.metricsTimestampFormatter.string(from: Date())
+            ])
+        }
+    }
+
     func reload() {
         Task { [weak self] in
             await self?.requestHARSnapshot(reason: "user_reload", force: true)


### PR DESCRIPTION
Adds a **911** button right of Reload across the player UIs. Tapping it marks "something interesting just happened" — server (#310) writes a HAR snapshot of the current session timeline to /api/incidents and the dashboard's events swim lane shows the marker.

## Apple (iOS / iPadOS / tvOS)
- `PlayerViewModel.mark911()` — Task-launches `sendPlayerMetrics` with `event="user_marked"`; no playback side effects.
- `PlaybackScreen` / `PlayerView` — new icon button right of Reload using SF Symbol `exclamationmark.triangle.fill`.
  - iOS / iPadOS overlay row: extra `iconButton` between Reload and Settings.
  - tvOS transport bar: extra `UIAction("911")` in `transportBarCustomMenuItems`, same position.

## Android TV
- `PlayerViewModel.mark911()` delegates to `PlaybackMetrics.onUserMarked()`.
- `PlaybackMetrics.onUserMarked()` — `sendEvent("user_marked", emptyMap())`; the existing `buildPayload` stamps the event timestamp.
- `PlaybackScreen` — extra `RecoveryButton("911")` right of Reload in the transport row.

Server already accepts `player_metrics_last_event="user_marked"` and triggers a HAR snapshot via #310; the dashboard event swim lane shows the marker on receipt.

Refs #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)