### PR TITLE
feat(apple + androidtv): Reset All Settings under Settings → Advanced

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -233,6 +233,36 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    /**
+     * Wipe every persisted preference (server list, Advanced flags,
+     * playback history, view counts) and reset in-memory state to
+     * first-launch defaults. AppRoot reads `state.servers.isEmpty()` to
+     * route back to ServerPicker after reset.
+     *
+     * Stops the player first so nothing keeps a reference to a
+     * now-stale session.
+     */
+    fun resetAllSettings() {
+        player.stop(); player.clearMediaItems()
+        prefs().edit().clear().apply()
+        // Reset in-memory state to declared defaults; loadAdvancedFlags
+        // then re-reads the now-empty prefs to pick up each flag's
+        // default-on-miss value.
+        _state.update {
+            it.copy(
+                servers = emptyList(),
+                activeServerIndex = 0,
+                content = emptyList(),
+                selectedContent = "",
+                currentUrl = "",
+                lastPlayed = "",
+                viewCounts = emptyMap(),
+                statusText = "",
+            )
+        }
+        loadAdvancedFlags()
+    }
+
     /** Returns the index of the (possibly newly-added) server, or -1. */
     fun addServerFromUrl(url: String): Int {
         val u = android.net.Uri.parse(url)

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -213,7 +213,12 @@ private fun SettingsPanel(
                 } else {
                     PickerList(picker!!, state, vm,
                         firstRowFocus = pickerFirstFocus,
-                        onBack = { picker = null })
+                        onBack = { picker = null },
+                        // Reset All Settings (in the Advanced picker)
+                        // wipes the server list, so AppRoot needs to
+                        // route back to ServerPicker. Reuse the same
+                        // callback the Server row uses.
+                        onResetComplete = onOpenServerPicker)
                 }
             }
 
@@ -309,7 +314,11 @@ private fun PickerList(
     vm: PlayerViewModel,
     firstRowFocus: FocusRequester,
     onBack: () -> Unit,
+    onResetComplete: () -> Unit,
 ) {
+    // Confirmation dialog state for the destructive Reset All Settings
+    // row inside the Advanced picker. Local to this composable.
+    var showResetConfirm by remember { mutableStateOf(false) }
     Column(modifier = Modifier.fillMaxWidth().fillMaxHeight()) {
         Text(
             kind.headerLabel(),
@@ -411,9 +420,26 @@ private fun PickerList(
                             onClick = { vm.setDeveloperMode(!state.developerMode) },
                         )
                     }
+                    item {
+                        DestructiveRow(
+                            label = "Reset All Settings",
+                            onClick = { showResetConfirm = true },
+                        )
+                    }
                 }
             }
         }
+    }
+
+    if (showResetConfirm) {
+        ResetConfirmDialog(
+            onConfirm = {
+                showResetConfirm = false
+                vm.resetAllSettings()
+                onResetComplete()
+            },
+            onDismiss = { showResetConfirm = false },
+        )
     }
 }
 
@@ -454,6 +480,127 @@ private fun PickerKind.headerLabel(): String = when (this) {
     PickerKind.SegmentLength -> "Segment length"
     PickerKind.Codec -> "Codec"
     PickerKind.Advanced -> "Advanced"
+}
+
+/**
+ * Destructive action row — used at the bottom of the Advanced picker
+ * for "Reset All Settings". Same shape as [PickerItem] but the label
+ * renders in [Tokens.destructive] red so users see the danger signal
+ * before they tap. Tap fires [onClick]; the caller is expected to
+ * surface a confirmation dialog before doing anything irreversible.
+ */
+@Composable
+private fun DestructiveRow(
+    label: String,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .tvFocus(cornerRadius = Radius.row)
+            .clip(RoundedCornerShape(Radius.row))
+            .background(Tokens.bgSoft)
+            .clickable(onClick = onClick)
+            .padding(horizontal = Space.s4),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, style = AppType.body.copy(color = Tokens.destructive))
+        }
+    }
+}
+
+/**
+ * Confirmation dialog for [PlayerViewModel.resetAllSettings].
+ *
+ * Built with [androidx.compose.ui.window.Dialog] from core compose-ui
+ * — the project uses `androidx.tv:tv-material` and intentionally has
+ * no `androidx.compose.material3` dependency, so AlertDialog isn't
+ * available. The custom surface keeps us in the cinematic dark theme.
+ *
+ * Cancel is auto-focused on entry so D-pad Center on the remote
+ * dismisses by default, matching tvOS / iOS where the system alert's
+ * Cancel button is the safe action.
+ */
+@Composable
+private fun ResetConfirmDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        val cancelFocus = remember { FocusRequester() }
+        LaunchedEffect(Unit) {
+            // Wait for the dialog's compose tree to mount, then put
+            // focus on Cancel — same delay-then-requestFocus pattern
+            // the surrounding drawer uses for picker rows.
+            delay(120)
+            try { cancelFocus.requestFocus() } catch (_: Throwable) {}
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .clip(RoundedCornerShape(Radius.card))
+                .background(Tokens.bgCard)
+                .border(width = 1.dp, color = Tokens.line, shape = RoundedCornerShape(Radius.card))
+                .padding(Space.s5),
+        ) {
+            Text("Reset All Settings?", style = AppType.titleSm.copy(color = Tokens.fg))
+            Spacer(Modifier.height(Space.s3))
+            Text(
+                "This will forget all saved servers and return the app to its first-launch state. Downloaded content and account data are unaffected.",
+                style = AppType.body.copy(color = Tokens.fgDim),
+            )
+            Spacer(Modifier.height(Space.s5))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                DialogButton(
+                    label = "Cancel",
+                    color = Tokens.fg,
+                    focusRequester = cancelFocus,
+                    onClick = onDismiss,
+                )
+                Spacer(Modifier.width(Space.s2))
+                DialogButton(
+                    label = "Reset",
+                    color = Tokens.destructive,
+                    onClick = onConfirm,
+                )
+            }
+        }
+    }
+}
+
+/** Plain text button used inside [ResetConfirmDialog]. Picks up the
+ * same gold focus ring as the rest of the app via [tvFocus]. */
+@Composable
+private fun DialogButton(
+    label: String,
+    color: Color,
+    focusRequester: FocusRequester? = null,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .height(40.dp)
+            .let { if (focusRequester != null) it.focusRequester(focusRequester) else it }
+            .tvFocus(cornerRadius = Radius.row)
+            .clip(RoundedCornerShape(Radius.row))
+            .background(Tokens.bgSoft)
+            .clickable(onClick = onClick)
+            .padding(horizontal = Space.s4),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxHeight(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, style = AppType.body.copy(color = color))
+        }
+    }
 }
 
 /**

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/theme/Tokens.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/theme/Tokens.kt
@@ -39,6 +39,11 @@ object Tokens {
     // Online status (green).
     val ok      = Color(0xFF4ADE80)
     val offline = Color(0xFF6B6F77)
+
+    // Destructive red — used for irreversible actions ("Reset All
+    // Settings"). Distinct from `live` so the playback LIVE badge and
+    // a destructive setting don't read as the same affordance.
+    val destructive = Color(0xFFEB4D4D)
 }
 
 // ---- Spacing scale --------------------------------------------------------

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DesignTokens.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DesignTokens.swift
@@ -33,6 +33,10 @@ enum Tokens {
     static let live = Color(red: 0.98, green: 0.30, blue: 0.34)
     /// Cool blue reserved for diagnostic / dev-mode overlays.
     static let diag = Color(red: 0.36, green: 0.74, blue: 0.95)
+    /// Destructive red used for irreversible actions ("Reset All
+    /// Settings", "Forget Server"). Distinct from `live` (the playback
+    /// LIVE badge) so the two reds don't read as the same affordance.
+    static let destructive = Color(red: 0.92, green: 0.30, blue: 0.30)
 }
 
 enum Space {

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -247,6 +247,33 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Wipe every persisted preference and return the app to its
+    /// first-launch state: empty server list, default Advanced flags,
+    /// no playback history, no content cache. AppRoot reads
+    /// `servers.isEmpty` to route back to the ServerPicker.
+    ///
+    /// Stops the player and clears the current item before the wipe so
+    /// nothing keeps a reference to a now-stale URL or session.
+    func resetAllSettings() {
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        if let domain = Bundle.main.bundleIdentifier {
+            UserDefaults.standard.removePersistentDomain(forName: domain)
+        }
+        // Drop in-memory state and reload from the now-empty defaults
+        // so every published value snaps back to its declared default.
+        servers = []
+        activeServerID = nil
+        content = []
+        selectedContent = ""
+        currentURL = nil
+        lastPlayed = ""
+        viewCounts = [:]
+        statusText = ""
+        loadAdvancedFlags()
+        setSettingsOpen(false)
+    }
+
     // MARK: - Advanced flags
 
     func setDeveloperMode(_ on: Bool) { developerMode = on; persistFlags() }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
@@ -107,7 +107,16 @@ struct SettingsOverlay: View {
 
             Group {
                 if let kind = picker {
-                    PickerList(kind: kind, vm: vm, compact: isCompact) { picker = nil }
+                    PickerList(
+                        kind: kind,
+                        vm: vm,
+                        compact: isCompact,
+                        onBack: { picker = nil },
+                        // After a Reset All Settings the app needs to
+                        // route back to ServerPicker (no servers left).
+                        // Reuse the same callback the Server row uses.
+                        onResetComplete: onOpenServerPicker
+                    )
                 } else {
                     MainList(
                         vm: vm,
@@ -223,10 +232,18 @@ private struct PickerList: View {
     @ObservedObject var vm: PlayerViewModel
     let compact: Bool
     let onBack: () -> Void
+    /// Called after Reset All Settings finishes wiping state, so the
+    /// caller can re-route the app to ServerPicker (the empty-servers
+    /// path AppRoot would normally take on first launch).
+    let onResetComplete: () -> Void
 
     /// tvOS focus seed — set to 0 on appear so the first picker item
     /// receives focus when the page enters. Same reason as `MainList.rowIdx`.
     @FocusState private var itemIdx: Int?
+
+    /// Confirmation alert state for the destructive Reset All Settings
+    /// row. Local to the picker — no need to round-trip through the VM.
+    @State private var showResetConfirm: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -244,6 +261,18 @@ private struct PickerList: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 itemIdx = 0
             }
+        }
+        // Confirmation for the destructive Reset All Settings row.
+        // .alert renders natively on iOS / iPadOS / tvOS, no extra
+        // platform branching needed.
+        .alert("Reset All Settings?", isPresented: $showResetConfirm) {
+            Button("Cancel", role: .cancel) { }
+            Button("Reset", role: .destructive) {
+                vm.resetAllSettings()
+                onResetComplete()
+            }
+        } message: {
+            Text("This will forget all saved servers and return the app to its first-launch state. Downloaded content and account data are unaffected.")
         }
     }
 
@@ -322,6 +351,10 @@ private struct PickerList: View {
             ToggleRow(label: "Developer mode",
                       isOn: vm.developerMode, compact: compact) { vm.setDeveloperMode($0) }
                 .focused($itemIdx, equals: 8)
+            DestructiveRow(label: "Reset All Settings", compact: compact) {
+                showResetConfirm = true
+            }
+            .focused($itemIdx, equals: 9)
         }
     }
 }
@@ -536,5 +569,33 @@ private struct ToggleRow: View {
                 .offset(x: isOn ? travel : -travel)
         }
         .animation(.easeOut(duration: Motion.focusS), value: isOn)
+    }
+}
+
+/// Destructive action row — used at the bottom of the Advanced picker
+/// for "Reset All Settings". Same shape as `SettingRow` / `ToggleRow`
+/// (focusable HStack + tap gesture, cinematic focus ring) but the
+/// label renders in `Tokens.destructive` red so users see the danger
+/// signal before they tap. Tap fires `onTap`; the caller is expected
+/// to surface a confirmation alert before doing anything irreversible.
+private struct DestructiveRow: View {
+    let label: String
+    let compact: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(compact ? AppType.body(size: 15) : AppType.body())
+                .foregroundColor(Tokens.destructive)
+            Spacer()
+        }
+        .padding(.horizontal, compact ? Space.s3 : Space.s4)
+        .frame(height: compact ? 42 : 56)
+        .background(Tokens.bgSoft)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.row, style: .continuous))
+        .cinematicFocus(cornerRadius: Radius.row)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onTap)
     }
 }


### PR DESCRIPTION
## Summary

Adds a destructive **Reset All Settings** row at the bottom of the Advanced picker on every player platform (iOS, iPadOS, tvOS, AndroidTV).

- Tapping presents a confirmation dialog; on confirm the app wipes every persisted preference (server list, Advanced flags, playback history, view counts), resets in-memory state to first-launch defaults, and routes back to the ServerPicker via the existing \`onOpenServerPicker\` callback.
- \`PlayerViewModel.resetAllSettings()\` — stops the player, clears the prefs domain (\`UserDefaults\` on Apple, the app's \`SharedPreferences\` file on Android), resets state, re-loads default flags.
- New \`DestructiveRow\` component — same focus / sizing shape as \`ToggleRow\` / \`SettingRow\` but renders the label in \`Tokens.destructive\` red so the danger signal is visible before tap.
- New \`Tokens.destructive\` token (red, distinct from the LIVE badge's coral) added to the design system on both platforms.
- Apple uses SwiftUI \`.alert\`; Android rolls a custom Dialog with \`androidx.compose.ui.window.Dialog\` — the project doesn't pull in \`androidx.compose.material3\` (only \`androidx.tv:tv-material\`), so AlertDialog isn't available. Cancel is auto-focused as the safe default, mirroring the system alert convention.

Confirmation copy:
> This will forget all saved servers and return the app to its first-launch state. Downloaded content and account data are unaffected.

## Test plan

- [ ] iOS / iPadOS: Settings → Advanced → Reset All Settings → confirm. App routes to ServerPicker; servers list is empty; all toggles back to defaults.
- [ ] tvOS: same flow with Siri Remote (Cancel auto-focus, D-pad → for Reset).
- [ ] AndroidTV: same flow with D-pad on the Google TV Streamer.
- [ ] Cancel from the dialog leaves state untouched.
- [ ] After reset, relaunching the app still routes to ServerPicker (verifies persisted state was actually wiped, not just in-memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)