### PR TITLE
feat(dashboard): incidents page lets you click an incident to render its waterfall inline

### DIFF
--- a/content/dashboard/incidents.html
+++ b/content/dashboard/incidents.html
@@ -5,7 +5,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Incidents - InfiniteStream</title>
     <link rel="stylesheet" href="/shared-styles.css">
+    <link rel="stylesheet" href="/dashboard/testing-session-refactored.css">
     <style>
+        .incident-viewer {
+            margin-top: 20px;
+        }
+        .incident-viewer-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            padding: 8px 12px;
+            background: var(--surface-2, #f7f7f9);
+            border: 1px solid var(--border, #d1d5db);
+            border-radius: 6px;
+            font-size: 13px;
+        }
+        .incident-viewer-host {
+            border: 1px solid var(--border, #d1d5db);
+            border-radius: 6px;
+            background: #fff;
+            padding: 8px;
+            min-height: 200px;
+        }
+        .incident-viewer-empty {
+            text-align: center;
+            color: var(--text-secondary);
+            padding: 40px 12px;
+            font-style: italic;
+        }
+        .incidents-table tbody tr.is-selected {
+            background: rgba(33, 150, 243, 0.12) !important;
+        }
+        .incidents-table tbody tr {
+            cursor: pointer;
+        }
         .incidents-table {
             width: 100%;
             border-collapse: collapse;
@@ -162,11 +196,21 @@
                         <tbody id="rows"></tbody>
                     </table>
                 </div>
+
+                <div class="incident-viewer">
+                    <div class="incident-viewer-header" id="viewerHeader">
+                        <span>Click an incident row above to load its waterfall here.</span>
+                    </div>
+                    <div class="incident-viewer-host" id="viewerHost">
+                        <div class="incident-viewer-empty">No incident selected.</div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 
     <script src="/shared/shared-nav.js"></script>
+    <script src="/dashboard/testing-session-ui.js"></script>
     <script>
         const escapeHTML = (s) => {
             if (s === null || s === undefined) return '';
@@ -255,7 +299,7 @@
             }
             emptyState.style.display = 'none';
             tableWrap.style.display = '';
-            rows.innerHTML = filtered.map(i => {
+            rows.innerHTML = filtered.map((i, idx) => {
                 // i.path is server-controlled (it's the filesystem path of the
                 // saved HAR), but treat it as untrusted and escape into both
                 // URL and attribute contexts.
@@ -276,7 +320,7 @@
                 const filenameAttr = escapeHTML(i.filename || 'incident.har');
                 const hrefAttr = escapeHTML(downloadHref);
                 return `
-                    <tr>
+                    <tr data-incident-path="${escapeHTML(i.path || '')}" data-incident-idx="${idx}">
                         <td>
                             <div>${time}</div>
                             <div class="session-id">${age}</div>
@@ -287,11 +331,55 @@
                         <td>${sourceHTML}</td>
                         <td>${fmtSize(i.size_bytes)}</td>
                         <td>
-                            <a href="${hrefAttr}" download="${filenameAttr}" class="btn btn-mini btn-secondary">Download</a>
+                            <a href="${hrefAttr}" download="${filenameAttr}" class="btn btn-mini btn-secondary" data-no-row-click="1">Download</a>
                         </td>
                     </tr>
                 `;
             }).join('');
+            // Selection handler — clicking a row loads the HAR file and
+            // hands it to the shared waterfall renderer below the table.
+            rows.querySelectorAll('tr[data-incident-path]').forEach((tr) => {
+                tr.addEventListener('click', (event) => {
+                    if (event.target.closest('[data-no-row-click]')) return;
+                    rows.querySelectorAll('tr.is-selected').forEach((r) => r.classList.remove('is-selected'));
+                    tr.classList.add('is-selected');
+                    const path = tr.dataset.incidentPath;
+                    const idx = parseInt(tr.dataset.incidentIdx, 10);
+                    const incident = filtered[idx];
+                    loadIncidentHar(path, incident);
+                });
+            });
+        }
+
+        async function loadIncidentHar(path, incident) {
+            const header = document.getElementById('viewerHeader');
+            const host = document.getElementById('viewerHost');
+            const segments = String(path || '').split('/').map(encodeURIComponent).join('/');
+            const url = `/api/incidents/${segments}`;
+            header.innerHTML = `<span>Loading <code>${escapeHTML(path)}</code>…</span>`;
+            host.innerHTML = '<div class="incident-viewer-empty">Loading…</div>';
+            try {
+                const r = await fetch(url);
+                if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                const har = await r.json();
+                const entryCount = (har.log && Array.isArray(har.log.entries)) ? har.log.entries.length : 0;
+                header.innerHTML = `
+                    <span>
+                        <strong>${escapeHTML(incident.filename || path)}</strong>
+                        — ${entryCount} request${entryCount === 1 ? '' : 's'}
+                        — reason <code>${escapeHTML(incident.reason || '—')}</code>
+                    </span>
+                    <a href="${escapeHTML(url)}" download="${escapeHTML(incident.filename || 'incident.har')}" class="btn btn-mini btn-secondary">Download</a>
+                `;
+                if (window.TestingSessionUI && typeof window.TestingSessionUI.renderHarWaterfall === 'function') {
+                    window.TestingSessionUI.renderHarWaterfall(host, har);
+                } else {
+                    host.innerHTML = '<div class="incident-viewer-empty">Waterfall renderer not loaded.</div>';
+                }
+            } catch (e) {
+                header.innerHTML = `<span style="color: var(--danger, #b91c1c);">Failed to load: ${escapeHTML(e.message)}</span>`;
+                host.innerHTML = '<div class="incident-viewer-empty">Could not parse incident HAR.</div>';
+            }
         }
 
         document.getElementById('refreshBtn').addEventListener('click', loadIncidents);

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -2753,6 +2753,85 @@
         initializeUI();
     }
 
+    // renderHarWaterfall(hostEl, harDoc) — drop a one-shot read-only
+    // waterfall view of a HAR document into hostEl. Used by the
+    // Incidents page so a clicked incident expands into the same
+    // network-log visualisation the testing session shows. Reuses
+    // the same DOM/CSS scaffold by synthesising a stripped session
+    // card and routing through updateNetworkWaterfall, so visual
+    // changes here track the live testing view automatically.
+    function renderHarWaterfall(hostEl, harDoc) {
+        if (!hostEl) return;
+        const entries = (harDoc && harDoc.log && Array.isArray(harDoc.log.entries))
+            ? harDoc.log.entries
+            : [];
+        const sessionId = `har-incident-${Date.now()}`;
+        // Build a fake-card scaffold matching what the live network
+        // log section emits in renderSessionCard. Only the
+        // network-log piece is needed.
+        hostEl.innerHTML = `
+            <div class="session-card" data-session-id="${escapeHtml(sessionId)}">
+                <div class="network-log-waterfall-wrap">
+                    <div class="netwf-summary" data-field="netwf_summary"></div>
+                    <div class="netwf-overview-axis" data-field="netwf_overview_axis"></div>
+                    <div class="netwf-overview" data-field="netwf_overview">
+                        <div class="netwf-overview-bars" data-field="netwf_overview_bars"></div>
+                        <div class="netwf-brush" data-field="netwf_brush" style="left:0%;width:100%;">
+                            <div class="netwf-brush-handle left" data-field="netwf_brush_handle_left"></div>
+                            <div class="netwf-brush-handle right" data-field="netwf_brush_handle_right"></div>
+                        </div>
+                    </div>
+                    <div class="network-log-waterfall-scroll" data-field="network_log_waterfall_scroll">
+                        <div class="network-log-waterfall" data-field="network_log_waterfall"></div>
+                    </div>
+                    <div class="network-log-waterfall-empty" data-field="network_log_waterfall_empty" style="display:none;">No requests in this incident.</div>
+                </div>
+            </div>`;
+        const card = hostEl.querySelector('.session-card');
+        // Translate HAR entries → NetworkLogEntry shape that
+        // buildWaterfallRows expects. Most fields map straight; a few
+        // (transfer_ms / wait_ms / dns_ms / connect_ms / tls_ms) come
+        // from HAR timings.
+        const networkLogEntries = entries.map((e) => {
+            const timings = e.timings || {};
+            const req = e.request || {};
+            const resp = e.response || {};
+            const status = Number(resp.status) || 0;
+            const bytesOut = Number((resp.bodySize >= 0 ? resp.bodySize : 0)
+                || (resp.content && resp.content.size) || 0);
+            const ts = e.startedDateTime || new Date().toISOString();
+            const fault = e._fault || (e._extensions && e._extensions.fault) || null;
+            return {
+                timestamp: ts,
+                method: req.method || 'GET',
+                url: req.url || '',
+                path: (() => {
+                    try { return new URL(req.url).pathname; } catch (_) { return req.url || ''; }
+                })(),
+                status,
+                bytes_in: 0,
+                bytes_out: bytesOut,
+                content_type: (resp.content && resp.content.mimeType) || '',
+                dns_ms: timings.dns >= 0 ? timings.dns : 0,
+                connect_ms: timings.connect >= 0 ? timings.connect : 0,
+                tls_ms: timings.ssl >= 0 ? timings.ssl : 0,
+                ttfb_ms: 0,
+                transfer_ms: timings.receive >= 0 ? timings.receive : 0,
+                client_wait_ms: timings.wait >= 0 ? timings.wait : 0,
+                total_ms: e.time || 0,
+                faulted: !!(fault && fault.type) || status >= 400,
+                fault_type: fault ? fault.type : '',
+                fault_action: fault ? fault.action : '',
+                request_range: (req.headers || []).find((h) => /^range$/i.test(h.name || ''))?.value || '',
+                response_content_range: (resp.headers || []).find((h) => /^content-range$/i.test(h.name || ''))?.value || ''
+            };
+        });
+        networkLogEntriesBySession.set(sessionId, networkLogEntries);
+        // Default Follow Latest off — incident view is forensic, not live.
+        setNetworkLogFollowMode(sessionId, false);
+        updateNetworkWaterfall(card, sessionId);
+    }
+
     window.TestingSessionUI = {
         renderSessionCard,
         renderPatternStepRowContent,
@@ -2765,6 +2844,7 @@
         applyCollapsibleState,
         updateNetworkLog,
         applyNetworkLogFilters,
-        updateNetworkWaterfall
+        updateNetworkWaterfall,
+        renderHarWaterfall
     };
 })();


### PR DESCRIPTION
Adds a one-shot waterfall viewer below the incidents table. Click a row → fetch the HAR file → render with the same brushable overview / row list / status colour bands as the live testing session's network log.

## testing-session-ui.js
- New `TestingSessionUI.renderHarWaterfall(hostEl, harDoc)` — synthesises a stripped session-card scaffold inside hostEl, translates `har.log.entries[]` into the `NetworkLogEntry` shape `buildWaterfallRows` expects, seeds them into the per-session entries map, and routes through the existing `updateNetworkWaterfall`. Visual changes to the live waterfall carry over automatically.

## incidents.html
- Loads `testing-session-ui.js` + its CSS bundle.
- Row click selects the incident and calls `loadIncidentHar(path, incident)` → fetch the HAR via the existing `/api/incidents/<path>` endpoint → `renderHarWaterfall`.
- New viewer header with filename / request count / reason / Download button.
- The Download anchor is marked `data-no-row-click` so clicking it doesn't also load the HAR into the viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)