### PR TITLE
chore(go-proxy): label 911 HAR reason as "user 911" instead of "user_marked"

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1560,14 +1560,18 @@ func (a *App) takeUserMarkedSnapshot(sessionID string) {
 		log.Printf("911 USER_MARKED debounced sid=%s player_id=%s", sessionID, playerID)
 		return
 	}
+	// Label the saved HAR with a friendlier "user 911" reason
+	// (matches the on-screen button); the player-facing event type
+	// stays "user_marked" for the metrics path.
+	const harReason = "user 911"
 	incident := &har.Incident{
-		Reason:    "user_marked",
+		Reason:    harReason,
 		Source:    source,
 		SessionID: sessionID,
 		Timestamp: time.Now().UTC(),
 	}
 	doc := a.buildHARForSession(session, incident, HARBuildFilter{}, nil)
-	info, err := writeIncidentFile(sessionID, playerID, "user_marked", source, doc)
+	info, err := writeIncidentFile(sessionID, playerID, harReason, source, doc)
 	if err != nil {
 		log.Printf("911 USER_MARKED write-failed sid=%s err=%v", sessionID, err)
 		return


### PR DESCRIPTION
User feedback: when scanning the incidents list, `user_marked` is opaque next to neighbours like `frozen` / `segment_stall` / `user_reload`. `user 911` matches the on-screen button label.

The metrics-event type **stays** `user_marked` — that's the canonical identifier the dashboard's events swim lane and `isSignificantPlayerEvent` already key off. Only the human-facing `reason` embedded in the HAR file (and shown in the incidents table's Reason column) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)