### PR TITLE
feat(dashboard): chart pan/reset/click UX fixes

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -3567,8 +3567,32 @@
                     if (rightPanDragState && rightPanDragState.sessionId === sessionId) {
                         rightPanDragState = null;
                     }
+                    // Explicit snap-to-full-extent rather than chart.resetZoom().
+                    // The zoom plugin's `_originalScaleLimits` snapshot can
+                    // drift away from the live full domain, which made reset
+                    // restore to a previously-zoomed range instead of the
+                    // default. zoomScale + setWindow with the chart's live
+                    // x.max is deterministic.
                     for (const chart of getChartsForSession(sessionId)) {
-                        if (chart && typeof chart.resetZoom === 'function') {
+                        if (!chart) continue;
+                        if (chart.$isVisTimeline && typeof chart.setWindow === 'function') {
+                            const startMs = Number(chart.$windowStartMs) || 0;
+                            const xMax = Number(chart.$xMaxSeconds) || 600;
+                            if (startMs) {
+                                chart.setWindow(
+                                    new Date(startMs),
+                                    new Date(startMs + xMax * 1000),
+                                    { animation: false }
+                                );
+                            }
+                            continue;
+                        }
+                        const xMax = (chart.options?.scales?.x?.max != null)
+                            ? Number(chart.options.scales.x.max)
+                            : 600;
+                        if (typeof chart.zoomScale === 'function') {
+                            chart.zoomScale('x', { min: 0, max: xMax }, 'none');
+                        } else if (typeof chart.resetZoom === 'function') {
                             chart.resetZoom('none');
                         }
                     }
@@ -4260,6 +4284,15 @@
                     enabled: true,
                     mode: 'x',
                     threshold: 2,
+                    onPanStart: () => {
+                        // Panning while live drops the user off the
+                        // streaming edge — keep the chart on the range
+                        // they navigated to instead of snapping it back.
+                        if (!isChartPaused(key)) {
+                            chartPausedBySession.set(key, true);
+                            updatePauseButtonAndOverlays(key);
+                        }
+                    },
                     // Must be inside pan{} in chartjs-plugin-zoom v2
                     onPanComplete: ({ chart: chartRef }) => {
                         syncChartViewportAcrossSession(key, chartRef);
@@ -4321,6 +4354,10 @@
                 const span = rightPanDragState.startViewport.max - rightPanDragState.startViewport.min;
                 if (!Number.isFinite(span) || span <= 0) return;
                 const deltaPx = event.clientX - rightPanDragState.startClientX;
+                if (Math.abs(deltaPx) >= 2 && !isChartPaused(rightPanDragState.sessionId)) {
+                    chartPausedBySession.set(rightPanDragState.sessionId, true);
+                    updatePauseButtonAndOverlays(rightPanDragState.sessionId);
+                }
                 const deltaValue = (deltaPx / widthPx) * span;
                 const viewport = normalizeChartViewport(
                     rightPanDragState.startViewport.min - deltaValue,
@@ -4394,13 +4431,26 @@
             canvas.dataset.pauseHandlerBound = '1';
             let startX = 0;
             let startY = 0;
+            let dragged = false;
             canvas.addEventListener('mousedown', (e) => {
                 if (e.button !== 0) return;
                 startX = e.clientX;
                 startY = e.clientY;
+                dragged = false;
+            });
+            canvas.addEventListener('mousemove', (e) => {
+                // Track real movement while a button is held so the
+                // mouseup-after-pan doesn't get treated as a click and
+                // toggle pause. e.buttons is a bitmask; non-zero means
+                // at least one button is currently down.
+                if (e.buttons === 0) return;
+                if (Math.abs(e.clientX - startX) > 3 || Math.abs(e.clientY - startY) > 3) {
+                    dragged = true;
+                }
             });
             canvas.addEventListener('click', (e) => {
                 if (e.altKey) return;
+                if (dragged) return;
                 if (Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5) return;
                 // Only toggle pause for clicks inside the plot area.
                 // Clicks in the legend / title regions (outside chartArea) are for

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -1717,6 +1717,15 @@
                     enabled: true,
                     mode: 'x',
                     threshold: 2,
+                    onPanStart: () => {
+                        // Panning while live drops the user off the
+                        // streaming edge — keep the chart on the range
+                        // they navigated to instead of snapping it back.
+                        if (!isChartPaused(key)) {
+                            chartPausedBySession.set(key, true);
+                            updatePauseButtonAndOverlays(key);
+                        }
+                    },
                     onPanComplete: ({ chart: chartRef }) => {
                         syncChartViewportAcrossSession(key, chartRef);
                     }
@@ -1767,6 +1776,10 @@
                 const span = rightPanDragState.startViewport.max - rightPanDragState.startViewport.min;
                 if (!Number.isFinite(span) || span <= 0) return;
                 const deltaPx = event.clientX - rightPanDragState.startClientX;
+                if (Math.abs(deltaPx) >= 2 && !isChartPaused(rightPanDragState.sessionId)) {
+                    chartPausedBySession.set(rightPanDragState.sessionId, true);
+                    updatePauseButtonAndOverlays(rightPanDragState.sessionId);
+                }
                 const deltaValue = (deltaPx / widthPx) * span;
                 const viewport = normalizeChartViewport(
                     rightPanDragState.startViewport.min - deltaValue,
@@ -1834,13 +1847,26 @@
             canvas.dataset.pauseHandlerBound = '1';
             let startX = 0;
             let startY = 0;
+            let dragged = false;
             canvas.addEventListener('mousedown', (e) => {
                 if (e.button !== 0) return;
                 startX = e.clientX;
                 startY = e.clientY;
+                dragged = false;
+            });
+            canvas.addEventListener('mousemove', (e) => {
+                // Track real movement while a button is held so the
+                // mouseup-after-pan doesn't get treated as a click and
+                // toggle pause. e.buttons is a bitmask; non-zero means
+                // at least one button is currently down.
+                if (e.buttons === 0) return;
+                if (Math.abs(e.clientX - startX) > 3 || Math.abs(e.clientY - startY) > 3) {
+                    dragged = true;
+                }
             });
             canvas.addEventListener('click', (e) => {
                 if (e.altKey) return;
+                if (dragged) return;
                 if (Math.abs(e.clientX - startX) > 5 || Math.abs(e.clientY - startY) > 5) return;
                 const chartArea = chartRef.chartArea;
                 if (chartArea) {
@@ -4783,8 +4809,32 @@
                 if (rightPanDragState && rightPanDragState.sessionId === key) {
                     rightPanDragState = null;
                 }
+                // Explicit snap-to-full-extent. chart.resetZoom() relies on
+                // the zoom plugin's `_originalScaleLimits` snapshot, which
+                // drifts after applyChartXMax mutates scales.x.max — the
+                // result is that "reset" restores to a stale window
+                // instead of the current full domain. zoomScale + setWindow
+                // with the live x.max is deterministic.
                 for (const chart of getChartsForSession(key)) {
-                    if (chart && typeof chart.resetZoom === 'function') {
+                    if (!chart) continue;
+                    if (chart.$isVisTimeline && typeof chart.setWindow === 'function') {
+                        const startMs = Number(chart.$windowStartMs) || 0;
+                        const xMax = Number(chart.$xMaxSeconds) || 600;
+                        if (startMs) {
+                            chart.setWindow(
+                                new Date(startMs),
+                                new Date(startMs + xMax * 1000),
+                                { animation: false }
+                            );
+                        }
+                        continue;
+                    }
+                    const xMax = (chart.options?.scales?.x?.max != null)
+                        ? Number(chart.options.scales.x.max)
+                        : 600;
+                    if (typeof chart.zoomScale === 'function') {
+                        chart.zoomScale('x', { min: 0, max: xMax }, 'none');
+                    } else if (typeof chart.resetZoom === 'function') {
                         chart.resetZoom('none');
                     }
                 }


### PR DESCRIPTION
## Summary

Three small but compounding chart-control fixes in both \`session-shell.js\` and the inline copy in \`testing-session.html\`:

- **Reset-zoom snaps to the chart's current full extent** instead of the chart.js zoom plugin's stale \`_originalScaleLimits\` snapshot. Uses \`zoomScale('x', { min: 0, max: chart.options.scales.x.max })\` for Chart.js charts and \`setWindow()\` for vis-timelines.
- **Clicks following a pan no longer toggle pause.** Tracks real movement during a held button via \`mousemove\` + a \`dragged\` flag (>3 px threshold, \`e.buttons\` bitmask). Trailing click is suppressed when motion was registered.
- **Pan-while-live auto-pauses.** Both pan paths (chart.js zoom plugin via \`onPanStart\`, and the right-click pan handler via 2 px-of-motion) flip the chart to paused so the panned window doesn't get yanked back to the right edge by incoming live samples.

## Test plan

- [ ] Pan a live chart → confirm it auto-pauses
- [ ] Drag-release on a chart → click event suppressed (no pause toggle)
- [ ] Click Reset Zoom → snaps to current full extent (not stale extent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)