### PR TITLE
feat(dashboard): per-chart Expand/Collapse button (#327)

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1081,13 +1081,16 @@
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
                         </div>
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="bandwidth-chart" data-field="bandwidth_chart"></canvas>
                         </div>
                         ${showBufferDepthChart ? `
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="buffer-depth-chart" data-field="buffer_depth_chart"></canvas>
                         </div>
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="video-fps-chart" data-field="video_fps_chart"></canvas>
                         </div>
                         ` : ''}
@@ -1472,6 +1475,23 @@
             const actionButton = targetElement.closest('[data-action]');
             if (actionButton) {
                 const action = actionButton.dataset.action;
+                if (action === 'toggle-chart-expanded') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const wrap = actionButton.closest('.chart-wrap');
+                    if (!wrap) return;
+                    const card = wrap.closest('.session-card');
+                    const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                    wrap.classList.toggle('chart-expanded');
+                    if (sessionId) {
+                        requestAnimationFrame(() => {
+                            document.dispatchEvent(new CustomEvent('testing-session:charts-resize', {
+                                detail: { sessionId }
+                            }));
+                        });
+                    }
+                    return;
+                }
                 if (action === 'save-har-snapshot') {
                     const card = actionButton.closest('.session-card');
                     const sessionId = card ? String(card.dataset.sessionId || '') : '';

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -517,6 +517,55 @@
             width: 100%;
         }
 
+        .chart-expand-btn {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            z-index: 11;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            height: 26px;
+            padding: 0 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: #1e293b;
+            background: #ffffff;
+            border: 1px solid #94a3b8;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+            cursor: pointer;
+        }
+        .chart-expand-btn:hover {
+            background: #f1f5f9;
+            border-color: #475569;
+        }
+        .chart-expand-icon {
+            font-size: 14px;
+            line-height: 1;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn {
+            color: #ffffff;
+            background: #2563eb;
+            border-color: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn:hover {
+            background: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-label {
+            display: none;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn::after {
+            content: 'Collapse';
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .chart-wrap.chart-expanded .bandwidth-chart { height: 660px !important; }
+        .chart-wrap.chart-expanded .buffer-depth-chart { height: 510px !important; }
+        .chart-wrap.chart-expanded .video-fps-chart { height: 510px !important; }
+
         .chart-paused-badge {
             display: none;
             position: absolute;
@@ -6383,6 +6432,7 @@
                     }
                 }
                 eventsCharts.delete(sessionId);
+                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -565,6 +565,56 @@ maybe a histogram of b
         .chart-wrap {
             position: relative;
         }
+
+        .chart-expand-btn {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            z-index: 11;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            height: 26px;
+            padding: 0 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: #1e293b;
+            background: #ffffff;
+            border: 1px solid #94a3b8;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+            cursor: pointer;
+        }
+        .chart-expand-btn:hover {
+            background: #f1f5f9;
+            border-color: #475569;
+        }
+        .chart-expand-icon {
+            font-size: 14px;
+            line-height: 1;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn {
+            color: #ffffff;
+            background: #2563eb;
+            border-color: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn:hover {
+            background: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-label {
+            display: none;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn::after {
+            content: 'Collapse';
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .chart-wrap.chart-expanded .bandwidth-chart { height: 660px !important; }
+        .chart-wrap.chart-expanded .buffer-depth-chart { height: 510px !important; }
+        .chart-wrap.chart-expanded .video-fps-chart { height: 510px !important; }
+
         .events-timeline-wrap {
             margin-bottom: 12px;
             position: relative;
@@ -3384,6 +3434,7 @@ maybe a histogram of b
                     }
                 }
                 eventsCharts.delete(sessionId);
+                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);


### PR DESCRIPTION
## Summary
- Adds a labeled "⤢ Expand" / "⤢ Collapse" button at the bottom-right of each Chart.js chart-wrap (Bandwidth, Buffer Depth, Video FPS) on the testing-session view. Click triples the canvas height in place; click again to collapse. Independent per chart.
- Fixes a latent bug in the existing `testing-session:charts-resize` handler: it called `vis.Timeline.destroy()` but never removed the destroyed timeline from the `eventsTimelines` map, leaving a stale reference that crashed the next render. The expand button reliably triggers it.

Closes #327.

Player State / events-timeline section split is **not** in this PR — it is tracked separately in #331 and will land as a follow-up.

## Test plan
- [x] Build + deploy to test-dev
- [x] Open a session, click ⤢ Expand on Bandwidth chart → height ~3x, button turns blue, label flips to "Collapse"
- [x] Click again → restores
- [x] Repeat on Buffer Depth and Video FPS
- [x] Multiple charts expanded simultaneously work independently
- [x] Pause / Reset Zoom / Alt+scroll zoom / right-drag pan still functional after expand
- [x] No console errors when toggling repeatedly (latent timeline-map bug fix verified)
- [x] Sonnet pre-commit review: ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)
