### PR TITLE
feat(proxy): post-apply tc rate-limit verification (#352)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -896,6 +896,7 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 		_ = t.RemoveFilter(port)
 		_ = t.RemoveClass(port)
 		t.logTcState("rate_clear", port)
+		t.scheduleRateLimitVerification(port, 0, 3*time.Second)
 		return nil
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)
@@ -948,6 +949,7 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 		return fmt.Errorf("tc class not present after update: %s", strings.TrimSpace(verifyText))
 	}
 	t.logTcState("rate_apply", port)
+	t.scheduleRateLimitVerification(port, rateMbps, 3*time.Second)
 	return nil
 }
 
@@ -987,6 +989,44 @@ func (t *TcTrafficManager) ClearPortShaping(port int) {
 		"parent", "1:0", "prio", "1", "u32",
 		"match", "ip", "sport", fmt.Sprintf("%d", port), "0xffff").Run()
 	_ = exec.Command("tc", "class", "del", "dev", t.interfaceName, "classid", classid).Run()
+}
+
+// scheduleRateLimitVerification fires a one-shot check `delay` after
+// a rate limit was applied to confirm it stuck. Catches the case
+// where the apply command reports success but the kernel state
+// diverges within seconds — e.g. another process clears the rule,
+// the kernel drops it, a follow-up tc operation racing on the same
+// port wins. Logs `NETSHAPE LOST` if the kernel rate diverges from
+// expected, otherwise quietly logs `NETSHAPE VERIFIED` at info level
+// so a `grep "VERIFIED|LOST"` pass surfaces every apply.
+//
+// expectedMbps==0 means the apply was a CLEAR; the verification then
+// asserts the class is gone (ReadActualRateMbps returns -1).
+func (t *TcTrafficManager) scheduleRateLimitVerification(port int, expectedMbps float64, delay time.Duration) {
+	go func() {
+		time.Sleep(delay)
+		actualMbps := t.ReadActualRateMbps(port)
+		if expectedMbps == 0 {
+			if actualMbps >= 0 {
+				log.Printf("NETSHAPE LOST port=%d expected=clear kernel_mbps=%.3f delay=%s",
+					port, actualMbps, delay)
+			} else {
+				log.Printf("NETSHAPE VERIFIED port=%d cleared delay=%s", port, delay)
+			}
+			return
+		}
+		if actualMbps < 0 {
+			log.Printf("NETSHAPE LOST port=%d expected_mbps=%.3f kernel=no_class delay=%s",
+				port, expectedMbps, delay)
+			return
+		}
+		if math.Abs(actualMbps-expectedMbps) > 0.5 {
+			log.Printf("NETSHAPE LOST port=%d expected_mbps=%.3f kernel_mbps=%.3f delay=%s",
+				port, expectedMbps, actualMbps, delay)
+			return
+		}
+		log.Printf("NETSHAPE VERIFIED port=%d mbps=%.3f delay=%s", port, actualMbps, delay)
+	}()
 }
 
 // ReadActualRateMbps queries the kernel for the live rate of the


### PR DESCRIPTION
## Summary

Layer 4 of the leftover-tc-rule fix (#352). After every \`tc class change\` / \`add\` / \`del\` for a per-port rate limit, schedule a one-shot goroutine 3 s later that re-reads kernel state via \`ReadActualRateMbps\` and logs one of:

\`\`\`
NETSHAPE VERIFIED port=N mbps=R delay=3s
NETSHAPE VERIFIED port=N cleared delay=3s
NETSHAPE LOST port=N expected_mbps=R kernel_mbps=K delay=3s
NETSHAPE LOST port=N expected=clear kernel_mbps=K delay=3s
\`\`\`

A \`grep "NETSHAPE (VERIFIED|LOST)"\` over the proxy log is now a complete record of every rate-limit op and whether it actually held in the kernel — catches the case where the apply command reports success but kernel state diverges within seconds.

Wired into both the apply and clear branches of \`UpdateRateLimit\`. Verification runs in its own goroutine after the call returns; zero added latency on the hot path.

## Test plan

- [ ] Apply rate=15Mbps; within 3s confirm \`NETSHAPE VERIFIED port=… mbps=15.000\` in proxy log
- [ ] Manually \`tc class del\` after apply; within 3s confirm \`NETSHAPE LOST\` line appears
- [ ] Clear (rate=0); confirm \`NETSHAPE VERIFIED port=… cleared\` in proxy log

🤖 Generated with [Claude Code](https://claude.com/claude-code)