### PR TITLE
feat(player + go-proxy): 911 button writes "911" log lines on client + server

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -364,6 +364,9 @@ public final class PlaybackMetrics {
      * an event timestamp — no extras needed.
      */
     public void onUserMarked() {
+        // Console marker — easy to grep adb logcat / OS logs for "911"
+        // alongside the network log entry the server writes.
+        Log.i("InfiniteStream", "911 user-marked at " + iso8601.format(new Date()));
         sendEvent("user_marked", Collections.<String, Object>emptyMap());
     }
 

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -827,11 +827,15 @@ final class PlayerViewModel: ObservableObject {
     /// HAR snapshot of the current session timeline lands on the
     /// server's incidents directory. The metrics POST also surfaces
     /// the marker on the dashboard's events swim lane. Doesn't touch
-    /// playback — purely a forensic capture.
+    /// playback — purely a forensic capture. Also writes a "911" line
+    /// to the device console so screen-recording / OS log captures
+    /// have a synchronisation point.
     func mark911() {
+        let stamp = Self.metricsTimestampFormatter.string(from: Date())
+        print("911 user-marked at \(stamp) currentURL=\(currentURL ?? "—")")
         Task { [weak self] in
             await self?.sendPlayerMetrics(event: "user_marked", extra: [
-                "player_metrics_user_marked_at": Self.metricsTimestampFormatter.string(from: Date())
+                "player_metrics_user_marked_at": stamp
             ])
         }
     }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1542,20 +1542,22 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 // takeUserMarkedSnapshot fires a HAR snapshot for the session in
 // response to the player's 911 button. Reuses the same plumbing the
 // REST endpoint and the auto-snapshot path use; the only difference
-// is reason="user_marked" and source="player_button".
+// is reason="user_marked" and source="player_button". Logs prefixed
+// with "911 USER_MARKED" for easy grep/cross-correlation with the
+// client-side "911" lines in adb logcat / Apple device logs.
 func (a *App) takeUserMarkedSnapshot(sessionID string) {
 	if sessionID == "" {
 		return
 	}
 	session := a.findSessionByID(sessionID)
 	if session == nil {
-		log.Printf("[HAR_USER_MARKED] session not found sid=%s", sessionID)
+		log.Printf("911 USER_MARKED session-not-found sid=%s", sessionID)
 		return
 	}
 	playerID := getString(session, "player_id")
 	const source = "player_button"
 	if snapshotShouldDebounce(playerID, source, false) {
-		log.Printf("[HAR_USER_MARKED] debounced sid=%s player_id=%s", sessionID, playerID)
+		log.Printf("911 USER_MARKED debounced sid=%s player_id=%s", sessionID, playerID)
 		return
 	}
 	incident := &har.Incident{
@@ -1567,10 +1569,10 @@ func (a *App) takeUserMarkedSnapshot(sessionID string) {
 	doc := a.buildHARForSession(session, incident, HARBuildFilter{}, nil)
 	info, err := writeIncidentFile(sessionID, playerID, "user_marked", source, doc)
 	if err != nil {
-		log.Printf("[HAR_USER_MARKED] write failed sid=%s err=%v", sessionID, err)
+		log.Printf("911 USER_MARKED write-failed sid=%s err=%v", sessionID, err)
 		return
 	}
-	log.Printf("[HAR_USER_MARKED] saved sid=%s file=%s bytes=%d", sessionID, info.Filename, info.SizeBytes)
+	log.Printf("911 USER_MARKED saved sid=%s player_id=%s file=%s bytes=%d", sessionID, playerID, info.Filename, info.SizeBytes)
 }
 
 func isSignificantPlayerEvent(event string) bool {


### PR DESCRIPTION
User asked for a stable grep token that crosses the three layers so a 911 tap leaves a clear breadcrumb trail across `adb logcat` / Apple device logs / `docker logs`.

## Apple (`PlayerViewModel.mark911`)
`print("911 user-marked at <iso8601> currentURL=<url>")`

## Android (`PlaybackMetrics.onUserMarked`)
`Log.i("InfiniteStream", "911 user-marked at <iso8601>")`

## go-proxy (`takeUserMarkedSnapshot`)
Renamed the existing log lines from `[HAR_USER_MARKED]` to `911 USER_MARKED` prefix so they grep alongside the client lines. Logs cover saved / debounced / write-failed / session-not-found paths and now include `player_id` for cross-correlation.

Refs #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)