### PR TITLE
fix(grafana): dashboard suite — time picker, retention tiers, WS/login, defaults

### DIFF
--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -39,7 +39,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time ORDER BY time",
+          "rawSql": "SELECT * FROM ( SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time ) ORDER BY time ASC, type ASC",
           "format": 0
         }
       ]

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -13,10 +13,11 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Messages by type",
-      "description": "Per-minute row count ingested into each ClickHouse table.",
+      "title": "Messages by type (last 24h)",
+      "description": "Per-minute row count ingested into each ClickHouse table over the last 24 hours. The time scope is hard-coded inside the panel — independent of the dashboard time picker — so a misconfigured URL (e.g. from=now/y&to=now/y) can't blank the chart.",
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
       "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
+      "timeFrom": "24h",
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -38,7 +39,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time ORDER BY time",
+          "rawSql": "SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time ORDER BY time",
           "format": 0
         }
       ]

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -13,8 +13,8 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Messages by type (last 24h)",
-      "description": "Per-minute row count ingested into each ClickHouse table over the last 24 hours. The time scope is hard-coded inside the panel — independent of the dashboard time picker — so a misconfigured URL (e.g. from=now/y&to=now/y) can't blank the chart.",
+      "title": "Messages by retention tier (last 24h)",
+      "description": "Per-minute row count grouped by classification across both session_snapshots and network_requests. Maps directly to retention tier: 'other' (gray) ages out at 30 d, 'interesting' (amber) at 90 d, 'favourite' (green) is kept forever. Eyeballing the gray slice tells you how much of the recent 24h's data will be gone in a month.",
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
       "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
       "timeFrom": "24h",
@@ -23,13 +23,22 @@
           "unit": "short",
           "custom": {
             "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 12,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 100,
             "showPoints": "never",
+            "spanNulls": true,
             "stacking": { "mode": "normal", "group": "A" }
           }
         },
-        "overrides": []
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "other" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#6b7280" } }] },
+          { "matcher": { "id": "byName", "options": "interesting" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#f59e0b" } }] },
+          { "matcher": { "id": "byName", "options": "favourite" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#10b981" } }] }
+        ]
       },
       "options": {
         "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] },
@@ -39,7 +48,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT * FROM ( SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'session_snapshots' AS type, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, 'network_requests' AS type, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time ) ORDER BY time ASC, type ASC",
+          "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time, classification UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
           "format": 0
         }
       ]

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -47,7 +47,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT toStartOfInterval(ts, $__timeInterval(ts)) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time, classification UNION ALL SELECT toStartOfInterval(ts, $__timeInterval(ts)) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
+          "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT $__timeInterval(ts) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time, classification UNION ALL SELECT $__timeInterval(ts) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
           "format": 0
         }
       ]

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -13,11 +13,10 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Messages by retention tier (last 24h)",
-      "description": "Per-minute row count grouped by classification across both session_snapshots and network_requests. Maps directly to retention tier: 'other' (gray) ages out at 30 d, 'interesting' (amber) at 90 d, 'favourite' (green) is kept forever. Eyeballing the gray slice tells you how much of the recent 24h's data will be gone in a month.",
+      "title": "Messages by retention tier",
+      "description": "Per-minute row count grouped by classification across both session_snapshots and network_requests. Time scope follows the dashboard time picker. Tiers: 'other' (gray, TTL 30 d), 'interesting' (amber, TTL 90 d), 'favourite' (green, kept forever). Eyeballing the gray slice tells you how much of the visible window will be gone in a month.",
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
       "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
-      "timeFrom": "24h",
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -48,7 +47,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time, classification UNION ALL SELECT toStartOfInterval(ts, INTERVAL 1 MINUTE) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE ts >= now() - INTERVAL 24 HOUR GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
+          "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT toStartOfInterval(ts, $__timeInterval(ts)) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time, classification UNION ALL SELECT toStartOfInterval(ts, $__timeInterval(ts)) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
           "format": 0
         }
       ]

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -4,10 +4,19 @@
   "schemaVersion": 39,
   "editable": true,
   "tags": ["infinite-streaming"],
-  "time": { "from": "now-6h", "to": "now" },
+  "time": { "from": "now-24h", "to": "now" },
   "refresh": "30s",
   "timepicker": {
-    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "1h"]
+    "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "1h"],
+    "quick_ranges": [
+      { "from": "now-15m",  "to": "now",     "display": "Last 15 minutes" },
+      { "from": "now-1h",   "to": "now",     "display": "Last hour"       },
+      { "from": "now-6h",   "to": "now",     "display": "Last 6 hours"    },
+      { "from": "now-24h",  "to": "now",     "display": "Last 24 hours"   },
+      { "from": "now-7d",   "to": "now",     "display": "Last 7 days"     },
+      { "from": "now-30d",  "to": "now",     "display": "Last 30 days"    },
+      { "from": "now-90d",  "to": "now",     "display": "Last 90 days"    }
+    ]
   },
   "panels": [
     {

--- a/analytics/grafana/provisioning/dashboards/infinite-streaming.json
+++ b/analytics/grafana/provisioning/dashboards/infinite-streaming.json
@@ -92,8 +92,8 @@
     {
       "id": 3,
       "type": "table",
-      "title": "Storage by table",
-      "description": "Active part bytes and row counts per table.",
+      "title": "Storage by table × tier",
+      "description": "Per-table on-disk bytes and row counts split by retention tier. Bytes are proportional: total table bytes from system.parts × (tier_rows / total_table_rows). Compression is part-level, not row-level, so this is an estimate — accurate to within a few percent for typical mixes.",
       "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
       "gridPos": { "x": 8, "y": 10, "w": 16, "h": 6 },
       "fieldConfig": {
@@ -111,7 +111,7 @@
         {
           "refId": "A",
           "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
-          "rawSql": "SELECT table, sum(rows) AS rows, sum(bytes_on_disk) AS bytes FROM system.parts WHERE database = 'infinite_streaming' AND active GROUP BY table ORDER BY bytes DESC",
+          "rawSql": "WITH part_sizes AS ( SELECT table, sum(rows) AS table_rows, sum(bytes_on_disk) AS table_bytes FROM system.parts WHERE database = 'infinite_streaming' AND active GROUP BY table ), class_counts AS ( SELECT 'session_snapshots' AS table, classification, count() AS class_rows FROM infinite_streaming.session_snapshots GROUP BY classification UNION ALL SELECT 'network_requests', classification, count() FROM infinite_streaming.network_requests GROUP BY classification ) SELECT c.table AS table, c.classification AS tier, c.class_rows AS rows, toUInt64(p.table_bytes * (c.class_rows / nullIf(p.table_rows, 0))) AS bytes FROM class_counts c LEFT JOIN part_sizes p ON c.table = p.table ORDER BY c.table ASC, c.classification ASC",
           "format": 1
         }
       ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,12 +99,19 @@ services:
     container_name: infinite-streaming-grafana
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
-      # Viewer (not Editor) — anonymous LAN visitors can read dashboards
-      # but can't mutate them. Dashboards are provisioned-as-code from
-      # analytics/grafana/provisioning/, so editing through the web UI
-      # was never the workflow anyway.
+      # Viewer (not Editor) — anonymous LAN visitors can read
+      # dashboards but can't edit them. To edit, log in via the form
+      # in the bottom-right (default admin/admin on first login;
+      # Grafana forces a password change). The new password persists
+      # in the grafana_data volume.
+      #
+      # UI edits to dashboards are *per-instance only* — provisioning
+      # rewrites them from analytics/grafana/provisioning/ on every
+      # container restart and on the 30s auto-reload tick. Use the UI
+      # to iterate on a layout, then export the panel JSON and paste
+      # it into infinite-streaming.json so the change survives.
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
-      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
       # Grafana is reachable via the nginx /grafana/ prefix; the root
       # URL must reflect the user-facing host:port so OAuth / login
       # redirects land back on nginx, not Grafana's internal :3000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,14 @@ services:
       # public URL differs from the default localhost:30000.
       - GF_SERVER_ROOT_URL=${INFINITE_STREAM_BASE_URL:-http://localhost:30000}/grafana/
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      # Grafana Live's WebSocket handshake checks the browser's Origin
+      # header against ROOT_URL by default. The dev box is reachable
+      # at multiple hostnames (.local vs not, IP, Tailscale name) so
+      # pinning ROOT_URL to one of them blocks WS from the others.
+      # Wildcard the Live origins for dev — the WS endpoint serves
+      # only data the user could already pull over HTTPS, so the
+      # origin check is more about csrf-style replay than auth.
+      - GF_LIVE_ALLOWED_ORIGINS=*
       - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
     volumes:

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -8,6 +8,16 @@ log_format nginx_access 'NGINX access time=$time_iso8601 remote=$remote_addr '
                         'request="$request" status=$status bytes=$body_bytes_sent '
                         'referer="$http_referer" ua="$http_user_agent"';
 
+# WebSocket Upgrade header pass-through. Used by the /grafana/ location
+# to make Grafana Live (/grafana/api/live/ws) work through nginx.
+# `Connection: upgrade` only fires when the client actually sent
+# Upgrade: websocket — for plain HTTP requests this evaluates to
+# `close` and behaves as a normal proxy.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 upstream go_upload_service {
     server 127.0.0.1:8003;
     keepalive 4;
@@ -191,13 +201,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_buffering off;
-    }
-    location ^~ /api/live/ {
-        proxy_pass http://analytics_grafana;
+        # WebSocket upgrade for Grafana Live (/grafana/api/live/ws).
+        # Headers are harmless on non-upgrade requests — $http_upgrade
+        # is empty for plain HTTP, so Connection: "upgrade" only takes
+        # effect when the client actually sent Upgrade: websocket.
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
+        proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 1h;
     }
 

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -262,11 +262,14 @@ spec:
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
         # Viewer (not Editor) — anonymous visitors can read dashboards
-        # but can't mutate them. Dashboards are provisioned-as-code.
+        # but can't edit them. Log in via the form (admin/admin on
+        # first login, Grafana forces a password change) to edit. UI
+        # edits are per-instance only; the source of truth is the
+        # provisioned JSON in analytics/grafana/provisioning/.
         - name: GF_AUTH_ANONYMOUS_ORG_ROLE
           value: "Viewer"
         - name: GF_AUTH_DISABLE_LOGIN_FORM
-          value: "true"
+          value: "false"
         - name: GF_INSTALL_PLUGINS
           value: "grafana-clickhouse-datasource"
         # Grafana is served behind the go-server nginx at /grafana/,

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -278,6 +278,11 @@ spec:
           value: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
         - name: GF_SERVER_SERVE_FROM_SUB_PATH
           value: "true"
+        # Grafana Live origin check — wildcard so WebSocket works
+        # when the cluster is reached via multiple hostnames
+        # (.local, IP, Tailscale, etc.). See docker-compose.yml note.
+        - name: GF_LIVE_ALLOWED_ORIGINS
+          value: "*"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Bundles 9 small Grafana / nginx fixes that accumulated during the analytics-tier work:

- Pin Messages panel to last 24 h regardless of time picker
- Sort Messages-by-type query strictly time-ASC
- Split Messages chart by retention tier (#342)
- Re-enable login form + split Storage panel by table × tier
- Wire dashboard time picker to Messages panel
- Correct \`\$__timeInterval\` usage in Messages query
- Pass WebSocket Upgrade through to /grafana/ (nginx)
- Allow Live WebSocket from any Origin (Grafana CSP)
- Default the dashboard to Last 24 hours

Each commit on the source branch is small and self-explanatory; rolling them as one PR keeps the merge-noise on `main` proportional to the body of work.

## Test plan

- [ ] \`make analytics-update\` and load \`/grafana/\` — login form appears
- [ ] Default time range = Last 24 h; Messages panel pinned and ordered correctly
- [ ] Storage panel: separate rows per (table × tier)
- [ ] Live WS streaming works (no Origin rejection in browser console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)