### PR TITLE
fix(dashboard): align right edges across stacked charts; reorder Y-Max controls

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1036,6 +1036,10 @@
                         <span class="collapsible-title">Bitrate Chart</span>
                     </div>
                     <div class="collapsible-content" data-content="bitrate-chart" style="display: ${bitrateChartOpen ? 'block' : 'none'};">
+                        <div class="chart-wrap events-timeline-wrap">
+                            <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
+                            <div class="events-timeline" data-field="events_timeline"></div>
+                        </div>
                         <div class="chart-axis-row">
                             <label>Bitrate Y Max</label>
                             <div class="shape-pattern-modes" data-field="bitrate_chart_max_mbps_group">
@@ -1075,10 +1079,6 @@
                             <button type="button" class="btn btn-secondary btn-mini" data-action="reset-bitrate-zoom">Reset Zoom</button>
                             <button type="button" class="btn btn-secondary btn-mini" data-action="pause-bitrate-chart">⏸ Pause</button>
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
-                        </div>
-                        <div class="chart-wrap events-timeline-wrap">
-                            <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
-                            <div class="events-timeline" data-field="events_timeline"></div>
                         </div>
                         <div class="chart-wrap">
                             <canvas class="bandwidth-chart" data-field="bandwidth_chart"></canvas>

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1046,6 +1046,13 @@
         const controlRevisionBySession = new Map();
         const bandwidthHistory = new Map();
         const bandwidthEventHistory = new Map();
+        // Width of the right-side Y-axis on the FPS chart (Dropped/s).
+        // Used to pin every chart's right-axis or right padding to the
+        // same value so the plot areas (and x-axis ticks) line up
+        // vertically across the bandwidth / buffer-depth / FPS charts
+        // and the events-timeline above. Matches testing.html's
+        // RIGHT_AXIS_PAD_PX and the events-timeline-wrap CSS.
+        const RIGHT_AXIS_PAD_PX = 60;
         const bandwidthCharts = new Map();
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
@@ -5876,6 +5883,11 @@
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
+                        // Reserve right padding equal to the FPS chart's
+                        // right-side Y-axis (Dropped/s) width so all
+                        // stacked charts' plot areas share the same right
+                        // edge, keeping x-axis ticks vertically aligned.
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
                         scales: {
                             x: {
                                 type: 'linear',
@@ -6052,6 +6064,9 @@
                                 position: 'right',
                                 min: 0,
                                 max: maxWallClock,
+                                // Pin width so the plot's right edge
+                                // matches the bandwidth and FPS charts.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
                                 grid: { drawOnChartArea: false },
                                 ticks: {
                                     color: '#6b7280',
@@ -6316,6 +6331,10 @@
                                 position: 'right',
                                 min: 0,
                                 max: maxDroppedFps,
+                                // Pin width so the plot's right edge
+                                // matches the bandwidth and buffer-depth
+                                // charts (and the events-timeline above).
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
                                 grid: { drawOnChartArea: false },
                                 ticks: {
                                     color: '#9a3412',

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -4003,9 +4003,6 @@ maybe a histogram of b
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
-                        // Match FPS chart's right Y-axis width — see
-                        // bandwidth chart for full rationale.
-                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
                         scales: {
                             x: {
                                 type: 'linear',
@@ -4044,6 +4041,12 @@ maybe a histogram of b
                                 position: 'right',
                                 min: 0,
                                 max: maxWallClock,
+                                // Pin width to RIGHT_AXIS_PAD_PX so the
+                                // plot's right edge matches the bandwidth
+                                // and FPS charts (and the events-timeline
+                                // above), keeping x-axis ticks vertically
+                                // aligned across all stacked charts.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
                                 grid: { drawOnChartArea: false },
                                 ticks: {
                                     color: '#6b7280',


### PR DESCRIPTION
## Summary

Two related fixes to the per-session card's chart stack so timestamps line up vertically across every chart and the Y-Max controls sit right above the bitrate canvas they affect.

**Right-edge alignment** (\`testing.html\` + \`testing-session.html\`):

- \`testing.html\` buffer-depth chart was reserving **both** a 60 px \`layout.padding.right\` AND an auto-width \`y1\` axis (Wall-Clock Offset), so its plot ended ~25 px left of the bandwidth and FPS charts. Drop the padding and pin \`y1.width = RIGHT_AXIS_PAD_PX\` via \`afterFit\` so the y1 column itself provides the spacer.
- \`testing-session.html\` had no alignment compensation at all. Add a local \`RIGHT_AXIS_PAD_PX = 60\` constant; bandwidth chart now reserves it as \`layout.padding.right\` (no right axis on that chart); buffer-depth \`y1\` and FPS \`yDrop\` axes both pin to 60 px via \`afterFit\`. All three charts now end at the same x-coordinate.

**Y-Max control reorder** (\`testing-session-ui.js\`):

- The \`chart-axis-row\` (Bitrate Y Max radios + Reset Zoom + Pause + Alt-zoom hint) used to render above the events timeline, separated from the bitrate canvas it controlled. Move it to sit directly above the \`bandwidth-chart\` canvas, below the events timeline.

## Test plan

- [ ] Open testing.html, confirm the bandwidth, buffer-depth, and FPS charts' right edges all align vertically — the \`hh:mm:ss\` x-axis tick at the right edge of each chart lands at the same x-coordinate.
- [ ] Same on \`testing-session.html\`.
- [ ] The \`Bitrate Y Max\` row (Auto / 5 / 10 / 20 / 30 / 40 / 50 / 100 Mbps + Reset Zoom + Pause + Alt-zoom hint) renders directly above the bitrate canvas, below the events timeline lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)