### PR TITLE
fix(ios): serialize metrics PATCHes to preserve submission order

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -150,6 +150,15 @@ final class PlayerViewModel: ObservableObject {
     private var lastReportedStallDuration: Double = 0
     private var lastReportedLoopCount: Int = 0
     private let metricsHeartbeatSeconds: TimeInterval = 1
+    // Tail of the serialized chain of in-flight metrics PATCHes. Each
+    // new sendPlayerMetrics call chains onto this Task so URLSession
+    // requests reach the proxy in iOS-clock submission order. Without
+    // this, concurrent URLSession.shared requests can complete out of
+    // order and the proxy's last-writer-wins merge stomps a fresher
+    // event (e.g. rate_shift_up bps=3.46) with an earlier-submitted
+    // heartbeat (bps=1.84) that arrived later. See plan
+    // humming-sleeping-squid.md.
+    private var metricsTaskTail: Task<Void, Never>?
     private let metricsSessionLookupSeconds: TimeInterval = 30
     private let autoRecoveryThresholdSeconds: TimeInterval = 60
     private let autoRecoveryBaseDelaySeconds: TimeInterval = 2
@@ -1442,10 +1451,30 @@ extension PlayerViewModel {
     fileprivate func sendPlayerMetrics(event: String, extra: [String: Any] = [:]) async {
         guard currentURL != nil else { return }
         guard let baseURL = metricsBaseURL() else { return }
-        guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }
+        // Build payload NOW so the iOS-clock-time of submission is
+        // captured in player_metrics_event_time and the bitrate field
+        // reflects diagnostics state at this instant. The actual HTTP
+        // send is serialized below to preserve submission order on the
+        // wire — see plan humming-sleeping-squid.md.
         let payload = buildMetricsPayload(event: event, extra: extra)
         if payload.isEmpty { return }
-        await patchSessionMetrics(sessionId: sessionId, baseURL: baseURL, payload: payload)
+        // Resolve session ID outside the chain (cached after first
+        // lookup; idempotent and safe to run concurrently).
+        guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }
+        // Serialize the PATCH onto the tail of the in-flight chain so
+        // wire-arrival order matches iOS submission order. URLSession
+        // .shared runs concurrent requests in arbitrary order; without
+        // this, a heartbeat sent 8ms before a rate_shift can arrive
+        // AFTER it and the proxy's last-writer-wins merge stomps the
+        // fresher value. See plan humming-sleeping-squid.md.
+        let prev = metricsTaskTail
+        let next = Task { [weak self] in
+            if let prev { await prev.value }
+            guard let self else { return }
+            await self.patchSessionMetrics(sessionId: sessionId, baseURL: baseURL, payload: payload)
+        }
+        metricsTaskTail = next
+        await next.value
     }
 
     fileprivate func metricsBaseURL() -> URL? {


### PR DESCRIPTION
## Summary

iOS heartbeats reported phantom variant flapping in the analytics archive — \`player_metrics_video_bitrate_mbps\` interleaved between adjacent ladder values (e.g. 7.06 ↔ 3.46) on the same \`play_id\` even though the player was monotonically committed to one variant.

**Root cause:** each \`sendPlayerMetrics\` call dispatches its HTTP PATCH via \`Task { ... }\` with \`URLSession.shared\`, which runs requests concurrently. A heartbeat sent at T=0 with the iOS-clock-current bitrate (1.84 Mbps) could arrive at the proxy *after* a \`rate_shift_up\` event sent at T=8ms with the new value (3.46 Mbps). The proxy's last-writer-wins merge then stomps the fresher value with the stale one and the snapshot archive shows a regression.

**Fix:** each \`sendPlayerMetrics\` builds its payload eagerly (capturing iOS-clock state at submission), then chains the HTTP PATCH onto a \`@MainActor\`-isolated tail Task. Each new send awaits the previous tail's \`.value\` before going on the wire — wire-arrival order now matches iOS-clock submission order. No events are dropped; all heartbeats, \`rate_shift_*\`, \`video_bitrate_change\`, \`stall\`, etc. still PATCH, just in order.

Applies on iPhone, iPad, and tvOS — single \`PlayerViewModel.swift\` shared by both targets, no platform conditionals.

## Test plan

- [ ] Reproduce flap conditions (rapid bandwidth toggle 5 Mbps ↔ unlimited a few times)
- [ ] Query \`/analytics/api/snapshots?session=…&play_id=…\` for the resulting play
- [ ] Confirm \`player_metrics_video_bitrate_mbps\` walks the ladder monotonically — no \`7.06 → 3.46 → 7.06\` interleaving
- [ ] Build for tvOS scheme too: \`xcodebuild -scheme 'InfiniteStreamPlayer (tvOS)' -sdk appletvos build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)