### PR TITLE
fix(ios): preview/main AVPlayer doppleganger pollution (#348)

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer-iOS/Info.plist
@@ -16,6 +16,17 @@
     <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <!-- Disable iPadOS multi-window. Each WindowGroup scene would get
+         its own @StateObject AppRoot → its own PlayerViewModel → its
+         own metrics-emitting heartbeat timer, all POSTing for the same
+         per-installation player_id. Two scenes produced two interleaved
+         heartbeat streams in the analytics archive (issue #348). The
+         app is a single-player experience anyway. -->
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
     <key>UILaunchScreen</key>
     <dict/>
     <key>NSCameraUsageDescription</key>

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/AppRoot.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/AppRoot.swift
@@ -49,6 +49,16 @@ struct AppRoot: View {
         .preferredColorScheme(.dark)
         .onAppear { decideInitialRoute() }
         .onChange(of: route) { _, newRoute in
+            // playbackActive is the gate the Home preview tiles use to
+            // decide whether to instantiate their AVPlayers. While the
+            // main playback is running we don't want Home tiles still
+            // alive in the background — every one is its own AVPlayer
+            // with its own access log and decoder, and prior to this
+            // gate they polluted the analytics archive with phantom
+            // heartbeats / rendition switches stamped to the main
+            // session_id (issue #348).
+            vm.playbackActive = (newRoute == .playback)
+
             // The main vm.player is shared across Playback / Home and
             // keeps its own lifecycle. When leaving Playback we need to
             // fully stop it: pausing alone leaves the audio renderer

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
@@ -103,8 +103,16 @@ private struct ContinueWatchingHero: View {
                     // pointing at the new clip's 720p URL. Without
                     // .id, updateUIView would run with the new content
                     // value but the AVPlayer would keep the old URL.
-                    HeroLiveVideo(server: server, content: item)
-                        .id(item.id)
+                    //
+                    // Skip while playbackActive — the main Playback
+                    // screen is on top and we don't need a second
+                    // AVPlayer running behind it. SwiftUI dismantles
+                    // the UIViewRepresentable cleanly via the `if`
+                    // omission, so the AVPlayer is fully gone.
+                    if !vm.playbackActive {
+                        HeroLiveVideo(server: server, content: item)
+                            .id(item.id)
+                    }
 
                     LinearGradient(
                         stops: [
@@ -245,7 +253,14 @@ private struct LiveRow: View {
                                     LivePreviewTile(
                                         content: item,
                                         server: server,
-                                        videoEnabled: vm.previewVideoSlots > 0
+                                        // Disable preview AVPlayers entirely while
+                                        // the main Playback screen is up — see the
+                                        // playbackActive comment on PlayerViewModel
+                                        // (issue #348). Falls back to static
+                                        // thumbnail; SwiftUI dismantles the
+                                        // MutedLoopingTile UIViewRepresentable so
+                                        // the AVPlayer is gone, not just paused.
+                                        videoEnabled: vm.previewVideoSlots > 0 && !vm.playbackActive
                                     ) { tapped in
                                         vm.setSelectedContent(tapped.name)
                                         onPlay()

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
@@ -262,8 +262,29 @@ private struct LiveRow: View {
                                         // the AVPlayer is gone, not just paused.
                                         videoEnabled: vm.previewVideoSlots > 0 && !vm.playbackActive
                                     ) { tapped in
-                                        vm.setSelectedContent(tapped.name)
+                                        // Order matters here:
+                                        // 1. onPlay() flips route to .playback,
+                                        //    which sets playbackActive=true and
+                                        //    causes SwiftUI to re-evaluate the
+                                        //    tile grid — but actual UIView-
+                                        //    Representable dismantling happens
+                                        //    on the NEXT runloop cycle.
+                                        // 2. setSelectedContent() triggers
+                                        //    buildURLAndLoad → replaceCurrentItem
+                                        //    on the main player → diagnostics
+                                        //    starts emitting metrics.
+                                        // If we ran (2) before (1), the main
+                                        // player's first-second metrics would
+                                        // be polluted by the still-alive preview
+                                        // AVPlayers' access-log activity. By
+                                        // dispatching (2) on the next runloop,
+                                        // SwiftUI gets a chance to call
+                                        // dismantleUIView on every tile + the
+                                        // hero before main playback begins.
                                         onPlay()
+                                        DispatchQueue.main.async {
+                                            vm.setSelectedContent(tapped.name)
+                                        }
                                     }
                                     .id(item.id)
                                 }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -679,7 +679,21 @@ final class PlaybackDiagnostics: ObservableObject {
     }
 
     private func refreshLiveAccessLogMetrics(from item: AVPlayerItem) {
-        guard let event = item.accessLog()?.events.last else { return }
+        // After player.replaceCurrentItem, the new item's accessLog
+        // is empty until AVFoundation fetches the first segment. If
+        // we early-return here without clearing the bitrate fields,
+        // heartbeats will keep emitting the *previous* item's
+        // observedBitrate / indicatedBitrate / averageVideoBitrate
+        // until a fresh access-log event lands — typically 200-500 ms
+        // of bridging stale data into the new (session_id, play_id).
+        // Clear them on the empty case so the new play starts from a
+        // clean slate.
+        guard let event = item.accessLog()?.events.last else {
+            observedBitrate = nil
+            indicatedBitrate = nil
+            averageVideoBitrate = nil
+            return
+        }
         observedBitrate = event.observedBitrate
         indicatedBitrate = event.indicatedBitrate
         averageVideoBitrate = event.averageVideoBitrate

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -171,6 +171,15 @@ final class PlayerViewModel: ObservableObject {
     // MARK: - Init
 
     init() {
+        // Defensive log — there should only ever be ONE PlayerViewModel
+        // alive in the process. iPadOS's WindowGroup multi-window
+        // would have minted one per scene before we set
+        // UIApplicationSupportsMultipleScenes=false in Info.plist; if
+        // a regression brings multi-window back, two PlayerViewModels
+        // start emitting metrics for the same player_id and the
+        // analytics archive shows interleaved heartbeats (issue #348).
+        // grep `[VM-INIT]` in the device console to count them.
+        print("[VM-INIT] PlayerViewModel \(ObjectIdentifier(self))")
         // Migrate legacy UserDefaults keys (boss* → is* → new is.flag.*
         // namespace) before loading so users upgrading from a pre-rework
         // build keep their saved server list, codec / segment / protocol
@@ -206,6 +215,7 @@ final class PlayerViewModel: ObservableObject {
     }
 
     deinit {
+        print("[VM-DEINIT] PlayerViewModel \(ObjectIdentifier(self))")
         if let o = didPlayToEndObserver { NotificationCenter.default.removeObserver(o) }
         if let o = failedToPlayObserver { NotificationCenter.default.removeObserver(o) }
         if let o = willEnterForegroundObserver { NotificationCenter.default.removeObserver(o) }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -78,6 +78,15 @@ final class PlayerViewModel: ObservableObject {
 
     @Published var hudVisible: Bool = false
     @Published var settingsOpen: Bool = false
+    /// True while the user is on the main Playback screen. Pause-source
+    /// for ancillary AVPlayers (Home preview tiles) so only the main
+    /// player owns the audio session, the codec budget, and — most
+    /// importantly — the metrics-emitting state. Without this gate,
+    /// preview-tile AVPlayer instances and their access-log timers
+    /// keep running behind the main player and pollute the analytics
+    /// archive with phantom heartbeats and rendition switches that
+    /// look like the main player but aren't (issue #348).
+    @Published var playbackActive: Bool = false
 
     // -- Player ---------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #348.

Three coordinated fixes for the iOS / iPadOS doppleganger that produced two parallel `PlayerViewModel` instances POSTing for the same `player_id`, interleaving heartbeat streams in the analytics archive:

- **Tear down Home preview AVPlayers** while main Playback is up. Preview tiles drove their own AVPlayer instances; on tap they handed control off to the main playback player but didn't release the preview decoders. Fixes the resource pressure and also the metric-source ambiguity.
- **Disable iPadOS multi-window** via `UIApplicationSupportsMultipleScenes=false` in `Info.plist`. Each WindowGroup scene was constructing its own \`@StateObject AppRoot → PlayerViewModel\`, and two scenes produced two interleaved heartbeat streams.
- **Close the preview-decode → main-playback race.** Tile-tap reordered: \`onPlay()\` first, then \`DispatchQueue.main.async { vm.setSelectedContent(...) }\` so SwiftUI gets a runloop tick to dismantle preview \`UIViewRepresentable\`s before the main playback player attaches its decoder. Also resets the access-log bitrate latches on item replacement so the new play doesn't bridge stale data.

## Test plan

- [ ] Two iPad Slide-Over windows of the app: only one scene is created
- [ ] Tap a tile from Home → confirm preview decoders are released before main playback starts
- [ ] Replay the issue-#348 reproducer: heartbeats in the analytics archive should now have a stable single source per `player_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)