### PR TITLE
fix(apple): mark911 — coerce currentURL to String for the print

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -832,7 +832,7 @@ final class PlayerViewModel: ObservableObject {
     /// have a synchronisation point.
     func mark911() {
         let stamp = Self.metricsTimestampFormatter.string(from: Date())
-        print("911 user-marked at \(stamp) currentURL=\(currentURL ?? "—")")
+        print("911 user-marked at \(stamp) currentURL=\(currentURL?.absoluteString ?? "—")")
         Task { [weak self] in
             await self?.sendPlayerMetrics(event: "user_marked", extra: [
                 "player_metrics_user_marked_at": stamp


### PR DESCRIPTION
Compile error from #314: `currentURL` is `URL?` but the `??` branch substituted a `String` literal, so Swift refused to unify the types.

Fix: `currentURL?.absoluteString ?? "—"` — chains a `String?` through the optional, which the `??` operator can resolve against the `"—"` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)