### PR TITLE
ci: make Claude PR review opt-in via `@claude review` comment (#334)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,13 +1,20 @@
 name: Claude PR Review
 
-# Auto-review every non-draft PR via anthropics/claude-code-action.
-# The `prompt:` field flips the action from "wait for @claude mention"
-# into automation mode, so it runs without manual invocation.
+# Opt-in PR review: fires when an authorised user posts the literal
+# phrase `@claude review` as a comment on a PR. The previous
+# auto-review-on-every-push behaviour was burning the Max-plan token
+# budget on routine PRs (dep bumps, docs, small fixes) where the
+# author didn't want a review pass anyway.
+#
+# To request a review: comment `@claude review` on the PR.
+# `claude.yml` (the general @claude handler) explicitly excludes this
+# exact phrase so the two workflows don't double-fire.
+#
 # Auth: CLAUDE_CODE_OAUTH_TOKEN (Max plan) — same secret as claude.yml.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
@@ -17,13 +24,14 @@ permissions:
 jobs:
   review:
     if: |
-      !github.event.pull_request.draft &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-review')
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@claude review')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,10 +24,12 @@ jobs:
   claude:
     # Skip runs that can't possibly contain a mention, to avoid burning
     # Actions minutes (and API tokens) on every random comment.
+    # `@claude review` is handled by claude-review.yml — explicitly
+    # exclude it here so the two workflows don't double-fire.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !startsWith(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !startsWith(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !startsWith(github.event.review.body, '@claude review')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- `claude-review.yml` no longer fires on every PR open/sync. It now triggers only when a comment on the PR **starts with** `@claude review`.
- Same structured review prompt (Sonnet 4.6, `--max-turns 80`) — just opt-in instead of automatic.
- `claude.yml` (the general `@claude` mention handler) is updated to skip comments that start with `@claude review`, so the two workflows don't double-fire on the same trigger.
- Dropped the `skip-review` label check and the non-draft gate from `claude-review.yml` — opt-in makes both moot.

Closes #334.

## Test plan
- [ ] After merge: open a routine PR, push commits — no Claude review run fires
- [ ] Comment `@claude review` on a PR — `claude-review.yml` runs, posts a review
- [ ] Comment `@claude help me with X` on a PR — `claude.yml` runs, `claude-review.yml` does not
- [ ] Comment `@claude review`-prefixed text on a PR — only `claude-review.yml` runs (no double-fire)

## Notes
- `startsWith` rather than `contains` so casual phrases like "please @claude review the comments above" don't trigger the workflow. To invoke, the comment must begin with `@claude review`.
- This is a workflow-only change — can't be tested locally; verification happens against the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
