### PR TITLE
feat(analytics): session bundle ZIP + replay UI (#344)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ __pycache__/
 go-proxy/server
 go-live/server
 go-upload/server
+analytics/go-forwarder/go-forwarder
 
 # Test artifacts
 tests/.hls_failure_probe_last_failed

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,35 @@ test-deploy-dev:
 	scp tests/deploy/override-dev.yml $(TEST_SSH):~/test-dev/docker-compose.override.yml
 	ssh $(TEST_SSH) 'cd ~/test-dev && docker compose build && docker compose up -d'
 
+# Iterate on Grafana provisioning (dashboards / datasources) without
+# touching go-server. Sessions keep flowing live; Grafana auto-reloads
+# the dashboard JSON within 30s, but we --force-recreate to pick it up
+# immediately and to refresh the bind mount in case files were added.
+analytics-update:
+	@echo "=== Updating analytics provisioning on test-dev (no go-server restart) ==="
+	rsync -az --delete \
+		/Users/jonathanoliver/Projects/smashing/analytics/grafana/ \
+		$(TEST_SSH):~/test-dev/analytics/grafana/
+	ssh $(TEST_SSH) 'cd ~/test-dev && docker compose up -d --force-recreate grafana'
+
+# Rebuild the forwarder binary and recreate just that container. Sessions
+# keep flowing live (go-server is untouched); archival pauses for ~1s
+# while the forwarder restarts. --no-deps prevents docker compose from
+# pulling go-server into the recreate.
+analytics-rebuild-forwarder:
+	@echo "=== Rebuilding forwarder on test-dev (no go-server restart) ==="
+	ssh $(TEST_SSH) 'mkdir -p ~/test-dev/analytics/go-forwarder'
+	rsync -az --delete \
+		/Users/jonathanoliver/Projects/smashing/analytics/go-forwarder/ \
+		$(TEST_SSH):~/test-dev/analytics/go-forwarder/
+	ssh $(TEST_SSH) 'cd ~/test-dev && docker compose build forwarder && docker compose up -d --no-deps forwarder'
+
+# Apply a one-line ClickHouse migration without restarting anything.
+# Usage: make analytics-migrate SQL='ALTER TABLE session_snapshots ADD COLUMN ...'
+analytics-migrate:
+	@test -n "$(SQL)" || { echo "set SQL=..."; exit 1; }
+	ssh $(TEST_SSH) 'curl -fsS -X POST "http://localhost:21123/?database=infinite_streaming" --data-binary @- <<<"$(SQL)" && echo "ok"'
+
 test-clean-dev:
 	ssh $(TEST_SSH) 'docker rm -f test-dev-server 2>/dev/null'
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ The iOS, tvOS, Android, and Roku apps in this repo are reference implementations
 | [`android/InfiniteStreamPlayer/`](android/InfiniteStreamPlayer/) | yes (`/api/content`) | `?player_id=UUID` | auto-follow (ExoPlayer) | — | — |
 | [`roku/InfiniteStreamPlayer/`](roku/InfiniteStreamPlayer/) | yes (`/api/content`) | `?player_id=roku_<ts>` | auto-follow | — | — |
 
-They're all intended as very simple video consumption devices, each with slightly different ABR characteristics and error-recovery implementations. The web players (HLS.js / Shaka / Video.js) are the simplest to use and very handy to confirm everything is wired up — but they're also the least reliable for stress testing. Most of the validation of the server's content generation is done against iOS and tvOS.
+They're all intended as very simple video consumption devices, each with slightly different ABR characteristics and error-recovery implementations. The web players (HLS.js / Shaka / Video.js) are the simplest to use and very handy to confirm everything is wired up — but they're also the least reliable for stress testing. See [Project scope and roadmap](#project-scope-and-roadmap) for which paths get the most testing time.
 
 Point at any of them as a starting template for a new platform.
 
@@ -480,6 +480,31 @@ Common LL-HLS/LL-DASH features that are **not fully implemented**:
 - Chunked CMAF transfer for LL-DASH partials
 
 Full list in [`PRD.md`](PRD.md).
+
+---
+
+## Project scope and roadmap
+
+This is a hobbyist QA tool, built and primarily run on an M5 MacBook. The web UI isn't perf-tuned, and the server isn't built for production scale — it's tuned for a handful of test sessions running locally, where the goal is *deterministic, reproducible* behaviour over throughput. The "When not to use it" call-outs near the top of this README list the limits that implies.
+
+### Platform priorities
+
+Where the time goes, in order:
+
+- **LL-HLS / fmp4 on Apple (iOS / iPadOS / tvOS)** — primary tested path. New content-generation behaviour gets validated here first.
+- **Android TV / Google TV** — second-tier. The reference app works, but the surface area exercised against it is narrower (no SSE, no metrics reporting yet).
+- **LL-DASH** — functional but exercised less than HLS. Some dashboard features (Content-tab manifest rewriting) are HLS-only.
+
+### Roadmap
+
+The project is built in stages, each one depending on the previous:
+
+1. **Repeatable playback, independent of external factors.** *Done.* Looping VOD-as-live with a shared clock across LL / 2s / 6s variants — the same run produces the same timing.
+2. **Repeatable failures and controls.** *Done.* Fault injection, traffic shaping, content manipulation — all per-session, all scriptable through the REST API.
+3. **Persistent session storage for offline viewing and analysis.** *In progress.* The [analytics sidecar](analytics/README.md) (`feat/336-analytics-sidecar`) subscribes to the proxy's SSE session stream, writes snapshots into ClickHouse, exposes them to Grafana, and powers `testing.html?replay=1&session=<id>` replay mode.
+4. **Scripted characterization and cross-thing comparison.** *Future.* Use the controls from stage 2 and the recorded sessions from stage 3 to systematically compare ABR behaviour across players, codecs, ladders, platforms, and network conditions — turning side-by-side eyeballing into reproducible benchmarks.
+
+No dates, no commitments — this is a side project.
 
 ---
 
@@ -657,6 +682,7 @@ Captured from the live dashboard; files live in [`docs/screenshots/`](docs/scree
 
 **Subsystems:**
 - [`go-live/IMPLEMENTATION_SUMMARY.md`](go-live/IMPLEMENTATION_SUMMARY.md), [`go-live/PLAN.md`](go-live/PLAN.md)
+- [`analytics/README.md`](analytics/README.md) — analytics sidecar (ClickHouse + Grafana + replay mode)
 - [`tests/integration/README.md`](tests/integration/README.md), [`tests/integration/PLAYER_CHARACTERIZATION_PYTEST.md`](tests/integration/PLAYER_CHARACTERIZATION_PYTEST.md)
 
 ---

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,160 @@
+# analytics
+
+Sidecar analytics tier for InfiniteStream. Subscribes to the SSE session
+stream emitted by `go-proxy`, writes session-state snapshots into
+ClickHouse, and exposes them to Grafana (ad-hoc dashboards) and to
+`testing.html` (historical replay mode).
+
+The streaming app does not store anything itself — if `forwarder` is
+down the live UI keeps working, archival just pauses until it restarts.
+
+## Components
+
+- `go-forwarder/` — standalone Go binary. Subscribes to
+  `/api/sessions/stream`, dedupes by snapshot fingerprint, batches
+  inserts into ClickHouse. Also serves the read-only HTTP API at
+  `:8080` that nginx proxies as `/analytics/api/*`. All ClickHouse
+  queries use parameterized `{name:Type}` placeholders — no string
+  interpolation of user input.
+- `clickhouse/init.d/01-schema.sql` — bootstrap schema. ClickHouse
+  applies it on first start. One wide `session_snapshots` table with
+  hot fields as typed columns and a `session_json` column for the long
+  tail. 30-day TTL.
+- `grafana/provisioning/` — datasource + starter dashboard, picked up
+  automatically by Grafana.
+
+## Local (Docker Compose)
+
+`make run` brings up the analytics services alongside the main stack:
+
+| Service     | Port  | Notes                                    |
+|-------------|-------|------------------------------------------|
+| ClickHouse  | 30123 | HTTP interface (native 9000 not exposed) |
+| Grafana     | 30300 | Anonymous editor; pre-provisioned        |
+
+Then:
+
+- Grafana dashboard: <http://localhost:30300/d/is-session-analytics>
+- Replay a session: <http://localhost:30000/testing.html?replay=1&session=SESSION_ID>
+
+## k3s
+
+Apply `k8s-analytics.yaml` alongside the main deployment. Set
+`ANALYTICS_SSE_URL` (default `http://infinite-streaming-dev:30081/api/sessions/stream`)
+and `ANALYTICS_GRAFANA_NODEPORT`.
+
+## Replay mode
+
+`testing.html?replay=1&session=<id>[&from=<rfc3339>][&to=<rfc3339>]`
+fetches snapshots from `/analytics/api/snapshots`, then re-feeds them
+through the same `applySessionsList` renderer the live stream uses.
+`Date.now` is briefly patched per snapshot so chart point timestamps
+line up with recorded `ts`.
+
+## Re-provisioning the dashboard
+
+Edits to `grafana/provisioning/dashboards/*.json` are picked up
+automatically by the running Grafana container (every 30s). However,
+adding/removing files in this directory after `docker compose up`
+sometimes leaves the bind mount stale. If a new dashboard or datasource
+isn't showing up:
+
+```sh
+docker compose up -d --force-recreate grafana
+```
+
+## Schema notes
+
+- Hot columns (used by charts and dashboards) are typed: `buffer_depth_s`,
+  `network_bitrate_mbps`, `dropped_frames`, `player_state`, etc.
+- Everything else lives in `session_json`. Promote a column when a
+  query starts using it frequently.
+- `ORDER BY (session_id, ts)` makes per-session replay queries cheap.
+- `TTL toDateTime(ts) + INTERVAL 30 DAY` enforces retention; tune via
+  `ALTER TABLE ... MODIFY TTL`.
+
+## Securing a WAN-exposed deployment
+
+Default docker-compose binds ClickHouse to `127.0.0.1` (host-only) and
+keeps Grafana off the host network entirely — Grafana is reachable only
+via nginx at `/grafana/`. The dashboard, `/analytics/api/`, and
+`/grafana/` routes can be gated with HTTP Basic auth so only known
+clients can read or write through nginx. Player apps (Apple, Roku,
+AndroidTV) keep working without credentials because their endpoints
+(`/api/sessions/stream`, `/api/version`, segment fetches under
+`/go-live/`) stay public.
+
+To enable:
+
+```sh
+# 1. Generate an htpasswd file (bcrypt; pick your own user/pass)
+docker run --rm httpd:alpine htpasswd -nbB myuser mypassword > ./htpasswd
+
+# 2. Mount it into the go-server container and tell launch.sh where it is
+#    (docker-compose.override.yml or similar):
+services:
+  go-server:
+    environment:
+      - INFINITE_STREAM_AUTH_HTPASSWD=/etc/nginx/auth.htpasswd
+    volumes:
+      - ./htpasswd:/etc/nginx/auth.htpasswd:ro
+```
+
+When `INFINITE_STREAM_AUTH_HTPASSWD` is unset (the default), auth is
+disabled — same behaviour as before. With it set, the dashboard pages,
+`/analytics/api/*`, and `/grafana/*` all return 401 without credentials.
+
+### k3s deployment (lenovo)
+
+```sh
+# Generate htpasswd
+docker run --rm httpd:alpine htpasswd -nbB myuser 'mypass' > /tmp/htpasswd
+
+# Create a Secret holding the file
+kubectl create secret generic infinite-streaming-auth \
+  --from-file=htpasswd=/tmp/htpasswd
+
+# Patch the deployment (use `infinite-streaming` for release,
+# `infinite-streaming-dev` for the dev stack)
+kubectl patch deployment infinite-streaming --patch '
+spec:
+  template:
+    spec:
+      containers:
+      - name: go-server
+        env:
+        - name: INFINITE_STREAM_AUTH_HTPASSWD
+          value: /etc/secret/htpasswd
+        volumeMounts:
+        - name: auth-secret
+          mountPath: /etc/secret
+          readOnly: true
+      volumes:
+      - name: auth-secret
+        secret:
+          secretName: infinite-streaming-auth
+'
+
+# Verify
+kubectl rollout status deployment/infinite-streaming
+curl -s -o /dev/null -w '%{http_code}\n' http://lenovo.local:30000/dashboard/dashboard.html
+# → 401
+curl -s -o /dev/null -w '%{http_code}\n' -u myuser:mypass http://lenovo.local:30000/dashboard/dashboard.html
+# → 200
+```
+
+Rotate the password by re-creating the secret and restarting the rollout:
+
+```sh
+docker run --rm httpd:alpine htpasswd -nbB myuser 'newpass' > /tmp/htpasswd
+kubectl create secret generic infinite-streaming-auth --from-file=htpasswd=/tmp/htpasswd \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl rollout restart deployment/infinite-streaming
+```
+
+Disable auth without removing the secret by setting the env var to an
+empty string:
+
+```sh
+kubectl set env deployment/infinite-streaming INFINITE_STREAM_AUTH_HTPASSWD=
+```

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -1,0 +1,310 @@
+-- Analytics schema for InfiniteStream session snapshots.
+--
+-- One row per session per SSE broadcast tick. The forwarder dedupes by
+-- payload fingerprint, so an unchanging session does not generate rows.
+-- Grafana, ad-hoc SQL, and testing.html replay mode all read from here.
+
+CREATE DATABASE IF NOT EXISTS infinite_streaming;
+
+CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
+(
+    ts                    DateTime64(3, 'UTC')        CODEC(DoubleDelta, ZSTD(1)),
+    revision              UInt64                      CODEC(DoubleDelta, ZSTD(1)),
+    session_id            String                      CODEC(ZSTD(1)),
+    play_id               LowCardinality(String)      CODEC(ZSTD(1)),
+    player_id             LowCardinality(String)      CODEC(ZSTD(1)),
+    group_id              LowCardinality(String)      CODEC(ZSTD(1)),
+    user_agent            String                      CODEC(ZSTD(1)),
+
+    -- Content / manifest
+    manifest_url          String                      CODEC(ZSTD(1)),
+    manifest_variants     String                      CODEC(ZSTD(3)),
+    last_request_url      String                      CODEC(ZSTD(1)),
+    content_id            LowCardinality(String)      CODEC(ZSTD(1)),
+
+    -- Player state (hot path for charts)
+    player_state          LowCardinality(String)      CODEC(ZSTD(1)),
+    waiting_reason        LowCardinality(String)      CODEC(ZSTD(1)),
+    buffer_depth_s        Float32                     CODEC(ZSTD(1)),
+    network_bitrate_mbps  Float32                     CODEC(ZSTD(1)),
+    video_bitrate_mbps    Float32                     CODEC(ZSTD(1)),
+    measured_mbps         Float32                     CODEC(ZSTD(1)),
+    mbps_shaper_rate      Float32                     CODEC(ZSTD(1)),
+    mbps_shaper_avg       Float32                     CODEC(ZSTD(1)),
+    display_resolution    LowCardinality(String)      CODEC(ZSTD(1)),
+    video_resolution      LowCardinality(String)      CODEC(ZSTD(1)),
+    frames_displayed      UInt64                      DEFAULT 0,
+    dropped_frames        UInt32                      DEFAULT 0,
+    stall_count           UInt32                      DEFAULT 0,
+    stall_time_s          Float32                     CODEC(ZSTD(1)),
+    position_s            Float32                     CODEC(ZSTD(1)),
+    live_edge_s           Float32                     CODEC(ZSTD(1)),
+    true_offset_s         Float32                     CODEC(ZSTD(1)),
+    playback_rate         Float32                     CODEC(ZSTD(1)),
+    loop_count_player     UInt32                      DEFAULT 0,
+    loop_count_server     UInt32                      DEFAULT 0,
+
+    -- Player events (discrete signals embedded in the heartbeat snapshot;
+    -- testing.html derives event-lane points from transitions in these).
+    last_event            LowCardinality(String)      CODEC(ZSTD(1)),
+    last_event_at         String                      CODEC(ZSTD(1)),
+    trigger_type          LowCardinality(String)      CODEC(ZSTD(1)),
+    event_time            String                      CODEC(ZSTD(1)),
+    player_error          String                      CODEC(ZSTD(1)),
+
+    -- Player metrics (extended)
+    avg_network_bitrate_mbps     Float32 CODEC(ZSTD(1)),
+    buffer_end_s                 Float32 CODEC(ZSTD(1)),
+    last_stall_time_s            Float32 CODEC(ZSTD(1)),
+    live_offset_s                Float32 CODEC(ZSTD(1)),
+    playhead_wallclock_ms        Int64   CODEC(ZSTD(1)),
+    seekable_end_s               Float32 CODEC(ZSTD(1)),
+    metrics_source               LowCardinality(String) CODEC(ZSTD(1)),
+    video_first_frame_time_s     Float32 CODEC(ZSTD(1)),
+    video_quality_pct            Float32 CODEC(ZSTD(1)),
+    video_start_time_s           Float32 CODEC(ZSTD(1)),
+
+    -- Network / transfer
+    mbps_transfer_complete       Float32 CODEC(ZSTD(1)),
+    mbps_transfer_rate           Float32 CODEC(ZSTD(1)),
+    player_ip                    LowCardinality(String) CODEC(ZSTD(1)),
+    server_received_at_ms        Int64   CODEC(ZSTD(1)),
+    x_forwarded_port             UInt16  DEFAULT 0,
+    x_forwarded_port_external    UInt16  DEFAULT 0,
+
+    -- Master manifest failure injection
+    master_manifest_url               String                 CODEC(ZSTD(1)),
+    master_manifest_failure_type      LowCardinality(String) CODEC(ZSTD(1)),
+    master_manifest_failure_mode      LowCardinality(String) CODEC(ZSTD(1)),
+    master_manifest_failure_frequency Float32                CODEC(ZSTD(1)),
+    master_manifest_consecutive_failures UInt32              DEFAULT 0,
+    master_manifest_requests_count    UInt32                 DEFAULT 0,
+
+    -- Manifest failure injection (extended)
+    manifest_failure_frequency      Float32 CODEC(ZSTD(1)),
+    manifest_failure_urls           String  CODEC(ZSTD(3)),
+    manifest_consecutive_failures   UInt32  DEFAULT 0,
+    manifest_requests_count         UInt32  DEFAULT 0,
+
+    -- Segment failure injection (extended)
+    segment_failure_frequency       Float32 CODEC(ZSTD(1)),
+    segment_failure_urls            String  CODEC(ZSTD(3)),
+    segment_consecutive_failures    UInt32  DEFAULT 0,
+    segments_count                  UInt32  DEFAULT 0,
+
+    -- "All" (cross-cutting) failure injection
+    all_failure_type                LowCardinality(String) CODEC(ZSTD(1)),
+    all_failure_mode                LowCardinality(String) CODEC(ZSTD(1)),
+    all_failure_frequency           Float32                CODEC(ZSTD(1)),
+    all_failure_urls                String                 CODEC(ZSTD(3)),
+    all_consecutive_failures        UInt32                 DEFAULT 0,
+
+    -- Transport failure / fault details
+    transport_failure_frequency     Float32                CODEC(ZSTD(1)),
+    transport_failure_mode          LowCardinality(String) CODEC(ZSTD(1)),
+    transport_failure_units         LowCardinality(String) CODEC(ZSTD(1)),
+    transport_consecutive_failures  UInt32                 DEFAULT 0,
+    transport_consecutive_seconds   Float32                CODEC(ZSTD(1)),
+    transport_consecutive_units     UInt32                 DEFAULT 0,
+    transport_frequency_seconds     Float32                CODEC(ZSTD(1)),
+    transport_fault_drop_packets    UInt8                  DEFAULT 0,
+    transport_fault_reject_packets  UInt8                  DEFAULT 0,
+    transport_fault_off_seconds     Float32                CODEC(ZSTD(1)),
+    transport_fault_on_seconds      Float32                CODEC(ZSTD(1)),
+    transport_fault_type            LowCardinality(String) CODEC(ZSTD(1)),
+    fault_count_transfer_active_timeout  UInt32            DEFAULT 0,
+    fault_count_transfer_idle_timeout    UInt32            DEFAULT 0,
+
+    -- Transfer timeouts
+    transfer_active_timeout_seconds   Float32 CODEC(ZSTD(1)),
+    transfer_idle_timeout_seconds     Float32 CODEC(ZSTD(1)),
+    transfer_timeout_applies_manifests UInt8  DEFAULT 0,
+    transfer_timeout_applies_master    UInt8  DEFAULT 0,
+    transfer_timeout_applies_segments  UInt8  DEFAULT 0,
+
+    -- nftables (extended)
+    nftables_pattern_step               UInt32  DEFAULT 0,
+    nftables_pattern_step_runtime       UInt32  DEFAULT 0,
+    nftables_pattern_steps              String  CODEC(ZSTD(3)),
+    nftables_pattern_rate_runtime_mbps  Float32 CODEC(ZSTD(1)),
+    nftables_pattern_margin_pct         Float32 CODEC(ZSTD(1)),
+    nftables_pattern_template_mode      LowCardinality(String) CODEC(ZSTD(1)),
+
+    -- Content config
+    content_allowed_variants    String                 CODEC(ZSTD(3)),
+    content_live_offset         Float32                CODEC(ZSTD(1)),
+    content_strip_codecs        String                 CODEC(ZSTD(1)),
+
+    -- Misc
+    abrchar_run_lock            UInt8                  DEFAULT 0,
+    control_revision            UInt64                 DEFAULT 0,
+
+    -- Server-side variant
+    server_video_rendition       LowCardinality(String) CODEC(ZSTD(1)),
+    server_video_rendition_mbps  Float32                CODEC(ZSTD(1)),
+
+    -- Failure injection (categorical hot fields)
+    manifest_failure_type    LowCardinality(String)   CODEC(ZSTD(1)),
+    manifest_failure_mode    LowCardinality(String)   CODEC(ZSTD(1)),
+    segment_failure_type     LowCardinality(String)   CODEC(ZSTD(1)),
+    segment_failure_mode     LowCardinality(String)   CODEC(ZSTD(1)),
+    transport_failure_type   LowCardinality(String)   CODEC(ZSTD(1)),
+    transport_fault_active   UInt8                    DEFAULT 0,
+
+    -- Network shaping
+    nftables_bandwidth_mbps  Float32                  CODEC(ZSTD(1)),
+    nftables_delay_ms        UInt32                   DEFAULT 0,
+    nftables_packet_loss     Float32                  CODEC(ZSTD(1)),
+    nftables_pattern_enabled UInt8                    DEFAULT 0,
+
+    -- Lifecycle
+    first_request_time   String                       CODEC(ZSTD(1)),
+    last_request         String                       CODEC(ZSTD(1)),
+    session_duration     Float32                      CODEC(ZSTD(1)),
+
+    -- Long tail: full session map as JSON, for fields not promoted to columns.
+    session_json         String                       CODEC(ZSTD(3))
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (session_id, ts)
+TTL toDateTime(ts) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;
+
+-- Bloom filter on session_id for fast point lookups in replay mode.
+ALTER TABLE infinite_streaming.session_snapshots
+    ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 4;
+
+ALTER TABLE infinite_streaming.session_snapshots
+    ADD INDEX IF NOT EXISTS idx_player_id player_id TYPE bloom_filter(0.01) GRANULARITY 4;
+
+ALTER TABLE infinite_streaming.session_snapshots
+    ADD INDEX IF NOT EXISTS idx_play_id play_id TYPE bloom_filter(0.01) GRANULARITY 4;
+
+-- Bring older deployments up to date if the column predates this column.
+ALTER TABLE infinite_streaming.session_snapshots
+    ADD COLUMN IF NOT EXISTS play_id LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS content_id LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS last_event LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS last_event_at String CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS trigger_type LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS event_time String CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS player_error String CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS avg_network_bitrate_mbps Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS buffer_end_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS last_stall_time_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS live_offset_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS playhead_wallclock_ms Int64 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS seekable_end_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS metrics_source LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS video_first_frame_time_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS video_quality_pct Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS video_start_time_s Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS mbps_transfer_complete Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS mbps_transfer_rate Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS player_ip LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS server_received_at_ms Int64 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS x_forwarded_port UInt16 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS x_forwarded_port_external UInt16 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS master_manifest_url String CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS master_manifest_failure_type LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS master_manifest_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS master_manifest_failure_frequency Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS master_manifest_consecutive_failures UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS master_manifest_requests_count UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS manifest_failure_frequency Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS manifest_failure_urls String CODEC(ZSTD(3)),
+    ADD COLUMN IF NOT EXISTS manifest_consecutive_failures UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS manifest_requests_count UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS segment_failure_frequency Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS segment_failure_urls String CODEC(ZSTD(3)),
+    ADD COLUMN IF NOT EXISTS segment_consecutive_failures UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS segments_count UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS all_failure_type LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS all_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS all_failure_frequency Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS all_failure_urls String CODEC(ZSTD(3)),
+    ADD COLUMN IF NOT EXISTS all_consecutive_failures UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transport_failure_frequency Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_failure_units LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_consecutive_failures UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transport_consecutive_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_consecutive_units UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transport_frequency_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_fault_drop_packets UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transport_fault_reject_packets UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transport_fault_off_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_fault_on_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transport_fault_type LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS fault_count_transfer_active_timeout UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS fault_count_transfer_idle_timeout UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transfer_active_timeout_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transfer_idle_timeout_seconds Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS transfer_timeout_applies_manifests UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transfer_timeout_applies_master UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS transfer_timeout_applies_segments UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS nftables_pattern_step UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS nftables_pattern_step_runtime UInt32 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS nftables_pattern_steps String CODEC(ZSTD(3)),
+    ADD COLUMN IF NOT EXISTS nftables_pattern_rate_runtime_mbps Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS nftables_pattern_margin_pct Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS nftables_pattern_template_mode LowCardinality(String) CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS content_allowed_variants String CODEC(ZSTD(3)),
+    ADD COLUMN IF NOT EXISTS content_live_offset Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS content_strip_codecs String CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS abrchar_run_lock UInt8 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS control_revision UInt64 DEFAULT 0;
+
+-- Convert legacy manifest_variants UInt16 (broken: always stored 0 because
+-- the SSE field is an array, not a number) to String (JSON of the variant
+-- ladder). Safe MODIFY since the only existing values are zero.
+ALTER TABLE infinite_streaming.session_snapshots
+    MODIFY COLUMN IF EXISTS manifest_variants String CODEC(ZSTD(3));
+
+-- Per-request HAR-style log so the session-viewer's network log fold
+-- can replay archived sessions whose go-proxy buffer is gone. Forwarder
+-- polls /api/session/<id>/network for live sessions and dedupes rows
+-- via entry_fingerprint. Headers/query are stored as JSON strings —
+-- almost never queried column-by-column and often empty.
+CREATE TABLE IF NOT EXISTS infinite_streaming.network_requests
+(
+    ts                       DateTime64(3, 'UTC')   CODEC(Delta, ZSTD(1)),
+    session_id               String                 CODEC(ZSTD(1)),
+    play_id                  LowCardinality(String) CODEC(ZSTD(1)),
+    method                   LowCardinality(String) CODEC(ZSTD(1)),
+    url                      String                 CODEC(ZSTD(3)),
+    upstream_url             String                 CODEC(ZSTD(3)),
+    path                     String                 CODEC(ZSTD(3)),
+    request_kind             LowCardinality(String) CODEC(ZSTD(1)),
+    status                   UInt16                 DEFAULT 0,
+    bytes_in                 Int64                  DEFAULT 0,
+    bytes_out                Int64                  DEFAULT 0,
+    content_type             LowCardinality(String) CODEC(ZSTD(1)),
+    request_range            String                 CODEC(ZSTD(1)),
+    response_content_range   String                 CODEC(ZSTD(1)),
+    dns_ms                   Float32                CODEC(ZSTD(1)),
+    connect_ms               Float32                CODEC(ZSTD(1)),
+    tls_ms                   Float32                CODEC(ZSTD(1)),
+    ttfb_ms                  Float32                CODEC(ZSTD(1)),
+    transfer_ms              Float32                CODEC(ZSTD(1)),
+    total_ms                 Float32                CODEC(ZSTD(1)),
+    client_wait_ms           Float32                CODEC(ZSTD(1)),
+    faulted                  UInt8                  DEFAULT 0,
+    fault_type               LowCardinality(String) CODEC(ZSTD(1)),
+    fault_action             LowCardinality(String) CODEC(ZSTD(1)),
+    fault_category           LowCardinality(String) CODEC(ZSTD(1)),
+    request_headers          String                 CODEC(ZSTD(3)),
+    response_headers         String                 CODEC(ZSTD(3)),
+    query_string             String                 CODEC(ZSTD(3)),
+    -- Fingerprint over the immutable identity (ts ms, path, method,
+    -- status, play_id) so re-polling go-proxy doesn't double-insert.
+    entry_fingerprint        UInt64                 CODEC(ZSTD(1)),
+    INDEX idx_play_id play_id TYPE bloom_filter GRANULARITY 4,
+    INDEX idx_status status TYPE minmax GRANULARITY 4
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (session_id, ts, entry_fingerprint)
+TTL toDateTime(ts) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;

--- a/analytics/go-forwarder/Dockerfile
+++ b/analytics/go-forwarder/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 GOFLAGS=-trimpath go build -o /out/forwarder .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/forwarder /forwarder
+USER nonroot:nonroot
+ENTRYPOINT ["/forwarder"]

--- a/analytics/go-forwarder/bundle.go
+++ b/analytics/go-forwarder/bundle.go
@@ -1,0 +1,576 @@
+// Session-bundle download: fetches snapshots + HAR + events for a single
+// (session_id, play_id) and streams them back as a ZIP. The HAR file is
+// constructed inside the bundle so it loads directly in Chrome DevTools'
+// Network panel; the rest is JSON / NDJSON / a README so the bundle is
+// self-describing for offline triage long after the 30-day TTL has
+// dropped the source rows.
+//
+// Streamed end-to-end: ClickHouse query → JSON parse → ZIP writer →
+// http.ResponseWriter. Peak memory is dominated by a single page of
+// network rows (~10 MB), not the full bundle.
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Header names that can carry credentials. Stripped from HAR entries
+// before they reach the browser. The proxy's capture path already
+// drops most of these, but defense-in-depth: the bundle is meant to
+// be attachable to a bug report without further scrubbing.
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+}
+
+// Query-string param names whose values are redacted (replaced with
+// "[REDACTED]"). Matched case-insensitively against the param name.
+var sensitiveQueryNames = regexp.MustCompile(`(?i)^(token|auth|access[_-]?token|api[_-]?key|key|password|secret|signature|sig)$`)
+
+func registerBundleHandler(mux *http.ServeMux, cfg config) {
+	// GET /api/session_bundle?session=<id>&play_id=<id>
+	mux.HandleFunc("/api/session_bundle", func(w http.ResponseWriter, r *http.Request) {
+		sessionID := r.URL.Query().Get("session")
+		if sessionID == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		playID := r.URL.Query().Get("play_id")
+		// Sentinel "—" means "rows ingested before play_id was
+		// stamped" — translate back to empty string.
+		if playID == "—" {
+			playID = ""
+		}
+
+		// Build a useful filename — small enough to fit in a Slack
+		// upload column without needing a tooltip, but with enough
+		// detail that a folder of bundles is still scannable.
+		shortPlay := playID
+		if len(shortPlay) > 8 {
+			shortPlay = shortPlay[:8]
+		}
+		if shortPlay == "" {
+			shortPlay = "noplay"
+		}
+		stamp := time.Now().UTC().Format("20060102-1504")
+		safeSession := safeFilenameSegment(sessionID)
+		filename := fmt.Sprintf("session-%s-%s-%s.zip", safeSession, shortPlay, stamp)
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%q`, filename))
+		w.Header().Set("Cache-Control", "no-store")
+
+		zw := zip.NewWriter(w)
+		// Always close — finalises the central directory. If we error
+		// mid-stream the client gets a truncated zip, but headers are
+		// already on the wire so we can't switch to plain http.Error.
+		defer zw.Close()
+
+		ctx := r.Context()
+
+		if err := writeSessionMetadata(ctx, zw, cfg, sessionID, playID); err != nil {
+			fmt.Fprintf(w, "\n[bundle error: session.json: %v]\n", err)
+			return
+		}
+		if err := writeSnapshotsNDJSON(ctx, zw, cfg, sessionID, playID); err != nil {
+			fmt.Fprintf(w, "\n[bundle error: snapshots.ndjson: %v]\n", err)
+			return
+		}
+		if err := writeNetworkHAR(ctx, zw, cfg, sessionID, playID); err != nil {
+			fmt.Fprintf(w, "\n[bundle error: network.har: %v]\n", err)
+			return
+		}
+		if err := writeEventsJSON(ctx, zw, cfg, sessionID, playID); err != nil {
+			fmt.Fprintf(w, "\n[bundle error: events.json: %v]\n", err)
+			return
+		}
+		if err := writeREADME(zw, sessionID, playID); err != nil {
+			return
+		}
+	})
+}
+
+// safeFilenameSegment trims any character likely to confuse a shell or
+// download manager. Session IDs are usually small integers so this is
+// belt-and-braces.
+func safeFilenameSegment(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z',
+			r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// session.json — at-a-glance summary that opens first. Reuses the
+// /api/sessions per-play row plus a couple of derived fields the picker
+// already computes, so the bundle reads naturally next to a screenshot
+// of the picker row.
+func writeSessionMetadata(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
+	params := map[string]string{"session": sessionID}
+	pidPred := "play_id = ''"
+	if playID != "" {
+		pidPred = "play_id = {play:String}"
+		params["play"] = playID
+	}
+	query := fmt.Sprintf(`
+		SELECT
+		  toString(min(ts)) AS started,
+		  toString(max(ts)) AS last_seen,
+		  count() AS snapshots,
+		  any(player_id) AS player_id,
+		  any(group_id) AS group_id,
+		  any(content_id) AS content_id,
+		  argMax(player_state, ts) AS last_player_state,
+		  argMax(player_error, ts) AS last_player_error,
+		  max(stall_count) AS stalls,
+		  max(dropped_frames) AS dropped_frames,
+		  max(loop_count_server) AS loops_server,
+		  round(avgIf(video_quality_pct, video_quality_pct > 0), 1) AS avg_quality_pct,
+		  max(master_manifest_consecutive_failures) AS master_manifest_failures,
+		  max(manifest_consecutive_failures) AS manifest_failures,
+		  max(segment_consecutive_failures) AS segment_failures,
+		  max(transport_consecutive_failures) AS transport_failures
+		FROM %s.%s
+		WHERE session_id = {session:String} AND %s
+		FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, pidPred)
+	body, err := chQueryBytes(ctx, cfg, query, params)
+	if err != nil {
+		return err
+	}
+	row := bytes.TrimSpace(body)
+	if len(row) == 0 {
+		row = []byte("{}")
+	}
+	// Wrap the row with our own envelope so the file is self-describing
+	// (vs. a bare per-table aggregate row that needs context).
+	envelope := map[string]json.RawMessage{
+		"session_id": jsonString(sessionID),
+		"play_id":    jsonString(playID),
+		"summary":    row,
+	}
+	out, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeZipFile(zw, "session.json", out)
+}
+
+// snapshots.ndjson — one row per session_snapshots line. NDJSON (not a
+// JSON array) so it streams; jq, ripgrep, awk all handle it natively.
+func writeSnapshotsNDJSON(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
+	params := map[string]string{"session": sessionID}
+	pidPred := "play_id = ''"
+	if playID != "" {
+		pidPred = "play_id = {play:String}"
+		params["play"] = playID
+	}
+	// Project all typed columns except `session_json`. The blob is
+	// redundant with the typed columns and ~10× larger; for a 4-hour
+	// session at 1 Hz, dropping it shrinks snapshots.ndjson from
+	// ~400 MB to ~30 MB (and ~4 MB after deflate). Hot fields the
+	// dashboard relies on are all promoted to typed columns anyway.
+	query := fmt.Sprintf(`
+		SELECT * EXCEPT (session_json, revision)
+		FROM %s.%s
+		WHERE session_id = {session:String} AND %s
+		ORDER BY ts ASC
+		FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, pidPred)
+	body, err := chQueryBytes(ctx, cfg, query, params)
+	if err != nil {
+		return err
+	}
+	// Each line of body is already JSONEachRow — write straight through.
+	return writeZipFile(zw, "snapshots.ndjson", body)
+}
+
+// network.har — HAR 1.2 envelope built from network_requests rows. The
+// header / query-string sanitiser runs over each entry before it's
+// written so the on-disk bundle is safe to share. Custom proxy fields
+// (fault_type, upstream_url, etc.) live under `_extensions`.
+func writeNetworkHAR(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
+	params := map[string]string{"session": sessionID}
+	clauses := []string{"session_id = {session:String}"}
+	// HAR rows are scoped to the play's time range (not play_id) for
+	// the same reason /api/session_events does — iOS strips play_id
+	// from variant/segment URLs. We use a subquery on the snapshots
+	// table to find min/max ts for the play.
+	if playID != "" {
+		params["play"] = playID
+		clauses = append(clauses, fmt.Sprintf(
+			"nr.ts BETWEEN (SELECT min(ts) FROM %s.%s WHERE session_id = {session:String} AND play_id = {play:String}) "+
+				"AND (SELECT max(ts) FROM %s.%s WHERE session_id = {session:String} AND play_id = {play:String})",
+			cfg.chDatabase, cfg.chTable, cfg.chDatabase, cfg.chTable))
+	} else {
+		clauses = append(clauses, "play_id = ''")
+	}
+	query := fmt.Sprintf(`
+		SELECT
+		  toString(ts) AS ts, method, url, upstream_url, path, request_kind,
+		  status, bytes_in, bytes_out, content_type,
+		  request_range, response_content_range,
+		  dns_ms, connect_ms, tls_ms, ttfb_ms, transfer_ms, total_ms, client_wait_ms,
+		  faulted = 1 AS faulted, fault_type, fault_action, fault_category,
+		  request_headers, response_headers, query_string
+		FROM %s.network_requests AS nr
+		WHERE %s
+		ORDER BY nr.ts ASC
+		FORMAT JSONEachRow`, cfg.chDatabase, strings.Join(clauses, " AND "))
+	body, err := chQueryBytes(ctx, cfg, query, params)
+	if err != nil {
+		return err
+	}
+	entries := []json.RawMessage{}
+	for _, line := range bytes.Split(body, []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		entry, err := harEntryFromRow(line)
+		if err != nil {
+			// Best effort: skip a single malformed row rather than
+			// fail the whole bundle.
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	har := map[string]any{
+		"log": map[string]any{
+			"version": "1.2",
+			"creator": map[string]any{
+				"name":    "InfiniteStream forwarder",
+				"version": "1",
+			},
+			"entries": entries,
+		},
+	}
+	out, err := json.MarshalIndent(har, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeZipFile(zw, "network.har", out)
+}
+
+// harEntryFromRow converts one network_requests row into a HAR 1.2
+// `entries[]` element. Sanitises sensitive headers + query-string
+// params; preserves proxy-specific fields under `_extensions`.
+func harEntryFromRow(line []byte) (json.RawMessage, error) {
+	var row struct {
+		TS                   string `json:"ts"`
+		Method               string `json:"method"`
+		URL                  string `json:"url"`
+		UpstreamURL          string `json:"upstream_url"`
+		Path                 string `json:"path"`
+		RequestKind          string `json:"request_kind"`
+		Status               int    `json:"status"`
+		BytesIn              int64  `json:"bytes_in,string"`
+		BytesOut             int64  `json:"bytes_out,string"`
+		ContentType          string `json:"content_type"`
+		RequestRange         string `json:"request_range"`
+		ResponseContentRange string `json:"response_content_range"`
+		DNS_ms               float64
+		Connect_ms           float64
+		TLS_ms               float64
+		TTFB_ms              float64
+		Transfer_ms          float64
+		Total_ms             float64
+		ClientWait_ms        float64
+		Faulted              int    `json:"faulted"`
+		FaultType            string `json:"fault_type"`
+		FaultAction          string `json:"fault_action"`
+		FaultCategory        string `json:"fault_category"`
+		RequestHeaders       string `json:"request_headers"`
+		ResponseHeaders      string `json:"response_headers"`
+		QueryString          string `json:"query_string"`
+	}
+	// Manual decode for the timing fields because JSONEachRow emits
+	// floats as bare numbers but our struct doesn't have explicit
+	// json tags for the *_ms fields (their JSON keys collide with
+	// Go's default case-insensitive match).
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(line, &row); err != nil {
+		return nil, err
+	}
+	row.DNS_ms = numberFromRaw(raw["dns_ms"])
+	row.Connect_ms = numberFromRaw(raw["connect_ms"])
+	row.TLS_ms = numberFromRaw(raw["tls_ms"])
+	row.TTFB_ms = numberFromRaw(raw["ttfb_ms"])
+	row.Transfer_ms = numberFromRaw(raw["transfer_ms"])
+	row.Total_ms = numberFromRaw(raw["total_ms"])
+	row.ClientWait_ms = numberFromRaw(raw["client_wait_ms"])
+
+	reqHeaders := sanitizeHeaders(parseHeaderArray(row.RequestHeaders))
+	respHeaders := sanitizeHeaders(parseHeaderArray(row.ResponseHeaders))
+	queryParams := sanitizeQueryParams(parseHeaderArray(row.QueryString))
+
+	startedDateTime := normaliseTSToISO(row.TS)
+
+	entry := map[string]any{
+		"startedDateTime": startedDateTime,
+		"time":            row.Total_ms,
+		"request": map[string]any{
+			"method":      defaultIfEmpty(row.Method, "GET"),
+			"url":         row.URL,
+			"httpVersion": "HTTP/1.1",
+			"headers":     reqHeaders,
+			"queryString": queryParams,
+			"cookies":     []any{},
+			"headersSize": -1,
+			"bodySize":    row.BytesOut,
+		},
+		"response": map[string]any{
+			"status":      row.Status,
+			"statusText":  "",
+			"httpVersion": "HTTP/1.1",
+			"headers":     respHeaders,
+			"cookies":     []any{},
+			"content": map[string]any{
+				"size":     row.BytesIn,
+				"mimeType": defaultIfEmpty(row.ContentType, "application/octet-stream"),
+			},
+			"redirectURL":  "",
+			"headersSize":  -1,
+			"bodySize":     row.BytesIn,
+		},
+		"cache": map[string]any{},
+		"timings": map[string]any{
+			"blocked": -1,
+			"dns":     row.DNS_ms,
+			"connect": row.Connect_ms,
+			"send":    0,
+			"wait":    row.TTFB_ms,
+			"receive": row.Transfer_ms,
+			"ssl":     row.TLS_ms,
+		},
+		"_extensions": map[string]any{
+			"upstream_url":           row.UpstreamURL,
+			"path":                   row.Path,
+			"request_kind":           row.RequestKind,
+			"request_range":          row.RequestRange,
+			"response_content_range": row.ResponseContentRange,
+			"client_wait_ms":         row.ClientWait_ms,
+			"faulted":                row.Faulted != 0,
+			"fault_type":             row.FaultType,
+			"fault_action":           row.FaultAction,
+			"fault_category":         row.FaultCategory,
+		},
+	}
+	return json.Marshal(entry)
+}
+
+// parseHeaderArray takes a serialised JSON array of {name,value} pairs
+// (the way ClickHouse stores request_headers / response_headers / query_string)
+// and returns it as a Go slice. Returns nil on parse error so the
+// downstream sanitiser sees an empty slice.
+func parseHeaderArray(s string) []map[string]string {
+	if s == "" {
+		return nil
+	}
+	var out []map[string]string
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// sanitizeHeaders returns a copy with sensitive header values replaced
+// by "[REDACTED]". Preserves the header name so the on-disk bundle
+// still tells the reader "yes, an Authorization header was present"
+// without exposing the value.
+func sanitizeHeaders(in []map[string]string) []map[string]string {
+	out := make([]map[string]string, 0, len(in))
+	for _, h := range in {
+		name := h["name"]
+		value := h["value"]
+		if _, sensitive := sensitiveHeaderNames[strings.ToLower(name)]; sensitive {
+			value = "[REDACTED]"
+		}
+		out = append(out, map[string]string{"name": name, "value": value})
+	}
+	return out
+}
+
+// sanitizeQueryParams redacts query-string values whose names look
+// credential-shaped. The full list is in `sensitiveQueryNames`.
+func sanitizeQueryParams(in []map[string]string) []map[string]string {
+	out := make([]map[string]string, 0, len(in))
+	for _, q := range in {
+		name := q["name"]
+		value := q["value"]
+		if sensitiveQueryNames.MatchString(name) {
+			value = "[REDACTED]"
+		}
+		out = append(out, map[string]string{"name": name, "value": value})
+	}
+	return out
+}
+
+func numberFromRaw(raw json.RawMessage) float64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var n float64
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n
+	}
+	// Fall back to string-encoded numbers (some ClickHouse types emit
+	// String JSON for large integers).
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			return v
+		}
+	}
+	return 0
+}
+
+func defaultIfEmpty(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}
+
+// normaliseTSToISO converts the ClickHouse "YYYY-MM-DD HH:MM:SS.mmm"
+// format into the HAR-spec ISO 8601 with explicit Z suffix.
+func normaliseTSToISO(s string) string {
+	if s == "" {
+		return ""
+	}
+	// "2026-05-03 12:34:56.789" → "2026-05-03T12:34:56.789Z"
+	return strings.Replace(s, " ", "T", 1) + "Z"
+}
+
+// events.json — flat list of player-emitted events from last_event.
+// This is the "simple half" of /api/session_events: the player tells
+// us "stall_start", "rate_shift_down" etc. directly. The complex
+// derived events (lag-based fault transitions, paired stall-start /
+// stall-end durations, HAR-derived http_5xx etc.) are NOT included
+// here — recompute them live via /api/session_events while the
+// analytics tier is up. Note in README points the reader there.
+func writeEventsJSON(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
+	params := map[string]string{"session": sessionID}
+	pidPred := "play_id = ''"
+	if playID != "" {
+		pidPred = "play_id = {play:String}"
+		params["play"] = playID
+	}
+	query := fmt.Sprintf(`
+		SELECT toString(ts) AS ts, last_event AS type,
+		       player_error AS info
+		FROM %s.%s
+		WHERE session_id = {session:String} AND %s
+		  AND last_event != ''
+		  AND last_event NOT IN ('heartbeat','state_change','playing','video_bitrate_change')
+		ORDER BY ts ASC
+		FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, pidPred)
+	body, err := chQueryBytes(ctx, cfg, query, params)
+	if err != nil {
+		return err
+	}
+	// Wrap NDJSON-style output as a JSON array for events.json so it's
+	// easy to load (`json.load(open('events.json'))` from Python /
+	// jq one-liners). Body is `{...}\n{...}\n...`; convert by joining.
+	var out bytes.Buffer
+	out.WriteByte('[')
+	first := true
+	for _, line := range bytes.Split(bytes.TrimSpace(body), []byte{'\n'}) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		if !first {
+			out.WriteByte(',')
+		}
+		out.WriteByte('\n')
+		out.Write(line)
+		first = false
+	}
+	if !first {
+		out.WriteByte('\n')
+	}
+	out.WriteByte(']')
+	out.WriteByte('\n')
+	return writeZipFile(zw, "events.json", out.Bytes())
+}
+
+// writeREADME — short orientation file for whoever opens the zip in
+// six months. Not auto-generated from a template because the prose
+// belongs in source.
+func writeREADME(zw *zip.Writer, sessionID, playID string) error {
+	body := fmt.Sprintf(`# InfiniteStream session bundle
+
+session_id: %s
+play_id:    %s
+generated:  %s
+
+## Files
+
+- session.json        Top-level summary (player, content, timing, fault counts).
+- snapshots.ndjson    One JSON object per per-second snapshot, all
+                      typed columns (stall_count, video_bitrate_mbps,
+                      transport_fault_active, etc.). Use jq:
+                        cat snapshots.ndjson | jq 'select(.stall_count > 0)'
+- network.har         HAR 1.2 envelope. Open in Chrome DevTools:
+                        chrome://devtools  →  Network panel  →  Import HAR
+                      Custom proxy fields (fault_type, upstream_url, etc.)
+                      live under each entry's _extensions key.
+- events.json         Player-emitted events (stall_start, rate_shift_down,
+                      error, user_marked, etc.) — the "simple half" of
+                      the events query. Derived events (paired stall
+                      durations, lag-based fault transitions, HAR-derived
+                      http_5xx, etc.) are recomputable live via
+                      /analytics/api/session_events while the analytics
+                      tier is up.
+
+## Sanitisation
+
+Authorization, Cookie, Set-Cookie, X-API-Key headers redacted.
+Query-string parameters with names matching token / auth / api_key /
+key / password / secret / signature / sig also redacted. The proxy
+capture path drops most of these upstream; this is defense-in-depth.
+`, sessionID, playID, time.Now().UTC().Format(time.RFC3339))
+	return writeZipFile(zw, "README.md", []byte(body))
+}
+
+// writeZipFile creates one entry inside the zip writer with deflate
+// compression. Returns the writer's error directly so the caller can
+// abort the bundle.
+func writeZipFile(zw *zip.Writer, name string, body []byte) error {
+	header := &zip.FileHeader{
+		Name:     name,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	}
+	w, err := zw.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, bytes.NewReader(body))
+	return err
+}
+
+func jsonString(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}

--- a/analytics/go-forwarder/bundle.go
+++ b/analytics/go-forwarder/bundle.go
@@ -94,10 +94,6 @@ func registerBundleHandler(mux *http.ServeMux, cfg config) {
 			fmt.Fprintf(w, "\n[bundle error: network.har: %v]\n", err)
 			return
 		}
-		if err := writeEventsJSON(ctx, zw, cfg, sessionID, playID); err != nil {
-			fmt.Fprintf(w, "\n[bundle error: events.json: %v]\n", err)
-			return
-		}
 		if err := writeREADME(zw, sessionID, playID); err != nil {
 			return
 		}
@@ -464,58 +460,6 @@ func normaliseTSToISO(s string) string {
 	return strings.Replace(s, " ", "T", 1) + "Z"
 }
 
-// events.json — flat list of player-emitted events from last_event.
-// This is the "simple half" of /api/session_events: the player tells
-// us "stall_start", "rate_shift_down" etc. directly. The complex
-// derived events (lag-based fault transitions, paired stall-start /
-// stall-end durations, HAR-derived http_5xx etc.) are NOT included
-// here — recompute them live via /api/session_events while the
-// analytics tier is up. Note in README points the reader there.
-func writeEventsJSON(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
-	params := map[string]string{"session": sessionID}
-	pidPred := "play_id = ''"
-	if playID != "" {
-		pidPred = "play_id = {play:String}"
-		params["play"] = playID
-	}
-	query := fmt.Sprintf(`
-		SELECT toString(ts) AS ts, last_event AS type,
-		       player_error AS info
-		FROM %s.%s
-		WHERE session_id = {session:String} AND %s
-		  AND last_event != ''
-		  AND last_event NOT IN ('heartbeat','state_change','playing','video_bitrate_change')
-		ORDER BY ts ASC
-		FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, pidPred)
-	body, err := chQueryBytes(ctx, cfg, query, params)
-	if err != nil {
-		return err
-	}
-	// Wrap NDJSON-style output as a JSON array for events.json so it's
-	// easy to load (`json.load(open('events.json'))` from Python /
-	// jq one-liners). Body is `{...}\n{...}\n...`; convert by joining.
-	var out bytes.Buffer
-	out.WriteByte('[')
-	first := true
-	for _, line := range bytes.Split(bytes.TrimSpace(body), []byte{'\n'}) {
-		if len(bytes.TrimSpace(line)) == 0 {
-			continue
-		}
-		if !first {
-			out.WriteByte(',')
-		}
-		out.WriteByte('\n')
-		out.Write(line)
-		first = false
-	}
-	if !first {
-		out.WriteByte('\n')
-	}
-	out.WriteByte(']')
-	out.WriteByte('\n')
-	return writeZipFile(zw, "events.json", out.Bytes())
-}
-
 // writeREADME — short orientation file for whoever opens the zip in
 // six months. Not auto-generated from a template because the prose
 // belongs in source.
@@ -533,17 +477,20 @@ generated:  %s
                       original blob the go-proxy SSE stream emitted,
                       pre-typed-column-extraction. Use jq:
                         cat snapshots.ndjson | jq 'select(.stall_count > 0)'
+                      Player-emitted events live in the .last_event
+                      field of every snapshot, e.g.:
+                        cat snapshots.ndjson \
+                          | jq 'select(.last_event != "" and .last_event != "heartbeat")
+                                | {ts: .last_event_at, type: .last_event,
+                                   error: .player_error}'
+                      Derived events (paired stall durations, lag-based
+                      fault transitions, HAR-derived http_5xx, etc.)
+                      are recomputable live via the analytics tier's
+                      /analytics/api/session_events endpoint.
 - network.har         HAR 1.2 envelope. Open in Chrome DevTools:
                         chrome://devtools  →  Network panel  →  Import HAR
                       Custom proxy fields (fault_type, upstream_url, etc.)
                       live under each entry's _extensions key.
-- events.json         Player-emitted events (stall_start, rate_shift_down,
-                      error, user_marked, etc.) — the "simple half" of
-                      the events query. Derived events (paired stall
-                      durations, lag-based fault transitions, HAR-derived
-                      http_5xx, etc.) are recomputable live via
-                      /analytics/api/session_events while the analytics
-                      tier is up.
 
 ## Sanitisation
 

--- a/analytics/go-forwarder/bundle.go
+++ b/analytics/go-forwarder/bundle.go
@@ -175,8 +175,16 @@ func writeSessionMetadata(ctx context.Context, zw *zip.Writer, cfg config, sessi
 	return writeZipFile(zw, "session.json", out)
 }
 
-// snapshots.ndjson — one row per session_snapshots line. NDJSON (not a
-// JSON array) so it streams; jq, ripgrep, awk all handle it natively.
+// snapshots.ndjson — one raw session_json blob per line, the same
+// payload the go-proxy SSE stream emitted before the forwarder split
+// hot fields into typed columns. We deliberately drop the typed
+// columns (and `revision`, `ts`) here: the blobs already carry every
+// field the live session-viewer reads, and offline replay should see
+// exactly what the proxy sent — not a denormalised view of it.
+//
+// TabSeparatedRaw emits each session_json value as a single newline-
+// terminated line, no escaping. The proxy serialises blobs as one
+// line of compact JSON so this round-trips cleanly into NDJSON.
 func writeSnapshotsNDJSON(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {
 	params := map[string]string{"session": sessionID}
 	pidPred := "play_id = ''"
@@ -184,22 +192,16 @@ func writeSnapshotsNDJSON(ctx context.Context, zw *zip.Writer, cfg config, sessi
 		pidPred = "play_id = {play:String}"
 		params["play"] = playID
 	}
-	// Project all typed columns except `session_json`. The blob is
-	// redundant with the typed columns and ~10× larger; for a 4-hour
-	// session at 1 Hz, dropping it shrinks snapshots.ndjson from
-	// ~400 MB to ~30 MB (and ~4 MB after deflate). Hot fields the
-	// dashboard relies on are all promoted to typed columns anyway.
 	query := fmt.Sprintf(`
-		SELECT * EXCEPT (session_json, revision)
+		SELECT session_json
 		FROM %s.%s
 		WHERE session_id = {session:String} AND %s
 		ORDER BY ts ASC
-		FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, pidPred)
+		FORMAT TabSeparatedRaw`, cfg.chDatabase, cfg.chTable, pidPred)
 	body, err := chQueryBytes(ctx, cfg, query, params)
 	if err != nil {
 		return err
 	}
-	// Each line of body is already JSONEachRow — write straight through.
 	return writeZipFile(zw, "snapshots.ndjson", body)
 }
 
@@ -527,9 +529,9 @@ generated:  %s
 ## Files
 
 - session.json        Top-level summary (player, content, timing, fault counts).
-- snapshots.ndjson    One JSON object per per-second snapshot, all
-                      typed columns (stall_count, video_bitrate_mbps,
-                      transport_fault_active, etc.). Use jq:
+- snapshots.ndjson    One JSON object per per-second snapshot — the
+                      original blob the go-proxy SSE stream emitted,
+                      pre-typed-column-extraction. Use jq:
                         cat snapshots.ndjson | jq 'select(.stall_count > 0)'
 - network.har         HAR 1.2 envelope. Open in Chrome DevTools:
                         chrome://devtools  →  Network panel  →  Import HAR

--- a/analytics/go-forwarder/go.mod
+++ b/analytics/go-forwarder/go.mod
@@ -1,0 +1,3 @@
+module github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder
+
+go 1.25.0

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -1454,6 +1454,10 @@ func serveHTTP(ctx context.Context, cfg config) {
 		w.Write([]byte("]}"))
 	})
 
+	// /api/session_bundle — ZIP of snapshots + HAR + events for one
+	// (session_id, play_id). Defined in bundle.go.
+	registerBundleHandler(mux, cfg)
+
 	srv := &http.Server{
 		Addr:              cfg.httpListen,
 		Handler:           mux,

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -1,0 +1,1534 @@
+// Subscribes to go-proxy's session SSE stream and forwards each changed
+// session snapshot to ClickHouse. Standalone, no dependency on go-proxy
+// internals; if this binary dies the live UI keeps working — we just
+// stop archiving until it restarts.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type config struct {
+	sseURL        string
+	clickhouseURL string
+	chDatabase    string
+	chTable       string
+	chUser        string
+	chPassword    string
+	flushEvery    time.Duration
+	flushBatch    int
+	httpListen    string
+}
+
+func loadConfig() config {
+	c := config{
+		sseURL:        getenv("FORWARDER_SSE_URL", "http://go-server:30081/api/sessions/stream"),
+		clickhouseURL: getenv("FORWARDER_CLICKHOUSE_URL", "http://clickhouse:8123"),
+		chDatabase:    getenv("FORWARDER_CLICKHOUSE_DB", "infinite_streaming"),
+		chTable:       getenv("FORWARDER_CLICKHOUSE_TABLE", "session_snapshots"),
+		chUser:        getenv("FORWARDER_CLICKHOUSE_USER", "default"),
+		chPassword:    getenv("FORWARDER_CLICKHOUSE_PASSWORD", ""),
+		// flushEvery is the upper bound on per-row visibility lag — the
+		// inserter empties whichever happens first (timer or batch
+		// fills). 250ms keeps the picker's "x seconds ago" honest
+		// without significantly raising ClickHouse insert pressure.
+		flushEvery:    250 * time.Millisecond,
+		flushBatch:    500,
+		httpListen:    getenv("FORWARDER_HTTP_LISTEN", ":8080"),
+	}
+	return c
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// row mirrors the ClickHouse session_snapshots column set. Field names
+// are the JSONEachRow keys; the schema accepts these directly.
+type row struct {
+	Ts                       string  `json:"ts"`
+	Revision                 uint64  `json:"revision"`
+	SessionID                string  `json:"session_id"`
+	PlayID                   string  `json:"play_id"`
+	PlayerID                 string  `json:"player_id"`
+	GroupID                  string  `json:"group_id"`
+	UserAgent                string  `json:"user_agent"`
+	ManifestURL              string  `json:"manifest_url"`
+	ManifestVariants         string  `json:"manifest_variants"`
+	LastRequestURL           string  `json:"last_request_url"`
+	ContentID                string  `json:"content_id"`
+	PlayerState              string  `json:"player_state"`
+	WaitingReason            string  `json:"waiting_reason"`
+	BufferDepthS             float32 `json:"buffer_depth_s"`
+	NetworkBitrateMbps       float32 `json:"network_bitrate_mbps"`
+	VideoBitrateMbps         float32 `json:"video_bitrate_mbps"`
+	MeasuredMbps             float32 `json:"measured_mbps"`
+	MbpsShaperRate           float32 `json:"mbps_shaper_rate"`
+	MbpsShaperAvg            float32 `json:"mbps_shaper_avg"`
+	DisplayResolution        string  `json:"display_resolution"`
+	VideoResolution          string  `json:"video_resolution"`
+	FramesDisplayed          uint64  `json:"frames_displayed"`
+	DroppedFrames            uint32  `json:"dropped_frames"`
+	StallCount               uint32  `json:"stall_count"`
+	StallTimeS               float32 `json:"stall_time_s"`
+	PositionS                float32 `json:"position_s"`
+	LiveEdgeS                float32 `json:"live_edge_s"`
+	TrueOffsetS              float32 `json:"true_offset_s"`
+	PlaybackRate             float32 `json:"playback_rate"`
+	LoopCountPlayer          uint32  `json:"loop_count_player"`
+	LoopCountServer          uint32  `json:"loop_count_server"`
+	LastEvent                string  `json:"last_event"`
+	LastEventAt              string  `json:"last_event_at"`
+	TriggerType              string  `json:"trigger_type"`
+	EventTime                string  `json:"event_time"`
+	PlayerError              string  `json:"player_error"`
+
+	AvgNetworkBitrateMbps    float32 `json:"avg_network_bitrate_mbps"`
+	BufferEndS               float32 `json:"buffer_end_s"`
+	LastStallTimeS           float32 `json:"last_stall_time_s"`
+	LiveOffsetS              float32 `json:"live_offset_s"`
+	PlayheadWallclockMs      int64   `json:"playhead_wallclock_ms"`
+	SeekableEndS             float32 `json:"seekable_end_s"`
+	MetricsSource            string  `json:"metrics_source"`
+	VideoFirstFrameTimeS     float32 `json:"video_first_frame_time_s"`
+	VideoQualityPct          float32 `json:"video_quality_pct"`
+	VideoStartTimeS          float32 `json:"video_start_time_s"`
+
+	MbpsTransferComplete     float32 `json:"mbps_transfer_complete"`
+	MbpsTransferRate         float32 `json:"mbps_transfer_rate"`
+	PlayerIP                 string  `json:"player_ip"`
+	ServerReceivedAtMs       int64   `json:"server_received_at_ms"`
+	XForwardedPort           uint16  `json:"x_forwarded_port"`
+	XForwardedPortExternal   uint16  `json:"x_forwarded_port_external"`
+
+	MasterManifestURL                  string  `json:"master_manifest_url"`
+	MasterManifestFailureType          string  `json:"master_manifest_failure_type"`
+	MasterManifestFailureMode          string  `json:"master_manifest_failure_mode"`
+	MasterManifestFailureFrequency     float32 `json:"master_manifest_failure_frequency"`
+	MasterManifestConsecutiveFailures  uint32  `json:"master_manifest_consecutive_failures"`
+	MasterManifestRequestsCount        uint32  `json:"master_manifest_requests_count"`
+
+	ManifestFailureFrequency     float32 `json:"manifest_failure_frequency"`
+	ManifestFailureURLs          string  `json:"manifest_failure_urls"`
+	ManifestConsecutiveFailures  uint32  `json:"manifest_consecutive_failures"`
+	ManifestRequestsCount        uint32  `json:"manifest_requests_count"`
+
+	SegmentFailureFrequency     float32 `json:"segment_failure_frequency"`
+	SegmentFailureURLs          string  `json:"segment_failure_urls"`
+	SegmentConsecutiveFailures  uint32  `json:"segment_consecutive_failures"`
+	SegmentsCount               uint32  `json:"segments_count"`
+
+	AllFailureType            string  `json:"all_failure_type"`
+	AllFailureMode            string  `json:"all_failure_mode"`
+	AllFailureFrequency       float32 `json:"all_failure_frequency"`
+	AllFailureURLs            string  `json:"all_failure_urls"`
+	AllConsecutiveFailures    uint32  `json:"all_consecutive_failures"`
+
+	TransportFailureFrequency    float32 `json:"transport_failure_frequency"`
+	TransportFailureMode         string  `json:"transport_failure_mode"`
+	TransportFailureUnits        string  `json:"transport_failure_units"`
+	TransportConsecutiveFailures uint32  `json:"transport_consecutive_failures"`
+	TransportConsecutiveSeconds  float32 `json:"transport_consecutive_seconds"`
+	TransportConsecutiveUnits    uint32  `json:"transport_consecutive_units"`
+	TransportFrequencySeconds    float32 `json:"transport_frequency_seconds"`
+	TransportFaultDropPackets    uint8   `json:"transport_fault_drop_packets"`
+	TransportFaultRejectPackets  uint8   `json:"transport_fault_reject_packets"`
+	TransportFaultOffSeconds     float32 `json:"transport_fault_off_seconds"`
+	TransportFaultOnSeconds      float32 `json:"transport_fault_on_seconds"`
+	TransportFaultType           string  `json:"transport_fault_type"`
+	FaultCountTransferActiveTimeout uint32 `json:"fault_count_transfer_active_timeout"`
+	FaultCountTransferIdleTimeout   uint32 `json:"fault_count_transfer_idle_timeout"`
+
+	TransferActiveTimeoutSeconds   float32 `json:"transfer_active_timeout_seconds"`
+	TransferIdleTimeoutSeconds     float32 `json:"transfer_idle_timeout_seconds"`
+	TransferTimeoutAppliesManifests uint8  `json:"transfer_timeout_applies_manifests"`
+	TransferTimeoutAppliesMaster    uint8  `json:"transfer_timeout_applies_master"`
+	TransferTimeoutAppliesSegments  uint8  `json:"transfer_timeout_applies_segments"`
+
+	NftablesPatternStep             uint32  `json:"nftables_pattern_step"`
+	NftablesPatternStepRuntime      uint32  `json:"nftables_pattern_step_runtime"`
+	NftablesPatternSteps            string  `json:"nftables_pattern_steps"`
+	NftablesPatternRateRuntimeMbps  float32 `json:"nftables_pattern_rate_runtime_mbps"`
+	NftablesPatternMarginPct        float32 `json:"nftables_pattern_margin_pct"`
+	NftablesPatternTemplateMode     string  `json:"nftables_pattern_template_mode"`
+
+	ContentAllowedVariants string  `json:"content_allowed_variants"`
+	ContentLiveOffset      float32 `json:"content_live_offset"`
+	ContentStripCodecs     string  `json:"content_strip_codecs"`
+
+	AbrcharRunLock   uint8  `json:"abrchar_run_lock"`
+	ControlRevision  uint64 `json:"control_revision"`
+	ServerVideoRendition     string  `json:"server_video_rendition"`
+	ServerVideoRenditionMbps float32 `json:"server_video_rendition_mbps"`
+	ManifestFailureType      string  `json:"manifest_failure_type"`
+	ManifestFailureMode      string  `json:"manifest_failure_mode"`
+	SegmentFailureType       string  `json:"segment_failure_type"`
+	SegmentFailureMode       string  `json:"segment_failure_mode"`
+	TransportFailureType     string  `json:"transport_failure_type"`
+	TransportFaultActive     uint8   `json:"transport_fault_active"`
+	NftablesBandwidthMbps    float32 `json:"nftables_bandwidth_mbps"`
+	NftablesDelayMs          uint32  `json:"nftables_delay_ms"`
+	NftablesPacketLoss       float32 `json:"nftables_packet_loss"`
+	NftablesPatternEnabled   uint8   `json:"nftables_pattern_enabled"`
+	FirstRequestTime         string  `json:"first_request_time"`
+	LastRequest              string  `json:"last_request"`
+	SessionDuration          float32 `json:"session_duration"`
+	SessionJSON              string  `json:"session_json"`
+}
+
+type ssePayload struct {
+	Revision uint64                   `json:"revision"`
+	Sessions []map[string]interface{} `json:"sessions"`
+}
+
+// fingerprintCache tracks the last-seen fingerprint per session so we
+// only insert when something changed (the SSE stream re-emits unchanged
+// sessions on every tick).
+type fingerprintCache struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func newFingerprintCache() *fingerprintCache {
+	return &fingerprintCache{m: make(map[string]string)}
+}
+
+func (c *fingerprintCache) changed(sessionID, fp string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if prev, ok := c.m[sessionID]; ok && prev == fp {
+		return false
+	}
+	c.m[sessionID] = fp
+	return true
+}
+
+func (c *fingerprintCache) prune(activeIDs map[string]struct{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id := range c.m {
+		if _, ok := activeIDs[id]; !ok {
+			delete(c.m, id)
+		}
+	}
+}
+
+func main() {
+	cfg := loadConfig()
+	log.Printf("forwarder starting: sse=%s ch=%s/%s.%s", cfg.sseURL, cfg.clickhouseURL, cfg.chDatabase, cfg.chTable)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Printf("shutdown signal received")
+		cancel()
+	}()
+
+	rows := make(chan row, 4096)
+	go batchInserter(ctx, cfg, rows)
+	go serveHTTP(ctx, cfg)
+
+	// Network log archival: subscribe to go-proxy's /api/network/stream
+	// SSE endpoint and forward each per-request event to ClickHouse so
+	// the session-viewer can replay them after the session is gone.
+	netRows := make(chan netRow, 8192)
+	netSeenSet := newNetSeen(50000)
+	go batchInsertNet(ctx, cfg, netRows)
+	go runNetworkStream(ctx, cfg, netSeenSet, netRows)
+
+	cache := newFingerprintCache()
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := streamSSE(ctx, cfg, cache, netSeenSet, rows)
+		if ctx.Err() != nil {
+			return
+		}
+		log.Printf("sse stream ended: %v (reconnecting in %s)", err, backoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+func streamSSE(ctx context.Context, cfg config, cache *fingerprintCache, netSeen *netSeen, out chan<- row) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.sseURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("sse status %d", resp.StatusCode)
+	}
+
+	reader := bufio.NewReaderSize(resp.Body, 1<<20)
+	var dataBuf bytes.Buffer
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if dataBuf.Len() > 0 {
+				handlePayload(dataBuf.Bytes(), cache, netSeen, out)
+				dataBuf.Reset()
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") {
+			dataBuf.WriteString(line[len("data: "):])
+		}
+	}
+}
+
+func handlePayload(data []byte, cache *fingerprintCache, netSeen *netSeen, out chan<- row) {
+	var payload ssePayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		log.Printf("bad sse payload: %v", err)
+		return
+	}
+	now := time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	active := make(map[string]struct{}, len(payload.Sessions))
+	for _, s := range payload.Sessions {
+		sessionID, _ := s["session_id"].(string)
+		if sessionID == "" {
+			continue
+		}
+		active[sessionID] = struct{}{}
+		fp := fingerprint(s)
+		if !cache.changed(sessionID, fp) {
+			continue
+		}
+		out <- toRow(now, payload.Revision, sessionID, s)
+	}
+	cache.prune(active)
+	// Free network-log fingerprint memory for sessions that have aged
+	// out of the SSE stream.
+	if netSeen != nil {
+		netSeen.prune(active)
+	}
+}
+
+func fingerprint(s map[string]interface{}) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8])
+}
+
+func toRow(ts string, revision uint64, sessionID string, s map[string]interface{}) row {
+	full, _ := json.Marshal(s)
+	return row{
+		Ts:                       ts,
+		Revision:                 revision,
+		SessionID:                sessionID,
+		PlayID:                   getStr(s, "play_id"),
+		PlayerID:                 getStr(s, "player_id"),
+		GroupID:                  getStr(s, "group_id"),
+		UserAgent:                getStr(s, "user_agent"),
+		ManifestURL:              getStr(s, "manifest_url"),
+		ManifestVariants:         getJSON(s, "manifest_variants"),
+		LastRequestURL:           getStr(s, "last_request_url"),
+		ContentID:                contentIDFromURL(getStr(s, "manifest_url"), getStr(s, "last_request_url")),
+		PlayerState:              getStr(s, "player_metrics_state"),
+		WaitingReason:            getStr(s, "player_metrics_waiting_reason"),
+		BufferDepthS:             getF32(s, "player_metrics_buffer_depth_s"),
+		NetworkBitrateMbps:       getF32(s, "player_metrics_network_bitrate_mbps"),
+		VideoBitrateMbps:         getF32(s, "player_metrics_video_bitrate_mbps"),
+		MeasuredMbps:             getF32(s, "measured_mbps"),
+		MbpsShaperRate:           getF32(s, "mbps_shaper_rate"),
+		MbpsShaperAvg:            getF32(s, "mbps_shaper_avg"),
+		DisplayResolution:        getStr(s, "player_metrics_display_resolution"),
+		VideoResolution:          getStr(s, "player_metrics_video_resolution"),
+		FramesDisplayed:          getU64(s, "player_metrics_frames_displayed"),
+		DroppedFrames:            uint32(getU64(s, "player_metrics_dropped_frames")),
+		StallCount:               uint32(getU64(s, "player_metrics_stall_count")),
+		StallTimeS:               getF32(s, "player_metrics_stall_time_s"),
+		PositionS:                getF32(s, "player_metrics_position_s"),
+		LiveEdgeS:                getF32(s, "player_metrics_live_edge_s"),
+		TrueOffsetS:              getF32(s, "player_metrics_true_offset_s"),
+		PlaybackRate:             getF32(s, "player_metrics_playback_rate"),
+		LoopCountPlayer:          uint32(getU64(s, "loop_count_player")),
+		LoopCountServer:          uint32(getU64(s, "loop_count_server")),
+		LastEvent:                getStr(s, "player_metrics_last_event"),
+		LastEventAt:              getStr(s, "player_metrics_last_event_at"),
+		TriggerType:              getStr(s, "player_metrics_trigger_type"),
+		EventTime:                getStr(s, "player_metrics_event_time"),
+		PlayerError:              getStr(s, "player_metrics_error"),
+
+		AvgNetworkBitrateMbps: getF32(s, "player_metrics_avg_network_bitrate_mbps"),
+		BufferEndS:            getF32(s, "player_metrics_buffer_end_s"),
+		LastStallTimeS:        getF32(s, "player_metrics_last_stall_time_s"),
+		LiveOffsetS:           getF32(s, "player_metrics_live_offset_s"),
+		PlayheadWallclockMs:   int64(getU64(s, "player_metrics_playhead_wallclock_ms")),
+		SeekableEndS:          getF32(s, "player_metrics_seekable_end_s"),
+		MetricsSource:         getStr(s, "player_metrics_source"),
+		VideoFirstFrameTimeS:  getF32(s, "player_metrics_video_first_frame_time_s"),
+		VideoQualityPct:       getF32(s, "player_metrics_video_quality_pct"),
+		VideoStartTimeS:       getF32(s, "player_metrics_video_start_time_s"),
+
+		MbpsTransferComplete:   getF32(s, "mbps_transfer_complete"),
+		MbpsTransferRate:       getF32(s, "mbps_transfer_rate"),
+		PlayerIP:               getStr(s, "player_ip"),
+		ServerReceivedAtMs:     int64(getU64(s, "server_received_at_ms")),
+		XForwardedPort:         uint16(getU64(s, "x_forwarded_port")),
+		XForwardedPortExternal: uint16(getU64(s, "x_forwarded_port_external")),
+
+		MasterManifestURL:                 getStr(s, "master_manifest_url"),
+		MasterManifestFailureType:         getStr(s, "master_manifest_failure_type"),
+		MasterManifestFailureMode:         getStr(s, "master_manifest_failure_mode"),
+		MasterManifestFailureFrequency:    getF32(s, "master_manifest_failure_frequency"),
+		MasterManifestConsecutiveFailures: uint32(getU64(s, "master_manifest_consecutive_failures")),
+		MasterManifestRequestsCount:       uint32(getU64(s, "master_manifest_requests_count")),
+
+		ManifestFailureFrequency:    getF32(s, "manifest_failure_frequency"),
+		ManifestFailureURLs:         getJSON(s, "manifest_failure_urls"),
+		ManifestConsecutiveFailures: uint32(getU64(s, "manifest_consecutive_failures")),
+		ManifestRequestsCount:       uint32(getU64(s, "manifest_requests_count")),
+
+		SegmentFailureFrequency:    getF32(s, "segment_failure_frequency"),
+		SegmentFailureURLs:         getJSON(s, "segment_failure_urls"),
+		SegmentConsecutiveFailures: uint32(getU64(s, "segment_consecutive_failures")),
+		SegmentsCount:              uint32(getU64(s, "segments_count")),
+
+		AllFailureType:         getStr(s, "all_failure_type"),
+		AllFailureMode:         getStr(s, "all_failure_mode"),
+		AllFailureFrequency:    getF32(s, "all_failure_frequency"),
+		AllFailureURLs:         getJSON(s, "all_failure_urls"),
+		AllConsecutiveFailures: uint32(getU64(s, "all_consecutive_failures")),
+
+		TransportFailureFrequency:       getF32(s, "transport_failure_frequency"),
+		TransportFailureMode:            getStr(s, "transport_failure_mode"),
+		TransportFailureUnits:           getStr(s, "transport_failure_units"),
+		TransportConsecutiveFailures:    uint32(getU64(s, "transport_consecutive_failures")),
+		TransportConsecutiveSeconds:     getF32(s, "transport_consecutive_seconds"),
+		TransportConsecutiveUnits:       uint32(getU64(s, "transport_consecutive_units")),
+		TransportFrequencySeconds:       getF32(s, "transport_frequency_seconds"),
+		TransportFaultDropPackets:       uint8(getU64(s, "transport_fault_drop_packets")),
+		TransportFaultRejectPackets:     uint8(getU64(s, "transport_fault_reject_packets")),
+		TransportFaultOffSeconds:        getF32(s, "transport_fault_off_seconds"),
+		TransportFaultOnSeconds:         getF32(s, "transport_fault_on_seconds"),
+		TransportFaultType:              getStr(s, "transport_fault_type"),
+		FaultCountTransferActiveTimeout: uint32(getU64(s, "fault_count_transfer_active_timeout")),
+		FaultCountTransferIdleTimeout:   uint32(getU64(s, "fault_count_transfer_idle_timeout")),
+
+		TransferActiveTimeoutSeconds:    getF32(s, "transfer_active_timeout_seconds"),
+		TransferIdleTimeoutSeconds:      getF32(s, "transfer_idle_timeout_seconds"),
+		TransferTimeoutAppliesManifests: uint8(getU64(s, "transfer_timeout_applies_manifests")),
+		TransferTimeoutAppliesMaster:    uint8(getU64(s, "transfer_timeout_applies_master")),
+		TransferTimeoutAppliesSegments:  uint8(getU64(s, "transfer_timeout_applies_segments")),
+
+		NftablesPatternStep:            uint32(getU64(s, "nftables_pattern_step")),
+		NftablesPatternStepRuntime:     uint32(getU64(s, "nftables_pattern_step_runtime")),
+		NftablesPatternSteps:           getJSON(s, "nftables_pattern_steps"),
+		NftablesPatternRateRuntimeMbps: getF32(s, "nftables_pattern_rate_runtime_mbps"),
+		NftablesPatternMarginPct:       getF32(s, "nftables_pattern_margin_pct"),
+		NftablesPatternTemplateMode:    getStr(s, "nftables_pattern_template_mode"),
+
+		ContentAllowedVariants: getJSON(s, "content_allowed_variants"),
+		ContentLiveOffset:      getF32(s, "content_live_offset"),
+		ContentStripCodecs:     getStr(s, "content_strip_codecs"),
+
+		AbrcharRunLock:  uint8(getU64(s, "abrchar_run_lock")),
+		ControlRevision: getU64(s, "control_revision"),
+		ServerVideoRendition:     getStr(s, "server_video_rendition"),
+		ServerVideoRenditionMbps: getF32(s, "server_video_rendition_mbps"),
+		ManifestFailureType:      getStr(s, "manifest_failure_type"),
+		ManifestFailureMode:      getStr(s, "manifest_failure_mode"),
+		SegmentFailureType:       getStr(s, "segment_failure_type"),
+		SegmentFailureMode:       getStr(s, "segment_failure_mode"),
+		TransportFailureType:     getStr(s, "transport_failure_type"),
+		TransportFaultActive:     uint8(getU64(s, "transport_fault_active")),
+		NftablesBandwidthMbps:    getF32(s, "nftables_bandwidth_mbps"),
+		NftablesDelayMs:          uint32(getU64(s, "nftables_delay_ms")),
+		NftablesPacketLoss:       getF32(s, "nftables_packet_loss"),
+		NftablesPatternEnabled:   uint8(getU64(s, "nftables_pattern_enabled")),
+		FirstRequestTime:         getStr(s, "first_request_time"),
+		LastRequest:              getStr(s, "last_request"),
+		SessionDuration:          getF32(s, "session_duration"),
+		SessionJSON:              string(full),
+	}
+}
+
+// contentIDFromURL pulls the {content} path segment out of a go-live URL.
+// nginx routes /go-live/{content}/<file> for both manifests and segments,
+// so either manifest_url or last_request_url usually contains it.
+func contentIDFromURL(urls ...string) string {
+	for _, u := range urls {
+		if u == "" {
+			continue
+		}
+		if i := strings.Index(u, "/go-live/"); i >= 0 {
+			rest := u[i+len("/go-live/"):]
+			if j := strings.Index(rest, "/"); j > 0 {
+				return rest[:j]
+			}
+			if rest != "" {
+				return rest
+			}
+		}
+	}
+	return ""
+}
+
+func getStr(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// getJSON returns m[key] re-encoded as a JSON string. Use for fields
+// whose SSE shape is an array or object — we keep them queryable via
+// JSONExtract*() on the ClickHouse side without committing to a fixed
+// schema for nested data.
+func getJSON(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func getF32(m map[string]interface{}, key string) float32 {
+	switch v := m[key].(type) {
+	case float64:
+		return float32(v)
+	case float32:
+		return v
+	case string:
+		var f float64
+		if _, err := fmt.Sscanf(v, "%f", &f); err == nil {
+			return float32(f)
+		}
+	}
+	return 0
+}
+
+func getU64(m map[string]interface{}, key string) uint64 {
+	switch v := m[key].(type) {
+	case float64:
+		if v < 0 {
+			return 0
+		}
+		return uint64(v)
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	case string:
+		var u uint64
+		if _, err := fmt.Sscanf(v, "%d", &u); err == nil {
+			return u
+		}
+	}
+	return 0
+}
+
+func batchInserter(ctx context.Context, cfg config, in <-chan row) {
+	buf := make([]row, 0, cfg.flushBatch)
+	tick := time.NewTicker(cfg.flushEvery)
+	defer tick.Stop()
+	flush := func() {
+		if len(buf) == 0 {
+			return
+		}
+		if err := insert(ctx, cfg, buf); err != nil {
+			log.Printf("insert failed (%d rows dropped): %v", len(buf), err)
+		}
+		buf = buf[:0]
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return
+		case r, ok := <-in:
+			if !ok {
+				flush()
+				return
+			}
+			buf = append(buf, r)
+			if len(buf) >= cfg.flushBatch {
+				flush()
+			}
+		case <-tick.C:
+			flush()
+		}
+	}
+}
+
+func insert(ctx context.Context, cfg config, rows []row) error {
+	var body bytes.Buffer
+	enc := json.NewEncoder(&body)
+	for i := range rows {
+		if err := enc.Encode(&rows[i]); err != nil {
+			return err
+		}
+	}
+	q := fmt.Sprintf("INSERT INTO %s.%s FORMAT JSONEachRow", cfg.chDatabase, cfg.chTable)
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		return err
+	}
+	qs := u.Query()
+	qs.Set("query", q)
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), &body)
+	if err != nil {
+		return err
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// serveHTTP runs the read-only query API. nginx proxies /analytics/api/*
+// here, so the browser never talks to ClickHouse directly. Endpoints:
+//
+//	GET /api/sessions?since=<rfc3339>
+//	GET /api/snapshots?session=<id>&from=<rfc3339>&to=<rfc3339>&limit=<n>
+//	GET /healthz
+func serveHTTP(ctx context.Context, cfg config) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
+		since := r.URL.Query().Get("since")
+		until := r.URL.Query().Get("until")
+		params := map[string]string{}
+		var clauses []string
+		if since != "" {
+			clauses = append(clauses, "ts >= parseDateTime64BestEffort({since:String})")
+			params["since"] = since
+		} else {
+			clauses = append(clauses, "ts >= now() - INTERVAL 24 HOUR")
+		}
+		if until != "" {
+			clauses = append(clauses, "ts <= parseDateTime64BestEffort({until:String})")
+			params["until"] = until
+		}
+		where := "WHERE " + strings.Join(clauses, " AND ")
+		// Per-(session_id, play_id) row so the Session Viewer picker
+		// can offer per-playback granularity. A session that hosted
+		// three loadStream() calls produces three rows here, one per
+		// fresh play_id. Empty play_ids (rows ingested before go-proxy
+		// started stamping the field) are surfaced as "—" so they
+		// remain selectable rather than collapsing into one bucket.
+		// Per-(session_id, play_id) summary. We pre-window the rows so we
+		// can count ABR shifts (bitrate / resolution changes) using
+		// lagInFrame — the *count* of shifts isn't stored directly but
+		// the per-snapshot value is, and a transition between adjacent
+		// snapshots is a shift event.
+		query := fmt.Sprintf(`
+			WITH base AS (
+			  SELECT
+			    session_id, play_id, ts,
+			    player_id, group_id, content_id,
+			    player_state, player_error,
+			    stall_count, dropped_frames, frames_displayed,
+			    video_bitrate_mbps, video_resolution, video_quality_pct,
+			    video_first_frame_time_s,
+			    master_manifest_consecutive_failures,
+			    manifest_consecutive_failures,
+			    segment_consecutive_failures,
+			    all_consecutive_failures,
+			    transport_consecutive_failures,
+			    fault_count_transfer_active_timeout,
+			    fault_count_transfer_idle_timeout,
+			    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate,
+			    lagInFrame(video_resolution,   1, video_resolution)   OVER w AS prev_resolution
+			  FROM %s.%s
+			  %s
+			  WINDOW w AS (PARTITION BY session_id, play_id ORDER BY ts)
+			),
+			net_counts AS (
+			  SELECT session_id, play_id, count() AS net_rows,
+			         countIf(status >= 400) AS net_errors,
+			         countIf(faulted = 1)  AS net_faults
+			  FROM %s.network_requests
+			  %s
+			  GROUP BY session_id, play_id
+			),
+			agg AS (
+			  SELECT
+			    session_id,
+			    play_id AS raw_play_id,
+			    any(player_id) AS player_id,
+			    any(group_id) AS group_id,
+			    any(content_id) AS content_id,
+			    min(ts) AS started,
+			    max(ts) AS last_seen,
+			    count() AS metric_events,
+			    max(stall_count) AS stalls,
+			    max(dropped_frames) AS dropped_frames,
+			    argMax(player_state, ts) AS last_state,
+			    argMax(player_error, ts) AS last_player_error,
+			    max(master_manifest_consecutive_failures) AS master_manifest_failures,
+			    max(manifest_consecutive_failures) AS manifest_failures,
+			    max(segment_consecutive_failures) AS segment_failures,
+			    max(all_consecutive_failures) AS all_failures,
+			    max(transport_consecutive_failures) AS transport_failures,
+			    max(fault_count_transfer_active_timeout) AS active_timeouts,
+			    max(fault_count_transfer_idle_timeout) AS idle_timeouts,
+			    countIf(video_bitrate_mbps != prev_bitrate AND video_bitrate_mbps > 0 AND prev_bitrate > 0)                       AS bitrate_shifts,
+			    countIf(video_bitrate_mbps < prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0)                         AS downshifts,
+			    countIf(video_bitrate_mbps > prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0)                         AS upshifts,
+			    countIf(video_resolution != prev_resolution AND video_resolution != '' AND prev_resolution != '')                  AS resolution_changes,
+			    round(avgIf(video_quality_pct, video_quality_pct > 0), 1) AS avg_quality_pct,
+			    round(minIf(video_quality_pct, video_quality_pct > 0), 1) AS min_quality_pct,
+			    max(frames_displayed) AS frames_displayed,
+			    round(max(video_first_frame_time_s), 2) AS first_frame_s
+			  FROM base
+			  GROUP BY session_id, play_id
+			)
+			SELECT
+			  agg.session_id AS session_id,
+			  if(agg.raw_play_id = '', '—', agg.raw_play_id) AS play_id,
+			  agg.player_id, agg.group_id, agg.content_id,
+			  agg.started, agg.last_seen,
+			  agg.metric_events,
+			  agg.metric_events AS rows,
+			  ifNull(net_counts.net_rows,   0) AS net_events,
+			  ifNull(net_counts.net_errors, 0) AS net_errors,
+			  ifNull(net_counts.net_faults, 0) AS net_faults,
+			  agg.stalls, agg.dropped_frames, agg.last_state, agg.last_player_error,
+			  agg.master_manifest_failures, agg.manifest_failures, agg.segment_failures,
+			  agg.all_failures, agg.transport_failures, agg.active_timeouts, agg.idle_timeouts,
+			  agg.bitrate_shifts, agg.downshifts, agg.upshifts, agg.resolution_changes,
+			  agg.avg_quality_pct, agg.min_quality_pct,
+			  agg.frames_displayed, agg.first_frame_s
+			FROM agg
+			LEFT JOIN net_counts
+			  ON agg.session_id = net_counts.session_id
+			 AND agg.raw_play_id = net_counts.play_id
+			ORDER BY agg.started DESC
+			LIMIT 1000
+			FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, where, cfg.chDatabase, where)
+		proxyClickHouseJSON(w, r, cfg, query, params)
+	})
+	mux.HandleFunc("/api/snapshot_count", func(w http.ResponseWriter, r *http.Request) {
+		session := r.URL.Query().Get("session")
+		if session == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		params := map[string]string{"session": session}
+		clauses := []string{"session_id = {session:String}"}
+		if v := r.URL.Query().Get("play_id"); v != "" {
+			if v == "—" {
+				clauses = append(clauses, "play_id = ''")
+			} else {
+				clauses = append(clauses, "play_id = {play:String}")
+				params["play"] = v
+			}
+		}
+		if v := r.URL.Query().Get("from"); v != "" {
+			clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+			params["from"] = v
+		}
+		if v := r.URL.Query().Get("to"); v != "" {
+			clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
+			params["to"] = v
+		}
+		query := fmt.Sprintf(`
+			SELECT
+			  count() AS count,
+			  toString(min(ts)) AS first_ts,
+			  toString(max(ts)) AS last_ts
+			FROM %s.%s
+			WHERE %s
+			FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "))
+		proxyClickHouseJSON(w, r, cfg, query, params)
+	})
+	mux.HandleFunc("/api/snapshots", func(w http.ResponseWriter, r *http.Request) {
+		session := r.URL.Query().Get("session")
+		if session == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		params := map[string]string{"session": session}
+		clauses := []string{"session_id = {session:String}"}
+		if v := r.URL.Query().Get("play_id"); v != "" {
+			// Sentinel "—" stands for "rows ingested before go-proxy
+			// stamped play_id" — translate back to the empty string
+			// the column actually stores.
+			if v == "—" {
+				clauses = append(clauses, "play_id = ''")
+			} else {
+				clauses = append(clauses, "play_id = {play:String}")
+				params["play"] = v
+			}
+		}
+		if v := r.URL.Query().Get("from"); v != "" {
+			clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+			params["from"] = v
+		}
+		if v := r.URL.Query().Get("to"); v != "" {
+			clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
+			params["to"] = v
+		}
+		limit := 50000
+		if v := r.URL.Query().Get("limit"); v != "" {
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 50000 {
+				limit = n
+			}
+		}
+		// Default ASC; replay UI passes order=desc so most-recent
+		// snapshots arrive first and the end-of-session window paints
+		// before older data has finished streaming.
+		order := "ASC"
+		if strings.EqualFold(r.URL.Query().Get("order"), "desc") {
+			order = "DESC"
+		}
+		// Adaptive downsampling: when stride_ms is set, return one
+		// snapshot per N-ms bucket (the latest in each bucket) so wide
+		// windows don't blow the browser. Default unset = raw stream.
+		strideMs := 0
+		if v := r.URL.Query().Get("stride_ms"); v != "" {
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 60000 {
+				strideMs = n
+			}
+		}
+		var query string
+		if strideMs > 0 {
+			// argMax(session_json, ts) within each bucket picks the latest
+			// row in the bucket, preserving monotonic counters. We name the
+			// inner aggregates with a `_max` suffix so the inner `ts` in
+			// GROUP BY still refers to the underlying DateTime64 column —
+			// otherwise ClickHouse resolves it to the argMax aggregate and
+			// rejects the query (ILLEGAL_AGGREGATION).
+			query = fmt.Sprintf(`
+				SELECT toString(ts_max) AS ts, session_json_max AS session_json FROM (
+				  SELECT
+				    argMax(ts, ts) AS ts_max,
+				    argMax(session_json, ts) AS session_json_max
+				  FROM %s.%s
+				  WHERE %s
+				  GROUP BY intDiv(toUnixTimestamp64Milli(ts), %d)
+				)
+				ORDER BY ts_max %s
+				LIMIT %d
+				FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "), strideMs, order, limit)
+		} else {
+			// Don't alias the projection as `ts` — that would shadow the
+			// real DateTime64 column for the WHERE clause's reference,
+			// breaking the from/to comparison ("No operation greaterOrEquals
+			// between String and DateTime64(3)"). Wrap in a subquery and
+			// rename in the outer SELECT instead.
+			query = fmt.Sprintf(`
+				SELECT toString(ts_raw) AS ts, session_json FROM (
+				  SELECT
+				    ts AS ts_raw,
+				    session_json
+				  FROM %s.%s
+				  WHERE %s
+				  ORDER BY ts %s
+				  LIMIT %d
+				)
+				FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "), order, limit)
+		}
+		proxyClickHouseJSON(w, r, cfg, query, params)
+	})
+
+	// Health heatmap: returns N time buckets with bad-event counts so
+	// the session-viewer can paint a colored mini-map above the scrubber.
+	// GET /api/session_heatmap?session=<id>&play_id=<id>&buckets=<N>
+	mux.HandleFunc("/api/session_heatmap", func(w http.ResponseWriter, r *http.Request) {
+		session := r.URL.Query().Get("session")
+		if session == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		params := map[string]string{"session": session}
+		clauses := []string{"session_id = {session:String}"}
+		if v := r.URL.Query().Get("play_id"); v != "" {
+			if v == "—" {
+				clauses = append(clauses, "play_id = ''")
+			} else {
+				clauses = append(clauses, "play_id = {play:String}")
+				params["play"] = v
+			}
+		}
+		buckets := 120
+		if v := r.URL.Query().Get("buckets"); v != "" {
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n >= 10 && n <= 1000 {
+				buckets = n
+			}
+		}
+		// Compute bucket size from session bounds so the strip always
+		// has exactly `buckets` cells regardless of session duration.
+		query := fmt.Sprintf(`
+			WITH bounds AS (
+			  SELECT
+			    toUnixTimestamp64Milli(min(ts)) AS start_ms,
+			    toUnixTimestamp64Milli(max(ts)) AS end_ms
+			  FROM %s.%s WHERE %s
+			),
+			sized AS (
+			  SELECT start_ms, end_ms, greatest(1, intDiv(end_ms - start_ms, %d)) AS bucket_ms FROM bounds
+			),
+			base AS (
+			  SELECT
+			    toUnixTimestamp64Milli(ts) AS ts_ms,
+			    intDiv(toUnixTimestamp64Milli(ts) - (SELECT start_ms FROM sized),
+			           (SELECT bucket_ms FROM sized)) AS bucket,
+			    stall_count, dropped_frames, player_error, transport_fault_active,
+			    manifest_failure_type, segment_failure_type, all_failure_type,
+			    video_bitrate_mbps,
+			    lagInFrame(stall_count, 1, stall_count)             OVER w AS prev_stall,
+			    lagInFrame(dropped_frames, 1, dropped_frames)       OVER w AS prev_drops,
+			    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate
+			  FROM %s.%s
+			  WHERE %s
+			  WINDOW w AS (ORDER BY ts)
+			)
+			SELECT
+			  (SELECT start_ms FROM sized) + bucket * (SELECT bucket_ms FROM sized) AS bucket_start_ms,
+			  (SELECT bucket_ms FROM sized) AS bucket_size_ms,
+			  countIf(stall_count > prev_stall)                                                  AS stalls,
+			  countIf(player_error != '')                                                        AS error_rows,
+			  countIf(transport_fault_active = 1
+			          OR (manifest_failure_type != '' AND manifest_failure_type != 'none')
+			          OR (segment_failure_type  != '' AND segment_failure_type  != 'none')
+			          OR (all_failure_type      != '' AND all_failure_type      != 'none'))     AS fault_rows,
+			  countIf(video_bitrate_mbps < prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0) AS downshifts,
+			  max(dropped_frames) - min(dropped_frames)                                          AS drops
+			FROM base
+			GROUP BY bucket
+			ORDER BY bucket
+			FORMAT JSONEachRow`,
+			cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "),
+			buckets,
+			cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "))
+		proxyClickHouseJSON(w, r, cfg, query, params)
+	})
+
+	// Notable session events for the jump-list. Returns rows like
+	//   { ts, type: 'stall'|'error'|'fault_on'|'downshift', info }
+	// sorted by ts so the UI can render them as a chronological list.
+	// GET /api/session_events?session=<id>&play_id=<id>&limit=<n>
+	mux.HandleFunc("/api/session_events", func(w http.ResponseWriter, r *http.Request) {
+		session := r.URL.Query().Get("session")
+		if session == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		params := map[string]string{"session": session}
+		clauses := []string{"session_id = {session:String}"}
+		// HAR events come from network_requests, which on iOS often
+		// has play_id='' on variant/segment URLs (the iOS player
+		// strips the query param). Filter HAR by time range derived
+		// from session_snapshots instead of play_id directly.
+		// We qualify ts as `nr.ts` because the inner sub-selects
+		// alias `toString(ts) AS ts` and that String alias would
+		// otherwise shadow the column in the WHERE clause.
+		harClauses := []string{"session_id = {session:String}"}
+		if v := r.URL.Query().Get("play_id"); v != "" {
+			var pidPred string
+			if v == "—" {
+				pidPred = "play_id = ''"
+			} else {
+				pidPred = "play_id = {play:String}"
+				params["play"] = v
+			}
+			clauses = append(clauses, pidPred)
+			harClauses = append(harClauses, fmt.Sprintf(
+				"nr.ts BETWEEN (SELECT min(ts) FROM %s.%s WHERE session_id = {session:String} AND %s) "+
+					"AND (SELECT max(ts) FROM %s.%s WHERE session_id = {session:String} AND %s)",
+				cfg.chDatabase, cfg.chTable, pidPred,
+				cfg.chDatabase, cfg.chTable, pidPred))
+		}
+		limit := 500
+		if v := r.URL.Query().Get("limit"); v != "" {
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 5000 {
+				limit = n
+			}
+		}
+		where := strings.Join(clauses, " AND ")
+		harWhere := strings.Join(harClauses, " AND ")
+		// Event taxonomy:
+		//   - Player-emitted events come from the last_event column directly
+		//     (the player tells us "buffering_start", "rate_shift_down", etc.)
+		//   - Stall vs buffering are kept distinct: AVPlayer (iOS) emits both
+		//     and they mean different things; Chrome/HLS.js only emits stall_*
+		//   - Stall and buffering durations are computed by pairing onsets
+		//     with the next end event in the same family (stall vs buffer)
+		//   - Server-side counters (faults, manifest/segment failures) are
+		//     not surfaced by the player, so we keep lagInFrame for those
+		//
+		// Priority (computed in outer SELECT):
+		//   P1 Critical : error, master/all failure, stall ≥ 3s
+		//   P2 High     : stall < 3s, restart, manifest/segment/transport_failure,
+		//                 transfer_*_timeout
+		//   P3 Medium   : downshift, fault_on, timejump, buffering
+		//   P4 Low      : upshift, fault_off, playback_start
+		query := fmt.Sprintf(`
+			WITH stall_or_buffer_pairs AS (
+			  SELECT start_ts, start_event, duration_s
+			  FROM (
+			    SELECT
+			      ts AS start_ts,
+			      last_event AS start_event,
+			      multiIf(
+			        last_event IN ('stall_start','stall_end'),         'stall',
+			        last_event IN ('buffering_start','buffering_end'), 'buffer',
+			        ''
+			      ) AS family,
+			      leadInFrame(last_event, 1, '') OVER w AS next_event,
+			      dateDiff('millisecond', ts, leadInFrame(ts, 1, ts) OVER w) / 1000.0 AS duration_s
+			    FROM %s.%s
+			    WHERE %s
+			      AND last_event IN ('stall_start','stall_end','buffering_start','buffering_end')
+			    WINDOW w AS (PARTITION BY family ORDER BY ts
+			                 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+			  )
+			  -- Only emit when the lead landed on the matching close event;
+			  -- otherwise we'd surface the gap to the NEXT start (which can
+			  -- be hours away — happens when an _end was never received).
+			  WHERE (start_event = 'stall_start'     AND next_event = 'stall_end')
+			     OR (start_event = 'buffering_start' AND next_event = 'buffering_end')
+			),
+			rate_shifts AS (
+			  SELECT ts, last_event, video_bitrate_mbps,
+			         lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate
+			  FROM %s.%s
+			  WHERE %s
+			  WINDOW w AS (ORDER BY ts)
+			),
+			base AS (
+			  SELECT
+			    ts,
+			    player_error, transport_fault_active,
+			    manifest_consecutive_failures,
+			    segment_consecutive_failures,
+			    master_manifest_consecutive_failures,
+			    all_consecutive_failures,
+			    transport_consecutive_failures,
+			    fault_count_transfer_active_timeout,
+			    fault_count_transfer_idle_timeout,
+			    loop_count_server,
+			    -- row_number used to suppress first-snapshot artifacts: the
+			    -- first row per play has no real prior row, so the lag-default
+			    -- would otherwise spurious-fire if a counter is non-zero on
+			    -- entry (e.g. transport_consecutive_failures = 1 from a prior
+			    -- session leaving state behind).
+			    row_number() OVER w AS rn,
+			    lagInFrame(player_error, 1, '')                       OVER w AS prev_error,
+			    lagInFrame(transport_fault_active, 1, 0)              OVER w AS prev_fault,
+			    lagInFrame(manifest_consecutive_failures, 1, 0)       OVER w AS prev_manifest_fail,
+			    lagInFrame(segment_consecutive_failures, 1, 0)        OVER w AS prev_segment_fail,
+			    lagInFrame(master_manifest_consecutive_failures, 1, 0) OVER w AS prev_master_fail,
+			    lagInFrame(all_consecutive_failures, 1, 0)            OVER w AS prev_all_fail,
+			    lagInFrame(transport_consecutive_failures, 1, 0)      OVER w AS prev_transport_fail,
+			    lagInFrame(fault_count_transfer_active_timeout, 1, 0) OVER w AS prev_active_to,
+			    lagInFrame(fault_count_transfer_idle_timeout, 1, 0)   OVER w AS prev_idle_to,
+			    lagInFrame(loop_count_server, 1, 0)                   OVER w AS prev_loop_server
+			  FROM %s.%s
+			  WHERE %s
+			  WINDOW w AS (PARTITION BY play_id ORDER BY ts)
+			)
+			SELECT
+			  ts, type, info,
+			  -- 'cause' = proxy / system action that *might* produce a user-visible
+			  -- effect (fault injection, server-side failure counters, timeouts).
+			  -- 'effect' = something the player or user actually saw (stall, error,
+			  -- bitrate change, restart). Causes default to P3 (diagnostic context)
+			  -- unless they are the kill-switch types that by design break playback.
+			  multiIf(
+			    -- Inverted classification: explicitly enumerate KNOWN
+			    -- causes (proxy/system actions); everything else —
+			    -- including unrecognised player-emitted events from
+			    -- the catch-all UNION ALL — defaults to 'effect'.
+			    type IN ('master_manifest_failure', 'all_failure',
+			             'manifest_failure', 'segment_failure',
+			             'transport_failure',
+			             'transfer_active_timeout', 'transfer_idle_timeout',
+			             'fault_on', 'fault_off',
+			             'http_5xx', 'http_4xx',
+			             'request_timeout', 'request_incomplete', 'request_faulted',
+			             'slow_request', 'slow_segment', 'request_retry',
+			             'loop_server'), 'cause',
+			    'effect'
+			  ) AS kind,
+			  multiIf(
+			    -- User-marked moments are explicit "this matters" flags
+			    -- from a human watching live — always P1 so they don't
+			    -- get hidden by the default Critical+High+Medium chip
+			    -- selection.
+			    type = 'user_marked', 1,
+			    type = 'error', 1,
+			    -- These two causes break playback by design — stay Critical.
+			    type IN ('master_manifest_failure', 'all_failure'), 1,
+			    type = 'stall' AND duration_s >= 3, 1,
+			    type = 'stall', 2,
+			    type = 'restart', 2,
+			    -- Other causes are diagnostic context, not Critical/High by default.
+			    type IN ('manifest_failure', 'segment_failure',
+			             'transport_failure',
+			             'transfer_active_timeout', 'transfer_idle_timeout',
+			             'fault_on', 'fault_off'), 3,
+			    type IN ('downshift', 'timejump', 'buffering'), 3,
+			    -- HAR-derived events. http_5xx & request_timeout are
+			    -- High because they indicate real failures that often
+			    -- precede a stall. The rest are diagnostic Medium /
+			    -- Low (retries especially are very chatty).
+			    type IN ('http_5xx', 'request_timeout'), 2,
+			    type IN ('http_4xx', 'request_incomplete', 'request_faulted',
+			             'slow_request', 'slow_segment'), 3,
+			    type = 'request_retry', 4,
+			    type IN ('upshift', 'playback_start'), 4,
+			    -- Server loop boundaries are routine in this testing
+			    -- platform (the stream loops the source repeatedly).
+			    -- P4 keeps them available for triage but hidden by
+			    -- default so they don't drown out real signals.
+			    type = 'loop_server', 4,
+			    -- Default for unrecognised types: Medium so they're
+			    -- visible (vs P4 Low which is off by default).
+			    3
+			  ) AS priority
+			FROM (
+			  -- Stalls (paired stall_start → stall_end)
+			  SELECT toString(start_ts) AS ts, 'stall' AS type,
+			         concat(toString(round(duration_s, 2)), 's') AS info,
+			         duration_s
+			  FROM stall_or_buffer_pairs
+			  WHERE start_event = 'stall_start' AND duration_s > 0
+
+			  UNION ALL
+			  -- Buffering (paired buffering_start → buffering_end). Distinct
+			  -- from stall: AVPlayer emits both as separate notifications.
+			  SELECT toString(start_ts) AS ts, 'buffering' AS type,
+			         concat(toString(round(duration_s, 2)), 's') AS info,
+			         duration_s
+			  FROM stall_or_buffer_pairs
+			  WHERE start_event = 'buffering_start' AND duration_s > 0
+
+			  UNION ALL
+			  -- frozen / segment_stall: no explicit *_end emitted, so duration
+			  -- is unknown — emit as zero-duration stall events. frozen is
+			  -- always Critical via a hard-coded subtype hint in info.
+			  SELECT toString(ts) AS ts, 'stall' AS type,
+			         if(last_event = 'frozen', '(frozen)', '(segment)') AS info,
+			         0 AS duration_s
+			  FROM %s.%s WHERE %s AND last_event IN ('frozen', 'segment_stall')
+
+			  UNION ALL
+			  -- Restart, playback_start, downshift, upshift, timejump, error
+			  -- (player-emitted directly via last_event)
+			  SELECT toString(ts) AS ts, 'restart' AS type, '' AS info, 0 AS duration_s
+			  FROM %s.%s WHERE %s AND last_event = 'restart'
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'playback_start' AS type, '' AS info, 0
+			  FROM %s.%s WHERE %s AND last_event IN ('video_start_time', 'video_first_frame')
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'downshift' AS type,
+			         concat(toString(round(prev_bitrate, 2)), '→', toString(round(video_bitrate_mbps, 2)), ' Mbps') AS info,
+			         0
+			  FROM rate_shifts WHERE last_event = 'rate_shift_down' AND prev_bitrate > 0 AND video_bitrate_mbps > 0
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'upshift' AS type,
+			         concat(toString(round(prev_bitrate, 2)), '→', toString(round(video_bitrate_mbps, 2)), ' Mbps') AS info,
+			         0
+			  FROM rate_shifts WHERE last_event = 'rate_shift_up' AND prev_bitrate > 0 AND video_bitrate_mbps > 0
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'timejump' AS type, '' AS info, 0
+			  FROM %s.%s WHERE %s AND last_event = 'timejump'
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'error' AS type, player_error AS info, 0
+			  FROM %s.%s WHERE %s AND last_event = 'error'
+			  UNION ALL
+			  -- User-marked moments — the iOS / iPadOS player has a
+			  -- "911" button that fires last_event='user_marked' so an
+			  -- operator viewing live can flag "something interesting
+			  -- just happened" without us having to detect what. Always
+			  -- surface as Critical so it's never hidden by chip filter.
+			  SELECT toString(ts) AS ts, 'user_marked' AS type, '' AS info, 0
+			  FROM %s.%s WHERE %s AND last_event = 'user_marked'
+			  UNION ALL
+			  -- Catch-all: any last_event value we haven't explicitly
+			  -- mapped above shows up here verbatim. Lets new player
+			  -- events appear in the dropdown without a forwarder
+			  -- redeploy. 'heartbeat' / 'state_change' / 'playing' /
+			  -- 'video_bitrate_change' are intentionally excluded as
+			  -- noise. The explicitly-handled types are also excluded
+			  -- so we don't double-emit.
+			  SELECT toString(ts) AS ts, last_event AS type, '' AS info, 0
+			  FROM %s.%s WHERE %s
+			    AND last_event != ''
+			    AND last_event NOT IN (
+			      'heartbeat', 'state_change', 'playing', 'video_bitrate_change',
+			      'stall_start', 'stall_end',
+			      'buffering_start', 'buffering_end',
+			      'frozen', 'segment_stall',
+			      'restart', 'video_first_frame', 'video_start_time',
+			      'rate_shift_down', 'rate_shift_up',
+			      'timejump', 'error', 'user_marked'
+			    )
+
+			  -- Server-side state-change events (lag-based — player can't
+			  -- tell us about these). All filters require rn > 1 so the
+			  -- first snapshot per play (where the lag-default of 0 / ''
+			  -- would falsely trigger if the counter started non-zero) is
+			  -- suppressed.
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'error' AS type, player_error AS info, 0
+			  FROM base WHERE rn > 1 AND player_error != '' AND prev_error != player_error
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'master_manifest_failure' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND master_manifest_consecutive_failures > prev_master_fail
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'all_failure' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND all_consecutive_failures > prev_all_fail
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'manifest_failure' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND manifest_consecutive_failures > prev_manifest_fail
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'segment_failure' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND segment_consecutive_failures > prev_segment_fail
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'transport_failure' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND transport_consecutive_failures > prev_transport_fail
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'transfer_active_timeout' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND fault_count_transfer_active_timeout > prev_active_to
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'transfer_idle_timeout' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND fault_count_transfer_idle_timeout > prev_idle_to
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'fault_on' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND transport_fault_active = 1 AND prev_fault = 0
+			  UNION ALL
+			  SELECT toString(ts) AS ts, 'fault_off' AS type, '' AS info, 0
+			  FROM base WHERE rn > 1 AND transport_fault_active = 0 AND prev_fault = 1
+			  UNION ALL
+			  -- Server-loop boundary: loop_count_server increments each
+			  -- time the live LL-HLS/DASH worker rotates back to loop 0
+			  -- of the source. Useful as a periodic gridline for long
+			  -- testing sessions ("did the stall straddle a loop?").
+			  SELECT toString(ts) AS ts, 'loop_server' AS type,
+			         concat('loop ', toString(loop_count_server)) AS info, 0
+			  FROM base WHERE rn > 1 AND loop_count_server > prev_loop_server
+
+			  -- Network-request-derived events. These come from the
+			  -- network_requests table (HAR archive). Mirrors the
+			  -- waterfall's noteworthy classes: status-4xx/5xx,
+			  -- fault-timeout, fault-incomplete, is-retry, slow-transfer.
+			  -- Each row produces exactly one event via mutually-
+			  -- exclusive WHEREs; nothing double-counts.
+			  -- HAR sub-selects use a table alias 'nr' so the harWhere
+			  -- clause's nr.ts BETWEEN ... resolves to the DateTime64
+			  -- column. Without it, the projection's toString(ts) AS ts
+			  -- would shadow ts as a String and break the comparison.
+			  UNION ALL
+			  SELECT toString(nr.ts) AS ts, 'http_5xx' AS type,
+			         concat(toString(status), ' ', method, ' ', path) AS info, 0 AS duration_s
+			  FROM %s.network_requests AS nr WHERE %s AND status >= 500
+			  UNION ALL
+			  SELECT toString(nr.ts) AS ts, 'http_4xx' AS type,
+			         concat(toString(status), ' ', method, ' ', path) AS info, 0
+			  FROM %s.network_requests AS nr WHERE %s AND status >= 400 AND status < 500
+			  UNION ALL
+			  -- Faulted requests, categorised by fault_type:
+			  --   * 'timeout'  → request_timeout   (P2: picture may stop)
+			  --   * corrupt/partial/abandon, OR faulted 2xx → request_incomplete
+			  --   * everything else faulted → request_faulted
+			  SELECT toString(nr.ts) AS ts,
+			         multiIf(
+			           positionCaseInsensitive(fault_type, 'timeout') > 0, 'request_timeout',
+			           positionCaseInsensitive(fault_type, 'corrupt') > 0
+			             OR positionCaseInsensitive(fault_type, 'partial') > 0
+			             OR positionCaseInsensitive(fault_type, 'abandon') > 0
+			             OR (status >= 200 AND status < 300), 'request_incomplete',
+			           'request_faulted'
+			         ) AS type,
+			         concat(fault_type, ' ', method, ' ', path) AS info, 0
+			  FROM %s.network_requests AS nr WHERE %s AND faulted = 1
+			  UNION ALL
+			  -- Slow non-error requests: client_wait_ms > 2 s.
+			  SELECT toString(nr.ts) AS ts, 'slow_request' AS type,
+			         concat(toString(round(client_wait_ms, 0)), 'ms ', method, ' ', path) AS info, 0
+			  FROM %s.network_requests AS nr
+			  WHERE %s AND client_wait_ms > 2000 AND status < 400 AND faulted = 0
+			  UNION ALL
+			  -- Slow media-segment transfers: distinct from slow_request,
+			  -- this is about long actual transfer time on a segment-
+			  -- shaped URL. Mirrors the waterfall's slow-transfer class.
+			  SELECT toString(nr.ts) AS ts, 'slow_segment' AS type,
+			         concat(toString(round(transfer_ms, 0)), 'ms ', method, ' ', path) AS info, 0
+			  FROM %s.network_requests AS nr
+			  WHERE %s AND transfer_ms > 6000
+			    AND match(path, '\.(m4s|ts|mp4|m4a|m4v|aac|webm|mp3)($|\?)')
+			    AND status < 400 AND faulted = 0
+			  UNION ALL
+			  -- Retries: same URL fetched again within ~4 s. Detected
+			  -- via lagInFrame partitioned by url; the network log uses
+			  -- a per-segment-duration threshold but a fixed 4 s catches
+			  -- almost every real retry case (segments are 2 s/6 s).
+			  SELECT toString(retry_ts) AS ts, 'request_retry' AS type,
+			         concat(method, ' ', path) AS info, 0
+			  FROM (
+			    SELECT nr.ts AS retry_ts, method, url, path,
+			           lagInFrame(nr.ts, 1, nr.ts) OVER (PARTITION BY url ORDER BY nr.ts ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS prev_url_ts
+			    FROM %s.network_requests AS nr
+			    WHERE %s
+			  )
+			  WHERE prev_url_ts != retry_ts
+			    AND dateDiff('millisecond', prev_url_ts, retry_ts) BETWEEN 1 AND 4000
+			)
+			ORDER BY ts ASC
+			LIMIT %d
+			FORMAT JSONEachRow`,
+			// stall_or_buffer_pairs / rate_shifts / base CTEs
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			// frozen/segment_stall, restart, playback_start, timejump, error (5)
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			// user_marked + catch-all (2)
+			cfg.chDatabase, cfg.chTable, where,
+			cfg.chDatabase, cfg.chTable, where,
+			// HAR events: http_5xx, http_4xx, faulted, slow_request,
+			// slow_segment, request_retry — each filtered by harWhere
+			// (time range, NOT play_id) since iOS strips play_id from
+			// variant/segment URLs.
+			cfg.chDatabase, harWhere,
+			cfg.chDatabase, harWhere,
+			cfg.chDatabase, harWhere,
+			cfg.chDatabase, harWhere,
+			cfg.chDatabase, harWhere,
+			cfg.chDatabase, harWhere,
+			limit)
+		proxyClickHouseJSON(w, r, cfg, query, params)
+	})
+
+	// Per-request HAR-style log for the session-viewer's network log
+	// fold. Returns rows in the same shape the live go-proxy endpoint
+	// emits ({entries: [...]}) so the existing UI code can consume it
+	// without modification.
+	mux.HandleFunc("/api/network_requests", func(w http.ResponseWriter, r *http.Request) {
+		session := r.URL.Query().Get("session")
+		if session == "" {
+			http.Error(w, "missing session", http.StatusBadRequest)
+			return
+		}
+		params := map[string]string{"session": session}
+		clauses := []string{"session_id = {session:String}"}
+		if v := r.URL.Query().Get("play_id"); v != "" {
+			if v == "—" {
+				clauses = append(clauses, "play_id = ''")
+			} else {
+				clauses = append(clauses, "play_id = {play:String}")
+				params["play"] = v
+			}
+		}
+		if v := r.URL.Query().Get("from"); v != "" {
+			clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+			params["from"] = v
+		}
+		if v := r.URL.Query().Get("to"); v != "" {
+			clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
+			params["to"] = v
+		}
+		limit := 50000
+		if v := r.URL.Query().Get("limit"); v != "" {
+			var n int
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 50000 {
+				limit = n
+			}
+		}
+		// Wrap the rows into the {entries:[...]} envelope go-proxy
+		// returns so the browser code can be source-agnostic. We let
+		// ClickHouse build the JSON via JSONObjectEachRow + manual
+		// envelope rather than a string concat in Go (cheaper, fewer
+		// escapes, and the formatter handles types).
+		query := fmt.Sprintf(`
+			SELECT
+			  toString(ts) AS timestamp,
+			  method, url, upstream_url, path, request_kind AS request_kind,
+			  status, bytes_in, bytes_out, content_type, play_id,
+			  request_range, response_content_range,
+			  dns_ms, connect_ms, tls_ms, ttfb_ms, transfer_ms, total_ms, client_wait_ms,
+			  faulted = 1 AS faulted, fault_type, fault_action, fault_category,
+			  request_headers, response_headers, query_string
+			FROM %s.network_requests
+			WHERE %s
+			ORDER BY ts ASC
+			LIMIT %d
+			FORMAT JSONEachRow`, cfg.chDatabase, strings.Join(clauses, " AND "), limit)
+		// We can't directly stream JSONEachRow as the {entries:[...]}
+		// envelope without rewriting the body. Buffer + assemble.
+		body, err := chQueryBytes(r.Context(), cfg, query, params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.Write([]byte(`{"entries":[`))
+		first := true
+		for _, line := range bytes.Split(body, []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
+			// Each line is one JSONObject; strings stored as JSON-encoded
+			// header arrays need to be re-parsed so the consumer sees
+			// real arrays rather than escaped strings. Cheap trick: a
+			// post-pass per row.
+			if !first {
+				w.Write([]byte(","))
+			}
+			w.Write(reinflateNetRowJSON(line))
+			first = false
+		}
+		w.Write([]byte("]}"))
+	})
+
+	srv := &http.Server{
+		Addr:              cfg.httpListen,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(shutCtx)
+	}()
+	log.Printf("http api listening on %s", cfg.httpListen)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Printf("http server: %v", err)
+	}
+}
+
+// proxyClickHouseJSON forwards a SQL query to ClickHouse's HTTP
+// interface and streams the JSONEachRow response back to the caller.
+// User-supplied values must be passed via `params` (a map of name →
+// stringified value) and referenced in the SQL with `{name:Type}`
+// placeholders — never interpolated into the query string. ClickHouse
+// binds the parameters server-side, eliminating injection risk.
+func proxyClickHouseJSON(w http.ResponseWriter, r *http.Request, cfg config, query string, params map[string]string) {
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	qs := u.Query()
+	qs.Set("query", query)
+	qs.Set("default_format", "JSONEachRow")
+	for k, v := range params {
+		qs.Set("param_"+k, v)
+	}
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		http.Error(w, strings.TrimSpace(string(body)), resp.StatusCode)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("X-Accel-Buffering", "no") // tell nginx not to buffer
+	// Flush as ClickHouse delivers rows so the browser sees lines as
+	// they're produced, not at end-of-response. ClickHouse already emits
+	// JSONEachRow incrementally; without flushing the std http.Server
+	// would buffer up to its default chunk size before sending.
+	flusher, _ := w.(http.Flusher)
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/analytics/go-forwarder/net_log.go
+++ b/analytics/go-forwarder/net_log.go
@@ -1,0 +1,519 @@
+// Per-request HAR-style log archival. The forwarder polls go-proxy's
+// /api/session/<id>/network endpoint for each live session, dedupes
+// against an in-memory fingerprint set, and batch-inserts new rows into
+// the ClickHouse network_requests table. The session-viewer UI reads
+// from /analytics/api/network_requests so the network log fold replays
+// even after the proxy has released the session.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// netRow is the JSONEachRow shape for network_requests. Tags match the
+// ClickHouse column names exactly so the table accepts the body as-is.
+type netRow struct {
+	Ts                   string  `json:"ts"`
+	SessionID            string  `json:"session_id"`
+	PlayID               string  `json:"play_id"`
+	Method               string  `json:"method"`
+	URL                  string  `json:"url"`
+	UpstreamURL          string  `json:"upstream_url"`
+	Path                 string  `json:"path"`
+	RequestKind          string  `json:"request_kind"`
+	Status               uint16  `json:"status"`
+	BytesIn              int64   `json:"bytes_in"`
+	BytesOut             int64   `json:"bytes_out"`
+	ContentType          string  `json:"content_type"`
+	RequestRange         string  `json:"request_range"`
+	ResponseContentRange string  `json:"response_content_range"`
+	DNSMs                float32 `json:"dns_ms"`
+	ConnectMs            float32 `json:"connect_ms"`
+	TLSMs                float32 `json:"tls_ms"`
+	TTFBMs               float32 `json:"ttfb_ms"`
+	TransferMs           float32 `json:"transfer_ms"`
+	TotalMs              float32 `json:"total_ms"`
+	ClientWaitMs         float32 `json:"client_wait_ms"`
+	Faulted              uint8   `json:"faulted"`
+	FaultType            string  `json:"fault_type"`
+	FaultAction          string  `json:"fault_action"`
+	FaultCategory        string  `json:"fault_category"`
+	RequestHeaders       string  `json:"request_headers"`
+	ResponseHeaders      string  `json:"response_headers"`
+	QueryString          string  `json:"query_string"`
+	EntryFingerprint     uint64  `json:"entry_fingerprint"`
+}
+
+// netEntry mirrors go-proxy's NetworkLogEntry. Only the fields we keep
+// are listed; unknown JSON keys are tolerated by the decoder.
+type netEntry struct {
+	Timestamp            time.Time     `json:"timestamp"`
+	Method               string        `json:"method"`
+	URL                  string        `json:"url"`
+	UpstreamURL          string        `json:"upstream_url"`
+	Path                 string        `json:"path"`
+	RequestKind          string        `json:"request_kind"`
+	Status               int           `json:"status"`
+	BytesIn              int64         `json:"bytes_in"`
+	BytesOut             int64         `json:"bytes_out"`
+	ContentType          string        `json:"content_type"`
+	PlayID               string        `json:"play_id"`
+	RequestHeaders       []nameValue   `json:"request_headers"`
+	ResponseHeaders      []nameValue   `json:"response_headers"`
+	QueryString          []nameValue   `json:"query_string"`
+	DNSMs                float64       `json:"dns_ms"`
+	ConnectMs            float64       `json:"connect_ms"`
+	TLSMs                float64       `json:"tls_ms"`
+	TTFBMs               float64       `json:"ttfb_ms"`
+	TransferMs           float64       `json:"transfer_ms"`
+	TotalMs              float64       `json:"total_ms"`
+	ClientWaitMs         float64       `json:"client_wait_ms"`
+	Faulted              bool          `json:"faulted"`
+	FaultType            string        `json:"fault_type"`
+	FaultAction          string        `json:"fault_action"`
+	FaultCategory        string        `json:"fault_category"`
+	RequestRange         string        `json:"request_range"`
+	ResponseContentRange string        `json:"response_content_range"`
+}
+
+type nameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// netSeen tracks fingerprints already inserted, per session. Bounded
+// per-session so a chatty session can't OOM the forwarder.
+type netSeen struct {
+	mu  sync.Mutex
+	max int
+	m   map[string]map[uint64]struct{}
+}
+
+func newNetSeen(maxPerSession int) *netSeen {
+	return &netSeen{max: maxPerSession, m: make(map[string]map[uint64]struct{})}
+}
+
+func (s *netSeen) check(sessionID string, fp uint64) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	set, ok := s.m[sessionID]
+	if !ok {
+		set = make(map[uint64]struct{})
+		s.m[sessionID] = set
+	}
+	if _, hit := set[fp]; hit {
+		return true
+	}
+	if len(set) >= s.max {
+		// Bound: drop ~25% of old fingerprints. Coarse, but in practice
+		// re-polling a long-lived session never hands back rows older
+		// than the proxy's ring buffer (which is itself bounded).
+		drop := s.max / 4
+		i := 0
+		for k := range set {
+			delete(set, k)
+			i++
+			if i >= drop {
+				break
+			}
+		}
+	}
+	set[fp] = struct{}{}
+	return false
+}
+
+func (s *netSeen) prune(active map[string]struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for k := range s.m {
+		if _, ok := active[k]; !ok {
+			delete(s.m, k)
+		}
+	}
+}
+
+// netFingerprint computes a stable hash of the entry's identity columns
+// so re-polling the same session doesn't re-insert. Includes ts ms,
+// path, method, status, play_id, bytes_in.
+func netFingerprint(e *netEntry) uint64 {
+	h := sha256.New()
+	tsBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(tsBytes, uint64(e.Timestamp.UnixMilli()))
+	h.Write(tsBytes)
+	h.Write([]byte{0})
+	h.Write([]byte(e.Path))
+	h.Write([]byte{0})
+	h.Write([]byte(e.Method))
+	h.Write([]byte{0})
+	bIn := make([]byte, 8)
+	binary.BigEndian.PutUint64(bIn, uint64(e.BytesIn))
+	h.Write(bIn)
+	h.Write([]byte{0})
+	statusBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(statusBytes, uint16(e.Status))
+	h.Write(statusBytes)
+	h.Write([]byte{0})
+	h.Write([]byte(e.PlayID))
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint64(sum[:8])
+}
+
+// jsonOrEmpty marshals a value to JSON, returning "" on nil/empty/error
+// so we don't pollute the column with "null".
+func jsonOrEmpty(v interface{}) string {
+	switch t := v.(type) {
+	case []nameValue:
+		if len(t) == 0 {
+			return ""
+		}
+	}
+	b, err := json.Marshal(v)
+	if err != nil || string(b) == "null" {
+		return ""
+	}
+	return string(b)
+}
+
+func entryToRow(sessionID string, e *netEntry) netRow {
+	faulted := uint8(0)
+	if e.Faulted {
+		faulted = 1
+	}
+	return netRow{
+		Ts:                   e.Timestamp.UTC().Format("2006-01-02 15:04:05.000"),
+		SessionID:            sessionID,
+		PlayID:               e.PlayID,
+		Method:               e.Method,
+		URL:                  e.URL,
+		UpstreamURL:          e.UpstreamURL,
+		Path:                 e.Path,
+		RequestKind:          e.RequestKind,
+		Status:               uint16(e.Status),
+		BytesIn:              e.BytesIn,
+		BytesOut:             e.BytesOut,
+		ContentType:          e.ContentType,
+		RequestRange:         e.RequestRange,
+		ResponseContentRange: e.ResponseContentRange,
+		DNSMs:                float32(e.DNSMs),
+		ConnectMs:            float32(e.ConnectMs),
+		TLSMs:                float32(e.TLSMs),
+		TTFBMs:               float32(e.TTFBMs),
+		TransferMs:           float32(e.TransferMs),
+		TotalMs:              float32(e.TotalMs),
+		ClientWaitMs:         float32(e.ClientWaitMs),
+		Faulted:              faulted,
+		FaultType:            e.FaultType,
+		FaultAction:          e.FaultAction,
+		FaultCategory:        e.FaultCategory,
+		RequestHeaders:       jsonOrEmpty(e.RequestHeaders),
+		ResponseHeaders:      jsonOrEmpty(e.ResponseHeaders),
+		QueryString:          jsonOrEmpty(e.QueryString),
+		EntryFingerprint:     netFingerprint(e),
+	}
+}
+
+// proxyBaseFromSSE derives the proxy's base URL from the configured SSE
+// URL so the network poller hits the same origin (e.g. go-server:30081).
+func proxyBaseFromSSE(sseURL string) string {
+	u, err := url.Parse(sseURL)
+	if err != nil {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// netStreamEvent matches the JSON go-proxy emits on /api/network/stream.
+type netStreamEvent struct {
+	SessionID string   `json:"session_id"`
+	Entry     netEntry `json:"entry"`
+}
+
+// streamNetworkSSE subscribes to go-proxy's /api/network/stream endpoint.
+// One SSE `data:` line per request as it lands in the proxy's ring
+// buffer; we dedup (best-effort, in case of reconnects mid-burst) and
+// forward to the batch inserter. On disconnect we reconnect with
+// exponential backoff (capped); nothing is replayed by the proxy, so
+// a long outage means we miss whatever entries were emitted while down.
+func streamNetworkSSE(ctx context.Context, cfg config, seen *netSeen, out chan<- netRow) error {
+	base := proxyBaseFromSSE(cfg.sseURL)
+	if base == "" {
+		return fmt.Errorf("cannot derive proxy base from SSE URL %q", cfg.sseURL)
+	}
+	endpoint := strings.TrimRight(base, "/") + "/api/network/stream"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("net stream %d", resp.StatusCode)
+	}
+	br := newSSEReader(resp.Body)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		data, err := br.next()
+		if err != nil {
+			return err
+		}
+		if len(data) == 0 {
+			continue
+		}
+		var ev netStreamEvent
+		if err := json.Unmarshal(data, &ev); err != nil {
+			continue
+		}
+		if ev.SessionID == "" || ev.Entry.Timestamp.IsZero() {
+			continue
+		}
+		fp := netFingerprint(&ev.Entry)
+		if seen.check(ev.SessionID, fp) {
+			continue
+		}
+		select {
+		case out <- entryToRow(ev.SessionID, &ev.Entry):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// runNetworkStream drives streamNetworkSSE with reconnect + backoff.
+// Replaces the old netPoller. We keep netActiveSet as a no-op for now
+// (handlePayload still calls .replace()) so we don't ripple the change
+// further — pruning the seen set on SSE pulse is still useful even with
+// the new event source.
+func runNetworkStream(ctx context.Context, cfg config, seen *netSeen, out chan<- netRow) {
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := streamNetworkSSE(ctx, cfg, seen, out)
+		if ctx.Err() != nil {
+			return
+		}
+		log.Printf("net sse stream ended: %v (reconnecting in %s)", err, backoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return
+		}
+		if backoff < 30*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+// newSSEReader / .next() decode SSE event frames. We only care about the
+// `data:` field; comments (lines starting with `:`) and empty heartbeats
+// produce empty results that the caller skips.
+type sseReader struct {
+	r   io.Reader
+	buf []byte
+}
+
+func newSSEReader(r io.Reader) *sseReader {
+	return &sseReader{r: r, buf: make([]byte, 0, 16*1024)}
+}
+
+func (s *sseReader) next() ([]byte, error) {
+	tmp := make([]byte, 4096)
+	for {
+		// Look for the end-of-frame marker `\n\n` in the accumulated buffer.
+		if idx := indexDoubleNewline(s.buf); idx >= 0 {
+			frame := s.buf[:idx]
+			s.buf = s.buf[idx+2:]
+			return parseSSEData(frame), nil
+		}
+		n, err := s.r.Read(tmp)
+		if n > 0 {
+			s.buf = append(s.buf, tmp[:n]...)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
+func indexDoubleNewline(b []byte) int {
+	for i := 0; i+1 < len(b); i++ {
+		if b[i] == '\n' && b[i+1] == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+func parseSSEData(frame []byte) []byte {
+	// Multi-line `data:` fields are joined with `\n` per the SSE spec,
+	// but our publisher always emits a single-line `data:` per event.
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		if len(line) >= 5 && bytes.Equal(line[:5], []byte("data:")) {
+			v := line[5:]
+			if len(v) > 0 && v[0] == ' ' {
+				v = v[1:]
+			}
+			return v
+		}
+	}
+	return nil
+}
+
+func batchInsertNet(ctx context.Context, cfg config, in <-chan netRow) {
+	buf := make([]netRow, 0, cfg.flushBatch)
+	tick := time.NewTicker(cfg.flushEvery)
+	defer tick.Stop()
+	flush := func() {
+		if len(buf) == 0 {
+			return
+		}
+		if err := insertNet(ctx, cfg, buf); err != nil {
+			log.Printf("net insert failed (%d rows dropped): %v", len(buf), err)
+		}
+		buf = buf[:0]
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			flush()
+			return
+		case r, ok := <-in:
+			if !ok {
+				flush()
+				return
+			}
+			buf = append(buf, r)
+			if len(buf) >= cfg.flushBatch {
+				flush()
+			}
+		case <-tick.C:
+			flush()
+		}
+	}
+}
+
+// chQueryBytes runs a ClickHouse query and returns the full response
+// body. Used for endpoints that need to massage the result before
+// sending to the client (e.g. wrapping JSONEachRow lines in an envelope).
+// User-supplied values must be passed via `params` and referenced in the
+// SQL with `{name:Type}` placeholders — never interpolated.
+func chQueryBytes(ctx context.Context, cfg config, query string, params map[string]string) ([]byte, error) {
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		return nil, err
+	}
+	qs := u.Query()
+	qs.Set("default_format", "JSONEachRow")
+	for k, v := range params {
+		qs.Set("param_"+k, v)
+	}
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(query))
+	if err != nil {
+		return nil, err
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+// reinflateNetRowJSON converts the JSONEachRow row from network_requests
+// into the shape the browser network log code expects. The three
+// columns request_headers / response_headers / query_string are stored
+// as JSON-encoded strings (so e.g. "[{\"name\":...}]" arrives as a
+// String), but the consumer wants actual arrays. We re-parse those
+// columns and splice them back in.
+func reinflateNetRowJSON(line []byte) []byte {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return line
+	}
+	for _, key := range [...]string{"request_headers", "response_headers", "query_string"} {
+		val, ok := raw[key]
+		if !ok {
+			continue
+		}
+		// val is a JSON String containing JSON. Decode the outer string
+		// then re-emit the inner JSON as raw.
+		var inner string
+		if err := json.Unmarshal(val, &inner); err != nil {
+			continue
+		}
+		if inner == "" {
+			raw[key] = json.RawMessage("[]")
+			continue
+		}
+		raw[key] = json.RawMessage(inner)
+	}
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return line
+	}
+	return out
+}
+
+func insertNet(ctx context.Context, cfg config, rows []netRow) error {
+	var body bytes.Buffer
+	enc := json.NewEncoder(&body)
+	for i := range rows {
+		if err := enc.Encode(&rows[i]); err != nil {
+			return err
+		}
+	}
+	q := fmt.Sprintf("INSERT INTO %s.network_requests FORMAT JSONEachRow", cfg.chDatabase)
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		return err
+	}
+	qs := u.Query()
+	qs.Set("query", q)
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), &body)
+	if err != nil {
+		return err
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/analytics/grafana/provisioning/dashboards/default.yml
+++ b/analytics/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: infinite-streaming
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -1,0 +1,110 @@
+{
+  "title": "InfiniteStream Storage",
+  "uid": "is-session-analytics",
+  "schemaVersion": 39,
+  "editable": true,
+  "tags": ["infinite-streaming"],
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "timepicker": {
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "1h"]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Messages by type",
+      "description": "Per-minute row count ingested into each ClickHouse table.",
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 12,
+            "showPoints": "never",
+            "stacking": { "mode": "normal", "group": "A" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "rawSql": "SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time ORDER BY time",
+          "format": 0
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Total storage",
+      "description": "On-disk bytes across all active parts in the infinite_streaming database.",
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+      "gridPos": { "x": 0, "y": 10, "w": 8, "h": 6 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5368709120 },
+              { "color": "red", "value": 21474836480 }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "rawSql": "SELECT sum(bytes_on_disk) AS bytes FROM system.parts WHERE database = 'infinite_streaming' AND active",
+          "format": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Storage by table",
+      "description": "Active part bytes and row counts per table.",
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+      "gridPos": { "x": 8, "y": 10, "w": 16, "h": 6 },
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "bytes" }, "properties": [{ "id": "unit", "value": "decbytes" }] },
+          { "matcher": { "id": "byName", "options": "rows" },  "properties": [{ "id": "unit", "value": "short" }] }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": { "show": false }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "rawSql": "SELECT table, sum(rows) AS rows, sum(bytes_on_disk) AS bytes FROM system.parts WHERE database = 'infinite_streaming' AND active GROUP BY table ORDER BY bytes DESC",
+          "format": 1
+        }
+      ]
+    }
+  ]
+}

--- a/analytics/grafana/provisioning/datasources/clickhouse.yml
+++ b/analytics/grafana/provisioning/datasources/clickhouse.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+  - name: ClickHouse
+    type: grafana-clickhouse-datasource
+    uid: ch_infinite_streaming
+    access: proxy
+    isDefault: true
+    jsonData:
+      host: clickhouse
+      port: 9000
+      protocol: native
+      defaultDatabase: infinite_streaming
+      tlsSkipVerify: true
+      username: default
+    secureJsonData:
+      password: ""
+    editable: true

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -749,28 +749,21 @@ final class PlayerViewModel: ObservableObject {
     /// willing to switch to — when 4K is off we cap at 1080p so the
     /// device decoder isn't asked to do 4K H.264.
     ///
-    /// Simulator override: the iOS / iPadOS simulator's video decoder
-    /// can't reliably handle 4K H.264 (or HEVC at any resolution above
-    /// 1080p) regardless of what the user picks. Hard-cap at 1080p on
-    /// simulator builds so clips with 4K renditions in their master
-    /// (e.g. "Samsung Ride on Board 4K Demo") play cleanly during
-    /// local development. Real-device builds honour the user toggle.
+    /// The simulator used to be hard-capped at 1080p regardless of the
+    /// toggle because Intel-host sims couldn't reliably decode 4K HEVC.
+    /// On Apple-Silicon hosts the simulator routes decode through the
+    /// host's hardware HEVC decoder and 4K plays fine, so the override
+    /// is gone — sim now honours `allow4K`. If a particular host can't
+    /// decode, AVPlayer surfaces `decodeFailedNotification` and the
+    /// existing recovery pipeline kicks in (same path real devices use).
     private func apply4kPreference(to item: AVPlayerItem) {
-        #if targetEnvironment(simulator)
-        if #available(iOS 15.0, tvOS 15.0, *) {
-            item.preferredMaximumResolution = CGSize(width: 1920, height: 1080)
-        }
         item.preferredPeakBitRate = 0
-        #else
+        guard #available(iOS 15.0, tvOS 15.0, *) else { return }
         if allow4K {
-            item.preferredPeakBitRate = 0
-            if #available(iOS 15.0, tvOS 15.0, *) {
-                item.preferredMaximumResolution = CGSize(width: 3840, height: 2160)
-            }
-        } else if #available(iOS 15.0, tvOS 15.0, *) {
+            item.preferredMaximumResolution = CGSize(width: 3840, height: 2160)
+        } else {
             item.preferredMaximumResolution = CGSize(width: 1920, height: 1080)
         }
-        #endif
     }
 
     private func seekToLiveEdge(item: AVPlayerItem) {

--- a/content/dashboard/session-viewer.html
+++ b/content/dashboard/session-viewer.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Testing Monitor - InfiniteStream</title>
+    <title>Session Viewer - InfiniteStream</title>
     <link rel="stylesheet" href="/shared-styles.css">
     <style>
         .page-header {
@@ -407,26 +407,17 @@
             filter: grayscale(0.5);
         }
 
-
     </style>
 </head>
-<body>
+<body class="replay-mode">
     <div class="ism-content-wide">
         <div class="page-header">
-            <div class="page-title">Testing Monitor</div>
-            <div class="page-subtitle" id="testingSubtitle">Launch sessions and tune failure settings per session.</div>
+            <div class="page-title">Session Viewer</div>
+            <div class="page-subtitle" id="testingSubtitle">Browse and replay archived streaming sessions from the analytics tier.</div>
         </div>
 
-        <div class="panel">
-            <div class="panel-header">
-                <div class="panel-title">Active Sessions <span class="status-message" id="sseMissedBadge"></span></div>
-                <div class="btn-row">
-                    <button class="btn btn-secondary" id="refreshSessions">Refresh</button>
-                    <button class="btn btn-danger" id="clearSessions">Release All Sessions</button>
-                </div>
-            </div>
-            <div id="sessionsContainer"></div>
-        </div>
+        <span id="sseMissedBadge" hidden></span>
+        <div id="sessionsContainer"></div>
     </div>
 
     <script src="/shared/shared-nav.js"></script>
@@ -456,6 +447,5 @@
     <script src="/dashboard/player-characterization.js"></script>
     <script src="/shared/session-shell.js"></script>
     <script src="/shared/session-replay.js"></script>
-    <script src="/shared/session-live.js"></script>
 </body>
 </html>

--- a/content/dashboard/sessions.html
+++ b/content/dashboard/sessions.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Testing Monitor - InfiniteStream</title>
+    <title>Sessions - InfiniteStream</title>
     <link rel="stylesheet" href="/shared-styles.css">
     <style>
         .page-header {
@@ -407,14 +407,21 @@
             filter: grayscale(0.5);
         }
 
+        /* Selector page: the picker is the page content, hide the empty
+         * Active Sessions panel that gets inherited from the testing-page
+         * template clone. Page header (title + subtitle) is preserved.
+         * The picker itself uses .session-picker-panel so we exclude it. */
+        body.session-selector .ism-content-wide > .panel:not(.session-picker-panel) {
+            display: none !important;
+        }
 
     </style>
 </head>
-<body>
+<body class="replay-mode session-selector">
     <div class="ism-content-wide">
         <div class="page-header">
-            <div class="page-title">Testing Monitor</div>
-            <div class="page-subtitle" id="testingSubtitle">Launch sessions and tune failure settings per session.</div>
+            <div class="page-title">Sessions</div>
+            <div class="page-subtitle" id="testingSubtitle">Browse archived streaming sessions. Click one to open it in the Session Viewer.</div>
         </div>
 
         <div class="panel">
@@ -430,23 +437,6 @@
     </div>
 
     <script src="/shared/shared-nav.js"></script>
-    <script>
-        (() => {
-            const subtitle = document.getElementById('testingSubtitle');
-            if (!subtitle) return;
-            let port = window.location.port || (window.location.protocol === 'https:' ? '443' : '80');
-            if (window.ISMNav && typeof window.ISMNav.normalizeTestingBaseUrl === 'function') {
-                try {
-                    const normalized = window.ISMNav.normalizeTestingBaseUrl(window.location.origin);
-                    const parsed = new URL(normalized);
-                    port = parsed.port || port;
-                } catch (err) {
-                    console.warn('Failed to resolve testing port', err);
-                }
-            }
-            subtitle.textContent = `Launch sessions on port ${port} and tune failure settings per session.`;
-        })();
-    </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/styles/vis-timeline-graph2d.min.css">
@@ -456,6 +446,5 @@
     <script src="/dashboard/player-characterization.js"></script>
     <script src="/shared/session-shell.js"></script>
     <script src="/shared/session-replay.js"></script>
-    <script src="/shared/session-live.js"></script>
 </body>
 </html>

--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -681,30 +681,37 @@
 
 .netwf-brush {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    background: rgba(33, 150, 243, 0.10);
-    border-left: 2px solid #2196F3;
-    border-right: 2px solid #2196F3;
+    top: -2px;
+    bottom: -2px;
+    background: rgba(37, 99, 235, 0.20);
+    border: 2px solid #1d4ed8;
+    border-radius: 4px;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.6),
+                0 4px 12px rgba(29, 78, 216, 0.35);
     cursor: grab;
     box-sizing: border-box;
+    z-index: 2;
 }
 
 .netwf-brush.dragging {
     cursor: grabbing;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.7),
+                0 6px 18px rgba(29, 78, 216, 0.55);
 }
 
 .netwf-brush-handle {
     position: absolute;
     top: 0;
     bottom: 0;
-    width: 6px;
-    background: rgba(33, 150, 243, 0.35);
+    width: 10px;
+    background: #1d4ed8;
+    border-radius: 2px;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.7);
     cursor: ew-resize;
 }
 
-.netwf-brush-handle.left { left: -3px; }
-.netwf-brush-handle.right { right: -3px; }
+.netwf-brush-handle.left  { left: -5px; }
+.netwf-brush-handle.right { right: -5px; }
 
 /* Global-axis waterfall: each row's bar is positioned within the
  * brush's time window. Bars on the same horizontal pixel = requests
@@ -1430,7 +1437,8 @@ button[data-action="reset-bitrate-zoom"].zoom-active::before {
    Live/Pause toggle button (chart-live highlight + pulsing dot).
    ============================================================================ */
 
-button[data-action="pause-bitrate-chart"].chart-live {
+button[data-action="pause-bitrate-chart"].chart-live,
+button[data-action="pause-network-log"].netwf-live {
     color: #16a34a;
     border-color: #16a34a;
     font-weight: 600;
@@ -1439,7 +1447,8 @@ button[data-action="pause-bitrate-chart"].chart-live {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.35; }
 }
-button[data-action="pause-bitrate-chart"].chart-live::before {
+button[data-action="pause-bitrate-chart"].chart-live::before,
+button[data-action="pause-network-log"].netwf-live::before {
     content: '● ';
     animation: chart-pulse-dot 1.2s ease-in-out infinite;
 }

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -50,6 +50,18 @@
     // means the brush sticks to the right edge as new entries arrive
     // (Following Latest). Drag-pan flips it to false.
     const networkWaterfallBrushBySession = new Map();
+    // Per-session event-marker state — { tsMs, label } picked from the
+    // session-replay events dropdown / rail. Painted as a cyan vertical
+    // guide on both the overview rail and the row-list time scale so
+    // the user can see exactly where the picked event lands among the
+    // network requests.
+    const networkLogEventMarkerBySession = new Map();
+    // Session ids whose next paint should auto-scroll the row list to
+    // the row closest to the marker's timestamp. We only scroll on a
+    // fresh pick (not on every brush drag / re-render) so the user
+    // can scroll away to read nearby rows without being yanked back.
+    const networkLogPendingScrollBySession = new Set();
+    const NETLOG_EVENT_MARKER_COLOR = '#0891b2';
     // Per-session column sort state: { col, dir } where dir is 'asc' or
     // 'desc'. col=null (or absent) means default chronological order.
     const networkWaterfallSortBySession = new Map();
@@ -58,9 +70,26 @@
     // axis gets too granular to be useful; this is also the default
     // initial span when a session first opens.
     const networkWaterfallMinBrushMs = 30 * 1000;
+    // In replay mode the network log brush should match the main page
+    // brush span (10 min) by default rather than the live-mode 30s tail.
+    // Using the same span makes the two scrub bars feel coordinated even
+    // before the user touches either one. Live testing.html keeps the
+    // small default — there entries arrive in real time and a tight
+    // tail is more useful.
+    const networkWaterfallReplayDefaultMs = 10 * 60 * 1000;
     const networkLogAutoRefreshTimers = new Map();
     const networkLogFetchInFlight = new Set();
     const networkLogAutoRefreshMs = 1500;
+    // True when the user explicitly paused fetching for this session.
+    // While paused, the auto-refresh timer is stopped — entries don't
+    // grow, the brush stays where the user left it, and a "PAUSED"
+    // overlay sits on top of the waterfall. Click Live to resume.
+    const networkLogPausedBySession = new Map();
+    // Set of session_ids whose own network-log brush is being dragged.
+    // Used to gate the 1.5s auto-refresh poll so the row table doesn't
+    // rebuild mid-gesture. Distinct from SessionShell's
+    // brushDraggingBySession (the main session-viewer brush).
+    const networkLogBrushDragging = new Set();
     // Network log used to be developer-only; now enabled for everyone.
     // The constant stays as `true` so the runtime gates still compile.
     const networkLogDeveloperEnabled = true;
@@ -556,12 +585,13 @@
         const playerStateOpen = resolveSectionDefault(options, 'player-state', false);
         const playerMetricsOpen = resolveSectionDefault(options, 'player-metrics', false);
 
+        const hideHeader = options.hideHeader || false;
         return `
             <div class="session-card" data-session-id="${sessionId}" data-session-port="${session.x_forwarded_port_external || session.x_forwarded_port || ''}" data-segment-duration-seconds="${segmentDurationSeconds}" data-shaping-presets="${encodedPresets}" data-shaping-video-presets="${encodedVideoPresets}" data-shaping-overhead-mbps="${overheadMbps}">
-                <div class="session-header">
+                ${hideHeader ? '' : `<div class="session-header">
                     ${hideTitle ? '' : `<div class="session-title">Session ${sessionId}</div>`}
                     <div class="session-meta" title="Port">${portDisplay}</div>
-                </div>
+                </div>`}
                 ${inlineHost ? `<div class="session-inline-player" data-inline-host="${sessionId}"></div>` : ''}
 
                 <!-- Collapsible Session Details -->
@@ -574,6 +604,7 @@
                     <div class="collapsible-content" data-content="session-details" style="display: ${sessionDetailsOpen ? 'block' : 'none'};">
                         <div class="session-grid">
                             <div class="session-item"><span class="label">Session ID</span><span class="value" data-field="session_session_id">${session.session_id || '—'}</span></div>
+                            <div class="session-item"><span class="label">Play ID</span><span class="value" data-field="session_play_id" title="Fresh UUID minted by the player at every loadStream() boundary (issue #280). Each fresh playback episode gets its own play_id; the analytics pipeline partitions on (session_id, play_id).">${session.play_id || '—'}</span></div>
                             <div class="session-item"><span class="label">Player ID</span><span class="value" data-field="session_player_id">${session.player_id || '—'}</span></div>
                             <div class="session-item"><span class="label">User Agent</span><span class="value" data-field="session_user_agent">${session.user_agent || '—'}</span></div>
                             <div class="session-item"><span class="label">Player IP</span><span class="value" data-field="session_player_ip">${session.player_ip || '—'}</span></div>
@@ -1140,6 +1171,7 @@
                         <div class="network-log-section">
                             <div class="network-log-controls">
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="refresh-network-log">Refresh</button>
+                                <button type="button" class="btn btn-mini btn-secondary" data-action="pause-network-log" title="Stop fetching new entries — freeze the current view until you click Live">⏸ Pause</button>
                                 <button type="button" class="btn btn-mini btn-secondary" data-action="save-har-snapshot" title="Save the current network timeline as a HAR file: downloads to your machine and adds it to the Incidents list">Download HAR</button>
                                 <a href="/dashboard/incidents.html" target="_blank" rel="noopener" class="btn btn-mini btn-secondary" title="Browse saved HAR snapshots">Incidents</a>
                                 <label class="network-log-filter" title="When checked, the row list snaps to the latest entry on every refresh.">
@@ -1442,6 +1474,34 @@
 
     // Initialize collapsible sections and tabs
     function initializeUI() {
+        // Click on empty space inside the network-log waterfall toggles
+        // pause/live, mirroring the chart canvas behaviour. Skip clicks
+        // on rows, the brush, controls, and links — those have their
+        // own behaviour. Drag-detection uses a 5-pixel threshold so a
+        // brush-drag that ends inside the wrap doesn't accidentally
+        // toggle pause.
+        let netwfMouseDownX = 0, netwfMouseDownY = 0;
+        document.addEventListener('mousedown', (e) => {
+            if (e.button === 0 && e.target.closest('.network-log-waterfall-wrap')) {
+                netwfMouseDownX = e.clientX;
+                netwfMouseDownY = e.clientY;
+            }
+        });
+        document.addEventListener('click', (e) => {
+            const wrap = e.target.closest('.network-log-waterfall-wrap');
+            if (!wrap) return;
+            // Was this a real click, not the end of a drag?
+            if (Math.abs(e.clientX - netwfMouseDownX) > 5 || Math.abs(e.clientY - netwfMouseDownY) > 5) return;
+            // Skip clicks on interactive sub-elements that have their
+            // own meaning (rows, the brush, controls, links).
+            const skipSelectors = '.netwf-row, .netwf-brush, .netwf-brush-handle, .netwf-overview-bars, .netwf-overview-tick, button, input, label, select, textarea, a';
+            if (e.target.closest(skipSelectors)) return;
+            const card = wrap.closest('.session-card');
+            const sessionId = card ? String(card.dataset.sessionId || '') : '';
+            if (!sessionId) return;
+            toggleNetworkLogPaused(sessionId);
+        });
+
         // "All" checkbox toggles all sibling scope checkboxes
         document.addEventListener('change', (e) => {
             const cb = e.target;
@@ -1510,6 +1570,22 @@
                             }));
                         });
                     }
+                    return;
+                }
+                if (action === 'pause-network-log') {
+                    const card = actionButton.closest('.session-card');
+                    const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                    if (!sessionId) return;
+                    toggleNetworkLogPaused(sessionId);
+                    return;
+                }
+                if (action === 'refresh-network-log') {
+                    const card = actionButton.closest('.session-card');
+                    const sessionId = card ? String(card.dataset.sessionId || '') : '';
+                    if (!sessionId) return;
+                    // One-shot refresh ignores the pause state — the user
+                    // explicitly asked for fresh data right now.
+                    updateNetworkLog(sessionId);
                     return;
                 }
                 if (action === 'save-har-snapshot') {
@@ -1679,6 +1755,10 @@
         if (!networkLogDeveloperEnabled) return;
         const key = String(sessionId || '');
         if (!key || document.hidden) return;
+        // Honour the user's Pause toggle — even when the fold opens or
+        // the page becomes visible again, don't resume polling unless
+        // the user has explicitly clicked Live.
+        if (isNetworkLogPaused(key)) return;
         const hostCard = card || document.querySelector(`.session-card[data-session-id="${key}"]`);
         if (!hostCard) return;
         if (networkLogAutoRefreshTimers.has(key)) return;
@@ -1687,6 +1767,64 @@
             updateNetworkLog(key, { skipIfInFlight: true });
         }, networkLogAutoRefreshMs);
         networkLogAutoRefreshTimers.set(key, timer);
+    }
+
+    function isNetworkLogPaused(sessionId) {
+        return networkLogPausedBySession.get(String(sessionId || '')) === true;
+    }
+
+    // Sync the visible button label + PAUSED badge to the persisted
+    // pause state. Called from setNetworkLogPaused (after toggle) and
+    // from updateNetworkWaterfall (after every refresh) so SSE-driven
+    // session-card re-renders don't reset the visual state.
+    function applyNetworkLogPauseUI(sessionId, card) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        const hostCard = card || document.querySelector(`.session-card[data-session-id="${key}"]`);
+        if (!hostCard) return;
+        const paused = isNetworkLogPaused(key);
+        for (const btn of hostCard.querySelectorAll('button[data-action="pause-network-log"]')) {
+            if (paused) {
+                btn.textContent = '▶ Live';
+                btn.classList.add('netwf-live');
+                btn.title = 'Resume fetching new entries';
+            } else {
+                btn.textContent = '⏸ Pause';
+                btn.classList.remove('netwf-live');
+                btn.title = 'Stop fetching new entries — freeze the current view until you click Live';
+            }
+        }
+        const wrap = hostCard.querySelector('.network-log-waterfall-wrap');
+        if (wrap) {
+            let badge = wrap.querySelector('.network-log-paused-badge');
+            if (!badge) {
+                badge = document.createElement('div');
+                badge.className = 'network-log-paused-badge';
+                badge.textContent = 'PAUSED';
+                badge.style.cssText = 'position:absolute;top:8px;right:8px;padding:2px 10px;border-radius:10px;background:rgba(220,38,38,0.85);color:#fff;font:600 11px system-ui;letter-spacing:0.06em;pointer-events:none;display:none;z-index:5;';
+                if (getComputedStyle(wrap).position === 'static') wrap.style.position = 'relative';
+                wrap.appendChild(badge);
+            }
+            badge.style.display = paused ? 'block' : 'none';
+        }
+    }
+
+    function setNetworkLogPaused(sessionId, paused) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        networkLogPausedBySession.set(key, !!paused);
+        const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+        applyNetworkLogPauseUI(key, card);
+        if (paused) {
+            stopNetworkLogAutoRefresh(key);
+        } else {
+            // Resume: kick off a fresh poll immediately.
+            startNetworkLogAutoRefresh(key, card);
+        }
+    }
+
+    function toggleNetworkLogPaused(sessionId) {
+        setNetworkLogPaused(sessionId, !isNetworkLogPaused(sessionId));
     }
 
     function isNetworkLogFollowMode(sessionId) {
@@ -1953,7 +2091,22 @@
         };
 
         const rows = entries.slice().map((entry, index) => {
-            const timestamp = Date.parse(entry.timestamp || '') || 0;
+            // Two on-the-wire formats:
+            //   live (go-proxy):       "2026-05-02T23:18:20.608Z"  (RFC3339, UTC)
+            //   archived (ClickHouse): "2026-05-02 23:18:20.608"   (no TZ marker)
+            // Date.parse defaults the second form to LOCAL time, which shifts
+            // every archived entry by the user's UTC offset and makes the
+            // network log times disagree with the chart/heatmap times.
+            // Normalise the unspaced/no-TZ form to ISO+Z before parsing.
+            const tsRaw = String(entry.timestamp || '');
+            let timestamp;
+            if (!tsRaw) {
+                timestamp = 0;
+            } else if (tsRaw.includes('T') && (tsRaw.endsWith('Z') || /[+-]\d\d:?\d\d$/.test(tsRaw))) {
+                timestamp = Date.parse(tsRaw) || 0;
+            } else {
+                timestamp = Date.parse(tsRaw.replace(' ', 'T') + 'Z') || 0;
+            }
             // Upstream-perspective phases (proxy → origin) — surfaced in the
             // tooltip for forensics but not part of the player-perceived bar.
             const dns = Number(entry.dns_ms || 0);
@@ -2027,6 +2180,15 @@
             row.totalAttempts = attemptByKey.get(k) || 1;
         }
         const newestTimestamp = ordered[ordered.length - 1].timestamp;
+        // Live testing.html uses a 10-min rolling cutoff so the table
+        // doesn't grow forever as new requests stream in. In replay mode
+        // we WANT the whole session — the user is investigating history,
+        // not tailing live traffic — so don't trim. Otherwise a 75-min
+        // session would silently lose 65 min of HAR rows before the rail
+        // / brush even sees them.
+        if (document.body.classList.contains('replay-mode')) {
+            return ordered;
+        }
         const cutoff = newestTimestamp - networkWaterfallRollingWindowMs;
         return ordered.filter((row) => (row.timestamp + row.duration) >= cutoff);
     }
@@ -2039,6 +2201,11 @@
     // DevTools' Network panel pattern.
     function updateNetworkWaterfall(card, sessionId) {
         const key = String(sessionId);
+        // Re-establish the pause-state UI on every render — SSE-driven
+        // session-card re-renders on testing.html / testing-session.html
+        // would otherwise drop the "▶ Live" label and PAUSED badge even
+        // though the persisted pause state still suppresses polling.
+        applyNetworkLogPauseUI(key, card);
         const chartHost = card.querySelector('[data-field="network_log_waterfall"]');
         const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
         const emptyHost = card.querySelector('[data-field="network_log_waterfall_empty"]');
@@ -2060,40 +2227,78 @@
         }
         emptyHost.style.display = 'none';
 
-        // Full session range (the overview always shows this).
+        // The overview rail used to span just the HAR data extent. In
+        // session-viewer the user can expand the main brush past the
+        // available data — we extend the rail to the union of data
+        // range and brush range so the rail always covers what the
+        // user is looking at, with empty area for "no requests here."
         const dataStartMs = rows[0].timestamp;
         const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
-        const fullSpan = Math.max(50, dataEndMs - dataStartMs);
+        // Span of the actual HAR data — used for default brush sizing.
+        // Distinct from `fullSpan` (= rail span = max(data, brush))
+        // computed once the brush is settled, below.
+        const dataSpan = Math.max(50, dataEndMs - dataStartMs);
 
         // Brush state — Following Latest = stick to the right edge.
         // Default: zoom to the most recent 2 minutes (or full session
         // if shorter). 2 min is also the floor we enforce on user
         // resize so bars stay scannable.
+        const isReplay = document.body.classList.contains('replay-mode');
+        const defaultSpanMs = isReplay ? networkWaterfallReplayDefaultMs : networkWaterfallMinBrushMs;
         let brush = networkWaterfallBrushBySession.get(key);
         if (!brush) {
-            const initialSpan = Math.min(fullSpan, networkWaterfallMinBrushMs);
+            const initialSpan = Math.min(dataSpan, defaultSpanMs);
             brush = { startMs: dataEndMs - initialSpan, endMs: dataEndMs, follow: true };
             networkWaterfallBrushBySession.set(key, brush);
+        }
+        // External callers (e.g. the bitrate chart's pan/zoom or the
+        // session-viewer scrubber) may have set a brush range that's
+        // entirely outside the actual HAR data — for example, a session
+        // viewer scrubbed to "last 30s" but the proxy buffer only holds
+        // entries from earlier. If the requested range has no overlap
+        // with the data we have, fall back to a sensible default
+        // (follow-latest) so the user sees *something*. The next user
+        // gesture re-anchors the brush.
+        const noOverlap = (brush.endMs < dataStartMs) || (brush.startMs > dataEndMs);
+        if (noOverlap) {
+            const initialSpan = Math.min(dataSpan, networkWaterfallMinBrushMs);
+            brush.startMs = Math.max(dataStartMs, dataEndMs - initialSpan);
+            brush.endMs = dataEndMs;
+            brush.follow = true;
         }
         // Sync brush.follow with the Follow Latest button. Clicking
         // the button re-engages right-edge stickiness even if the user
         // had previously dragged the brush.
-        brush.follow = isNetworkLogFollowMode(key);
+        brush.follow = brush.follow || isNetworkLogFollowMode(key);
         if (brush.follow) {
             const span = brush.endMs - brush.startMs;
             brush.endMs = dataEndMs;
             brush.startMs = Math.max(dataStartMs, brush.endMs - span);
         }
         // Clamp to data range and enforce the minimum brush width.
-        if (brush.endMs > dataEndMs) brush.endMs = dataEndMs;
-        if (brush.startMs < dataStartMs) brush.startMs = dataStartMs;
-        if (brush.endMs - brush.startMs < networkWaterfallMinBrushMs) {
-            // Try to expand left first; if there's not enough history,
-            // accept whatever we can fit (full session shorter than
-            // the minimum is fine — the floor only applies when the
-            // user could have a wider view).
-            brush.startMs = Math.max(dataStartMs, brush.endMs - networkWaterfallMinBrushMs);
+        // Defensive: end can still be <= start if the requested range
+        // was zero or otherwise pathological. Fall back to a sensible
+        // default brush at the data tail.
+        if (brush.endMs <= brush.startMs) {
+            brush.endMs = dataEndMs;
+            const initialSpan = Math.min(dataEndMs - dataStartMs, defaultSpanMs);
+            brush.startMs = Math.max(dataStartMs, dataEndMs - initialSpan);
         }
+        // Min-brush-width enforcement only kicks in when the brush would
+        // otherwise be uselessly small. Don't clamp to data range here —
+        // the rail extends to encompass the brush below.
+        if (brush.endMs - brush.startMs < networkWaterfallMinBrushMs) {
+            brush.startMs = brush.endMs - networkWaterfallMinBrushMs;
+        }
+
+        // Rail coordinate system = union of data range and brush range.
+        // When the brush extends past the data (typical when expanding
+        // the session-viewer focus window past available HAR archival),
+        // the rail grows to include the brush — empty space rendered
+        // for "no requests in this part" rather than clipping the brush.
+        const railStartMs = Math.min(dataStartMs, brush.startMs);
+        const railEndMs   = Math.max(dataEndMs,   brush.endMs);
+        const fullSpan = Math.max(50, railEndMs - railStartMs);
 
         // Summary row: total + categorical counts. Read at a glance
         // before the user starts panning the brush.
@@ -2102,23 +2307,22 @@
             renderWaterfallSummary(summaryEl, rows, dataStartMs, dataEndMs);
         }
 
-        // Time labels above the overview pane — full session range,
-        // independent of the brush. So the user sees both the
-        // big-picture wall clock (this row) and the zoomed-in
-        // wall clock (the row above the bars below).
+        // Time labels above the overview pane — span the rail (which
+        // covers data + brush) so axis ticks line up with the rail
+        // beneath them.
         const overviewAxis = card.querySelector('[data-field="netwf_overview_axis"]');
         if (overviewAxis) {
-            renderWaterfallAxisTicks(overviewAxis, dataStartMs, dataEndMs);
+            renderWaterfallAxisTicks(overviewAxis, railStartMs, railEndMs);
         }
 
         // Render overview ticks (one per row, positioned by absolute
-        // time). Re-render is cheap; we redraw on every refresh.
-        // Apply the same status/fault classes the main rows use so
-        // bad requests stand out on the strip too.
+        // time within the rail). Rail bounds in use; data ticks fall
+        // wherever they are, with empty rail beyond if the brush
+        // extends past data range.
         if (overviewBars) {
             overviewBars.replaceChildren();
             for (const row of rows) {
-                const left = ((row.timestamp - dataStartMs) / fullSpan) * 100;
+                const left = ((row.timestamp - railStartMs) / fullSpan) * 100;
                 const width = Math.max(0.05, (Math.max(50, row.duration) / fullSpan) * 100);
                 const tick = document.createElement('div');
                 tick.className = 'netwf-overview-tick' + waterfallRowStatusClasses(row);
@@ -2128,9 +2332,9 @@
             }
         }
 
-        // Position the brush to match its current state.
+        // Position the brush to match its current state, in rail coords.
         if (brushEl) {
-            const left = ((brush.startMs - dataStartMs) / fullSpan) * 100;
+            const left = ((brush.startMs - railStartMs) / fullSpan) * 100;
             const width = ((brush.endMs - brush.startMs) / fullSpan) * 100;
             brushEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
             brushEl.style.width = `${Math.max(0.5, width).toFixed(3)}%`;
@@ -2204,6 +2408,9 @@
         // knows the full data range.
         networkWaterfallRowsBySession.set(key, rows);
         networkWaterfallRenderSignatureBySession.set(key, sigs.length + ':' + (sigs[sigs.length - 1] || ''));
+        // Repaint the event-marker guide (if any) using the freshly
+        // rendered axis scale and brush window.
+        paintNetworkLogEventMarker(card, key);
 
         // Following Latest: snap the *inner* scroll to the bottom.
         // The list now has its own scroll surface (max-height +
@@ -2802,6 +3009,33 @@
         return `${hh}:${mm}:${ss}`;
     }
 
+    // Cheap mid-drag brush reposition — updates the brush element's
+    // left/width CSS only, without rebuilding the row table or
+    // recomputing summaries. Used during drag so the waterfall
+    // doesn't re-render on every mousemove. Mirrors the rail bounds
+    // logic from updateNetworkWaterfall (rail = data ∪ brush).
+    function repositionBrushOnly(card, sessionId) {
+        const brush = networkWaterfallBrushBySession.get(String(sessionId));
+        if (!brush) return;
+        const brushEl = card.querySelector('[data-field="netwf_brush"]');
+        if (!brushEl) return;
+        const rows = networkWaterfallRowsBySession.get(String(sessionId)) || [];
+        if (!rows.length) return;
+        const dataStartMs = rows[0].timestamp;
+        const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+        const railStartMs = Math.min(dataStartMs, brush.startMs);
+        const railEndMs   = Math.max(dataEndMs,   brush.endMs);
+        const fullSpan = Math.max(50, railEndMs - railStartMs);
+        const left = ((brush.startMs - railStartMs) / fullSpan) * 100;
+        const width = ((brush.endMs - brush.startMs) / fullSpan) * 100;
+        brushEl.style.left = `${Math.max(0, left).toFixed(3)}%`;
+        brushEl.style.width = `${Math.max(0.5, width).toFixed(3)}%`;
+        // Mid-drag reposition of the event-marker guide too — the row
+        // list isn't re-rendered until release, but the rail line and
+        // the row-list line should track the brush in real time.
+        paintNetworkLogEventMarker(card, sessionId);
+    }
+
     // Brush drag/resize handlers. The brush is positioned in % of the
     // overview's width, so we convert px deltas to % via the
     // overview's bounding rect. Drag-pan or drag-resize disables
@@ -2834,6 +3068,7 @@
                 pointerStartX: event.clientX
             };
             brushEl?.classList.add('dragging');
+            networkLogBrushDragging.add(sessionId);
             event.preventDefault();
             event.stopPropagation();
         };
@@ -2876,13 +3111,45 @@
                 setNetworkLogFollowMode(sessionId, false);
                 updateNetworkLogFollowButton(card, sessionId);
             }
-            updateNetworkWaterfall(card, sessionId);
+            // Mid-drag: cheap reposition only (brush CSS left/width).
+            // Full waterfall re-render fires on mouseup.
+            repositionBrushOnly(card, sessionId);
+            // Live-sync the main session-viewer brush so both rails
+            // move together. live:true means "no chart re-render yet"
+            // — the chart-side listener just repositions its brush.
+            document.dispatchEvent(new CustomEvent('replay:brush-range-change', {
+                detail: {
+                    sessionId,
+                    startMs: brush.startMs,
+                    endMs: brush.endMs,
+                    source: 'network-log',
+                    live: true
+                }
+            }));
         };
 
         const onPointerUp = () => {
             if (!drag) return;
             drag = null;
             brushEl?.classList.remove('dragging');
+            networkLogBrushDragging.delete(sessionId);
+            // Final full render on release — picks up the brush range
+            // and rebuilds the row table to match.
+            updateNetworkWaterfall(card, sessionId);
+            // Tell the main session-viewer brush to settle on this
+            // range and trigger its full chart re-render.
+            const brush = networkWaterfallBrushBySession.get(sessionId);
+            if (brush) {
+                document.dispatchEvent(new CustomEvent('replay:brush-range-change', {
+                    detail: {
+                        sessionId,
+                        startMs: brush.startMs,
+                        endMs: brush.endMs,
+                        source: 'network-log',
+                        live: false
+                    }
+                }));
+            }
         };
 
         // Brush body = pan. Handles = resize. Click on bare overview
@@ -2919,6 +3186,17 @@
                 updateNetworkLogFollowButton(card, sessionId);
             }
             updateNetworkWaterfall(card, sessionId);
+            // Sync the main brush — discrete click is a settle event,
+            // so live:false to trigger the full chart re-render.
+            document.dispatchEvent(new CustomEvent('replay:brush-range-change', {
+                detail: {
+                    sessionId,
+                    startMs: brush.startMs,
+                    endMs: brush.endMs,
+                    source: 'network-log',
+                    live: false
+                }
+            }));
         });
 
         document.addEventListener('mousemove', onPointerMove);
@@ -2931,6 +3209,29 @@
         const key = String(sessionId || '');
         if (!key) return;
         if (options.skipIfInFlight && networkLogFetchInFlight.has(key)) return;
+        // Skip while the user is actively dragging the main session-
+        // viewer brush. Ambient 1.5s polling otherwise flickers the
+        // waterfall mid-gesture; one render fires on release via
+        // syncNetworkLogToBrush. Manual user actions (clicking
+        // Refresh) bypass this check by passing skipIfDragging=false.
+        const skipIfDragging = options.skipIfDragging !== false;
+        if (skipIfDragging) {
+            // Two drag sources to consider:
+            //   1) the session-viewer's main brush (SessionShell flag)
+            //   2) the network-log fold's own brush (local flag)
+            // Either one being active means we should skip the
+            // ambient refresh — the rebuild would flicker the row
+            // table mid-gesture. Manual user actions (clicking
+            // Refresh) bypass via skipIfDragging:false.
+            if (window.SessionShell
+                && window.SessionShell.brushDraggingBySession
+                && window.SessionShell.brushDraggingBySession.has(key)) {
+                return;
+            }
+            if (networkLogBrushDragging.has(key)) {
+                return;
+            }
+        }
 
         const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
         if (!card) {
@@ -2941,25 +3242,71 @@
         const countBadge = card.querySelector('[data-field="network_log_count"]');
         networkLogFetchInFlight.add(key);
 
-        fetch(`/api/session/${key}/network`)
-            .then(response => response.json())
+        // In replay mode, the live go-proxy session is gone — go straight
+        // to the analytics archive. In live mode we hit go-proxy first
+        // (cheaper, freshest); the archive is queried only as a fallback
+        // for sessions whose proxy buffer has aged out.
+        //
+        // We deliberately do NOT filter by play_id on the archive query.
+        // iOS HLS doesn't preserve the master-manifest's `?play_id=…`
+        // query string on variant / segment URLs, so many requests land
+        // with empty play_id even when the session is bound to a single
+        // playback episode. Filtering by play_id would hide them. We
+        // scope by TIME RANGE instead, using the play bounds that
+        // session-replay.js publishes to SessionShell after first batch.
+        // Without this scope the rail extends back to *the earliest
+        // entry across all plays of this session_id* — easily hours
+        // earlier than the play we're actually viewing.
+        const isReplay = document.body.classList.contains('replay-mode');
+        const archiveParams = new URLSearchParams({ session: key });
+        if (isReplay && window.SessionShell && window.SessionShell.playBoundsBySession) {
+            const bounds = window.SessionShell.playBoundsBySession.get(key);
+            if (bounds && Number.isFinite(bounds.startMs) && Number.isFinite(bounds.endMs)) {
+                archiveParams.set('from', new Date(bounds.startMs).toISOString());
+                archiveParams.set('to',   new Date(bounds.endMs).toISOString());
+            }
+        }
+        const archiveURL = `/analytics/api/network_requests?${archiveParams.toString()}`;
+        const liveURL = `/api/session/${key}/network`;
+
+        const apply = (entries) => {
+            const count = entries.length;
+            networkLogEntriesBySession.set(key, entries);
+            if (countBadge) {
+                countBadge.textContent = `${count} request${count !== 1 ? 's' : ''}`;
+            }
+            applyNetworkLogFilters(card);
+        };
+
+        const fetchFrom = (u) => fetch(u).then(r => {
+            if (!r.ok) throw new Error(`HTTP ${r.status}`);
+            return r.json();
+        });
+
+        const primary = isReplay ? archiveURL : liveURL;
+        const fallback = isReplay ? null : archiveURL;
+        fetchFrom(primary)
             .then(data => {
                 const entries = data.entries || [];
-                const count = entries.length;
-                networkLogEntriesBySession.set(key, entries);
-
-                // Update count badge
-                if (countBadge) {
-                    countBadge.textContent = `${count} request${count !== 1 ? 's' : ''}`;
+                if (entries.length === 0 && fallback) {
+                    return fetchFrom(fallback).then(d => apply(d.entries || []));
                 }
-                applyNetworkLogFilters(card);
+                apply(entries);
             })
             .catch(error => {
-                console.error('Failed to fetch network log:', error);
-                networkLogEntriesBySession.delete(key);
-                if (countBadge) {
-                    countBadge.textContent = '0 requests';
+                if (fallback) {
+                    return fetchFrom(fallback)
+                        .then(d => apply(d.entries || []))
+                        .catch(err2 => {
+                            console.error('Network log fetch (both sources) failed:', error, err2);
+                            networkLogEntriesBySession.delete(key);
+                            if (countBadge) countBadge.textContent = '0 requests';
+                            updateNetworkWaterfall(card, key);
+                        });
                 }
+                console.error('Network log fetch failed:', error);
+                networkLogEntriesBySession.delete(key);
+                if (countBadge) countBadge.textContent = '0 requests';
                 updateNetworkWaterfall(card, key);
             })
             .finally(() => {
@@ -3060,6 +3407,256 @@
         updateNetworkWaterfall(card, sessionId);
     }
 
+    // Sync the network-log brush to a given wall-clock range, so other
+    // controls (e.g. the bitrate chart's pan/zoom) can drive the
+    // waterfall's visible time window. Disengages Follow-Latest because
+    // the caller is asserting a specific range.
+    function setNetworkLogTimeRange(sessionId, fromMs, toMs) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        if (!Number.isFinite(fromMs) || !Number.isFinite(toMs) || toMs <= fromMs) return;
+        networkWaterfallBrushBySession.set(key, { startMs: fromMs, endMs: toMs, follow: false });
+        setNetworkLogFollowMode(key, false);
+        const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+        if (!card) return;
+        // Only re-render if the network log fold is open — collapsed
+        // sections will pick up the new range when the user opens them.
+        const content = card.querySelector('[data-content="network-log"]');
+        if (!content || content.style.display === 'none') return;
+        updateNetworkWaterfall(card, key);
+    }
+
+    // Listen for replay event-marker picks. If the picked event's
+    // timestamp falls outside the current network-log brush window,
+    // shift the window (preserving its span) so the event lands at
+    // the centre. Ignores in-window picks so the user's existing
+    // zoom level is preserved when scanning nearby events.
+    // Guarded against duplicate registration if this module's IIFE
+    // runs more than once (live-reload, future SPA navigation).
+    if (!window.__networkLogEventMarkerListenerBound) {
+    window.__networkLogEventMarkerListenerBound = true;
+    document.addEventListener('replay:event-marker', (ev) => {
+        if (!ev || !ev.detail) return;
+        const sessionId = String(ev.detail.sessionId || '');
+        const tsMs = Number(ev.detail.tsMs);
+        if (!sessionId) return;
+        const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+        if (!Number.isFinite(tsMs)) {
+            networkLogEventMarkerBySession.delete(sessionId);
+            if (card) paintNetworkLogEventMarker(card, sessionId);
+            return;
+        }
+        // Stash the marker so the next updateNetworkWaterfall (or
+        // brush-only reposition) can paint the cyan guide line.
+        networkLogEventMarkerBySession.set(sessionId, {
+            tsMs,
+            label: String(ev.detail.label || '')
+        });
+        // Fresh pick → ask the next paint to scroll the row list so
+        // the closest-to-event row is in view. One-shot; cleared by
+        // paintNetworkLogEventMarker once the scroll is performed.
+        networkLogPendingScrollBySession.add(sessionId);
+        const brush = networkWaterfallBrushBySession.get(sessionId);
+        // No brush yet (network log fold not opened) — bail; the
+        // marker we just stashed will be painted on first render.
+        if (!brush) {
+            if (card) paintNetworkLogEventMarker(card, sessionId);
+            return;
+        }
+        const span = brush.endMs - brush.startMs;
+        if (span <= 0) {
+            if (card) paintNetworkLogEventMarker(card, sessionId);
+            return;
+        }
+        // 5 % padding inside the brush so the marker doesn't sit
+        // exactly on the edge.
+        const pad = span * 0.05;
+        if (tsMs >= brush.startMs + pad && tsMs <= brush.endMs - pad) {
+            // Already in view — just repaint the line at the current
+            // position; no scroll needed.
+            if (card) paintNetworkLogEventMarker(card, sessionId);
+            return;
+        }
+        const half = span / 2;
+        let newStart = tsMs - half;
+        let newEnd = tsMs + half;
+        // Clamp against the data range so we never scroll past the
+        // first/last archived row.
+        const rows = networkWaterfallRowsBySession.get(sessionId) || [];
+        if (rows.length) {
+            const dataStartMs = rows[0].timestamp;
+            const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+            if (newStart < dataStartMs) { newStart = dataStartMs; newEnd = newStart + span; }
+            if (newEnd > dataEndMs)     { newEnd = dataEndMs;     newStart = newEnd - span; }
+        }
+        setNetworkLogTimeRange(sessionId, newStart, newEnd);
+        // setNetworkLogTimeRange runs updateNetworkWaterfall which
+        // will pick up the marker via paintNetworkLogEventMarker
+        // below.
+    });
+    }
+
+    // Paint (or remove) the cyan event-marker guide on the network
+    // log's overview rail and on the row-list's time scale. Called
+    // at the end of updateNetworkWaterfall and also directly from
+    // the replay:event-marker listener for in-window picks.
+    function paintNetworkLogEventMarker(card, sessionId) {
+        const key = String(sessionId);
+        const marker = networkLogEventMarkerBySession.get(key);
+        const overviewEl = card.querySelector('[data-field="netwf_overview"]');
+        const chartHost = card.querySelector('[data-field="network_log_waterfall"]');
+        const RAIL_ID = 'netwf_event_marker_rail';
+        const ROW_ID  = 'netwf_event_marker_row';
+
+        const removeIf = (host, id) => {
+            if (!host) return;
+            const el = host.querySelector(`[data-field="${id}"]`);
+            if (el) el.remove();
+        };
+        if (!marker) {
+            removeIf(overviewEl, RAIL_ID);
+            removeIf(chartHost, ROW_ID);
+            return;
+        }
+
+        // Overview rail line: rail coords = union(data, brush).
+        if (overviewEl) {
+            const rows = networkWaterfallRowsBySession.get(key) || [];
+            const brush = networkWaterfallBrushBySession.get(key);
+            if (rows.length && brush) {
+                const dataStartMs = rows[0].timestamp;
+                const dataEndMs = Math.max(...rows.map((r) => r.timestamp + Math.max(50, r.duration)));
+                const railStartMs = Math.min(dataStartMs, brush.startMs);
+                const railEndMs   = Math.max(dataEndMs,   brush.endMs);
+                const fullSpan = Math.max(50, railEndMs - railStartMs);
+                let line = overviewEl.querySelector(`[data-field="${RAIL_ID}"]`);
+                if (marker.tsMs < railStartMs || marker.tsMs > railEndMs) {
+                    if (line) line.remove();
+                } else {
+                    if (!line) {
+                        line = document.createElement('div');
+                        line.dataset.field = RAIL_ID;
+                        line.style.cssText =
+                            'position:absolute;top:-2px;bottom:-2px;width:2px;' +
+                            `background:${NETLOG_EVENT_MARKER_COLOR};` +
+                            'pointer-events:none;z-index:6;';
+                        overviewEl.appendChild(line);
+                    }
+                    const leftPct = ((marker.tsMs - railStartMs) / fullSpan) * 100;
+                    line.style.left = `calc(${leftPct.toFixed(3)}% - 1px)`;
+                }
+            }
+        }
+
+        // Row-list line: spans the entire chartHost vertically and is
+        // positioned within the time-scale region (right of the resizable
+        // columns). We anchor x to the axis's `netwf-axis-scale` element
+        // because that's the live width of the time area as columns
+        // resize. Time coords = brush window only.
+        if (chartHost) {
+            const brush = networkWaterfallBrushBySession.get(key);
+            const axisScale = chartHost.querySelector('[data-field="netwf_axis_scale"]');
+            if (!brush || !axisScale) {
+                removeIf(chartHost, ROW_ID);
+                return;
+            }
+            const span = brush.endMs - brush.startMs;
+            if (span <= 0 || marker.tsMs < brush.startMs || marker.tsMs > brush.endMs) {
+                removeIf(chartHost, ROW_ID);
+                return;
+            }
+            // chartHost must be position:relative for absolute children
+            // to anchor to it. Set on first paint; harmless to re-set.
+            const cs = window.getComputedStyle(chartHost).position;
+            if (cs === 'static') chartHost.style.position = 'relative';
+            const hostRect = chartHost.getBoundingClientRect();
+            const scaleRect = axisScale.getBoundingClientRect();
+            const scaleLeftPx = scaleRect.left - hostRect.left;
+            const scaleWidthPx = scaleRect.width;
+            const fracInBrush = (marker.tsMs - brush.startMs) / span;
+            const linePx = scaleLeftPx + fracInBrush * scaleWidthPx;
+            let line = chartHost.querySelector(`[data-field="${ROW_ID}"]`);
+            if (!line) {
+                line = document.createElement('div');
+                line.dataset.field = ROW_ID;
+                line.style.cssText =
+                    'position:absolute;top:0;bottom:0;width:0;' +
+                    `border-left:1.5px dashed ${NETLOG_EVENT_MARKER_COLOR};` +
+                    'pointer-events:none;z-index:6;';
+                const label = document.createElement('div');
+                label.dataset.field = ROW_ID + '_label';
+                label.style.cssText =
+                    'position:absolute;top:2px;left:4px;' +
+                    `background:${NETLOG_EVENT_MARKER_COLOR};color:#fff;` +
+                    'font:10px system-ui,-apple-system,sans-serif;' +
+                    'padding:2px 4px;border-radius:2px;white-space:nowrap;';
+                line.appendChild(label);
+                chartHost.appendChild(line);
+            }
+            line.style.left = `${linePx.toFixed(2)}px`;
+            line.style.height = `${chartHost.scrollHeight}px`;
+            const labelEl = line.querySelector(`[data-field="${ROW_ID}_label"]`);
+            if (labelEl) labelEl.textContent = marker.label || '';
+
+            // Auto-scroll the row list vertically so the row whose
+            // timestamp is closest to the event lands roughly at the
+            // centre of the visible scroll area. One-shot per pick —
+            // scrolling on every brush drag would yank the user
+            // around while they're reading nearby rows.
+            if (networkLogPendingScrollBySession.has(key)) {
+                networkLogPendingScrollBySession.delete(key);
+                const scrollHost = card.querySelector('[data-field="network_log_waterfall_scroll"]');
+                if (scrollHost) {
+                    // Disable Following Latest — its bottom-snap would
+                    // immediately overwrite our targeted scroll.
+                    if (isNetworkLogFollowMode(key)) {
+                        setNetworkLogFollowMode(key, false);
+                        updateNetworkLogFollowButton(card, key);
+                    }
+                    // chartHost children: [axis, row, row, ...]. Walk
+                    // them and pick the row whose data-ts is closest
+                    // to (and ≤, when possible) the marker timestamp.
+                    let bestEl = null;
+                    let bestDiff = Infinity;
+                    for (let i = 1; i < chartHost.children.length; i++) {
+                        const child = chartHost.children[i];
+                        const rowData = child.__netwfRow;
+                        const ts = rowData ? Number(rowData.timestamp) : Number(child.dataset.ts);
+                        if (!Number.isFinite(ts)) continue;
+                        const diff = Math.abs(ts - marker.tsMs);
+                        if (diff < bestDiff) {
+                            bestDiff = diff;
+                            bestEl = child;
+                        }
+                    }
+                    if (bestEl) {
+                        const visibleH = scrollHost.clientHeight;
+                        const targetTop = bestEl.offsetTop - (visibleH / 2) + (bestEl.offsetHeight / 2);
+                        scrollHost.scrollTo({
+                            top: Math.max(0, targetTop),
+                            behavior: 'smooth'
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // Release the network-log brush back to its default (follow-latest,
+    // rolling 2 min window). Used when the bitrate chart zoom is reset
+    // so the waterfall doesn't stay pinned to a stale range.
+    function clearNetworkLogTimeRange(sessionId) {
+        const key = String(sessionId || '');
+        if (!key) return;
+        networkWaterfallBrushBySession.delete(key);
+        setNetworkLogFollowMode(key, true);
+        const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+        if (!card) return;
+        const content = card.querySelector('[data-content="network-log"]');
+        if (!content || content.style.display === 'none') return;
+        updateNetworkWaterfall(card, key);
+    }
+
     window.TestingSessionUI = {
         renderSessionCard,
         renderPatternStepRowContent,
@@ -3073,6 +3670,8 @@
         updateNetworkLog,
         applyNetworkLogFilters,
         updateNetworkWaterfall,
-        renderHarWaterfall
+        renderHarWaterfall,
+        setNetworkLogTimeRange,
+        clearNetworkLogTimeRange
     };
 })();

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -637,6 +637,7 @@
         })();
     </script>
     <script src="/shared/shared-nav.js"></script>
+    <script src="/shared/play-id.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vis-timeline@7.7.3/styles/vis-timeline-graph2d.min.css">
@@ -2017,7 +2018,22 @@
             videoEl.setAttribute('height', '2160');
         }
 
+        // play_id (issue #280) — mint a fresh UUID at every loadStream
+        // boundary and stamp it on every outgoing player request via the
+        // engine-specific interceptor. Mirrors PlayerViewModel.swift /
+        // PlayerViewModel.kt. Lets the analytics pipeline partition on
+        // (session_id, play_id) so each fresh playback gets its own row
+        // in the Session Viewer table.
+        let currentPlayId = '';
+        function getCurrentPlayId() { return currentPlayId; }
+
         function loadStream(url) {
+            // Fresh play_id for this playback episode. Subsequent retries
+            // re-enter loadStream and mint a new one.
+            currentPlayId = (window.PlayId && window.PlayId.mint) ? window.PlayId.mint() : '';
+            if (currentPlayId && window.PlayId) {
+                url = window.PlayId.apply(url, currentPlayId);
+            }
             currentUrl = url;
             markPlaybackStart();
             clearLiveOffsetSeekTimer();
@@ -2048,6 +2064,7 @@
                     return;
                 }
                 shakaPlayer = new shaka.Player(video);
+                if (window.PlayId) window.PlayId.installShaka(shakaPlayer, getCurrentPlayId);
                 shakaPlayer.addEventListener('error', (e) => {
                     log(`ERROR: ${e.detail.code} ${e.detail.message}`);
                     const shakaHttp = extractShakaHttpFailure(e.detail);
@@ -2080,10 +2097,12 @@
                     // segments exist); on 2s/6s it just enables a fetch
                     // path that has nothing to fetch.
                     const isLL = (derived.segment || '').toUpperCase() === 'LL';
-                    hlsInstance = new Hls({
+                    const hlsConfig = {
                         enableWorker: true,
                         lowLatencyMode: isLL
-                    });
+                    };
+                    if (window.PlayId) window.PlayId.installHls(hlsConfig, getCurrentPlayId);
+                    hlsInstance = new Hls(hlsConfig);
                     hlsInstance.on(Hls.Events.ERROR, (evt, data) => {
                         log(`HLS ERROR: ${data.type} ${data.details}`);
                         const hlsHttp = extractHlsHttpFailure(data);
@@ -2128,6 +2147,7 @@
                     return;
                 }
                 video.className = 'video-js vjs-default-skin';
+                if (window.PlayId && window.videojs) window.PlayId.installVideoJs(window.videojs, getCurrentPlayId);
                 videojsPlayer = videojs(video, {
                     controls: true,
                     autoplay: true,
@@ -3837,6 +3857,7 @@
             };
             const portDisplay = session.x_forwarded_port_external || session.x_forwarded_port || '—';
             setText('[data-field="session_session_id"]', session.session_id || '—');
+            setText('[data-field="session_play_id"]', session.play_id || '—');
             setText('[data-field="session_player_id"]', session.player_id || '—');
             setText('[data-field="session_user_agent"]', session.user_agent || '—');
             setText('[data-field="session_player_ip"]', session.player_ip || '—');

--- a/content/shared/play-id.js
+++ b/content/shared/play-id.js
@@ -1,0 +1,123 @@
+// Browser-side play_id helper. Mirrors what the Apple (PlayerViewModel.swift)
+// and Android (PlayerViewModel.kt) clients already do for issue #280:
+// every `loadStream()` boundary mints a fresh UUID and stamps it as
+// `?play_id=<uuid>` on every URL the player issues to go-proxy. This lets
+// the analytics pipeline (HAR snapshots, ClickHouse session_snapshots,
+// Grafana dashboard, Session Viewer picker) partition by playback episode
+// rather than by go-proxy session.
+//
+// Each helper takes a `getPlayId` function (not a static value) so callers
+// can roll the play_id without re-installing the interceptor — important
+// for retry / restart paths that should look like a fresh playback.
+(function () {
+    'use strict';
+
+    // Mint a fresh UUID. Uses crypto.randomUUID() where available
+    // (Safari 15.4+, Chrome 92+, Firefox 95+); falls back to a manually
+    // assembled v4-shaped string elsewhere.
+    function mintPlayId() {
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return window.crypto.randomUUID();
+        }
+        const bytes = new Uint8Array(16);
+        if (window.crypto && window.crypto.getRandomValues) {
+            window.crypto.getRandomValues(bytes);
+        } else {
+            for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+        }
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+        return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`;
+    }
+
+    // Add or replace `play_id=<id>` on a URL string. Returns a new string.
+    // Handles relative URLs by anchoring against location.origin.
+    function applyPlayId(url, playId) {
+        if (!url || !playId) return url;
+        try {
+            const u = new URL(url, window.location.origin);
+            u.searchParams.set('play_id', playId);
+            // Re-emit relative if the input was relative.
+            if (!/^https?:\/\//i.test(url)) {
+                return u.pathname + (u.search ? u.search : '') + u.hash;
+            }
+            return u.toString();
+        } catch {
+            // Not a parseable URL — fall back to a string append.
+            const sep = url.includes('?') ? '&' : '?';
+            const stripped = url.replace(/([?&])play_id=[^&]*(&|$)/, (_m, p1, p2) => p2 ? p1 : '');
+            return stripped + sep + 'play_id=' + encodeURIComponent(playId);
+        }
+    }
+
+    // HLS.js: hooks an `xhrSetup` callback into the config so every
+    // request the loader issues (manifests, parts, segments, init
+    // segments, key files) carries the current play_id.
+    function installPlayIdHls(hlsConfig, getPlayId) {
+        const prior = hlsConfig.xhrSetup;
+        hlsConfig.xhrSetup = function (xhr, url) {
+            const playId = typeof getPlayId === 'function' ? getPlayId() : getPlayId;
+            const stamped = applyPlayId(url, playId);
+            // hls.js has already opened the XHR by the time xhrSetup
+            // fires, but it accepts the rewritten URL via xhr's
+            // re-open machinery. Easiest: intercept xhr.open up front.
+            if (stamped !== url) {
+                const originalOpen = xhr.open;
+                xhr.open = function (method, _u, ...rest) {
+                    return originalOpen.call(xhr, method, stamped, ...rest);
+                };
+            }
+            if (typeof prior === 'function') {
+                try { prior.call(this, xhr, url); } catch (e) { console.warn(e); }
+            }
+        };
+        return hlsConfig;
+    }
+
+    // Shaka: registers a request filter on the player's networking
+    // engine so every outgoing request gets play_id appended. Filter
+    // runs for manifests AND segments AND license requests.
+    function installPlayIdShaka(player, getPlayId) {
+        const eng = player && typeof player.getNetworkingEngine === 'function'
+            ? player.getNetworkingEngine() : null;
+        if (!eng) return;
+        eng.registerRequestFilter((_type, request) => {
+            const playId = typeof getPlayId === 'function' ? getPlayId() : getPlayId;
+            if (!playId || !Array.isArray(request.uris)) return;
+            request.uris = request.uris.map(u => applyPlayId(u, playId));
+        });
+    }
+
+    // Video.js (videojs-http-streaming) exposes the underlying VHS via
+    // `xhr-hooks`. We register a beforeRequest hook that rewrites the
+    // outgoing URL on every request.
+    function installPlayIdVideoJs(videojsLib, getPlayId) {
+        if (!videojsLib || !videojsLib.Vhs || typeof videojsLib.Vhs.xhr !== 'function') return;
+        videojsLib.Vhs.xhr.beforeRequest = function (options) {
+            const playId = typeof getPlayId === 'function' ? getPlayId() : getPlayId;
+            if (options && options.uri) options.uri = applyPlayId(options.uri, playId);
+            else if (options && options.url) options.url = applyPlayId(options.url, playId);
+            return options;
+        };
+    }
+
+    // Native HTML5: there's no programmatic way to intercept the
+    // browser's internal segment fetches once it has parsed the
+    // manifest. Best we can do is stamp the master URL at video.src
+    // time; play_id only flows on that single request. The analytics
+    // pipeline still gets it (it's all the proxy needs to associate
+    // the episode), but per-segment requests will be missing it.
+    function applyPlayIdToNativeSrc(url, playId) {
+        return applyPlayId(url, playId);
+    }
+
+    window.PlayId = {
+        mint: mintPlayId,
+        apply: applyPlayId,
+        installHls: installPlayIdHls,
+        installShaka: installPlayIdShaka,
+        installVideoJs: installPlayIdVideoJs,
+        applyNative: applyPlayIdToNativeSrc
+    };
+})();

--- a/content/shared/session-live.js
+++ b/content/shared/session-live.js
@@ -1,0 +1,90 @@
+// Live-SSE entry path for testing.html. Pairs with session-shell.js
+// (must be loaded first); reads applySessionsList from
+// window.SessionShell. The Session Viewer pages do not load this
+// module — the chart engine and replay loader handle their own
+// session-list ingestion. Public API: window.SessionLive.start()
+// returns true if EventSource attached, false to fall back to polling.
+(function () {
+    'use strict';
+    if (!window.SessionShell) {
+        console.error('session-live.js: SessionShell not loaded');
+        return;
+    }
+    const { applySessionsList } = window.SessionShell;
+
+    const sseMissedBadge = document.getElementById('sseMissedBadge');
+    let sessionsStream = null;
+    let sseLastRevision = 0;
+    let sseMissedTotal = 0;
+
+        function updateSseMissedBadge() {
+            if (!sseMissedBadge) return;
+            if (sseMissedTotal > 0) {
+                sseMissedBadge.textContent = `Missed updates: ${sseMissedTotal}`;
+            } else {
+                sseMissedBadge.textContent = '';
+            }
+        }
+
+        function parseSessionsStreamPayload(event) {
+            const data = JSON.parse(event.data);
+            if (Array.isArray(data)) {
+                return { sessions: data, revision: Number(event.lastEventId || 0), dropped: 0, active_sessions: null };
+            }
+            const sessions = Array.isArray(data.sessions) ? data.sessions : [];
+            const revision = Number(data.revision || event.lastEventId || 0);
+            const dropped = Number(data.dropped || 0);
+            const active_sessions = Array.isArray(data.active_sessions) ? data.active_sessions : null;
+            return { sessions, revision, dropped, active_sessions };
+        }
+
+
+        function startSessionsStream() {
+            if (!window.EventSource) return false;
+            const source = new EventSource('/api/sessions/stream');
+            sessionsStream = source;
+            source.addEventListener('sessions', (event) => {
+                try {
+                    const payload = parseSessionsStreamPayload(event);
+                    const sessions = payload.sessions;
+                    const revision = Number(payload.revision || 0);
+                    const dropped = Number(payload.dropped || 0);
+                    let missed = 0;
+                    if (Number.isFinite(revision) && revision > 0 && sseLastRevision > 0) {
+                        const gap = revision - sseLastRevision - 1;
+                        if (gap > 0) {
+                            missed += gap;
+                        }
+                    }
+                    if (Number.isFinite(dropped) && dropped > 0) {
+                        missed += dropped;
+                    }
+                    if (missed > 0) {
+                        sseMissedTotal += missed;
+                        updateSseMissedBadge();
+                        console.warn(`SSE missed ${missed} update${missed === 1 ? '' : 's'}`);
+                    }
+                    if (Number.isFinite(revision) && revision > 0) {
+                        sseLastRevision = revision;
+                    }
+                    applySessionsList(sessions);
+                } catch (err) {
+                    console.error('Error parsing sessions stream payload', err);
+                }
+            });
+            source.addEventListener('error', () => {
+                if (source.readyState === EventSource.CLOSED) {
+                    source.close();
+                    sessionsStream = null;
+                    startSessionsPolling();
+                }
+            });
+            return true;
+        }
+
+    function start() {
+        return startSessionsStream();
+    }
+
+    window.SessionLive = { start };
+})();

--- a/content/shared/session-replay.js
+++ b/content/shared/session-replay.js
@@ -1,0 +1,2550 @@
+// Session Viewer / replay engine. Pairs with session-shell.js (must be
+// loaded first); reads chart-history Maps + applySessionsList /
+// pushBandwidthSample from window.SessionShell. Exposes startMode (full
+// replay loader for ?session=<id>) and startPicker (filterable session
+// list shown when ?replay=1 has no &session=) on window.SessionReplay.
+(function () {
+    'use strict';
+    if (!window.SessionShell) {
+        console.error('session-replay.js: SessionShell not loaded');
+        return;
+    }
+    const {
+        sessionsById,
+        applySessionsList,
+        pushBandwidthSample,
+        bandwidthHistory,
+        bandwidthEventHistory,
+        bandwidthCharts,
+        bufferDepthCharts,
+        videoFpsCharts,
+        eventsCharts,
+        bandwidthVisibility,
+        bitrateAxisMaxBySession,
+        chartViewportBySession,
+        chartPausedBySession,
+        lastRecordedPlayerEventBySession,
+        lastRecordedLoopCountBySession,
+        lastRecordedServerLoopCountBySession,
+        lastRecordedLoopEventStampBySession,
+        lastRecordedServerLoopEventStampBySession,
+        lastRecordedControlsBySession,
+        lastRecordedPlayIdBySession,
+        chartRenderSuppressedBySession,
+        chartWindowMsBySession,
+        playBoundsBySession,
+        brushDraggingBySession
+    } = window.SessionShell;
+
+        // shared-nav.js wraps page content into <div class="ism-app">…<div id="ism-content">.
+        // Banners must mount inside the content area, otherwise they end up as a sibling of
+        // the entire app shell and stretch across the viewport above the sidebar.
+        function mountPoint() {
+            return document.getElementById('ism-content') || document.body;
+        }
+
+        function makeReplayBanner(initialText) {
+            // Clean dashboard panel — no historical-stripe chrome. The
+            // "back to sessions" link and the scrubber row live here.
+            const banner = document.createElement('div');
+            banner.id = 'replay-banner';
+            banner.className = 'panel';
+            banner.style.cssText = 'position:sticky;top:0;z-index:1000;font:13px system-ui;color:var(--text-primary);';
+            const topRow = document.createElement('div');
+            topRow.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap;';
+            const left = document.createElement('div');
+            left.style.cssText = 'display:flex;align-items:center;gap:10px;flex-wrap:wrap;';
+            const text = document.createElement('span');
+            text.id = 'replay-banner-text';
+            text.style.cssText = 'color:var(--text-secondary);';
+            text.textContent = initialText;
+            left.append(text);
+            const right = document.createElement('div');
+            right.style.cssText = 'display:flex;align-items:center;gap:8px;';
+            const exit = document.createElement('a');
+            exit.textContent = '← Back to sessions';
+            exit.href = '/dashboard/sessions.html';
+            exit.className = 'btn btn-secondary';
+            right.appendChild(exit);
+            topRow.append(left, right);
+            const scrubRow = document.createElement('div');
+            scrubRow.id = 'replay-scrub-row';
+            scrubRow.style.cssText = 'display:none;align-items:center;gap:10px;margin-top:10px;font:500 12px system-ui;color:var(--text-secondary);';
+            banner.append(topRow, scrubRow);
+            // Mount inside .ism-content-wide *after* the page-header so it
+            // sits in the document flow with the page title above it.
+            const wide = document.querySelector('.ism-content-wide');
+            if (wide) {
+                const header = wide.querySelector('.page-header');
+                if (header && header.nextSibling) wide.insertBefore(banner, header.nextSibling);
+                else if (header) wide.appendChild(banner);
+                else wide.insertBefore(banner, wide.firstChild);
+            } else {
+                const mp = mountPoint();
+                mp.insertBefore(banner, mp.firstChild);
+            }
+            document.body.classList.add('replay-mode');
+            return { banner, text, scrubRow };
+        }
+
+        // Reset the per-session state Maps that pushBandwidthSample populates,
+        // so we can re-feed a different time window of snapshots without
+        // ghost data from the previous window. We *don't* destroy the
+        // Chart.js / vis-timeline instances here — that triggers ~150-
+        // 400ms of teardown + reconstruction per brush move, which is
+        // why scrubbing felt slow. Instead we wipe the underlying
+        // history Maps; the next pushBandwidthSample run rebuilds them
+        // and the existing chart instances pick up the new data via
+        // chart.update('none') (cheap).
+        function clearReplaySessionState(sessionId) {
+            const key = String(sessionId);
+            bandwidthHistory.delete(key);
+            bandwidthEventHistory.delete(key);
+            bandwidthVisibility.delete(key);
+            bitrateAxisMaxBySession.delete(key);
+            chartViewportBySession.delete(key);
+            chartPausedBySession.delete(key);
+            lastRecordedPlayerEventBySession.delete(key);
+            lastRecordedLoopCountBySession.delete(key);
+            lastRecordedServerLoopCountBySession.delete(key);
+            lastRecordedLoopEventStampBySession.delete(key);
+            lastRecordedServerLoopEventStampBySession.delete(key);
+            lastRecordedControlsBySession.delete(key);
+            lastRecordedPlayIdBySession.delete(key);
+        }
+
+        // Render-without-fetch: feed a windowed slice of the cached
+        // snapshot array through the renderer. Date.now is patched so the
+        // chart accumulators key off recorded ts. Performance: rather than
+        // call applySessionsList → renderSessions per snapshot (which
+        // would redraw Chart.js + vis-timeline every iteration), we update
+        // the history Maps directly via pushBandwidthSample for all but
+        // the last snapshot, then call applySessionsList once at the end
+        // to trigger a single full render. Yields to the main thread
+        // every YIELD_EVERY iterations to keep the page responsive.
+        async function replayWindow(sessionId, snapshots, endMs, windowMs, progressFn) {
+            const startMs = endMs - windowMs;
+            // Tell pushBandwidthSample / renderBandwidthChart to use the
+            // brush window as the chart's rolling cap (instead of the
+            // hard-coded 10 minutes). This lets expanding the focus
+            // window in the session viewer actually grow the bitrate /
+            // buffer / FPS / events chart x-axis. Cleared when the user
+            // exits replay; live mode never sets it.
+            chartWindowMsBySession.set(String(sessionId), windowMs);
+            // Filter then sort — `snapshots` is in receive order (whatever
+            // direction the stream arrived), but pushBandwidthSample needs
+            // chronological feeding. Subset is bounded by window size, so
+            // an O(W log W) sort here is much cheaper than maintaining a
+            // sorted invariant on every line.
+            const subset = snapshots.filter(s => s.tsMs >= startMs && s.tsMs <= endMs);
+            subset.sort((a, b) => a.tsMs - b.tsMs);
+            clearReplaySessionState(sessionId);
+            const realDateNow = Date.now.bind(Date);
+            let mockNow = realDateNow();
+            Date.now = () => mockNow;
+            // Suppress per-snapshot chart re-renders during the bulk
+            // pushBandwidthSample loop — otherwise we'd pay for a full
+            // chart.update() per snapshot (N updates for an N-snapshot
+            // window). The history Maps still get populated; we then do
+            // ONE render at the end via applySessionsList. Refcount-
+            // based so overlapping replayWindow calls (rapid brush
+            // dragging) don't permanently strand the suppression.
+            const sidStr = String(sessionId);
+            chartRenderSuppressedBySession.enter(sidStr);
+            let exited = false;
+            const YIELD_EVERY = 250;
+            try {
+                for (let i = 0; i < subset.length - 1; i++) {
+                    const s = subset[i];
+                    if (Number.isFinite(s.tsMs)) mockNow = s.tsMs;
+                    sessionsById.set(sidStr, s.snap);
+                    try { pushBandwidthSample(s.snap); } catch (_e) {}
+                    if ((i + 1) % YIELD_EVERY === 0) {
+                        if (progressFn) progressFn(i + 1, subset.length);
+                        await new Promise(r => setTimeout(r, 0));
+                    }
+                }
+                // Last snapshot: drop our refcount and do the full render
+                // path. If no other replayWindow is also suppressing,
+                // depth hits 0 and the render fires inside the
+                // applySessionsList → pushBandwidthSamplesForAllSessions
+                // chain. If another is overlapping, that one's exit will
+                // be the one to actually render.
+                if (subset.length > 0) {
+                    const last = subset[subset.length - 1];
+                    if (Number.isFinite(last.tsMs)) mockNow = last.tsMs;
+                    chartRenderSuppressedBySession.exit(sidStr);
+                    exited = true;
+                    // {force:true} bypasses the live-mode version-gate
+                    // — replay deliberately re-applies older snapshots
+                    // when the user scrubs back through history.
+                    try { applySessionsList([last.snap], { force: true }); } catch (err) { console.warn('replay render error', err); }
+                }
+                if (progressFn) progressFn(subset.length, subset.length);
+            } finally {
+                Date.now = realDateNow;
+                if (!exited) chartRenderSuppressedBySession.exit(sidStr);
+            }
+            return subset.length;
+        }
+
+        function fmtIsoLocal(ms) {
+            if (!Number.isFinite(ms)) return '—';
+            const d = new Date(ms);
+            const pad = n => String(n).padStart(2, '0');
+            return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+        }
+
+        function fmtDuration(ms) {
+            if (!Number.isFinite(ms) || ms <= 0) return '0s';
+            const s = Math.round(ms / 1000);
+            const h = Math.floor(s / 3600);
+            const m = Math.floor((s % 3600) / 60);
+            const ss = s % 60;
+            if (h) return `${h}h${String(m).padStart(2,'0')}m`;
+            if (m) return `${m}m${String(ss).padStart(2,'0')}s`;
+            return `${ss}s`;
+        }
+
+        async function startReplayMode(sessionId, fromIso, toIso, playId) {
+            const { banner, text, scrubRow } = makeReplayBanner(`session ${sessionId} — loading snapshots…`);
+
+            const fail = (msg) => {
+                banner.style.background = '#fef2f2';
+                banner.style.borderColor = '#fecaca';
+                text.style.color = '#991b1b';
+                text.textContent = msg;
+            };
+
+            // Pre-flight: fetch count + bounds so we can pick an adaptive
+            // stride. Hour-long sessions with 100k+ snapshots get bucketed
+            // server-side; short sessions stream raw at full fidelity.
+            let expectedTotal = null;
+            let preflightFirstTs = '';
+            let preflightLastTs = '';
+            const countParams = new URLSearchParams({ session: sessionId });
+            if (playId) countParams.set('play_id', playId);
+            if (fromIso) countParams.set('from', fromIso);
+            if (toIso) countParams.set('to', toIso);
+            try {
+                const cr = await fetch(`/analytics/api/snapshot_count?${countParams.toString()}`);
+                if (cr.ok) {
+                    const ct = await cr.text();
+                    const line = (ct || '').split('\n').find(l => l);
+                    if (line) {
+                        const meta = JSON.parse(line);
+                        const n = Number(meta.count);
+                        if (Number.isFinite(n) && n > 0) expectedTotal = n;
+                        preflightFirstTs = meta.first_ts || '';
+                        preflightLastTs  = meta.last_ts  || '';
+                    }
+                }
+            } catch (err) { console.warn('snapshot_count failed:', err); }
+
+            // Adaptive stride: target ~5000 sampled snapshots so the
+            // browser stays responsive on long sessions. Anything below
+            // that streams raw.
+            const TARGET_PTS = 5000;
+            let strideMs = 0;
+            if (expectedTotal && expectedTotal > TARGET_PTS && preflightFirstTs && preflightLastTs) {
+                const startMs = Date.parse(preflightFirstTs.replace(' ', 'T') + 'Z');
+                const endMs   = Date.parse(preflightLastTs.replace(' ', 'T') + 'Z');
+                const span    = endMs - startMs;
+                if (Number.isFinite(span) && span > 0) {
+                    strideMs = Math.max(100, Math.ceil(span / TARGET_PTS));
+                }
+            }
+
+            // Stream snapshots from ClickHouse in reverse-chronological
+            // order so the end-of-session window paints first.
+            const params = new URLSearchParams({
+                session: sessionId,
+                limit: '200000',
+                order: 'desc'
+            });
+            if (playId) params.set('play_id', playId);
+            if (fromIso) params.set('from', fromIso);
+            if (toIso) params.set('to', toIso);
+            if (strideMs > 0) params.set('stride_ms', String(strideMs));
+            let resp;
+            try {
+                resp = await fetch(`/analytics/api/snapshots?${params.toString()}`);
+            } catch (err) {
+                fail(`Replay failed: ${err.message}`); return;
+            }
+            if (!resp.ok) { fail(`Replay failed: HTTP ${resp.status} (analytics forwarder reachable?)`); return; }
+            if (!resp.body || !resp.body.getReader) { fail('Replay failed: streaming reader not supported by this browser'); return; }
+
+            // Snapshots accumulate in receive order (no sort during ingest)
+            // and only get sorted in replayWindow's small filtered subset
+            // before feeding pushBandwidthSample. Bounds are tracked inline
+            // for O(1) per-line cost.
+            const snapshots = [];
+            let observedStartMs = Infinity;
+            let observedEndMs = -Infinity;
+            const BATCH_SIZE = 250;
+
+            // Progress UI: a thin progress bar + text under the main banner
+            // line. Updated as bytes/lines stream in. Total count comes from
+            // a separate /api/snapshot_count fetch fired in parallel.
+            const progressWrap = document.createElement('div');
+            progressWrap.style.cssText = 'display:flex;align-items:center;gap:10px;margin-top:8px;font:500 11px ui-monospace,Menlo,monospace;color:var(--text-secondary);';
+            const progressBarOuter = document.createElement('div');
+            progressBarOuter.style.cssText = 'flex:1;min-width:160px;height:6px;background:var(--bg-secondary,#e5e7eb);border-radius:3px;overflow:hidden;position:relative;';
+            const progressBarFill = document.createElement('div');
+            progressBarFill.style.cssText = 'position:absolute;left:0;top:0;bottom:0;width:0%;background:linear-gradient(90deg,#3b82f6,#1d4ed8);transition:width 120ms linear;';
+            const progressBarShimmer = document.createElement('div');
+            progressBarShimmer.style.cssText = 'position:absolute;left:0;top:0;bottom:0;width:100%;background:repeating-linear-gradient(45deg,transparent 0 8px,rgba(255,255,255,0.3) 8px 16px);animation:replay-shimmer 1s linear infinite;opacity:0.5;';
+            progressBarOuter.append(progressBarFill, progressBarShimmer);
+            const progressText = document.createElement('span');
+            progressText.style.cssText = 'flex-shrink:0;white-space:nowrap;';
+            progressText.textContent = 'streaming…';
+            progressWrap.append(progressBarOuter, progressText);
+            banner.appendChild(progressWrap);
+            // Inject keyframes once for the shimmer animation.
+            if (!document.getElementById('replay-shimmer-keyframes')) {
+                const style = document.createElement('style');
+                style.id = 'replay-shimmer-keyframes';
+                style.textContent = '@keyframes replay-shimmer { from { background-position: 0 0; } to { background-position: 16px 0; } }';
+                document.head.appendChild(style);
+            }
+
+            // expectedTotal already set in the pre-flight above; the
+            // progress UI also accounts for stride downsampling: the
+            // server returns ceil(span/stride) rows, not `count`.
+            const downsampledTotal = strideMs > 0 && preflightFirstTs && preflightLastTs
+                ? Math.max(1, Math.ceil(
+                    (Date.parse(preflightLastTs.replace(' ', 'T') + 'Z') -
+                     Date.parse(preflightFirstTs.replace(' ', 'T') + 'Z')) / strideMs))
+                : 0;
+            if (downsampledTotal > 0) expectedTotal = downsampledTotal;
+
+            const streamStartedAt = performance.now();
+            const updateProgress = () => {
+                const elapsedSec = (performance.now() - streamStartedAt) / 1000;
+                const rate = elapsedSec > 0 ? totalLines / elapsedSec : 0;
+                const kb = (bytesIn / 1024);
+                const kbRate = elapsedSec > 0 ? kb / elapsedSec : 0;
+                if (expectedTotal != null && expectedTotal > 0) {
+                    const pct = Math.min(100, (totalLines / expectedTotal) * 100);
+                    progressBarFill.style.width = pct.toFixed(1) + '%';
+                    progressBarShimmer.style.display = pct >= 100 ? 'none' : 'block';
+                    const remaining = Math.max(0, expectedTotal - totalLines);
+                    const etaSec = rate > 0 ? remaining / rate : null;
+                    const etaStr = etaSec == null
+                        ? '—'
+                        : (etaSec < 1 ? '<1s' : etaSec < 60 ? `${etaSec.toFixed(0)}s` : `${(etaSec/60).toFixed(1)}m`);
+                    progressText.textContent = `${totalLines.toLocaleString()}/${expectedTotal.toLocaleString()} · ${pct.toFixed(0)}% · ${kb.toFixed(0)} KB · ${kbRate.toFixed(0)} KB/s · ${rate.toFixed(0)}/s · ETA ${etaStr}`;
+                } else {
+                    // No total yet — show indeterminate progress.
+                    progressBarFill.style.width = '0%';
+                    progressText.textContent = `${totalLines.toLocaleString()} streamed · ${kb.toFixed(0)} KB · ${kbRate.toFixed(0)} KB/s · ${rate.toFixed(0)}/s`;
+                }
+            };
+            const finishProgress = (label) => {
+                progressBarFill.style.width = '100%';
+                progressBarFill.style.background = '#16a34a';
+                progressBarShimmer.style.display = 'none';
+                const elapsedSec = (performance.now() - streamStartedAt) / 1000;
+                progressText.textContent = `${label} · ${totalLines.toLocaleString()} snapshots in ${elapsedSec.toFixed(1)}s`;
+                // Once the stream is done the progress bar is just visual
+                // weight. Fade it down to a small caption after a moment.
+                setTimeout(() => {
+                    progressBarOuter.style.display = 'none';
+                    progressWrap.style.fontSize = '10px';
+                    progressWrap.style.opacity = '0.55';
+                }, 1500);
+            };
+            const failProgress = (label) => {
+                progressBarFill.style.background = '#dc2626';
+                progressBarShimmer.style.display = 'none';
+                progressText.textContent = label;
+            };
+
+            // First-line gate: we don't know session bounds until at least
+            // one row arrives. Initialise the UI on first batch.
+            let initialized = false;
+            let sessionStartMs = 0, sessionEndMs = 0, sessionDurationMs = 0;
+            const WINDOW_MS = 10 * 60 * 1000;
+            const MIN_WINDOW_MS = 5000;
+            let brushStart = 0, brushEnd = 0;
+            let userMovedBrush = false;
+
+            // Brush UI is built once on first batch (when we know session
+            // bounds). Subsequent batches just refresh the ticks and
+            // bounds without rebuilding the DOM scaffolding.
+            let overviewEl, ticksEl, markersEl, brushEl, windowText;
+            let leftHandle, rightHandle;
+
+            const setHeader = (extra) => {
+                // session_id is just a small integer with no meaning to humans
+                // beyond "the proxy port slot", so drop it. play_id is the
+                // useful one (it identifies the playback episode).
+                const idChip = (label, value) => `<code style="background:rgba(0,0,0,0.06);padding:1px 5px;border-radius:3px;font:600 11px ui-monospace,Menlo,monospace;" title="${label}">${value}</code>`;
+                const parts = [];
+                if (playId) parts.push(`play ${idChip('play_id', playId)}`);
+                parts.push(`duration <strong>${fmtDuration(sessionDurationMs)}</strong>`);
+                parts.push(`${snapshots.length} snapshots`);
+                text.innerHTML = parts.join(' · ') + (extra ? ' · ' + extra : '');
+            };
+
+            const updateBrushVisuals = () => {
+                if (!brushEl) return;
+                const span = Math.max(1, sessionDurationMs);
+                const leftPct = Math.max(0, Math.min(100, ((brushStart - sessionStartMs) / span) * 100));
+                const widthPct = Math.max(0.5, Math.min(100 - leftPct, ((brushEnd - brushStart) / span) * 100));
+                brushEl.style.left = `${leftPct}%`;
+                brushEl.style.width = `${widthPct}%`;
+                // Position the floating windowText so it sits under the
+                // brush midpoint, clamped so it never spills off the rail.
+                if (windowText) {
+                    const midPct = Math.max(8, Math.min(92, leftPct + widthPct / 2));
+                    windowText.style.left = midPct.toFixed(2) + '%';
+                }
+                // Update start/end rail labels — only on first paint or
+                // when bounds change (cheap DOM writes).
+                if (scrubRow && scrubRow._startLabel && scrubRow._endLabel) {
+                    scrubRow._startLabel.textContent = fmtIsoLocal(sessionStartMs);
+                    scrubRow._endLabel.textContent = fmtIsoLocal(sessionEndMs);
+                }
+            };
+            const updateWindowText = (status) => {
+                if (!windowText) return;
+                const winSpan = brushEnd - brushStart;
+                const fromEnd = sessionEndMs - brushEnd;
+                const place = fromEnd < 1500 ? 'at end' : `${fmtDuration(fromEnd)} from end`;
+                // Compact form for the brush-anchored label — full
+                // ISO range is overkill once start/end labels show it.
+                const tail = status ? ` · ${status}` : '';
+                windowText.textContent = `${fmtDuration(winSpan)} · ${place}${tail}`;
+            };
+
+            // Health-heatmap data (filled by fetchHeatmap) and notable
+            // session events (filled by fetchEvents). Both share the
+            // brush overview rail: heatmap paints cell backgrounds,
+            // events paint vertical markers + populate the jump-list.
+            let heatmapBuckets = null;
+            let sessionEvents = null;
+
+            // Lazy-create a singleton tooltip pinned to the body so
+            // it can overflow any container. Used by rail-marker
+            // hover; positioned via fixed coords from mouse events.
+            let railTooltip = null;
+            const ensureRailTooltip = () => {
+                if (railTooltip) return railTooltip;
+                railTooltip = document.createElement('div');
+                railTooltip.style.cssText =
+                    'position:fixed;z-index:9999;pointer-events:none;' +
+                    'background:rgba(17,24,39,0.95);color:#f9fafb;' +
+                    'padding:6px 8px;border-radius:4px;' +
+                    'font:12px system-ui,-apple-system,sans-serif;' +
+                    'box-shadow:0 4px 10px rgba(0,0,0,0.25);' +
+                    'max-width:320px;display:none;line-height:1.35;' +
+                    'border-left:3px solid #0891b2;';
+                document.body.appendChild(railTooltip);
+                return railTooltip;
+            };
+            const showRailTooltip = (ev, mouseX, mouseY) => {
+                const tip = ensureRailTooltip();
+                const typeSty = EVENT_TYPE_STYLE[ev.type] || { label: ev.type, icon: '•' };
+                const prSty   = PRIORITY_STYLE[ev.priority] || PRIORITY_STYLE[4];
+                const offsetMs = Math.max(0, ev.tsMs - sessionStartMs);
+                const kindTag = ev.kind === 'cause'
+                    ? '<span style="opacity:0.7;font-size:10px;">cause</span>'
+                    : '<span style="opacity:0.7;font-size:10px;">effect</span>';
+                tip.innerHTML =
+                    `<div style="font-weight:600;margin-bottom:2px;">` +
+                        `${typeSty.icon} ${typeSty.label}` +
+                    `</div>` +
+                    `<div style="font-size:11px;opacity:0.85;">` +
+                        `T+${fmtDuration(offsetMs)} · ` +
+                        `<span style="color:${prSty.color};font-weight:600;">${prSty.label}</span> · ` +
+                        `${kindTag}` +
+                    `</div>` +
+                    (ev.label && ev.label !== `${typeSty.label} (T+${fmtDuration(offsetMs)})`
+                        ? `<div style="font-size:11px;opacity:0.85;margin-top:3px;">${ev.label}</div>`
+                        : '') +
+                    `<div style="font-size:10px;opacity:0.6;margin-top:4px;">click to jump</div>`;
+                tip.style.display = 'block';
+                // Position above the cursor, flipping below if too close to top.
+                const TIP_PAD = 12;
+                const rect = tip.getBoundingClientRect();
+                let left = mouseX + TIP_PAD;
+                let top  = mouseY - rect.height - TIP_PAD;
+                if (left + rect.width > window.innerWidth) left = mouseX - rect.width - TIP_PAD;
+                if (top < 4) top = mouseY + TIP_PAD;
+                tip.style.left = `${Math.max(4, left)}px`;
+                tip.style.top  = `${top}px`;
+            };
+            const hideRailTooltip = () => {
+                if (railTooltip) railTooltip.style.display = 'none';
+            };
+
+            // Centre the brush on an event's timestamp, fire the marker
+            // dispatch (so charts below draw their guide lines), and
+            // sync the dropdown selection. Single source of truth for
+            // both the dropdown change handler and rail-marker clicks.
+            const selectEvent = (idx) => {
+                if (!Number.isFinite(idx) || !sessionEvents || !sessionEvents[idx]) return;
+                const ev = sessionEvents[idx];
+                const span = brushEnd - brushStart;
+                const half = span / 2;
+                let newStart = ev.tsMs - half;
+                let newEnd = ev.tsMs + half;
+                if (newStart < sessionStartMs) { newStart = sessionStartMs; newEnd = newStart + span; }
+                if (newEnd > sessionEndMs)     { newEnd = sessionEndMs; newStart = newEnd - span; }
+                brushStart = newStart; brushEnd = newEnd;
+                userMovedBrush = true;
+                updateBrushVisuals();
+                triggerRender();
+                const typeSty = EVENT_TYPE_STYLE[ev.type] || { label: ev.type, icon: '•' };
+                document.dispatchEvent(new CustomEvent('replay:event-marker', {
+                    detail: {
+                        sessionId,
+                        tsMs: ev.tsMs,
+                        label: `${typeSty.icon} ${typeSty.label}`,
+                        type: ev.type
+                    }
+                }));
+                // Mirror the pick into the dropdown so it always
+                // reflects the most recently selected event regardless
+                // of whether the user came in via dropdown or rail.
+                if (eventsSelect) {
+                    const opt = Array.from(eventsSelect.options).find(o => Number(o.value) === idx);
+                    if (opt) eventsSelect.value = String(idx);
+                }
+            };
+
+            // Compute a severity score per heatmap bucket so we can pick a
+            // single color cell. Errors and faults dominate; stalls and
+            // downshifts are moderate; drops are bucketed per 100 frames.
+            const bucketSeverity = (b) => {
+                const n = (k) => Number(b[k]) || 0;
+                const score = n('error_rows') * 10
+                            + n('fault_rows') * 3
+                            + n('stalls') * 1
+                            + n('downshifts') * 1
+                            + Math.ceil(n('drops') / 100);
+                return score;
+            };
+            // Green for nominal so a clean session reads as "all clear"
+            // rather than "broken viz". Amber/red still flag trouble.
+            const severityColor = (s) => {
+                if (s === 0)  return '#a7f3d0'; // nominal: light green
+                if (s <= 2)   return '#fde68a'; // minor: light amber
+                if (s <= 9)   return '#f59e0b'; // moderate: amber
+                return '#dc2626';               // severe: red
+            };
+
+            // Re-build the overview rail. With heatmap data: colored cells.
+            // Without it (still loading): fall back to per-snapshot ticks.
+            const SAMPLE_LIMIT = 1500;
+            // Heatmap cell background colors keyed by bucket-max priority.
+            // Light enough to read as background; the foreground markers
+            // sit on top. A bucket with no filtered events is light green
+            // (clean) so a session with no problems reads positively.
+            const HEATMAP_CELL_BG = {
+                1: '#fecaca', // P1 Critical — light red
+                2: '#fde68a', // P2 High — light amber
+                3: '#bfdbfe', // P3 Medium — light blue
+                4: '#e5e7eb', // P4 Low — light gray
+                0: '#dcfce7'  // none — light green (clean)
+            };
+
+            const rebuildTicks = () => {
+                if (!ticksEl) return;
+                ticksEl.replaceChildren();
+                if (markersEl) markersEl.replaceChildren();
+                const span = Math.max(1, sessionDurationMs);
+
+                if (sessionEvents) {
+                    // Bucket events by time and color each cell by the
+                    // max-priority event that fell into it (P1 wins over
+                    // P2, etc.). Filters from the chip toggles apply
+                    // here too — toggling Critical off recolors all
+                    // P1-only buckets to whatever's next-highest, or
+                    // green if no filtered events landed in the bucket.
+                    // 120 cells gives ~1 cell per 30s for a 1-hour
+                    // session — enough resolution for at-a-glance scan.
+                    const NUM_BUCKETS = 120;
+                    const bucketSize  = Math.max(1, span / NUM_BUCKETS);
+                    const bucketMaxPriority = new Array(NUM_BUCKETS).fill(0);
+                    const bucketCount = new Array(NUM_BUCKETS).fill(0);
+                    for (const e of sessionEvents) {
+                        if (!priorityEnabled[e.priority]) continue;
+                        if (!kindEnabled[e.kind]) continue;
+                        if (!isEventTypeEnabled(e.type)) continue;
+                        if (!uncategorizedEnabled && isUncategorizedType(e.type)) continue;
+                        const offset = e.tsMs - sessionStartMs;
+                        if (offset < 0 || offset >= span) continue;
+                        const idx = Math.min(NUM_BUCKETS - 1, Math.floor(offset / bucketSize));
+                        // Lower number = higher priority. 0 means "none yet."
+                        if (bucketMaxPriority[idx] === 0 || e.priority < bucketMaxPriority[idx]) {
+                            bucketMaxPriority[idx] = e.priority;
+                        }
+                        bucketCount[idx]++;
+                    }
+                    const cellWidth = 100 / NUM_BUCKETS;
+                    for (let i = 0; i < NUM_BUCKETS; i++) {
+                        const left = i * cellWidth;
+                        const cell = document.createElement('div');
+                        const p = bucketMaxPriority[i];
+                        cell.style.cssText = `position:absolute;top:0;bottom:0;left:${left.toFixed(4)}%;width:${cellWidth.toFixed(4)}%;background:${HEATMAP_CELL_BG[p]};`;
+                        if (bucketCount[i] > 0) {
+                            cell.title = `${bucketCount[i]} event${bucketCount[i] === 1 ? '' : 's'} (max: ${PRIORITY_STYLE[p].label})`;
+                        }
+                        ticksEl.appendChild(cell);
+                    }
+
+                    // Overlay event markers on top of the cells so the
+                    // user sees both bucket-density and discrete moments.
+                    // Each marker is a transparent ~10 px wide hit-zone
+                    // wrapping a thin coloured visible bar — gives a
+                    // clickable target without making every marker
+                    // visually fat. Hover paints a styled tooltip
+                    // (richer than the native title) and click jumps
+                    // the brush + fires the marker dispatch.
+                    sessionEvents.forEach((e, idx) => {
+                        if (!priorityEnabled[e.priority]) return;
+                        if (!kindEnabled[e.kind]) return;
+                        if (!isEventTypeEnabled(e.type)) return;
+                        if (!uncategorizedEnabled && isUncategorizedType(e.type)) return;
+                        const offset = (e.tsMs - sessionStartMs) / span;
+                        if (offset < 0 || offset > 1) return;
+                        const w = e.priority === 1 ? 3 : (e.priority === 2 ? 2 : 1);
+                        const op = e.kind === 'cause' ? 0.5 : 1;
+                        const HIT_W = 10;
+                        const m = document.createElement('div');
+                        m.style.cssText =
+                            `position:absolute;top:0;bottom:0;` +
+                            `left:calc(${(offset*100).toFixed(4)}% - ${HIT_W/2}px);` +
+                            `width:${HIT_W}px;cursor:pointer;` +
+                            `display:flex;justify-content:center;align-items:stretch;` +
+                            `pointer-events:auto;`;
+                        m.dataset.eventIdx = String(idx);
+                        const bar = document.createElement('div');
+                        bar.style.cssText =
+                            `width:${w}px;background:${e.color};opacity:${op};` +
+                            `pointer-events:none;` +
+                            `transition:width 60ms ease, box-shadow 60ms ease;`;
+                        m.appendChild(bar);
+                        m.addEventListener('mouseenter', (mev) => {
+                            // Highlight the visual bar on hover so the
+                            // user sees which marker the tooltip belongs
+                            // to even when several are clustered nearby.
+                            bar.style.width = `${Math.max(w, 4)}px`;
+                            bar.style.boxShadow = '0 0 0 1px #0891b2';
+                            showRailTooltip(e, mev.clientX, mev.clientY);
+                        });
+                        m.addEventListener('mousemove', (mev) => {
+                            showRailTooltip(e, mev.clientX, mev.clientY);
+                        });
+                        m.addEventListener('mouseleave', () => {
+                            bar.style.width = `${w}px`;
+                            bar.style.boxShadow = '';
+                            hideRailTooltip();
+                        });
+                        m.addEventListener('click', (mev) => {
+                            mev.stopPropagation();
+                            hideRailTooltip();
+                            selectEvent(idx);
+                        });
+                        (markersEl || ticksEl).appendChild(m);
+                    });
+                    return;
+                }
+
+                // Pre-events fallback: per-snapshot tick lines until the
+                // events fetch lands.
+                const stride = Math.max(1, Math.ceil(snapshots.length / SAMPLE_LIMIT));
+                for (let i = 0; i < snapshots.length; i += stride) {
+                    const s = snapshots[i];
+                    const offset = (s.tsMs - sessionStartMs) / span;
+                    const tick = document.createElement('div');
+                    tick.style.cssText = `position:absolute;top:0;bottom:0;left:${(offset*100).toFixed(4)}%;width:1px;`;
+                    const fault = Number(s.snap?.transport_fault_active) === 1
+                        || (s.snap?.manifest_failure_type && s.snap.manifest_failure_type !== 'none')
+                        || (s.snap?.segment_failure_type && s.snap.segment_failure_type !== 'none')
+                        || (s.snap?.all_failure_type && s.snap.all_failure_type !== 'none');
+                    const stalled = String(s.snap?.player_metrics_state || '').toLowerCase() === 'stalled';
+                    tick.style.background = fault ? '#dc2626' : (stalled ? '#f59e0b' : '#9ca3af');
+                    ticksEl.appendChild(tick);
+                }
+            };
+
+            // Fetch the per-bucket health summary once we know session
+            // bounds. 120 buckets gives ~1 cell per 30s for a 1-hour
+            // session, which paints clearly without overflowing the rail.
+            async function fetchHeatmap() {
+                const p = new URLSearchParams({ session: sessionId, buckets: '120' });
+                if (playId) p.set('play_id', playId);
+                try {
+                    const r = await fetch(`/analytics/api/session_heatmap?${p.toString()}`);
+                    if (!r.ok) return;
+                    const t = await r.text();
+                    heatmapBuckets = t.split('\n').filter(l => l).map(l => {
+                        try { return JSON.parse(l); } catch { return null; }
+                    }).filter(Boolean);
+                    rebuildTicks();
+                } catch (err) {
+                    console.warn('session_heatmap failed:', err);
+                }
+            }
+
+            // Per-event-type display: label + icon. Color comes from the
+            // event's priority (set by the forwarder) so we can re-tier
+            // events server-side without rebuilding the client palette.
+            const EVENT_TYPE_STYLE = {
+                error:                   { label: 'Error',          icon: '⚠' },
+                user_marked:             { label: '911 / User flag',icon: '🚨' },
+                master_manifest_failure: { label: 'Master fail',    icon: '◉' },
+                all_failure:             { label: 'All-fault',      icon: '◉' },
+                stall:                   { label: 'Stall',          icon: '⏸' },
+                buffering:               { label: 'Buffering',      icon: '◐' },
+                playback_start:          { label: 'Playback start', icon: '▶' },
+                restart:                 { label: 'Restart',        icon: '↻' },
+                timejump:                { label: 'Time jump',      icon: '⤺' },
+                manifest_failure:        { label: 'Manifest fail',  icon: '✕' },
+                segment_failure:         { label: 'Segment fail',   icon: '✕' },
+                transport_failure:       { label: 'Transport fail', icon: '✕' },
+                transfer_active_timeout: { label: 'Active timeout', icon: '⏱' },
+                transfer_idle_timeout:   { label: 'Idle timeout',   icon: '⏱' },
+                downshift:               { label: 'Downshift',      icon: '⤓' },
+                fault_on:                { label: 'Fault on',       icon: '⚡' },
+                upshift:                 { label: 'Upshift',        icon: '⤒' },
+                fault_off:               { label: 'Fault off',      icon: '✓' },
+                loop_server:             { label: 'Server loop',    icon: '↻' },
+                // HAR-derived events (network_requests). All classified
+                // as 'cause' kind by the forwarder.
+                http_5xx:                { label: 'HTTP 5xx',        icon: '⛔' },
+                http_4xx:                { label: 'HTTP 4xx',        icon: '⚠' },
+                request_timeout:         { label: 'Request timeout', icon: '⏱' },
+                request_incomplete:      { label: 'Incomplete req',  icon: '✂' },
+                request_faulted:         { label: 'Faulted request', icon: '✕' },
+                slow_request:            { label: 'Slow request',    icon: '🐢' },
+                slow_segment:            { label: 'Slow segment',    icon: '🐢' },
+                request_retry:           { label: 'Retry',           icon: '↺' }
+            };
+            const PRIORITY_STYLE = {
+                1: { label: 'Critical', color: '#dc2626', bg: '#fee2e2', border: '#fca5a5' },
+                2: { label: 'High',     color: '#b45309', bg: '#fef3c7', border: '#fcd34d' },
+                3: { label: 'Medium',   color: '#1d4ed8', bg: '#dbeafe', border: '#93c5fd' },
+                4: { label: 'Low',      color: '#4b5563', bg: '#e5e7eb', border: '#9ca3af' }
+            };
+            // Default chip state — P1+P2+P3 visible, P4 hidden. Persisted
+            // across reloads so a power user's preference sticks.
+            const PRIORITY_FILTER_KEY = 'ismReplayPriorityFilter';
+            const priorityEnabled = (() => {
+                try {
+                    const v = JSON.parse(localStorage.getItem(PRIORITY_FILTER_KEY) || 'null');
+                    if (v && typeof v === 'object') return Object.assign({1:true,2:true,3:true,4:false}, v);
+                } catch {}
+                return {1:true, 2:true, 3:true, 4:false};
+            })();
+            const savePriorityFilter = () => {
+                try { localStorage.setItem(PRIORITY_FILTER_KEY, JSON.stringify(priorityEnabled)); } catch {}
+            };
+
+            // Helper: an event type is "categorized" if it has an entry
+            // in EVENT_TYPE_STYLE; otherwise it came from the forwarder's
+            // catch-all UNION ALL — a player-emitted last_event value
+            // we don't have a label / icon / priority opinion for. The
+            // Uncategorized chip toggles all of those as a group.
+            const isUncategorizedType = (type) => !Object.prototype.hasOwnProperty.call(EVENT_TYPE_STYLE, type);
+
+            // Per-event-type filter (default all-true). Toggled via the
+            // right-click popover on each priority chip — fine-grained
+            // override of the priority-level toggle. Persisted across
+            // reloads so a user's "I only care about stalls and errors"
+            // preference sticks.
+            const TYPE_FILTER_KEY = 'ismReplayEventTypeFilter';
+            const eventTypeEnabled = (() => {
+                try {
+                    const v = JSON.parse(localStorage.getItem(TYPE_FILTER_KEY) || 'null');
+                    if (v && typeof v === 'object') return v;
+                } catch {}
+                return {};
+            })();
+            const isEventTypeEnabled = (type) => eventTypeEnabled[type] !== false;
+            const saveTypeFilter = () => {
+                try { localStorage.setItem(TYPE_FILTER_KEY, JSON.stringify(eventTypeEnabled)); } catch {}
+            };
+
+            // Bulk on/off for the Uncategorized class. Persisted via
+            // the same localStorage backing as per-type filter — toggling
+            // the chip flips every uncategorized type's flag in one go.
+            const UNCATEGORIZED_FILTER_KEY = 'ismReplayUncategorizedFilter';
+            let uncategorizedEnabled = (() => {
+                try {
+                    const v = JSON.parse(localStorage.getItem(UNCATEGORIZED_FILTER_KEY) || 'null');
+                    return v !== false;
+                } catch { return true; }
+            })();
+            const saveUncategorizedFilter = () => {
+                try { localStorage.setItem(UNCATEGORIZED_FILTER_KEY, JSON.stringify(uncategorizedEnabled)); } catch {}
+            };
+
+            // Kind filter: effects (what the user saw) vs causes (proxy /
+            // system actions that *might* produce an effect — fault firings,
+            // server-side failure counters). Effects on by default; causes
+            // off so triage isn't drowned in operator-injected noise.
+            const KIND_FILTER_KEY = 'ismReplayKindFilter';
+            const kindEnabled = (() => {
+                try {
+                    const v = JSON.parse(localStorage.getItem(KIND_FILTER_KEY) || 'null');
+                    if (v && typeof v === 'object') return Object.assign({effect:true, cause:false}, v);
+                } catch {}
+                return {effect: true, cause: false};
+            })();
+            const saveKindFilter = () => {
+                try { localStorage.setItem(KIND_FILTER_KEY, JSON.stringify(kindEnabled)); } catch {}
+            };
+
+            // Build the events jump-list dropdown. Each option, when
+            // selected, centers the brush on the event's timestamp.
+            let eventsSelect = null;
+            async function fetchEvents() {
+                // Default LIMIT was 500; for a chatty play (lots of
+                // ABR shifts) the latest events were silently truncated.
+                // Forwarder caps at 5000 so use that here. Replay mode
+                // wants the whole picture; the chip / type filters handle
+                // visual density downstream.
+                const p = new URLSearchParams({ session: sessionId, limit: '5000' });
+                if (playId) p.set('play_id', playId);
+                try {
+                    const r = await fetch(`/analytics/api/session_events?${p.toString()}`);
+                    if (!r.ok) return;
+                    const t = await r.text();
+                    const rows = t.split('\n').filter(l => l).map(l => {
+                        try { return JSON.parse(l); } catch { return null; }
+                    }).filter(Boolean);
+                    sessionEvents = rows.map(e => {
+                        const tsMs = Date.parse((e.ts || '').replace(' ', 'T') + 'Z');
+                        const typeSty  = EVENT_TYPE_STYLE[e.type] || { label: e.type, icon: '•' };
+                        const priority = Number(e.priority) || 4;
+                        const kind     = e.kind === 'cause' ? 'cause' : 'effect';
+                        const prSty = PRIORITY_STYLE[priority] || PRIORITY_STYLE[4];
+                        const labelInfo = e.info ? ` ${e.info}` : '';
+                        const offsetMs = Number.isFinite(tsMs) && Number.isFinite(sessionStartMs)
+                            ? Math.max(0, tsMs - sessionStartMs) : 0;
+                        const offsetStr = fmtDuration(offsetMs);
+                        // Cause events get a hollow dot prefix in the dropdown
+                        // so the user can distinguish "system did this" from
+                        // "user saw this" at a glance. The dropdown's job is
+                        // "jump to the next event of this type" — drop the
+                        // per-instance info (5.2→1.8 Mbps, durations, error
+                        // messages) so all downshifts read as one scannable
+                        // group. The detail text still shows on the rail-
+                        // marker hover tooltip via the `label` field.
+                        const kindMark = kind === 'cause' ? '◇ ' : '';
+                        return {
+                            tsMs,
+                            type: e.type,
+                            priority,
+                            kind,
+                            color: prSty.color,
+                            label: `${typeSty.label}${labelInfo} (T+${offsetStr})`,
+                            optionLabel: `${kindMark}${typeSty.icon} ${typeSty.label} (T+${offsetStr})`
+                        };
+                    }).filter(e => Number.isFinite(e.tsMs));
+                    populateEventsDropdown();
+                    rebuildPriorityChips();
+                    rebuildTicks();
+                } catch (err) {
+                    console.warn('session_events failed:', err);
+                }
+            }
+            function populateEventsDropdown() {
+                if (!eventsSelect || !sessionEvents) return;
+                eventsSelect.replaceChildren();
+
+                // Filter by enabled priorities AND enabled kinds; group by
+                // priority via <optgroup> so the dropdown is scannable.
+                const visible = sessionEvents
+                    .map((e, i) => ({ e, i }))
+                    .filter(({ e }) => priorityEnabled[e.priority] && kindEnabled[e.kind] && isEventTypeEnabled(e.type) && (uncategorizedEnabled || !isUncategorizedType(e.type)));
+                const placeholder = document.createElement('option');
+                placeholder.value = '';
+                placeholder.textContent = sessionEvents.length === 0
+                    ? '✓ Clean playback — no notable events'
+                    : visible.length === 0
+                        ? `${sessionEvents.length} events — all hidden by priority filter`
+                        : `Jump to event (${visible.length} of ${sessionEvents.length})…`;
+                eventsSelect.appendChild(placeholder);
+
+                if (visible.length === 0) {
+                    eventsSelect.disabled = sessionEvents.length === 0;
+                    return;
+                }
+
+                // Group visible events by priority for the optgroup labels.
+                const byPriority = new Map();
+                for (const v of visible) {
+                    if (!byPriority.has(v.e.priority)) byPriority.set(v.e.priority, []);
+                    byPriority.get(v.e.priority).push(v);
+                }
+                const order = [1, 2, 3, 4];
+                for (const p of order) {
+                    const group = byPriority.get(p);
+                    if (!group || group.length === 0) continue;
+                    const og = document.createElement('optgroup');
+                    og.label = `${PRIORITY_STYLE[p].label} (${group.length})`;
+                    for (const { e, i } of group) {
+                        const opt = document.createElement('option');
+                        opt.value = String(i);
+                        opt.textContent = e.optionLabel;
+                        og.appendChild(opt);
+                    }
+                    eventsSelect.appendChild(og);
+                }
+                eventsSelect.disabled = false;
+            }
+
+            // Priority chips above the events dropdown — toggleable filter
+            // with per-priority counts. Click toggles visibility of that
+            // priority class everywhere (dropdown + rail markers).
+            let priorityChipsHost = null;
+            let kindChipsHost = null;
+            function rebuildKindChips() {
+                if (!kindChipsHost) return;
+                const counts = { effect: 0, cause: 0 };
+                for (const e of (sessionEvents || [])) {
+                    if (counts[e.kind] !== undefined) counts[e.kind]++;
+                }
+                const KIND_STYLE = {
+                    effect: { label: 'Effects', color: '#1d4ed8', bg: '#dbeafe', border: '#93c5fd', tip: 'What the player or user saw — stalls, errors, bitrate changes' },
+                    cause:  { label: 'Causes',  color: '#7c2d12', bg: '#fed7aa', border: '#fdba74', tip: 'Proxy / system actions that may or may not have produced a user-visible effect' }
+                };
+                kindChipsHost.replaceChildren();
+                const heading = document.createElement('span');
+                heading.style.cssText = 'font-size:11px;color:var(--text-secondary);font-weight:600;margin-right:4px;';
+                heading.textContent = 'Show:';
+                kindChipsHost.appendChild(heading);
+                for (const k of ['effect', 'cause']) {
+                    const sty = KIND_STYLE[k];
+                    const enabled = !!kindEnabled[k];
+                    const chip = document.createElement('button');
+                    chip.type = 'button';
+                    chip.title = sty.tip;
+                    chip.style.cssText = [
+                        'display:inline-flex','align-items:center','gap:6px',
+                        'padding:3px 10px','border-radius:999px',
+                        'font:600 11px system-ui',
+                        `border:1px solid ${sty.border}`,
+                        `background:${enabled ? sty.bg : 'transparent'}`,
+                        `color:${enabled ? sty.color : 'var(--text-secondary)'}`,
+                        `opacity:${counts[k] === 0 ? '0.45' : '1'}`,
+                        `cursor:${counts[k] === 0 ? 'default' : 'pointer'}`,
+                        'user-select:none'
+                    ].join(';');
+                    const dot = document.createElement('span');
+                    dot.style.cssText = `display:inline-block;width:8px;height:8px;border-radius:50%;background:${sty.color};${enabled ? '' : 'opacity:0.3;'}`;
+                    chip.appendChild(dot);
+                    chip.appendChild(document.createTextNode(` ${counts[k]} ${sty.label}`));
+                    if (counts[k] > 0) {
+                        chip.addEventListener('click', () => {
+                            kindEnabled[k] = !kindEnabled[k];
+                            // Don't let both go off at once — leave one on.
+                            if (!kindEnabled.effect && !kindEnabled.cause) kindEnabled[k === 'effect' ? 'cause' : 'effect'] = true;
+                            saveKindFilter();
+                            rebuildPriorityChips();
+                            populateEventsDropdown();
+                            rebuildTicks();
+                        });
+                    }
+                    kindChipsHost.appendChild(chip);
+                }
+            }
+            function rebuildPriorityChips() {
+                rebuildKindChips();
+                if (!priorityChipsHost) return;
+                // Counts respect the active kind filter — so when "causes"
+                // is off, the chip counts reflect only effects, matching
+                // what's in the dropdown.
+                const counts = {1:0, 2:0, 3:0, 4:0};
+                let uncategorizedCount = 0;
+                for (const e of (sessionEvents || [])) {
+                    if (!kindEnabled[e.kind]) continue;
+                    if (counts[e.priority] !== undefined) counts[e.priority]++;
+                    if (isUncategorizedType(e.type)) uncategorizedCount++;
+                }
+                priorityChipsHost.replaceChildren();
+                for (const p of [1, 2, 3, 4]) {
+                    const sty = PRIORITY_STYLE[p];
+                    const enabled = !!priorityEnabled[p];
+                    const chip = document.createElement('button');
+                    chip.type = 'button';
+                    chip.style.cssText = [
+                        'display:inline-flex', 'align-items:center', 'gap:6px',
+                        'padding:3px 10px', 'border-radius:999px',
+                        'font:600 11px system-ui',
+                        `border:1px solid ${sty.border}`,
+                        `background:${enabled ? sty.bg : 'transparent'}`,
+                        `color:${enabled ? sty.color : 'var(--text-secondary)'}`,
+                        `opacity:${counts[p] === 0 ? '0.45' : '1'}`,
+                        `cursor:${counts[p] === 0 ? 'default' : 'pointer'}`,
+                        'user-select:none'
+                    ].join(';');
+                    chip.title = `${sty.label} (priority ${p}) — click to ${enabled ? 'hide' : 'show'}`;
+                    const dot = document.createElement('span');
+                    dot.style.cssText = `display:inline-block;width:8px;height:8px;border-radius:50%;background:${sty.color};${enabled ? '' : 'opacity:0.3;'}`;
+                    chip.appendChild(dot);
+                    chip.appendChild(document.createTextNode(` ${counts[p]} ${sty.label}`));
+                    if (counts[p] > 0) {
+                        chip.addEventListener('click', () => {
+                            priorityEnabled[p] = !priorityEnabled[p];
+                            savePriorityFilter();
+                            rebuildPriorityChips();
+                            populateEventsDropdown();
+                            rebuildTicks();
+                        });
+                        // Right-click → per-event-type popover so the
+                        // user can disable individual types (e.g. hide
+                        // upshifts but keep downshifts) without losing
+                        // the whole priority class.
+                        chip.addEventListener('contextmenu', (e) => {
+                            e.preventDefault();
+                            openTypeFilterPopover(chip, p);
+                        });
+                        chip.title += ' · right-click to toggle individual event types';
+                    }
+                    priorityChipsHost.appendChild(chip);
+                }
+
+                // Uncategorized chip — events whose `type` isn't in our
+                // EVENT_TYPE_STYLE table. Comes from the forwarder's
+                // catch-all UNION ALL on last_event values we haven't
+                // explicitly mapped. Toggle hides them everywhere.
+                const uncStyle = { color:'#6b7280', bg:'#f3f4f6', border:'#d1d5db' };
+                const uncEnabled = !!uncategorizedEnabled;
+                const uncChip = document.createElement('button');
+                uncChip.type = 'button';
+                uncChip.style.cssText = [
+                    'display:inline-flex','align-items:center','gap:6px',
+                    'padding:3px 10px','border-radius:999px',
+                    'font:600 11px system-ui',
+                    `border:1px dashed ${uncStyle.border}`,
+                    `background:${uncEnabled ? uncStyle.bg : 'transparent'}`,
+                    `color:${uncEnabled ? uncStyle.color : 'var(--text-secondary)'}`,
+                    `opacity:${uncategorizedCount === 0 ? '0.45' : '1'}`,
+                    `cursor:${uncategorizedCount === 0 ? 'default' : 'pointer'}`,
+                    'user-select:none'
+                ].join(';');
+                uncChip.title = `Uncategorized event types (player_emitted last_event values not in our taxonomy) — click to ${uncEnabled ? 'hide' : 'show'}`;
+                const uncDot = document.createElement('span');
+                uncDot.style.cssText = `display:inline-block;width:8px;height:8px;border-radius:50%;background:${uncStyle.color};${uncEnabled ? '' : 'opacity:0.3;'}`;
+                uncChip.appendChild(uncDot);
+                uncChip.appendChild(document.createTextNode(` ${uncategorizedCount} Uncategorized`));
+                if (uncategorizedCount > 0) {
+                    uncChip.addEventListener('click', () => {
+                        uncategorizedEnabled = !uncategorizedEnabled;
+                        saveUncategorizedFilter();
+                        rebuildPriorityChips();
+                        populateEventsDropdown();
+                        rebuildTicks();
+                    });
+                    uncChip.addEventListener('contextmenu', (e) => {
+                        // Right-click: open a popover listing the actual
+                        // unrecognised type names so the user can toggle
+                        // each one individually (e.g. ignore one new
+                        // event type but keep watching the others).
+                        e.preventDefault();
+                        openUncategorizedPopover(uncChip);
+                    });
+                }
+                priorityChipsHost.appendChild(uncChip);
+            }
+
+            // Right-click popover for the Uncategorized chip — same shape
+            // as the priority chip popover but lists every unrecognised
+            // type observed in this session.
+            function openUncategorizedPopover(anchor) {
+                closeTypeFilterPopover();
+                const counts = new Map();
+                for (const e of (sessionEvents || [])) {
+                    if (!isUncategorizedType(e.type)) continue;
+                    counts.set(e.type, (counts.get(e.type) || 0) + 1);
+                }
+                if (counts.size === 0) return;
+
+                const pop = document.createElement('div');
+                pop.style.cssText = [
+                    'position:absolute','z-index:5000',
+                    'background:var(--bg-primary,#fff)',
+                    'border:1px dashed #d1d5db','border-radius:6px',
+                    'box-shadow:0 10px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.08)',
+                    'padding:6px 0','min-width:240px',
+                    'max-height:60vh','overflow:auto',
+                    'font:13px system-ui','color:var(--text-primary)'
+                ].join(';');
+
+                const header = document.createElement('div');
+                header.style.cssText = `padding:6px 12px;font:600 11px system-ui;letter-spacing:0.04em;color:#6b7280;border-bottom:1px solid var(--border-color,#e5e7eb);text-transform:uppercase;`;
+                header.textContent = `Uncategorized · ${counts.size} type${counts.size === 1 ? '' : 's'}`;
+                pop.appendChild(header);
+
+                const setAll = (val) => {
+                    for (const [t] of counts) eventTypeEnabled[t] = val;
+                    saveTypeFilter();
+                    rebuildPriorityChips();
+                    populateEventsDropdown();
+                    rebuildTicks();
+                    refreshRows();
+                };
+                const allRow = document.createElement('div');
+                allRow.style.cssText = 'display:flex;gap:6px;padding:6px 12px;border-bottom:1px solid var(--border-color,#f3f4f6);';
+                for (const [label, val] of [['All on', true], ['All off', false]]) {
+                    const b = document.createElement('button');
+                    b.type = 'button'; b.textContent = label; b.className = 'btn btn-secondary';
+                    b.style.cssText = 'padding:2px 8px;font:600 11px system-ui;';
+                    b.addEventListener('click', () => setAll(val));
+                    allRow.appendChild(b);
+                }
+                pop.appendChild(allRow);
+
+                const rowsHost = document.createElement('div');
+                pop.appendChild(rowsHost);
+                const refreshRows = () => {
+                    rowsHost.replaceChildren();
+                    const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+                    for (const [type, n] of sorted) {
+                        const enabled = isEventTypeEnabled(type);
+                        const row = document.createElement('label');
+                        row.style.cssText = `display:flex;align-items:center;gap:8px;padding:5px 12px;cursor:pointer;${enabled ? '' : 'opacity:0.55;'}`;
+                        row.addEventListener('mouseenter', () => row.style.background = 'var(--bg-hover,#f9fafb)');
+                        row.addEventListener('mouseleave', () => row.style.background = '');
+                        const cb = document.createElement('input');
+                        cb.type = 'checkbox'; cb.checked = enabled;
+                        cb.addEventListener('change', () => {
+                            eventTypeEnabled[type] = cb.checked;
+                            saveTypeFilter();
+                            rebuildPriorityChips();
+                            populateEventsDropdown();
+                            rebuildTicks();
+                            refreshRows();
+                        });
+                        const icon = document.createElement('span');
+                        icon.textContent = '•';
+                        icon.style.cssText = 'min-width:16px;text-align:center;color:#6b7280;';
+                        const label = document.createElement('span');
+                        label.textContent = type;
+                        label.style.cssText = 'flex:1;font:500 12px ui-monospace,Menlo,monospace;';
+                        const count = document.createElement('span');
+                        count.textContent = String(n);
+                        count.style.cssText = 'color:var(--text-secondary);font:600 11px ui-monospace,Menlo,monospace;min-width:32px;text-align:right;';
+                        row.append(cb, icon, label, count);
+                        rowsHost.appendChild(row);
+                    }
+                };
+                refreshRows();
+
+                document.body.appendChild(pop);
+                const r = anchor.getBoundingClientRect();
+                const pr = pop.getBoundingClientRect();
+                let top = window.scrollY + r.bottom + 6;
+                let left = window.scrollX + r.left;
+                if (top + pr.height > window.scrollY + window.innerHeight - 8) {
+                    top = window.scrollY + r.top - pr.height - 6;
+                }
+                if (left + pr.width > window.scrollX + window.innerWidth - 8) {
+                    left = window.scrollX + window.innerWidth - pr.width - 8;
+                }
+                pop.style.top = top + 'px';
+                pop.style.left = Math.max(8, left) + 'px';
+                openPopover = pop;
+                setTimeout(() => {
+                    document.addEventListener('click', closeOnOutsideClick, true);
+                    document.addEventListener('keydown', closeOnEsc, true);
+                }, 0);
+            }
+
+            // The popover is a small floating menu anchored to the chip.
+            // It lists every event TYPE observed at this priority in
+            // the current session, with a checkbox per type. Toggling
+            // any updates eventTypeEnabled and re-renders the dropdown
+            // / rail / chip counts.
+            let openPopover = null;
+            function closeTypeFilterPopover() {
+                if (openPopover && openPopover.parentNode) {
+                    openPopover.parentNode.removeChild(openPopover);
+                }
+                openPopover = null;
+                document.removeEventListener('click', closeOnOutsideClick, true);
+                document.removeEventListener('keydown', closeOnEsc, true);
+            }
+            function closeOnOutsideClick(ev) {
+                if (openPopover && !openPopover.contains(ev.target)) closeTypeFilterPopover();
+            }
+            function closeOnEsc(ev) {
+                if (ev.key === 'Escape') closeTypeFilterPopover();
+            }
+            function openTypeFilterPopover(anchor, priority) {
+                closeTypeFilterPopover();
+                // Distinct event types observed at this priority,
+                // grouped with their counts so the user sees what
+                // they're toggling.
+                const counts = new Map();
+                for (const e of (sessionEvents || [])) {
+                    if (e.priority !== priority) continue;
+                    counts.set(e.type, (counts.get(e.type) || 0) + 1);
+                }
+                if (counts.size === 0) return;
+
+                const sty = PRIORITY_STYLE[priority];
+                const pop = document.createElement('div');
+                pop.style.cssText = [
+                    'position:absolute', 'z-index:5000',
+                    'background:var(--bg-primary,#fff)',
+                    `border:1px solid ${sty.border}`,
+                    'border-radius:6px',
+                    'box-shadow:0 10px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.08)',
+                    'padding:6px 0',
+                    'min-width:220px',
+                    'max-height:60vh', 'overflow:auto',
+                    'font:13px system-ui',
+                    'color:var(--text-primary)'
+                ].join(';');
+
+                const header = document.createElement('div');
+                header.style.cssText = `padding:6px 12px 6px 12px;font:600 11px system-ui;letter-spacing:0.04em;color:${sty.color};border-bottom:1px solid var(--border-color,#e5e7eb);text-transform:uppercase;`;
+                header.textContent = `${sty.label} · types`;
+                pop.appendChild(header);
+
+                // "All" / "None" quick-set row.
+                const setAll = (val) => {
+                    for (const [t] of counts) eventTypeEnabled[t] = val;
+                    saveTypeFilter();
+                    rebuildPriorityChips();
+                    populateEventsDropdown();
+                    rebuildTicks();
+                    refreshRows();
+                };
+                const allRow = document.createElement('div');
+                allRow.style.cssText = 'display:flex;gap:6px;padding:6px 12px;border-bottom:1px solid var(--border-color,#f3f4f6);';
+                for (const [label, val] of [['All on', true], ['All off', false]]) {
+                    const b = document.createElement('button');
+                    b.type = 'button';
+                    b.textContent = label;
+                    b.className = 'btn btn-secondary';
+                    b.style.cssText = 'padding:2px 8px;font:600 11px system-ui;';
+                    b.addEventListener('click', () => setAll(val));
+                    allRow.appendChild(b);
+                }
+                pop.appendChild(allRow);
+
+                const refreshRows = () => {
+                    // Re-render the row container in place rather than
+                    // closing/reopening the popover.
+                    rowsHost.replaceChildren();
+                    const sorted = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+                    for (const [type, n] of sorted) {
+                        const enabled = isEventTypeEnabled(type);
+                        const typeSty = EVENT_TYPE_STYLE[type] || { label: type, icon: '•' };
+                        const row = document.createElement('label');
+                        row.style.cssText = `display:flex;align-items:center;gap:8px;padding:5px 12px;cursor:pointer;${enabled ? '' : 'opacity:0.55;'}`;
+                        row.addEventListener('mouseenter', () => row.style.background = 'var(--bg-hover,#f9fafb)');
+                        row.addEventListener('mouseleave', () => row.style.background = '');
+                        const cb = document.createElement('input');
+                        cb.type = 'checkbox';
+                        cb.checked = enabled;
+                        cb.style.cssText = 'cursor:pointer;';
+                        cb.addEventListener('change', () => {
+                            eventTypeEnabled[type] = cb.checked;
+                            saveTypeFilter();
+                            rebuildPriorityChips();
+                            populateEventsDropdown();
+                            rebuildTicks();
+                            refreshRows();
+                        });
+                        const icon = document.createElement('span');
+                        icon.textContent = typeSty.icon;
+                        icon.style.cssText = 'min-width:16px;text-align:center;color:' + sty.color + ';';
+                        const label = document.createElement('span');
+                        label.textContent = typeSty.label;
+                        label.style.cssText = 'flex:1;';
+                        const count = document.createElement('span');
+                        count.textContent = String(n);
+                        count.style.cssText = 'color:var(--text-secondary);font:600 11px ui-monospace,Menlo,monospace;min-width:32px;text-align:right;';
+                        row.append(cb, icon, label, count);
+                        rowsHost.appendChild(row);
+                    }
+                };
+                const rowsHost = document.createElement('div');
+                pop.appendChild(rowsHost);
+                refreshRows();
+
+                // Position next to the chip (below by default; if it
+                // would clip the viewport bottom, flip above).
+                document.body.appendChild(pop);
+                const r = anchor.getBoundingClientRect();
+                const pr = pop.getBoundingClientRect();
+                let top = window.scrollY + r.bottom + 6;
+                let left = window.scrollX + r.left;
+                if (top + pr.height > window.scrollY + window.innerHeight - 8) {
+                    top = window.scrollY + r.top - pr.height - 6;
+                }
+                if (left + pr.width > window.scrollX + window.innerWidth - 8) {
+                    left = window.scrollX + window.innerWidth - pr.width - 8;
+                }
+                pop.style.top = top + 'px';
+                pop.style.left = Math.max(8, left) + 'px';
+                openPopover = pop;
+                // Defer outside-click registration to next tick so this
+                // contextmenu's bubbling doesn't immediately close it.
+                setTimeout(() => {
+                    document.addEventListener('click', closeOnOutsideClick, true);
+                    document.addEventListener('keydown', closeOnEsc, true);
+                }, 0);
+            }
+
+            // Push the current brush window down to the network log so its
+            // waterfall fold filters to the same time range. The waterfall
+            // re-renders only if its fold is open; otherwise the brush
+            // state is stashed and the next open picks it up.
+            const syncNetworkLogToBrush = () => {
+                const TUI = window.TestingSessionUI;
+                if (!TUI || typeof TUI.setNetworkLogTimeRange !== 'function') return;
+                if (!Number.isFinite(brushStart) || !Number.isFinite(brushEnd)) return;
+                if (brushEnd <= brushStart) return;
+                TUI.setNetworkLogTimeRange(sessionId, brushStart, brushEnd);
+            };
+
+            let renderToken = 0;
+            const triggerRender = async () => {
+                const myToken = ++renderToken;
+                const winMs = brushEnd - brushStart;
+                updateWindowText('rendering…');
+                syncNetworkLogToBrush();
+                const done = await replayWindow(sessionId, snapshots, brushEnd, winMs, (i, n) => {
+                    if (myToken !== renderToken) return;
+                    updateWindowText(`${i}/${n}`);
+                });
+                if (myToken !== renderToken) return;
+                updateWindowText(`${done} rendered`);
+            };
+            let renderDebounce;
+            const scheduleRender = () => {
+                clearTimeout(renderDebounce);
+                renderDebounce = setTimeout(triggerRender, 180);
+            };
+
+            const buildBrushUI = () => {
+                scrubRow.innerHTML = '';
+                scrubRow.style.cssText = 'display:flex;flex-direction:column;gap:8px;margin-top:10px;font:500 12px system-ui;color:var(--text-secondary);';
+
+                const topControls = document.createElement('div');
+                topControls.style.cssText = 'display:flex;align-items:center;gap:10px;';
+
+                const jumpStart = document.createElement('button');
+                jumpStart.type = 'button';
+                jumpStart.textContent = '⏮';
+                jumpStart.title = 'Jump to start of session';
+                const btnCss = 'background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-color, #d1d5db);padding:4px 10px;border-radius:4px;font:600 12px system-ui;cursor:pointer;flex-shrink:0;';
+                jumpStart.style.cssText = btnCss;
+                const jumpEnd = document.createElement('button');
+                jumpEnd.type = 'button';
+                jumpEnd.textContent = '⏭';
+                jumpEnd.title = 'Jump to end of session';
+                jumpEnd.style.cssText = btnCss;
+
+                const overviewWrap = document.createElement('div');
+                overviewWrap.style.cssText = 'flex:1;min-width:300px;position:relative;';
+                overviewEl = document.createElement('div');
+                overviewEl.className = 'netwf-overview';
+                overviewEl.style.cssText = 'background:var(--bg-secondary,#f3f4f6);height:44px;border:1px solid var(--border-color,#e5e7eb);border-radius:6px;position:relative;cursor:crosshair;user-select:none;overflow:hidden;';
+                ticksEl = document.createElement('div');
+                ticksEl.className = 'netwf-overview-bars';
+                ticksEl.style.cssText = 'position:absolute;inset:3px 0;pointer-events:none;';
+                // Markers live on a separate layer that paints on top
+                // of the brush so hover/click on event markers always
+                // wins over the brush's drag handler. Layer itself is
+                // pointer-events:none; only individual marker elements
+                // opt back in via pointer-events:auto, leaving the
+                // brush draggable everywhere except the ~10 px hit
+                // zones around each marker.
+                markersEl = document.createElement('div');
+                markersEl.className = 'netwf-overview-markers';
+                markersEl.style.cssText = 'position:absolute;inset:3px 0;pointer-events:none;z-index:5;';
+                // Brush is the visible selection box — beefed up so it
+                // unambiguously tells the user "this is the time window
+                // you're looking at." Outer ring (box-shadow) + thicker
+                // borders + slightly higher fill alpha + a thin glow
+                // halo ensure it pops over heatmap colors.
+                brushEl = document.createElement('div');
+                brushEl.className = 'netwf-brush';
+                brushEl.style.cssText = [
+                    'position:absolute',
+                    'top:-2px',
+                    'bottom:-2px',
+                    'background:rgba(37,99,235,0.20)',
+                    'border:2px solid #1d4ed8',
+                    'border-radius:4px',
+                    'box-shadow:0 0 0 1px rgba(255,255,255,0.6), 0 4px 12px rgba(29,78,216,0.35)',
+                    'cursor:grab',
+                    'box-sizing:border-box',
+                    'z-index:2',
+                ].join(';');
+                leftHandle = document.createElement('div');
+                leftHandle.className = 'netwf-brush-handle left';
+                leftHandle.style.cssText = 'position:absolute;top:0;bottom:0;left:-5px;width:10px;background:#1d4ed8;border-radius:2px;cursor:ew-resize;box-shadow:0 0 0 1px rgba(255,255,255,0.7);';
+                rightHandle = document.createElement('div');
+                rightHandle.className = 'netwf-brush-handle right';
+                rightHandle.style.cssText = 'position:absolute;top:0;bottom:0;right:-5px;width:10px;background:#1d4ed8;border-radius:2px;cursor:ew-resize;box-shadow:0 0 0 1px rgba(255,255,255,0.7);';
+                brushEl.append(leftHandle, rightHandle);
+                overviewEl.append(ticksEl, brushEl, markersEl);
+                overviewWrap.append(overviewEl);
+
+                // Tick labels under the rail anchor the user in absolute
+                // time. Three labels: session start, brush midpoint
+                // (windowText), session end. The midpoint is positioned
+                // by left% so it tracks the brush and the rail width
+                // never reflows due to text length changes.
+                const railLabels = document.createElement('div');
+                railLabels.style.cssText = 'position:relative;height:18px;margin-top:4px;font:500 11px ui-monospace,Menlo,monospace;color:var(--text-secondary);user-select:none;';
+                const startLabel = document.createElement('span');
+                startLabel.style.cssText = 'position:absolute;left:0;top:0;white-space:nowrap;';
+                const endLabel = document.createElement('span');
+                endLabel.style.cssText = 'position:absolute;right:0;top:0;white-space:nowrap;';
+                windowText = document.createElement('span');
+                windowText.style.cssText = 'position:absolute;top:0;transform:translateX(-50%);white-space:nowrap;color:var(--text-primary);font-weight:600;background:var(--bg-primary);padding:0 6px;border-radius:3px;';
+                railLabels.append(startLabel, windowText, endLabel);
+                overviewWrap.appendChild(railLabels);
+
+                topControls.append(jumpStart, overviewWrap, jumpEnd);
+                scrubRow.appendChild(topControls);
+
+                // Stash the rail label refs so updateWindowText can position
+                // the brush-anchored label without re-finding them.
+                scrubRow._startLabel = startLabel;
+                scrubRow._endLabel   = endLabel;
+
+                // Kind toggle (Effects / Causes) — what the user saw vs
+                // what the proxy/system did. Effects on by default; causes
+                // off so triage isn't drowned in operator-injected noise.
+                kindChipsHost = document.createElement('div');
+                kindChipsHost.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;';
+                scrubRow.appendChild(kindChipsHost);
+
+                // Priority chip row sits above the dropdown. Toggling a
+                // chip filters both the dropdown and the rail markers.
+                priorityChipsHost = document.createElement('div');
+                priorityChipsHost.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;';
+                scrubRow.appendChild(priorityChipsHost);
+                rebuildPriorityChips();
+
+                // Event jump-list: dropdown of notable events (stalls,
+                // errors, fault toggles, ABR downshifts). Selecting one
+                // centers the brush window on that event ±half-window.
+                const eventsRow = document.createElement('div');
+                eventsRow.style.cssText = 'display:flex;align-items:center;gap:10px;';
+                const eventsLbl = document.createElement('span');
+                eventsLbl.textContent = 'Events:';
+                eventsLbl.style.cssText = 'font-size:12px;color:var(--text-secondary);';
+                eventsSelect = document.createElement('select');
+                eventsSelect.style.cssText = 'padding:4px 8px;font:13px system-ui;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-color,#d1d5db);border-radius:4px;flex:1;min-width:200px;';
+                const placeholder = document.createElement('option');
+                placeholder.value = ''; placeholder.textContent = 'Loading events…';
+                eventsSelect.appendChild(placeholder);
+                eventsSelect.addEventListener('change', () => {
+                    const idx = Number(eventsSelect.value);
+                    if (!Number.isFinite(idx)) return;
+                    selectEvent(idx);
+                });
+                eventsRow.append(eventsLbl, eventsSelect);
+                scrubRow.appendChild(eventsRow);
+                if (sessionEvents) populateEventsDropdown();
+
+                let drag = null;
+                const pxPerMs = () => overviewEl.clientWidth / Math.max(1, sessionDurationMs);
+                const startDrag = (e, mode) => {
+                    drag = { mode, startX: e.clientX, startStart: brushStart, startEnd: brushEnd };
+                    brushEl.classList.add('dragging');
+                    // Tell ambient timers to back off mid-drag — the
+                    // network-log auto-refresh otherwise flickers the
+                    // waterfall every 1.5s while the user is actively
+                    // moving the brush.
+                    brushDraggingBySession.add(String(sessionId));
+                    e.preventDefault(); e.stopPropagation();
+                };
+                const onMove = (e) => {
+                    if (!drag) return;
+                    const dx = e.clientX - drag.startX;
+                    const dms = dx / pxPerMs();
+                    const span = drag.startEnd - drag.startStart;
+                    if (drag.mode === 'pan') {
+                        let newStart = drag.startStart + dms;
+                        let newEnd = newStart + span;
+                        if (newStart < sessionStartMs) { newStart = sessionStartMs; newEnd = newStart + span; }
+                        if (newEnd > sessionEndMs)     { newEnd = sessionEndMs; newStart = newEnd - span; }
+                        brushStart = newStart; brushEnd = newEnd;
+                    } else if (drag.mode === 'resize-left') {
+                        let newStart = drag.startStart + dms;
+                        if (newStart < sessionStartMs) newStart = sessionStartMs;
+                        if (newStart > drag.startEnd - MIN_WINDOW_MS) newStart = drag.startEnd - MIN_WINDOW_MS;
+                        brushStart = newStart;
+                    } else if (drag.mode === 'resize-right') {
+                        let newEnd = drag.startEnd + dms;
+                        if (newEnd > sessionEndMs) newEnd = sessionEndMs;
+                        if (newEnd < drag.startStart + MIN_WINDOW_MS) newEnd = drag.startStart + MIN_WINDOW_MS;
+                        brushEnd = newEnd;
+                    }
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    updateWindowText('…');
+                    // Don't render mid-drag — just update the visible
+                    // brush position. Charts re-render on mouseup so
+                    // the user gets one snappy update at release time
+                    // instead of debounced flicker through the gesture.
+                };
+                const onUp = () => {
+                    if (!drag) return;
+                    drag = null;
+                    brushEl.classList.remove('dragging');
+                    brushDraggingBySession.delete(String(sessionId));
+                    // Single render at release time. No `schedule` —
+                    // we want the chart to update immediately, not in
+                    // 180ms.
+                    triggerRender();
+                };
+
+                brushEl.addEventListener('mousedown', (e) => {
+                    if (e.target.classList.contains('netwf-brush-handle')) return;
+                    startDrag(e, 'pan');
+                });
+                leftHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-left'));
+                rightHandle.addEventListener('mousedown', (e) => startDrag(e, 'resize-right'));
+                overviewEl.addEventListener('mousedown', (e) => {
+                    if (e.target !== overviewEl && e.target !== ticksEl) return;
+                    const rect = overviewEl.getBoundingClientRect();
+                    if (rect.width <= 0) return;
+                    const fracX = (e.clientX - rect.left) / rect.width;
+                    const targetMs = sessionStartMs + fracX * sessionDurationMs;
+                    const span = brushEnd - brushStart;
+                    let newStart = targetMs - span / 2;
+                    let newEnd = newStart + span;
+                    if (newStart < sessionStartMs) { newStart = sessionStartMs; newEnd = newStart + span; }
+                    if (newEnd > sessionEndMs)     { newEnd = sessionEndMs; newStart = newEnd - span; }
+                    brushStart = newStart; brushEnd = newEnd;
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    updateWindowText('…');
+                    scheduleRender();
+                });
+                document.addEventListener('mousemove', onMove);
+                document.addEventListener('mouseup', onUp);
+
+                // Reverse-sync: when the network-log fold's own brush
+                // moves (drag, resize, click-to-recenter), reflect the
+                // change back onto the main session-viewer brush so
+                // both rails always stay in lockstep. live:true =
+                // mid-drag (visual update only); live:false = release
+                // (full chart re-render). The main → network log
+                // direction is already handled in syncNetworkLogToBrush.
+                document.addEventListener('replay:brush-range-change', (ev) => {
+                    if (!ev || !ev.detail) return;
+                    if (String(ev.detail.sessionId) !== String(sessionId)) return;
+                    if (ev.detail.source !== 'network-log') return;
+                    const startMs = Number(ev.detail.startMs);
+                    const endMs   = Number(ev.detail.endMs);
+                    if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return;
+                    brushStart = startMs;
+                    brushEnd   = endMs;
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    updateWindowText(ev.detail.live ? '…' : 'rendering…');
+                    if (!ev.detail.live) {
+                        triggerRender();
+                    }
+                });
+
+                // Alt/Option + wheel = zoom the selection window around
+                // the cursor position, mirroring the bitrate chart's
+                // chartjs-plugin-zoom behaviour. passive:false because we
+                // preventDefault so the page doesn't scroll while zooming.
+                const ZOOM_STEP = 1.18;
+                overviewEl.addEventListener('wheel', (e) => {
+                    if (!e.altKey) return;
+                    e.preventDefault();
+                    const rect = overviewEl.getBoundingClientRect();
+                    if (rect.width <= 0) return;
+                    const fracX = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+                    const cursorMs = sessionStartMs + fracX * sessionDurationMs;
+                    const span = Math.max(1, brushEnd - brushStart);
+                    // Where in the current window does the cursor sit?
+                    // Preserve that fraction so the cursor stays parked
+                    // at the same on-screen pixel through the zoom.
+                    const cursorWindowFrac = Math.max(0, Math.min(1, (cursorMs - brushStart) / span));
+                    const zoomIn = e.deltaY < 0;
+                    let newSpan = zoomIn ? span / ZOOM_STEP : span * ZOOM_STEP;
+                    if (newSpan < MIN_WINDOW_MS) newSpan = MIN_WINDOW_MS;
+                    if (newSpan > sessionDurationMs) newSpan = sessionDurationMs;
+                    let newStart = cursorMs - cursorWindowFrac * newSpan;
+                    let newEnd = newStart + newSpan;
+                    if (newStart < sessionStartMs) { newStart = sessionStartMs; newEnd = newStart + newSpan; }
+                    if (newEnd > sessionEndMs)     { newEnd = sessionEndMs; newStart = newEnd - newSpan; }
+                    brushStart = newStart; brushEnd = newEnd;
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    updateWindowText('…');
+                    scheduleRender();
+                }, { passive: false });
+
+                jumpStart.addEventListener('click', () => {
+                    const span = brushEnd - brushStart;
+                    brushStart = sessionStartMs;
+                    brushEnd = Math.min(sessionEndMs, brushStart + span);
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    triggerRender();
+                });
+                jumpEnd.addEventListener('click', () => {
+                    const span = brushEnd - brushStart;
+                    brushEnd = sessionEndMs;
+                    brushStart = Math.max(sessionStartMs, brushEnd - span);
+                    userMovedBrush = true;
+                    updateBrushVisuals();
+                    triggerRender();
+                });
+            };
+
+            // Stream the NDJSON response. Each line is a JSON object with
+            // {ts, session_json}. Most-recent first (order=desc), so the
+            // FIRST batch holds the end-of-session window; we render that
+            // immediately. Older batches arrive next, extend the brush
+            // overview and (only) re-render if the user is parked on the
+            // earliest part of the session.
+            const reader = resp.body.getReader();
+            const decoder = new TextDecoder();
+            let leftover = '';
+            let totalLines = 0;
+            let bytesIn = 0;
+            let firstBatchSeen = false;
+            text.textContent = `session ${sessionId} — streaming…`;
+
+            const ingestLine = (line) => {
+                let row;
+                try { row = JSON.parse(line); } catch { return; }
+                let snap;
+                try { snap = JSON.parse(row.session_json || '{}'); } catch { return; }
+                if (!snap || typeof snap !== 'object') return;
+                const tsMs = Date.parse((row.ts || '').replace(' ', 'T') + 'Z');
+                if (!Number.isFinite(tsMs)) return;
+                // O(1) push regardless of stream direction. The array is
+                // intentionally NOT kept sorted — that was the O(N²) tax
+                // of reverse streaming. Nothing in the brush/rail/header
+                // path needs ordering; replayWindow sorts its small
+                // filtered subset before feeding the chart.
+                snapshots.push({ tsMs, snap });
+                if (tsMs < observedStartMs) observedStartMs = tsMs;
+                if (tsMs > observedEndMs)   observedEndMs   = tsMs;
+                totalLines++;
+            };
+
+            // Bounds are maintained inline in ingestLine (O(1) per line).
+            const onBatchBoundary = async () => {
+                if (snapshots.length === 0) return;
+                sessionStartMs = observedStartMs;
+                sessionEndMs   = observedEndMs;
+                sessionDurationMs = sessionEndMs - sessionStartMs;
+                // Publish play bounds for other modules (network log)
+                // so they can scope their fetch to this play instead
+                // of pulling all rows for the session_id.
+                playBoundsBySession.set(String(sessionId), {
+                    startMs: sessionStartMs,
+                    endMs:   sessionEndMs
+                });
+                if (!firstBatchSeen) {
+                    firstBatchSeen = true;
+                    buildBrushUI();
+                    brushEnd = sessionEndMs;
+                    brushStart = Math.max(sessionStartMs, brushEnd - Math.min(WINDOW_MS, sessionDurationMs || WINDOW_MS));
+                    updateBrushVisuals();
+                    updateWindowText('first paint…');
+                    setHeader(`streaming…`);
+                    rebuildTicks();
+                    // Kick off the events query in parallel with the rest
+                    // of the snapshot stream. The heatmap cells used to be
+                    // a separate /api/session_heatmap call but are now
+                    // derived directly from sessionEvents, so toggling
+                    // chip filters recolors the rail in real time.
+                    fetchEvents();
+                    await triggerRender();
+                } else {
+                    rebuildTicks();
+                    setHeader(`streaming…`);
+                    // If user hasn't moved the brush, keep it pinned to
+                    // the new end-of-session window. If they have, leave
+                    // it alone.
+                    if (!userMovedBrush) {
+                        brushEnd = sessionEndMs;
+                        brushStart = Math.max(sessionStartMs, brushEnd - Math.min(WINDOW_MS, sessionDurationMs || WINDOW_MS));
+                        updateBrushVisuals();
+                    }
+                    updateWindowText('streaming…');
+                    // Re-render charts as more (older) snapshots arrive so
+                    // the brush window fills in from right→left rather than
+                    // freezing on the first batch's slice. Debounced so a
+                    // dense stream doesn't thrash Chart.js.
+                    scheduleRender();
+                }
+                updateProgress();
+            };
+
+            // Periodic ticker so the progress text stays fresh between
+            // batch boundaries (rate / KB / ETA).
+            const progressTicker = setInterval(updateProgress, 250);
+
+            try {
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    bytesIn += value.byteLength;
+                    leftover += decoder.decode(value, { stream: true });
+                    let nl;
+                    while ((nl = leftover.indexOf('\n')) >= 0) {
+                        const line = leftover.slice(0, nl);
+                        leftover = leftover.slice(nl + 1);
+                        if (line.length > 0) ingestLine(line);
+                        if (totalLines > 0 && totalLines % BATCH_SIZE === 0) {
+                            await onBatchBoundary();
+                        }
+                    }
+                }
+                if (leftover.length > 0) ingestLine(leftover);
+                await onBatchBoundary();
+            } catch (err) {
+                clearInterval(progressTicker);
+                failProgress(`stream error: ${err.message}`);
+                fail(`Replay stream error: ${err.message}`);
+                return;
+            }
+
+            clearInterval(progressTicker);
+            if (snapshots.length === 0) { failProgress('no data'); fail(`No snapshots archived for session ${sessionId}`); return; }
+            setHeader(`${snapshots.length} snapshots cached`);
+            updateWindowText('done');
+            finishProgress('complete');
+            // Final render: any straggler snapshots since the last batch
+            // boundary may not have triggered a render yet, and rebuildTicks
+            // needs the heatmap (which arrives async) to overlay correctly.
+            rebuildTicks();
+            scheduleRender();
+
+            // Live-tail mode: if the session is still being broadcast on
+            // the SSE stream, new snapshots will keep arriving. Poll for
+            // them and append; auto-advance the brush *only* if it was
+            // anchored at the end of the session before the new data
+            // arrived (so a user who's parked the brush back in time
+            // doesn't get yanked forward).
+            startLiveTail();
+
+            function startLiveTail() {
+                // The live-tail badge is mounted *into the banner* (next to
+                // the back-to-sessions row) so it's discoverable from the
+                // moment the page loads. It starts in "polling…" state and
+                // graduates to "LIVE" the first time the loop sees fresh
+                // data. After ~3 empty polls (~12s of silence) it switches
+                // to "ended" state and stops polling.
+                const liveBadge = document.createElement('span');
+                liveBadge.id = 'replay-live-badge';
+                liveBadge.style.cssText = 'display:inline-flex;align-items:center;gap:6px;padding:2px 8px;border-radius:10px;background:#e5e7eb;color:#4b5563;font:600 11px system-ui;letter-spacing:0.04em;margin-left:8px;';
+                const setBadge = (state, label) => {
+                    const colors = {
+                        pending: ['#e5e7eb', '#4b5563', '#9ca3af', false],
+                        live:    ['#dcfce7', '#166534', '#16a34a', true],
+                        ended:   ['#fee2e2', '#991b1b', '#dc2626', false]
+                    }[state] || ['#e5e7eb', '#4b5563', '#9ca3af', false];
+                    const [bg, fg, dot, pulse] = colors;
+                    liveBadge.style.background = bg;
+                    liveBadge.style.color = fg;
+                    liveBadge.innerHTML = `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${dot};${pulse ? 'animation:replay-live-pulse 1.2s ease-in-out infinite;' : ''}"></span> ${label}`;
+                };
+                setBadge('pending', 'polling…');
+                // Mount as the LAST element in the banner's left cluster so
+                // it sits next to the session header text.
+                if (text && text.parentElement) {
+                    text.parentElement.appendChild(liveBadge);
+                } else {
+                    banner.appendChild(liveBadge);
+                }
+                console.debug('[replay] live-tail starting; cursor=', new Date(sessionEndMs).toISOString());
+                if (!document.getElementById('replay-live-pulse-keyframes')) {
+                    const style = document.createElement('style');
+                    style.id = 'replay-live-pulse-keyframes';
+                    style.textContent = '@keyframes replay-live-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }';
+                    document.head.appendChild(style);
+                }
+
+                const POLL_INTERVAL_MS = 3000;
+                const HEATMAP_REFRESH_EVERY = 6;        // ~18s
+                const END_TOLERANCE_MS = 1500;          // brush "at end" if within this many ms of sessionEnd
+                const QUIESCE_AFTER_EMPTY_POLLS = 4;    // ~12s of silence ⇒ stop polling
+
+                let cursorMs = sessionEndMs;
+                let pollIdx = 0;
+                let emptyStreak = 0;
+                let stopped = false;
+                let activeFetch = null;
+
+                async function tick() {
+                    if (stopped) return;
+                    pollIdx++;
+                    const sinceIso = new Date(cursorMs + 1).toISOString();
+                    const params = new URLSearchParams({
+                        session: sessionId,
+                        order: 'asc',
+                        limit: '5000',
+                        from: sinceIso
+                    });
+                    if (playId) params.set('play_id', playId);
+                    const url = '/analytics/api/snapshots?' + params.toString();
+                    let resp;
+                    try {
+                        activeFetch = fetch(url);
+                        resp = await activeFetch;
+                    } catch (err) {
+                        console.warn('[replay] live-tail fetch failed:', err);
+                        scheduleNext();
+                        return;
+                    } finally {
+                        activeFetch = null;
+                    }
+                    if (!resp.ok) {
+                        console.warn('[replay] live-tail HTTP', resp.status, 'for', url);
+                        scheduleNext();
+                        return;
+                    }
+                    const body = await resp.text();
+                    const lines = body.split('\n').filter(l => l);
+                    console.debug('[replay] live-tail tick', pollIdx, 'got', lines.length, 'rows since', sinceIso);
+                    if (lines.length === 0) {
+                        emptyStreak++;
+                        if (emptyStreak >= QUIESCE_AFTER_EMPTY_POLLS) {
+                            // Session has plausibly ended — switch the badge
+                            // to "ended" and stop polling. Resume requires
+                            // page reload.
+                            setBadge('ended', 'session ended');
+                            console.debug('[replay] live-tail quiescing after', emptyStreak, 'empty polls');
+                            stopped = true;
+                            return;
+                        }
+                        scheduleNext();
+                        return;
+                    }
+                    emptyStreak = 0;
+
+                    // Was the brush parked at the end before this batch?
+                    // Compute *before* we mutate sessionEndMs so we know
+                    // whether to keep tailing or stay parked.
+                    const wasAtEnd = (sessionEndMs - brushEnd) <= END_TOLERANCE_MS;
+                    const prevWindowSpan = brushEnd - brushStart;
+
+                    // Parse new rows, push to the snapshot array, advance
+                    // cursor + bounds. Collect into newRows for the
+                    // incremental render below.
+                    const newRows = [];
+                    for (const line of lines) {
+                        let row;
+                        try { row = JSON.parse(line); } catch { continue; }
+                        let snap;
+                        try { snap = JSON.parse(row.session_json || '{}'); } catch { continue; }
+                        if (!snap || typeof snap !== 'object') continue;
+                        const tsMs = Date.parse((row.ts || '').replace(' ', 'T') + 'Z');
+                        if (!Number.isFinite(tsMs)) continue;
+                        if (tsMs <= cursorMs) continue; // dedup against the floor
+                        snapshots.push({ tsMs, snap });
+                        if (tsMs > observedEndMs) observedEndMs = tsMs;
+                        if (tsMs > cursorMs) cursorMs = tsMs;
+                        totalLines++;
+                        newRows.push({ tsMs, snap });
+                    }
+                    sessionEndMs = observedEndMs;
+                    sessionDurationMs = sessionEndMs - sessionStartMs;
+                    setBadge('live', `LIVE · ${snapshots.length} events`);
+
+                    if (wasAtEnd) {
+                        brushEnd = sessionEndMs;
+                        brushStart = Math.max(sessionStartMs, brushEnd - prevWindowSpan);
+                    }
+
+                    setHeader('streaming live');
+                    updateBrushVisuals();
+                    rebuildTicks();
+
+                    // Smooth incremental render: instead of replayWindow
+                    // (which clears all chart state and re-feeds the whole
+                    // 10-min window through pushBandwidthSample on every
+                    // tick — expensive), feed only the NEW snapshots and
+                    // let Chart.js update its datasets in place. This is
+                    // exactly what testing.html does on each SSE pulse.
+                    //
+                    // Only do this when the brush was at the end. If the
+                    // user has dragged back, the chart shows a different
+                    // window and they'd see the new data flicker in/out;
+                    // skip the chart push (data still records into the
+                    // shell's history Maps). When they pan the brush back
+                    // to the end, the existing brush handler triggers a
+                    // full replayWindow that picks up everything.
+                    if (wasAtEnd && newRows.length > 0) {
+                        const sidStr = String(sessionId);
+                        for (const r of newRows) {
+                            sessionsById.set(sidStr, r.snap);
+                            try {
+                                pushBandwidthSample(r.snap);
+                            } catch (err) {
+                                console.warn('[replay] pushBandwidthSample failed:', err);
+                            }
+                        }
+                        // One DOM update for session-details fields,
+                        // events-timeline, etc. — applySessionsList does
+                        // the heavy DOM render path; calling it once per
+                        // tick (with the latest snap) is what testing.html
+                        // also does per SSE event.
+                        try {
+                            applySessionsList([newRows[newRows.length - 1].snap]);
+                        } catch (err) {
+                            console.warn('[replay] applySessionsList failed:', err);
+                        }
+                    }
+
+                    // Refresh events occasionally so the rail markers and
+                    // bucket colors track real time. (Heatmap cells are
+                    // now derived from sessionEvents — no separate fetch.)
+                    if (pollIdx % HEATMAP_REFRESH_EVERY === 0) {
+                        fetchEvents();
+                    }
+                    scheduleNext();
+                }
+
+                function scheduleNext() {
+                    if (stopped) return;
+                    setTimeout(tick, POLL_INTERVAL_MS);
+                }
+
+                // First tick fires immediately so a still-active session
+                // shows the LIVE badge fast.
+                tick();
+            }
+        }
+
+        // Replay session picker: shown when ?replay=1 has no &session=<id>.
+        // Lists recent archived sessions from the analytics forwarder so the
+        // user can pick one without copy-pasting an id from Grafana.
+        async function startReplayPicker() {
+            // Render the picker as a standard dashboard panel so it matches
+            // the rest of the app shell instead of using the amber "replay"
+            // chrome (which only makes sense on the single-session viewer).
+            const banner = document.createElement('div');
+            banner.className = 'panel session-picker-panel';
+            banner.style.cssText = 'font:13px system-ui;color:var(--text-primary);';
+            banner.innerHTML = '<strong>Loading sessions…</strong>';
+            const wide = document.querySelector('.ism-content-wide');
+            if (wide) {
+                const header = wide.querySelector('.page-header');
+                if (header && header.nextSibling) wide.insertBefore(banner, header.nextSibling);
+                else if (header) wide.appendChild(banner);
+                else wide.insertBefore(banner, wide.firstChild);
+            } else {
+                const mp = mountPoint();
+                mp.insertBefore(banner, mp.firstChild);
+            }
+            // The selector page is not actually a "replay" view — it's a
+            // session index. Don't add replay-mode (which dims controls
+            // intended for live testing) and don't prefix the page title.
+
+            // Inject the live-pulse keyframes once if not already present
+            // (they're also added by the session-viewer; either page may
+            // load first depending on user navigation).
+            if (!document.getElementById('replay-live-pulse-keyframes')) {
+                const style = document.createElement('style');
+                style.id = 'replay-live-pulse-keyframes';
+                style.textContent = '@keyframes replay-live-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }';
+                document.head.appendChild(style);
+            }
+
+            // Splunk-style time-range presets. Stored in localStorage so the
+            // selection persists across reloads. "Custom" exposes datetime-local
+            // inputs and an Apply button.
+            const RANGES = [
+                { id: '15m',  label: 'Last 15 minutes', ms: 15 * 60 * 1000 },
+                { id: '1h',   label: 'Last hour',       ms: 60 * 60 * 1000 },
+                { id: '4h',   label: 'Last 4 hours',    ms: 4 * 60 * 60 * 1000 },
+                { id: '24h',  label: 'Last 24 hours',   ms: 24 * 60 * 60 * 1000 },
+                { id: '7d',   label: 'Last 7 days',     ms: 7 * 24 * 60 * 60 * 1000 },
+                { id: '30d',  label: 'Last 30 days',    ms: 30 * 24 * 60 * 60 * 1000 },
+                { id: 'all',  label: 'All time',        ms: 0 },
+                { id: 'custom', label: 'Custom range…', ms: -1 }
+            ];
+            const RANGE_KEY = 'ismSessionsRange';
+            const RANGE_CUSTOM_KEY = 'ismSessionsRangeCustom';
+            let activeRangeId = localStorage.getItem(RANGE_KEY) || '24h';
+            if (!RANGES.find(r => r.id === activeRangeId)) activeRangeId = '24h';
+            const customStored = (() => {
+                try { return JSON.parse(localStorage.getItem(RANGE_CUSTOM_KEY) || 'null'); }
+                catch { return null; }
+            })();
+            let customFrom = customStored?.from || '';
+            let customTo   = customStored?.to   || '';
+            const computeRange = () => {
+                if (activeRangeId === 'custom') {
+                    return { since: customFrom || '', until: customTo || '', label: 'Custom range' };
+                }
+                const meta = RANGES.find(r => r.id === activeRangeId);
+                if (!meta || meta.ms === 0) return { since: '1970-01-01T00:00:00Z', until: '', label: meta?.label || 'All time' };
+                const since = new Date(Date.now() - meta.ms).toISOString();
+                return { since, until: '', label: meta.label };
+            };
+
+            // Mutable rows array — replaced in place on time-range change so all
+            // closures (refreshSelects, rebuildTable) see the new data.
+            const rows = [];
+            let rowsLoaded = false;
+
+            async function loadRows() {
+                const { since, until } = computeRange();
+                const params = new URLSearchParams();
+                if (since) params.set('since', since);
+                if (until) params.set('until', until);
+                const url = '/analytics/api/sessions' + (params.toString() ? '?' + params : '');
+                let resp;
+                try { resp = await fetch(url); }
+                catch (err) {
+                    banner.style.background = '#fee2e2'; banner.style.color = '#991b1b';
+                    banner.textContent = `Picker failed: ${err.message}`;
+                    return false;
+                }
+                if (!resp.ok) {
+                    banner.style.background = '#fee2e2'; banner.style.color = '#991b1b';
+                    banner.textContent = `Picker failed: HTTP ${resp.status} (analytics forwarder reachable?)`;
+                    return false;
+                }
+                const body = await resp.text();
+                const fresh = body.split('\n').filter(l => l).map(l => {
+                    try { return JSON.parse(l); } catch { return null; }
+                }).filter(Boolean);
+                for (const r of fresh) {
+                    const t0 = Date.parse(r.started);
+                    const t1 = Date.parse(r.last_seen);
+                    r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;
+                    deriveHealth(r);
+                }
+                rows.splice(0, rows.length, ...fresh);
+                rowsLoaded = true;
+                return true;
+            }
+
+            // Derive synthetic per-session metrics shown as columns A/B/C in
+            // the picker. The forwarder query returns raw counters; we roll
+            // them up here so we can iterate on weights without redeploying
+            // the forwarder.
+            function deriveHealth(r) {
+                const n = (k) => Number(r[k]) || 0;
+                const stalls    = n('stalls');
+                const drops     = n('dropped_frames');
+                const downshifts = n('downshifts');
+                const upshifts   = n('upshifts');
+                const resChanges = n('resolution_changes');
+                const errors    = (r.last_player_error && r.last_player_error.length > 0) ? 1 : 0;
+                const faults    = n('master_manifest_failures') + n('manifest_failures') + n('segment_failures')
+                                + n('all_failures') + n('transport_failures')
+                                + n('active_timeouts') + n('idle_timeouts');
+                // Drops are noisy — scale to "drop blocks" of 100 frames
+                // so a session with 543 drops counts as 6, not 543.
+                const dropBlocks = Math.ceil(drops / 100);
+
+                r.errors_count = errors;
+                r.faults_count = faults;
+                r.downshifts_count = downshifts;
+                r.upshifts_count   = upshifts;
+
+                // (A) Issues badge — single weighted total. Weights chosen so
+                // a clean session is 0 and a session with one fatal error is
+                // already in the red bucket.
+                r.issues_count = stalls + errors * 5 + faults + downshifts + dropBlocks;
+                r.issues_breakdown = {
+                    stalls, errors, faults, downshifts, drops, dropBlocks,
+                    resolution_changes: resChanges,
+                    upshifts, player_error: r.last_player_error || ''
+                };
+
+                // (C) Health score — 100 minus weighted deductions. Faults
+                // and drops are capped because they're either intentional
+                // (faults are injected) or noisy (drops are per-frame).
+                const deductStalls = stalls * 2;
+                const deductErrors = errors * 25;
+                const deductFaults = Math.min(faults * 1, 10);
+                const deductDrops  = Math.min(dropBlocks, 20);
+                const deductShifts = downshifts * 1;
+                const total = deductStalls + deductErrors + deductFaults + deductDrops + deductShifts;
+                r.health_score = Math.max(0, 100 - total);
+                r.health_breakdown = {
+                    stalls: deductStalls, errors: deductErrors,
+                    faults: deductFaults, drops: deductDrops, downshifts: deductShifts
+                };
+            }
+
+            const escapeHtml = (s) => String(s == null ? '' : s)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
+            // (A) Color-coded badge cell for Issues count.
+            const fmtIssuesBadge = (count, r) => {
+                const c = Number(count) || 0;
+                let bg, fg;
+                if (c === 0)      { bg = '#d1fae5'; fg = '#065f46'; }
+                else if (c <= 4)  { bg = '#fef3c7'; fg = '#92400e'; }
+                else              { bg = '#fee2e2'; fg = '#991b1b'; }
+                const b = r.issues_breakdown || {};
+                const tipParts = [];
+                if (b.stalls)      tipParts.push(`${b.stalls} stall${b.stalls === 1 ? '' : 's'}`);
+                if (b.errors)      tipParts.push(`player error: ${b.player_error || 'yes'}`);
+                if (b.faults)      tipParts.push(`${b.faults} injected fault${b.faults === 1 ? '' : 's'}`);
+                if (b.downshifts)  tipParts.push(`${b.downshifts} ABR downshift${b.downshifts === 1 ? '' : 's'}`);
+                if (b.drops)       tipParts.push(`${b.drops} dropped frames (~${b.dropBlocks} blocks)`);
+                if (b.resolution_changes) tipParts.push(`${b.resolution_changes} resolution changes`);
+                const tip = tipParts.length ? tipParts.join(' · ') : 'no noteworthy events';
+                return `<span title="${escapeHtml(tip)}" style="display:inline-block;min-width:28px;text-align:center;padding:2px 8px;border-radius:10px;background:${bg};color:${fg};font-weight:700;font-family:system-ui;">${c}</span>`;
+            };
+
+            // (B) Per-category numeric cell with simple thresholding.
+            const fmtCount = (thresholds /* [warn, bad] */) => (v) => {
+                const n = Number(v) || 0;
+                let color = '#065f46';
+                if (n >= thresholds[1]) color = '#991b1b';
+                else if (n >= thresholds[0]) color = '#92400e';
+                else if (n === 0)      color = '#9ca3af';
+                return `<span style="color:${color};font-weight:${n === 0 ? '400' : '600'};">${n}</span>`;
+            };
+
+            // (C) Health score 0-100 with green/amber/red.
+            const fmtHealth = (score, r) => {
+                const s = Number(score);
+                let bg, fg;
+                if (s >= 90)      { bg = '#d1fae5'; fg = '#065f46'; }
+                else if (s >= 70) { bg = '#fef3c7'; fg = '#92400e'; }
+                else              { bg = '#fee2e2'; fg = '#991b1b'; }
+                const b = r.health_breakdown || {};
+                const tip = `100 − stalls:${b.stalls||0} − errors:${b.errors||0} − faults:${b.faults||0} − drops:${b.drops||0} − downshifts:${b.downshifts||0}`;
+                return `<span title="${escapeHtml(tip)}" style="display:inline-block;min-width:36px;text-align:center;padding:2px 8px;border-radius:4px;background:${bg};color:${fg};font-weight:700;">${s}</span>`;
+            };
+
+            const fmtPct = (v) => {
+                const n = Number(v);
+                if (!Number.isFinite(n) || n === 0) return '<span style="color:#9ca3af;">—</span>';
+                let color = '#065f46';
+                if (n < 60)      color = '#991b1b';
+                else if (n < 85) color = '#92400e';
+                return `<span style="color:${color};">${n.toFixed(1)}%</span>`;
+            };
+
+            if (!await loadRows()) return;
+
+            // Cascading filter UI: Player → Group → Content → Play (id) →
+            // Session row. Each select narrows the next; the table at the
+            // bottom shows the rows that match all active filters.
+            const distinct = (key) => Array.from(new Set(rows.map(r => r[key] || '').filter(v => v))).sort();
+            const filters = { player_id: '', group_id: '', content_id: '', play_id: '' };
+            const matches = (r) =>
+                (!filters.player_id  || r.player_id  === filters.player_id) &&
+                (!filters.group_id   || r.group_id   === filters.group_id) &&
+                (!filters.content_id || r.content_id === filters.content_id) &&
+                (!filters.play_id    || r.play_id    === filters.play_id);
+
+            const wrap = document.createElement('div');
+            wrap.style.cssText = 'display:flex;flex-direction:column;gap:10px;';
+            const heading = document.createElement('div');
+            heading.style.cssText = 'font-size:13px;color:var(--text-secondary);';
+            const updateHeading = () => {
+                const { label } = computeRange();
+                heading.textContent = `${rows.length} playback episodes archived (${label.toLowerCase()}). Filter then pick one to replay.`;
+            };
+            updateHeading();
+
+            // Time-range row: Splunk-style preset dropdown, plus custom-range
+            // datetime inputs that show only when "Custom" is selected.
+            const ctrlInputCss = 'padding:4px 8px;font:13px system-ui;background:var(--bg-primary);color:var(--text-primary);border:1px solid var(--border-color, #d1d5db);border-radius:4px;';
+            const labelCss = 'display:flex;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);font-weight:500;';
+            const rangeRow = document.createElement('div');
+            rangeRow.style.cssText = 'display:flex;flex-wrap:wrap;gap:10px;align-items:center;';
+            const rangeLbl = document.createElement('label');
+            rangeLbl.style.cssText = labelCss;
+            const rangeSel = document.createElement('select');
+            rangeSel.style.cssText = ctrlInputCss;
+            for (const r of RANGES) {
+                const opt = document.createElement('option');
+                opt.value = r.id; opt.textContent = r.label;
+                if (r.id === activeRangeId) opt.selected = true;
+                rangeSel.appendChild(opt);
+            }
+            rangeLbl.append('Time range:', rangeSel);
+            rangeRow.appendChild(rangeLbl);
+
+            const customWrap = document.createElement('span');
+            customWrap.style.cssText = 'display:none;align-items:center;gap:6px;font-size:12px;color:var(--text-secondary);';
+            const fromInput = document.createElement('input');
+            fromInput.type = 'datetime-local';
+            fromInput.style.cssText = ctrlInputCss;
+            const toInput = document.createElement('input');
+            toInput.type = 'datetime-local';
+            toInput.style.cssText = ctrlInputCss;
+            const applyBtn = document.createElement('button');
+            applyBtn.type = 'button';
+            applyBtn.className = 'btn btn-secondary';
+            applyBtn.textContent = 'Apply';
+            // datetime-local is local-naive; convert to UTC ISO so the user's
+            // "2pm" means 2pm in their timezone, not 2pm UTC.
+            const localToISO = (v) => {
+                if (!v) return '';
+                const d = new Date(v);
+                return Number.isFinite(d.getTime()) ? d.toISOString() : '';
+            };
+            const isoToLocal = (iso) => {
+                if (!iso) return '';
+                const d = new Date(iso);
+                if (!Number.isFinite(d.getTime())) return '';
+                const pad = (n) => String(n).padStart(2, '0');
+                return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+            };
+            fromInput.value = isoToLocal(customFrom);
+            toInput.value   = isoToLocal(customTo);
+            customWrap.append('from', fromInput, 'to', toInput, applyBtn);
+            rangeRow.appendChild(customWrap);
+
+            const reloadingTag = document.createElement('span');
+            reloadingTag.style.cssText = 'font-size:12px;color:var(--text-secondary);font-style:italic;display:none;';
+            reloadingTag.textContent = 'Reloading…';
+            rangeRow.appendChild(reloadingTag);
+
+            const filterRow = document.createElement('div');
+            filterRow.style.cssText = 'display:flex;flex-wrap:wrap;gap:10px;align-items:center;';
+
+            const buildSelect = (key, label) => {
+                const lbl = document.createElement('label');
+                lbl.style.cssText = labelCss;
+                const sel = document.createElement('select');
+                sel.dataset.key = key;
+                sel.style.cssText = ctrlInputCss;
+                lbl.append(label + ':', sel);
+                filterRow.appendChild(lbl);
+                return sel;
+            };
+            const playerSel  = buildSelect('player_id',  'Player');
+            const groupSel   = buildSelect('group_id',   'Group');
+            const contentSel = buildSelect('content_id', 'Content');
+            const playSel    = buildSelect('play_id',    'Play');
+            const clearBtn = document.createElement('button');
+            clearBtn.type = 'button';
+            clearBtn.className = 'btn btn-secondary';
+            clearBtn.textContent = 'Clear filters';
+            filterRow.appendChild(clearBtn);
+
+            const matchCount = document.createElement('span');
+            matchCount.style.cssText = 'margin-left:auto;font-size:12px;color:var(--text-secondary);';
+            filterRow.appendChild(matchCount);
+
+            // Sessions list as a scrollable table.
+            const tableWrap = document.createElement('div');
+            tableWrap.style.cssText = 'max-height:60vh;overflow:auto;background:var(--bg-primary);border:1px solid var(--border-color, #e5e7eb);border-radius:6px;';
+            const table = document.createElement('table');
+            table.style.cssText = 'width:100%;border-collapse:collapse;font:12px ui-monospace,Menlo,monospace;';
+            tableWrap.appendChild(table);
+            wrap.append(heading, rangeRow, filterRow, tableWrap);
+            banner.replaceChildren(wrap);
+
+            const showCustomInputs = () => {
+                customWrap.style.display = activeRangeId === 'custom' ? 'inline-flex' : 'none';
+            };
+            showCustomInputs();
+
+            // Re-fetch from the forwarder and rebuild the table. `silent`
+            // suppresses the "Reloading…" tag for ambient auto-refresh so
+            // it doesn't flash every tick. A concurrent-reload guard
+            // prevents overlapping fetches if the forwarder is slow.
+            let reloadInFlight = false;
+            async function reloadForRange(opts = {}) {
+                if (reloadInFlight) return;
+                reloadInFlight = true;
+                if (!opts.silent) reloadingTag.style.display = 'inline';
+                try {
+                    const ok = await loadRows();
+                    if (!ok) return;
+                    updateHeading();
+                    refreshSelects();
+                } finally {
+                    if (!opts.silent) reloadingTag.style.display = 'none';
+                    reloadInFlight = false;
+                }
+            }
+
+            rangeSel.addEventListener('change', () => {
+                activeRangeId = rangeSel.value;
+                localStorage.setItem(RANGE_KEY, activeRangeId);
+                showCustomInputs();
+                if (activeRangeId !== 'custom') reloadForRange();
+            });
+            applyBtn.addEventListener('click', () => {
+                customFrom = localToISO(fromInput.value);
+                customTo   = localToISO(toInput.value);
+                localStorage.setItem(RANGE_CUSTOM_KEY, JSON.stringify({ from: customFrom, to: customTo }));
+                reloadForRange();
+            });
+
+            const refreshSelects = () => {
+                const visible = rows.filter(matches);
+                const fillSelect = (sel, key) => {
+                    const candidates = (key === 'player_id'  ? rows :
+                                        key === 'group_id'   ? rows.filter(r => !filters.player_id || r.player_id === filters.player_id) :
+                                        key === 'content_id' ? rows.filter(r =>
+                                            (!filters.player_id || r.player_id === filters.player_id) &&
+                                            (!filters.group_id  || r.group_id  === filters.group_id)) :
+                                        rows.filter(r =>
+                                            (!filters.player_id  || r.player_id  === filters.player_id) &&
+                                            (!filters.group_id   || r.group_id   === filters.group_id) &&
+                                            (!filters.content_id || r.content_id === filters.content_id))
+                                       );
+                    const values = Array.from(new Set(candidates.map(r => r[key] || '').filter(Boolean))).sort();
+                    sel.replaceChildren();
+                    const all = document.createElement('option');
+                    all.value = ''; all.textContent = `all (${values.length})`;
+                    sel.appendChild(all);
+                    for (const v of values) {
+                        const opt = document.createElement('option');
+                        opt.value = v; opt.textContent = v;
+                        sel.appendChild(opt);
+                    }
+                    if (values.includes(filters[key])) sel.value = filters[key];
+                    else { sel.value = ''; filters[key] = ''; }
+                };
+                fillSelect(playerSel,  'player_id');
+                fillSelect(groupSel,   'group_id');
+                fillSelect(contentSel, 'content_id');
+                fillSelect(playSel,    'play_id');
+                matchCount.textContent = `${visible.length} matching`;
+                rebuildTable(visible);
+            };
+
+            // Column metadata: display label, source field on the row,
+            // and how to coerce for sort (string vs number). Click a
+            // header to sort; click again to flip direction. Default
+            // sort is "started DESC" (newest first). duration_ms is
+            // computed in loadRows() from started/last_seen.
+            const fmtDur = (ms) => {
+                if (!ms) return '—';
+                const s = Math.round(ms / 1000);
+                const h = Math.floor(s / 3600);
+                const m = Math.floor((s % 3600) / 60);
+                const sec = s % 60;
+                if (h) return `${h}h ${m}m ${sec}s`;
+                if (m) return `${m}m ${sec}s`;
+                return `${sec}s`;
+            };
+
+            // Columns are grouped: identification, then (A) Issues badge,
+            // then (C) Health score, then (B) per-category counts. Hover any
+            // colored cell for tooltip breakdown.
+            // Relative-time formatter for "Last updated". Includes a tiny
+            // pulse dot when the session was updated very recently so a
+            // user scanning the list can spot active sessions at a glance.
+            const fmtRelTime = (iso) => {
+                if (!iso) return '<span style="color:#9ca3af;">—</span>';
+                const t = Date.parse(String(iso).replace(' ', 'T') + 'Z');
+                if (!Number.isFinite(t)) return '<span style="color:#9ca3af;">—</span>';
+                const ageSec = Math.max(0, (Date.now() - t) / 1000);
+                let label;
+                if (ageSec < 60)        label = `${Math.round(ageSec)}s ago`;
+                else if (ageSec < 3600) label = `${Math.round(ageSec / 60)}m ago`;
+                else if (ageSec < 86400) label = `${Math.round(ageSec / 3600)}h ago`;
+                else                    label = `${Math.round(ageSec / 86400)}d ago`;
+                const tip = String(iso);
+                if (ageSec < 30) {
+                    return `<span title="${escapeHtml(tip)}" style="color:#16a34a;font-weight:600;display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#16a34a;animation:replay-live-pulse 1.2s ease-in-out infinite;"></span>${label}</span>`;
+                }
+                const color = ageSec < 300 ? 'var(--text-primary)' : 'var(--text-secondary)';
+                return `<span title="${escapeHtml(tip)}" style="color:${color};">${label}</span>`;
+            };
+
+            const columns = [
+                { label: 'Started',     key: 'started',          type: 'string' },
+                { label: 'Last updated', key: 'last_seen',       type: 'string', html: true, format: fmtRelTime },
+                { label: 'Duration',    key: 'duration_ms',      type: 'number', format: fmtDur },
+                { label: 'Player',      key: 'player_id',        type: 'string' },
+                { label: 'Content',     key: 'content_id',       type: 'string' },
+                { label: 'Play ID',     key: 'play_id',          type: 'string' },
+                { label: 'State',       key: 'last_state',       type: 'string' },
+                { label: 'Issues',      key: 'issues_count',     type: 'number', html: true, format: fmtIssuesBadge },
+                { label: 'Health',      key: 'health_score',     type: 'number', html: true, format: fmtHealth },
+                { label: 'Stalls',      key: 'stalls',           type: 'number', html: true, format: fmtCount([1, 5]) },
+                { label: 'Errors',      key: 'errors_count',     type: 'number', html: true, format: fmtCount([1, 1]) },
+                { label: 'Faults',      key: 'faults_count',     type: 'number', html: true, format: fmtCount([1, 10]) },
+                { label: 'Downshifts',  key: 'downshifts_count', type: 'number', html: true, format: fmtCount([1, 5]) },
+                { label: 'Drops',       key: 'dropped_frames',   type: 'number', html: true, format: fmtCount([100, 1000]) },
+                { label: 'Avg Q%',      key: 'avg_quality_pct',  type: 'number', html: true, format: fmtPct },
+                { label: 'Metrics',     key: 'metric_events',    type: 'number' },
+                { label: 'HAR',         key: 'net_events',       type: 'number' }
+            ];
+            let sortKey = 'started';
+            let sortDir = 'desc';
+            let lastVisible = [];
+
+            const cmp = (a, b, key, type) => {
+                const av = a[key];
+                const bv = b[key];
+                if (type === 'number') {
+                    const an = Number(av) || 0;
+                    const bn = Number(bv) || 0;
+                    return an - bn;
+                }
+                const as = String(av || '');
+                const bs = String(bv || '');
+                return as < bs ? -1 : as > bs ? 1 : 0;
+            };
+
+            const rebuildTable = (visible) => {
+                lastVisible = visible.slice();
+                const colMeta = columns.find(c => c.key === sortKey) || columns[0];
+                const sorted = lastVisible.sort((a, b) => {
+                    const c = cmp(a, b, sortKey, colMeta.type);
+                    return sortDir === 'asc' ? c : -c;
+                });
+
+                const head = document.createElement('thead');
+                const headTr = document.createElement('tr');
+                headTr.style.cssText = 'background:var(--bg-secondary, #f5f5f5);position:sticky;top:0;text-align:left;';
+                for (const col of columns) {
+                    const th = document.createElement('th');
+                    th.style.cssText = 'padding:8px 10px;border-bottom:1px solid var(--border-color, #e5e7eb);font-weight:600;color:var(--text-primary);cursor:pointer;user-select:none;white-space:nowrap;';
+                    th.title = `Sort by ${col.label}`;
+                    const arrow = sortKey === col.key
+                        ? (sortDir === 'asc' ? ' ▲' : ' ▼')
+                        : ' <span style="color:#9ca3af;">⇅</span>';
+                    th.innerHTML = col.label + arrow;
+                    th.addEventListener('click', () => {
+                        if (sortKey === col.key) {
+                            sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+                        } else {
+                            sortKey = col.key;
+                            sortDir = col.type === 'number' ? 'desc' : 'asc';
+                        }
+                        rebuildTable(lastVisible);
+                    });
+                    headTr.appendChild(th);
+                }
+                head.appendChild(headTr);
+
+                const body = document.createElement('tbody');
+                if (sorted.length === 0) {
+                    body.innerHTML = `<tr><td colspan="${columns.length}" style="padding:16px;text-align:center;color:var(--text-secondary);">No sessions match the current filters.</td></tr>`;
+                } else {
+                    for (const r of sorted) {
+                        const tr = document.createElement('tr');
+                        // position:relative so the stretched <a> below
+                        // resolves against the row, not the table.
+                        tr.style.cssText = 'cursor:pointer;border-bottom:1px solid var(--border-color, #f3f4f6);position:relative;';
+                        tr.addEventListener('mouseenter', () => tr.style.background = 'var(--bg-hover, #f9fafb)');
+                        tr.addEventListener('mouseleave', () => tr.style.background = '');
+
+                        const params = new URLSearchParams({ replay: '1', session: r.session_id });
+                        if (r.play_id && r.play_id !== '—') params.set('play_id', r.play_id);
+                        const href = '/dashboard/session-viewer.html?' + params.toString();
+
+                        const cells = columns.map(col => {
+                            const v = r[col.key];
+                            if (col.format) {
+                                const out = col.format(v, r);
+                                return col.html ? out : escapeHtml(out);
+                            }
+                            if (col.type === 'number') return escapeHtml(String(v || 0));
+                            return escapeHtml(v || '');
+                        });
+                        tr.innerHTML = cells.map((c, i) => {
+                            const colKey = columns[i].key;
+                            const styles = colKey === 'play_id'
+                                ? 'padding:5px 8px;font-weight:600;color:#1d4ed8;'
+                                : 'padding:5px 8px;';
+                            return `<td style="${styles}">${c}</td>`;
+                        }).join('');
+
+                        // Add a hidden full-row link so middle-click / Cmd-
+                        // click / right-click → "Open in New Tab" all work
+                        // natively. The link is added to the LAST cell with
+                        // position:absolute against the relatively-positioned
+                        // <tr>, so it covers the whole row. We also keep a JS
+                        // click handler for plain left-click so per-cell
+                        // tooltips (Issues / Health breakdowns) keep working
+                        // — left-click bubbles past the link only when JS
+                        // isn't disabled, but the link is the right-click /
+                        // middle-click / Cmd-click target.
+                        const lastTd = tr.lastElementChild;
+                        if (lastTd) {
+                            const a = document.createElement('a');
+                            a.href = href;
+                            a.setAttribute('aria-label', `Open session ${r.session_id}${r.play_id ? ' / ' + r.play_id : ''}`);
+                            a.tabIndex = -1;
+                            a.style.cssText = 'position:absolute;inset:0;z-index:0;text-decoration:none;';
+                            // Suppress the link's own left-click — we let
+                            // the JS handler below decide. Cmd/Ctrl/middle/
+                            // right-click bypass click handlers and use the
+                            // browser's native link affordances.
+                            a.addEventListener('click', (e) => {
+                                if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+                                e.preventDefault();
+                            });
+                            lastTd.appendChild(a);
+                        }
+                        // Cells need position:relative so the link's
+                        // inset:0 (which resolves against the <tr>) doesn't
+                        // visually clip them. Cells also need z-index:1 so
+                        // their interactive content (badge tooltips) sits
+                        // above the link for hover purposes.
+                        for (const td of tr.children) {
+                            td.style.position = 'relative';
+                            if (td !== lastTd) td.style.zIndex = '1';
+                        }
+
+                        tr.addEventListener('click', (e) => {
+                            // If the click was on the link, the link's own
+                            // handler already chose to either preventDefault
+                            // (plain left-click → fall through to here) or
+                            // let the browser navigate (modifier click).
+                            // For modifier clicks we just bail.
+                            if (e.metaKey || e.ctrlKey || e.shiftKey) return;
+                            window.location.href = href;
+                        });
+                        body.appendChild(tr);
+                    }
+                }
+                table.replaceChildren(head, body);
+            };
+
+            const onFilterChange = (e) => {
+                filters[e.target.dataset.key] = e.target.value || '';
+                refreshSelects();
+            };
+            playerSel.addEventListener('change', onFilterChange);
+            groupSel.addEventListener('change', onFilterChange);
+            contentSel.addEventListener('change', onFilterChange);
+            playSel.addEventListener('change', onFilterChange);
+            clearBtn.addEventListener('click', () => {
+                filters.player_id = filters.group_id = filters.content_id = filters.play_id = '';
+                refreshSelects();
+            });
+
+            refreshSelects();
+
+            // Auto-refresh: every 5s re-fetch from the forwarder so
+            // last_seen advances and new sessions appear. Silent (no
+            // "Reloading…" flash). Tightening past 5s mostly buys nothing
+            // — the upstream pipeline (proxy SSE debounce 250ms +
+            // forwarder batch flush 1s) caps how fresh ClickHouse can
+            // ever be. 5s × concurrent-fetch guard ≈ steady-state load.
+            const autoRefreshTicker = setInterval(() => {
+                reloadForRange({ silent: true });
+            }, 5000);
+            window.addEventListener('beforeunload', () => clearInterval(autoRefreshTicker), { once: true });
+        }
+
+    window.SessionReplay = {
+        startMode: startReplayMode,
+        startPicker: startReplayPicker
+    };
+})();

--- a/content/shared/session-replay.js
+++ b/content/shared/session-replay.js
@@ -43,7 +43,7 @@
             return document.getElementById('ism-content') || document.body;
         }
 
-        function makeReplayBanner(initialText) {
+        function makeReplayBanner(initialText, sessionId, playId) {
             // Clean dashboard panel — no historical-stripe chrome. The
             // "back to sessions" link and the scrubber row live here.
             const banner = document.createElement('div');
@@ -61,6 +61,21 @@
             left.append(text);
             const right = document.createElement('div');
             right.style.cssText = 'display:flex;align-items:center;gap:8px;';
+            // Session bundle download — full snapshots + HAR + events
+            // archived as a ZIP. Server builds it; browser just clicks
+            // <a download>. Live during the replay session, no need to
+            // wait for snapshots to finish loading.
+            if (sessionId) {
+                const bundleHref = '/analytics/api/session_bundle?session=' + encodeURIComponent(sessionId)
+                    + (playId ? '&play_id=' + encodeURIComponent(playId) : '');
+                const bundleBtn = document.createElement('a');
+                bundleBtn.href = bundleHref;
+                bundleBtn.setAttribute('download', '');
+                bundleBtn.textContent = '📥 Download bundle';
+                bundleBtn.title = 'Download session as .zip (snapshots, HAR, events)';
+                bundleBtn.className = 'btn btn-secondary';
+                right.appendChild(bundleBtn);
+            }
             const exit = document.createElement('a');
             exit.textContent = '← Back to sessions';
             exit.href = '/dashboard/sessions.html';
@@ -207,7 +222,7 @@
         }
 
         async function startReplayMode(sessionId, fromIso, toIso, playId) {
-            const { banner, text, scrubRow } = makeReplayBanner(`session ${sessionId} — loading snapshots…`);
+            const { banner, text, scrubRow } = makeReplayBanner(`session ${sessionId} — loading snapshots…`, sessionId, playId);
 
             const fail = (msg) => {
                 banner.style.background = '#fef2f2';
@@ -2380,7 +2395,25 @@
                 { label: 'Drops',       key: 'dropped_frames',   type: 'number', html: true, format: fmtCount([100, 1000]) },
                 { label: 'Avg Q%',      key: 'avg_quality_pct',  type: 'number', html: true, format: fmtPct },
                 { label: 'Metrics',     key: 'metric_events',    type: 'number' },
-                { label: 'HAR',         key: 'net_events',       type: 'number' }
+                { label: 'HAR',         key: 'net_events',       type: 'number' },
+                { label: '',            key: '__bundle',         type: 'string', html: true,
+                  format: (_, r) => {
+                      const pid = (r.play_id && r.play_id !== '—') ? r.play_id : '';
+                      const url = '/analytics/api/session_bundle?'
+                          + 'session=' + encodeURIComponent(r.session_id)
+                          + (pid ? '&play_id=' + encodeURIComponent(pid) : '');
+                      // data-bundle-link signals to the row's click handler
+                      // that this is a bundle download — we intercept and
+                      // prevent the page-level navigation that would
+                      // otherwise replace the picker view with the viewer.
+                      return `<a href="${url}" download data-bundle-link
+                          title="Download session bundle (.zip)"
+                          style="display:inline-block;padding:2px 8px;border-radius:4px;
+                                 background:var(--bg-secondary,#f3f4f6);
+                                 color:var(--text-primary,#111827);text-decoration:none;
+                                 font-size:13px;line-height:1.2;
+                                 position:relative;z-index:2;">📥</a>`;
+                  } }
             ];
             let sortKey = 'started';
             let sortDir = 'desc';
@@ -2502,6 +2535,9 @@
                         }
 
                         tr.addEventListener('click', (e) => {
+                            // Bundle download link — let the browser
+                            // start the .zip download, don't navigate.
+                            if (e.target.closest && e.target.closest('[data-bundle-link]')) return;
                             // If the click was on the link, the link's own
                             // handler already chose to either preventDefault
                             // (plain left-click → fall through to here) or

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -1,0 +1,5135 @@
+        if (window.Chart && window['chartjs-plugin-zoom']) {
+            const zoomPlugin = window['chartjs-plugin-zoom'].default || window['chartjs-plugin-zoom'];
+            if (zoomPlugin && typeof Chart.register === 'function') {
+                try {
+                    Chart.register(zoomPlugin);
+                } catch (_) {
+                    // Ignore duplicate registration errors.
+                }
+            }
+        }
+
+        // Event-marker plugin: draws a single vertical guide line on
+        // any chart whose `chart.$eventMarkerTsMs` is set, plus a
+        // small label box at the top so the user can read the event
+        // identifier without hovering. Color is intentionally distinct
+        // from every priority/lane/state colour in the chart palette.
+        const EVENT_MARKER_COLOR = '#0891b2';      // cyan-600
+        const EVENT_MARKER_TEXT_COLOR = '#ffffff';
+        if (window.Chart && typeof Chart.register === 'function') {
+            try {
+                Chart.register({
+                    id: 'eventMarker',
+                    afterDraw(chart) {
+                        const ts = Number(chart.$eventMarkerTsMs);
+                        const startMs = Number(chart.$windowStartMs);
+                        if (!Number.isFinite(ts) || !Number.isFinite(startMs)) return;
+                        const xScale = chart.scales && chart.scales.x;
+                        if (!xScale) return;
+                        const xVal = (ts - startMs) / 1000;
+                        if (xVal < xScale.min || xVal > xScale.max) return;
+                        const px = xScale.getPixelForValue(xVal);
+                        const { top, bottom, left, right } = chart.chartArea || {};
+                        if (!Number.isFinite(top) || !Number.isFinite(bottom)) return;
+                        const ctx = chart.ctx;
+                        ctx.save();
+                        ctx.strokeStyle = EVENT_MARKER_COLOR;
+                        ctx.lineWidth = 1.5;
+                        ctx.setLineDash([4, 3]);
+                        ctx.beginPath();
+                        ctx.moveTo(px, top);
+                        ctx.lineTo(px, bottom);
+                        ctx.stroke();
+                        ctx.setLineDash([]);
+                        const label = String(chart.$eventMarkerLabel || '');
+                        if (label) {
+                            ctx.font = '10px system-ui, -apple-system, sans-serif';
+                            const padX = 4, padY = 2;
+                            const textW = ctx.measureText(label).width;
+                            const boxW = textW + padX * 2;
+                            const boxH = 14;
+                            // Prefer right of the line; flip to left if it
+                            // would overflow the plot area.
+                            let boxX = px + 4;
+                            if (boxX + boxW > right) boxX = px - 4 - boxW;
+                            if (boxX < left) boxX = left + 1;
+                            const boxY = top + 2;
+                            ctx.fillStyle = EVENT_MARKER_COLOR;
+                            ctx.fillRect(boxX, boxY, boxW, boxH);
+                            ctx.fillStyle = EVENT_MARKER_TEXT_COLOR;
+                            ctx.textBaseline = 'middle';
+                            ctx.fillText(label, boxX + padX, boxY + boxH / 2);
+                        }
+                        ctx.restore();
+                    },
+                });
+            } catch (_) {
+                /* duplicate-registration is fine */
+            }
+        }
+
+        const failureTypes = [
+            { value: 'none', text: 'None' },
+            { value: '404', text: '404' },
+            { value: '500', text: '500' },
+            { value: 'timeout', text: 'Timeout' },
+            { value: 'connection_refused', text: 'Conn Refused' },
+            { value: 'dns_failure', text: 'DNS Failure' },
+            { value: 'rate_limiting', text: 'Rate Limit' }
+        ];
+
+        const unitOptions = [
+            { value: 'requests', text: 'Requests' },
+            { value: 'seconds', text: 'Seconds' }
+        ];
+
+        const sessionsById = new Map();
+        const selectedSessionIds = new Set();
+        const pendingFailureEdits = new Map();
+        const controlRevisionBySession = new Map();
+        let activeSessionId = null;
+        let isTabLocked = false;
+        let lastAppliedSnapshotVersion = 0;
+        const failureSaveTimers = new Map();
+        const failureSaveFields = new Map();
+        const bandwidthHistory = new Map();
+        const bandwidthEventHistory = new Map();
+        const bandwidthCharts = new Map();
+        const bufferDepthCharts = new Map();
+        const videoFpsCharts = new Map();
+        const eventsCharts = new Map();
+        const eventsTimelines = new Map();
+        // Width reserved on the RIGHT side of every chart's plot area
+        // so the four Chart.js charts (bandwidth, buffer, fps, events
+        // scatter) and the vis-timeline events-timeline above all end
+        // at the same X coordinate. Sized to fit the FPS chart's
+        // right-side "Dropped/s" Y-axis (numeric ticks + rotated title).
+        const RIGHT_AXIS_PAD_PX = 60;
+        // Per-session collapse state for the PLAYER / SERVER section
+        // headers. setGroups replaces the entire groups dataset on
+        // every render, which would otherwise reset the user's
+        // collapse choice to default (expanded) every tick. We read
+        // the live state from the timeline before each rebuild and
+        // mirror it here so the choice survives across renders AND
+        // across full timeline re-creations (e.g. orphan-detection
+        // rebuilds when the session card is regenerated).
+        const eventsTimelineSectionCollapsed = new Map();
+        const chartViewportBySession = new Map();
+        const chartPausedBySession = new Map();
+        // Set of session_ids whose main brush is currently being dragged
+        // by the user. Brush handlers in session-replay.js add/delete
+        // entries here; ambient timers (e.g. the network-log auto-
+        // refresh) check it to skip work that would visually flicker
+        // mid-gesture and only resume on release.
+        const brushDraggingBySession = new Set();
+
+        // Per-session play bounds (in ms) — start and end timestamps of
+        // the currently-viewed play. session-replay.js sets these when
+        // the session-viewer page loads and updates them as live-tail
+        // extends sessionEndMs. Other modules (the network log fetch
+        // in particular) use them to scope analytics queries to this
+        // play instead of pulling all rows for the session_id.
+        const playBoundsBySession = new Map();
+
+        // Per-session override of the chart's rolling time window (in ms).
+        // Default (no entry) is 10 minutes — the live-mode value used by
+        // testing.html. Replay mode sets this to match the brush span so
+        // expanding the focus window past 10 minutes actually grows the
+        // chart's time range instead of being silently clipped.
+        const chartWindowMsBySession = new Map();
+        const DEFAULT_CHART_WINDOW_MS = 10 * 60 * 1000;
+        const getChartWindowMs = (sessionId) => {
+            const v = chartWindowMsBySession.get(String(sessionId || ''));
+            return Number.isFinite(v) && v > 0 ? v : DEFAULT_CHART_WINDOW_MS;
+        };
+
+        // Refcount of active chart-render suppressions per session_id
+        // — used by the brush-move replay loop to feed many snapshots
+        // through pushBandwidthSample without paying for a Chart.js
+        // update on every one. A Map of sessionId → integer depth
+        // (rather than a Set) handles overlapping replayWindow calls
+        // correctly: if two calls suppress concurrently, both must
+        // unsuppress before the count reaches 0 and renders resume.
+        const chartRenderSuppressionByDepth = new Map();
+        // Public Set-like façade so callers don't need to know the
+        // implementation detail. Exposed methods: enter(sessionId)
+        // increments the depth, exit(sessionId) decrements (clamped
+        // to 0), has(sessionId) reports whether render is suppressed.
+        const chartRenderSuppressedBySession = {
+            enter(sessionId) {
+                const k = String(sessionId || '');
+                chartRenderSuppressionByDepth.set(k, (chartRenderSuppressionByDepth.get(k) || 0) + 1);
+            },
+            exit(sessionId) {
+                const k = String(sessionId || '');
+                const d = (chartRenderSuppressionByDepth.get(k) || 0) - 1;
+                if (d <= 0) chartRenderSuppressionByDepth.delete(k);
+                else chartRenderSuppressionByDepth.set(k, d);
+            },
+            has(sessionId) {
+                return (chartRenderSuppressionByDepth.get(String(sessionId || '')) || 0) > 0;
+            }
+        };
+        const bandwidthVisibility = new Map();
+        const bitrateAxisMaxBySession = new Map();
+        const lastRecordedPlayerEventBySession = new Map();
+        const lastRecordedLoopCountBySession = new Map();
+        const lastRecordedServerLoopCountBySession = new Map();
+        const lastRecordedLoopEventStampBySession = new Map();
+        const lastRecordedServerLoopEventStampBySession = new Map();
+        // Per-session memo of the most-recently-seen play_id. When this
+        // changes between snapshots we emit a PLAYBACK_START event into
+        // the PLAYBACK swim lane — the visual marker for "fresh
+        // loadStream() on the client". The first observed value seeds
+        // the memo without firing (so a session-card reload doesn't
+        // pretend playback restarted).
+        const lastRecordedPlayIdBySession = new Map();
+        const pendingShaping = new Map();
+        // Per-session memo of last-seen control-attribute values. Drives the
+        // CONTROL swim lane: whenever any of these fields differs from the
+        // previously seen snapshot for a given session, we emit a
+        // CONTROL_CHANGE event with field name + old → new value. Tracked
+        // fields mirror the Grafana "Control changes" panel so the in-page
+        // and dashboard views agree.
+        const lastRecordedControlsBySession = new Map();
+        const CONTROL_FIELDS = [
+            'nftables_bandwidth_mbps', 'nftables_pattern_enabled',
+            'nftables_pattern_template_mode', 'nftables_delay_ms', 'nftables_packet_loss',
+            'transport_fault_active', 'transport_fault_type',
+            'transport_fault_drop_packets', 'transport_fault_reject_packets',
+            'manifest_failure_type', 'manifest_failure_mode', 'manifest_failure_frequency',
+            'segment_failure_type', 'segment_failure_mode', 'segment_failure_frequency',
+            'transport_failure_type', 'all_failure_type', 'master_manifest_failure_type',
+            'transfer_active_timeout_seconds', 'transfer_idle_timeout_seconds'
+        ];
+
+        function shapingValuesMatch(serverSession, pendingValues) {
+            if (!serverSession || !pendingValues) return false;
+            const sameNumber = (a, b, tolerance = 0.001) => {
+                const left = Number(a);
+                const right = Number(b);
+                if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+                return Math.abs(left - right) <= tolerance;
+            };
+            const sameBool = (a, b) => {
+                const toBool = (value) => value === true || value === 1 || value === 'true';
+                return toBool(a) === toBool(b);
+            };
+            const sameJson = (a, b) => {
+                try {
+                    return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+                } catch {
+                    return false;
+                }
+            };
+            if (!sameNumber(serverSession.nftables_bandwidth_mbps, pendingValues.nftables_bandwidth_mbps, 0.01)) return false;
+            if (!sameNumber(serverSession.nftables_delay_ms, pendingValues.nftables_delay_ms, 0.1)) return false;
+            if (!sameNumber(serverSession.nftables_packet_loss, pendingValues.nftables_packet_loss, 0.01)) return false;
+            if (!sameBool(serverSession.nftables_pattern_enabled, pendingValues.nftables_pattern_enabled)) return false;
+            if (!sameJson(serverSession.nftables_pattern_steps, pendingValues.nftables_pattern_steps)) return false;
+            return true;
+        }
+        const shapingTimers = new Map();
+        const collapseState = new Map();
+        const collapseDefaults = {
+            'session-details': true,
+            'player-metrics': false,
+            'fault-injection': false,
+            'network-shaping': false,
+            'bitrate-chart': false
+        };
+        const collapseStoragePrefix = 'testing_collapse_';
+
+        function getStoredCollapseState(key) {
+            try {
+                const value = localStorage.getItem(`${collapseStoragePrefix}${key}`);
+                if (value === null) return undefined;
+                return value === 'true';
+            } catch (err) {
+                return undefined;
+            }
+        }
+
+        function getSessionSnapshotVersion(session) {
+            const uiVersion = Number(session?.ui_state_version);
+            if (Number.isFinite(uiVersion) && uiVersion > 0) {
+                return uiVersion;
+            }
+            const controlRevisionMs = Date.parse(String(session?.control_revision || ''));
+            if (Number.isFinite(controlRevisionMs) && controlRevisionMs > 0) {
+                return controlRevisionMs;
+            }
+            return 0;
+        }
+
+        function setStoredCollapseState(key, value) {
+            try {
+                localStorage.setItem(`${collapseStoragePrefix}${key}`, value ? 'true' : 'false');
+            } catch (err) {
+                collapseState.set(key, !!value);
+            }
+        }
+
+        window.TestingSessionUICollapseState = {
+            get: (key) => {
+                const stored = getStoredCollapseState(key);
+                if (typeof stored === 'boolean') return stored;
+                if (collapseState.has(key)) return collapseState.get(key);
+                return collapseDefaults[key];
+            },
+            set: (key, value) => {
+                collapseState.set(key, !!value);
+                setStoredCollapseState(key, value);
+            }
+        };
+
+        const TestingSessionUI = window.TestingSessionUI;
+        const isDeveloperMode = new URLSearchParams(window.location.search).get('developer') === '1';
+
+        function mountPlayerCharacterizationForCard(card, session) {
+            if (!isDeveloperMode) return;
+            if (!card || !session) return;
+            const host = card.querySelector('[data-field="player_characterization_host"]');
+            if (!host) return;
+            if (!window.PlayerCharacterization || typeof window.PlayerCharacterization.mount !== 'function') return;
+            const mountKey = `session-${session.session_id}`;
+            if (host.dataset.abrcharMounted === mountKey) return;
+            window.PlayerCharacterization.mount({
+                hostElement: host,
+                instanceKey: mountKey,
+                getSession: () => {
+                    if (!activeSessionId) return null;
+                    return sessionsById.get(String(activeSessionId)) || null;
+                },
+                getCurrentUrl: () => {
+                    const current = activeSessionId ? sessionsById.get(String(activeSessionId)) : null;
+                    return current ? (current.master_manifest_url || current.manifest_url || '') : '';
+                }
+            });
+            host.dataset.abrcharMounted = mountKey;
+        }
+
+        function getShapingPresets(card) {
+            const raw = card.dataset.shapingPresets || '';
+            if (!raw) return [];
+            try {
+                const parsed = JSON.parse(decodeURIComponent(raw));
+                return Array.isArray(parsed) ? parsed : [];
+            } catch (err) {
+                console.warn('Failed to parse shaping presets', err);
+                return [];
+            }
+        }
+
+        function getShapingVideoPresets(card) {
+            const raw = card.dataset.shapingVideoPresets || '';
+            if (!raw) return [];
+            try {
+                const parsed = JSON.parse(decodeURIComponent(raw));
+                return Array.isArray(parsed) ? parsed : [];
+            } catch (err) {
+                console.warn('Failed to parse shaping video presets', err);
+                return [];
+            }
+        }
+
+        function getShapingOverheadMbps(card) {
+            const parsed = Number(card.dataset.shapingOverheadMbps || 0);
+            if (!Number.isFinite(parsed) || parsed < 0) return 0;
+            return parsed;
+        }
+
+        function getStallRiskThresholdMbps(card) {
+            const videoPresets = getShapingVideoPresets(card);
+            if (!videoPresets.length) return null;
+            const minVideo = Math.min(...videoPresets
+                .map((preset) => Number(preset.mbps))
+                .filter((value) => Number.isFinite(value) && value > 0));
+            if (!Number.isFinite(minVideo) || minVideo <= 0) return null;
+            return Math.round(minVideo * 1.1 * 1000) / 1000;
+        }
+
+        function normalizeBitrateAxisMaxMode(value) {
+            const normalized = String(value || 'auto').toLowerCase();
+            return ['auto', '5', '10', '20', '30', '40', '50', '100'].includes(normalized) ? normalized : 'auto';
+        }
+
+        function updateStepRiskUi(card, row) {
+            if (!card || !row) return;
+            const enabled = !!row.querySelector('input[data-field="shaping_step_enabled"]')?.checked;
+            const threshold = getStallRiskThresholdMbps(card);
+            const rate = Number(row.querySelector('input[data-field="shaping_step_mbps"]')?.value ?? 0);
+            const isRisk = enabled && Number.isFinite(threshold) && Number.isFinite(rate) && rate > 0 && rate < threshold;
+            row.classList.toggle('shape-step-risk', isRisk);
+            if (isRisk) {
+                row.title = `Likely stall risk: ${rate} Mbps is below min variant +10% (${threshold} Mbps)`;
+            } else {
+                row.removeAttribute('title');
+            }
+        }
+
+        function updateAllStepRiskUi(card) {
+            if (!card) return;
+            card.querySelectorAll('.shape-step-row').forEach((row) => updateStepRiskUi(card, row));
+        }
+
+        function syncStepPreset(row) {
+            const presetSelect = row.querySelector('select[data-field="shaping_step_mbps_preset"]');
+            const mbpsInput = row.querySelector('input[data-field="shaping_step_mbps"]');
+            if (!presetSelect || !mbpsInput) return;
+            const value = Number(mbpsInput.value);
+            if (!Number.isFinite(value)) {
+                presetSelect.value = 'custom';
+                return;
+            }
+            const matched = Array.from(presetSelect.options).find((option) => {
+                if (option.value === 'custom') return false;
+                return Math.abs(Number(option.value) - value) < 0.001;
+            });
+            presetSelect.value = matched ? matched.value : 'custom';
+        }
+
+        function setStepEnabledUi(card, row, enabled) {
+            row.classList.toggle('shape-step-disabled', !enabled);
+            row.querySelectorAll('select[data-field="shaping_step_mbps_preset"], input[data-field="shaping_step_mbps"], input[data-field="shaping_step_seconds"]').forEach((el) => {
+                el.disabled = !enabled;
+            });
+            updateStepRiskUi(card, row);
+        }
+
+        function makeShapeStepRow(card, rate, seconds, enabled = true, matchOptions = {}) {
+            const row = document.createElement('div');
+            row.className = 'shape-step-row';
+            row.innerHTML = TestingSessionUI.renderPatternStepRowContent(
+                { rate_mbps: rate, duration_seconds: seconds, enabled },
+                getShapingPresets(card),
+                matchOptions
+            );
+            syncStepPreset(row);
+            setStepEnabledUi(card, row, enabled);
+            return row;
+        }
+
+        function updateStepIndices(card) {
+            const rows = card.querySelectorAll('.shape-step-row');
+            rows.forEach((row, idx) => {
+                row.dataset.stepIndex = String(idx);
+            });
+        }
+
+        function getDefaultStepSeconds(card) {
+            const pattern = TestingSessionUI.readShapingPattern(card);
+            return pattern.default_step_seconds;
+        }
+
+        function getTemplateMode(card) {
+            const selected = card.querySelector('input[data-field="shaping_template_mode"]:checked');
+            return selected ? selected.value : 'sliders';
+        }
+
+        function updateTemplateModeUi(card) {
+            const mode = getTemplateMode(card);
+            const throughputRow = card.querySelector('[data-field="shaping_throughput_row"]');
+            const throughputInput = card.querySelector('input[data-field="shaping_throughput_mbps"]');
+            const stepList = card.querySelector('[data-field="shaping_pattern_rows"]');
+            const stepActions = card.querySelector('.shape-step-actions');
+            const applyButton = card.querySelector('[data-field="shaping_apply_pattern_row"]');
+            const usePattern = mode !== 'sliders';
+            if (throughputRow) throughputRow.classList.toggle('range-row-disabled', usePattern);
+            if (throughputInput) throughputInput.disabled = usePattern;
+            if (stepList) stepList.style.display = usePattern ? '' : 'none';
+            if (stepActions) stepActions.style.display = usePattern ? '' : 'none';
+            if (applyButton) applyButton.style.display = usePattern ? '' : 'none';
+        }
+
+        function buildTemplateSteps(card) {
+            const mode = getTemplateMode(card);
+            const presets = getShapingVideoPresets(card);
+            if (mode === 'sliders' || !presets.length) return [];
+            const marginPct = Number(card.querySelector('input[data-field="shaping_template_margin_pct"]:checked')?.value || 0);
+            const overheadMbps = getShapingOverheadMbps(card);
+            const defaultSeconds = getDefaultStepSeconds(card);
+            const adjustRate = (rate) => {
+                let adjusted = Number(rate);
+                if (!Number.isFinite(adjusted)) adjusted = 0;
+                adjusted = adjusted * (1 + (marginPct / 100));
+                adjusted += overheadMbps;
+                if (adjusted < 0) adjusted = 0;
+                return Math.round(adjusted * 1000) / 1000;
+            };
+            const baseRates = presets
+                .map((preset) => Number(preset.mbps))
+                .filter((rate) => Number.isFinite(rate) && rate >= 0);
+            if (!baseRates.length) return [];
+            const minRate = baseRates[0];
+            const maxRate = baseRates[baseRates.length - 1];
+            const maxRatePlus50 = Math.round(maxRate * 1.5 * 1000) / 1000;
+            let rates = [];
+            if (mode === 'square_wave') {
+                rates = maxRatePlus50 === minRate ? [maxRatePlus50] : [maxRatePlus50, minRate];
+            } else if (mode === 'ramp_up') {
+                rates = baseRates.slice();
+                if (maxRatePlus50 > maxRate) rates.push(maxRatePlus50);
+            } else if (mode === 'ramp_down') {
+                rates = baseRates.slice().reverse();
+                if (maxRatePlus50 > maxRate) rates.unshift(maxRatePlus50);
+            } else if (mode === 'pyramid') {
+                const ascending = baseRates.slice();
+                if (maxRatePlus50 > maxRate) ascending.push(maxRatePlus50);
+                rates = ascending.concat(ascending.slice(0, -1).reverse());
+            }
+            return rates
+                .filter((rate) => Number.isFinite(rate) && rate >= 0)
+                .map((rate) => ({ rate_mbps: adjustRate(rate), duration_seconds: defaultSeconds }));
+        }
+
+        function applyTemplatePattern(card, shouldSchedule, resetState = false, preserveStepDurations = true) {
+            const mode = getTemplateMode(card);
+            const rowsHost = card.querySelector('[data-field="shaping_pattern_rows"]');
+
+            // Capture current step states before regenerating (unless resetting)
+            const currentSteps = [];
+            if (rowsHost && !resetState) {
+                const existingRows = rowsHost.querySelectorAll('.shape-step-row');
+                existingRows.forEach((row) => {
+                    const presetSelect = row.querySelector('select[data-field="shaping_step_mbps_preset"]');
+                    const mbpsInput = row.querySelector('input[data-field="shaping_step_mbps"]');
+                    const secondsInput = row.querySelector('input[data-field="shaping_step_seconds"]');
+                    const enabledCheckbox = row.querySelector('input[data-field="shaping_step_enabled"]');
+                    currentSteps.push({
+                        isCustom: presetSelect?.value === 'custom',
+                        customMbps: mbpsInput ? Number(mbpsInput.value) : null,
+                        customSeconds: secondsInput ? Number(secondsInput.value) : null,
+                        enabled: enabledCheckbox ? enabledCheckbox.checked : true
+                    });
+                });
+            }
+
+            const steps = buildTemplateSteps(card);
+            updateTemplateModeUi(card);
+            if (rowsHost && mode !== 'sliders' && steps.length > 0) {
+                // Preserve custom values and disabled states (unless resetting)
+                if (!resetState) {
+                    steps.forEach((step, index) => {
+                        if (currentSteps[index]) {
+                            if (currentSteps[index].isCustom && Number.isFinite(currentSteps[index].customMbps)) {
+                                step.rate_mbps = currentSteps[index].customMbps;
+                            }
+                            if (preserveStepDurations && Number.isFinite(currentSteps[index].customSeconds)) {
+                                step.duration_seconds = currentSteps[index].customSeconds;
+                            }
+                            step.enabled = currentSteps[index].enabled;
+                        }
+                    });
+                }
+
+                // Get current margin and overhead for preset labels
+                const marginPct = Number(card.querySelector('input[data-field="shaping_template_margin_pct"]:checked')?.value || 0);
+                const overheadMbps = getShapingOverheadMbps(card);
+                const matchOptions = { marginPct, overheadMbps };
+
+                rowsHost.innerHTML = '';
+                steps.forEach((step) => {
+                    rowsHost.appendChild(makeShapeStepRow(card, step.rate_mbps, step.duration_seconds, step.enabled, matchOptions));
+                });
+                updateStepIndices(card);
+                const throughputInput = card.querySelector('input[data-field="shaping_throughput_mbps"]');
+                const throughputValue = card.querySelector('[data-field="shaping_throughput_row"] .range-value');
+                if (throughputInput) throughputInput.value = String(steps[0].rate_mbps);
+                if (throughputValue) throughputValue.textContent = String(steps[0].rate_mbps);
+            }
+            if (shouldSchedule) {
+                scheduleShapingApply(card);
+            }
+        }
+
+        function scheduleShapingApply(card) {
+            const sessionId = card.dataset.sessionId;
+            if (sessionId && isAbrcharRunLocked(sessionId)) {
+                console.warn('[NETSHAPE] Ignoring manual shaping update while ABR characterization lock is active.');
+                return;
+            }
+            if (sessionId) {
+                const getValue = (field) => {
+                    const input = card.querySelector(`input[data-field="${field}"]`);
+                    return input ? Number(input.value) : 0;
+                };
+                const pattern = TestingSessionUI.readShapingPattern(card);
+                const usePattern = pattern.template_mode !== 'sliders'
+                    && Array.isArray(pattern.steps)
+                    && pattern.steps.length > 0;
+                pendingShaping.set(sessionId, {
+                    timestamp: Date.now(),
+                    values: {
+                        nftables_bandwidth_mbps: getValue('shaping_throughput_mbps'),
+                        nftables_delay_ms: getValue('shaping_delay_ms'),
+                        nftables_packet_loss: getValue('shaping_loss_pct'),
+                        nftables_pattern_enabled: usePattern,
+                        nftables_pattern_steps: usePattern ? (pattern.steps || []) : [],
+                        nftables_pattern_segment_duration_seconds: pattern.segment_duration_seconds,
+                        nftables_pattern_default_segments: pattern.default_segments,
+                        nftables_pattern_default_step_seconds: pattern.default_step_seconds,
+                        nftables_pattern_template_mode: pattern.template_mode,
+                        nftables_pattern_margin_pct: pattern.template_margin_pct
+                    }
+                });
+            }
+            if (shapingTimers.has(sessionId)) {
+                clearTimeout(shapingTimers.get(sessionId));
+            }
+            shapingTimers.set(sessionId, setTimeout(() => {
+                applyNetworkShapingForCard(card).catch(error => console.error('Error applying network shaping:', error));
+            }, 250));
+        }
+
+        function scheduleSingleShapingApply(card, serverField, value) {
+            const sessionId = card.dataset.sessionId;
+            if (!sessionId) return;
+            if (isAbrcharRunLocked(sessionId)) return;
+            const existing = pendingShaping.get(sessionId);
+            const values = existing ? { ...existing.values } : {};
+            values[serverField] = value;
+            pendingShaping.set(sessionId, { timestamp: Date.now(), values });
+            if (shapingTimers.has(sessionId)) {
+                clearTimeout(shapingTimers.get(sessionId));
+            }
+            shapingTimers.set(sessionId, setTimeout(() => {
+                const pending = pendingShaping.get(sessionId);
+                if (!pending) return;
+                const fields = Object.keys(pending.values);
+                sendSessionPatch(card, fields);
+            }, 250));
+        }
+
+        function renderSessionTabs(sessions) {
+            if (!sessions.length) return '';
+            const hasMultipleSessions = sessions.length > 1;
+            const validIds = new Set(sessions.map(s => String(s.session_id)));
+            Array.from(selectedSessionIds).forEach(id => {
+                if (!validIds.has(String(id))) selectedSessionIds.delete(id);
+            });
+
+            return `
+                ${hasMultipleSessions ? `
+                <div class="group-controls">
+                    <button class="btn btn-sm btn-secondary" id="linkSelectedSessions">Group Selected Sessions</button>
+                    <span class="status-message" data-role="link-status">Select 2+ sessions to group</span>
+                </div>
+                ` : ''}
+                <div class="session-tabs">
+                    ${sessions.map(session => {
+                        const id = session.session_id;
+                        const isActive = id === activeSessionId ? 'active' : '';
+                        const isGrouped = session.group_id ? 'grouped' : '';
+                        const portValue = session.x_forwarded_port_external || session.x_forwarded_port || '';
+                        const portSuffix = portValue ? ` (Port ${portValue})` : '';
+                        const label = `Session ${id}${portSuffix} · ${session.player_id || 'Unknown Player'}`;
+                        const groupBadge = session.group_id ? `<span class="group-badge">${session.group_id}</span>` : '';
+                        const isChecked = selectedSessionIds.has(String(id)) ? 'checked' : '';
+                        const checkbox = hasMultipleSessions ?
+                            `<input type="checkbox" class="session-checkbox" data-session-id="${id}" ${isChecked}>` : '';
+                        return `<button class="session-tab ${isActive} ${isGrouped}" data-session-tab="${id}">
+                            ${checkbox}${label}${groupBadge}
+                        </button>`;
+                    }).join('')}
+                </div>
+            `;
+        }
+
+        function updateTabsAndGroupInfo(container, sessions, activeSession) {
+            if (!container) return;
+            // Replay viewer renders no tabs/group chip, so don't re-introduce
+            // them on later partial updates either.
+            if (document.body.classList.contains('replay-mode')) {
+                container.querySelector('.session-tabs')?.remove();
+                container.querySelector('.group-controls')?.remove();
+                container.querySelector('.group-info')?.remove();
+                return;
+            }
+            const tabsHost = document.createElement('div');
+            tabsHost.innerHTML = renderSessionTabs(sessions);
+            const nextGroupControls = tabsHost.querySelector('.group-controls');
+            const nextTabs = tabsHost.querySelector('.session-tabs');
+            const existingGroupControls = container.querySelector('.group-controls');
+            const existingTabs = container.querySelector('.session-tabs');
+            if (nextGroupControls) {
+                if (existingGroupControls) {
+                    existingGroupControls.replaceWith(nextGroupControls);
+                } else {
+                    container.prepend(nextGroupControls);
+                }
+            } else if (existingGroupControls) {
+                existingGroupControls.remove();
+            }
+            if (nextTabs) {
+                if (existingTabs) {
+                    existingTabs.replaceWith(nextTabs);
+                } else {
+                    const insertAfter = container.querySelector('.group-controls');
+                    if (insertAfter) {
+                        insertAfter.insertAdjacentElement('afterend', nextTabs);
+                    } else {
+                        container.prepend(nextTabs);
+                    }
+                }
+            }
+            const groupHost = document.createElement('div');
+            groupHost.innerHTML = activeSession ? renderGroupInfo(activeSession, sessions) : '';
+            const nextGroupInfo = groupHost.querySelector('.group-info');
+            const existingGroupInfo = container.querySelector('.group-info');
+            if (nextGroupInfo) {
+                if (existingGroupInfo) {
+                    existingGroupInfo.replaceWith(nextGroupInfo);
+                } else {
+                    const card = container.querySelector('.session-card');
+                    if (card) {
+                        card.insertAdjacentElement('beforebegin', nextGroupInfo);
+                    } else if (nextTabs) {
+                        nextTabs.insertAdjacentElement('afterend', nextGroupInfo);
+                    } else {
+                        container.appendChild(nextGroupInfo);
+                    }
+                }
+            } else if (existingGroupInfo) {
+                existingGroupInfo.remove();
+            }
+        }
+
+        function updateSessionDetailFields(card, session) {
+            if (!card || !session) return;
+            const setField = (field, value) => {
+                const el = card.querySelector(`[data-field="${field}"]`);
+                if (el) el.textContent = value;
+            };
+            setField('session_session_id', session.session_id || '—');
+            setField('session_play_id', session.play_id || '—');
+            setField('session_player_id', session.player_id || '—');
+            setField('session_user_agent', session.user_agent || '—');
+            setField('session_player_ip', session.player_ip || '—');
+            setField('session_port_display', session.x_forwarded_port_external || session.x_forwarded_port || '—');
+            setField('session_last_request', TestingSessionUI.formatDate(session.last_request));
+            setField('session_first_request', TestingSessionUI.formatDate(session.first_request_time));
+            setField('session_duration', TestingSessionUI.formatDuration(session.session_duration));
+            setField('session_manifest_url', session.manifest_url || '—');
+            setField('session_master_manifest_url', session.master_manifest_url || '—');
+            setField('session_last_request_url', session.last_request_url || '—');
+            setField('session_measured_mbps', session.measured_mbps ?? '—');
+            setField('session_mbps_shaper_rate', session.mbps_shaper_rate ?? '—');
+            setField('session_mbps_shaper_avg', session.mbps_shaper_avg ?? '—');
+            setField('session_mbps_transfer_rate', session.mbps_transfer_rate ?? '—');
+            setField('session_mbps_transfer_complete', session.mbps_transfer_complete ?? '—');
+            const counts = card.querySelector('[data-field="session_detail_counts"]');
+            if (counts) {
+                const masterCount = session.master_manifest_requests_count || 0;
+                const manifestCount = session.manifest_requests_count || 0;
+                const segmentCount = session.segments_count || 0;
+                counts.textContent = `M:${masterCount} / Man:${manifestCount} / Seg:${segmentCount}`;
+            }
+        }
+
+        function normalizeTransportFaultType(session) {
+            const raw = String(session.transport_failure_type || session.transport_fault_type || 'none').toLowerCase();
+            if (raw === 'drop' || raw === 'reject') return raw;
+            return 'none';
+        }
+
+        function normalizeTransportFailureMode(session) {
+            const modeRaw = String(session.transport_failure_mode || '').toLowerCase();
+            if (modeRaw === 'failures_per_packets' || modeRaw === 'failures_per_packet') {
+                return 'failures_per_packets';
+            }
+            const unitsRaw = String(session.transport_consecutive_units || session.transport_failure_units || '').toLowerCase();
+            if (unitsRaw === 'packet' || unitsRaw === 'packets' || unitsRaw === 'pkt' || unitsRaw === 'pkts') {
+                return 'failures_per_packets';
+            }
+            return 'failures_per_seconds';
+        }
+
+        function getControlRevision(session) {
+            const revision = session ? session.control_revision : null;
+            if (revision === undefined || revision === null || revision === '') {
+                return null;
+            }
+            return String(revision);
+        }
+
+        function shouldSyncControls(sessionId, session) {
+            const key = String(sessionId || session?.session_id || '');
+            if (!key) return true;
+            const revision = getControlRevision(session);
+            const lastRevision = controlRevisionBySession.get(key);
+            if (revision === null) {
+                if (lastRevision === undefined) {
+                    controlRevisionBySession.set(key, null);
+                    return true;
+                }
+                return false;
+            }
+            if (lastRevision !== revision) {
+                controlRevisionBySession.set(key, revision);
+                return true;
+            }
+            return false;
+        }
+
+        function isAbrcharRunLocked(sessionId) {
+            const key = String(sessionId || '');
+            if (!key) return false;
+            const session = sessionsById.get(key);
+            if (!session) return false;
+            return session.abrchar_run_lock === true
+                || session.abrchar_run_lock === 1
+                || session.abrchar_run_lock === 'true';
+        }
+
+        function applyActiveFaultTab(card, tabName) {
+            if (!card || !tabName) return;
+            const container = card.querySelector('.tabs-container');
+            if (!container) return;
+            const targetButton = container.querySelector(`.tab-button[data-tab="${tabName}"]`);
+            const targetPanel = container.querySelector(`.tab-panel[data-panel="${tabName}"]`);
+            if (!targetButton || !targetPanel) return;
+            container.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
+            targetButton.classList.add('active');
+            container.querySelectorAll('.tab-panel').forEach(panel => panel.classList.remove('active'));
+            targetPanel.classList.add('active');
+        }
+
+        function syncContentControls(card, session) {
+            if (!card || !session) return;
+            const strip = card.querySelector('input[data-field="content_strip_codecs"]');
+            if (strip) {
+                strip.checked = !!session.content_strip_codecs;
+            }
+            const liveOffsetVal = String(session.content_live_offset || 'none');
+            card.querySelectorAll('input[data-field="content_live_offset"]').forEach(radio => {
+                radio.checked = (radio.value === liveOffsetVal) || (liveOffsetVal === '0' && radio.value === 'none');
+            });
+            const allowed = Array.isArray(session.content_allowed_variants)
+                ? session.content_allowed_variants.map(String)
+                : [];
+            const allowedSet = new Set(allowed);
+            const allChecked = allowedSet.size === 0;
+            card.querySelectorAll('input[data-field="content_allowed_variants"]').forEach((input) => {
+                input.checked = allChecked || allowedSet.has(String(input.value));
+            });
+        }
+
+        function syncServerFaultControls(card, session) {
+            if (!card || !session) return;
+            const sessionId = String(card.dataset.sessionId || session.session_id || '');
+            if (!sessionId) return;
+            const syncSelect = (namePrefix, value) => {
+                const select = card.querySelector(`select[name="${namePrefix}_${sessionId}"]`);
+                if (select && value) {
+                    select.value = value;
+                }
+            };
+            const syncRange = (field, value, fallback) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (!input) return;
+                const numeric = Number(value);
+                const resolved = Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+                input.value = String(resolved);
+                const valueEl = input.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = input.value;
+            };
+            const syncFailureScope = (field, values) => {
+                const selected = Array.isArray(values) ? values.map(String) : [];
+                const selectedSet = new Set(selected);
+                const allChecked = values == null
+                    ? true
+                    : selectedSet.has('All');
+                card.querySelectorAll(`input[data-field="${field}"]`).forEach(input => {
+                    if (input.value === 'All') {
+                        input.checked = allChecked;
+                        return;
+                    }
+                    input.checked = allChecked || selectedSet.has(input.value);
+                });
+            };
+            const syncRadio = (namePrefix, value) => {
+                const radios = card.querySelectorAll(`input[name="${namePrefix}_${sessionId}"]`);
+                radios.forEach((radio) => {
+                    radio.checked = radio.value === value;
+                });
+            };
+            syncRadio('segment_failure_type', String(session.segment_failure_type || 'none'));
+            syncRadio('manifest_failure_type', String(session.manifest_failure_type || 'none'));
+            syncRadio('master_manifest_failure_type', String(session.master_manifest_failure_type || 'none'));
+            syncRadio('all_failure_type', String(session.all_failure_type || 'none'));
+            syncRadio('transport_failure_type', normalizeTransportFaultType(session));
+            syncRadio('transport_failure_mode', normalizeTransportFailureMode(session));
+            syncSelect('segment_failure_mode', String(session.segment_failure_mode || 'failures_per_seconds'));
+            syncSelect('manifest_failure_mode', String(session.manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('master_manifest_failure_mode', String(session.master_manifest_failure_mode || 'failures_per_seconds'));
+            syncSelect('all_failure_mode', String(session.all_failure_mode || 'failures_per_seconds'));
+            syncRange('segment_consecutive_failures', session.segment_consecutive_failures, 1);
+            syncRange('segment_failure_frequency', session.segment_failure_frequency, 6);
+            syncRange('manifest_consecutive_failures', session.manifest_consecutive_failures, 1);
+            syncRange('manifest_failure_frequency', session.manifest_failure_frequency, 6);
+            syncRange('master_manifest_consecutive_failures', session.master_manifest_consecutive_failures, 1);
+            syncRange('master_manifest_failure_frequency', session.master_manifest_failure_frequency, 6);
+            syncRange('all_consecutive_failures', session.all_consecutive_failures, 1);
+            syncRange('all_failure_frequency', session.all_failure_frequency, 6);
+            syncFailureScope('segment_failure_urls', session.segment_failure_urls, true);
+            syncFailureScope('manifest_failure_urls', session.manifest_failure_urls, true);
+            syncFailureScope('all_failure_urls', session.all_failure_urls, true);
+            TestingSessionUI.updateTransportModeUi(card);
+            const transportConsecutiveInput = card.querySelector('input[data-field="transport_consecutive_failures"]');
+            const transportFrequencyInput = card.querySelector('input[data-field="transport_failure_frequency"]');
+            if (transportConsecutiveInput) {
+                const value = Number(
+                    session.transport_consecutive_failures ??
+                    session.transport_consecutive_seconds ??
+                    session.transport_fault_on_seconds ??
+                    0
+                );
+                transportConsecutiveInput.value = String(Number.isFinite(value) ? value : 0);
+                const valueEl = transportConsecutiveInput.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = transportConsecutiveInput.value;
+            }
+            if (transportFrequencyInput) {
+                const value = Number(
+                    session.transport_failure_frequency ??
+                    session.transport_frequency_seconds ??
+                    session.transport_fault_off_seconds ??
+                    0
+                );
+                transportFrequencyInput.value = String(Number.isFinite(value) ? value : 0);
+                const valueEl = transportFrequencyInput.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = transportFrequencyInput.value;
+            }
+            syncRange('transfer_active_timeout_seconds', session.transfer_active_timeout_seconds, 0);
+            syncRange('transfer_idle_timeout_seconds', session.transfer_idle_timeout_seconds, 0);
+            const syncTransferCheckbox = (field, value) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (input) input.checked = !!value;
+            };
+            syncTransferCheckbox('transfer_timeout_applies_segments', session.transfer_timeout_applies_segments);
+            syncTransferCheckbox('transfer_timeout_applies_manifests', session.transfer_timeout_applies_manifests);
+            syncTransferCheckbox('transfer_timeout_applies_master', session.transfer_timeout_applies_master);
+        }
+
+        function syncServerFaultData(card, session) {
+            if (!card || !session) return;
+            const stateEl = card.querySelector('[data-field="transport_fault_state"]');
+            if (stateEl) {
+                stateEl.textContent = session.transport_fault_active ? 'Active' : 'Idle';
+            }
+            const countersEl = card.querySelector('[data-field="transport_fault_counters"]');
+            if (countersEl) {
+                const dropPackets = Number(session.transport_fault_drop_packets || 0);
+                const rejectPackets = Number(session.transport_fault_reject_packets || 0);
+                countersEl.textContent = `Drop ${dropPackets} pkts · Reject ${rejectPackets} pkts`;
+            }
+            const transferCountersEl = card.querySelector('[data-field="transfer_timeout_counters"]');
+            if (transferCountersEl) {
+                const activeCount = Number(session.fault_count_transfer_active_timeout || 0);
+                const idleCount = Number(session.fault_count_transfer_idle_timeout || 0);
+                transferCountersEl.textContent = `Active ${activeCount} · Idle ${idleCount}`;
+            }
+        }
+        function formatDate(value) {
+            if (!value) return '—';
+            const date = new Date(value);
+            return date.toLocaleString();
+        }
+        function formatMetricNumber(value, suffix = '') {
+            if (value === null || value === undefined || value === '') return '—';
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) return String(value);
+            const rounded = Math.round(numeric * 100) / 100;
+            return `${rounded}${suffix}`;
+        }
+        function formatSeconds(value) {
+            if (value === null || value === undefined || value === '') return '—';
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) return String(value);
+            return `${numeric.toFixed(3)}s`;
+        }
+
+        function parseVariantResolution(resolution) {
+            const value = String(resolution || '').trim().toLowerCase();
+            if (!value) return { width: null, height: null };
+            const dimensions = value.match(/(\d{3,4})\s*x\s*(\d{3,4})/i);
+            if (dimensions) {
+                return {
+                    width: Number(dimensions[1]),
+                    height: Number(dimensions[2])
+                };
+            }
+            const progressive = value.match(/(\d{3,4})\s*p$/i);
+            if (progressive) {
+                return {
+                    width: null,
+                    height: Number(progressive[1])
+                };
+            }
+            const numeric = Number(value);
+            if (Number.isFinite(numeric) && numeric > 0) {
+                return {
+                    width: null,
+                    height: numeric
+                };
+            }
+            return { width: null, height: null };
+        }
+
+        function parseVideoResolution(resolution) {
+            return parseVariantResolution(resolution);
+        }
+
+        function isSessionNativeSafari(session) {
+            const browser = String(session?.player_metrics_browser_family || '').trim().toLowerCase();
+            const engine = String(session?.player_metrics_playback_engine || '').trim().toLowerCase();
+            return browser === 'safari' && engine === 'native';
+        }
+
+        function inferSessionNativeRenditionMbps(session) {
+            if (!isSessionNativeSafari(session)) return null;
+            const videoResolution = parseVideoResolution(session?.player_metrics_video_resolution);
+            const videoHeight = Number(videoResolution.height || 0);
+            if (!Number.isFinite(videoHeight) || videoHeight <= 0) return null;
+            const videoWidth = Number(videoResolution.width || 0);
+            const variants = Array.isArray(session?.manifest_variants) ? session.manifest_variants : [];
+            if (!variants.length) return null;
+
+            let best = null;
+            variants.forEach((variant) => {
+                const bandwidth = Number(variant?.bandwidth || 0);
+                if (!Number.isFinite(bandwidth) || bandwidth <= 0) return;
+                const parsed = parseVariantResolution(variant?.resolution);
+                const height = Number(parsed.height || 0);
+                const width = Number(parsed.width || 0);
+                if (!Number.isFinite(height) || height <= 0) return;
+                const heightDelta = Math.abs(height - videoHeight);
+                const hasWidth = Number.isFinite(width) && width > 0 && Number.isFinite(videoWidth) && videoWidth > 0;
+                const widthDelta = hasWidth ? Math.abs(width - videoWidth) : 0;
+                const score = (heightDelta * 10000) + widthDelta;
+                if (!best || score < best.score || (score === best.score && bandwidth > best.bandwidth)) {
+                    best = { score, bandwidth };
+                }
+            });
+
+            if (!best) return null;
+            return Math.round((best.bandwidth / 1000000) * 1000) / 1000;
+        }
+
+        function updateThroughputSlider(card, session) {
+            if (!card || !session) return;
+            const patternEnabled = session.nftables_pattern_enabled === true
+                || session.nftables_pattern_enabled === 1
+                || session.nftables_pattern_enabled === 'true';
+            if (!patternEnabled) return;
+            const runtimeRate = Number(session.nftables_pattern_rate_runtime_mbps);
+            const stepIndex = Number(session.nftables_pattern_step_runtime || session.nftables_pattern_step || 0);
+            const steps = Array.isArray(session.nftables_pattern_steps) ? session.nftables_pattern_steps : [];
+            let stepRate = NaN;
+            if (stepIndex > 0 && stepIndex <= steps.length) {
+                stepRate = Number(steps[stepIndex - 1]?.rate_mbps);
+            }
+            const baseRate = Number(session.nftables_bandwidth_mbps);
+            let target = runtimeRate;
+            if (!Number.isFinite(target)) target = stepRate;
+            if (!Number.isFinite(target)) target = baseRate;
+            if (Number.isFinite(target) && target >= 0) {
+                const throughputInput = card.querySelector('input[data-field="shaping_throughput_mbps"]');
+                const throughputValue = card.querySelector('[data-field="shaping_throughput_row"] .range-value');
+                if (throughputInput) throughputInput.value = String(target);
+                if (throughputValue) throughputValue.textContent = String(target);
+            }
+        }
+
+        function updateSessionDetailData(card, session) {
+            if (!card || !session) return;
+            const setText = (selector, value) => {
+                const el = card.querySelector(selector);
+                if (!el) return;
+                el.textContent = value;
+            };
+            const inferredVideoBitrateMbps = inferSessionNativeRenditionMbps(session);
+            const rawVideoBitrate = Number(session.player_metrics_video_bitrate_mbps);
+            const hasMeasuredVideoBitrate = Number.isFinite(rawVideoBitrate) && rawVideoBitrate > 0;
+            const displayVideoBitrate = hasMeasuredVideoBitrate
+                ? formatMetricNumber(rawVideoBitrate, ' Mbps')
+                : (Number.isFinite(inferredVideoBitrateMbps) ? `~${formatMetricNumber(inferredVideoBitrateMbps, ' Mbps')}` : '—');
+            setText('[data-field="player_metrics_last_event"]', session.player_metrics_last_event || '—');
+            setText('[data-field="player_metrics_trigger_type"]', session.player_metrics_trigger_type || '—');
+            setText('[data-field="player_metrics_last_event_at"]', formatDate(session.player_metrics_last_event_at));
+            setText('[data-field="player_metrics_event_time"]', formatDate(session.player_metrics_event_time));
+            setText('[data-field="player_metrics_state"]', session.player_metrics_state || '—');
+            setText('[data-field="player_metrics_position_s"]', formatSeconds(session.player_metrics_position_s));
+            setText('[data-field="player_metrics_playback_rate"]', formatMetricNumber(session.player_metrics_playback_rate, 'x'));
+            setText('[data-field="player_metrics_buffer_depth_s"]', formatSeconds(session.player_metrics_buffer_depth_s));
+            setText('[data-field="player_metrics_buffer_end_s"]', formatSeconds(session.player_metrics_buffer_end_s));
+            setText('[data-field="player_metrics_seekable_end_s"]', formatSeconds(session.player_metrics_seekable_end_s));
+            setText('[data-field="player_metrics_live_edge_s"]', formatSeconds(session.player_metrics_live_edge_s));
+            setText('[data-field="player_metrics_live_offset_s"]', formatSeconds(session.player_metrics_live_offset_s));
+            setText('[data-field="player_metrics_true_offset_s"]', formatSeconds(session.player_metrics_true_offset_s));
+            setText('[data-field="player_metrics_display_resolution"]', session.player_metrics_display_resolution || '—');
+            setText('[data-field="player_metrics_video_resolution"]', session.player_metrics_video_resolution || '—');
+            setText('[data-field="player_metrics_video_first_frame_time_s"]', formatSeconds(session.player_metrics_video_first_frame_time_s));
+            setText('[data-field="player_metrics_video_start_time_s"]', formatSeconds(session.player_metrics_video_start_time_s));
+            setText('[data-field="player_metrics_video_bitrate_mbps"]', displayVideoBitrate);
+            setText('[data-field="server_video_rendition"]', session.server_video_rendition || '—');
+            setText('[data-field="server_video_rendition_mbps"]', formatMetricNumber(session.server_video_rendition_mbps, ' Mbps'));
+            setText('[data-field="player_metrics_video_quality_pct"]', formatMetricNumber(session.player_metrics_video_quality_pct, '%'));
+            setText('[data-field="player_metrics_avg_network_bitrate_mbps"]', formatMetricNumber(session.player_metrics_avg_network_bitrate_mbps, ' Mbps'));
+            setText('[data-field="player_metrics_network_bitrate_mbps"]', formatMetricNumber(session.player_metrics_network_bitrate_mbps, ' Mbps'));
+            setText('[data-field="player_metrics_frames_displayed"]', formatMetricNumber(session.player_metrics_frames_displayed));
+            setText('[data-field="player_metrics_dropped_frames"]', formatMetricNumber(session.player_metrics_dropped_frames));
+            setText('[data-field="player_metrics_stall_count"]', formatMetricNumber(session.player_metrics_stall_count));
+            setText('[data-field="player_metrics_stall_time_s"]', formatSeconds(session.player_metrics_stall_time_s));
+            setText('[data-field="player_metrics_last_stall_time_s"]', formatSeconds(session.player_metrics_last_stall_time_s));
+            setText('[data-field="player_metrics_error"]', session.player_metrics_error || '—');
+            setText('[data-field="player_metrics_source"]', session.player_metrics_source || '—');
+        }
+
+        function closestStepDuration(seconds) {
+            const options = [6, 12, 18, 24];
+            const numeric = Number(seconds);
+            if (!Number.isFinite(numeric) || numeric <= 0) return 12;
+            let best = options[0];
+            let bestDiff = Math.abs(numeric - best);
+            options.forEach((value) => {
+                const diff = Math.abs(numeric - value);
+                if (diff < bestDiff) {
+                    best = value;
+                    bestDiff = diff;
+                }
+            });
+            return best;
+        }
+
+        function inferSegmentDurationSeconds(session) {
+            const explicit = Number(session?.nftables_pattern_segment_duration_seconds || 0);
+            if (Number.isFinite(explicit) && explicit > 0) {
+                return explicit;
+            }
+            const candidates = [
+                session?.manifest_url || '',
+                session?.master_manifest_url || '',
+                session?.last_request_url || ''
+            ];
+            for (const value of candidates) {
+                const match = value.match(/(?:_|\/)(\d+)s(?:[._/?]|$)/i);
+                if (match) {
+                    const parsed = Number(match[1]);
+                    if (Number.isFinite(parsed) && parsed > 0) {
+                        return parsed;
+                    }
+                }
+            }
+            return 1;
+        }
+
+        function resolvePatternDefaults(session) {
+            const segmentDurationSeconds = inferSegmentDurationSeconds(session);
+            const defaultSegments = Number(session?.nftables_pattern_default_segments || 2);
+            const storedDefaultStepSeconds = Number(session?.nftables_pattern_default_step_seconds || 0);
+            const defaultStepSeconds = Number.isFinite(storedDefaultStepSeconds) && storedDefaultStepSeconds > 0
+                ? storedDefaultStepSeconds
+                : segmentDurationSeconds * defaultSegments;
+            return {
+                segmentDurationSeconds,
+                selectedStepSeconds: closestStepDuration(defaultStepSeconds)
+            };
+        }
+
+        function syncNetworkShapingControls(card, session) {
+            if (!card || !session) return;
+            const sessionId = String(card.dataset.sessionId || session.session_id || '');
+            if (!sessionId) return;
+            const templateModeRaw = String(session.nftables_pattern_template_mode || '').toLowerCase();
+            const templateMode = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid'].includes(templateModeRaw)
+                ? templateModeRaw
+                : 'sliders';
+            card.querySelectorAll(`input[name="shaping_template_mode_${sessionId}"]`).forEach((radio) => {
+                radio.checked = radio.value === templateMode;
+            });
+            const marginRaw = Number(session.nftables_pattern_margin_pct);
+            const marginPct = [0, 10, 25, 50].includes(marginRaw) ? marginRaw : 0;
+            card.querySelectorAll(`input[name="shaping_template_margin_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === marginPct;
+            });
+            const defaults = resolvePatternDefaults(session);
+            card.querySelectorAll(`input[name="shaping_default_step_seconds_${sessionId}"]`).forEach((radio) => {
+                radio.checked = Number(radio.value) === defaults.selectedStepSeconds;
+            });
+            if (card) {
+                card.dataset.segmentDurationSeconds = String(defaults.segmentDurationSeconds);
+            }
+            const syncRange = (field, value, fallback = 0) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                if (!input) return;
+                const numeric = Number(value);
+                const resolved = Number.isFinite(numeric) ? numeric : fallback;
+                input.value = String(resolved);
+                const valueEl = input.parentElement?.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = String(resolved);
+            };
+            syncRange('shaping_delay_ms', session.nftables_delay_ms, 0);
+            syncRange('shaping_loss_pct', session.nftables_packet_loss, 0);
+            const rowsHost = card.querySelector('[data-field="shaping_pattern_rows"]');
+            if (rowsHost) {
+                const rawSteps = Array.isArray(session.nftables_pattern_steps) ? session.nftables_pattern_steps : [];
+                const normalizedSteps = rawSteps
+                    .map((step) => {
+                        const rate = Number(step?.rate_mbps);
+                        const seconds = Number(step?.duration_seconds);
+                        const enabled = step?.enabled !== false;
+                        if (!Number.isFinite(rate) || rate < 0) return null;
+                        return {
+                            rate_mbps: Math.round(rate * 1000) / 1000,
+                            duration_seconds: Number.isFinite(seconds) && seconds > 0
+                                ? Math.round(seconds * 10) / 10
+                                : defaults.selectedStepSeconds,
+                            enabled
+                        };
+                    })
+                    .filter(Boolean);
+                const fallbackRate = Number(session.nftables_bandwidth_mbps || 0);
+                const steps = normalizedSteps.length
+                    ? normalizedSteps
+                    : [{ rate_mbps: fallbackRate, duration_seconds: defaults.selectedStepSeconds, enabled: true }];
+                const marginPctForMatch = [0, 10, 25, 50].includes(marginPct) ? marginPct : 0;
+                const matchOptions = { marginPct: marginPctForMatch, overheadMbps: getShapingOverheadMbps(card) };
+                rowsHost.innerHTML = '';
+                steps.forEach((step) => {
+                    rowsHost.appendChild(makeShapeStepRow(card, step.rate_mbps, step.duration_seconds, step.enabled, matchOptions));
+                });
+                updateStepIndices(card);
+                updateAllStepRiskUi(card);
+                const throughputFallback = Number(session.nftables_bandwidth_mbps);
+                const throughputValue = Number.isFinite(throughputFallback) ? throughputFallback : steps[0].rate_mbps;
+                syncRange('shaping_throughput_mbps', throughputValue, 0);
+            }
+            updateTemplateModeUi(card);
+        }
+
+        let deferredRender = false;
+        function renderSessions() {
+            if (activeSliderSessionId) {
+                deferredRender = true;
+                return;
+            }
+            deferredRender = false;
+            const container = document.getElementById('sessionsContainer');
+            if (!sessionsById.size) {
+                container.innerHTML = '<div class="status-message">No active sessions.</div>';
+                return;
+            }
+            const sessions = Array.from(sessionsById.values());
+            const sessionIds = sessions.map(session => session.session_id);
+            if (!activeSessionId || !sessionIds.includes(activeSessionId)) {
+                activeSessionId = sessionIds[0];
+                isTabLocked = false;
+            }
+            let activeSession = sessions.find(session => session.session_id === activeSessionId);
+            const sessionKey = String(activeSession?.session_id || '');
+            const existingCard = container.querySelector('.session-card');
+            const pending = activeSession ? pendingShaping.get(String(activeSession.session_id)) : null;
+            if (activeSession && pending) {
+                if (shapingValuesMatch(activeSession, pending.values)) {
+                    pendingShaping.delete(String(activeSession.session_id));
+                } else {
+                    activeSession = {
+                        ...activeSession,
+                        ...pending.values
+                    };
+                }
+            }
+            const pendingFailure = activeSession ? pendingFailureEdits.get(String(activeSession.session_id)) : null;
+            if (activeSession && pendingFailure && Date.now() - pendingFailure.timestamp < 5000) {
+                activeSession = {
+                    ...activeSession,
+                    ...pendingFailure.values
+                };
+            }
+            if (activeSession) {
+                const savedAxisMode = normalizeBitrateAxisMaxMode(
+                    bitrateAxisMaxBySession.get(String(activeSession.session_id)) || activeSession.ui_bitrate_axis_max || 'auto'
+                );
+                activeSession = {
+                    ...activeSession,
+                    ui_bitrate_axis_max: savedAxisMode
+                };
+            }
+            if (activeSession && existingCard && String(existingCard.dataset.sessionId || '') === sessionKey) {
+                // Check if manifest_variants just became available - need full re-render for presets
+                const hasVariants = Array.isArray(activeSession.manifest_variants) && activeSession.manifest_variants.length > 0;
+                let hadPresets = false;
+                const presetsRaw = existingCard.dataset.shapingPresets || '';
+                if (presetsRaw) {
+                    try {
+                        const decoded = JSON.parse(decodeURIComponent(presetsRaw));
+                        hadPresets = Array.isArray(decoded) && decoded.length > 0;
+                    } catch (err) {
+                        hadPresets = presetsRaw !== 'W10%3D' && presetsRaw !== '%5B%5D';
+                    }
+                }
+                if (hasVariants && !hadPresets) {
+                    // Fall through to full re-render below
+                } else {
+                    updateTabsAndGroupInfo(container, sessions, activeSession);
+                    updateSessionDetailFields(existingCard, activeSession);
+                    const shouldSync = shouldSyncControls(sessionKey, activeSession);
+                    if (shouldSync) {
+                        syncServerFaultControls(existingCard, activeSession);
+                        syncNetworkShapingControls(existingCard, activeSession);
+                        syncContentControls(existingCard, activeSession);
+                    }
+                    syncServerFaultData(existingCard, activeSession);
+                    updateSessionDetailData(existingCard, activeSession);
+                    updateThroughputSlider(existingCard, activeSession);
+                    mountPlayerCharacterizationForCard(existingCard, activeSession);
+                    pushBandwidthSamplesForAllSessions();
+                    return;
+                }
+            }
+            const activeTab = existingCard?.querySelector('.tab-button.active')?.dataset?.tab || '';
+            // Replay viewer always has exactly one session, so the tab strip
+            // and the group-info chip are pure noise — skip both.
+            const isReplay = document.body.classList.contains('replay-mode');
+            const tabsHtml = isReplay ? '' : renderSessionTabs(sessions);
+            const groupHtml = (isReplay || !activeSession) ? '' : renderGroupInfo(activeSession, sessions);
+            container.innerHTML = tabsHtml + (activeSession ?
+                groupHtml +
+                TestingSessionUI.renderSessionCard(activeSession, {
+                    hideTitle: true,
+                    hideHeader: isReplay,
+                    showPortItem: true,
+                    showBufferDepthChart: true,
+                    developerMode: isDeveloperMode,
+                    sectionDefaults: collapseDefaults
+                }) : '');
+            if (activeSession) {
+                const restoredCard = container.querySelector('.session-card');
+                if (restoredCard) {
+                    applyActiveFaultTab(restoredCard, activeTab);
+                    TestingSessionUI.applyCollapsibleState(restoredCard);
+                    updateTemplateModeUi(restoredCard);
+                    updateAllStepRiskUi(restoredCard);
+                    TestingSessionUI.updateTransportModeUi(restoredCard);
+                    updateSessionDetailData(restoredCard, activeSession);
+                    updateThroughputSlider(restoredCard, activeSession);
+                    mountPlayerCharacterizationForCard(restoredCard, activeSession);
+                }
+                pushBandwidthSamplesForAllSessions();
+            }
+        }
+
+        let compareMode = false;
+
+        const SESSION_COLORS = [
+            { main: '#2563eb', light: '#93c5fd' },  // blue
+            { main: '#ea580c', light: '#fdba74' },  // orange
+            { main: '#16a34a', light: '#86efac' },  // green
+            { main: '#9333ea', light: '#c4b5fd' },  // purple
+            { main: '#dc2626', light: '#fca5a5' },  // red
+            { main: '#0891b2', light: '#67e8f9' },  // cyan
+        ];
+
+        function getGroupSessionIds(session, allSessions) {
+            if (!session || !session.group_id) return [session?.session_id].filter(Boolean);
+            return allSessions
+                .filter(s => s.group_id === session.group_id)
+                .map(s => s.session_id);
+        }
+
+        function sessionColorIndex(sessionId, groupIds) {
+            const idx = groupIds.indexOf(sessionId);
+            return idx >= 0 ? idx % SESSION_COLORS.length : 0;
+        }
+
+        function renderGroupInfo(session, allSessions) {
+            if (!session.group_id) return '';
+            const groupMembers = allSessions.filter(s => s.group_id === session.group_id && s.session_id !== session.session_id);
+            const memberLabels = groupMembers.length > 0
+                ? groupMembers.map(s => {
+                    const portValue = s.x_forwarded_port_external || s.x_forwarded_port || '';
+                    const portSuffix = portValue ? ` (Port ${portValue})` : '';
+                    return `Session ${s.session_id}${portSuffix}`;
+                }).join(', ')
+                : 'no other members';
+            const compareChecked = compareMode ? 'checked' : '';
+            const showCompare = groupMembers.length > 0;
+            return `
+                <div class="group-info">
+                    🔗 Grouped with: ${memberLabels}
+                    ${showCompare ? `<label style="margin-left:12px;cursor:pointer;">
+                        <input type="checkbox" id="compareModeToggle" ${compareChecked}> Compare Charts
+                    </label>` : ''}
+                    <button class="unlink-btn" data-session-id="${session.session_id}" data-group-id="${session.group_id}">Ungroup</button>
+                </div>
+            `;
+        }
+
+        function getCompareGroupIds() {
+            if (!compareMode || !activeSessionId) return [];
+            const session = sessionsById.get(activeSessionId);
+            if (!session?.group_id) return [];
+            const allSessions = Array.from(sessionsById.values());
+            const ids = getGroupSessionIds(session, allSessions);
+            return ids.length >= 2 ? ids : [];
+        }
+
+        function bandwidthSeriesKey(label) {
+            return String(label || '').replace(/\s*\(V\d+\)$/, '');
+        }
+
+
+
+        function buildVariantLadder(variants) {
+            if (!Array.isArray(variants) || !variants.length) return [];
+            const ladder = variants
+                .map((variant) => Number(variant?.bandwidth || 0))
+                .filter((bandwidth) => Number.isFinite(bandwidth) && bandwidth > 0)
+                .map((bandwidth) => Math.round((bandwidth / 1000000) * 1000) / 1000)
+                .filter((value, index, array) => array.indexOf(value) === index)
+                .sort((a, b) => a - b);
+            return ladder.map((mbps, index) => ({
+                vx: `V${index + 1}`,
+                mbps
+            }));
+        }
+
+        function parseBandwidthChartEventType(rawEventType) {
+            const eventType = String(rawEventType || '').trim().toLowerCase();
+            if (!eventType) return null;
+            if (eventType === 'stall_start') return 'STALL';
+            if (eventType === 'frozen') return 'FROZEN';
+            if (eventType === 'segment_stall') return 'SEGMENT_STALL';
+            if (eventType === 'error') return 'ERROR';
+            if (eventType === 'restart') return 'RESTART';
+            if (eventType === 'playing') return 'PLAYING';
+            if (eventType === 'buffering_start') return 'BUFFERING';
+            if (eventType === 'video_first_frame') return 'FIRST_FRAME';
+            if (eventType === 'video_start_time') return 'START_TIME';
+            if (eventType === 'rate_shift_up') return 'SHIFT_UP';
+            if (eventType === 'rate_shift_down') return 'SHIFT_DOWN';
+            if (eventType === 'timejump') return 'TIMEJUMP';
+            // 911 / user-flagged moment from the iOS / iPadOS player.
+            // Lives on the CONTROL lane since it's a human-driven
+            // marker, not a player-observed effect.
+            if (eventType === 'user_marked') return 'USER_MARKED';
+            return null;
+        }
+
+        function getBandwidthChartEventTimestampMs(session, fallbackMs) {
+            const candidates = [
+                session?.player_metrics_last_event_at,
+                session?.player_metrics_event_time,
+                session?.control_revision
+            ];
+            for (const candidate of candidates) {
+                const parsed = Date.parse(String(candidate || ''));
+                if (Number.isFinite(parsed) && parsed > 0) {
+                    return parsed;
+                }
+            }
+            return fallbackMs;
+        }
+
+        function formatBitrateChartAbsoluteTick(windowStartMs, offsetSeconds) {
+            const ts = Number(windowStartMs) + (Number(offsetSeconds) * 1000);
+            if (!Number.isFinite(ts)) return '';
+            return new Date(ts).toLocaleTimeString([], {
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            });
+        }
+
+        function formatBitrateChartRange(windowStartMs, windowEndMs) {
+            const start = formatBitrateChartAbsoluteTick(windowStartMs, 0);
+            const end = formatBitrateChartAbsoluteTick(windowStartMs, (Number(windowEndMs) - Number(windowStartMs)) / 1000);
+            if (!start || !end) return 'Window: —';
+            return `Window: ${start} → ${end}`;
+        }
+
+        // In live (not paused) mode, intercept Alt+wheel and apply a custom
+        // zoom anchored at the right edge (live point), ignoring mouse position.
+        // In paused mode we let the plugin do its normal mouse-centered zoom.
+        //
+        // One document-level non-passive wheel listener handles every
+        // bandwidth/events/buffer/fps chart on the page. Per-canvas
+        // listeners would fire a Chrome "non-passive scroll-blocking
+        // wheel listener" violation per session × per chart; the
+        // single delegated listener is one warning instead of N×4.
+        let chartLiveWheelInstalled = false;
+        function ensureChartLiveWheelAnchor() {
+            if (chartLiveWheelInstalled) return;
+            chartLiveWheelInstalled = true;
+            const canvasClassToMap = {
+                'bandwidth-chart': bandwidthCharts,
+                'events-chart': eventsCharts,
+                'buffer-depth-chart': bufferDepthCharts,
+                'video-fps-chart': videoFpsCharts
+            };
+            document.addEventListener('wheel', (event) => {
+                if (!event.altKey) return;
+                const canvas = event.target && event.target.closest && event.target.closest('canvas');
+                if (!canvas) return;
+                let chartMap = null;
+                for (const cls in canvasClassToMap) {
+                    if (canvas.classList.contains(cls)) { chartMap = canvasClassToMap[cls]; break; }
+                }
+                if (!chartMap) return;
+                const card = canvas.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const chartRef = chartMap.get(String(sessionId));
+                if (!chartRef) return;
+                if (isChartPaused(String(sessionId))) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const xScale = chartRef.scales && chartRef.scales.x;
+                if (!xScale) return;
+                const currentMin = Number(xScale.min);
+                const currentMax = Number(xScale.max);
+                if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
+                const span = currentMax - currentMin;
+                const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
+                const newSpan = Math.max(2, Math.min(600, span * factor));
+                const nextMax = 600;
+                const nextMin = Math.max(0, nextMax - newSpan);
+                if (typeof chartRef.zoomScale === 'function') {
+                    chartRef.zoomScale('x', { min: nextMin, max: nextMax }, 'none');
+                } else if (chartRef.options && chartRef.options.scales && chartRef.options.scales.x) {
+                    chartRef.options.scales.x.min = nextMin;
+                    chartRef.options.scales.x.max = nextMax;
+                    chartRef.update('none');
+                }
+                syncChartViewportAcrossSession(String(sessionId), chartRef);
+            }, { capture: true, passive: false });
+        }
+
+        // vis-timeline counterpart to installLiveWheelAnchor: in live mode
+        // (not paused) Alt+wheel must zoom anchored at the right edge ("now")
+        // independent of mouse position, matching the Chart.js charts. In
+        // paused mode we let vis-timeline's own zoom plugin handle the
+        // wheel as mouse-centered zoom.
+        //
+        // One document-level non-passive wheel listener handles every
+        // events-timeline on the page — much cheaper than attaching a
+        // listener per session (which Chrome flags as a scroll-blocking
+        // perf hit).
+        let visTimelineLiveWheelInstalled = false;
+        function ensureVisTimelineLiveWheelAnchor() {
+            if (visTimelineLiveWheelInstalled) return;
+            visTimelineLiveWheelInstalled = true;
+            const ZOOM_MIN_MS = 1000;
+            const ZOOM_MAX_MS = 6 * 60 * 60 * 1000;
+            document.addEventListener('wheel', (event) => {
+                if (!event.altKey) return;
+                const container = event.target && event.target.closest && event.target.closest('.events-timeline');
+                if (!container) return;
+                const card = container.closest('.session-card');
+                const sessionId = card ? card.dataset.sessionId : null;
+                if (!sessionId) return;
+                const timeline = eventsTimelines.get(String(sessionId));
+                if (!timeline) return;
+                if (isChartPaused(String(sessionId))) return;
+                event.preventDefault();
+                event.stopPropagation();
+                const win = timeline.getWindow();
+                const span = win.end.getTime() - win.start.getTime();
+                if (!Number.isFinite(span) || span <= 0) return;
+                const factor = event.deltaY < 0 ? 0.9 : 1 / 0.9;
+                const newSpan = Math.max(ZOOM_MIN_MS, Math.min(ZOOM_MAX_MS, span * factor));
+                const nowMs = Date.now();
+                timeline.setWindow(
+                    new Date(nowMs - newSpan),
+                    new Date(nowMs),
+                    { animation: false }
+                );
+                syncChartViewportAcrossSession(String(sessionId), timeline);
+            }, { capture: true, passive: false });
+        }
+
+        function pinBitrateChartToLiveEdge(chartRef) {
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return;
+            const domainMin = 0;
+            const domainMax = 600;
+            const currentMin = Number(xScale.min);
+            const currentMax = Number(xScale.max);
+            if (!Number.isFinite(currentMin) || !Number.isFinite(currentMax)) return;
+            const span = Math.max(2, Math.min(domainMax - domainMin, currentMax - currentMin));
+            const nextMax = domainMax;
+            const nextMin = Math.max(domainMin, nextMax - span);
+            if (typeof chartRef.zoomScale === 'function') {
+                chartRef.zoomScale('x', { min: nextMin, max: nextMax }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = nextMin;
+                chartRef.options.scales.x.max = nextMax;
+            }
+        }
+
+        function normalizeChartViewport(minValue, maxValue) {
+            const domainMin = 0;
+            const domainMax = 600;
+            let min = Number(minValue);
+            let max = Number(maxValue);
+            if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+            if (max < min) { const tmp = min; min = max; max = tmp; }
+            let span = max - min;
+            if (!Number.isFinite(span) || span <= 0) return { min: domainMin, max: domainMax };
+            span = Math.max(2, Math.min(domainMax - domainMin, span));
+            max = Math.min(domainMax, max);
+            min = Math.max(domainMin, max - span);
+            max = min + span;
+            if (max > domainMax) { max = domainMax; min = domainMax - span; }
+            if (min < domainMin) { min = domainMin; max = domainMin + span; }
+            return { min, max };
+        }
+
+        function readChartViewport(chartRef) {
+            if (!chartRef) return null;
+            // vis-timeline branch: marker `$isVisTimeline` set when we
+            // construct it. Window is Date objects; convert to the
+            // seconds-from-windowStart convention the Chart.js charts use.
+            if (chartRef.$isVisTimeline && typeof chartRef.getWindow === 'function') {
+                const win = chartRef.getWindow();
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return null;
+                const min = (win.start.getTime() - startMs) / 1000;
+                const max = (win.end.getTime() - startMs) / 1000;
+                return normalizeChartViewport(min, max);
+            }
+            const xScale = chartRef?.scales?.x;
+            if (!xScale) return null;
+            return normalizeChartViewport(xScale.min, xScale.max);
+        }
+
+        function applyChartViewport(chartRef, viewport) {
+            if (!chartRef || !viewport) return;
+            if (chartRef.$isVisTimeline && typeof chartRef.setWindow === 'function') {
+                const startMs = Number(chartRef.$windowStartMs) || 0;
+                if (!startMs) return;
+                chartRef.setWindow(
+                    new Date(startMs + viewport.min * 1000),
+                    new Date(startMs + viewport.max * 1000),
+                    { animation: false }
+                );
+                return;
+            }
+            if (typeof chartRef.zoomScale === 'function') {
+                chartRef.zoomScale('x', { min: viewport.min, max: viewport.max }, 'none');
+            } else if (chartRef.options?.scales?.x) {
+                chartRef.options.scales.x.min = viewport.min;
+                chartRef.options.scales.x.max = viewport.max;
+            }
+        }
+
+        function applyStoredChartViewport(sessionId, chartRef) {
+            const viewport = chartViewportBySession.get(String(sessionId || ''));
+            if (!viewport) return false;
+            applyChartViewport(chartRef, viewport);
+            updateResetZoomButtonState(sessionId);
+            return true;
+        }
+
+        function updateResetZoomButtonState(sessionId) {
+            const key = String(sessionId || '');
+            const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+            if (!card) return;
+            const zoomed = chartViewportBySession.has(key);
+            for (const btn of card.querySelectorAll('button[data-action="reset-bitrate-zoom"]')) {
+                btn.classList.toggle('zoom-active', zoomed);
+            }
+        }
+
+        function getChartsForSession(sessionId) {
+            const key = String(sessionId || '');
+            return [
+                eventsCharts.get(key),
+                bandwidthCharts.get(key),
+                bufferDepthCharts.get(key),
+                videoFpsCharts.get(key),
+                eventsTimelines.get(key)
+            ].filter((chartRef) => !!chartRef);
+        }
+
+        function isDefaultChartViewport(viewport) {
+            return !!viewport && viewport.min <= 0 && viewport.max >= 600;
+        }
+
+        function syncChartViewportAcrossSession(sessionId, sourceChart) {
+            const key = String(sessionId || '');
+            const viewport = readChartViewport(sourceChart);
+            if (!viewport) return;
+            if (isDefaultChartViewport(viewport)) {
+                chartViewportBySession.delete(key);
+            } else {
+                chartViewportBySession.set(key, viewport);
+            }
+            for (const chartRef of getChartsForSession(key)) {
+                if (!chartRef || chartRef === sourceChart) continue;
+                applyChartViewport(chartRef, viewport);
+                if (chartRef.$isVisTimeline) continue;
+                if (typeof chartRef.zoomScale !== 'function' && typeof chartRef.update === 'function') {
+                    chartRef.update('none');
+                }
+            }
+            updateResetZoomButtonState(key);
+            // Bind the network log's visible time range to the bitrate
+            // chart's viewport. Chart x is seconds within a 10-min window;
+            // x=0 is windowStart (maxTs − 10min) and x=600 is maxTs (most
+            // recent sample). Convert to wall-clock ms and tell the
+            // network log to filter. On reset (default viewport), release
+            // the override so the waterfall returns to follow-latest.
+            try {
+                const TUI = window.TestingSessionUI;
+                if (!TUI) return;
+                if (isDefaultChartViewport(viewport)) {
+                    if (typeof TUI.clearNetworkLogTimeRange === 'function') {
+                        TUI.clearNetworkLogTimeRange(key);
+                    }
+                    return;
+                }
+                const series = bandwidthHistory.get(key);
+                if (series && series.length && typeof TUI.setNetworkLogTimeRange === 'function') {
+                    const maxTs = series[series.length - 1].ts;
+                    // Match the chart's actual window (per-session override
+                    // in chartWindowMsBySession; default 10 min in live)
+                    // rather than hard-coding 10 min — otherwise pan/zoom
+                    // on a chart with an expanded window would map the
+                    // viewport to a stale 10-min reference range.
+                    const windowMs = getChartWindowMs(key);
+                    const windowStartMs = maxTs - windowMs;
+                    const fromMs = windowStartMs + viewport.min * 1000;
+                    const toMs   = windowStartMs + viewport.max * 1000;
+                    TUI.setNetworkLogTimeRange(key, fromMs, toMs);
+                }
+            } catch (err) {
+                console.warn('network log range sync failed:', err);
+            }
+        }
+
+        function buildUnifiedChartZoomOptions(sessionId) {
+            const key = String(sessionId || '');
+            return {
+                pan: {
+                    enabled: true,
+                    mode: 'x',
+                    threshold: 2,
+                    onPanComplete: ({ chart: chartRef }) => {
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                },
+                limits: {
+                    x: { min: 0, max: 600, minRange: 2 }
+                },
+                zoom: {
+                    wheel: { enabled: true, modifierKey: 'alt' },
+                    drag: {
+                        enabled: true,
+                        modifierKey: 'alt',
+                        borderColor: '#1d4ed8',
+                        borderWidth: 1,
+                        backgroundColor: 'rgba(37, 99, 235, 0.12)'
+                    },
+                    mode: 'x',
+                    onZoomComplete: ({ chart: chartRef }) => {
+                        syncChartViewportAcrossSession(key, chartRef);
+                    }
+                }
+            };
+        }
+
+        let rightPanDragState = null;
+        let rightPanListenersInstalled = false;
+
+        function installRightMousePanHandlers(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.rightPanBound === '1') return;
+            canvas.dataset.rightPanBound = '1';
+            const key = String(sessionId || '');
+            canvas.addEventListener('contextmenu', (event) => { event.preventDefault(); });
+            canvas.addEventListener('mousedown', (event) => {
+                if (event.button !== 2) return;
+                event.preventDefault();
+                const viewport = readChartViewport(chartRef) || { min: 0, max: 600 };
+                rightPanDragState = { sessionId: key, sourceChart: chartRef, startClientX: event.clientX, startViewport: viewport };
+            });
+            if (rightPanListenersInstalled) return;
+            rightPanListenersInstalled = true;
+            window.addEventListener('mousemove', (event) => {
+                if (!rightPanDragState) return;
+                const sourceChart = rightPanDragState.sourceChart;
+                const chartArea = sourceChart?.chartArea;
+                if (!sourceChart || !chartArea) return;
+                const widthPx = Math.max(1, chartArea.right - chartArea.left);
+                const span = rightPanDragState.startViewport.max - rightPanDragState.startViewport.min;
+                if (!Number.isFinite(span) || span <= 0) return;
+                const deltaPx = event.clientX - rightPanDragState.startClientX;
+                const deltaValue = (deltaPx / widthPx) * span;
+                const viewport = normalizeChartViewport(
+                    rightPanDragState.startViewport.min - deltaValue,
+                    rightPanDragState.startViewport.max - deltaValue
+                );
+                if (!viewport) return;
+                chartViewportBySession.set(rightPanDragState.sessionId, viewport);
+                for (const chart of getChartsForSession(rightPanDragState.sessionId)) {
+                    applyChartViewport(chart, viewport);
+                    if (chart.$isVisTimeline) continue;
+                    if (typeof chart.zoomScale !== 'function' && typeof chart.update === 'function') {
+                        chart.update('none');
+                    }
+                }
+                updateResetZoomButtonState(rightPanDragState.sessionId);
+            });
+            window.addEventListener('mouseup', (event) => {
+                if (!rightPanDragState) return;
+                if (event.button === 2) { rightPanDragState = null; }
+            });
+            window.addEventListener('blur', () => { rightPanDragState = null; });
+        }
+
+        function isChartPaused(sessionId) {
+            return chartPausedBySession.get(String(sessionId || '')) === true;
+        }
+
+        function updatePauseButtonAndOverlays(sessionId) {
+            const key = String(sessionId || '');
+            const paused = isChartPaused(key);
+            const card = document.querySelector(`.session-card[data-session-id="${key}"]`);
+            if (!card) return;
+            for (const btn of card.querySelectorAll('button[data-action="pause-bitrate-chart"]')) {
+                if (paused) {
+                    btn.textContent = 'Live';
+                    btn.classList.add('chart-live');
+                } else {
+                    btn.textContent = '⏸ Pause';
+                    btn.classList.remove('chart-live');
+                }
+            }
+            for (const wrap of card.querySelectorAll('.chart-wrap')) {
+                let badge = wrap.querySelector('.chart-paused-badge');
+                if (!badge) {
+                    badge = document.createElement('div');
+                    badge.className = 'chart-paused-badge';
+                    badge.textContent = 'PAUSED';
+                    wrap.appendChild(badge);
+                }
+                wrap.classList.toggle('chart-paused', paused);
+            }
+        }
+
+        function toggleChartPause(sessionId) {
+            const key = String(sessionId || '');
+            const wasPaused = isChartPaused(key);
+            chartPausedBySession.set(key, !wasPaused);
+            updatePauseButtonAndOverlays(key);
+            if (wasPaused) { renderBandwidthChart(key); }
+        }
+
+        function installChartClickPauseHandler(sessionId, chartRef) {
+            const canvas = chartRef?.canvas;
+            if (!canvas || canvas.dataset.pauseHandlerBound === '1') return;
+            canvas.dataset.pauseHandlerBound = '1';
+            let startX = 0;
+            let startY = 0;
+            canvas.addEventListener('mousedown', (e) => {
+                if (e.button !== 0) return;
+                startX = e.clientX;
+                startY = e.clientY;
+            });
+            canvas.addEventListener('click', (e) => {
+                if (e.altKey) return;
+                if (Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5) return;
+                const chartArea = chartRef.chartArea;
+                if (chartArea) {
+                    const rect = canvas.getBoundingClientRect();
+                    const cx = e.clientX - rect.left;
+                    const cy = e.clientY - rect.top;
+                    if (cx < chartArea.left || cx > chartArea.right || cy < chartArea.top || cy > chartArea.bottom) return;
+                }
+                toggleChartPause(sessionId);
+            });
+        }
+
+        // Stretch a chart's x-axis to match a target window in ms. The
+        // chart's x-coordinates are seconds-since-windowStart; setting
+        // max to windowMs/1000 gives full visibility. Also nudges the
+        // zoom-plugin's limit so reset-zoom snaps to the new extent.
+        function applyChartXMax(chart, windowMs) {
+            if (!chart || !chart.options || !chart.options.scales || !chart.options.scales.x) return;
+            const sec = Math.max(1, Math.round(windowMs / 1000));
+            chart.options.scales.x.max = sec;
+            const zoom = chart.options.plugins && chart.options.plugins.zoom;
+            if (zoom && zoom.limits && zoom.limits.x) {
+                zoom.limits.x.max = sec;
+            }
+        }
+
+        function pushBandwidthSample(session) {
+            const now = Date.now();
+            const windowMs = getChartWindowMs(session.session_id);
+            const shaperRate = Number.isFinite(Number(session.mbps_shaper_rate)) ? Number(session.mbps_shaper_rate) : null;
+            const shaperAvg = Number.isFinite(Number(session.mbps_shaper_avg)) ? Number(session.mbps_shaper_avg) : null;
+            const transferRate = session.mbps_transfer_rate != null && Number.isFinite(Number(session.mbps_transfer_rate)) ? Number(session.mbps_transfer_rate) : null;
+            const transferComplete = session.mbps_transfer_complete != null && Number.isFinite(Number(session.mbps_transfer_complete)) ? Number(session.mbps_transfer_complete) : null;
+            const metricsAtMs = session.player_metrics_event_time
+                ? Date.parse(session.player_metrics_event_time) || null
+                : null;
+            const bufferDepth = Number.isFinite(Number(session.player_metrics_buffer_depth_s))
+                ? Number(session.player_metrics_buffer_depth_s)
+                : null;
+            // Wall-clock offset = (clock authority) − encoded PDT (epoch ms).
+            // Preference order:
+            //   1. server_received_at_ms − playhead_wallclock_ms (no client skew)
+            //   2. player_metrics_true_offset_s (client computed; biased by skew)
+            //   3. Date.now() − playhead_wallclock_ms (browser's clock as authority)
+            let wallClockOffset = null;
+            const reportedPdtMs = Number(session.player_metrics_playhead_wallclock_ms);
+            const serverReceivedAtMs = Number(session.server_received_at_ms);
+            const reportedTrueOff = Number(session.player_metrics_true_offset_s);
+            if (Number.isFinite(reportedPdtMs) && reportedPdtMs > 0
+                && Number.isFinite(serverReceivedAtMs) && serverReceivedAtMs > 0) {
+                wallClockOffset = Math.round((serverReceivedAtMs - reportedPdtMs) / 10) / 100;
+            } else if (Number.isFinite(reportedTrueOff)) {
+                wallClockOffset = reportedTrueOff;
+            } else if (Number.isFinite(reportedPdtMs) && reportedPdtMs > 0) {
+                wallClockOffset = Math.round((Date.now() - reportedPdtMs) / 10) / 100;
+            }
+            const measuredVideoBitrate = Number(session.player_metrics_video_bitrate_mbps);
+            const inferredVideoBitrate = inferSessionNativeRenditionMbps(session);
+            const currentRendition = (Number.isFinite(measuredVideoBitrate) && measuredVideoBitrate > 0)
+                ? measuredVideoBitrate
+                : (Number.isFinite(inferredVideoBitrate) ? inferredVideoBitrate : null);
+            // Renamed fields (issue #146):
+            //  - player_metrics_avg_network_bitrate_mbps: long-window AVG
+            //    (iOS observedBitrate; Android DefaultBandwidthMeter)
+            //  - player_metrics_network_bitrate_mbps: short-window INSTANT
+            //    (iOS LocalHTTPProxy wire bytes; null on clients without
+            //    per-request wire visibility)
+            const playerEstimate = Number.isFinite(Number(session.player_metrics_avg_network_bitrate_mbps))
+                ? Number(session.player_metrics_avg_network_bitrate_mbps)
+                : null;
+            const rawPlayerWireBitrate = session.player_metrics_network_bitrate_mbps;
+            const playerWireBitrate = (rawPlayerWireBitrate === null || rawPlayerWireBitrate === undefined
+                || !Number.isFinite(Number(rawPlayerWireBitrate)))
+                ? null
+                : Number(rawPlayerWireBitrate);
+            const serverRendition = Number.isFinite(Number(session.server_video_rendition_mbps))
+                ? Number(session.server_video_rendition_mbps)
+                : null;
+            const framesDisplayed = Number.isFinite(Number(session.player_metrics_frames_displayed))
+                ? Number(session.player_metrics_frames_displayed)
+                : null;
+            const framesDropped = Number.isFinite(Number(session.player_metrics_dropped_frames))
+                ? Number(session.player_metrics_dropped_frames)
+                : null;
+            const variantLadder = buildVariantLadder(session.manifest_variants);
+            const patternSteps = Array.isArray(session.nftables_pattern_steps) ? session.nftables_pattern_steps : [];
+            const patternStepIndex = Number(session.nftables_pattern_step_runtime || session.nftables_pattern_step || 0);
+            const patternEnabled = session.nftables_pattern_enabled === true
+                || session.nftables_pattern_enabled === 1
+                || session.nftables_pattern_enabled === 'true';
+            const runtimeTarget = Number(session.nftables_pattern_rate_runtime_mbps);
+            const bandwidthTarget = Number(session.nftables_bandwidth_mbps);
+            const key = session.session_id;
+            if (!key) return;
+
+            const numericLoopCount = Number(session.player_metrics_loop_count_player);
+            if (Number.isFinite(numericLoopCount) && numericLoopCount >= 0) {
+                const loopCount = Math.max(0, Math.round(numericLoopCount));
+                const prevLoopCount = lastRecordedLoopCountBySession.get(String(key));
+                if (Number.isFinite(prevLoopCount) && loopCount > prevLoopCount) {
+                    const stamp = `${String(key)}|player|${loopCount}`;
+                    if (lastRecordedLoopEventStampBySession.get(String(key)) !== stamp) {
+                        const eventSeries = bandwidthEventHistory.get(key) || [];
+                        const loopEventAtMs = getBandwidthChartEventTimestampMs(session, now);
+                        eventSeries.push({ ts: loopEventAtMs, type: 'LOOP_PLAYER' });
+                        const eventCutoff = now - windowMs;
+                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                        lastRecordedLoopEventStampBySession.set(String(key), stamp);
+                    }
+                }
+                lastRecordedLoopCountBySession.set(String(key), loopCount);
+            }
+
+            const numericServerLoopCount = Number(session.loop_count_server);
+            if (Number.isFinite(numericServerLoopCount) && numericServerLoopCount >= 0) {
+                const serverLoopCount = Math.max(0, Math.round(numericServerLoopCount));
+                const prevServerLoopCount = lastRecordedServerLoopCountBySession.get(String(key));
+                if (Number.isFinite(prevServerLoopCount) && serverLoopCount > prevServerLoopCount) {
+                    const stamp = `${String(key)}|server|${serverLoopCount}`;
+                    if (lastRecordedServerLoopEventStampBySession.get(String(key)) !== stamp) {
+                        const eventSeries = bandwidthEventHistory.get(key) || [];
+                        const loopEventAtMs = getBandwidthChartEventTimestampMs(session, now);
+                        eventSeries.push({ ts: loopEventAtMs, type: 'LOOP_SERVER' });
+                        const eventCutoff = now - windowMs;
+                        bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                        lastRecordedServerLoopEventStampBySession.set(String(key), stamp);
+                    }
+                }
+                lastRecordedServerLoopCountBySession.set(String(key), serverLoopCount);
+            }
+
+            // PLAYBACK_START event on play_id rollover (issue #280).
+            // The client mints a fresh play_id at every loadStream
+            // boundary; a change here is the high-level "new playback
+            // episode" signal — distinct from the per-event lane that
+            // tracks individual transitions like SHIFT_UP/STALL. Fires
+            // on the FIRST observation too (prevPlayId === undefined),
+            // so opening the page mid-playback still gets a marker.
+            const newPlayId = String(session.play_id || '').trim();
+            if (newPlayId) {
+                const prevPlayId = lastRecordedPlayIdBySession.get(String(key));
+                if (prevPlayId !== newPlayId) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({
+                        ts: now,
+                        type: 'PLAYBACK_START',
+                        playId: newPlayId,
+                        prevPlayId: prevPlayId || ''
+                    });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                }
+                lastRecordedPlayIdBySession.set(String(key), newPlayId);
+            }
+
+            const eventType = parseBandwidthChartEventType(session.player_metrics_last_event || session.player_metrics_trigger_type);
+            if (eventType) {
+                const eventAtMs = getBandwidthChartEventTimestampMs(session, now);
+                const eventStamp = `${eventType}|${session.player_metrics_last_event_at || session.player_metrics_event_time || eventAtMs}`;
+                const lastStamp = lastRecordedPlayerEventBySession.get(String(key));
+                if (eventStamp !== lastStamp) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: eventAtMs, type: eventType });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                    lastRecordedPlayerEventBySession.set(String(key), eventStamp);
+                }
+            }
+
+            // PLAYERSTATE lane: sample player_metrics_state every poll
+            // and let the renderer coalesce same-label runs. The
+            // AVFoundation reasonForWaitingToPlay
+            // (player_metrics_waiting_reason) is part of the rendered
+            // label so reason transitions within a state (e.g.
+            // toMinimizeStalls vs evaluatingBufferingRate) split into
+            // distinct ranges.
+            const stateValue = String(session.player_metrics_state || '').trim();
+            const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
+            if (stateValue) {
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+            }
+
+            // VARIANT lane: bitrate is the leading-edge fetch-time
+            // signal (accessLog updates when a segment download
+            // completes). Resolution is the lagging render-time signal
+            // (presentation-size updates when the new frame is shown).
+            // To avoid phantom (new-resolution, old-bitrate) entries
+            // during the shift window, drive resolution from the
+            // manifest BANDWIDTH lookup keyed off the bitrate, falling
+            // back to the player's reported resolution only when no
+            // manifest match exists. The session payload is heartbeat-
+            // style — every poll carries the current values — so push
+            // unconditionally and let the renderer coalesce same-value
+            // runs into single ranges.
+            const variantMbpsRaw = Number(session.player_metrics_video_bitrate_mbps);
+            if (Number.isFinite(variantMbpsRaw) && variantMbpsRaw > 0) {
+                const variantMbps = Math.round(variantMbpsRaw * 10) / 10;
+                const reportedRes = String(session.player_metrics_video_resolution || '').trim();
+                const manifestRes = manifestResolutionForBitrate(session, variantMbps);
+                const variantRes = manifestRes || reportedRes;
+                if (variantRes) {
+                    const eventSeries = bandwidthEventHistory.get(key) || [];
+                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    const eventCutoff = now - windowMs;
+                    bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+                }
+            }
+
+            // DISPLAY_RES lane: the player's actually-presented frame
+            // resolution (player_metrics_video_resolution). Distinct
+            // from VARIANT — gap between VARIANT shifting and
+            // DISPLAY_RES shifting is the fetch-to-render lag.
+            const displayRes = String(session.player_metrics_video_resolution || '').trim();
+            if (displayRes) {
+                const eventSeries = bandwidthEventHistory.get(key) || [];
+                eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
+            }
+
+            // CONTROL lane: emit one event per (field, old → new) any time
+            // a tracked control attribute (failure injection / shaping /
+            // timeouts) changes between snapshots. First snapshot for a
+            // session seeds the memo without emitting events. Skipped on
+            // the very first call so the lane doesn't fire for "0 → 0"
+            // defaults; subsequent diffs are real user actions.
+            const prevControls = lastRecordedControlsBySession.get(String(key));
+            const nextControls = {};
+            const eventSeriesControl = bandwidthEventHistory.get(key) || [];
+            for (const field of CONTROL_FIELDS) {
+                const raw = session[field];
+                const value = raw === undefined || raw === null ? '' : raw;
+                nextControls[field] = value;
+                if (prevControls === undefined) continue;
+                const prev = prevControls[field];
+                if (prev === undefined) continue;
+                if (prev === value) continue;
+                eventSeriesControl.push({
+                    ts: now,
+                    type: 'CONTROL_CHANGE',
+                    field,
+                    oldValue: prev,
+                    newValue: value
+                });
+            }
+            if (eventSeriesControl.length) {
+                const eventCutoff = now - windowMs;
+                bandwidthEventHistory.set(key, eventSeriesControl.filter((event) => Number(event.ts) >= eventCutoff));
+            }
+            lastRecordedControlsBySession.set(String(key), nextControls);
+
+            const series = bandwidthHistory.get(key) || [];
+            const lastLimit = series.length ? Number(series[series.length - 1].target) : NaN;
+            let target = Number.isFinite(bandwidthTarget) ? bandwidthTarget : (Number.isFinite(lastLimit) ? lastLimit : 0);
+            let usedRuntime = false;
+            if (patternEnabled && Number.isFinite(runtimeTarget)) {
+                target = runtimeTarget;
+                usedRuntime = true;
+            }
+            if (!usedRuntime && patternStepIndex > 0 && patternStepIndex <= patternSteps.length) {
+                const activeStepRate = Number(patternSteps[patternStepIndex - 1]?.rate_mbps);
+                if (Number.isFinite(activeStepRate) && activeStepRate >= 0) {
+                    target = activeStepRate;
+                }
+            }
+            series.push({
+                ts: now,
+                shaperRate,
+                shaperAvg,
+                transferRate,
+                transferComplete,
+                metricsAtMs,
+                bufferDepth,
+                wallClockOffset,
+                playerEstimate,
+                playerWireBitrate,
+                currentRendition,
+                serverRendition,
+                framesDisplayed,
+                framesDropped,
+                target,
+                variantLadder
+            });
+            const cutoff = now - windowMs;
+            const filtered = series.filter(point => point.ts >= cutoff);
+            bandwidthHistory.set(key, filtered);
+            if (key === activeSessionId && !chartRenderSuppressedBySession.has(key)) {
+                renderBandwidthChart(key);
+            }
+        }
+
+        function pushBandwidthSamplesForAllSessions() {
+            for (const [sid, session] of sessionsById) {
+                pushBandwidthSample(session);
+            }
+        }
+
+        // Swim-lane events chart (STALL / RESTART / LOOP_PLAYER / LOOP_SERVER).
+        // Shares x-axis with bitrate chart via syncChartViewportAcrossSession.
+        const EVENT_LANES = {
+            'CONTROL':     { y: 7, color: '#7c3aed', label: 'CONTROL' },
+            'VARIANT':     { y: 6, color: '#16a34a', label: 'VARIANT' },
+            'DISPLAY_RES': { y: 5, color: '#0ea5e9', label: 'DISPLAY RES' },
+            'PLAYERSTATE': { y: 4, color: '#6b7280', label: 'PLAYERSTATE' },
+            'PLAYBACK':    { y: 3, color: '#16a34a', label: 'PLAYBACK' },
+            'IMPAIRMENT':  { y: 2, color: '#000000', label: 'IMPAIRMENT' },
+            'LOOP_SERVER': { y: 1, color: '#84cc16', label: 'LOOP SERVER' }
+        };
+        // Subtype → lane mapping. Each event-source string from
+        // parseBandwidthChartEventType resolves to the lane it
+        // appears in. Subtype tooltip labels and per-point colours
+        // live alongside.
+        const EVENT_SUBTYPE_LANE = {
+            'PLAYING': 'PLAYBACK', 'FIRST_FRAME': 'PLAYBACK', 'START_TIME': 'PLAYBACK',
+            'RESTART': 'PLAYBACK', 'TIMEJUMP': 'PLAYBACK', 'PLAYBACK_START': 'PLAYBACK',
+            'SHIFT_UP': 'PLAYBACK', 'SHIFT_DOWN': 'PLAYBACK',
+            'STALL': 'IMPAIRMENT', 'FROZEN': 'IMPAIRMENT',
+            'SEGMENT_STALL': 'IMPAIRMENT', 'ERROR': 'IMPAIRMENT',
+            // BUFFERING events still flow on the wire but have no lane
+            // here — buffering is already visible on the PLAYERSTATE
+            // ribbon and the dedicated lane was redundant. LOOP_PLAYER
+            // is omitted while the player-side loop counter is broken
+            // (always 0); LOOP_SERVER is the only meaningful loop lane.
+            'LOOP_SERVER': 'LOOP_SERVER',
+            // CONTROL_CHANGE — failure injection / shaping / timeout
+            // toggles applied to the session. One event per (field, old →
+            // new) emitted by pushBandwidthSample when a tracked attr
+            // differs between snapshots.
+            'CONTROL_CHANGE': 'CONTROL',
+            // USER_MARKED — operator-pressed 911 button on the iOS /
+            // iPadOS player. Also a human action, so on CONTROL.
+            'USER_MARKED': 'CONTROL'
+        };
+        const EVENT_SUBTYPE_COLOR = {
+            'PLAYING':       '#16a34a',
+            'FIRST_FRAME':   '#14b8a6',
+            'START_TIME':    '#15803d',
+            'RESTART':       '#a855f7',
+            'TIMEJUMP':      '#d97706',
+            'SHIFT_UP':      '#3b82f6',
+            'SHIFT_DOWN':    '#ef4444',
+            'STALL':         '#000000',
+            'FROZEN':        '#4c1d95',
+            'SEGMENT_STALL': '#c2410c',
+            'ERROR':         '#e11d48',
+            'BUFFERING':     '#f59e0b',
+            'PLAYBACK_START':'#0d9488',
+            'USER_MARKED':   '#dc2626'
+        };
+        const EVENT_SUBTYPE_LABEL = {
+            'PLAYING': 'PLAYING', 'FIRST_FRAME': 'FIRST FRAME', 'START_TIME': 'START TIME',
+            'RESTART': 'RESTART', 'TIMEJUMP': 'TIMEJUMP',
+            'SHIFT_UP': 'SHIFT UP', 'SHIFT_DOWN': 'SHIFT DOWN',
+            'STALL': 'STALL', 'FROZEN': 'FROZEN',
+            'SEGMENT_STALL': 'SEGMENT STALL', 'ERROR': 'ERROR',
+            'BUFFERING': 'BUFFERING',
+            'CONTROL_CHANGE': 'CONTROL',
+            'PLAYBACK_START': 'PLAYBACK START',
+            'USER_MARKED': '911 / USER FLAG'
+        };
+        // Per-state colour for the PLAYERSTATE lane. Keys are lowercase
+        // because clients emit a mix of casings ("Playing" on Apple,
+        // "playing" on Android-test/Roku/web) — playerStateColor()
+        // normalises before lookup so all map to the same colour.
+        const PLAYER_STATE_COLOR = {
+            'playing':   '#16a34a', // green
+            'buffering': '#f59e0b', // amber — expected refill (pre-roll, post-seek)
+            'stalled':   '#dc2626', // red — unexpected mid-play rebuffer
+            'paused':    '#9333ea', // purple
+            'idle':      '#6b7280', // gray
+            'ended':     '#1f2937', // near-black
+            'unknown':   '#d1d5db'  // light gray
+        };
+        function playerStateColor(s) {
+            return PLAYER_STATE_COLOR[String(s || '').trim().toLowerCase()] || '#d1d5db';
+        }
+        // Variant colour buckets — lower bitrate = redder, higher = greener.
+        // Drives the colour of segments / dots on the VARIANT swim lane so
+        // an upshift/downshift is visually obvious before reading the label.
+        function variantColor(mbps) {
+            const m = Number(mbps);
+            if (!Number.isFinite(m) || m <= 0) return '#9ca3af';
+            if (m < 1)  return '#dc2626'; // red
+            if (m < 2)  return '#ea580c'; // orange
+            if (m < 4)  return '#f59e0b'; // amber
+            if (m < 8)  return '#84cc16'; // lime
+            if (m < 16) return '#16a34a'; // green
+            return '#10b981';             // emerald
+        }
+        function variantLabel(mbps, resolution) {
+            const m = Number(mbps);
+            const mbpsStr = Number.isFinite(m) && m > 0 ? `${m.toFixed(1)}Mbps` : '';
+            const res = String(resolution || '').trim();
+            if (res && mbpsStr) return `${res}:${mbpsStr}`;
+            return res || mbpsStr || '—';
+        }
+        // Look up the manifest variant whose BANDWIDTH best matches the
+        // bitrate the player just reported. Used to drive VARIANT's
+        // resolution from the bitrate (which leads the
+        // presentation-size update by the segment's decode/render delay)
+        // — eliminates phantom (new-resolution, old-bitrate) lanes.
+        function manifestResolutionForBitrate(session, mbps) {
+            const variants = Array.isArray(session?.manifest_variants) ? session.manifest_variants : [];
+            if (!variants.length) return null;
+            let best = null;
+            let bestDelta = Infinity;
+            for (const v of variants) {
+                const vMbps = Number(v?.bandwidth || 0) / 1_000_000;
+                if (!Number.isFinite(vMbps) || vMbps <= 0) continue;
+                const delta = Math.abs(vMbps - mbps);
+                const tol = Math.max(0.5, vMbps * 0.05);
+                if (delta < tol && delta < bestDelta) {
+                    bestDelta = delta;
+                    best = String(v.resolution || '').trim() || null;
+                }
+            }
+            return best;
+        }
+        // DISPLAY RES lane colour scheme — bucketed by frame height so a
+        // 4K presentation reads as green/emerald and a 360p reads as red.
+        function displayResColor(res) {
+            const m = /(\d+)\s*[xX]\s*(\d+)/.exec(String(res || ''));
+            if (!m) return '#9ca3af';
+            const h = Number(m[2]);
+            if (!Number.isFinite(h) || h <= 0) return '#9ca3af';
+            if (h <= 360)  return '#dc2626';
+            if (h <= 540)  return '#ea580c';
+            if (h <= 720)  return '#f59e0b';
+            if (h <= 1080) return '#84cc16';
+            if (h <= 1440) return '#16a34a';
+            return '#10b981';
+        }
+        let legendHoverIndex = null;
+        let legendHoverChartId = null;
+        let legendHoverMetricKind = null;
+
+        // Maps a bitrate-chart legend label to a canonical metric kind so that
+        // a hover on one session's series can half-highlight the same metric on
+        // other sessions' series (compare mode appends "(Sn)" per session, and
+        // a couple of labels differ from the own-session name, e.g.
+        // "mbps_shaper_avg" vs "Shaper Avg (S2)").
+        function bitrateLegendMetricKind(label) {
+            if (!label) return null;
+            const base = String(label).replace(/\s*\(S[^)]+\)\s*$/, '').trim();
+            switch (base) {
+                case 'Player avg_network_bitrate':
+                    return 'player_est';
+                case 'Player network_bitrate':
+                    return 'player_wire';
+                case 'Player Variant':
+                    return 'player_variant';
+                case 'Server Variant':
+                    return 'server_variant';
+                case 'mbps_shaper_avg':
+                case 'Shaper Avg':
+                    return 'shaper_avg';
+                default:
+                    return null;
+            }
+        }
+
+        const legendHoverCallbacks = {
+            onHover: (event, legendItem, legend) => {
+                legendHoverIndex = legendItem.datasetIndex;
+                legendHoverChartId = legend.chart.id;
+                const ds = legend.chart.data.datasets[legendItem.datasetIndex];
+                legendHoverMetricKind = bitrateLegendMetricKind(ds && ds.label);
+                refreshLegendHoverAll();
+            },
+            onLeave: () => {
+                legendHoverIndex = null;
+                legendHoverChartId = null;
+                legendHoverMetricKind = null;
+                refreshLegendHoverAll();
+            }
+        };
+
+        // Apply primary (+3) and cross-session (+1.5) borderWidth boosts based
+        // on the current hover state, clearing any stale boost on other datasets.
+        function applyLegendHover(chart) {
+            if (!chart || !chart.data || !Array.isArray(chart.data.datasets)) return;
+            chart.data.datasets.forEach((ds, idx) => {
+                const isPrimary = legendHoverChartId === chart.id
+                    && legendHoverIndex != null
+                    && idx === legendHoverIndex;
+                const kind = bitrateLegendMetricKind(ds.label);
+                const isCross = !isPrimary
+                    && legendHoverMetricKind != null
+                    && kind === legendHoverMetricKind;
+                if (isPrimary) {
+                    if (ds._origWidth === undefined) ds._origWidth = ds.borderWidth;
+                    if (ds._origWidthXHover !== undefined) {
+                        delete ds._origWidthXHover;
+                    }
+                    ds.borderWidth = ds._origWidth + 6;
+                } else if (isCross) {
+                    if (ds._origWidthXHover === undefined) ds._origWidthXHover = ds.borderWidth;
+                    if (ds._origWidth !== undefined) {
+                        ds.borderWidth = ds._origWidth;
+                        delete ds._origWidth;
+                    }
+                    ds.borderWidth = ds._origWidthXHover + 2.5;
+                } else {
+                    if (ds._origWidth !== undefined) {
+                        ds.borderWidth = ds._origWidth;
+                        delete ds._origWidth;
+                    }
+                    if (ds._origWidthXHover !== undefined) {
+                        ds.borderWidth = ds._origWidthXHover;
+                        delete ds._origWidthXHover;
+                    }
+                }
+            });
+        }
+
+        function refreshLegendHoverAll() {
+            const pools = [bandwidthCharts, bufferDepthCharts, videoFpsCharts];
+            for (const pool of pools) {
+                if (!pool) continue;
+                pool.forEach((chart) => {
+                    if (!chart) return;
+                    applyLegendHover(chart);
+                    chart.update('none');
+                });
+            }
+        }
+
+        function renderEventsChart(sessionId, windowStart, eventSeries) {
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            const canvas = card.querySelector('canvas.events-chart');
+            if (!canvas) return;
+            if (isChartPaused(sessionId)) return;
+            const chartEvents = (eventSeries || [])
+                .filter((e) => Number(e.ts) >= windowStart)
+                .map((e) => ({ x: (e.ts - windowStart) / 1000, type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution, ts: Number(e.ts) }))
+                .filter((e) => Number.isFinite(e.x) && e.x >= 0 && e.x <= 600);
+            const datasets = Object.entries(EVENT_LANES).map(([laneKey, cfg]) => {
+                // An event's lane comes either from a 1:1 mapping
+                // (PLAYERSTATE / VARIANT / DISPLAY_RES / LOOP_*) or
+                // via EVENT_SUBTYPE_LANE for the merged PLAYBACK /
+                // IMPAIRMENT / BUFFERING lanes.
+                const points = chartEvents.filter((e) => {
+                    const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                    return lane === laneKey;
+                }).map((e) => ({
+                    x: e.x, y: cfg.y, ts: e.ts,
+                    type: e.type, state: e.state, reason: e.reason, mbps: e.mbps, resolution: e.resolution
+                }));
+                let colors = cfg.color;
+                if (laneKey === 'PLAYERSTATE') colors = points.map(p => playerStateColor(p.state));
+                else if (laneKey === 'VARIANT') colors = points.map(p => variantColor(p.mbps));
+                else if (laneKey === 'DISPLAY_RES') colors = points.map(p => displayResColor(p.resolution));
+                else if (laneKey === 'PLAYBACK' || laneKey === 'IMPAIRMENT') {
+                    colors = points.map(p => EVENT_SUBTYPE_COLOR[p.type] || cfg.color);
+                }
+                return {
+                    label: cfg.label,
+                    data: points,
+                    backgroundColor: colors,
+                    borderColor: colors,
+                    pointRadius: 5,
+                    pointHoverRadius: 7,
+                    showLine: false,
+                };
+            });
+            let chart = eventsCharts.get(sessionId);
+            if (chart && chart.canvas !== canvas) {
+                chart.destroy();
+                chart = null;
+                eventsCharts.delete(sessionId);
+            }
+            if (!chart) {
+                chart = new Chart(canvas, {
+                    type: 'scatter',
+                    data: { datasets },
+                    options: {
+                        responsive: true, maintainAspectRatio: false, animation: false,
+                        plugins: {
+                            legend: { display: true, position: 'bottom',
+                                labels: { color: '#6b7280', font: { family: 'Courier New, monospace', size: 10 }, boxWidth: 8, usePointStyle: true } },
+                            tooltip: {
+                                callbacks: {
+                                    title: (items) => {
+                                        const first = Array.isArray(items) && items.length ? items[0] : null;
+                                        const ts = Number(first && first.raw && first.raw.ts);
+                                        if (!Number.isFinite(ts)) return '';
+                                        const d = new Date(ts);
+                                        const hh = String(d.getHours()).padStart(2, '0');
+                                        const mm = String(d.getMinutes()).padStart(2, '0');
+                                        const ss = String(d.getSeconds()).padStart(2, '0');
+                                        const ms = String(d.getMilliseconds()).padStart(3, '0');
+                                        return `${hh}:${mm}:${ss}.${ms}`;
+                                    },
+                                    label: (ctx) => {
+                                        const ts = Number(ctx && ctx.raw && ctx.raw.ts);
+                                        const startMs = Number(ctx.chart && ctx.chart.$windowStartMs) || 0;
+                                        const offset = Number.isFinite(ts) && startMs > 0
+                                            ? `  (+${((ts - startMs) / 1000).toFixed(3)}s)`
+                                            : '';
+                                        let extra = '';
+                                        let label = ctx.dataset.label;
+                                        if (ctx && ctx.raw) {
+                                            if (ctx.raw.state) {
+                                                extra = ctx.raw.reason
+                                                    ? `: ${ctx.raw.state} (${ctx.raw.reason})`
+                                                    : `: ${ctx.raw.state}`;
+                                            }
+                                            else if (Number.isFinite(Number(ctx.raw.mbps))) extra = `: ${variantLabel(ctx.raw.mbps, ctx.raw.resolution)}`;
+                                            else if (ctx.raw.field) extra = `: ${ctx.raw.field} ${ctx.raw.oldValue} → ${ctx.raw.newValue}`;
+                                            else if (ctx.raw.playId) extra = `: ${ctx.raw.playId.slice(0, 8)} (was ${(ctx.raw.prevPlayId || '∅').slice(0,8)})`;
+                                            else if (ctx.raw.type && EVENT_SUBTYPE_LABEL[ctx.raw.type]) extra = `: ${EVENT_SUBTYPE_LABEL[ctx.raw.type]}`;
+                                        }
+                                        return `${label}${extra}${offset}`;
+                                    }
+                                }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
+                        },
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
+                        scales: {
+                            x: {
+                                type: 'linear', min: 0, max: 600,
+                                ticks: {
+                                    maxTicksLimit: 8,
+                                    align: 'inner',
+                                    callback: (value) => {
+                                        const startMs = Number(chart && chart.$windowStartMs) || 0;
+                                        return formatBitrateChartAbsoluteTick(startMs, Number(value));
+                                    },
+                                    font: { family: 'Courier New, monospace', size: 9 },
+                                    color: '#6b7280'
+                                },
+                                grid: { color: 'rgba(0,0,0,0.05)' }
+                            },
+                            y: {
+                                type: 'linear', min: 0.5, max: 7.5,
+                                // Force a fixed Y-axis width so this chart's
+                                // X-axis lines up vertically with the bandwidth /
+                                // buffer / fps charts below (they all use the
+                                // same afterFit width).
+                                afterFit: (axis) => { axis.width = 90; },
+                                title: { display: true, text: 'Events', font: { family: 'Courier New, monospace', size: 11, weight: 'bold' }, color: '#4b5563' },
+                                ticks: {
+                                    stepSize: 1,
+                                    callback: (value) => {
+                                        const entry = Object.values(EVENT_LANES).find((l) => l.y === value);
+                                        return entry ? entry.label : '';
+                                    },
+                                    font: { family: 'Courier New, monospace', size: 9 },
+                                    color: '#6b7280'
+                                },
+                                grid: { color: 'rgba(0,0,0,0.05)' }
+                            }
+                        }
+                    }
+                });
+                chart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, chart);
+                installRightMousePanHandlers(sessionId, chart);
+                installChartClickPauseHandler(sessionId, chart);
+                ensureChartLiveWheelAnchor();
+                eventsCharts.set(sessionId, chart);
+            } else {
+                chart.data.datasets = datasets;
+                chart.$windowStartMs = windowStart;
+                applyChartXMax(chart, getChartWindowMs(sessionId));
+                chart.update('none');
+            }
+        }
+
+        // Real swim-lane chart using vis-timeline. Stacked above the
+        // Chart.js scatter approximation so we can compare. PLAYERSTATE
+        // becomes a continuous coloured ribbon (one segment per state
+        // span). Other lanes remain point markers since their underlying
+        // events are point-in-time. BUFFERING and STALL stay as points
+        // for now — pairing start/end into ranges needs the *_end events
+        // to flow through the dashboard event capture (currently only
+        // *_start variants reach parseBandwidthChartEventType).
+        function renderEventsTimelineChart(sessionId, windowStart, eventSeries) {
+            if (typeof vis === 'undefined' || !vis.Timeline) {
+                console.warn('[events-timeline] vis-timeline not loaded');
+                return;
+            }
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            const container = card.querySelector('.events-timeline');
+            if (!container) {
+                console.warn('[events-timeline] container .events-timeline not in DOM for session', sessionId);
+                return;
+            }
+            // Render the legend strip above the chart. We hide vis-
+            // timeline's left label panel via CSS so the chart area
+            // lines up with the Chart.js charts; the legend gives back
+            // the lane → colour mapping.
+            const legendEl = card.querySelector('.events-timeline-legend');
+            if (legendEl) {
+                const baseLegend = Object.entries(EVENT_LANES)
+                    .map(([type, cfg]) => `<span class="legend-item"><span class="legend-swatch" style="background:${cfg.color}"></span>${cfg.label}</span>`)
+                    .join('');
+                legendEl.innerHTML = baseLegend;
+            }
+
+            const nowMs = Date.now();
+            const events = (eventSeries || []).filter((e) => Number(e.ts) >= windowStart);
+
+            // Three top-level sections so user-driven control toggles,
+            // player-side events, and server-originated events are
+            // visually grouped. Lane order within each section follows
+            // EVENT_LANES.
+            const SERVER_LANES = new Set(['LOOP_SERVER']);
+            const CONTROL_LANES = new Set(['CONTROL']);
+            const playerLanes = Object.keys(EVENT_LANES).filter((k) =>
+                !SERVER_LANES.has(k) && !CONTROL_LANES.has(k) && k !== 'VARIANT');
+            const serverLanes = Object.keys(EVENT_LANES).filter((k) => SERVER_LANES.has(k));
+            const controlLanes = Object.keys(EVENT_LANES).filter((k) => CONTROL_LANES.has(k));
+
+            // Sync our collapse-state mirror from the live timeline
+            // BEFORE we rebuild the groups array — captures any user
+            // toggle that happened since the last render.
+            const existingTimeline = eventsTimelines.get(sessionId);
+            if (existingTimeline && existingTimeline.groupsData) {
+                const live = eventsTimelineSectionCollapsed.get(sessionId) || {};
+                const p = existingTimeline.groupsData.get('PLAYER_SECTION');
+                const c = existingTimeline.groupsData.get('CONTROL_SECTION');
+                const s = existingTimeline.groupsData.get('SERVER_SECTION');
+                if (p) live.player = (p.showNested === false);
+                if (c) live.control = (c.showNested === false);
+                if (s) live.server = (s.showNested === false);
+                eventsTimelineSectionCollapsed.set(sessionId, live);
+            }
+            const sectionState = eventsTimelineSectionCollapsed.get(sessionId) || {};
+            const playerShowNested = !sectionState.player;   // default true (expanded)
+            const controlShowNested = !sectionState.control;
+            const serverShowNested = !sectionState.server;
+
+            // VARIANT subgroups: one lane per observed (resolution,
+            // bitrate) tuple. Multi-bitrate-per-resolution variants are
+            // a real ABR ladder pattern (e.g. H.264 + HEVC at 1080p),
+            // so each gets its own row. Sorted by bitrate DESCENDING,
+            // so the visual ladder runs highest at the top, lowest at
+            // the bottom.
+            const variantEvents = events.filter((e) => e.type === 'VARIANT');
+            const seenVariants = new Map(); // key (res|mbps) -> {mbps, resolution}
+            for (const v of variantEvents) {
+                const res = String(v.resolution || '').trim();
+                const m = Number(v.mbps);
+                if (!res || !Number.isFinite(m) || m <= 0) continue;
+                const k = `${res}|${m}`;
+                if (!seenVariants.has(k)) {
+                    seenVariants.set(k, { mbps: m, resolution: res });
+                }
+            }
+            const variantOrder = Array.from(seenVariants.entries())
+                .sort((a, b) => Number(b[1].mbps) - Number(a[1].mbps));
+            const variantGroups = variantOrder.map(([k, v]) => ({
+                id: `VARIANT::${k}`,
+                content: variantLabel(v.mbps, v.resolution)
+            }));
+            const variantGroupIds = variantGroups.map((g) => g.id);
+
+            const groups = [
+                { id: 'PLAYER_SECTION', content: 'PLAYER', nestedGroups: [...variantGroupIds, ...playerLanes], showNested: playerShowNested },
+                ...variantGroups,
+                ...playerLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
+                { id: 'CONTROL_SECTION', content: 'CONTROL', nestedGroups: controlLanes, showNested: controlShowNested },
+                ...controlLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label })),
+                { id: 'SERVER_SECTION', content: 'SERVER', nestedGroups: serverLanes, showNested: serverShowNested },
+                ...serverLanes.map((type) => ({ id: type, content: EVENT_LANES[type].label }))
+            ];
+
+            const items = [];
+            let itemId = 0;
+
+            // Format absolute times for hover tooltips (matches the
+            // bitrate chart's HH:MM:SS).
+            function formatHoverTime(ms) {
+                const d = new Date(ms);
+                const hh = String(d.getHours()).padStart(2, '0');
+                const mm = String(d.getMinutes()).padStart(2, '0');
+                const ss = String(d.getSeconds()).padStart(2, '0');
+                return `${hh}:${mm}:${ss}`;
+            }
+
+            // Helper to render an event-series sequence as continuous
+            // ranges (one segment per stable value, transition on
+            // change). Heartbeat-style writers emit one event per poll
+            // even when nothing changed, so consecutive same-label
+            // entries are coalesced into a single range.
+            function pushRanges(typeKey, getLabel, getColor) {
+                const seq = events.filter((e) => e.type === typeKey)
+                    .sort((a, b) => Number(a.ts) - Number(b.ts));
+                let i = 0;
+                while (i < seq.length) {
+                    const start = Number(seq[i].ts);
+                    const label = getLabel(seq[i]);
+                    const color = getColor(seq[i]);
+                    let j = i + 1;
+                    while (j < seq.length && getLabel(seq[j]) === label) j++;
+                    const end = j < seq.length ? Number(seq[j].ts) : nowMs;
+                    const durationSec = ((end - start) / 1000).toFixed(1);
+                    const title = `${EVENT_LANES[typeKey].label}: ${label}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
+                    items.push({
+                        id: itemId++,
+                        group: typeKey,
+                        content: label,
+                        start: new Date(start),
+                        end: new Date(end),
+                        type: 'range',
+                        title: title,
+                        style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                    });
+                    i = j;
+                }
+            }
+
+            // PLAYERSTATE label includes the AVPlayer waiting reason
+            // (when present) so the user can disambiguate buffering
+            // causes — e.g. "buffering (toMinimizeStalls)".
+            pushRanges('PLAYERSTATE',
+                (e) => {
+                    const s = e.state || 'Unknown';
+                    return e.reason ? `${s} (${e.reason})` : s;
+                },
+                (e) => playerStateColor(e.state));
+            pushRanges('DISPLAY_RES',
+                (e) => String(e.resolution || '?'),
+                (e) => displayResColor(e.resolution));
+
+            // VARIANT: each (resolution, bitrate) tuple gets its own
+            // swim lane. Lane key matches seenVariants. Heartbeat-style
+            // emission means consecutive same-key entries coalesce into
+            // a single range.
+            const variantSeq = variantEvents.sort((a, b) => Number(a.ts) - Number(b.ts));
+            let vi = 0;
+            while (vi < variantSeq.length) {
+                const v = variantSeq[vi];
+                const res = String(v.resolution || '').trim();
+                const m = Number(v.mbps);
+                if (!res || !Number.isFinite(m) || m <= 0) { vi++; continue; }
+                const k = `${res}|${m}`;
+                let vj = vi + 1;
+                while (vj < variantSeq.length) {
+                    const nv = variantSeq[vj];
+                    const nres = String(nv.resolution || '').trim();
+                    const nm = Number(nv.mbps);
+                    if (`${nres}|${nm}` !== k) break;
+                    vj++;
+                }
+                const start = Number(v.ts);
+                const end = vj < variantSeq.length ? Number(variantSeq[vj].ts) : nowMs;
+                const color = variantColor(m);
+                const durationSec = ((end - start) / 1000).toFixed(1);
+                const title = `Variant: ${variantLabel(m, res)}\n${formatHoverTime(start)} → ${formatHoverTime(end)} (${durationSec}s)`;
+                items.push({
+                    id: itemId++,
+                    group: `VARIANT::${k}`,
+                    content: '',
+                    start: new Date(start),
+                    end: new Date(end),
+                    type: 'range',
+                    title: title,
+                    style: `background-color: ${color}; border-color: ${color}; color: #fff;`
+                });
+                vi = vj;
+            }
+
+            for (const e of events) {
+                if (e.type === 'PLAYERSTATE' || e.type === 'VARIANT' || e.type === 'DISPLAY_RES') continue;
+                const lane = EVENT_SUBTYPE_LANE[e.type] || e.type;
+                const cfg = EVENT_LANES[lane];
+                if (!cfg) continue;
+                const color = EVENT_SUBTYPE_COLOR[e.type] || cfg.color;
+                const subLabel = EVENT_SUBTYPE_LABEL[e.type] || e.type;
+                const ts = Number(e.ts);
+                const detail = e.field
+                    ? `\n${e.field}: ${e.oldValue} → ${e.newValue}`
+                    : (e.playId
+                        ? `\nplay_id: ${e.playId}${e.prevPlayId ? `\nwas: ${e.prevPlayId}` : ''}`
+                        : '');
+                items.push({
+                    id: itemId++,
+                    group: lane,
+                    content: '',
+                    start: new Date(ts),
+                    type: 'point',
+                    title: `${subLabel}${detail}\n${formatHoverTime(ts)}`,
+                    style: `background-color: ${color}; border-color: ${color};`
+                });
+            }
+
+            // Live-edge window: same span as the other charts (per-session
+            // override in chartWindowMsBySession; defaults to 10 min for
+            // live mode). Right edge anchored to "now" so events scroll
+            // left as time advances. Updated on every render so the view
+            // tracks live AND tracks the session-viewer brush expansion.
+            const liveWindowMs = getChartWindowMs(sessionId);
+            const liveStart = new Date(nowMs - liveWindowMs);
+            const liveEnd = new Date(nowMs);
+
+            // Compute explicit height. vis-timeline's height:'auto'
+            // collapses to 0 because the wrap has no intrinsic height
+            // (its internal panels are absolutely positioned). Use a
+            // uniform per-row estimate — section headers and lane
+            // rows share the same auto height now that we no longer
+            // CSS-override section-header heights (which broke
+            // label-to-lane alignment). Slight over-estimate is
+            // safer than under (under-estimate hides top rows).
+            const ROW_PX = 28;
+            const AXIS_PAD_PX = 50;
+            const computedHeight = (groups.length * ROW_PX) + AXIS_PAD_PX;
+            const heightPx = `${computedHeight}px`;
+            container.style.height = heightPx;
+
+            // If the session card was rebuilt (innerHTML rewrite, etc.)
+            // the cached timeline points at an orphaned div that's no
+            // longer in the DOM. Detect that and recreate against the
+            // new container — same defence the Chart.js code does
+            // (`if (chart.canvas !== canvas) destroy + recreate`).
+            let timeline = eventsTimelines.get(sessionId);
+            if (timeline && timeline.$container !== container) {
+                timeline.destroy();
+                eventsTimelines.delete(sessionId);
+                timeline = null;
+            }
+            if (!timeline) {
+                timeline = new vis.Timeline(
+                    container,
+                    new vis.DataSet(items),
+                    new vis.DataSet(groups),
+                    {
+                        stack: false,
+                        showCurrentTime: true,
+                        zoomable: true,
+                        moveable: true,
+                        margin: { item: 4 },
+                        orientation: { axis: 'top' },
+                        height: heightPx,
+                        start: liveStart,
+                        end: liveEnd,
+                        // Match the Chart.js bitrate chart's HH:MM:SS
+                        // 24-hour tick format. Suppress the date strip.
+                        // timeAxis.scale='second' + step=60 forces a
+                        // tick every 60 seconds at consistent spacing,
+                        // matching the bitrate chart's tick density.
+                        timeAxis: { scale: 'second', step: 60 },
+                        format: {
+                            minorLabels: {
+                                millisecond: 'HH:mm:ss',
+                                second: 'HH:mm:ss',
+                                minute: 'HH:mm:ss',
+                                hour: 'HH:mm:ss',
+                                weekday: 'HH:mm:ss',
+                                day: 'HH:mm:ss',
+                                week: 'HH:mm:ss',
+                                month: 'HH:mm:ss',
+                                year: 'HH:mm:ss'
+                            },
+                            majorLabels: {
+                                millisecond: '',
+                                second: '',
+                                minute: '',
+                                hour: '',
+                                weekday: '',
+                                day: '',
+                                week: '',
+                                month: '',
+                                year: ''
+                            }
+                        },
+                        // Match the Chart.js charts' zoom UX:
+                        //   plain wheel = page scroll (do not intercept)
+                        //   Alt/Option + wheel = zoom in/out
+                        // Pan is left-drag on the timeline (vis-timeline
+                        // doesn't support right-drag natively; close enough
+                        // to the Chart.js right-drag-pan behaviour).
+                        zoomKey: 'altKey',
+                        horizontalScroll: false,
+                        // Reasonable zoom bounds: 1s lower (heavy zoom in)
+                        // to 6h upper (back-out enough to see longer
+                        // sessions if user pans backward).
+                        zoomMin: 1000,
+                        zoomMax: 6 * 60 * 60 * 1000
+                    }
+                );
+                eventsTimelines.set(sessionId, timeline);
+                // Re-paint the event-marker overlay if a marker was
+                // picked before this timeline existed (lazy section
+                // open) or if the timeline was just recreated due to
+                // an orphaned-container detection.
+                reapplyEventMarkerToTimeline(sessionId);
+                ensureVisTimelineLiveWheelAnchor();
+                // Tag for the cross-chart viewport sync helpers, anchor
+                // the seconds-from-windowStart frame to liveStart so
+                // vis-timeline ranges convert consistently to the 0–600
+                // units the Chart.js charts use, and remember the DOM
+                // container so a session-card rebuild is detected on
+                // the next render.
+                timeline.$isVisTimeline = true;
+                timeline.$windowStartMs = liveStart.getTime();
+                timeline.$container = container;
+                applyStoredChartViewport(sessionId, timeline);
+                // After a user-driven range change (zoom or pan): if
+                // the chart is NOT paused, re-snap the right edge to
+                // "now" while preserving whatever zoom width the user
+                // landed on. This matches the Chart.js charts'
+                // live-mode behaviour — they auto-track live edge
+                // unless the explicit pause button is engaged. When
+                // paused, accept the user's range as-is.
+                timeline.on('rangechanged', (props) => {
+                    if (!props || !props.byUser) return;
+                    syncChartViewportAcrossSession(sessionId, timeline);
+                    if (isChartPaused(sessionId)) return;
+                    const width = props.end.getTime() - props.start.getTime();
+                    const nowMsLocal = Date.now();
+                    timeline.setWindow(
+                        new Date(nowMsLocal - width),
+                        new Date(nowMsLocal),
+                        { animation: false }
+                    );
+                });
+                // Click toggles pause (matches Chart.js
+                // installChartClickPauseHandler). Skip clicks on the
+                // group label / collapse arrow (those expand/collapse
+                // sections) and skip Alt-clicks (Alt is the zoom
+                // modifier). vis-timeline already distinguishes click
+                // from drag — `click` only fires on a real click.
+                timeline.on('click', (props) => {
+                    if (!props) return;
+                    if (props.event && props.event.altKey) return;
+                    if (props.what === 'group-label') return;
+                    toggleChartPause(sessionId);
+                });
+                // Container width is sometimes 0 on first paint (parent
+                // ScrollView not yet laid out, session card just inserted,
+                // etc). A single requestAnimationFrame isn't reliable —
+                // the next frame can still report width 0. Use a
+                // ResizeObserver that fires redraw() the moment the
+                // container actually has dimensions, then disconnects.
+                if (typeof ResizeObserver !== 'undefined') {
+                    const ro = new ResizeObserver((entries) => {
+                        for (const entry of entries) {
+                            if (entry.contentRect.width > 0) {
+                                timeline.redraw();
+                                ro.disconnect();
+                                return;
+                            }
+                        }
+                    });
+                    ro.observe(container);
+                } else {
+                    requestAnimationFrame(() => timeline.redraw());
+                }
+                timeline.$lastAppliedWindowMs = liveWindowMs;
+            } else {
+                timeline.setItems(new vis.DataSet(items));
+                timeline.setGroups(new vis.DataSet(groups));
+                // Re-apply height each render — group count changes as
+                // variant lanes appear/disappear.
+                timeline.setOptions({ height: heightPx });
+                timeline.$windowStartMs = liveStart.getTime();
+                // If the configured window span has changed since the
+                // last render — typically because the session-viewer
+                // user expanded the brush past 10 minutes — force the
+                // timeline width to match. Otherwise preserve whatever
+                // zoom width the user has interactively set.
+                const prevAppliedWindowMs = Number(timeline.$lastAppliedWindowMs) || 0;
+                const windowMsChanged = prevAppliedWindowMs !== liveWindowMs;
+                if (windowMsChanged) {
+                    timeline.setWindow(
+                        new Date(nowMs - liveWindowMs),
+                        new Date(nowMs),
+                        { animation: false }
+                    );
+                    timeline.$lastAppliedWindowMs = liveWindowMs;
+                } else if (!isChartPaused(sessionId)) {
+                    // Live-edge tracking: slide the visible window so
+                    // its right edge stays pinned to "now". Preserve
+                    // whatever zoom width the user has set.
+                    const win = timeline.getWindow();
+                    const width = win.end.getTime() - win.start.getTime();
+                    timeline.setWindow(
+                        new Date(nowMs - width),
+                        new Date(nowMs),
+                        { animation: false }
+                    );
+                }
+            }
+
+            // Right-edge-anchored tick markers placed at the same
+            // wall-clock times as the Chart.js charts' axis ticks
+            // (every 100s for the 10-min window). Items keep their
+            // exact timestamp positions regardless of where these
+            // tick lines fall.
+            //
+            // When the chart is paused, anchor the ticks to the
+            // visible window's right edge (frozen in time) so the
+            // tick lines stay on top of the events that were visible
+            // when the user paused — not slide right with wall-clock
+            // time while the events stay frozen.
+            const tickAnchorMs = isChartPaused(sessionId)
+                ? timeline.getWindow().end.getTime()
+                : nowMs;
+            refreshLiveTickMarkers(timeline, tickAnchorMs, liveWindowMs);
+        }
+
+        // Add vis-timeline custom-time markers at fixed intervals
+        // back from "now" — matches the Chart.js charts' tick spacing
+        // so HH:MM:SS labels line up vertically across events-timeline
+        // / bandwidth / buffer / fps charts. We rebuild every render
+        // (remove all, add fresh) because vis-timeline's setCustomTime
+        // updates internal state but the DOM line element does not
+        // always reposition — leaving labels that move while the
+        // vertical lines stay put.
+        function refreshLiveTickMarkers(timeline, nowMs, windowMs) {
+            // 100s interval matches Chart.js's auto-pick for the
+            // [0, 600] (seconds) range with maxTicksLimit:8 → ticks
+            // every 100s = 7 visible labels in the 10-min window.
+            const TICK_INTERVAL_MS = 100000;
+            const tickCount = Math.floor(windowMs / TICK_INTERVAL_MS) + 1;
+            if (!timeline.$tickIds) timeline.$tickIds = new Set();
+            const fmt = (ms) => {
+                const d = new Date(ms);
+                return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}:${String(d.getSeconds()).padStart(2,'0')}`;
+            };
+            // Drop every existing tick marker; the DOM line for a
+            // setCustomTime'd marker doesn't always re-render at the
+            // new x even though its label does.
+            for (const id of Array.from(timeline.$tickIds)) {
+                try { timeline.removeCustomTime(id); } catch (e) {}
+            }
+            timeline.$tickIds.clear();
+            // Re-add at the current wall-clock anchored positions.
+            for (let i = 0; i < tickCount; i++) {
+                const id = `live-tick-${i}`;
+                const t = nowMs - i * TICK_INTERVAL_MS;
+                try {
+                    timeline.addCustomTime(new Date(t), id);
+                    timeline.$tickIds.add(id);
+                    try { timeline.setCustomTimeMarker(fmt(t), id, false); } catch (e) {}
+                } catch (e) {}
+            }
+        }
+
+        document.addEventListener('testing-session:charts-resize', (event) => {
+            const sessionId = event.detail && event.detail.sessionId;
+            if (!sessionId) return;
+            const rebuildEventsTimeline = !!(event.detail && event.detail.rebuildEventsTimeline);
+            requestAnimationFrame(() => {
+                // Always destroy Chart.js charts; renderBandwidthChart
+                // recreates them.
+                const chartsToDestroy = [
+                    eventsCharts.get(sessionId),
+                    bandwidthCharts.get(sessionId),
+                    bufferDepthCharts.get(sessionId),
+                    videoFpsCharts.get(sessionId)
+                ];
+                for (const chart of chartsToDestroy) {
+                    if (chart && typeof chart.destroy === 'function') {
+                        chart.destroy();
+                    }
+                }
+                eventsCharts.delete(sessionId);
+                bandwidthCharts.delete(sessionId);
+                bufferDepthCharts.delete(sessionId);
+                videoFpsCharts.delete(sessionId);
+                // The events-timeline (vis.Timeline) is preserved by
+                // default — destroying it on every resize would cause a
+                // visible blink in the Player State section. Rebuild
+                // only when the caller signals the container went from
+                // hidden → visible (vis.Timeline initialized in a
+                // display:none container has broken internal layout
+                // that redraw() can't fix).
+                const tl = eventsTimelines.get(sessionId);
+                if (rebuildEventsTimeline && tl) {
+                    tl.destroy();
+                    eventsTimelines.delete(sessionId);
+                } else if (tl && typeof tl.redraw === 'function') {
+                    tl.redraw();
+                }
+                renderBandwidthChart(sessionId);
+            });
+        });
+
+        function renderBandwidthChart(sessionId) {
+            if (isChartPaused(sessionId)) return;
+            const series = bandwidthHistory.get(sessionId) || [];
+            const eventSeries = bandwidthEventHistory.get(sessionId) || [];
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            // Lazy render: skip the whole chart pass when both visualising
+            // sections are collapsed. Samples are still recorded in
+            // bandwidthHistory / bandwidthEventHistory above, so when the
+            // user opens either section the existing toggle handler fires
+            // testing-session:charts-resize → destroys charts → re-invokes
+            // this function, which rebuilds from history.
+            const bitrateContent = card.querySelector('[data-content="bitrate-chart"]');
+            const playerStateContent = card.querySelector('[data-content="player-state"]');
+            const bitrateClosed = bitrateContent && bitrateContent.style.display === 'none';
+            const playerStateClosed = playerStateContent && playerStateContent.style.display === 'none';
+            if (bitrateClosed && playerStateClosed) return;
+            const canvas = card.querySelector('canvas.bandwidth-chart');
+            if (!canvas || !series.length) return;
+            const windowMs = getChartWindowMs(sessionId);
+            const maxTs = series[series.length - 1].ts;
+            const windowStart = maxTs - windowMs;
+            const chartRangeLabel = card.querySelector('[data-field="bandwidth_chart_range"]');
+            if (chartRangeLabel) {
+                chartRangeLabel.textContent = formatBitrateChartRange(windowStart, maxTs);
+            }
+            const points = series
+                .filter(point => point.ts >= windowStart)
+                .map(point => ({
+                    x: (point.ts - windowStart) / 1000,
+                    shaperRate: point.shaperRate,
+                    shaperAvg: point.shaperAvg,
+                    transferRate: point.transferRate,
+                    transferComplete: point.transferComplete,
+                    metricsAtMs: point.metricsAtMs,
+                    bufferDepth: point.bufferDepth,
+                    wallClockOffset: point.wallClockOffset,
+                    playerEstimate: point.playerEstimate,
+                    playerWireBitrate: point.playerWireBitrate,
+                    currentRendition: point.currentRendition,
+                    serverRendition: point.serverRendition,
+                    framesDisplayed: point.framesDisplayed,
+                    framesDropped: point.framesDropped,
+                    target: point.target,
+                    variantLadder: point.variantLadder
+                }));
+            const chartEvents = eventSeries
+                .filter((event) => Number(event.ts) >= windowStart)
+                .map((event) => ({
+                    x: (event.ts - windowStart) / 1000,
+                    type: event.type
+                }))
+                .filter((event) => Number.isFinite(event.x) && event.x >= 0 && event.x <= 600);
+            renderEventsChart(sessionId, windowStart, eventSeries);
+            // Hide the per-session events swim-lane in compare mode —
+            // it shows events for ONE session only, which is confusing
+            // alongside the multi-session line charts below.
+            const compareActiveForTimeline = getCompareGroupIds().length >= 2;
+            const eventsTimelineWrap = card.querySelector('.events-timeline-wrap');
+            if (eventsTimelineWrap) {
+                eventsTimelineWrap.style.display = compareActiveForTimeline ? 'none' : '';
+            }
+            if (!compareActiveForTimeline) {
+                renderEventsTimelineChart(sessionId, windowStart, eventSeries);
+            }
+            const shaperRateData = points.map(point => ({ x: point.x, y: point.shaperRate }));
+            const shaperAvgData = points.map(point => ({ x: point.x, y: point.shaperAvg }));
+            const transferRateData = points.map(point => ({ x: point.x, y: point.transferRate }));
+            const transferCompleteData = points.map(point => ({ x: point.x, y: point.transferComplete }));
+            const bufferDepthData = points.map(point => ({ x: point.x, y: Number.isFinite(point.bufferDepth) ? point.bufferDepth : null }));
+            const wallClockOffsetData = points.map(point => ({ x: point.x, y: Number.isFinite(point.wallClockOffset) ? point.wallClockOffset : null }));
+            const estimateData = points.map(point => ({ x: point.x, y: point.playerEstimate || null }));
+            const playerWireBitrateData = points.map(point => ({
+                x: point.x,
+                y: (point.playerWireBitrate === null || point.playerWireBitrate === undefined) ? null : point.playerWireBitrate
+            }));
+            const renditionData = points.map(point => ({ x: point.x, y: point.currentRendition || null }));
+            const serverRenditionData = points.map(point => ({ x: point.x, y: point.serverRendition || null }));
+            const framesDisplayedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDisplayed) ? point.framesDisplayed : null, atMs: point.metricsAtMs || null }));
+            const framesDroppedData = points.map(point => ({ x: point.x, y: Number.isFinite(point.framesDropped) ? point.framesDropped : null, atMs: point.metricsAtMs || null }));
+            const targetData = points.map(point => ({ x: point.x, y: point.target }));
+
+            let variantLadder = [];
+            for (let idx = points.length - 1; idx >= 0; idx -= 1) {
+                if (Array.isArray(points[idx].variantLadder) && points[idx].variantLadder.length) {
+                    variantLadder = points[idx].variantLadder;
+                    break;
+                }
+            }
+
+            const visibility = bandwidthVisibility.get(sessionId) || {};
+            const compareGroupIdsForDefaults = getCompareGroupIds();
+            const compareActive = compareGroupIdsForDefaults.length >= 2;
+            const compareVisibleLabels = new Set([
+                'Player avg_network_bitrate',
+                'Player network_bitrate',
+                'Player Variant',
+                'Server Variant',
+                'Variants',
+                'Limit',
+                'mbps_shaper_avg',
+                'STALL',
+                'RESTART'
+            ]);
+            if (compareActive) {
+                for (const sid of compareGroupIdsForDefaults) {
+                    const tag = `S${sid}`;
+                    compareVisibleLabels.add(`Player Variant (${tag})`);
+                    compareVisibleLabels.add(`Player avg_network_bitrate (${tag})`);
+                    compareVisibleLabels.add(`Player network_bitrate (${tag})`);
+                    compareVisibleLabels.add(`Server Variant (${tag})`);
+                    compareVisibleLabels.add(`Shaper Avg (${tag})`);
+                }
+            }
+            const defaultVisibleLabels = compareActive
+                ? compareVisibleLabels
+                : new Set([
+                    'mbps_shaper_rate',
+                    'mbps_shaper_avg',
+                    'mbps_transfer_rate',
+                    'mbps_transfer_complete',
+                    'Player avg_network_bitrate',
+                    'Player network_bitrate',
+                    'Player Variant',
+                    'Server Variant',
+                    'Variants',
+                    'Limit',
+                    'STALL',
+                    'RESTART'
+                ]);
+            const isSeriesHidden = (label) => {
+                const key = bandwidthSeriesKey(label);
+                if (Object.prototype.hasOwnProperty.call(visibility, label)) {
+                    return visibility[label] === true;
+                }
+                if (Object.prototype.hasOwnProperty.call(visibility, key)) {
+                    return visibility[key] === true;
+                }
+                return !defaultVisibleLabels.has(key);
+            };
+            const axisMode = normalizeBitrateAxisMaxMode(
+                bitrateAxisMaxBySession.get(String(sessionId)) ||
+                card.querySelector('input[data-field="bitrate_chart_max_mbps"]:checked')?.value ||
+                'auto'
+            );
+            bitrateAxisMaxBySession.set(String(sessionId), axisMode);
+            const maxFor = (hidden, data) => (hidden ? [0] : data.map(point => point.y || 0));
+            // Exclude Limit — it can be set arbitrarily high (e.g. 10 Gbps when
+            // shaping is off) and would otherwise saturate auto-mode at the 100 cap.
+            const maxYAutoRaw = Math.max(1,
+                ...maxFor(isSeriesHidden('mbps_shaper_rate'), shaperRateData),
+                ...maxFor(isSeriesHidden('mbps_shaper_avg'), shaperAvgData),
+                ...maxFor(isSeriesHidden('mbps_transfer_rate'), transferRateData),
+                ...maxFor(isSeriesHidden('mbps_transfer_complete'), transferCompleteData),
+                ...maxFor(isSeriesHidden('Player avg_network_bitrate'), estimateData),
+                ...maxFor(isSeriesHidden('Player network_bitrate'), playerWireBitrateData),
+                ...maxFor(isSeriesHidden('Player Variant'), renditionData),
+                ...maxFor(isSeriesHidden('Server Variant'), serverRenditionData)
+            );
+            const maxYAuto = Math.min(100, Math.max(1, (Math.ceil((maxYAutoRaw * 1.05) * 10) / 10)));
+            const maxY = axisMode === 'auto' ? maxYAuto : Number(axisMode);
+
+            const variantsHidden = isSeriesHidden('Variants');
+            const variantDatasets = variantLadder.map((variant, index) => {
+                return {
+                    label: index === 0 ? 'Variants' : `_Variant ${variant.vx}`,
+                    data: points.map(point => ({ x: point.x, y: variant.mbps })),
+                    borderColor: '#9ca3af',
+                    backgroundColor: 'rgba(156,163,175,0.12)',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: index % 2 === 0 ? [2, 6] : [6, 3],
+                    hidden: variantsHidden
+                };
+            });
+
+            const datasets = [
+                {
+                    label: 'mbps_shaper_rate',
+                    data: shaperRateData,
+                    borderColor: '#0f766e',
+                    backgroundColor: 'rgba(15,118,110,0.12)',
+                    borderWidth: 1.7,
+                    pointRadius: 0,
+                    tension: 0.15,
+                    borderDash: [8, 2],
+                    hidden: isSeriesHidden('mbps_shaper_rate')
+                },
+                {
+                    label: compareActive ? `Shaper Avg (S${sessionId})` : 'mbps_shaper_avg',
+                    data: shaperAvgData,
+                    borderColor: '#0d9488',
+                    backgroundColor: 'rgba(13,148,136,0.12)',
+                    borderWidth: 1.7,
+                    pointRadius: 0,
+                    tension: 0.15,
+                    borderDash: [10, 3],
+                    hidden: isSeriesHidden(compareActive ? `Shaper Avg (S${sessionId})` : 'mbps_shaper_avg')
+                },
+                {
+                    label: 'mbps_transfer_rate',
+                    data: transferRateData,
+                    borderColor: '#f97316',
+                    backgroundColor: 'rgba(249,115,22,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [4, 2],
+                    hidden: isSeriesHidden('mbps_transfer_rate')
+                },
+                {
+                    label: 'mbps_transfer_complete',
+                    data: transferCompleteData,
+                    borderColor: '#dc2626',
+                    backgroundColor: 'rgba(220,38,38,0.15)',
+                    borderWidth: 3,
+                    pointRadius: 3,
+                    pointBackgroundColor: '#dc2626',
+                    tension: 0,
+                    stepped: 'after',
+                    hidden: isSeriesHidden('mbps_transfer_complete')
+                },
+                {
+                    label: compareActive ? `Player avg_network_bitrate (S${sessionId})` : 'Player avg_network_bitrate',
+                    data: estimateData,
+                    borderColor: '#6366f1',
+                    backgroundColor: 'rgba(99,102,241,0.12)',
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    borderDash: [6, 4],
+                    hidden: isSeriesHidden(compareActive ? `Player avg_network_bitrate (S${sessionId})` : 'Player avg_network_bitrate')
+                },
+                {
+                    label: compareActive ? `Player network_bitrate (S${sessionId})` : 'Player network_bitrate',
+                    data: playerWireBitrateData,
+                    borderColor: '#059669',
+                    backgroundColor: 'rgba(5,150,105,0.15)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    spanGaps: false,
+                    hidden: isSeriesHidden(compareActive ? `Player network_bitrate (S${sessionId})` : 'Player network_bitrate')
+                },
+                {
+                    label: compareActive ? `Player Variant (S${sessionId})` : 'Player Variant',
+                    data: renditionData,
+                    borderColor: '#ef4444',
+                    backgroundColor: 'rgba(239,68,68,0.12)',
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    borderDash: [3, 3],
+                    hidden: isSeriesHidden(compareActive ? `Player Variant (S${sessionId})` : 'Player Variant')
+                },
+                {
+                    label: compareActive ? `Server Variant (S${sessionId})` : 'Server Variant',
+                    data: serverRenditionData,
+                    borderColor: '#b45309',
+                    backgroundColor: 'rgba(180,83,9,0.12)',
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    borderDash: [10, 4],
+                    hidden: isSeriesHidden(compareActive ? `Server Variant (S${sessionId})` : 'Server Variant')
+                },
+                ...variantDatasets,
+                {
+                    label: 'Limit',
+                    data: targetData,
+                    borderColor: '#f59e0b',
+                    backgroundColor: 'rgba(245,158,11,0.12)',
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    stepped: true,
+                    hidden: isSeriesHidden('Limit')
+                },
+            ];
+
+            // Compare mode: overlay grouped sessions' key metrics
+            const compareGroupIds = getCompareGroupIds();
+            if (compareGroupIds.length >= 2) {
+                const otherIds = compareGroupIds.filter(sid => sid !== sessionId);
+                otherIds.forEach((sid, idx) => {
+                    const ci = sessionColorIndex(sid, compareGroupIds);
+                    const color = SESSION_COLORS[ci];
+                    const otherSeries = (bandwidthHistory.get(sid) || [])
+                        .filter(p => p.ts >= windowStart)
+                        .map(p => ({ x: (p.ts - windowStart) / 1000, y: p }));
+                    const tag = `S${sid}`;
+                    // Player Variant (visible by default in compare)
+                    datasets.push({
+                        label: `Player Variant (${tag})`,
+                        data: otherSeries.map(p => ({ x: p.x, y: p.y.currentRendition || null })),
+                        borderColor: color.main,
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [3, 3],
+                        hidden: isSeriesHidden(`Player Variant (${tag})`)
+                    });
+                    // Player avg_network_bitrate (visible by default in compare)
+                    datasets.push({
+                        label: `Player avg_network_bitrate (${tag})`,
+                        data: otherSeries.map(p => ({ x: p.x, y: p.y.playerEstimate || null })),
+                        borderColor: color.light,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [6, 4],
+                        hidden: isSeriesHidden(`Player avg_network_bitrate (${tag})`)
+                    });
+                    // Player Network Rate (visible by default in compare; null when session has no wire metric)
+                    datasets.push({
+                        label: `Player network_bitrate (${tag})`,
+                        data: otherSeries.map(p => ({
+                            x: p.x,
+                            y: (p.y.playerWireBitrate === null || p.y.playerWireBitrate === undefined)
+                                ? null
+                                : p.y.playerWireBitrate
+                        })),
+                        borderColor: color.main,
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [4, 2],
+                        spanGaps: false,
+                        hidden: isSeriesHidden(`Player network_bitrate (${tag})`)
+                    });
+                    // Server Variant (hidden by default)
+                    datasets.push({
+                        label: `Server Variant (${tag})`,
+                        data: otherSeries.map(p => ({ x: p.x, y: p.y.serverRendition || null })),
+                        borderColor: color.main,
+                        borderWidth: 1,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [10, 4],
+                        hidden: true
+                    });
+                    // Shaper Avg (visible by default in compare)
+                    datasets.push({
+                        label: `Shaper Avg (${tag})`,
+                        data: otherSeries.map(p => ({ x: p.x, y: p.y.shaperAvg || null })),
+                        borderColor: color.light,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.15,
+                        borderDash: [10, 3],
+                        hidden: isSeriesHidden(`Shaper Avg (${tag})`)
+                    });
+                });
+            }
+
+            let chart = bandwidthCharts.get(sessionId);
+            if (chart && chart.canvas !== canvas) {
+                chart.destroy();
+                chart = null;
+                bandwidthCharts.delete(sessionId);
+            }
+            if (!chart) {
+                // Ensure the canvas uses CSS sizing (prevent huge drawing buffer)
+                try {
+                    canvas.style.height = '320px';
+                    canvas.style.width = '100%';
+                    canvas.removeAttribute && canvas.removeAttribute('width');
+                    canvas.removeAttribute && canvas.removeAttribute('height');
+                } catch (e) {
+                    /* ignore */
+                }
+
+                chart = new Chart(canvas, {
+                    type: 'line',
+                    data: {
+                        datasets
+                    },
+                    options: {
+                        // Let Chart.js size the drawing buffer to the CSS box (handles DPR)
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                ...legendHoverCallbacks,
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    filter: (item) => !item.text.startsWith('_')
+                                },
+                                onClick: (evt, item, legend) => {
+                                    const index = item.datasetIndex;
+                                    const chartRef = legend.chart;
+                                    const label = chartRef.data.datasets[index]?.label;
+                                    if (!label) return;
+                                    const state = bandwidthVisibility.get(sessionId) || {};
+                                    const isVisible = chartRef.isDatasetVisible(index);
+                                    if (label === 'Variants') {
+                                        const newVisible = !isVisible;
+                                        chartRef.data.datasets.forEach((ds, i) => {
+                                            if (ds.label === 'Variants' || (ds.label && ds.label.startsWith('_Variant'))) {
+                                                chartRef.setDatasetVisibility(i, newVisible);
+                                            }
+                                        });
+                                        state['Variants'] = !newVisible;
+                                    } else {
+                                        chartRef.setDatasetVisibility(index, !isVisible);
+                                        state[label] = isVisible;
+                                        state[bandwidthSeriesKey(label)] = isVisible;
+                                    }
+                                    bandwidthVisibility.set(sessionId, state);
+                                    const currentAxisMode = normalizeBitrateAxisMaxMode(
+                                        bitrateAxisMaxBySession.get(String(sessionId)) || 'auto'
+                                    );
+                                    if (currentAxisMode === 'auto') {
+                                        const visibleMax = chartRef.data.datasets
+                                            .filter((_, i) => chartRef.isDatasetVisible(i))
+                                            .flatMap(ds => ds.data.map(pt => Number(pt.y) || 0))
+                                            .reduce((m, v) => Math.max(m, v), 1);
+                                        chartRef.options.scales.y.max = Math.min(100, Math.max(1, Math.ceil(visibleMax * 1.05 * 10) / 10));
+                                    }
+                                    chartRef.update('none');
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    title: (items) => {
+                                        const first = Array.isArray(items) && items.length ? items[0] : null;
+                                        if (!first) return '';
+                                        const xValue = Number(first.parsed?.x);
+                                        const startMs = Number(chart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, xValue);
+                                    }
+                                }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
+                        },
+                        // Reserve right padding equal to the FPS chart's
+                        // right-side Y-axis (Dropped/s) width so all four
+                        // charts' plot areas share the same right edge,
+                        // and so vertical tick lines line up across all
+                        // charts and the events-timeline above.
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
+                        scales: {
+                            x: {
+                                type: 'linear',
+                                min: 0,
+                                max: 600,
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    maxTicksLimit: 8,
+                                    align: 'inner',
+                                    callback: (value) => {
+                                        const startMs = Number(chart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, Number(value));
+                                    }
+                                }
+                            },
+                            y: {
+                                min: 0,
+                                max: maxY,
+                                afterFit: (axis) => { axis.width = 90; },
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Bitrate (Mbps)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            }
+                        }
+                    }
+                });
+                chart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, chart);
+                installRightMousePanHandlers(sessionId, chart);
+                installChartClickPauseHandler(sessionId, chart);
+                ensureChartLiveWheelAnchor();
+                bandwidthCharts.set(sessionId, chart);
+            } else {
+                chart.data.datasets = datasets;
+                chart.data.datasets.forEach((dataset, idx) => {
+                    const label = dataset.label;
+                    const hidden = (label && label.startsWith('_Variant'))
+                        ? isSeriesHidden('Variants')
+                        : isSeriesHidden(label);
+                    dataset.hidden = hidden;
+                    chart.setDatasetVisibility(idx, !hidden);
+                });
+                chart.$windowStartMs = windowStart;
+                chart.options.scales.y.max = maxY;
+                // Stretch the chart x-axis to match the active window
+                // — replay mode can grow this past the live default of
+                // 600s when the user expands the brush. Update zoom-
+                // plugin limits in lockstep so reset-zoom snaps back to
+                // the new full extent.
+                applyChartXMax(chart, windowMs);
+                applyLegendHover(chart);
+                chart.update('none');
+            }
+
+            const bufferCanvas = card.querySelector('canvas.buffer-depth-chart');
+            if (!bufferCanvas) return;
+            const bufferChartRangeLabel = card.querySelector('[data-field="buffer_depth_chart_range"]');
+            if (bufferChartRangeLabel) {
+                bufferChartRangeLabel.textContent = formatBitrateChartRange(windowStart, maxTs);
+            }
+            let bufferChart = bufferDepthCharts.get(sessionId);
+            if (bufferChart && bufferChart.canvas !== bufferCanvas) {
+                bufferChart.destroy();
+                bufferChart = null;
+                bufferDepthCharts.delete(sessionId);
+            }
+            const bufferDatasets = [
+                {
+                    label: compareActive ? `Buffer (S${sessionId})` : 'Buffer Depth',
+                    data: bufferDepthData,
+                    borderColor: '#2563eb',
+                    backgroundColor: 'rgba(37,99,235,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    yAxisID: 'y'
+                },
+                {
+                    // Wall-clock offset shares this chart on a right-side axis.
+                    // The two metrics are related — buffer drains tend to
+                    // coincide with offset jumps — so plotting them together
+                    // makes correlation immediate.
+                    label: compareActive ? `Wall-Clock (S${sessionId})` : 'Wall-Clock Offset',
+                    data: wallClockOffsetData,
+                    borderColor: '#0d9488',
+                    backgroundColor: 'rgba(13,148,136,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    yAxisID: 'y1'
+                }
+            ];
+            if (compareGroupIds.length >= 2) {
+                const otherIds = compareGroupIds.filter(sid => sid !== sessionId);
+                otherIds.forEach((sid) => {
+                    const ci = sessionColorIndex(sid, compareGroupIds);
+                    const color = SESSION_COLORS[ci];
+                    const otherBufferSeries = (bandwidthHistory.get(sid) || [])
+                        .filter(p => p.ts >= windowStart)
+                        .map(p => ({ x: (p.ts - windowStart) / 1000, y: Number.isFinite(p.bufferDepth) ? p.bufferDepth : null }));
+                    const otherWallSeries = (bandwidthHistory.get(sid) || [])
+                        .filter(p => p.ts >= windowStart)
+                        .map(p => ({ x: (p.ts - windowStart) / 1000, y: Number.isFinite(p.wallClockOffset) ? p.wallClockOffset : null }));
+                    bufferDatasets.push({
+                        label: `Buffer (S${sid})`,
+                        data: otherBufferSeries,
+                        borderColor: color.main,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [4, 3],
+                        yAxisID: 'y'
+                    });
+                    bufferDatasets.push({
+                        label: `Wall-Clock (S${sid})`,
+                        data: otherWallSeries,
+                        borderColor: color.light,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [2, 4],
+                        yAxisID: 'y1'
+                    });
+                });
+            }
+            // Buffer-depth bound (left axis): cap 60.
+            const bufferValues = bufferDatasets
+                .filter(ds => ds.yAxisID === 'y')
+                .flatMap(ds => ds.data)
+                .map((point) => Number(point && point.y))
+                .filter((value) => Number.isFinite(value) && value >= 0);
+            const maxBufferDepthRaw = Math.max(5, ...bufferValues, 0);
+            const maxBufferDepth = Math.min(60, Math.ceil(maxBufferDepthRaw / 5) * 5);
+            // Wall-clock bound (right axis): cap 120.
+            const wallValues = bufferDatasets
+                .filter(ds => ds.yAxisID === 'y1')
+                .flatMap(ds => ds.data)
+                .map((point) => Number(point && point.y))
+                .filter((value) => Number.isFinite(value));
+            const maxWallClockRaw = Math.max(5, ...wallValues, 0);
+            const maxWallClock = Math.min(120, Math.ceil(maxWallClockRaw / 5) * 5);
+            if (!bufferChart) {
+                bufferChart = new Chart(bufferCanvas, {
+                    type: 'line',
+                    data: {
+                        datasets: bufferDatasets
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                ...legendHoverCallbacks,
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    title: (items) => {
+                                        const first = Array.isArray(items) && items.length ? items[0] : null;
+                                        if (!first) return '';
+                                        const xValue = Number(first.parsed?.x);
+                                        const startMs = Number(bufferChart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, xValue);
+                                    }
+                                }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
+                        },
+                        scales: {
+                            x: {
+                                type: 'linear',
+                                min: 0,
+                                max: 600,
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    maxTicksLimit: 8,
+                                    align: 'inner',
+                                    callback: (value) => {
+                                        const startMs = Number(bufferChart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, Number(value));
+                                    }
+                                }
+                            },
+                            y: {
+                                position: 'left',
+                                min: 0,
+                                max: maxBufferDepth,
+                                afterFit: (axis) => { axis.width = 90; },
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Buffer Depth (s)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            y1: {
+                                position: 'right',
+                                min: 0,
+                                max: maxWallClock,
+                                // Pin width to RIGHT_AXIS_PAD_PX so the
+                                // plot's right edge matches the bandwidth
+                                // and FPS charts (and the events-timeline
+                                // above), keeping x-axis ticks vertically
+                                // aligned across all stacked charts.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
+                                grid: { drawOnChartArea: false },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Wall-Clock Offset (s)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            }
+                        }
+                    }
+                });
+                bufferChart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, bufferChart);
+                installRightMousePanHandlers(sessionId, bufferChart);
+                installChartClickPauseHandler(sessionId, bufferChart);
+                ensureChartLiveWheelAnchor();
+                bufferDepthCharts.set(sessionId, bufferChart);
+            } else {
+                const oldHidden = {};
+                bufferChart.data.datasets.forEach((ds, i) => {
+                    if (bufferChart.getDatasetMeta(i).hidden != null) {
+                        oldHidden[ds.label] = bufferChart.getDatasetMeta(i).hidden;
+                    }
+                });
+                bufferDatasets.forEach(ds => {
+                    if (ds.label in oldHidden) ds.hidden = oldHidden[ds.label];
+                });
+                bufferChart.data.datasets = bufferDatasets;
+                bufferChart.$windowStartMs = windowStart;
+                bufferChart.options.scales.y.max = maxBufferDepth;
+                bufferChart.options.scales.y1.max = maxWallClock;
+                applyChartXMax(bufferChart, windowMs);
+                applyLegendHover(bufferChart);
+                bufferChart.update('none');
+            }
+
+            const fpsCanvas = card.querySelector('canvas.video-fps-chart');
+            if (!fpsCanvas) return;
+            const fpsChartRangeLabel = card.querySelector('[data-field="video_fps_chart_range"]');
+            const fpsData = [];
+            const droppedFpsDataRaw = [];
+            const fpsWindowSeconds = 2.0;
+            const maxReasonableFps = 120;
+            const buildRateSeries = (counterSeries) => {
+                const out = [];
+                for (let idx = 0; idx < counterSeries.length; idx += 1) {
+                    const currentPoint = counterSeries[idx];
+                    const currentCount = Number(currentPoint.y);
+                    const currentX = Number(currentPoint.x);
+                    if (!Number.isFinite(currentCount) || !Number.isFinite(currentX)) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const targetX = currentX - fpsWindowSeconds;
+                    let anchorPoint = null;
+                    for (let j = idx - 1; j >= 0; j -= 1) {
+                        const candidateX = Number(counterSeries[j]?.x);
+                        if (!Number.isFinite(candidateX)) continue;
+                        if (candidateX <= targetX) {
+                            anchorPoint = counterSeries[j];
+                            break;
+                        }
+                    }
+                    if (!anchorPoint) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const anchorCount = Number(anchorPoint.y);
+                    const currentMs = Number(currentPoint.atMs);
+                    const anchorMs = Number(anchorPoint.atMs);
+                    const deltaSeconds = (Number.isFinite(currentMs) && Number.isFinite(anchorMs) && currentMs > anchorMs)
+                        ? (currentMs - anchorMs) / 1000
+                        : currentX - Number(anchorPoint.x);
+                    const deltaCount = currentCount - anchorCount;
+                    if (!Number.isFinite(anchorCount) || deltaSeconds <= 0 || deltaCount < 0) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    const rate = deltaCount / deltaSeconds;
+                    if (!Number.isFinite(rate) || rate < 0 || rate > maxReasonableFps) {
+                        out.push({ x: currentPoint.x, y: null });
+                        continue;
+                    }
+                    out.push({ x: currentPoint.x, y: rate });
+                }
+                return out;
+            };
+            fpsData.push(...buildRateSeries(framesDisplayedData));
+            droppedFpsDataRaw.push(...buildRateSeries(framesDroppedData));
+            const fpsValues = fpsData.map((point) => Number(point.y)).filter((value) => Number.isFinite(value) && value >= 0);
+            const droppedFpsValues = droppedFpsDataRaw.map((point) => Number(point.y)).filter((value) => Number.isFinite(value) && value >= 0);
+            const fpsSmoothedData = [];
+            let smooth = null;
+            const smoothingAlpha = 0.4;
+            for (const point of fpsData) {
+                const y = Number(point.y);
+                if (!Number.isFinite(y) || y < 0) {
+                    fpsSmoothedData.push({ x: point.x, y: null });
+                    continue;
+                }
+                if (smooth === null) {
+                    smooth = y;
+                } else {
+                    smooth = (smoothingAlpha * y) + ((1 - smoothingAlpha) * smooth);
+                }
+                fpsSmoothedData.push({ x: point.x, y: smooth });
+            }
+            const droppedFpsSmoothedData = [];
+            let droppedSmooth = null;
+            const droppedSmoothingAlpha = 0.35;
+            for (const point of droppedFpsDataRaw) {
+                const y = Number(point.y);
+                if (!Number.isFinite(y) || y < 0) {
+                    droppedFpsSmoothedData.push({ x: point.x, y: null });
+                    continue;
+                }
+                if (droppedSmooth === null) {
+                    droppedSmooth = y;
+                } else {
+                    droppedSmooth = (droppedSmoothingAlpha * y) + ((1 - droppedSmoothingAlpha) * droppedSmooth);
+                }
+                droppedFpsSmoothedData.push({ x: point.x, y: droppedSmooth });
+            }
+            const fpsSorted = [...fpsValues].sort((a, b) => a - b);
+            const baselineIdx = fpsSorted.length
+                ? Math.max(0, Math.min(fpsSorted.length - 1, Math.floor(fpsSorted.length * 0.75)))
+                : -1;
+            const baselineFps = baselineIdx >= 0 ? fpsSorted[baselineIdx] : 30;
+            const lowFpsThreshold = Math.max(8, baselineFps * 0.75);
+            const baselineData = points.map(point => ({ x: point.x, y: baselineFps }));
+            const lowThresholdData = points.map(point => ({ x: point.x, y: lowFpsThreshold }));
+            const lowFpsData = fpsSmoothedData.map(point => {
+                const y = Number(point.y);
+                return { x: point.x, y: (Number.isFinite(y) && y < lowFpsThreshold) ? y : null };
+            });
+            const maxFps = Math.min(120, Math.max(10, baselineFps * 1.2, ...fpsValues, 0));
+            const maxDroppedFps = Math.min(30, Math.max(2, ...droppedFpsValues, 0));
+            if (fpsChartRangeLabel) {
+                fpsChartRangeLabel.textContent = `${formatBitrateChartRange(windowStart, maxTs)} | baseline ${baselineFps.toFixed(1)} fps, low < ${lowFpsThreshold.toFixed(1)}, dropped max ${maxDroppedFps.toFixed(2)}/s`;
+            }
+            let fpsChart = videoFpsCharts.get(sessionId);
+            if (fpsChart && fpsChart.canvas !== fpsCanvas) {
+                fpsChart.destroy();
+                fpsChart = null;
+                videoFpsCharts.delete(sessionId);
+            }
+            const fpsDatasets = [
+                {
+                    label: compareActive ? `FPS (S${sessionId})` : 'FPS (smoothed)',
+                    data: fpsSmoothedData,
+                    borderColor: '#7e22ce',
+                    backgroundColor: 'rgba(126,34,206,0.10)',
+                    borderWidth: 2.2,
+                    pointRadius: 0,
+                    tension: 0.2
+                },
+                {
+                    label: 'Low FPS',
+                    data: lowFpsData,
+                    borderColor: '#dc2626',
+                    backgroundColor: 'rgba(220,38,38,0.22)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    spanGaps: false
+                },
+                {
+                    label: 'FPS Baseline',
+                    data: baselineData,
+                    borderColor: '#475569',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [6, 4]
+                },
+                {
+                    label: 'Low Threshold',
+                    data: lowThresholdData,
+                    borderColor: '#b91c1c',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [3, 4]
+                },
+                {
+                    label: compareActive ? `Dropped (S${sessionId})` : 'Dropped Frames/s',
+                    data: droppedFpsSmoothedData,
+                    yAxisID: 'yDrop',
+                    borderColor: '#ea580c',
+                    backgroundColor: 'rgba(234,88,12,0.14)',
+                    borderWidth: 1.8,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    borderDash: [5, 3]
+                }
+            ];
+            if (compareGroupIds.length >= 2) {
+                const otherIds = compareGroupIds.filter(sid => sid !== sessionId);
+                otherIds.forEach((sid) => {
+                    const ci = sessionColorIndex(sid, compareGroupIds);
+                    const color = SESSION_COLORS[ci];
+                    const otherSeries = (bandwidthHistory.get(sid) || []).filter(p => p.ts >= windowStart);
+                    // Compute FPS for other session
+                    const otherFps = [];
+                    const otherDropped = [];
+                    for (let i = 1; i < otherSeries.length; i++) {
+                        const dt = (otherSeries[i].ts - otherSeries[i - 1].ts) / 1000;
+                        if (dt <= 0) continue;
+                        if (otherSeries[i].framesDisplayed != null && otherSeries[i - 1].framesDisplayed != null) {
+                            const dFrames = otherSeries[i].framesDisplayed - otherSeries[i - 1].framesDisplayed;
+                            if (dFrames >= 0) {
+                                otherFps.push({ x: (otherSeries[i].ts - windowStart) / 1000, y: Math.round(dFrames / dt * 10) / 10 });
+                            }
+                        }
+                        if (otherSeries[i].framesDropped != null && otherSeries[i - 1].framesDropped != null) {
+                            const dDropped = otherSeries[i].framesDropped - otherSeries[i - 1].framesDropped;
+                            if (dDropped >= 0) {
+                                otherDropped.push({ x: (otherSeries[i].ts - windowStart) / 1000, y: Math.round(dDropped / dt * 100) / 100 });
+                            }
+                        }
+                    }
+                    const tag = `S${sid}`;
+                    fpsDatasets.push({
+                        label: `FPS (${tag})`,
+                        data: otherFps,
+                        borderColor: color.main,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [4, 3]
+                    });
+                    fpsDatasets.push({
+                        label: `Dropped (${tag})`,
+                        data: otherDropped,
+                        yAxisID: 'yDrop',
+                        borderColor: color.light,
+                        borderWidth: 1.5,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        borderDash: [5, 3]
+                    });
+                });
+            }
+            if (!fpsChart) {
+                fpsChart = new Chart(fpsCanvas, {
+                    type: 'line',
+                    data: {
+                        datasets: fpsDatasets
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                ...legendHoverCallbacks,
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    boxWidth: 14,
+                                    usePointStyle: true,
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    title: (items) => {
+                                        const first = Array.isArray(items) && items.length ? items[0] : null;
+                                        if (!first) return '';
+                                        const xValue = Number(first.parsed?.x);
+                                        const startMs = Number(fpsChart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, xValue);
+                                    }
+                                }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
+                        },
+                        scales: {
+                            x: {
+                                type: 'linear',
+                                min: 0,
+                                max: 600,
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    maxTicksLimit: 8,
+                                    align: 'inner',
+                                    callback: (value) => {
+                                        const startMs = Number(fpsChart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, Number(value));
+                                    }
+                                }
+                            },
+                            y: {
+                                min: 0,
+                                max: maxFps,
+                                afterFit: (axis) => { axis.width = 90; },
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Frames/s',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            yDrop: {
+                                position: 'right',
+                                min: 0,
+                                max: maxDroppedFps,
+                                // Pin width to RIGHT_AXIS_PAD_PX so all
+                                // four chart plot areas (and the events-
+                                // timeline above) end at the same X.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
+                                grid: { drawOnChartArea: false },
+                                ticks: {
+                                    color: '#9a3412',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Dropped/s',
+                                    color: '#9a3412',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            }
+                        }
+                    }
+                });
+                fpsChart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, fpsChart);
+                installRightMousePanHandlers(sessionId, fpsChart);
+                installChartClickPauseHandler(sessionId, fpsChart);
+                ensureChartLiveWheelAnchor();
+                videoFpsCharts.set(sessionId, fpsChart);
+            } else {
+                const oldHidden = {};
+                fpsChart.data.datasets.forEach((ds, i) => {
+                    if (fpsChart.getDatasetMeta(i).hidden != null) {
+                        oldHidden[ds.label] = fpsChart.getDatasetMeta(i).hidden;
+                    }
+                });
+                fpsDatasets.forEach(ds => {
+                    if (ds.label in oldHidden) ds.hidden = oldHidden[ds.label];
+                });
+                fpsChart.data.datasets = fpsDatasets;
+                fpsChart.$windowStartMs = windowStart;
+                fpsChart.options.scales.y.max = maxFps;
+                fpsChart.options.scales.yDrop.max = maxDroppedFps;
+                applyChartXMax(fpsChart, windowMs);
+                applyLegendHover(fpsChart);
+                fpsChart.update('none');
+            }
+        }
+
+        function saveSettingsForCard(card) {
+            const data = TestingSessionUI.readSessionSettings(card);
+            const fields = Object.keys(data || {}).filter(field => field !== 'session_id');
+            return sendSessionPatch(card, fields);
+        }
+
+        function applyNetworkShapingForCard(card) {
+            const sessionId = card.dataset.sessionId;
+            if (!sessionId) return Promise.resolve();
+            if (sessionId && isAbrcharRunLocked(sessionId)) {
+                console.warn('[NETSHAPE] Manual shaping apply blocked because ABR characterization is running.');
+                return Promise.resolve();
+            }
+            const getValue = (field) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                return input ? Number(input.value) : 0;
+            };
+            const payload = {
+                rate_mbps: getValue('shaping_throughput_mbps'),
+                delay_ms: getValue('shaping_delay_ms'),
+                loss_pct: getValue('shaping_loss_pct')
+            };
+            const pattern = TestingSessionUI.readShapingPattern(card);
+            const usePattern = pattern.template_mode !== 'sliders'
+                && Array.isArray(pattern.steps)
+                && pattern.steps.length > 0;
+            const patternSteps = usePattern ? (pattern.steps || []) : [];
+            pendingShaping.set(sessionId, {
+                timestamp: Date.now(),
+                values: {
+                    nftables_bandwidth_mbps: payload.rate_mbps,
+                    nftables_delay_ms: payload.delay_ms,
+                    nftables_packet_loss: payload.loss_pct,
+                    nftables_pattern_enabled: usePattern,
+                    nftables_pattern_steps: patternSteps,
+                    nftables_pattern_segment_duration_seconds: pattern.segment_duration_seconds,
+                    nftables_pattern_default_segments: pattern.default_segments,
+                    nftables_pattern_default_step_seconds: pattern.default_step_seconds,
+                    nftables_pattern_template_mode: pattern.template_mode,
+                    nftables_pattern_margin_pct: pattern.template_margin_pct
+                }
+            });
+            // Belt-and-suspenders cleanup: if the SSE handler hasn't already
+            // cleared the pending state once values match, drop it after 60s
+            // so we don't hold stale overrides forever.
+            setTimeout(() => {
+                const pending = pendingShaping.get(sessionId);
+                if (pending && Date.now() - pending.timestamp > 55000) {
+                    pendingShaping.delete(sessionId);
+                }
+            }, 60000);
+            const fields = [
+                'nftables_bandwidth_mbps',
+                'nftables_delay_ms',
+                'nftables_packet_loss',
+                'nftables_pattern_enabled',
+                'nftables_pattern_steps',
+                'nftables_pattern_segment_duration_seconds',
+                'nftables_pattern_default_segments',
+                'nftables_pattern_default_step_seconds',
+                'nftables_pattern_template_mode',
+                'nftables_pattern_margin_pct'
+            ];
+            return sendSessionPatch(card, fields);
+        }
+
+        function fetchSessions() {
+            fetch('/api/sessions', { cache: 'no-store' })
+                .then(async response => {
+                    if (!response.ok) {
+                        const body = await response.text();
+                        throw new Error(`/api/sessions failed (${response.status}): ${body.slice(0, 120)}`);
+                    }
+                    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+                    if (!contentType.includes('application/json')) {
+                        const body = await response.text();
+                        throw new Error(`/api/sessions returned non-JSON: ${body.slice(0, 120)}`);
+                    }
+                    return response.json();
+                })
+                .then(sessions => applySessionsList(sessions))
+                .catch(error => {
+                    console.error('Error fetching sessions:', error);
+                    document.getElementById('sessionsContainer').innerHTML = '<div class="status-message">Failed to load sessions.</div>';
+                });
+        }
+
+        function applySessionsList(sessions, options) {
+            const incomingList = Array.isArray(sessions) ? sessions : [];
+            const incomingMaxVersion = incomingList.reduce((max, session) => {
+                const version = getSessionSnapshotVersion(session);
+                return version > max ? version : max;
+            }, 0);
+            // Replay mode deliberately re-applies older snapshots when
+            // the user scrubs back through history — pass {force:true}
+            // to bypass the live-mode out-of-order guard. Without this
+            // the bandwidth/buffer/FPS/events charts wouldn't update on
+            // brush moves into earlier windows.
+            const force = !!(options && options.force);
+            if (
+                !force
+                && incomingMaxVersion > 0
+                && lastAppliedSnapshotVersion > 0
+                && incomingMaxVersion < lastAppliedSnapshotVersion
+            ) {
+                return;
+            }
+
+            const next = new Map();
+            incomingList.forEach((incomingSession) => {
+                const key = String(incomingSession?.session_id || '');
+                if (!key) return;
+                const existingSession = sessionsById.get(key);
+                if (!existingSession) {
+                    next.set(key, incomingSession);
+                    return;
+                }
+                const incomingVersion = getSessionSnapshotVersion(incomingSession);
+                const existingVersion = getSessionSnapshotVersion(existingSession);
+                if (incomingVersion === 0 && existingVersion > 0) {
+                    next.set(key, existingSession);
+                } else if (existingVersion === 0 || incomingVersion >= existingVersion) {
+                    next.set(key, incomingSession);
+                } else {
+                    next.set(key, existingSession);
+                }
+            });
+
+            if (incomingMaxVersion > lastAppliedSnapshotVersion) {
+                lastAppliedSnapshotVersion = incomingMaxVersion;
+            }
+
+            sessionsById.clear();
+            next.forEach((value, key) => sessionsById.set(key, value));
+            const validIds = new Set(next.keys());
+            Array.from(controlRevisionBySession.keys()).forEach((id) => {
+                if (!validIds.has(id)) {
+                    controlRevisionBySession.delete(id);
+                }
+            });
+            renderSessions();
+        }
+
+        function isFailureRangeField(field) {
+            return [
+                'segment_consecutive_failures',
+                'segment_failure_frequency',
+                'manifest_consecutive_failures',
+                'manifest_failure_frequency',
+                'master_manifest_consecutive_failures',
+                'master_manifest_failure_frequency',
+                'all_consecutive_failures',
+                'all_failure_frequency',
+                'transport_consecutive_failures',
+                'transport_failure_frequency',
+                'transfer_active_timeout_seconds',
+                'transfer_idle_timeout_seconds'
+            ].includes(field);
+        }
+
+        function getSessionBaseRevision(sessionId) {
+            const session = sessionsById.get(String(sessionId || ''));
+            const revision = session ? session.control_revision : null;
+            if (revision === undefined || revision === null) {
+                return '';
+            }
+            return String(revision);
+        }
+
+        function queuePendingFailureEdits(sessionId, values) {
+            if (!sessionId || !values) return;
+            const key = String(sessionId);
+            const existing = pendingFailureEdits.get(key);
+            const merged = {
+                ...(existing ? existing.values : {}),
+                ...values
+            };
+            pendingFailureEdits.set(key, {
+                timestamp: Date.now(),
+                values: merged
+            });
+            setTimeout(() => {
+                const pending = pendingFailureEdits.get(key);
+                if (pending && Date.now() - pending.timestamp > 4500) {
+                    pendingFailureEdits.delete(key);
+                }
+            }, 5000);
+        }
+
+        function resolvePendingFailureEdits(sessionId, fields) {
+            const key = String(sessionId || '');
+            const pending = pendingFailureEdits.get(key);
+            if (!pending) return;
+            const values = { ...pending.values };
+            (fields || []).forEach(field => {
+                delete values[field];
+            });
+            if (Object.keys(values).length === 0) {
+                pendingFailureEdits.delete(key);
+            } else {
+                pendingFailureEdits.set(key, {
+                    timestamp: pending.timestamp,
+                    values
+                });
+            }
+        }
+
+        function buildSessionPatch(card, fields) {
+            const data = TestingSessionUI.readSessionSettings(card);
+            const set = {};
+            const getShapingNumber = (field, fallback = 0) => {
+                const input = card.querySelector(`input[data-field="${field}"]`);
+                const value = input ? Number(input.value) : fallback;
+                return Number.isFinite(value) ? value : fallback;
+            };
+            const shapingPattern = TestingSessionUI.readShapingPattern(card);
+            const shapingFieldValues = {
+                nftables_bandwidth_mbps: getShapingNumber('shaping_throughput_mbps', 0),
+                nftables_delay_ms: getShapingNumber('shaping_delay_ms', 0),
+                nftables_packet_loss: getShapingNumber('shaping_loss_pct', 0),
+                nftables_pattern_enabled: shapingPattern.template_mode !== 'sliders' && Array.isArray(shapingPattern.steps) && shapingPattern.steps.length > 0,
+                nftables_pattern_steps: Array.isArray(shapingPattern.steps) ? shapingPattern.steps : [],
+                nftables_pattern_segment_duration_seconds: shapingPattern.segment_duration_seconds,
+                nftables_pattern_default_segments: shapingPattern.default_segments,
+                nftables_pattern_default_step_seconds: shapingPattern.default_step_seconds,
+                nftables_pattern_template_mode: shapingPattern.template_mode,
+                nftables_pattern_margin_pct: shapingPattern.template_margin_pct
+            };
+            (fields || []).forEach(field => {
+                if (Object.prototype.hasOwnProperty.call(data, field)) {
+                    set[field] = data[field];
+                } else if (Object.prototype.hasOwnProperty.call(shapingFieldValues, field)) {
+                    set[field] = shapingFieldValues[field];
+                }
+            });
+            return {
+                sessionId: data.session_id,
+                set,
+                fields: fields || []
+            };
+        }
+
+        function applySessionPatchResponse(session) {
+            if (!session || !session.session_id) return;
+            sessionsById.set(String(session.session_id), session);
+            renderSessions();
+        }
+
+        function sendSessionPatch(card, fields) {
+            const patch = buildSessionPatch(card, fields);
+            if (!patch.sessionId || Object.keys(patch.set).length === 0) {
+                return Promise.resolve();
+            }
+            queuePendingFailureEdits(patch.sessionId, patch.set);
+            return fetch(`/api/session/${patch.sessionId}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    set: patch.set,
+                    fields: patch.fields,
+                    base_revision: getSessionBaseRevision(patch.sessionId)
+                })
+            }).then(async response => {
+                const body = await response.json().catch(() => ({}));
+                if (!response.ok) {
+                    if (response.status === 409 && body.session) {
+                        resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                        pendingFailureEdits.delete(String(patch.sessionId));
+                        applySessionPatchResponse(body.session);
+                        return;
+                    }
+                    throw new Error(body.error || `HTTP ${response.status}`);
+                }
+                if (body.session) {
+                    resolvePendingFailureEdits(patch.sessionId, patch.fields);
+                    applySessionPatchResponse(body.session);
+                }
+            }).catch(error => {
+                console.error('Error saving settings:', error);
+            });
+        }
+
+        // Returns the full set of fields the server needs to keep
+        // mode / units / consecutive / frequency in sync for a given
+        // failure prefix. Used by both the slider-change handler and
+        // the Mode-dropdown handler so any single edit ships the
+        // coherent bundle.
+        function failureBundleFields(field) {
+            const prefixes = ['segment', 'manifest', 'master_manifest', 'all', 'transport'];
+            for (const prefix of prefixes) {
+                const matches =
+                    field === `${prefix}_failure_mode` ||
+                    field === `${prefix}_failure_units` ||
+                    field === `${prefix}_consecutive_units` ||
+                    field === `${prefix}_frequency_units` ||
+                    field === `${prefix}_consecutive_failures` ||
+                    field === `${prefix}_failure_frequency`;
+                if (matches) {
+                    return [
+                        `${prefix}_failure_mode`,
+                        `${prefix}_failure_units`,
+                        `${prefix}_consecutive_units`,
+                        `${prefix}_frequency_units`,
+                        `${prefix}_consecutive_failures`,
+                        `${prefix}_failure_frequency`,
+                    ];
+                }
+            }
+            return [field];
+        }
+
+        function scheduleFailureSave(card, field) {
+            const sessionId = card?.dataset?.sessionId;
+            if (!sessionId || !field) return;
+            const key = String(sessionId);
+            if (!failureSaveFields.has(key)) {
+                failureSaveFields.set(key, new Set());
+            }
+            // Touch any of the 6 related controls and we ship the
+            // whole bundle — keeps the server's view of mode/units/
+            // numbers self-consistent on every interaction.
+            failureBundleFields(field).forEach(f => failureSaveFields.get(key).add(f));
+            if (failureSaveTimers.has(key)) {
+                clearTimeout(failureSaveTimers.get(key));
+            }
+            failureSaveTimers.set(key, setTimeout(() => {
+                const fields = Array.from(failureSaveFields.get(key) || []);
+                failureSaveFields.delete(key);
+                failureSaveTimers.delete(key);
+                if (fields.length) {
+                    sendSessionPatch(card, fields);
+                }
+            }, 200));
+        }
+
+        function parseSessionControlName(name, sessionId) {
+            if (!name || !sessionId) return '';
+            const suffix = `_${sessionId}`;
+            if (!name.endsWith(suffix)) return '';
+            return name.slice(0, -suffix.length);
+        }
+
+        function resolveSessionPatchFields(target, sessionId, field) {
+            if (field === 'segment_failure_urls' || field === 'manifest_failure_urls' || field === 'all_failure_urls') {
+                return [field];
+            }
+            const prefix = parseSessionControlName(target.name, sessionId);
+            if (!prefix) return [];
+            if (prefix.endsWith('_failure_type')) {
+                return [prefix];
+            }
+            if (prefix.endsWith('_failure_mode')) {
+                // Same coherent bundle for every prefix — Mode change
+                // ships the units AND the slider values so the server
+                // can never end up with mode set but units missing.
+                return failureBundleFields(prefix);
+            }
+            return [];
+        }
+
+
+        function startSessionsPolling() {
+            if (sessionsPollTimer) return;
+            sessionsPollTimer = setInterval(fetchSessions, 5000);
+        }
+
+
+
+        // session-viewer.html removes the Active Sessions panel-header (and
+        // its Refresh / Release All buttons), so these getElementById calls
+        // can return null. Guard before binding.
+        document.getElementById('refreshSessions')?.addEventListener('click', fetchSessions);
+        document.getElementById('clearSessions')?.addEventListener('click', () => {
+            fetch('/api/clear-sessions', { method: 'POST' })
+                .then(() => fetchSessions())
+                .catch(error => console.error('Error clearing sessions:', error));
+        });
+
+        document.getElementById('sessionsContainer').addEventListener('change', (event) => {
+            if (event.target.id === 'compareModeToggle') {
+                compareMode = event.target.checked;
+                // Destroy existing charts so they rebuild with/without compare datasets
+                if (activeSessionId) {
+                    for (const chart of getChartsForSession(activeSessionId)) {
+                        if (chart && typeof chart.destroy === 'function') chart.destroy();
+                    }
+                    eventsCharts.delete(activeSessionId);
+                    bandwidthCharts.delete(activeSessionId);
+                    bufferDepthCharts.delete(activeSessionId);
+                    videoFpsCharts.delete(activeSessionId);
+                }
+                renderSessions();
+                return;
+            }
+        }, true);
+
+        let activeSliderSessionId = null;
+        document.getElementById('sessionsContainer').addEventListener('pointerdown', (event) => {
+            if (event.target.matches('input[type="range"]')) {
+                const card = event.target.closest('.session-card');
+                if (card) activeSliderSessionId = card.dataset.sessionId;
+            }
+        });
+        document.addEventListener('pointerup', () => {
+            activeSliderSessionId = null;
+            if (deferredRender) renderSessions();
+        });
+
+        document.getElementById('sessionsContainer').addEventListener('input', (event) => {
+            const input = event.target;
+            const card = input.closest('.session-card');
+            if (input.matches('input[type="range"]')) {
+                const value = input.value;
+                const valueEl = input.parentElement.querySelector('.range-value');
+                if (valueEl) valueEl.textContent = value;
+                if (card && isFailureRangeField(input.dataset.field)) {
+                    scheduleFailureSave(card, input.dataset.field);
+                }
+            }
+            if (input.dataset.field === 'shaping_step_mbps') {
+                const row = input.closest('.shape-step-row');
+                if (card && row) {
+                    syncStepPreset(row);
+                    updateStepRiskUi(card, row);
+                }
+            }
+            if (input.dataset.field === 'shaping_segment_duration_seconds' || input.dataset.field === 'shaping_default_segments') {
+                if (card) {
+                    TestingSessionUI.updatePatternDefaultLabel(card);
+                }
+            }
+        });
+
+        document.getElementById('sessionsContainer').addEventListener('change', (event) => {
+            const target = event.target;
+            if (target.classList.contains('session-checkbox')) {
+                const sessionId = target.dataset.sessionId;
+                if (sessionId) {
+                    const session = sessionsById.get(sessionId);
+                    const groupId = session?.group_id || '';
+                    if (target.checked) {
+                        selectedSessionIds.add(String(sessionId));
+                        // Auto-select all group members
+                        if (groupId) {
+                            for (const [sid, s] of sessionsById) {
+                                if (s.group_id === groupId) {
+                                    selectedSessionIds.add(String(sid));
+                                    const cb = document.querySelector(`.session-checkbox[data-session-id="${sid}"]`);
+                                    if (cb) cb.checked = true;
+                                }
+                            }
+                        }
+                    } else {
+                        selectedSessionIds.delete(String(sessionId));
+                        // Uncheck removes from group
+                        if (groupId) {
+                            fetch('/api/session-group/unlink', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ session_id: sessionId, group_id: groupId })
+                            }).then(() => fetchSessions()).catch(err => console.error('Unlink failed:', err));
+                        }
+                    }
+                }
+                event.stopPropagation();
+                return;
+            }
+            const card = target.closest('.session-card');
+            if (!card) return;
+            if (target.dataset.field === 'manifest_failure_urls' && target.value === 'All') {
+                const checks = card.querySelectorAll('input[data-field="manifest_failure_urls"]');
+                checks.forEach(input => {
+                    input.checked = target.checked;
+                });
+            }
+            if (target.dataset.field === 'manifest_failure_urls' && target.value !== 'All') {
+                const checks = Array.from(card.querySelectorAll('input[data-field="manifest_failure_urls"]'));
+                const allBox = checks.find(input => input.value === 'All');
+                const scopedChecks = checks.filter(input => input.value !== 'All');
+                if (allBox) {
+                    allBox.checked = scopedChecks.every(input => input.checked);
+                }
+            }
+            if (target.dataset.field === 'segment_failure_urls' && target.value === 'All') {
+                const checks = card.querySelectorAll('input[data-field="segment_failure_urls"]');
+                checks.forEach(input => {
+                    input.checked = target.checked;
+                });
+            }
+            if (target.dataset.field === 'segment_failure_urls' && target.value !== 'All') {
+                const checks = Array.from(card.querySelectorAll('input[data-field="segment_failure_urls"]'));
+                const allBox = checks.find(input => input.value === 'All');
+                const scopedChecks = checks.filter(input => input.value !== 'All');
+                if (allBox) {
+                    allBox.checked = scopedChecks.every(input => input.checked);
+                }
+            }
+            if (target.dataset.field === 'content_allowed_variants' || target.dataset.field === 'content_strip_codecs' || target.dataset.field === 'content_live_offset') {
+                sendSessionPatch(card, ['content_allowed_variants', 'content_strip_codecs', 'content_live_offset']);
+                return;
+            }
+            if (target.dataset.field === 'transfer_timeout_applies_segments' ||
+                target.dataset.field === 'transfer_timeout_applies_manifests' ||
+                target.dataset.field === 'transfer_timeout_applies_master') {
+                sendSessionPatch(card, [
+                    'transfer_timeout_applies_segments',
+                    'transfer_timeout_applies_manifests',
+                    'transfer_timeout_applies_master'
+                ]);
+                return;
+            }
+            if (target.dataset.field === 'shaping_step_enabled') {
+                const row = target.closest('.shape-step-row');
+                if (row) {
+                    setStepEnabledUi(card, row, !!target.checked);
+                }
+            }
+            if (target.dataset.field === 'transport_failure_mode') {
+                TestingSessionUI.updateTransportModeUi(card);
+            }
+            // Handle network log filter checkboxes
+            if (target.dataset.filter && target.closest('[data-content="network-log"]')) {
+                const card = target.closest('.session-card');
+                if (card && window.TestingSessionUI) {
+                    window.TestingSessionUI.applyNetworkLogFilters(card);
+                }
+                return;
+            }
+            if (target.dataset.field === 'bitrate_chart_max_mbps') {
+                const sessionId = String(card.dataset.sessionId || '');
+                const axisMode = normalizeBitrateAxisMaxMode(target.value);
+                bitrateAxisMaxBySession.set(sessionId, axisMode);
+                if (isChartPaused(sessionId)) {
+                    const chart = bandwidthCharts.get(sessionId);
+                    if (chart) {
+                        let maxY;
+                        if (axisMode === 'auto') {
+                            const visibleMax = chart.data.datasets
+                                .filter((_, idx) => chart.isDatasetVisible(idx))
+                                .flatMap(ds => ds.data.map(pt => Number(pt.y) || 0))
+                                .reduce((m, v) => Math.max(m, v), 1);
+                            maxY = Math.min(100, Math.max(1, Math.ceil(visibleMax * 1.05 * 10) / 10));
+                        } else {
+                            maxY = Number(axisMode);
+                        }
+                        chart.options.scales.y.max = maxY;
+                        chart.update('none');
+                    }
+                } else {
+                    renderBandwidthChart(sessionId);
+                }
+                return;
+            }
+            if (target.dataset.field && target.dataset.field.startsWith('shaping_template_')) {
+                // Reset state when template mode changes, preserve when margin/overhead changes
+                const resetState = target.dataset.field === 'shaping_template_mode';
+                const templateMode = getTemplateMode(card);
+                if (templateMode === 'sliders') {
+                    // In sliders mode, apply immediately as before
+                    applyTemplatePattern(card, true, resetState);
+                } else {
+                    // In pattern mode, any template change (mode/margin) reopens
+                    // the edit view and stops the currently-running pattern.
+                    const group = card.querySelector('.shaping-pattern-group');
+                    const wasApplied = group && group.classList.contains('pattern-applied');
+                    if (group) group.classList.remove('pattern-applied');
+                    if (wasApplied) {
+                        const sessionId = card.dataset.sessionId;
+                        if (sessionId) {
+                            fetch(`/api/session/${sessionId}`, {
+                                method: 'PATCH',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                    set: { nftables_pattern_enabled: false },
+                                    fields: ['nftables_pattern_enabled']
+                                })
+                            }).catch(err => console.warn('Failed to stop pattern on template change', err));
+                        }
+                    }
+                    applyTemplatePattern(card, false, resetState);
+                }
+                return;
+            }
+            if (target.dataset.field === 'shaping_default_step_seconds') {
+                const templateMode = getTemplateMode(card);
+                if (templateMode === 'sliders') {
+                    scheduleShapingApply(card);
+                } else {
+                    const group = card.querySelector('.shaping-pattern-group');
+                    const wasApplied = group && group.classList.contains('pattern-applied');
+                    if (group) group.classList.remove('pattern-applied');
+                    if (wasApplied) {
+                        const sessionId = card.dataset.sessionId;
+                        if (sessionId) {
+                            fetch(`/api/session/${sessionId}`, {
+                                method: 'PATCH',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({
+                                    set: { nftables_pattern_enabled: false },
+                                    fields: ['nftables_pattern_enabled']
+                                })
+                            }).catch(err => console.warn('Failed to stop pattern on step-seconds change', err));
+                        }
+                    }
+                    applyTemplatePattern(card, false, false, false);
+                }
+                return;
+            }
+            if (target.dataset.field === 'shaping_step_mbps_preset') {
+                const row = target.closest('.shape-step-row');
+                const mbpsInput = row ? row.querySelector('input[data-field="shaping_step_mbps"]') : null;
+                if (mbpsInput && target.value !== 'custom') {
+                    mbpsInput.value = target.value;
+                    updateStepRiskUi(card, row);
+                }
+            }
+            if (target.dataset.field && target.dataset.field.startsWith('shaping_')) {
+                const templateMode = getTemplateMode(card);
+                if (templateMode === 'sliders') {
+                    const sliderFieldMap = {
+                        'shaping_throughput_mbps': 'nftables_bandwidth_mbps',
+                        'shaping_delay_ms': 'nftables_delay_ms',
+                        'shaping_loss_pct': 'nftables_packet_loss'
+                    };
+                    const serverField = sliderFieldMap[target.dataset.field];
+                    if (serverField) {
+                        scheduleSingleShapingApply(card, serverField, Number(target.value));
+                    } else {
+                        scheduleShapingApply(card);
+                    }
+                }
+                return;
+            }
+            if (isFailureRangeField(target.dataset.field)) {
+                scheduleFailureSave(card, target.dataset.field);
+                return;
+            }
+            const sessionId = String(card.dataset.sessionId || '');
+            const field = target.dataset.field || '';
+            const fields = resolveSessionPatchFields(target, sessionId, field);
+            if (fields.length) {
+                sendSessionPatch(card, fields);
+            }
+        });
+
+        document.getElementById('sessionsContainer').addEventListener('click', (event) => {
+            const checkbox = event.target.closest('.session-checkbox');
+            if (checkbox) {
+                event.stopPropagation();
+                return;
+            }
+            const button = event.target.closest('button');
+            if (!button) return;
+            
+            // Handle link selected sessions button
+            if (button.id === 'linkSelectedSessions') {
+                const statusEl = button.closest('.group-controls')?.querySelector('[data-role="link-status"]');
+                const sessionIds = Array.from(selectedSessionIds);
+                if (sessionIds.length < 2) {
+                    alert('Please select at least 2 sessions to group');
+                    return;
+                }
+                if (statusEl) statusEl.textContent = 'Linking sessions...';
+                fetch('/api/session-group/link', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_ids: sessionIds })
+                })
+                    .then(async response => {
+                        if (!response.ok) {
+                            const body = await response.text();
+                            throw new Error(body || `HTTP ${response.status}`);
+                        }
+                        return response.json();
+                    })
+                    .then(data => {
+                        if (statusEl) statusEl.textContent = `Grouped ${data.group_id || ''}`.trim();
+                        fetchSessions();
+                    })
+                    .catch(error => {
+                        console.error('Error grouping sessions:', error);
+                        if (statusEl) statusEl.textContent = `Group failed: ${error.message || 'unknown error'}`;
+                    });
+                return;
+            }
+            
+            // Handle ungroup button
+            if (button.classList.contains('unlink-btn')) {
+                const sessionId = button.dataset.sessionId;
+                const groupId = button.dataset.groupId;
+                fetch('/api/session-group/unlink', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ session_id: sessionId, group_id: groupId, unlink_group: true })
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        fetchSessions();
+                    })
+                    .catch(error => console.error('Error unlinking session:', error));
+                return;
+            }
+            
+            if (button.dataset.sessionTab) {
+                activeSessionId = button.dataset.sessionTab;
+                isTabLocked = true;
+                renderSessions();
+                return;
+            }
+            const card = button.closest('.session-card');
+            if (!card) return;
+            const sessionId = card.dataset.sessionId;
+            if (button.dataset.action === 'reset-bitrate-zoom') {
+                const key = String(sessionId || '');
+                chartViewportBySession.delete(key);
+                if (rightPanDragState && rightPanDragState.sessionId === key) {
+                    rightPanDragState = null;
+                }
+                for (const chart of getChartsForSession(key)) {
+                    if (chart && typeof chart.resetZoom === 'function') {
+                        chart.resetZoom('none');
+                    }
+                }
+                updateResetZoomButtonState(key);
+                return;
+            }
+            if (button.dataset.action === 'pause-bitrate-chart') {
+                toggleChartPause(String(sessionId || ''));
+                return;
+            }
+            if (button.dataset.action === 'apply-pattern') {
+                scheduleShapingApply(card);
+                const group = card.querySelector('.shaping-pattern-group');
+                if (group) group.classList.add('pattern-applied');
+                return;
+            }
+            if (button.dataset.action === 'edit-pattern') {
+                const group = card.querySelector('.shaping-pattern-group');
+                if (group) group.classList.remove('pattern-applied');
+                return;
+            }
+            if (button.dataset.action === 'add-shaping-step') {
+                const rowsHost = card.querySelector('[data-field="shaping_pattern_rows"]');
+                const throughput = Number(card.querySelector('input[data-field="shaping_throughput_mbps"]')?.value || 0);
+                const defaultSeconds = getDefaultStepSeconds(card);
+                if (rowsHost) {
+                    rowsHost.appendChild(makeShapeStepRow(card, throughput, defaultSeconds));
+                    updateStepIndices(card);
+                    const templateMode = getTemplateMode(card);
+                    if (templateMode === 'sliders') {
+                        scheduleShapingApply(card);
+                    }
+                }
+                return;
+            }
+            if (button.dataset.action === 'remove-shaping-step') {
+                const row = button.closest('.shape-step-row');
+                if (row) {
+                    row.remove();
+                    updateStepIndices(card);
+                    const templateMode = getTemplateMode(card);
+                    if (templateMode === 'sliders') {
+                        scheduleShapingApply(card);
+                    }
+                }
+                return;
+            }
+            if (button.dataset.action === 'clear-shaping-pattern') {
+                const rowsHost = card.querySelector('[data-field="shaping_pattern_rows"]');
+                if (rowsHost) {
+                    rowsHost.innerHTML = '';
+                    const templateMode = getTemplateMode(card);
+                    if (templateMode === 'sliders') {
+                        scheduleShapingApply(card);
+                    }
+                }
+                return;
+            }
+            if (button.dataset.action === 'refresh-network-log') {
+                const sessionId = card.dataset.sessionId;
+                if (sessionId && window.TestingSessionUI) {
+                    window.TestingSessionUI.updateNetworkLog(sessionId);
+                }
+                return;
+            }
+            if (button.dataset.action === 'save-session') {
+                saveSettingsForCard(card).catch(error => console.error('Error saving settings:', error));
+            }
+            if (button.dataset.action === 'delete-session') {
+                fetch(`/api/session/${sessionId}`, { method: 'DELETE' })
+                    .then(() => fetchSessions())
+                    .catch(error => console.error('Error deleting session:', error));
+            }
+        });
+
+        // Right-click context menu on session tabs
+        let ctxMenu = null;
+        function hideContextMenu() { if (ctxMenu) { ctxMenu.remove(); ctxMenu = null; } }
+        document.addEventListener('click', hideContextMenu);
+        document.getElementById('sessionsContainer').addEventListener('contextmenu', (event) => {
+            const tab = event.target.closest('.session-tab');
+            if (!tab) return;
+            event.preventDefault();
+            hideContextMenu();
+            const sessionId = tab.dataset.sessionTab;
+            if (!sessionId) return;
+            const session = sessionsById.get(sessionId);
+            if (!session) return;
+            const allSessions = Array.from(sessionsById.values());
+            const groupId = session.group_id || '';
+            const existingGroups = [...new Set(allSessions.map(s => s.group_id).filter(Boolean))];
+
+            const menu = document.createElement('div');
+            menu.style.cssText = 'position:fixed;background:#fff;border:1px solid #ccc;border-radius:6px;padding:4px 0;box-shadow:0 4px 12px rgba(0,0,0,0.15);z-index:9999;min-width:180px;font-size:13px;';
+            menu.style.left = event.clientX + 'px';
+            menu.style.top = event.clientY + 'px';
+
+            const addItem = (text, onClick) => {
+                const item = document.createElement('div');
+                item.textContent = text;
+                item.style.cssText = 'padding:6px 16px;cursor:pointer;';
+                item.addEventListener('mouseenter', () => item.style.background = '#f0f0f0');
+                item.addEventListener('mouseleave', () => item.style.background = '');
+                item.addEventListener('click', () => { hideContextMenu(); onClick(); });
+                menu.appendChild(item);
+            };
+
+            if (groupId) {
+                addItem('Remove from Group', () => {
+                    fetch('/api/session-group/unlink', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ session_id: sessionId, group_id: groupId })
+                    }).then(() => fetchSessions()).catch(err => console.error('Unlink failed:', err));
+                });
+            }
+
+            if (!groupId) {
+                existingGroups.forEach(gid => {
+                    const members = allSessions.filter(s => s.group_id === gid);
+                    const memberLabel = members.map(s => `S${s.session_id}`).join(', ');
+                    addItem(`Add to ${gid} (${memberLabel})`, () => {
+                        const ids = [...members.map(s => s.session_id), sessionId];
+                        fetch('/api/session-group/link', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ session_ids: ids, group_id: gid })
+                        }).then(() => fetchSessions()).catch(err => console.error('Link failed:', err));
+                    });
+                });
+                const ungroupedOthers = allSessions.filter(s => s.session_id !== sessionId && !s.group_id);
+                ungroupedOthers.forEach(other => {
+                    addItem(`Group with Session ${other.session_id}`, () => {
+                        fetch('/api/session-group/link', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ session_ids: [sessionId, other.session_id] })
+                        }).then(() => fetchSessions()).catch(err => console.error('Link failed:', err));
+                    });
+                });
+            }
+
+            if (menu.children.length === 0) {
+                addItem('No group actions available', () => {});
+            }
+
+            document.body.appendChild(menu);
+            ctxMenu = menu;
+        });
+
+        // Replay mode: ?replay=1&session=<id>[&from=<rfc3339>][&to=<rfc3339>]
+        // Loads snapshots from the analytics forwarder and feeds them through
+        // the same applySessionsList renderer the live SSE stream uses. We
+        // patch Date.now during each snapshot's processing so the chart
+        // accumulators (which key time off Date.now) line up with the
+        // snapshot's recorded timestamp.
+
+
+        // Expose state + functions for sibling shared modules
+        // Per-session event-marker {tsMs, label}. The replay viewer's
+        // events dropdown publishes a `replay:event-marker` custom
+        // event; the listener below fans the value out to every chart
+        // (Chart.js + vis.Timeline) so the user sees a vertical guide
+        // line at exactly the event's moment in each panel, with a
+        // colored label box identifying the event type.
+        const eventMarkerBySession = new Map();
+
+        // Paint or update an event-marker overlay on the player-state
+        // vis-timeline. We don't use vis-timeline's built-in custom-
+        // time bar because: (1) it's only 1 px wide, (2) labels are
+        // hover-only, (3) styling has to fight vis-timeline's CSS
+        // specificity. Instead we inject our own absolute-positioned
+        // div into the timeline's centre panel and update its left
+        // coord whenever the timeline's range changes (zoom/pan).
+        function paintTimelineEventMarker(timeline, marker) {
+            if (!timeline || !timeline.body || !timeline.body.dom) return;
+            const center = timeline.body.dom.center;
+            if (!center) return;
+            const MARKER_CLASS = 'replay-event-marker';
+            // Remove existing marker first.
+            const existing = center.querySelector('.' + MARKER_CLASS);
+            if (existing) existing.remove();
+            if (!marker) return;
+            const range = timeline.range;
+            if (!range) return;
+            const startMs = Number(range.start);
+            const endMs = Number(range.end);
+            if (!(endMs > startMs)) return;
+            if (marker.tsMs < startMs || marker.tsMs > endMs) return;
+            const fraction = (marker.tsMs - startMs) / (endMs - startMs);
+            const wrapper = document.createElement('div');
+            wrapper.className = MARKER_CLASS;
+            wrapper.style.cssText =
+                'position:absolute;top:0;bottom:0;width:0;' +
+                'border-left:2px solid #0891b2;' +
+                'pointer-events:none;z-index:1000;';
+            wrapper.style.left = `${(fraction * 100).toFixed(3)}%`;
+            const label = document.createElement('div');
+            label.style.cssText =
+                'position:absolute;top:2px;left:4px;' +
+                'background:#0891b2;color:#fff;' +
+                'font:10px system-ui,-apple-system,sans-serif;' +
+                'padding:2px 4px;border-radius:2px;white-space:nowrap;' +
+                'box-shadow:0 1px 3px rgba(0,0,0,0.25);';
+            label.textContent = marker.label || '';
+            wrapper.appendChild(label);
+            center.appendChild(wrapper);
+        }
+
+        function applyEventMarker(sessionId, tsMs, label) {
+            const key = String(sessionId);
+            const markerLabel = (label == null ? '' : String(label));
+            if (tsMs == null || !Number.isFinite(Number(tsMs))) {
+                eventMarkerBySession.delete(key);
+            } else {
+                eventMarkerBySession.set(key, { tsMs: Number(tsMs), label: markerLabel });
+            }
+            const marker = eventMarkerBySession.get(key);
+            const pools = [bandwidthCharts, bufferDepthCharts, videoFpsCharts, eventsCharts];
+            for (const pool of pools) {
+                if (!pool) continue;
+                const chart = pool.get(key) || pool.get(sessionId);
+                if (!chart) continue;
+                chart.$eventMarkerTsMs = marker ? marker.tsMs : null;
+                chart.$eventMarkerLabel = marker ? marker.label : '';
+                try { chart.draw(); } catch (_) { /* chart may be tearing down */ }
+            }
+            const timeline = eventsTimelines.get(key) || eventsTimelines.get(sessionId);
+            if (timeline) {
+                paintTimelineEventMarker(timeline, marker);
+                // Re-paint on every range change so the line tracks
+                // zoom/pan. Lazily attach the listener once per
+                // timeline; subsequent applyEventMarker calls only
+                // update $eventMarker so the listener picks up the
+                // new value on next rangechange.
+                timeline.$eventMarker = marker || null;
+                if (!timeline.$eventMarkerBound) {
+                    timeline.$eventMarkerBound = true;
+                    timeline.on('rangechange', () => paintTimelineEventMarker(timeline, timeline.$eventMarker));
+                    timeline.on('rangechanged', () => paintTimelineEventMarker(timeline, timeline.$eventMarker));
+                }
+            }
+        }
+
+        // Re-paint the timeline marker after any code path that may
+        // have re-created the timeline (e.g. orphan-detection in
+        // pushBandwidthSample). External hook: callers that build a
+        // fresh timeline should fire this so the marker survives.
+        function reapplyEventMarkerToTimeline(sessionId) {
+            const key = String(sessionId);
+            const marker = eventMarkerBySession.get(key);
+            const timeline = eventsTimelines.get(key) || eventsTimelines.get(sessionId);
+            if (!timeline) return;
+            paintTimelineEventMarker(timeline, marker || null);
+            timeline.$eventMarker = marker || null;
+            if (!timeline.$eventMarkerBound) {
+                timeline.$eventMarkerBound = true;
+                timeline.on('rangechange', () => paintTimelineEventMarker(timeline, timeline.$eventMarker));
+                timeline.on('rangechanged', () => paintTimelineEventMarker(timeline, timeline.$eventMarker));
+            }
+        }
+
+        // Guard against duplicate listener registration if this module's
+        // boot runs more than once (live-reload, future SPA navigation).
+        // Each extra copy would call applyEventMarker redundantly.
+        if (!window.__replayEventMarkerListenerBound) {
+            window.__replayEventMarkerListenerBound = true;
+            document.addEventListener('replay:event-marker', (ev) => {
+                if (!ev || !ev.detail) return;
+                applyEventMarker(ev.detail.sessionId, ev.detail.tsMs, ev.detail.label);
+            });
+        }
+
+        // (session-replay.js needs the chart history Maps and the
+        // applySessionsList / pushBandwidthSample primitives). Both
+        // are loaded before this script's boot runs.
+        window.SessionShell = {
+            sessionsById: sessionsById,
+            applySessionsList: applySessionsList,
+            pushBandwidthSample: pushBandwidthSample,
+            bandwidthHistory: bandwidthHistory,
+            bandwidthEventHistory: bandwidthEventHistory,
+            bandwidthCharts: bandwidthCharts,
+            bufferDepthCharts: bufferDepthCharts,
+            videoFpsCharts: videoFpsCharts,
+            eventsCharts: eventsCharts,
+            bandwidthVisibility: bandwidthVisibility,
+            bitrateAxisMaxBySession: bitrateAxisMaxBySession,
+            chartViewportBySession: chartViewportBySession,
+            chartPausedBySession: chartPausedBySession,
+            chartRenderSuppressedBySession: chartRenderSuppressedBySession,
+            chartWindowMsBySession: chartWindowMsBySession,
+            playBoundsBySession: playBoundsBySession,
+            brushDraggingBySession: brushDraggingBySession,
+            lastRecordedPlayerEventBySession: lastRecordedPlayerEventBySession,
+            lastRecordedLoopCountBySession: lastRecordedLoopCountBySession,
+            lastRecordedServerLoopCountBySession: lastRecordedServerLoopCountBySession,
+            lastRecordedLoopEventStampBySession: lastRecordedLoopEventStampBySession,
+            lastRecordedServerLoopEventStampBySession: lastRecordedServerLoopEventStampBySession,
+            lastRecordedControlsBySession: lastRecordedControlsBySession,
+            lastRecordedPlayIdBySession: lastRecordedPlayIdBySession,
+            fetchSessions: fetchSessions,
+            startSessionsPolling: startSessionsPolling
+        };
+
+        // Boot dispatch — three pages, one shell:
+        //   sessions.html         (body.session-selector) → picker only
+        //   session-viewer.html   (body.replay-mode + ?session=) → viewer
+        //   session-viewer.html   (body.replay-mode, no session) →
+        //                                          redirect to selector
+        //   testing.html          (no flags) → live SSE / polling
+        // Legacy: testing.html?replay=1 still routes to viewer or
+        // picker depending on whether ?session= is present.
+        //
+        // Deferred until DOMContentLoaded (or next task if already
+        // fired) so sibling modules — session-replay.js and
+        // session-live.js — finish loading before we read their
+        // window.SessionReplay / window.SessionLive exports.
+        function bootDispatch() {
+            const replayParams = new URLSearchParams(window.location.search);
+            const isSelectorPage = document.body.classList.contains('session-selector');
+            const replayMode = replayParams.get('replay') === '1'
+                || document.body.classList.contains('replay-mode');
+            const replaySession = replayParams.get('session');
+            if (isSelectorPage) {
+                window.SessionReplay.startPicker();
+            } else if (replayMode && replaySession) {
+                window.SessionReplay.startMode(
+                    replaySession,
+                    replayParams.get('from'),
+                    replayParams.get('to'),
+                    replayParams.get('play_id')
+                );
+            } else if (replayMode) {
+                // Viewer reached without a session — bounce to selector.
+                window.location.replace('/dashboard/sessions.html');
+            } else {
+                fetchSessions();
+                if (!(window.SessionLive && window.SessionLive.start())) {
+                    startSessionsPolling();
+                }
+            }
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', bootDispatch);
+        } else {
+            setTimeout(bootDispatch, 0);
+        }

--- a/content/shared/shared-nav.js
+++ b/content/shared/shared-nav.js
@@ -21,6 +21,7 @@
             { id: 'playback', icon: '▶️', text: 'Playback', href: '/dashboard/playback.html' },
             { id: 'test-playback', icon: '🧭', text: 'Testing Playback', href: '/dashboard/testing-session.html?nav=1' },
             { id: 'testing', icon: '🧪', text: 'Testing Monitor', href: '/dashboard/testing.html' },
+            { id: 'sessions', icon: '⏪', text: 'Sessions', href: '/dashboard/sessions.html' },
             { id: 'incidents', icon: '🚨', text: 'Incidents', href: '/dashboard/incidents.html' },
             { id: 'quartet', icon: '🎬', text: 'Quartet', href: '/dashboard/quartet.html', alpha: true },
             { id: 'segment-duration', icon: '⏱️', text: 'Live Offset', href: '/dashboard/segment-duration-comparison.html', alpha: true }
@@ -152,15 +153,27 @@
         }
         const path = window.location.pathname;
         const filename = path.split('/').pop() || 'dashboard.html';
-        
+
+        // Backwards compat: testing.html?replay=1 used to be the
+        // Session Viewer URL. Highlight the Sessions nav item if
+        // anyone bookmarked the old form.
+        if (filename === 'testing.html') {
+            const params = new URLSearchParams(window.location.search);
+            if (params.get('replay') === '1') return 'sessions';
+        }
+        // session-viewer.html is a deep-link target (only meaningful
+        // with ?session=); highlight the Sessions list when a viewer
+        // tab is open so the user can jump back to the selector.
+        if (filename === 'session-viewer.html') return 'sessions';
+
         // Check all navigation items
         for (const section in NAVIGATION) {
-            const item = NAVIGATION[section].find(item => 
+            const item = NAVIGATION[section].find(item =>
                 item.href && item.href.includes(filename)
             );
             if (item) return item.id;
         }
-        
+
         // Default to dashboard
         return 'dashboard';
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,81 @@ services:
     restart: unless-stopped
     stop_grace_period: 1s
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    container_name: infinite-streaming-clickhouse
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - clickhouse_data:/var/lib/clickhouse
+      - ./analytics/clickhouse/init.d:/docker-entrypoint-initdb.d:ro
+    environment:
+      - CLICKHOUSE_DB=infinite_streaming
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    # Bind to loopback only — ClickHouse has no auth configured here,
+    # so anyone on the LAN reaching :30123 would have full DROP/INSERT
+    # rights. The forwarder + Grafana reach it via the docker bridge
+    # (http://clickhouse:8123); host-side tools (e.g. `make
+    # analytics-migrate`, ad-hoc curl) reach it via 127.0.0.1.
+    ports:
+      - "127.0.0.1:30123:8123"
+    networks:
+      - app_network
+    restart: unless-stopped
+
+  forwarder:
+    build: ./analytics/go-forwarder
+    image: infinite-streaming-forwarder
+    container_name: infinite-streaming-forwarder
+    environment:
+      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_snapshots
+    depends_on:
+      - clickhouse
+      - go-server
+    networks:
+      - app_network
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana-oss:11.3.0
+    container_name: infinite-streaming-grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      # Viewer (not Editor) — anonymous LAN visitors can read dashboards
+      # but can't mutate them. Dashboards are provisioned-as-code from
+      # analytics/grafana/provisioning/, so editing through the web UI
+      # was never the workflow anyway.
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      # Grafana is reachable via the nginx /grafana/ prefix; the root
+      # URL must reflect the user-facing host:port so OAuth / login
+      # redirects land back on nginx, not Grafana's internal :3000.
+      # Override INFINITE_STREAM_BASE_URL in your environment when the
+      # public URL differs from the default localhost:30000.
+      - GF_SERVER_ROOT_URL=${INFINITE_STREAM_BASE_URL:-http://localhost:30000}/grafana/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./analytics/grafana/provisioning:/etc/grafana/provisioning:ro
+    # No host-side port — reach Grafana through the nginx /grafana/
+    # prefix so the same basic-auth and host firewall rules apply.
+    depends_on:
+      - clickhouse
+    networks:
+      - app_network
+    restart: unless-stopped
+
+volumes:
+  clickhouse_data:
+  grafana_data:
+
 networks:
   app_network:
     driver: bridge

--- a/docker/launch.sh
+++ b/docker/launch.sh
@@ -27,7 +27,28 @@ mkdir -p /etc/nginx/certs
 ln -sf "$certdir/localhost.pem" /etc/nginx/certs/localhost.pem
 ln -sf "$certdir/localhost-key.pem" /etc/nginx/certs/localhost-key.pem
 export INFINITE_STREAM_PROXY_HOST="${INFINITE_STREAM_PROXY_HOST:-127.0.0.1}"
-envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_LISTEN_PORT}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
+export INFINITE_STREAM_FORWARDER_HOST="${INFINITE_STREAM_FORWARDER_HOST:-forwarder}"
+export INFINITE_STREAM_GRAFANA_HOST="${INFINITE_STREAM_GRAFANA_HOST:-grafana}"
+
+# Opt-in basic-auth on dashboard pages, /analytics/api/, and /grafana/.
+# When INFINITE_STREAM_AUTH_HTPASSWD points at a readable htpasswd file,
+# nginx requires Basic auth on those routes. HLS playback URLs and the
+# live /api/* endpoints used by player apps are unaffected so unattended
+# Apple/Roku/AndroidTV clients keep working without credentials.
+# When unset (default), auth is disabled — same behaviour as before.
+if [ -n "$INFINITE_STREAM_AUTH_HTPASSWD" ] && [ -r "$INFINITE_STREAM_AUTH_HTPASSWD" ]; then
+  cp "$INFINITE_STREAM_AUTH_HTPASSWD" /etc/nginx/htpasswd
+  # 0644 — nginx workers may run as a non-root user and need read.
+  # The hashed passwords inside are bcrypt/sha-crypt anyway; leaking
+  # this file is a brute-force opportunity, not a credential dump.
+  chmod 0644 /etc/nginx/htpasswd
+  export INFINITE_STREAM_AUTH_DIRECTIVES="auth_basic \"InfiniteStream\"; auth_basic_user_file /etc/nginx/htpasswd;"
+  echo "Basic auth ENABLED for dashboard / analytics / grafana routes."
+else
+  export INFINITE_STREAM_AUTH_DIRECTIVES="auth_basic off;"
+  echo "Basic auth disabled (set INFINITE_STREAM_AUTH_HTPASSWD to a htpasswd file path to enable)."
+fi
+envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_FORWARDER_HOST} ${INFINITE_STREAM_GRAFANA_HOST} ${INFINITE_STREAM_LISTEN_PORT} ${INFINITE_STREAM_AUTH_DIRECTIVES}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
 
 # Start background processes and nginx
 # All processes now log to stdout/stderr for proper Docker log interleaving

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -24,6 +24,20 @@ upstream go_proxy {
     keepalive 4;
 }
 
+# Upstream to analytics forwarder (read-only ClickHouse query proxy)
+upstream analytics_forwarder {
+    server ${INFINITE_STREAM_FORWARDER_HOST}:8080;
+    keepalive 4;
+}
+
+# Upstream to Grafana. Routed through nginx so that basic-auth and the
+# host firewall rules apply uniformly — Grafana is no longer reachable
+# directly via its container port from outside the docker network.
+upstream analytics_grafana {
+    server ${INFINITE_STREAM_GRAFANA_HOST}:3000;
+    keepalive 4;
+}
+
 # Normal server
 server {
 
@@ -104,6 +118,7 @@ server {
     }
 
     location /dashboard/ {
+        ${INFINITE_STREAM_AUTH_DIRECTIVES}
         alias /content/dashboard/;
         try_files $uri $uri/ /dashboard/dashboard.html;
     }
@@ -117,7 +132,7 @@ server {
         return 302 /dashboard/dashboard.html;
     }
 
-    location / { 
+    location / {
         root /content;
         try_files $uri $uri/  @fallback;
     }
@@ -145,6 +160,62 @@ server {
     location = /api/announce-now {
         proxy_pass http://go_upload_service;
         add_header Access-Control-Allow-Origin * always;
+    }
+
+    # Analytics: read-only proxy to the SSE→ClickHouse forwarder, which
+    # exposes /api/snapshots and /api/sessions for historical replay and
+    # cross-session queries. Failing closed (502) when the forwarder is
+    # not running keeps the live UI unaffected.
+    # Bare /grafana → /grafana/ — the prefix-match `location ^~
+    # /grafana/` requires the trailing slash, so without this redirect
+    # /grafana would fall through to the catch-all and 404.
+    # Use $http_host (the client's Host header) instead of $host:$server_port
+    # so the redirect preserves the port the client actually connected
+    # on (e.g. 21000 on test-dev) — nginx's default would otherwise
+    # build the URL with its own listen port (30000 inside the container).
+    location = /grafana {
+        return 301 $scheme://$http_host/grafana/;
+    }
+
+    # Grafana, routed through nginx so basic-auth applies uniformly.
+    # Set GF_SERVER_ROOT_URL in the grafana service to match this prefix
+    # (e.g. http://localhost:30000/grafana/) so dashboard URLs resolve.
+    location ^~ /grafana/ {
+        ${INFINITE_STREAM_AUTH_DIRECTIVES}
+        # No trailing slash on proxy_pass — Grafana expects to receive
+        # requests at /grafana/* and serves them via its sub-path
+        # config (GF_SERVER_SERVE_FROM_SUB_PATH=true).
+        proxy_pass http://analytics_grafana;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+    }
+    location ^~ /api/live/ {
+        proxy_pass http://analytics_grafana;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 1h;
+    }
+
+    location ^~ /analytics/api/ {
+        ${INFINITE_STREAM_AUTH_DIRECTIVES}
+        proxy_pass http://analytics_forwarder/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_read_timeout 60s;
+        # Stream NDJSON to the browser line-by-line so the replay UI
+        # can paint snapshots as they arrive instead of waiting for
+        # the entire response to buffer.
+        proxy_buffering off;
+        proxy_request_buffering off;
+        add_header X-Accel-Buffering "no" always;
+        add_header Access-Control-Allow-Origin * always;
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     }
 
     location = /api/sessions {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -341,6 +341,7 @@ type App struct {
 	sessionsBroadcastPending bool
 	sessionsBroadcastLatest  []SessionData
 	sessionsBroadcastSeq     uint64
+	networkHub               *NetworkEventHub
 	uiStateVersionSeq        uint64
 	segmentFlightMu          sync.Mutex
 	segmentFlight            map[int]segmentFlightInfo // internal port -> segment transfer info
@@ -431,6 +432,81 @@ type PortMapping struct {
 
 func NewSessionEventHub() *SessionEventHub {
 	return &SessionEventHub{clients: map[int]*SessionClient{}}
+}
+
+// NetworkEventHub fans out per-request network log entries to subscribed
+// SSE clients (currently: the analytics forwarder). Each Add() call
+// produces one event with {session_id, entry}. Slow clients lose old
+// events on overflow rather than blocking the proxy hot path.
+type NetworkEventHub struct {
+	mu      sync.Mutex
+	nextID  int
+	clients map[int]*NetworkClient
+}
+
+type NetworkClient struct {
+	ch      chan NetworkEvent
+	dropped uint64
+}
+
+type NetworkEvent struct {
+	SessionID string
+	Entry     NetworkLogEntry
+}
+
+func NewNetworkEventHub() *NetworkEventHub {
+	return &NetworkEventHub{clients: map[int]*NetworkClient{}}
+}
+
+func (h *NetworkEventHub) AddClient(buffer int) (int, <-chan NetworkEvent) {
+	if buffer <= 0 {
+		buffer = 256
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.nextID++
+	id := h.nextID
+	c := &NetworkClient{ch: make(chan NetworkEvent, buffer)}
+	h.clients[id] = c
+	return id, c.ch
+}
+
+func (h *NetworkEventHub) RemoveClient(id int) {
+	h.mu.Lock()
+	c, ok := h.clients[id]
+	if ok {
+		delete(h.clients, id)
+	}
+	h.mu.Unlock()
+	if ok {
+		close(c.ch)
+	}
+}
+
+func (h *NetworkEventHub) Broadcast(sessionID string, entry NetworkLogEntry) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.clients) == 0 {
+		return
+	}
+	ev := NetworkEvent{SessionID: sessionID, Entry: entry}
+	for _, c := range h.clients {
+		select {
+		case c.ch <- ev:
+		default:
+			// Buffer full — drop oldest, log occasionally.
+			select {
+			case <-c.ch:
+				c.dropped++
+			default:
+			}
+			select {
+			case c.ch <- ev:
+			default:
+				c.dropped++
+			}
+		}
+	}
 }
 
 func (h *SessionEventHub) AddClient(playerIDFilter string) (int, <-chan SessionsEvent) {
@@ -1255,6 +1331,7 @@ func main() {
 		shapeApply:         map[int]ShapeApplyState{},
 		faultLoops:         map[int]context.CancelFunc{},
 		sessionsHub:        NewSessionEventHub(),
+		networkHub:         NewNetworkEventHub(),
 		networkLogs:        map[string]*NetworkLogRingBuffer{},
 		loopStateBySession: map[string]ServerLoopState{},
 		segmentFlight:      map[int]segmentFlightInfo{},
@@ -1284,6 +1361,7 @@ func main() {
 	router.HandleFunc("/api/session/{id}", app.handlePatchSession).Methods(http.MethodPatch)
 	router.HandleFunc("/api/session/{id}/metrics", app.handlePostSessionMetrics).Methods(http.MethodPost)
 	router.HandleFunc("/api/session/{id}/network", app.handleGetNetworkLog).Methods(http.MethodGet)
+	router.HandleFunc("/api/network/stream", app.handleNetworkStream).Methods(http.MethodGet)
 	router.HandleFunc("/api/sessions/{player_id}/timeline.har", app.handleGetSessionTimelineHAR).Methods(http.MethodGet)
 	router.HandleFunc("/api/session/{id}/har/snapshot", app.handlePostHARSnapshot).Methods(http.MethodPost)
 	router.HandleFunc("/api/incidents", app.handleListIncidents).Methods(http.MethodGet)
@@ -1369,6 +1447,63 @@ func (a *App) handleGetSessions(w http.ResponseWriter, r *http.Request) {
 		sessions = sessions[:10]
 	}
 	writeJSON(w, a.normalizeSessionsForResponse(sessions))
+}
+
+// handleNetworkStream emits each network log entry as it lands in any
+// session's ring buffer. Body is one SSE `data:` line per entry,
+// {"session_id":"...","entry":{...}}. Subscribers must reconnect on
+// disconnect; nothing is replayed.
+func (a *App) handleNetworkStream(w http.ResponseWriter, r *http.Request) {
+	if a.networkHub == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, map[string]string{"error": "stream unavailable"})
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		w.WriteHeader(http.StatusInternalServerError)
+		writeJSON(w, map[string]string{"error": "stream unsupported"})
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	clientID, ch := a.networkHub.AddClient(1024)
+	defer a.networkHub.RemoveClient(clientID)
+
+	// Heartbeat keeps idle proxies through corp firewalls/load balancers.
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			payload := struct {
+				SessionID string          `json:"session_id"`
+				Entry     NetworkLogEntry `json:"entry"`
+			}{ev.SessionID, ev.Entry}
+			b, err := json.Marshal(payload)
+			if err != nil {
+				continue
+			}
+			if _, err := w.Write([]byte("data: " + string(b) + "\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 func (a *App) handleSessionStream(w http.ResponseWriter, r *http.Request) {
@@ -4034,6 +4169,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	sessionData["last_request"] = nowISO()
 	sessionData["last_request_url"] = filename
 	sessionData["user_agent"] = r.UserAgent()
+	// Stamp the player's current play_id on the session so the SSE stream
+	// (and downstream analytics) can partition by playback episode. The
+	// player regenerates play_id at every fresh loadStream boundary
+	// (issue #280); when this value differs from the prior snapshot,
+	// that's a "new playback started" signal in replay views.
+	if playID != "" {
+		sessionData["play_id"] = playID
+	}
 
 	// Extract client IP considering X-Forwarded-For
 	clientIP := extractClientIP(r.RemoteAddr, r.Header.Get("X-Forwarded-For"))
@@ -5386,12 +5529,47 @@ func (a *App) getOrCreateNetworkLog(sessionID string) *NetworkLogRingBuffer {
 }
 
 // addNetworkLogEntry adds a network log entry to the session's ring buffer
+// and fans it out to any subscribed SSE clients (the analytics forwarder).
+//
+// If the entry arrived with an empty PlayID (typical for variant manifests
+// and segments — iOS HLS doesn't preserve the master manifest's
+// `?play_id=…` query string on derived URLs), fall back to the session's
+// last-known sticky play_id from the live session map. session_snapshots
+// already does this implicitly via the "if playID != ''" guard at the
+// session level; without this fallback the network_requests table ends
+// up with most rows attributed to play_id='' and the session-viewer's
+// play_id filter only catches the master manifest hits.
 func (a *App) addNetworkLogEntry(sessionID string, entry NetworkLogEntry) {
 	if sessionID == "" {
 		return
 	}
+	if entry.PlayID == "" {
+		entry.PlayID = a.sessionStickyPlayID(sessionID)
+	}
 	rb := a.getOrCreateNetworkLog(sessionID)
 	rb.Add(entry)
+	if a.networkHub != nil {
+		a.networkHub.Broadcast(sessionID, entry)
+	}
+}
+
+// sessionStickyPlayID reads the session's last-known play_id from the
+// atomic snapshot without cloning the whole list. Returns "" if the
+// session isn't tracked or has no play_id stamped yet.
+func (a *App) sessionStickyPlayID(sessionID string) string {
+	snap := a.sessionsSnap.Load()
+	if snap == nil {
+		return ""
+	}
+	for _, s := range *snap {
+		id, _ := s["session_id"].(string)
+		if id != sessionID {
+			continue
+		}
+		pid, _ := s["play_id"].(string)
+		return pid
+	}
+	return ""
 }
 
 func durationToMilliseconds(d time.Duration) float64 {

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -1,0 +1,293 @@
+# Analytics sidecar: ClickHouse + Grafana + SSE→ClickHouse forwarder.
+# Apply alongside k8s-infinite-streaming-dev.yaml or k8s-infinite-streaming.yaml.
+# Uses envsubst at apply time for ${K3S_REGISTRY} and the SSE source URL
+# (${ANALYTICS_SSE_URL}). The forwarder defaults to the dev stack
+# (infinite-streaming-dev:30081); override ANALYTICS_SSE_URL for release.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-clickhouse-init
+data:
+  01-schema.sql: |
+    CREATE DATABASE IF NOT EXISTS infinite_streaming;
+    CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
+    (
+        ts DateTime64(3, 'UTC'),
+        revision UInt64,
+        session_id String,
+        play_id LowCardinality(String),
+        player_id LowCardinality(String),
+        group_id LowCardinality(String),
+        user_agent String,
+        manifest_url String,
+        manifest_variants String,
+        last_request_url String,
+        content_id LowCardinality(String),
+        player_state LowCardinality(String),
+        waiting_reason LowCardinality(String),
+        buffer_depth_s Float32,
+        network_bitrate_mbps Float32,
+        video_bitrate_mbps Float32,
+        measured_mbps Float32,
+        mbps_shaper_rate Float32,
+        mbps_shaper_avg Float32,
+        display_resolution LowCardinality(String),
+        video_resolution LowCardinality(String),
+        frames_displayed UInt64 DEFAULT 0,
+        dropped_frames UInt32 DEFAULT 0,
+        stall_count UInt32 DEFAULT 0,
+        stall_time_s Float32,
+        position_s Float32,
+        live_edge_s Float32,
+        true_offset_s Float32,
+        playback_rate Float32,
+        loop_count_player UInt32 DEFAULT 0,
+        loop_count_server UInt32 DEFAULT 0,
+        last_event LowCardinality(String),
+        last_event_at String,
+        trigger_type LowCardinality(String),
+        event_time String,
+        player_error String,
+        avg_network_bitrate_mbps Float32,
+        buffer_end_s Float32,
+        last_stall_time_s Float32,
+        live_offset_s Float32,
+        playhead_wallclock_ms Int64,
+        seekable_end_s Float32,
+        metrics_source LowCardinality(String),
+        video_first_frame_time_s Float32,
+        video_quality_pct Float32,
+        video_start_time_s Float32,
+        mbps_transfer_complete Float32,
+        mbps_transfer_rate Float32,
+        player_ip LowCardinality(String),
+        server_received_at_ms Int64,
+        x_forwarded_port UInt16 DEFAULT 0,
+        x_forwarded_port_external UInt16 DEFAULT 0,
+        master_manifest_url String,
+        master_manifest_failure_type LowCardinality(String),
+        master_manifest_failure_mode LowCardinality(String),
+        master_manifest_failure_frequency Float32,
+        master_manifest_consecutive_failures UInt32 DEFAULT 0,
+        master_manifest_requests_count UInt32 DEFAULT 0,
+        manifest_failure_frequency Float32,
+        manifest_failure_urls String,
+        manifest_consecutive_failures UInt32 DEFAULT 0,
+        manifest_requests_count UInt32 DEFAULT 0,
+        segment_failure_frequency Float32,
+        segment_failure_urls String,
+        segment_consecutive_failures UInt32 DEFAULT 0,
+        segments_count UInt32 DEFAULT 0,
+        all_failure_type LowCardinality(String),
+        all_failure_mode LowCardinality(String),
+        all_failure_frequency Float32,
+        all_failure_urls String,
+        all_consecutive_failures UInt32 DEFAULT 0,
+        transport_failure_frequency Float32,
+        transport_failure_mode LowCardinality(String),
+        transport_failure_units LowCardinality(String),
+        transport_consecutive_failures UInt32 DEFAULT 0,
+        transport_consecutive_seconds Float32,
+        transport_consecutive_units UInt32 DEFAULT 0,
+        transport_frequency_seconds Float32,
+        transport_fault_drop_packets UInt8 DEFAULT 0,
+        transport_fault_reject_packets UInt8 DEFAULT 0,
+        transport_fault_off_seconds Float32,
+        transport_fault_on_seconds Float32,
+        transport_fault_type LowCardinality(String),
+        fault_count_transfer_active_timeout UInt32 DEFAULT 0,
+        fault_count_transfer_idle_timeout UInt32 DEFAULT 0,
+        transfer_active_timeout_seconds Float32,
+        transfer_idle_timeout_seconds Float32,
+        transfer_timeout_applies_manifests UInt8 DEFAULT 0,
+        transfer_timeout_applies_master UInt8 DEFAULT 0,
+        transfer_timeout_applies_segments UInt8 DEFAULT 0,
+        nftables_pattern_step UInt32 DEFAULT 0,
+        nftables_pattern_step_runtime UInt32 DEFAULT 0,
+        nftables_pattern_steps String,
+        nftables_pattern_rate_runtime_mbps Float32,
+        nftables_pattern_margin_pct Float32,
+        nftables_pattern_template_mode LowCardinality(String),
+        content_allowed_variants String,
+        content_live_offset Float32,
+        content_strip_codecs String,
+        abrchar_run_lock UInt8 DEFAULT 0,
+        control_revision UInt64 DEFAULT 0,
+        server_video_rendition LowCardinality(String),
+        server_video_rendition_mbps Float32,
+        manifest_failure_type LowCardinality(String),
+        manifest_failure_mode LowCardinality(String),
+        segment_failure_type LowCardinality(String),
+        segment_failure_mode LowCardinality(String),
+        transport_failure_type LowCardinality(String),
+        transport_fault_active UInt8 DEFAULT 0,
+        nftables_bandwidth_mbps Float32,
+        nftables_delay_ms UInt32 DEFAULT 0,
+        nftables_packet_loss Float32,
+        nftables_pattern_enabled UInt8 DEFAULT 0,
+        first_request_time String,
+        last_request String,
+        session_duration Float32,
+        session_json String CODEC(ZSTD(3))
+    )
+    ENGINE = MergeTree
+    PARTITION BY toYYYYMMDD(ts)
+    ORDER BY (session_id, ts)
+    TTL toDateTime(ts) + INTERVAL 30 DAY;
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+spec:
+  serviceName: clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+      - name: clickhouse
+        image: clickhouse/clickhouse-server:24.8-alpine
+        ports:
+        - containerPort: 8123
+        - containerPort: 9000
+        env:
+        - name: CLICKHOUSE_DB
+          value: infinite_streaming
+        - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+          value: "1"
+        - name: CLICKHOUSE_SKIP_USER_SETUP
+          value: "1"
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/clickhouse
+        - name: init
+          mountPath: /docker-entrypoint-initdb.d
+      volumes:
+      - name: init
+        configMap:
+          name: analytics-clickhouse-init
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 20Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+spec:
+  selector:
+    app: clickhouse
+  ports:
+  - name: http
+    port: 8123
+    targetPort: 8123
+  - name: native
+    port: 9000
+    targetPort: 9000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forwarder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forwarder
+  template:
+    metadata:
+      labels:
+        app: forwarder
+    spec:
+      containers:
+      - name: forwarder
+        image: ${K3S_REGISTRY}/infinite-streaming-forwarder:dev
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: FORWARDER_SSE_URL
+          value: "${ANALYTICS_SSE_URL}"
+        - name: FORWARDER_CLICKHOUSE_URL
+          value: "http://clickhouse:8123"
+        - name: FORWARDER_CLICKHOUSE_DB
+          value: infinite_streaming
+        - name: FORWARDER_CLICKHOUSE_TABLE
+          value: session_snapshots
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: forwarder
+spec:
+  selector:
+    app: forwarder
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana-oss:11.3.0
+        ports:
+        - containerPort: 3000
+        env:
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        # Viewer (not Editor) — anonymous visitors can read dashboards
+        # but can't mutate them. Dashboards are provisioned-as-code.
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: "Viewer"
+        - name: GF_AUTH_DISABLE_LOGIN_FORM
+          value: "true"
+        - name: GF_INSTALL_PLUGINS
+          value: "grafana-clickhouse-datasource"
+        # Grafana is served behind the go-server nginx at /grafana/,
+        # so it must build URLs relative to that prefix.
+        - name: GF_SERVER_ROOT_URL
+          value: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
+        - name: GF_SERVER_SERVE_FROM_SUB_PATH
+          value: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  # ClusterIP, not NodePort — Grafana is reached via the go-server
+  # nginx at /grafana/ where basic-auth (when enabled) gates access.
+  # Exposing it directly on a node port would bypass that gate.
+  type: ClusterIP
+  selector:
+    app: grafana
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000

--- a/tests/deploy/override-dev.yml
+++ b/tests/deploy/override-dev.yml
@@ -13,3 +13,28 @@ services:
       - "21681:30681"
       - "21781:30781"
       - "21881:30881"
+  clickhouse:
+    container_name: test-dev-clickhouse
+    # Bind to loopback only — see docker-compose.yml. analytics-migrate
+    # SSHes into the host and curls localhost:21123 so loopback is
+    # sufficient; LAN access is blocked.
+    ports:
+      !override
+      - "127.0.0.1:21123:8123"
+  grafana:
+    container_name: test-dev-grafana
+    # No host port — reach Grafana via the test-dev nginx /grafana/
+    # prefix (e.g. http://jonathanoliver-ubuntu.local:21000/grafana/).
+    ports: !override []
+    environment:
+      # Public root URL for the test-deploy-dev box — overrides the
+      # docker-compose default localhost:30000 so Grafana's own
+      # redirects (login flow, etc.) land back on the right host:port.
+      - GF_SERVER_ROOT_URL=http://jonathanoliver-ubuntu.local:21000/grafana/
+  forwarder:
+    container_name: test-dev-forwarder
+    environment:
+      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_snapshots


### PR DESCRIPTION
## Summary

- **Session archival sidecar + session-viewer replay UI.** New `analytics/go-forwarder` ingests SSE → ClickHouse and serves the read API; the dashboard gets a session-viewer page that replays an archived session through the live charts.
- **`/api/session_bundle` endpoint** (#344) — streams a ZIP of `snapshots.ndjson` + `network.har` + `events.ndjson` for any archived session. Bundle download is the persistence escape hatch beyond the 30-day TTL.
- **Bundle format polish:** `snapshots.ndjson` carries raw `session_json` blobs (one row = one snapshot); dropped the redundant per-bundle `events.json` since snapshots already carry the event-time fields.

Pre-merge review fixes for bundle (HAR spec compliance, error-path log clarity, redactor) land separately with the tiered-retention PR because they touch `classification.go` introduced by that PR.

## Test plan

- [ ] Unit: `cd analytics/go-forwarder && go test ./...`
- [ ] Smoke: trigger a session, then `curl /analytics/api/session_bundle?session=…&play_id=…` and verify ZIP contents
- [ ] UI: open `dashboard/session-viewer.html?replay=1&session=…&play_id=…` and confirm charts render from archived data

🤖 Generated with [Claude Code](https://claude.com/claude-code)