### PR TITLE
chore(go-proxy): bump 911 HAR clip window from 60s to 10min

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1576,11 +1576,11 @@ func (a *App) takeUserMarkedSnapshot(sessionID string) {
 	// handful of entries when the user 911s right after a
 	// retry/reload because the current play hasn't accumulated much.
 	// Use IncludeAllPlays so the user sees across plays, but clip
-	// to the last minute so the file stays focused on "what just
-	// happened" rather than dragging in the whole ring buffer.
+	// to the last 10 minutes so the file stays focused on "what
+	// just happened" rather than dragging in the whole ring buffer.
 	doc := a.buildHARForSession(session, incident, HARBuildFilter{
 		IncludeAllPlays: true,
-		SinceWindow:     60 * time.Second,
+		SinceWindow:     10 * time.Minute,
 	}, nil)
 	info, err := writeIncidentFile(sessionID, playerID, harReason, source, doc)
 	if err != nil {


### PR DESCRIPTION
Per user feedback — 60 s was too tight for diagnosing slower-burn issues ("the player's been weird for a while, hit 911 to capture"). 10 min still keeps the file focused without dragging in the entire 5000-entry ring buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)