### PR TITLE
feat(dashboard): split Player State into its own collapsible section (#331)

### DIFF
--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -550,6 +550,7 @@
         const serverTimeoutsOpen = resolveSectionDefault(options, 'server-timeouts', false);
         const networkShapingOpen = resolveSectionDefault(options, 'network-shaping', true);
         const bitrateChartOpen = resolveSectionDefault(options, 'bitrate-chart', false);
+        const playerStateOpen = resolveSectionDefault(options, 'player-state', false);
         const playerMetricsOpen = resolveSectionDefault(options, 'player-metrics', false);
 
         return `
@@ -1029,6 +1030,20 @@
                     </div>
                 </div>
 
+                <!-- Collapsible Player State -->
+                <div class="collapsible-section" data-section="player-state" data-default-open="${playerStateOpen}">
+                    <div class="collapsible-header" data-toggle="player-state">
+                        <span class="collapsible-icon">${playerStateOpen ? '▼' : '▶'}</span>
+                        <span class="collapsible-title">Player State</span>
+                    </div>
+                    <div class="collapsible-content" data-content="player-state" style="display: ${playerStateOpen ? 'block' : 'none'};">
+                        <div class="chart-wrap events-timeline-wrap">
+                            <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
+                            <div class="events-timeline" data-field="events_timeline"></div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Collapsible Bitrate Chart -->
                 <div class="collapsible-section" data-section="bitrate-chart" data-default-open="${bitrateChartOpen}">
                     <div class="collapsible-header" data-toggle="bitrate-chart">
@@ -1036,10 +1051,6 @@
                         <span class="collapsible-title">Bitrate Chart</span>
                     </div>
                     <div class="collapsible-content" data-content="bitrate-chart" style="display: ${bitrateChartOpen ? 'block' : 'none'};">
-                        <div class="chart-wrap events-timeline-wrap">
-                            <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
-                            <div class="events-timeline" data-field="events_timeline"></div>
-                        </div>
                         <div class="chart-axis-row">
                             <label>Bitrate Y Max</label>
                             <div class="shape-pattern-modes" data-field="bitrate_chart_max_mbps_group">
@@ -1554,12 +1565,17 @@
                     if (section) {
                         setCollapsibleState(section, nextOpen);
                     }
-                    if (section === 'bitrate-chart' && nextOpen) {
+                    if ((section === 'bitrate-chart' || section === 'player-state') && nextOpen) {
                         const card = sectionEl ? sectionEl.closest('.session-card') : null;
                         const sessionId = card ? card.dataset.sessionId : null;
                         if (sessionId) {
+                            // When player-state opens from closed, force
+                            // the events-timeline to be rebuilt — vis.Timeline
+                            // created in a display:none container has broken
+                            // internal layout state that redraw() can't fix.
+                            const rebuildEventsTimeline = (section === 'player-state');
                             const event = new CustomEvent('testing-session:charts-resize', {
-                                detail: { sessionId }
+                                detail: { sessionId, rebuildEventsTimeline }
                             });
                             document.dispatchEvent(event);
                         }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1081,13 +1081,16 @@
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
                         </div>
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="bandwidth-chart" data-field="bandwidth_chart"></canvas>
                         </div>
                         ${showBufferDepthChart ? `
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="buffer-depth-chart" data-field="buffer_depth_chart"></canvas>
                         </div>
                         <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="video-fps-chart" data-field="video_fps_chart"></canvas>
                         </div>
                         ` : ''}
@@ -1472,6 +1475,23 @@
             const actionButton = targetElement.closest('[data-action]');
             if (actionButton) {
                 const action = actionButton.dataset.action;
+                if (action === 'toggle-chart-expanded') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    const wrap = actionButton.closest('.chart-wrap');
+                    if (!wrap) return;
+                    const card = wrap.closest('.session-card');
+                    const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                    wrap.classList.toggle('chart-expanded');
+                    if (sessionId) {
+                        requestAnimationFrame(() => {
+                            document.dispatchEvent(new CustomEvent('testing-session:charts-resize', {
+                                detail: { sessionId }
+                            }));
+                        });
+                    }
+                    return;
+                }
                 if (action === 'save-har-snapshot') {
                     const card = actionButton.closest('.session-card');
                     const sessionId = card ? String(card.dataset.sessionId || '') : '';

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -517,6 +517,55 @@
             width: 100%;
         }
 
+        .chart-expand-btn {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            z-index: 11;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            height: 26px;
+            padding: 0 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: #1e293b;
+            background: #ffffff;
+            border: 1px solid #94a3b8;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+            cursor: pointer;
+        }
+        .chart-expand-btn:hover {
+            background: #f1f5f9;
+            border-color: #475569;
+        }
+        .chart-expand-icon {
+            font-size: 14px;
+            line-height: 1;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn {
+            color: #ffffff;
+            background: #2563eb;
+            border-color: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn:hover {
+            background: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-label {
+            display: none;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn::after {
+            content: 'Collapse';
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .chart-wrap.chart-expanded .bandwidth-chart { height: 660px !important; }
+        .chart-wrap.chart-expanded .buffer-depth-chart { height: 510px !important; }
+        .chart-wrap.chart-expanded .video-fps-chart { height: 510px !important; }
+
         .chart-paused-badge {
             display: none;
             position: absolute;
@@ -6383,6 +6432,7 @@
                     }
                 }
                 eventsCharts.delete(sessionId);
+                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -6425,17 +6425,39 @@
         document.addEventListener('testing-session:charts-resize', (event) => {
             const sessionId = event.detail && event.detail.sessionId;
             if (!sessionId) return;
+            const rebuildEventsTimeline = !!(event.detail && event.detail.rebuildEventsTimeline);
             requestAnimationFrame(() => {
-                for (const chart of getChartsForSession(sessionId)) {
+                // Always destroy Chart.js charts; renderBandwidthChart
+                // recreates them.
+                const chartsToDestroy = [
+                    eventsCharts.get(sessionId),
+                    bandwidthCharts.get(sessionId),
+                    bufferDepthCharts.get(sessionId),
+                    videoFpsCharts.get(sessionId)
+                ];
+                for (const chart of chartsToDestroy) {
                     if (chart && typeof chart.destroy === 'function') {
                         chart.destroy();
                     }
                 }
                 eventsCharts.delete(sessionId);
-                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);
+                // The events-timeline (vis.Timeline) is preserved by
+                // default — destroying it on every resize would cause a
+                // visible blink in the Player State section. Rebuild
+                // only when the caller signals the container went from
+                // hidden → visible (vis.Timeline initialized in a
+                // display:none container has broken internal layout
+                // that redraw() can't fix).
+                const tl = eventsTimelines.get(sessionId);
+                if (rebuildEventsTimeline && tl) {
+                    tl.destroy();
+                    eventsTimelines.delete(sessionId);
+                } else if (tl && typeof tl.redraw === 'function') {
+                    tl.redraw();
+                }
                 renderBandwidthChart(sessionId);
             });
         });

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -3427,17 +3427,39 @@ maybe a histogram of b
         document.addEventListener('testing-session:charts-resize', (event) => {
             const sessionId = event.detail && event.detail.sessionId;
             if (!sessionId) return;
+            const rebuildEventsTimeline = !!(event.detail && event.detail.rebuildEventsTimeline);
             requestAnimationFrame(() => {
-                for (const chart of getChartsForSession(sessionId)) {
+                // Always destroy Chart.js charts; renderBandwidthChart
+                // recreates them.
+                const chartsToDestroy = [
+                    eventsCharts.get(sessionId),
+                    bandwidthCharts.get(sessionId),
+                    bufferDepthCharts.get(sessionId),
+                    videoFpsCharts.get(sessionId)
+                ];
+                for (const chart of chartsToDestroy) {
                     if (chart && typeof chart.destroy === 'function') {
                         chart.destroy();
                     }
                 }
                 eventsCharts.delete(sessionId);
-                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);
+                // The events-timeline (vis.Timeline) is preserved by
+                // default — destroying it on every resize would cause a
+                // visible blink in the Player State section. Rebuild
+                // only when the caller signals the container went from
+                // hidden → visible (vis.Timeline initialized in a
+                // display:none container has broken internal layout
+                // that redraw() can't fix).
+                const tl = eventsTimelines.get(sessionId);
+                if (rebuildEventsTimeline && tl) {
+                    tl.destroy();
+                    eventsTimelines.delete(sessionId);
+                } else if (tl && typeof tl.redraw === 'function') {
+                    tl.redraw();
+                }
                 renderBandwidthChart(sessionId);
             });
         });

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -565,6 +565,56 @@ maybe a histogram of b
         .chart-wrap {
             position: relative;
         }
+
+        .chart-expand-btn {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            z-index: 11;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
+            height: 26px;
+            padding: 0 10px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            color: #1e293b;
+            background: #ffffff;
+            border: 1px solid #94a3b8;
+            border-radius: 4px;
+            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+            cursor: pointer;
+        }
+        .chart-expand-btn:hover {
+            background: #f1f5f9;
+            border-color: #475569;
+        }
+        .chart-expand-icon {
+            font-size: 14px;
+            line-height: 1;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn {
+            color: #ffffff;
+            background: #2563eb;
+            border-color: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn:hover {
+            background: #1d4ed8;
+        }
+        .chart-wrap.chart-expanded .chart-expand-label {
+            display: none;
+        }
+        .chart-wrap.chart-expanded .chart-expand-btn::after {
+            content: 'Collapse';
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .chart-wrap.chart-expanded .bandwidth-chart { height: 660px !important; }
+        .chart-wrap.chart-expanded .buffer-depth-chart { height: 510px !important; }
+        .chart-wrap.chart-expanded .video-fps-chart { height: 510px !important; }
+
         .events-timeline-wrap {
             margin-bottom: 12px;
             position: relative;
@@ -3384,6 +3434,7 @@ maybe a histogram of b
                     }
                 }
                 eventsCharts.delete(sessionId);
+                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);


### PR DESCRIPTION
## Summary
- Extracts the events-timeline (player state visualization) out of the **Bitrate Chart** collapsible into its own new **Player State** section, sitting above it. Default closed, persisted state.
- Reworks the `testing-session:charts-resize` handler to preserve the `vis.Timeline` by default (calling `redraw()` instead of destroy/recreate) — avoids a visible blink in Player State whenever any other chart resizes.
- Rebuild path: when the toggle handler signals `rebuildEventsTimeline:true` (only on Player State going hidden→visible), full destroy + delete + recreate via `renderEventsTimelineChart`. Required because `vis.Timeline` initialized in a `display:none` container has broken internal layout state that `redraw()` alone can't fix.
- Replaces the simple `eventsTimelines.delete` fix from #332 with this more sophisticated pattern.

Closes #331. Built on top of #332 (per-chart Expand button).

## Test plan
- [x] Build + deploy to test-dev
- [x] Refresh with Player State **closed**, then open it → events-timeline renders correctly (was the trickiest path)
- [x] Refresh with Player State **open** → renders immediately on first data tick
- [x] Toggle Bitrate Chart open/closed while Player State is open → no blink in Player State
- [x] Click expand button on a Chart.js chart while Player State is open → no blink in Player State
- [x] Pause / zoom / pan still work on the events-timeline after rebuilds
- [x] Cross-page parity: same behavior on `testing-session.html` and `testing.html`
- [x] Sonnet pre-commit review: ship

## Notes
- Branch is based on `feat/327-chart-expand-button` (#332). Once #332 squash-merges, this branch will rebase cleanly onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
