### PR TITLE
feat(incidents): bulk delete + per-row delete + 911 last-minute clip + 911 in empty-state copy

### DIFF
--- a/content/dashboard/incidents.html
+++ b/content/dashboard/incidents.html
@@ -145,6 +145,7 @@
                 <div class="header-actions">
                     <h1>🚨 Incidents</h1>
                     <div class="header-actions-right">
+                        <button id="deleteSelectedBtn" class="btn btn-danger" disabled>Delete Selected</button>
                         <button id="refreshBtn" class="btn btn-secondary">Refresh</button>
                     </div>
                 </div>
@@ -177,13 +178,19 @@
                 <div id="emptyState" class="no-data" style="display: none;">
                     <div class="no-data-icon">📭</div>
                     <h2>No incidents captured yet</h2>
-                    <p>Open a testing session, induce a fault, and the freeze/recovery path will write a HAR here. Or hit <strong>Save HAR</strong> in the Network Log of a testing session.</p>
+                    <p>Three ways to land an incident here:</p>
+                    <ul style="text-align: left; max-width: 560px; margin: 0 auto;">
+                        <li>Tap <strong>911</strong> on the iOS / iPadOS / tvOS / Android TV player when you spot something interesting — server saves a HAR labelled <code>user 911</code>.</li>
+                        <li>Open a testing session and induce a fault — the freeze / segment-stall / auto-recovery path writes a HAR here.</li>
+                        <li>Hit <strong>Download HAR</strong> in the Network Log of a testing session for a manual snapshot.</li>
+                    </ul>
                 </div>
 
                 <div id="tableWrap" style="display: none;">
                     <table class="incidents-table">
                         <thead>
                             <tr>
+                                <th style="width: 32px;"><input type="checkbox" id="selectAll"></th>
                                 <th>When</th>
                                 <th>Reason</th>
                                 <th>Player</th>
@@ -321,6 +328,7 @@
                 const hrefAttr = escapeHTML(downloadHref);
                 return `
                     <tr data-incident-path="${escapeHTML(i.path || '')}" data-incident-idx="${idx}">
+                        <td><input type="checkbox" class="row-select" data-no-row-click="1" data-path="${escapeHTML(i.path || '')}"></td>
                         <td>
                             <div>${time}</div>
                             <div class="session-id">${age}</div>
@@ -332,6 +340,7 @@
                         <td>${fmtSize(i.size_bytes)}</td>
                         <td>
                             <a href="${hrefAttr}" download="${filenameAttr}" class="btn btn-mini btn-secondary" data-no-row-click="1">Download</a>
+                            <button class="btn btn-mini btn-danger row-delete" data-no-row-click="1" data-path="${escapeHTML(i.path || '')}" title="Delete this incident">×</button>
                         </td>
                     </tr>
                 `;
@@ -349,6 +358,66 @@
                     loadIncidentHar(path, incident);
                 });
             });
+            // Per-row checkboxes — keep "Delete Selected" enabled state
+            // in sync with how many are checked.
+            rows.querySelectorAll('input.row-select').forEach((cb) => {
+                cb.addEventListener('change', updateDeleteSelectedState);
+            });
+            // Per-row delete buttons — confirm + DELETE the single file.
+            rows.querySelectorAll('button.row-delete').forEach((btn) => {
+                btn.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const path = btn.dataset.path;
+                    if (!path) return;
+                    if (!window.confirm(`Delete this incident?\n\n${path}`)) return;
+                    deleteIncidents([path]);
+                });
+            });
+            updateDeleteSelectedState();
+        }
+
+        function updateDeleteSelectedState() {
+            const checked = document.querySelectorAll('input.row-select:checked').length;
+            const btn = document.getElementById('deleteSelectedBtn');
+            btn.disabled = checked === 0;
+            btn.textContent = checked > 0 ? `Delete ${checked} Selected` : 'Delete Selected';
+            // Keep the header select-all in tri-state agreement.
+            const all = document.querySelectorAll('input.row-select');
+            const selectAll = document.getElementById('selectAll');
+            if (all.length === 0) {
+                selectAll.checked = false;
+                selectAll.indeterminate = false;
+            } else if (checked === 0) {
+                selectAll.checked = false;
+                selectAll.indeterminate = false;
+            } else if (checked === all.length) {
+                selectAll.checked = true;
+                selectAll.indeterminate = false;
+            } else {
+                selectAll.indeterminate = true;
+            }
+        }
+
+        async function deleteIncidents(paths) {
+            const failures = [];
+            await Promise.all(paths.map(async (path) => {
+                const segs = String(path).split('/').map(encodeURIComponent).join('/');
+                try {
+                    const r = await fetch(`/api/incidents/${segs}`, { method: 'DELETE' });
+                    if (!r.ok) failures.push(`${path}: HTTP ${r.status}`);
+                } catch (e) {
+                    failures.push(`${path}: ${e.message}`);
+                }
+            }));
+            if (failures.length) {
+                window.alert(`Some deletes failed:\n${failures.join('\n')}`);
+            }
+            // Clear the viewer if the loaded incident was just deleted.
+            const host = document.getElementById('viewerHost');
+            const header = document.getElementById('viewerHeader');
+            host.innerHTML = '<div class="incident-viewer-empty">No incident selected.</div>';
+            header.innerHTML = '<span>Click an incident row above to load its waterfall here.</span>';
+            await loadIncidents();
         }
 
         async function loadIncidentHar(path, incident) {
@@ -383,6 +452,23 @@
         }
 
         document.getElementById('refreshBtn').addEventListener('click', loadIncidents);
+        document.getElementById('selectAll').addEventListener('change', (e) => {
+            document.querySelectorAll('input.row-select').forEach((cb) => {
+                cb.checked = e.target.checked;
+            });
+            updateDeleteSelectedState();
+        });
+        document.getElementById('deleteSelectedBtn').addEventListener('click', () => {
+            const paths = Array.from(document.querySelectorAll('input.row-select:checked'))
+                .map((cb) => cb.dataset.path)
+                .filter(Boolean);
+            if (paths.length === 0) return;
+            const msg = paths.length === 1
+                ? `Delete 1 incident?`
+                : `Delete ${paths.length} incidents?`;
+            if (!window.confirm(msg)) return;
+            deleteIncidents(paths);
+        });
         document.getElementById('filterPlayer').addEventListener('input', render);
         document.getElementById('filterReason').addEventListener('change', render);
         document.getElementById('filterSource').addEventListener('change', render);

--- a/go-proxy/cmd/server/har_handlers.go
+++ b/go-proxy/cmd/server/har_handlers.go
@@ -177,17 +177,22 @@ type IncidentFileInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// HARBuildFilter controls play_id scoping in buildHARForSession.
+// HARBuildFilter controls scoping in buildHARForSession.
 //
 //   - PlayID == "" and IncludeAllPlays == false: filter to the
 //     most-recent play_id in the ring buffer (default — matches what
 //     the player asks for at incident time).
 //   - PlayID != "": filter to that exact play_id.
-//   - IncludeAllPlays == true: no filter — every entry across every
-//     play is included (forensic mode).
+//   - IncludeAllPlays == true: no play-id filter — every entry across
+//     every play is included (forensic mode).
+//   - SinceWindow > 0: also drop entries older than `SinceWindow`
+//     before the latest entry. Use this to clip to a rolling tail
+//     (e.g. last 60s for the 911 button) without dragging in the
+//     entire ring buffer.
 type HARBuildFilter struct {
 	PlayID          string
 	IncludeAllPlays bool
+	SinceWindow     time.Duration
 }
 
 // buildHARForSession reads the session's network ring buffer and returns a HAR
@@ -210,9 +215,24 @@ func (a *App) buildHARForSession(session SessionData, incident *har.Incident, fi
 	var playStartedAt time.Time
 	if exists {
 		entries := rb.GetAll()
+		// Compute the time floor when SinceWindow is set: drop entries
+		// whose timestamp is older than (latest_entry_time - window).
+		var sinceFloor time.Time
+		if filter.SinceWindow > 0 && len(entries) > 0 {
+			latest := entries[0].Timestamp
+			for _, e := range entries {
+				if e.Timestamp.After(latest) {
+					latest = e.Timestamp
+				}
+			}
+			sinceFloor = latest.Add(-filter.SinceWindow)
+		}
 		sources = make([]har.Source, 0, len(entries))
 		for _, e := range entries {
 			if !filter.IncludeAllPlays && resolvedPlayID != "" && e.PlayID != resolvedPlayID {
+				continue
+			}
+			if !sinceFloor.IsZero() && e.Timestamp.Before(sinceFloor) {
 				continue
 			}
 			if playStartedAt.IsZero() || e.Timestamp.Before(playStartedAt) {
@@ -621,6 +641,49 @@ func (a *App) handleGetIncidentFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`attachment; filename="%s"`, filepath.Base(full)))
 	_, _ = io.Copy(w, f)
+}
+
+// handleDeleteIncidentFile removes a saved HAR file from disk.
+// DELETE /api/incidents/{path:.+}
+//
+// Same path-injection guards as handleGetIncidentFile: regex
+// whitelist + filepath-prefix check after Abs/Clean. Refuses any
+// path that escapes the incidents directory.
+func (a *App) handleDeleteIncidentFile(w http.ResponseWriter, r *http.Request) {
+	relPath := mux.Vars(r)["path"]
+	if relPath == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "path required"})
+		return
+	}
+	if !incidentPathRe.MatchString(relPath) {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid path"})
+		return
+	}
+	root, err := filepath.Abs(resolveIncidentDir())
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "incidents dir resolve failed"})
+		return
+	}
+	full := filepath.Clean(filepath.Join(root, filepath.FromSlash(relPath)))
+	if !strings.HasPrefix(full, root+string(filepath.Separator)) && full != root {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid path"})
+		return
+	}
+	if err := os.Remove(full); err != nil {
+		if os.IsNotExist(err) {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(w, map[string]string{"error": "not found"})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": fmt.Sprintf("delete failed: %v", err)})
+		return
+	}
+	writeJSON(w, map[string]string{"status": "deleted", "path": relPath})
 }
 
 // writeIncidentFile persists doc under {incidentDir}/{date}/{filename}.

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1288,6 +1288,7 @@ func main() {
 	router.HandleFunc("/api/session/{id}/har/snapshot", app.handlePostHARSnapshot).Methods(http.MethodPost)
 	router.HandleFunc("/api/incidents", app.handleListIncidents).Methods(http.MethodGet)
 	router.HandleFunc("/api/incidents/{path:.+}", app.handleGetIncidentFile).Methods(http.MethodGet)
+	router.HandleFunc("/api/incidents/{path:.+}", app.handleDeleteIncidentFile).Methods(http.MethodDelete)
 	router.HandleFunc("/api/external-ips", app.handleGetExternalIPs).Methods(http.MethodGet)
 	router.HandleFunc("/api/clear-sessions", app.handleClearSessions).Methods(http.MethodPost)
 	router.HandleFunc("/api/session-group/link", app.handleLinkSessions).Methods(http.MethodPost)
@@ -1570,12 +1571,17 @@ func (a *App) takeUserMarkedSnapshot(sessionID string) {
 		SessionID: sessionID,
 		Timestamp: time.Now().UTC(),
 	}
-	// 911 is forensic — "give me everything that led up to this".
-	// Default play_id scoping (most-recent play only) trims the file
-	// to a handful of entries when the user 911s right after a
+	// 911 is forensic — "give me what led up to this". Default
+	// play_id scoping (most-recent play only) trims the file to a
+	// handful of entries when the user 911s right after a
 	// retry/reload because the current play hasn't accumulated much.
-	// Use IncludeAllPlays so the user sees the full session timeline.
-	doc := a.buildHARForSession(session, incident, HARBuildFilter{IncludeAllPlays: true}, nil)
+	// Use IncludeAllPlays so the user sees across plays, but clip
+	// to the last minute so the file stays focused on "what just
+	// happened" rather than dragging in the whole ring buffer.
+	doc := a.buildHARForSession(session, incident, HARBuildFilter{
+		IncludeAllPlays: true,
+		SinceWindow:     60 * time.Second,
+	}, nil)
 	info, err := writeIncidentFile(sessionID, playerID, harReason, source, doc)
 	if err != nil {
 		log.Printf("911 USER_MARKED write-failed sid=%s err=%v", sessionID, err)


### PR DESCRIPTION
## go-proxy
- **New `DELETE /api/incidents/{path:.+}`** endpoint. Same path-injection guards as the GET handler (regex whitelist + Abs/Clean prefix check). Returns 404 if the file doesn't exist, 400 on bad path.
- `HARBuildFilter` gains `SinceWindow time.Duration`. When > 0, drops entries older than `(latest_entry_timestamp - SinceWindow)`.
- **911 (`takeUserMarkedSnapshot`) clips its HAR to the last 60 s** in addition to `IncludeAllPlays` — keeps the file focused on what led up to the tap rather than dragging in the whole ring buffer.

## incidents.html
- **Per-row checkbox** + a header **select-all** (tri-state, syncs with per-row state).
- **Per-row × delete** button next to Download (confirms before firing).
- **Top-bar "Delete N Selected"** button (disabled until ≥ 1 ticked, confirms with count).
- Both delete paths route through `deleteIncidents(paths)` which parallel-DELETEs and reloads the list. Clears the inline waterfall viewer if the deleted file was loaded.
- **Empty-state** copy now leads with the 911 button as the first capture path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)