### PR TITLE
fix(go-proxy): 911 HAR snapshot includes all plays, not just the latest

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1570,7 +1570,12 @@ func (a *App) takeUserMarkedSnapshot(sessionID string) {
 		SessionID: sessionID,
 		Timestamp: time.Now().UTC(),
 	}
-	doc := a.buildHARForSession(session, incident, HARBuildFilter{}, nil)
+	// 911 is forensic — "give me everything that led up to this".
+	// Default play_id scoping (most-recent play only) trims the file
+	// to a handful of entries when the user 911s right after a
+	// retry/reload because the current play hasn't accumulated much.
+	// Use IncludeAllPlays so the user sees the full session timeline.
+	doc := a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true}, nil)
 	info, err := writeIncidentFile(sessionID, playerID, harReason, source, doc)
 	if err != nil {
 		log.Printf("911 USER_MARKED write-failed sid=%s err=%v", sessionID, err)


### PR DESCRIPTION
User reported 911-captured HARs were only 2 entries long.

## Root cause

`takeUserMarkedSnapshot` used the default `HARBuildFilter`, which auto-scopes to the most-recent `play_id` (added in #280/#289). If the user hits 911 right after a retry/reload, the current play has only accumulated a handful of segments — those are all that ended up in the HAR.

## Fix

For 911 the intent is **"give me the full session forensic trail that led up to this moment"**, not "just the play I'm in". Pass `HARBuildFilter{IncludeAllPlays: true}` so the saved HAR reflects every entry in the per-session ring buffer (capped server-side at 5000 entries — same cap the dashboard's Save HAR button uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)