### PR TITLE
fix(dashboard): wire #337 Reset Zoom/Pause + chart toolbar hardening

### DIFF
--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -270,9 +270,31 @@
 }
 
 .chart-axis-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
     margin-top: 12px;
+    margin-bottom: 8px;
     padding-top: 10px;
     border-top: 1px solid #e0e0e0;
+}
+.chart-axis-row > label {
+    font-size: 11px;
+    color: var(--text-secondary);
+}
+
+/* Forces a wrap inside a flex `.chart-axis-row` (the layout
+ * testing-session.html applies via inline CSS) so the toolbar
+ * buttons fall onto a fresh row below the Y-Max radios. In
+ * non-flex contexts (testing.html) it's a zero-height block
+ * and the children already stack naturally. */
+.chart-axis-row-break {
+    flex-basis: 100%;
+    width: 100%;
+    height: 0;
+    margin: 0;
+    padding: 0;
 }
 
 /* ============================================================================
@@ -386,6 +408,22 @@
     display: flex;
     align-items: center;
     gap: 4px;
+}
+
+.shape-step-row.shape-step-disabled {
+    opacity: 0.55;
+}
+
+/* Likely-stall warning: this step's shaping rate is below the
+ * lowest video variant + a 10% safety margin, so the player will
+ * starve and stall at that rate. The class is toggled on by the
+ * stall-risk classifier in renderPatternStepRow; the visual lives
+ * here so both testing.html and testing-session.html show it. */
+.shape-step-row.shape-step-risk {
+    border: 1px solid #ef4444;
+    border-radius: 8px;
+    padding: 4px;
+    background: rgba(239, 68, 68, 0.08);
 }
 
 .shape-step-list {
@@ -723,11 +761,12 @@
  * single-label version used; users can drag from there. */
 .network-log-waterfall {
     --netwf-col-time: 116px; /* fits HH:MM:SS.mmm with padding */
-    --netwf-col-flags: 28px;
+    --netwf-col-flags: 36px;
     --netwf-col-method: 44px;
     --netwf-col-path: 200px;
     --netwf-col-bytes: 64px;
     --netwf-col-mbps: 72px;
+    --netwf-col-duration: 64px;
     --netwf-col-status: 56px;
 }
 
@@ -750,11 +789,67 @@
 .netwf-cell.path   { flex: 0 0 var(--netwf-col-path); }
 .netwf-cell.bytes  { flex: 0 0 var(--netwf-col-bytes); text-align: right; font-variant-numeric: tabular-nums; }
 .netwf-cell.mbps   { flex: 0 0 var(--netwf-col-mbps); text-align: right; font-variant-numeric: tabular-nums; }
+.netwf-cell.duration { flex: 0 0 var(--netwf-col-duration); text-align: right; font-variant-numeric: tabular-nums; }
 .netwf-cell.status {
     flex: 0 0 var(--netwf-col-status);
     text-align: center;
     font-weight: 600;
     color: #475569;
+}
+
+/* Reset Zoom button highlight when a chart viewport is stored
+ * (chart is zoomed). Solid blue fill + pulsing halo + 🔍 prefix —
+ * matches the chart-live pulse on the Pause button so both action
+ * states are visually loud. Lives in the shared stylesheet so
+ * testing.html and testing-session.html behave the same. */
+button[data-action="reset-bitrate-zoom"].zoom-active {
+    color: #ffffff;
+    border-color: #1d4ed8;
+    background-color: #1d4ed8;
+    font-weight: 600;
+    animation: chart-zoom-pulse 1.6s ease-in-out infinite;
+}
+@keyframes chart-zoom-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(29, 78, 216, 0.55); }
+    50%      { box-shadow: 0 0 0 6px rgba(29, 78, 216, 0); }
+}
+button[data-action="reset-bitrate-zoom"].zoom-active::before {
+    content: '🔍 ';
+}
+
+/* Slow segment-transfer warning: media segment took longer than
+ * the default HLS target duration (6 s) to download. Same warning
+ * palette as 4xx (amber) since it's a soft "your stream will
+ * stall" signal rather than a hard failure. */
+.netwf-row.slow-transfer {
+    background: #fffbeb;
+}
+.netwf-row.slow-transfer:hover {
+    background: #fef3c7;
+}
+.netwf-row.slow-transfer .netwf-cell.duration {
+    color: #92400e;
+    background: #fde68a;
+    font-weight: 600;
+}
+
+/* Sortable header cells: clickable, with a small arrow that lights
+ * up the active sort direction. Resizer continues to claim the
+ * right edge so the click + drag affordances don't conflict. */
+.netwf-axis .netwf-cell.sortable {
+    cursor: pointer;
+    user-select: none;
+}
+.netwf-axis .netwf-cell.sortable:hover {
+    background: #eef2f7;
+}
+.netwf-axis .netwf-cell.sort-active {
+    color: #1d4ed8;
+    background: #eff6ff;
+}
+.netwf-cell-sort-arrow {
+    font-size: 9px;
+    margin-left: 2px;
 }
 
 .netwf-row.status-2xx .netwf-cell.status { color: #065f46; background: #d1fae5; }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -50,6 +50,9 @@
     // means the brush sticks to the right edge as new entries arrive
     // (Following Latest). Drag-pan flips it to false.
     const networkWaterfallBrushBySession = new Map();
+    // Per-session column sort state: { col, dir } where dir is 'asc' or
+    // 'desc'. col=null (or absent) means default chronological order.
+    const networkWaterfallSortBySession = new Map();
     const networkWaterfallRollingWindowMs = 10 * 60 * 1000;
     // Default and minimum brush span. Tighter than this and the time
     // axis gets too granular to be useful; this is also the default
@@ -1037,6 +1040,11 @@
                         <span class="collapsible-title">Player State</span>
                     </div>
                     <div class="collapsible-content" data-content="player-state" style="display: ${playerStateOpen ? 'block' : 'none'};">
+                        <div class="chart-axis-row">
+                            <button type="button" class="btn btn-secondary btn-mini" data-action="reset-bitrate-zoom">Reset Zoom</button>
+                            <button type="button" class="btn btn-secondary btn-mini" data-action="pause-bitrate-chart">⏸ Pause</button>
+                            <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
+                        </div>
                         <div class="chart-wrap events-timeline-wrap">
                             <div class="events-timeline-legend" data-field="events_timeline_legend"></div>
                             <div class="events-timeline" data-field="events_timeline"></div>
@@ -1048,7 +1056,7 @@
                 <div class="collapsible-section" data-section="bitrate-chart" data-default-open="${bitrateChartOpen}">
                     <div class="collapsible-header" data-toggle="bitrate-chart">
                         <span class="collapsible-icon">${bitrateChartOpen ? '▼' : '▶'}</span>
-                        <span class="collapsible-title">Bitrate Chart</span>
+                        <span class="collapsible-title">Bitrate Chart etc</span>
                     </div>
                     <div class="collapsible-content" data-content="bitrate-chart" style="display: ${bitrateChartOpen ? 'block' : 'none'};">
                         <div class="chart-axis-row">
@@ -1087,6 +1095,7 @@
                                     <span>100 Mbps</span>
                                 </label>
                             </div>
+                            <div class="chart-axis-row-break"></div>
                             <button type="button" class="btn btn-secondary btn-mini" data-action="reset-bitrate-zoom">Reset Zoom</button>
                             <button type="button" class="btn btn-secondary btn-mini" data-action="pause-bitrate-chart">⏸ Pause</button>
                             <span class="chart-hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">Alt/⌥+scroll/drag to zoom · right-drag to pan</span>
@@ -2136,10 +2145,12 @@
         // Filter the row list to requests that overlap the brush
         // window. The overview above keeps showing the full session;
         // the list below shows only what the user has selected.
-        const visibleRows = rows.filter((row) => {
+        const visibleRowsRaw = rows.filter((row) => {
             const reqEnd = row.timestamp + Math.max(50, row.duration);
             return reqEnd >= brush.startMs && row.timestamp <= brush.endMs;
         });
+        const sort = getNetworkWaterfallSort(key);
+        const visibleRows = applyNetworkWaterfallSort(visibleRowsRaw, sort);
 
         // Sticky axis row at the top of the list — column headers (with
         // drag-to-resize handles) on the left, tick marks across the
@@ -2155,8 +2166,9 @@
             }
         }
         // Update the time-cell header text with current count.
-        const timeHdr = axisEl.querySelector('.netwf-cell.time');
+        const timeHdr = axisEl.querySelector('.netwf-cell.time .netwf-cell-label');
         if (timeHdr) timeHdr.textContent = `${visibleRows.length}/${rows.length}`;
+        paintWaterfallSortIndicators(axisEl, sort);
         const axisScale = axisEl.querySelector('[data-field="netwf_axis_scale"]');
         if (axisScale) {
             renderWaterfallAxisTicks(axisScale, brush.startMs, brush.endMs);
@@ -2358,7 +2370,20 @@
     }
 
     function buildRowSignature(row) {
-        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.entry.fault_category || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}`;
+        return `${row.timestamp}|${Math.round(row.duration)}|${row.entry.status || ''}|${row.entry.bytes_out || 0}|${row.label}|${row.entry.faulted ? 'F' : ''}|${row.entry.fault_type || ''}|${row.entry.fault_category || ''}|${row.attempt || 1}|${row.is_retry ? 'R' : ''}|${row.entry.request_range || ''}|${isSlowSegmentTransfer(row) ? 'S' : ''}`;
+    }
+
+    // HLS default target duration is 6s. A media-segment transfer that
+    // takes longer than that to download means the player will start to
+    // stall — flag it so it stands out in the row list. Only the actual
+    // transfer phase counts: dns/connect/tls/wait don't reduce segment
+    // availability.
+    const SLOW_SEGMENT_TRANSFER_MS = 6000;
+    const MEDIA_SEGMENT_PATH_RE = /\.(m4s|ts|mp4|m4a|m4v|aac|webm|mp3)(\?|$)/i;
+    function isSlowSegmentTransfer(row) {
+        const url = String((row && row.entry && (row.entry.url || row.entry.path)) || '');
+        if (!MEDIA_SEGMENT_PATH_RE.test(url)) return false;
+        return Number(row && row.transfer || 0) > SLOW_SEGMENT_TRANSFER_MS;
     }
 
     function waterfallRowStatusClasses(row) {
@@ -2376,6 +2401,7 @@
         else if (row.entry.faulted) cls.push(' is-faulted');
 
         if (row.is_retry) cls.push(' is-retry');
+        if (isSlowSegmentTransfer(row)) cls.push(' slow-transfer');
         return cls.join('');
     }
 
@@ -2430,16 +2456,24 @@
             else if (faultCategory === 'client_disconnect') faultGlyph = '!↩';
             else faultGlyph = '!';
         }
-        const flags = (row.is_retry ? '↻' : '') + faultGlyph;
+        // ⏰ flags a media-segment transfer that took longer than the
+        // default HLS target duration (6 s). Player stalls if this
+        // happens regularly.
+        const slowGlyph = isSlowSegmentTransfer(row) ? '⏰' : '';
+        const flags = (row.is_retry ? '↻' : '') + faultGlyph + slowGlyph;
         const statusCode = Number(row.entry.status) || 0;
+        const flagColor = row.is_retry
+            ? '#be185d'
+            : (row.entry.faulted ? '#7f1d1d' : (isSlowSegmentTransfer(row) ? '#92400e' : ''));
 
         const cells = [
             { col: 'time', text: tsLabel },
-            { col: 'flags', text: flags, color: row.is_retry ? '#be185d' : (row.entry.faulted ? '#7f1d1d' : '') },
+            { col: 'flags', text: flags, color: flagColor },
             { col: 'method', text: method },
             { col: 'path', text: path, title: row.entry.url || row.entry.path || '' },
             { col: 'bytes', text: bytesLabel },
             { col: 'mbps', text: mbpsLabel },
+            { col: 'duration', text: formatMilliseconds(row.duration) },
             { col: 'status', text: statusCode > 0 ? String(statusCode) : '—' }
         ];
         for (const c of cells) {
@@ -2508,17 +2542,66 @@
     // (`--netwf-col-${key}`) and the cell class. `min` is the smallest
     // pixel width we'll let the user drag the column to.
     const NETWF_COLUMNS = [
-        { key: 'time',   label: 'Time',     min: 60 },
+        { key: 'time',   label: 'Time',     min: 60, sortable: true },
         { key: 'flags',  label: '',         min: 16 },
-        { key: 'method', label: 'Method',   min: 30 },
-        { key: 'path',   label: 'Path',     min: 60 },
+        { key: 'method', label: 'Method',   min: 30, sortable: true },
+        { key: 'path',   label: 'Path',     min: 60, sortable: true },
         // Single-unit columns: header carries the unit, cells carry
         // tabular-aligned numbers. Bytes always rendered in KB,
         // throughput always in Mbps — easier to scan than mixed units.
-        { key: 'bytes',  label: 'KB',       min: 50 },
-        { key: 'mbps',   label: 'Mbps',     min: 50 },
-        { key: 'status', label: 'Status',   min: 40 }
+        { key: 'bytes',  label: 'KB',       min: 50, sortable: true },
+        { key: 'mbps',   label: 'Mbps',     min: 50, sortable: true },
+        // Duration is the request's full elapsed wall-clock from
+        // first byte sent to last byte received (dns + connect + tls
+        // + wait + transfer). Sortable so the slowest requests are
+        // one click away.
+        { key: 'duration', label: 'Dur',   min: 60, sortable: true },
+        { key: 'status', label: 'Status',   min: 40, sortable: true }
     ];
+
+    function netwfRowSortValue(row, col) {
+        switch (col) {
+            case 'time':     return Number(row.timestamp) || 0;
+            case 'method':   return String(row.entry.method || '');
+            case 'path':     return String(row.pathDisplay || row.filename || row.entry.path || '');
+            case 'bytes':    return Number(row.entry.bytes_out || 0);
+            case 'mbps':     return (Number(row.transfer || 0) > 0)
+                                 ? (Number(row.entry.bytes_out || 0) * 8) / (Number(row.transfer) * 1000)
+                                 : 0;
+            case 'duration': return Number(row.duration || 0);
+            case 'status':   return Number(row.entry.status || 0);
+            default:         return 0;
+        }
+    }
+
+    function getNetworkWaterfallSort(key) {
+        return networkWaterfallSortBySession.get(String(key || '')) || { col: null, dir: 'desc' };
+    }
+
+    function cycleNetworkWaterfallSort(key, col) {
+        const k = String(key || '');
+        const cur = getNetworkWaterfallSort(k);
+        let next;
+        if (cur.col !== col) next = { col, dir: 'desc' };
+        else if (cur.dir === 'desc') next = { col, dir: 'asc' };
+        else next = { col: null, dir: 'desc' };
+        networkWaterfallSortBySession.set(k, next);
+    }
+
+    function applyNetworkWaterfallSort(rows, sort) {
+        if (!sort || !sort.col) return rows;
+        const sign = sort.dir === 'asc' ? 1 : -1;
+        const sorted = rows.slice();
+        sorted.sort((a, b) => {
+            const av = netwfRowSortValue(a, sort.col);
+            const bv = netwfRowSortValue(b, sort.col);
+            if (typeof av === 'string' || typeof bv === 'string') {
+                return String(av).localeCompare(String(bv)) * sign;
+            }
+            return (av - bv) * sign;
+        });
+        return sorted;
+    }
 
     function buildWaterfallAxisRow(chartHost) {
         const axisEl = document.createElement('div');
@@ -2526,7 +2609,25 @@
         for (const col of NETWF_COLUMNS) {
             const cell = document.createElement('div');
             cell.className = `netwf-cell ${col.key}`;
-            cell.textContent = col.label;
+            cell.dataset.col = col.key;
+            const labelEl = document.createElement('span');
+            labelEl.className = 'netwf-cell-label';
+            labelEl.textContent = col.label;
+            cell.appendChild(labelEl);
+            if (col.sortable) {
+                cell.classList.add('sortable');
+                const arrowEl = document.createElement('span');
+                arrowEl.className = 'netwf-cell-sort-arrow';
+                cell.appendChild(arrowEl);
+                cell.addEventListener('click', (event) => {
+                    if (event.target.closest('.netwf-cell-resizer')) return;
+                    const card = chartHost.closest('.session-card');
+                    const sessionId = card ? card.dataset.sessionId : null;
+                    if (!sessionId) return;
+                    cycleNetworkWaterfallSort(sessionId, col.key);
+                    updateNetworkWaterfall(card, sessionId);
+                });
+            }
             const resizer = document.createElement('div');
             resizer.className = 'netwf-cell-resizer';
             resizer.dataset.col = col.key;
@@ -2540,6 +2641,22 @@
         scale.dataset.field = 'netwf_axis_scale';
         axisEl.appendChild(scale);
         return axisEl;
+    }
+
+    function paintWaterfallSortIndicators(axisEl, sort) {
+        if (!axisEl) return;
+        const activeCol = sort && sort.col;
+        const dir = sort && sort.dir;
+        for (const cell of axisEl.querySelectorAll('.netwf-cell.sortable')) {
+            const isActive = cell.dataset.col === activeCol;
+            cell.classList.toggle('sort-active', isActive);
+            cell.classList.toggle('sort-asc', isActive && dir === 'asc');
+            cell.classList.toggle('sort-desc', isActive && dir === 'desc');
+            const arrow = cell.querySelector('.netwf-cell-sort-arrow');
+            if (arrow) {
+                arrow.textContent = isActive ? (dir === 'asc' ? ' ▲' : ' ▼') : '';
+            }
+        }
     }
 
     function attachWaterfallColumnResizer(chartHost, resizer) {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -490,17 +490,6 @@
             color: var(--text-secondary);
         }
 
-        .shape-step-row.shape-step-disabled {
-            opacity: 0.55;
-        }
-
-        .shape-step-row.shape-step-risk {
-            border: 1px solid #ef4444;
-            border-radius: 8px;
-            padding: 4px;
-            background: rgba(239, 68, 68, 0.08);
-        }
-
         .session-actions {
             display: flex;
             gap: 10px;
@@ -3959,6 +3948,7 @@
                             chart.resetZoom('none');
                         }
                     }
+                    updateResetZoomButtonState(sessionId);
                     return;
                 }
                 if (button.dataset.action === 'pause-bitrate-chart') {
@@ -4390,11 +4380,37 @@
         // The default chartjs-plugin-zoom wheel is mouse-centered. We pre-empt
         // it in capture phase so our anchored zoom wins in live mode; in paused
         // mode we let the plugin do its normal mouse-centered zoom.
-        function installLiveWheelAnchor(sessionId, chartRef, canvas) {
-            if (!chartRef || !canvas) return;
-            canvas.addEventListener('wheel', (event) => {
-                if (!event.altKey) return; // plugin only zooms with Alt anyway
-                if (isChartPaused(String(sessionId))) return; // paused → let plugin handle (mouse-centered)
+        //
+        // One document-level non-passive wheel listener handles every
+        // bandwidth/events/buffer/fps chart on the page. Per-canvas
+        // listeners would fire a Chrome "non-passive scroll-blocking
+        // wheel listener" violation per session × per chart; the
+        // single delegated listener is one warning instead of N×4.
+        let chartLiveWheelInstalled = false;
+        function ensureChartLiveWheelAnchor() {
+            if (chartLiveWheelInstalled) return;
+            chartLiveWheelInstalled = true;
+            const canvasClassToMap = {
+                'bandwidth-chart': bandwidthCharts,
+                'events-chart': eventsCharts,
+                'buffer-depth-chart': bufferDepthCharts,
+                'video-fps-chart': videoFpsCharts
+            };
+            document.addEventListener('wheel', (event) => {
+                if (!event.altKey) return;
+                const canvas = event.target && event.target.closest && event.target.closest('canvas');
+                if (!canvas) return;
+                let chartMap = null;
+                for (const cls in canvasClassToMap) {
+                    if (canvas.classList.contains(cls)) { chartMap = canvasClassToMap[cls]; break; }
+                }
+                if (!chartMap) return;
+                const card = canvas.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const chartRef = chartMap.get(String(sessionId));
+                if (!chartRef) return;
+                if (isChartPaused(String(sessionId))) return;
                 event.preventDefault();
                 event.stopPropagation();
                 const xScale = chartRef.scales && chartRef.scales.x;
@@ -4403,9 +4419,8 @@
                 const currentMax = Number(xScale.max);
                 if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
                 const span = currentMax - currentMin;
-                // Zoom factor — match plugin's default speed of ~0.1
                 const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
-                let newSpan = Math.max(2, Math.min(600, span * factor));
+                const newSpan = Math.max(2, Math.min(600, span * factor));
                 const nextMax = 600;
                 const nextMin = Math.max(0, nextMax - newSpan);
                 if (typeof chartRef.zoomScale === 'function') {
@@ -4416,6 +4431,49 @@
                     chartRef.update('none');
                 }
                 syncChartViewportAcrossSession(String(sessionId), chartRef);
+            }, { capture: true, passive: false });
+        }
+
+        // vis-timeline counterpart to installLiveWheelAnchor: in live mode
+        // (not paused) Alt+wheel must zoom anchored at the right edge ("now")
+        // independent of mouse position, matching the Chart.js charts. In
+        // paused mode we let vis-timeline's own zoom plugin handle the
+        // wheel as mouse-centered zoom.
+        //
+        // One document-level non-passive wheel listener handles every
+        // events-timeline on the page — much cheaper than attaching a
+        // listener per session (which Chrome flags as a scroll-blocking
+        // perf hit).
+        let visTimelineLiveWheelInstalled = false;
+        function ensureVisTimelineLiveWheelAnchor() {
+            if (visTimelineLiveWheelInstalled) return;
+            visTimelineLiveWheelInstalled = true;
+            const ZOOM_MIN_MS = 1000;
+            const ZOOM_MAX_MS = 6 * 60 * 60 * 1000;
+            document.addEventListener('wheel', (event) => {
+                if (!event.altKey) return;
+                const container = event.target && event.target.closest && event.target.closest('.events-timeline');
+                if (!container) return;
+                const card = container.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const timeline = eventsTimelines.get(String(sessionId));
+                if (!timeline) return;
+                if (isChartPaused(String(sessionId))) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const win = timeline.getWindow();
+                const span = win.end.getTime() - win.start.getTime();
+                if (!Number.isFinite(span) || span <= 0) return;
+                const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
+                const newSpan = Math.max(ZOOM_MIN_MS, Math.min(ZOOM_MAX_MS, span * factor));
+                const nowMs = Date.now();
+                timeline.setWindow(
+                    new Date(nowMs - newSpan),
+                    new Date(nowMs),
+                    { animation: false }
+                );
+                syncChartViewportAcrossSession(String(sessionId), timeline);
             }, { capture: true, passive: false });
         }
 
@@ -4513,7 +4571,22 @@
             const viewport = chartViewportBySession.get(String(sessionId || ''));
             if (!viewport) return false;
             applyChartViewport(chartRef, viewport);
+            updateResetZoomButtonState(sessionId);
             return true;
+        }
+
+        function updateResetZoomButtonState(sessionId) {
+            const key = String(sessionId || '');
+            const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+            if (!card) return;
+            const zoomed = chartViewportBySession.has(key);
+            for (const btn of card.querySelectorAll('button[data-action="reset-bitrate-zoom"]')) {
+                btn.classList.toggle('zoom-active', zoomed);
+            }
+        }
+
+        function isDefaultChartViewport(viewport) {
+            return !!viewport && viewport.min <= 0 && viewport.max >= 600;
         }
 
         function getChartsForSession(sessionId) {
@@ -4531,16 +4604,28 @@
             const key = String(sessionId || '');
             const viewport = readChartViewport(sourceChart);
             if (!viewport) return;
-            chartViewportBySession.set(key, viewport);
+            // chart.resetZoom() fires onZoomComplete with the default
+            // 0..600 viewport — treat full-domain as "not zoomed" so
+            // the Reset Zoom highlight clears and we don't store an
+            // identity viewport that would re-pin charts on re-render.
+            if (isDefaultChartViewport(viewport)) {
+                chartViewportBySession.delete(key);
+            } else {
+                chartViewportBySession.set(key, viewport);
+            }
             for (const chartRef of getChartsForSession(key)) {
                 if (!chartRef || chartRef === sourceChart) continue;
                 applyChartViewport(chartRef, viewport);
+                // vis.Timeline lacks `update`; applyChartViewport above
+                // already redrew it via setWindow.
+                if (chartRef.$isVisTimeline) continue;
                 // zoomScale (used inside applyChartViewport) calls update internally;
                 // only call update explicitly when falling back to direct options writes.
-                if (typeof chartRef.zoomScale !== 'function') {
+                if (typeof chartRef.zoomScale !== 'function' && typeof chartRef.update === 'function') {
                     chartRef.update('none');
                 }
             }
+            updateResetZoomButtonState(key);
         }
 
         function buildUnifiedChartZoomOptions(sessionId) {
@@ -4620,10 +4705,12 @@
                 chartViewportBySession.set(rightPanDragState.sessionId, viewport);
                 for (const chart of getChartsForSession(rightPanDragState.sessionId)) {
                     applyChartViewport(chart, viewport);
-                    if (typeof chart.zoomScale !== 'function') {
+                    if (chart.$isVisTimeline) continue;
+                    if (typeof chart.zoomScale !== 'function' && typeof chart.update === 'function') {
                         chart.update('none');
                     }
                 }
+                updateResetZoomButtonState(rightPanDragState.sessionId);
             });
             window.addEventListener('mouseup', (event) => {
                 if (!rightPanDragState) return;
@@ -4645,8 +4732,7 @@
             const paused = isChartPaused(key);
             const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
             if (!card) return;
-            const btn = card.querySelector('button[data-action="pause-bitrate-chart"]');
-            if (btn) {
+            for (const btn of card.querySelectorAll('button[data-action="pause-bitrate-chart"]')) {
                 if (paused) {
                     btn.textContent = 'Live';
                     btn.classList.add('chart-live');
@@ -5236,7 +5322,7 @@
                 applyStoredChartViewport(sessionId, chart);
                 installRightMousePanHandlers(sessionId, chart);
                 installChartClickPauseHandler(sessionId, chart);
-                installLiveWheelAnchor(sessionId, chart, canvas);
+                ensureChartLiveWheelAnchor();
                 eventsCharts.set(sessionId, chart);
             } else {
                 chart.data.datasets = datasets;
@@ -5506,6 +5592,7 @@
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                ensureVisTimelineLiveWheelAnchor();
                 timeline.$isVisTimeline = true;
                 timeline.$windowStartMs = liveStart.getTime();
                 timeline.$container = container;
@@ -5976,7 +6063,7 @@
                 const restoredBitrateViewport = applyStoredChartViewport(sessionId, chart);
                 installRightMousePanHandlers(sessionId, chart);
                 installChartClickPauseHandler(sessionId, chart);
-                installLiveWheelAnchor(sessionId, chart, canvas);
+                ensureChartLiveWheelAnchor();
                 if (restoredBitrateViewport) {
                     chart.update('none');
                 }
@@ -6135,7 +6222,7 @@
                 const restoredBufferViewport = applyStoredChartViewport(sessionId, bufferChart);
                 installRightMousePanHandlers(sessionId, bufferChart);
                 installChartClickPauseHandler(sessionId, bufferChart);
-                installLiveWheelAnchor(sessionId, bufferChart, bufferCanvas);
+                ensureChartLiveWheelAnchor();
                 if (restoredBufferViewport) {
                     bufferChart.update('none');
                 }
@@ -6403,7 +6490,7 @@
                 const restoredFpsViewport = applyStoredChartViewport(sessionId, fpsChart);
                 installRightMousePanHandlers(sessionId, fpsChart);
                 installChartClickPauseHandler(sessionId, fpsChart);
-                installLiveWheelAnchor(sessionId, fpsChart, fpsCanvas);
+                ensureChartLiveWheelAnchor();
                 if (restoredFpsViewport) {
                     fpsChart.update('none');
                 }
@@ -6441,7 +6528,6 @@
                     }
                 }
                 eventsCharts.delete(sessionId);
-                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);

--- a/content/dashboard/testing.html
+++ b/content/dashboard/testing.html
@@ -2133,10 +2133,36 @@ maybe a histogram of b
         // In live (not paused) mode, intercept Alt+wheel and apply a custom
         // zoom anchored at the right edge (live point), ignoring mouse position.
         // In paused mode we let the plugin do its normal mouse-centered zoom.
-        function installLiveWheelAnchor(sessionId, chartRef, canvas) {
-            if (!chartRef || !canvas) return;
-            canvas.addEventListener('wheel', (event) => {
+        //
+        // One document-level non-passive wheel listener handles every
+        // bandwidth/events/buffer/fps chart on the page. Per-canvas
+        // listeners would fire a Chrome "non-passive scroll-blocking
+        // wheel listener" violation per session × per chart; the
+        // single delegated listener is one warning instead of N×4.
+        let chartLiveWheelInstalled = false;
+        function ensureChartLiveWheelAnchor() {
+            if (chartLiveWheelInstalled) return;
+            chartLiveWheelInstalled = true;
+            const canvasClassToMap = {
+                'bandwidth-chart': bandwidthCharts,
+                'events-chart': eventsCharts,
+                'buffer-depth-chart': bufferDepthCharts,
+                'video-fps-chart': videoFpsCharts
+            };
+            document.addEventListener('wheel', (event) => {
                 if (!event.altKey) return;
+                const canvas = event.target && event.target.closest && event.target.closest('canvas');
+                if (!canvas) return;
+                let chartMap = null;
+                for (const cls in canvasClassToMap) {
+                    if (canvas.classList.contains(cls)) { chartMap = canvasClassToMap[cls]; break; }
+                }
+                if (!chartMap) return;
+                const card = canvas.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const chartRef = chartMap.get(String(sessionId));
+                if (!chartRef) return;
                 if (isChartPaused(String(sessionId))) return;
                 event.preventDefault();
                 event.stopPropagation();
@@ -2147,7 +2173,7 @@ maybe a histogram of b
                 if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
                 const span = currentMax - currentMin;
                 const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
-                let newSpan = Math.max(2, Math.min(600, span * factor));
+                const newSpan = Math.max(2, Math.min(600, span * factor));
                 const nextMax = 600;
                 const nextMin = Math.max(0, nextMax - newSpan);
                 if (typeof chartRef.zoomScale === 'function') {
@@ -2158,6 +2184,49 @@ maybe a histogram of b
                     chartRef.update('none');
                 }
                 syncChartViewportAcrossSession(String(sessionId), chartRef);
+            }, { capture: true, passive: false });
+        }
+
+        // vis-timeline counterpart to installLiveWheelAnchor: in live mode
+        // (not paused) Alt+wheel must zoom anchored at the right edge ("now")
+        // independent of mouse position, matching the Chart.js charts. In
+        // paused mode we let vis-timeline's own zoom plugin handle the
+        // wheel as mouse-centered zoom.
+        //
+        // One document-level non-passive wheel listener handles every
+        // events-timeline on the page — much cheaper than attaching a
+        // listener per session (which Chrome flags as a scroll-blocking
+        // perf hit).
+        let visTimelineLiveWheelInstalled = false;
+        function ensureVisTimelineLiveWheelAnchor() {
+            if (visTimelineLiveWheelInstalled) return;
+            visTimelineLiveWheelInstalled = true;
+            const ZOOM_MIN_MS = 1000;
+            const ZOOM_MAX_MS = 6 * 60 * 60 * 1000;
+            document.addEventListener('wheel', (event) => {
+                if (!event.altKey) return;
+                const container = event.target && event.target.closest && event.target.closest('.events-timeline');
+                if (!container) return;
+                const card = container.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const timeline = eventsTimelines.get(String(sessionId));
+                if (!timeline) return;
+                if (isChartPaused(String(sessionId))) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const win = timeline.getWindow();
+                const span = win.end.getTime() - win.start.getTime();
+                if (!Number.isFinite(span) || span <= 0) return;
+                const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
+                const newSpan = Math.max(ZOOM_MIN_MS, Math.min(ZOOM_MAX_MS, span * factor));
+                const nowMs = Date.now();
+                timeline.setWindow(
+                    new Date(nowMs - newSpan),
+                    new Date(nowMs),
+                    { animation: false }
+                );
+                syncChartViewportAcrossSession(String(sessionId), timeline);
             }, { capture: true, passive: false });
         }
 
@@ -2240,7 +2309,18 @@ maybe a histogram of b
             const viewport = chartViewportBySession.get(String(sessionId || ''));
             if (!viewport) return false;
             applyChartViewport(chartRef, viewport);
+            updateResetZoomButtonState(sessionId);
             return true;
+        }
+
+        function updateResetZoomButtonState(sessionId) {
+            const key = String(sessionId || '');
+            const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+            if (!card) return;
+            const zoomed = chartViewportBySession.has(key);
+            for (const btn of card.querySelectorAll('button[data-action="reset-bitrate-zoom"]')) {
+                btn.classList.toggle('zoom-active', zoomed);
+            }
         }
 
         function getChartsForSession(sessionId) {
@@ -2254,18 +2334,28 @@ maybe a histogram of b
             ].filter((chartRef) => !!chartRef);
         }
 
+        function isDefaultChartViewport(viewport) {
+            return !!viewport && viewport.min <= 0 && viewport.max >= 600;
+        }
+
         function syncChartViewportAcrossSession(sessionId, sourceChart) {
             const key = String(sessionId || '');
             const viewport = readChartViewport(sourceChart);
             if (!viewport) return;
-            chartViewportBySession.set(key, viewport);
+            if (isDefaultChartViewport(viewport)) {
+                chartViewportBySession.delete(key);
+            } else {
+                chartViewportBySession.set(key, viewport);
+            }
             for (const chartRef of getChartsForSession(key)) {
                 if (!chartRef || chartRef === sourceChart) continue;
                 applyChartViewport(chartRef, viewport);
-                if (typeof chartRef.zoomScale !== 'function') {
+                if (chartRef.$isVisTimeline) continue;
+                if (typeof chartRef.zoomScale !== 'function' && typeof chartRef.update === 'function') {
                     chartRef.update('none');
                 }
             }
+            updateResetZoomButtonState(key);
         }
 
         function buildUnifiedChartZoomOptions(sessionId) {
@@ -2334,8 +2424,12 @@ maybe a histogram of b
                 chartViewportBySession.set(rightPanDragState.sessionId, viewport);
                 for (const chart of getChartsForSession(rightPanDragState.sessionId)) {
                     applyChartViewport(chart, viewport);
-                    if (typeof chart.zoomScale !== 'function') { chart.update('none'); }
+                    if (chart.$isVisTimeline) continue;
+                    if (typeof chart.zoomScale !== 'function' && typeof chart.update === 'function') {
+                        chart.update('none');
+                    }
                 }
+                updateResetZoomButtonState(rightPanDragState.sessionId);
             });
             window.addEventListener('mouseup', (event) => {
                 if (!rightPanDragState) return;
@@ -2353,8 +2447,7 @@ maybe a histogram of b
             const paused = isChartPaused(key);
             const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
             if (!card) return;
-            const btn = card.querySelector('button[data-action="pause-bitrate-chart"]');
-            if (btn) {
+            for (const btn of card.querySelectorAll('button[data-action="pause-bitrate-chart"]')) {
                 if (paused) {
                     btn.textContent = 'Live';
                     btn.classList.add('chart-live');
@@ -2976,7 +3069,7 @@ maybe a histogram of b
                 applyStoredChartViewport(sessionId, chart);
                 installRightMousePanHandlers(sessionId, chart);
                 installChartClickPauseHandler(sessionId, chart);
-                installLiveWheelAnchor(sessionId, chart, canvas);
+                ensureChartLiveWheelAnchor();
                 eventsCharts.set(sessionId, chart);
             } else {
                 chart.data.datasets = datasets;
@@ -3284,6 +3377,7 @@ maybe a histogram of b
                     }
                 );
                 eventsTimelines.set(sessionId, timeline);
+                ensureVisTimelineLiveWheelAnchor();
                 // Tag for the cross-chart viewport sync helpers, anchor
                 // the seconds-from-windowStart frame to liveStart so
                 // vis-timeline ranges convert consistently to the 0–600
@@ -3443,7 +3537,6 @@ maybe a histogram of b
                     }
                 }
                 eventsCharts.delete(sessionId);
-                eventsTimelines.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);
@@ -3939,7 +4032,7 @@ maybe a histogram of b
                 applyStoredChartViewport(sessionId, chart);
                 installRightMousePanHandlers(sessionId, chart);
                 installChartClickPauseHandler(sessionId, chart);
-                installLiveWheelAnchor(sessionId, chart, canvas);
+                ensureChartLiveWheelAnchor();
                 bandwidthCharts.set(sessionId, chart);
             } else {
                 chart.data.datasets = datasets;
@@ -4140,7 +4233,7 @@ maybe a histogram of b
                 applyStoredChartViewport(sessionId, bufferChart);
                 installRightMousePanHandlers(sessionId, bufferChart);
                 installChartClickPauseHandler(sessionId, bufferChart);
-                installLiveWheelAnchor(sessionId, bufferChart, bufferCanvas);
+                ensureChartLiveWheelAnchor();
                 bufferDepthCharts.set(sessionId, bufferChart);
             } else {
                 const oldHidden = {};
@@ -4462,7 +4555,7 @@ maybe a histogram of b
                 applyStoredChartViewport(sessionId, fpsChart);
                 installRightMousePanHandlers(sessionId, fpsChart);
                 installChartClickPauseHandler(sessionId, fpsChart);
-                installLiveWheelAnchor(sessionId, fpsChart, fpsCanvas);
+                ensureChartLiveWheelAnchor();
                 videoFpsCharts.set(sessionId, fpsChart);
             } else {
                 const oldHidden = {};
@@ -5250,6 +5343,24 @@ maybe a histogram of b
             const card = button.closest('.session-card');
             if (!card) return;
             const sessionId = card.dataset.sessionId;
+            if (button.dataset.action === 'reset-bitrate-zoom') {
+                const key = String(sessionId || '');
+                chartViewportBySession.delete(key);
+                if (rightPanDragState && rightPanDragState.sessionId === key) {
+                    rightPanDragState = null;
+                }
+                for (const chart of getChartsForSession(key)) {
+                    if (chart && typeof chart.resetZoom === 'function') {
+                        chart.resetZoom('none');
+                    }
+                }
+                updateResetZoomButtonState(key);
+                return;
+            }
+            if (button.dataset.action === 'pause-bitrate-chart') {
+                toggleChartPause(String(sessionId || ''));
+                return;
+            }
             if (button.dataset.action === 'apply-pattern') {
                 scheduleShapingApply(card);
                 const group = card.querySelector('.shaping-pattern-group');


### PR DESCRIPTION
## Summary
Closes #337 (Reset Zoom and ⏸ Pause buttons inert on `testing.html`) and fans out the surrounding chart-toolbar fixes to `testing-session.html` so the two pages render the same chart UX.

### Bug fixes
- **#337**: testing.html's click delegate had no cases for `data-action="reset-bitrate-zoom"` / `pause-bitrate-chart`. Buttons rendered (via shared `testing-session-ui.js`) but did nothing. Added handlers; ported to testing-session.html where applicable.
- **vis.Timeline `update is not a function` crash**: `chartRef.update('none')` was called on the vis.Timeline sibling whenever a Chart.js chart finished a zoom/pan, throwing `TypeError`. Skip vis.Timeline (it's already redrawn via `setWindow`) and guard `update` with `typeof`. Fix applied in both `syncChartViewportAcrossSession` and the right-pan mousemove handler, on both pages.
- **Player State stacking**: the resize handler unconditionally `eventsTimelines.delete()`-d before its destroy check, so `tl.destroy()` never fired. Each fold reopen orphaned the previous timeline DOM and stacked a new one on top. Removed the bad delete on both pages.

### UX additions
- **Reset Zoom highlight**: when a viewport is stored, the button gets `.zoom-active` — solid blue fill, pulsing halo, 🔍 prefix. Highlight clears the moment you click Reset Zoom or zoom all the way back out.
- **vis.Timeline live-edge Alt+wheel zoom**: in live mode, anchors zoom to the right edge ("now") regardless of mouse position, matching the Chart.js charts. Paused mode keeps vis.Timeline's default mouse-centered zoom.
- **Toolbar duplicated into Player State fold**: Reset Zoom + ⏸ Pause + hint also live inside the Player State collapsible so they're usable when the Bitrate Chart fold is closed. `data-action` click delegate handles either copy; helpers switched to `querySelectorAll` so both copies stay in sync.
- **Section title**: "Bitrate Chart" → "Bitrate Chart etc" (the fold also contains buffer-depth and FPS charts).
- **Network Log waterfall**:
  - New "Dur" column (between Mbps and Status).
  - Sortable column headers — cycle desc → asc → off, ▼/▲ glyph on the active column.
  - Slow-segment warning: any media segment whose download phase took longer than the default HLS target duration (6s) gets `slow-transfer` — amber row tint, ⏰ glyph in flags, amber bold Duration cell.

### Performance / hygiene
- **Chrome wheel-listener violations**: centralized `installLiveWheelAnchor` (Chart.js, was 4-per-session) and `installVisTimelineLiveWheelAnchor` (vis.Timeline, was 1-per-session) into single document-level listeners. Reduces non-passive wheel listeners from `O(N × 4 + N)` to 2 per page.
- **`isDefaultChartViewport`**: `chart.resetZoom('none')` fires `onZoomComplete` with the now-default 0..600 viewport, which `syncChartViewportAcrossSession` was re-storing into the viewport map. The reset zoom highlight would re-pulse forever. Treat full-domain viewport as "not zoomed" — delete from map instead.

### Cross-page consistency (shared CSS)
Moved into `testing-session-refactored.css` so both pages render identically:
- `.zoom-active` + `chart-zoom-pulse` keyframes (was inline in testing.html).
- `.shape-step-risk` + `.shape-step-disabled` (was inline in testing-session.html — now testing.html also shows the stall-risk red border).
- `.chart-axis-row` flex/wrap layout (was inline in testing-session.html — now testing.html stacks the toolbar correctly too).
- New `.chart-axis-row-break` helper (zero-height in block, forces wrap in flex) so the toolbar buttons fall to a row below the Y-Max radios in both layouts.
- `.netwf-cell.duration` column var + width, `.slow-transfer` palette, sortable header arrow styling, `--netwf-col-flags` bumped 28 → 36 px to fit ⏰ next to fault glyphs.

A separate cleanup PR for moving the remaining ~210 lines of duplicated inline CSS to the shared stylesheet is tracked in #338.

## Test plan
- [x] Deployed and tested on `test-dev` (`http://jonathanoliver-ubuntu.local:21000/`).
- [x] Reset Zoom + ⏸ Pause click correctly on testing.html and testing-session.html.
- [x] Reset Zoom highlight pulses while zoomed, clears on reset.
- [x] vis.Timeline does not crash on zoom-reset or right-pan.
- [x] Player State fold reopens without stacking timelines.
- [x] vis.Timeline Alt+wheel anchors to right edge in live mode, mouse-centered while paused.
- [x] Both copies of Reset Zoom + Pause stay in sync (across folds).
- [x] Network Log: Dur column visible, sortable, slow segments highlighted amber + ⏰.
- [x] Both pages render the chart toolbar with the same flex/stacked layout.
- [x] Chrome console: non-passive wheel-listener violations no longer scale with session count.
