### PR TITLE
feat(go-proxy + dashboard): All-tab fault-injection override + HAR wire-status truth (#320)

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -217,13 +217,14 @@
         return base;
     }
 
-    function renderSegmentOptions(sessionId, playlists, selected) {
+    function renderSegmentOptions(sessionId, playlists, selected, fieldName) {
+        const field = fieldName || 'segment_failure_urls';
         const selectedSet = new Set(selected || []);
         const list = sortedPlaylists(playlists);
         const allChecked = selected == null ? true : selectedSet.has('All');
         const checkbox = (value, label) => {
             const checked = allChecked || selectedSet.has(value) ? 'checked' : '';
-            return `<label><input type="checkbox" data-field="segment_failure_urls" value="${value}" ${checked}>${label}</label>`;
+            return `<label><input type="checkbox" data-field="${field}" value="${value}" ${checked}>${label}</label>`;
         };
         const variants = new Map();
         list.forEach(playlist => {
@@ -485,6 +486,8 @@
         const manifestVariants = session.manifest_variants || [];
         const manifestSelected = session.manifest_failure_urls;
         const segmentSelected = session.segment_failure_urls;
+        const allSelected = session.all_failure_urls;
+        const allOverrideActive = session.all_failure_type && session.all_failure_type !== 'none';
         const inlineHost = options.inlineHost || false;
         const hideTitle = options.hideTitle || false;
         const showPortItem = options.showPortItem || false;
@@ -656,15 +659,48 @@
                         <div class="fault-injection-section">
                             <div class="tabs-container">
                                 <div class="tabs-header">
-                                    <button class="tab-button active" data-tab="segment-failures">Segment</button>
+                                    <button class="tab-button active" data-tab="all-failures">All</button>
+                                    <button class="tab-button" data-tab="segment-failures">Segment</button>
                                     <button class="tab-button" data-tab="manifest-failures">Manifest</button>
                                     <button class="tab-button" data-tab="master-failures">Master</button>
                                     <button class="tab-button" data-tab="transport-faults">Transport</button>
                                     <button class="tab-button" data-tab="content-manipulation">Content</button>
                                 </div>
                                 <div class="tabs-content">
+                                    <!-- All Tab (override) -->
+                                    <div class="tab-panel active" data-panel="all-failures">
+                                        <div class="content-tab-note" style="margin-bottom:8px">
+                                            <strong>Override:</strong> when active, this rule applies to <em>every</em> HTTP request (segments, media manifests, master). The Segment / Manifest / Master tabs are bypassed while All is active.
+                                        </div>
+                                        <div class="fault-control-row">
+                                            <label>Failure Type</label>
+                                            <div class="radio-group">
+                                                ${renderFailureTypeOptions(`all_failure_type_${sessionId}`, session.all_failure_type)}
+                                            </div>
+                                        </div>
+                                        <div class="fault-control-row">
+                                            <label>Scope</label>
+                                            <div class="checkbox-group">${renderSegmentOptions(sessionId, manifestVariants, allSelected, 'all_failure_urls')}</div>
+                                        </div>
+                                        <div class="fault-control-row">
+                                            <label>Mode</label>
+                                            ${renderModeDropdown(`all_failure_mode_${sessionId}`, session.all_failure_mode || 'failures_per_seconds')}
+                                        </div>
+                                        <div class="range-row">
+                                            <label>Consecutive</label>
+                                            <input type="range" min="0" max="10" step="1" data-field="all_consecutive_failures" value="${Number.isFinite(Number(session.all_consecutive_failures)) && Number(session.all_consecutive_failures) >= 0 ? Number(session.all_consecutive_failures) : 1}">
+                                            <span class="range-value">${Number.isFinite(Number(session.all_consecutive_failures)) && Number(session.all_consecutive_failures) >= 0 ? Number(session.all_consecutive_failures) : 1}</span>
+                                        </div>
+                                        <div class="range-row">
+                                            <label>Frequency</label>
+                                            <input type="range" min="0" max="30" step="1" data-field="all_failure_frequency" value="${Number.isFinite(Number(session.all_failure_frequency)) && Number(session.all_failure_frequency) >= 0 ? Number(session.all_failure_frequency) : 6}">
+                                            <span class="range-value">${Number.isFinite(Number(session.all_failure_frequency)) && Number(session.all_failure_frequency) >= 0 ? Number(session.all_failure_frequency) : 6}</span>
+                                        </div>
+                                    </div>
+
                                     <!-- Segment Tab -->
-                                    <div class="tab-panel active" data-panel="segment-failures">
+                                    <div class="tab-panel" data-panel="segment-failures">
+                                        ${allOverrideActive ? '<div class="content-tab-note" style="margin-bottom:8px;background:#fffbe6;border-color:#f0c97b"><strong>All override active</strong> — this tab is ignored. Set <em>All → Failure Type</em> to <code>none</code> to re-enable per-kind tabs.</div>' : ''}
                                         <div class="fault-control-row">
                                             <label>Failure Type</label>
                                             <div class="radio-group">
@@ -686,13 +722,14 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="segment_failure_frequency" value="${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}">
+                                            <input type="range" min="0" max="30" step="1" data-field="segment_failure_frequency" value="${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}">
                                             <span class="range-value">${Number.isFinite(Number(session.segment_failure_frequency)) && Number(session.segment_failure_frequency) >= 0 ? Number(session.segment_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
 
                                     <!-- Manifest Tab -->
                                     <div class="tab-panel" data-panel="manifest-failures">
+                                        ${allOverrideActive ? '<div class="content-tab-note" style="margin-bottom:8px;background:#fffbe6;border-color:#f0c97b"><strong>All override active</strong> — this tab is ignored. Set <em>All → Failure Type</em> to <code>none</code> to re-enable per-kind tabs.</div>' : ''}
                                         <div class="fault-control-row">
                                             <label>Failure Type</label>
                                             <div class="radio-group">
@@ -714,13 +751,14 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="manifest_failure_frequency" value="${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}">
+                                            <input type="range" min="0" max="30" step="1" data-field="manifest_failure_frequency" value="${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}">
                                             <span class="range-value">${Number.isFinite(Number(session.manifest_failure_frequency)) && Number(session.manifest_failure_frequency) >= 0 ? Number(session.manifest_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
 
                                     <!-- Master Manifest Tab -->
                                     <div class="tab-panel" data-panel="master-failures">
+                                        ${allOverrideActive ? '<div class="content-tab-note" style="margin-bottom:8px;background:#fffbe6;border-color:#f0c97b"><strong>All override active</strong> — this tab is ignored. Set <em>All → Failure Type</em> to <code>none</code> to re-enable per-kind tabs.</div>' : ''}
                                         <div class="fault-control-row">
                                             <label>Failure Type</label>
                                             <div class="radio-group">
@@ -738,7 +776,7 @@
                                         </div>
                                         <div class="range-row">
                                             <label>Frequency</label>
-                                            <input type="range" min="0" max="10" step="1" data-field="master_manifest_failure_frequency" value="${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}">
+                                            <input type="range" min="0" max="30" step="1" data-field="master_manifest_failure_frequency" value="${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}">
                                             <span class="range-value">${Number.isFinite(Number(session.master_manifest_failure_frequency)) && Number(session.master_manifest_failure_frequency) >= 0 ? Number(session.master_manifest_failure_frequency) : 6}</span>
                                         </div>
                                     </div>
@@ -1132,16 +1170,19 @@
         const segmentFailureType = getRadioValue(`segment_failure_type_${sessionId}`);
         const manifestFailureType = getRadioValue(`manifest_failure_type_${sessionId}`);
         const masterManifestFailureType = getRadioValue(`master_manifest_failure_type_${sessionId}`);
+        const allFailureType = getRadioValue(`all_failure_type_${sessionId}`);
         const transportFaultType = getRadioValue(`transport_failure_type_${sessionId}`);
 
         const segmentMode = getSelectValue(`segment_failure_mode_${sessionId}`) || 'requests';
         const manifestMode = getSelectValue(`manifest_failure_mode_${sessionId}`) || 'requests';
         const masterManifestMode = getSelectValue(`master_manifest_failure_mode_${sessionId}`) || 'requests';
+        const allMode = getSelectValue(`all_failure_mode_${sessionId}`) || 'requests';
         const transportMode = normalizeTransportMode(getRadioValue(`transport_failure_mode_${sessionId}`));
 
         const segmentUnits = unitsFromMode(segmentMode);
         const manifestUnits = unitsFromMode(manifestMode);
         const masterManifestUnits = unitsFromMode(masterManifestMode);
+        const allUnits = unitsFromMode(allMode);
         const transportUnits = transportUnitsFromMode(transportMode);
 
         const getRangeValue = (field) => {
@@ -1152,6 +1193,8 @@
         const manifestChecks = Array.from(card.querySelectorAll('input[data-field="manifest_failure_urls"]:checked'))
             .map(input => input.value);
         const segmentChecks = Array.from(card.querySelectorAll('input[data-field="segment_failure_urls"]:checked'))
+            .map(input => input.value);
+        const allChecks = Array.from(card.querySelectorAll('input[data-field="all_failure_urls"]:checked'))
             .map(input => input.value);
         
         // Transfer timeout settings
@@ -1201,6 +1244,16 @@
             master_manifest_consecutive_units: masterManifestUnits.consecutiveUnits,
             master_manifest_frequency_units: masterManifestUnits.frequencyUnits,
             master_manifest_failure_mode: masterManifestMode,
+            all_failure_at: null,
+            all_failure_recover_at: null,
+            all_failure_type: allFailureType,
+            all_failure_frequency: getRangeValue('all_failure_frequency'),
+            all_consecutive_failures: getRangeValue('all_consecutive_failures'),
+            all_failure_units: allUnits.consecutiveUnits,
+            all_consecutive_units: allUnits.consecutiveUnits,
+            all_frequency_units: allUnits.frequencyUnits,
+            all_failure_mode: allMode,
+            all_failure_urls: allChecks,
             transport_failure_type: transportFaultType,
             transport_failure_frequency: getRangeValue('transport_failure_frequency'),
             transport_consecutive_failures: getRangeValue('transport_consecutive_failures'),
@@ -1394,7 +1447,7 @@
                 }
                 return;
             }
-            if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls') return;
+            if (field !== 'segment_failure_urls' && field !== 'manifest_failure_urls' && field !== 'all_failure_urls') return;
             const group = cb.closest('.checkbox-group');
             if (!group) return;
             const allCheckboxes = group.querySelectorAll(`input[data-field="${field}"]`);
@@ -2269,7 +2322,7 @@
     }
 
     function buildRowSignature(row) {
-        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}`;
+        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.entry.fault_category || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}`;
     }
 
     function waterfallRowStatusClasses(row) {
@@ -2319,7 +2372,29 @@
         const bytesLabel = formatKBNumber(bytesOut);
         const mbpsLabel = formatMbpsNumber(bytesOut, row.transfer);
         const path = row.pathDisplay || row.filename || '';
-        const flags = (row.is_retry ? '↻' : '') + (row.entry.faulted ? '!' : '');
+        // Distinguish the three "looked like 200, ended badly" cases
+        // since the status column alone can't tell them apart:
+        //   ✂ socket fault inject — server deliberately cut the body
+        //                           (request_body_*/connect_*/first_byte_*).
+        //                           Status is forced to 503 by the proxy.
+        //   ⏱ transfer timeout    — server gave up on slow upstream or
+        //                           idle player drain (transfer_active_/
+        //                           idle_timeout). Status is upstream's
+        //                           original (typ. 200) for mid-body, or
+        //                           504 if it tripped pre-headers.
+        //   ↩ client disconnect  — the player aborted mid-transfer.
+        //                           Status is upstream's original.
+        // Everything else (HTTP 4xx/5xx, transport drop/reject, corruption)
+        // keeps the plain "!" — the status code already tells the story.
+        const faultCategory = String(row.entry.fault_category || '').toLowerCase();
+        let faultGlyph = '';
+        if (row.entry.faulted) {
+            if (faultCategory === 'socket') faultGlyph = '!✂';
+            else if (faultCategory === 'transfer_timeout') faultGlyph = '!⏱';
+            else if (faultCategory === 'client_disconnect') faultGlyph = '!↩';
+            else faultGlyph = '!';
+        }
+        const flags = (row.is_retry ? '↻' : '') + faultGlyph;
         const statusCode = Number(row.entry.status) || 0;
 
         const cells = [

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -2896,19 +2896,24 @@
             syncRadio('segment_failure_type', String(session.segment_failure_type || 'none'));
             syncRadio('manifest_failure_type', String(session.manifest_failure_type || 'none'));
             syncRadio('master_manifest_failure_type', String(session.master_manifest_failure_type || 'none'));
+            syncRadio('all_failure_type', String(session.all_failure_type || 'none'));
             syncRadio('transport_failure_type', normalizeTransportFaultType(session));
             syncRadio('transport_failure_mode', normalizeTransportFailureMode(session));
             syncSelect('segment_failure_mode', String(session.segment_failure_mode || 'failures_per_seconds'));
             syncSelect('manifest_failure_mode', String(session.manifest_failure_mode || 'failures_per_seconds'));
             syncSelect('master_manifest_failure_mode', String(session.master_manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('all_failure_mode', String(session.all_failure_mode || 'failures_per_seconds'));
             syncRange('segment_consecutive_failures', session.segment_consecutive_failures, 1);
             syncRange('segment_failure_frequency', session.segment_failure_frequency, 6);
             syncRange('manifest_consecutive_failures', session.manifest_consecutive_failures, 1);
             syncRange('manifest_failure_frequency', session.manifest_failure_frequency, 6);
             syncRange('master_manifest_consecutive_failures', session.master_manifest_consecutive_failures, 1);
             syncRange('master_manifest_failure_frequency', session.master_manifest_failure_frequency, 6);
+            syncRange('all_consecutive_failures', session.all_consecutive_failures, 1);
+            syncRange('all_failure_frequency', session.all_failure_frequency, 6);
             syncFailureScope('segment_failure_urls', session.segment_failure_urls, true);
             syncFailureScope('manifest_failure_urls', session.manifest_failure_urls, false);
+            syncFailureScope('all_failure_urls', session.all_failure_urls, true);
             TestingSessionUI.updateTransportModeUi(card);
             const transportConsecutiveInput = card.querySelector('input[data-field="transport_consecutive_failures"]');
             const transportFrequencyInput = card.querySelector('input[data-field="transport_failure_frequency"]');
@@ -3163,6 +3168,8 @@
                 'manifest_failure_frequency',
                 'master_manifest_consecutive_failures',
                 'master_manifest_failure_frequency',
+                'all_consecutive_failures',
+                'all_failure_frequency',
                 'transport_consecutive_failures',
                 'transport_failure_frequency',
                 'transfer_active_timeout_seconds',
@@ -3334,7 +3341,7 @@
         }
 
         function resolveSessionPatchFields(target, sessionId, field) {
-            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls') {
+            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls' || field === 'all_failure_urls') {
                 return [field];
             }
             const prefix = parseSessionControlName(target.name, sessionId);

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -1497,19 +1497,24 @@ maybe a histogram of b
             syncRadio('segment_failure_type', String(session.segment_failure_type || 'none'));
             syncRadio('manifest_failure_type', String(session.manifest_failure_type || 'none'));
             syncRadio('master_manifest_failure_type', String(session.master_manifest_failure_type || 'none'));
+            syncRadio('all_failure_type', String(session.all_failure_type || 'none'));
             syncRadio('transport_failure_type', normalizeTransportFaultType(session));
             syncRadio('transport_failure_mode', normalizeTransportFailureMode(session));
             syncSelect('segment_failure_mode', String(session.segment_failure_mode || 'failures_per_seconds'));
             syncSelect('manifest_failure_mode', String(session.manifest_failure_mode || 'failures_per_seconds'));
             syncSelect('master_manifest_failure_mode', String(session.master_manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('all_failure_mode', String(session.all_failure_mode || 'failures_per_seconds'));
             syncRange('segment_consecutive_failures', session.segment_consecutive_failures, 1);
             syncRange('segment_failure_frequency', session.segment_failure_frequency, 6);
             syncRange('manifest_consecutive_failures', session.manifest_consecutive_failures, 1);
             syncRange('manifest_failure_frequency', session.manifest_failure_frequency, 6);
             syncRange('master_manifest_consecutive_failures', session.master_manifest_consecutive_failures, 1);
             syncRange('master_manifest_failure_frequency', session.master_manifest_failure_frequency, 6);
+            syncRange('all_consecutive_failures', session.all_consecutive_failures, 1);
+            syncRange('all_failure_frequency', session.all_failure_frequency, 6);
             syncFailureScope('segment_failure_urls', session.segment_failure_urls, true);
             syncFailureScope('manifest_failure_urls', session.manifest_failure_urls, true);
+            syncFailureScope('all_failure_urls', session.all_failure_urls, true);
             TestingSessionUI.updateTransportModeUi(card);
             const transportConsecutiveInput = card.querySelector('input[data-field="transport_consecutive_failures"]');
             const transportFrequencyInput = card.querySelector('input[data-field="transport_failure_frequency"]');
@@ -4545,6 +4550,8 @@ maybe a histogram of b
                 'manifest_failure_frequency',
                 'master_manifest_consecutive_failures',
                 'master_manifest_failure_frequency',
+                'all_consecutive_failures',
+                'all_failure_frequency',
                 'transport_consecutive_failures',
                 'transport_failure_frequency',
                 'transfer_active_timeout_seconds',
@@ -4680,7 +4687,7 @@ maybe a histogram of b
         // the Mode-dropdown handler so any single edit ships the
         // coherent bundle.
         function failureBundleFields(field) {
-            const prefixes = ['segment', 'manifest', 'master_manifest', 'transport'];
+            const prefixes = ['segment', 'manifest', 'master_manifest', 'all', 'transport'];
             for (const prefix of prefixes) {
                 const matches =
                     field === `${prefix}_failure_mode` ||
@@ -4735,7 +4742,7 @@ maybe a histogram of b
         }
 
         function resolveSessionPatchFields(target, sessionId, field) {
-            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls') {
+            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls' || field === 'all_failure_urls') {
                 return [field];
             }
             const prefix = parseSessionControlName(target.name, sessionId);

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3886,6 +3886,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"manifest_requests_count":                  0,
 			"master_manifest_requests_count":           0,
 			"segments_count":                           0,
+			"all_requests_count":                       0,
 			"last_request":                             createdAt,
 			"first_request_time":                       createdAt,
 			"session_start_time":                       createdAt,
@@ -3918,6 +3919,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"master_manifest_frequency_units":          "seconds",
 			"master_manifest_failure_mode":             "failures_per_seconds",
 			"master_manifest_consecutive_failures":     0,
+			// "All" fault override — when all_failure_type != "none",
+			// HandleRequest uses this rule for every HTTP request and
+			// ignores the per-kind tabs above. Same control shape as
+			// segment, plus all_failure_urls for variant scoping.
+			"all_failure_type":                         "none",
+			"all_failure_frequency":                    0,
+			"all_consecutive_failures":                 0,
+			"all_failure_units":                        "requests",
+			"all_consecutive_units":                    "requests",
+			"all_frequency_units":                      "seconds",
+			"all_failure_mode":                         "failures_per_seconds",
 			"current_failures":                         0,
 			"consecutive_failures_count":               0,
 			"player_ip":                                requesterIP,
@@ -3933,6 +3945,9 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"segment_failure_recover_at":               nil,
 			"master_manifest_failure_at":               nil,
 			"master_manifest_failure_recover_at":       nil,
+			"all_failure_at":                           nil,
+			"all_failure_recover_at":                   nil,
+			"all_failure_urls":                         []string{},
 			"transport_failure_type":                   "none",
 			"transport_failure_frequency":              0,
 			"transport_consecutive_failures":           1,
@@ -4244,11 +4259,28 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			bumpFaultCounter(sessionData, failureType)
 			logFaultEvent(sessionData, externalPort, failureType, requestKind, actionTaken)
 			updateSessionTraffic(sessionData, requestBytes, 0)
-			// Log network entry for socket fault
-			// Socket faults manipulate the connection directly (RST, hang, delay)
-			// and don't generate HTTP responses, so we log with 503 status
+			// The status logged here must reflect what the *client*
+			// saw on the wire, not an internal sentinel:
+			//  - request_connect_*  → nothing was written; no status.
+			//                         Use 0 so the dashboard renders "—".
+			//  - request_first_byte_*, request_body_* → applySocketFault
+			//                         emitted "HTTP/1.1 200 OK" via
+			//                         writeChunkedHeaders before the cut,
+			//                         so the wire status is 200.
+			//  - applySocketFault hijack-failure fallback → we wrote 503
+			//                         via w.WriteHeader, so 503.
 			sessionID := getString(sessionData, "session_id")
-			status := http.StatusServiceUnavailable
+			var status int
+			switch {
+			case actionTaken == "fallback_http_503":
+				status = http.StatusServiceUnavailable
+			case strings.HasPrefix(failureType, "request_connect_"):
+				status = 0
+			default:
+				// request_first_byte_*, request_body_*: chunked
+				// headers (200 OK) were written before the cut.
+				status = http.StatusOK
+			}
 			netEntry := createFaultLogEntry(playerURL, upstreamURL, requestKind, failureType, actionTaken, status, requestBytes, requestReceivedAt)
 			stampNetMeta(&netEntry, requestHeaders, queryString, nil)
 			logEntry(sessionID,netEntry)
@@ -5553,6 +5585,23 @@ func categorizeFaultType(faultType string) string {
 	// Transport faults
 	if strings.HasPrefix(faultType, "transport_") {
 		return "transport"
+	}
+
+	// Server-enforced transfer timeouts (active or idle). These look
+	// superficially like a 200 that got cut, same as a socket fault —
+	// but the cut came from go-proxy's transfer-timeout policy, not
+	// from injected request_body_*. Dashboard distinguishes via this
+	// category so the waterfall can render a clock glyph rather than
+	// the scissors used for deliberate fault injection.
+	if strings.HasPrefix(faultType, "transfer_") {
+		return "transfer_timeout"
+	}
+
+	// Client gave up mid-transfer (broken pipe / ECONNRESET from the
+	// player's side). Tagged at the call site, but mirrored here for
+	// consistency if anything else round-trips through this fn.
+	if faultType == "client_disconnect" {
+		return "client_disconnect"
 	}
 
 	// HTTP faults (404, 500, etc.)
@@ -7072,9 +7121,11 @@ func refreshFailureStateFromLatest(a *App, dst SessionData, sessionID string) {
 		// same snapshot.
 		for _, k := range []string{
 			"segments_count", "manifest_requests_count", "master_manifest_requests_count",
+			"all_requests_count",
 			"segment_failure_at", "segment_failure_recover_at",
 			"manifest_failure_at", "manifest_failure_recover_at",
 			"master_manifest_failure_at", "master_manifest_failure_recover_at",
+			"all_failure_at", "all_failure_recover_at",
 		} {
 			if v, ok := s[k]; ok {
 				dst[k] = v
@@ -7447,6 +7498,14 @@ func NewRequestHandler(isSegment, isUpdateManifest, isMasterManifest bool, sessi
 }
 
 func (h *RequestHandler) HandleRequest(filename string) string {
+	// "All" override — when set, every HTTP request runs through the
+	// single all-rule and the per-kind tabs (segment/manifest/master)
+	// are bypassed. The dashboard reflects this by disabling those
+	// tabs and showing an "All override active" banner.
+	if getString(h.session, "all_failure_type") != "" &&
+		getString(h.session, "all_failure_type") != "none" {
+		return h.handleAllFailure(filename)
+	}
 	switch h.mode {
 	case "segment":
 		return h.handleSegmentFailure(filename)
@@ -7457,6 +7516,45 @@ func (h *RequestHandler) HandleRequest(filename string) string {
 	default:
 		return "none"
 	}
+}
+
+func (h *RequestHandler) handleAllFailure(filename string) string {
+	h.session["all_requests_count"] = getInt(h.session, "all_requests_count") + 1
+	allURLs := getStringSlice(h.session, "all_failure_urls")
+	if len(allURLs) > 0 {
+		if !shouldApplyFailure(allURLs, filename, pathParent(filename)) {
+			return "none"
+		}
+	}
+	preFailureAt := h.session["all_failure_at"]
+	preFailureRecoverAt := h.session["all_failure_recover_at"]
+	failure := NewFailureHandler("all", h.session)
+	count := getInt(h.session, "all_requests_count")
+	failureType := failure.HandleFailure(count, time.Now())
+	log.Printf(
+		"ALL FAILURE DEBUG count=%d type_in=%s type_out=%s units=%s consecutiveUnits=%s frequencyUnits=%s freq=%d consecutive=%d preFailureAt=%v preFailureRecoverAt=%v postFailureAt=%v postFailureRecoverAt=%v file=%s",
+		count,
+		getString(h.session, "all_failure_type"),
+		failureType,
+		failure.failureUnits,
+		failure.consecutiveUnits,
+		failure.frequencyUnits,
+		failure.failureFrequency,
+		failure.consecutive,
+		preFailureAt,
+		preFailureRecoverAt,
+		failure.failureAt,
+		failure.failureRecoverAt,
+		filename,
+	)
+	h.session["all_failure_at"] = failure.failureAt
+	h.session["all_failure_recover_at"] = failure.failureRecoverAt
+	if failure.resetFailureType != nil {
+		h.session["all_failure_type"] = failure.resetFailureType
+		h.session["all_reset_failure_type"] = nil
+		h.session["control_revision"] = newControlRevision()
+	}
+	return failureType
 }
 
 func (h *RequestHandler) handleFailure(prefix, countKey string) string {


### PR DESCRIPTION
## Summary

- All tab applies one fault rule to every HTTP request kind; per-kind tabs disable with an "All override active" banner. Default-selected tab. Frequency slider extended to 0–30 across all fault tabs.
- HAR network-log status reflects the actual wire status for socket faults instead of a hard-coded 503 sentinel: 200 for body/header mid-stream cuts, 0 for connect-time aborts, 503 only on hijack fallback.
- Waterfall row glyphs distinguish the three "looked like 200, ended badly" classes: ✂ socket fault inject, ⏱ server transfer-timeout, ↩ client disconnect.
- \`categorizeFaultType\` correctly returns \`transfer_timeout\` for \`transfer_*\`; was previously masked into \`http\`.

Known issue (not blocking ship): Consecutive=1 may fire twice on close-spaced manifest requests; \`ALL FAILURE DEBUG\` instrumentation added for follow-up diagnosis.

Closes #320.

## Test plan
- [ ] Reach the dashboard, open Fault Injection — All is the default-selected tab.
- [ ] Set All → Failure Type=timeout (or any other) — Segment / Manifest / Master tabs show "All override active" banner; their controls are bypassed.
- [ ] Trigger a player session under the override — every HTTP request kind faults via the All rule.
- [ ] Set All → Failure Type=request_body_reset — waterfall rows show \`!✂\` and status 200 (the actual wire status), not 503.
- [ ] Set Server Timeouts → Active timeout, induce a slow upstream — affected rows show \`!⏱\`.
- [ ] Player aborts mid-transfer — affected rows show \`!↩\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)