### PR TITLE
docs: refresh README, PRD, CLAUDE for analytics tier + incidents removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,13 +78,18 @@ Default server target for tests is `$K3S_HOST:30000/30081`. Override with `--hos
 | `memcached` | 11211 | Session state storage (embedded in container) |
 | nginx | 30000 | Routing, static dashboard |
 
+Plus the optional **analytics sidecar** (separate compose services): `clickhouse` (archive, 30-day TTL), `forwarder` (SSE → ClickHouse + read API), `grafana` (provisioned dashboards). All under [`analytics/`](analytics/). The live streaming path is independent of the sidecar — if the forwarder dies, the live UI keeps working, archival just pauses.
+
 ### nginx routing (`nginx-content.conf.template`)
 
 - `/go-live/{content}/*.m3u8` and `*.mpd` → proxied to `go-live:8010` for dynamic generation
 - `/go-live/{content}/*.m4s`, `*.ts`, `*.mp4`, etc. → served directly from the output directory by nginx
 - `/api/content`, `/api/jobs`, `/api/sources`, `/api/upload`, `/api/setup` → `go-upload:8003`
 - `/api/sessions*`, `/api/session/*`, `/api/failure-settings/*`, `/api/session-group/*`, `/api/nftables/*` → `go-proxy:30081`
+- `/analytics/api/*` → `forwarder:8080` (read-only ClickHouse query proxy + bundle ZIP streaming)
+- `/grafana/*` → `grafana:3000` (with `GF_SERVER_SERVE_FROM_SUB_PATH=true`)
 - `/dashboard/` → `content/dashboard/` static files
+- HTTP Basic auth on `/dashboard/`, `/analytics/api/`, `/grafana/` is opt-in via `INFINITE_STREAM_AUTH_HTPASSWD` env var; player-app endpoints stay public.
 
 ### go-live (`go-live/`)
 
@@ -112,13 +117,29 @@ Per-session failure injection and traffic shaping proxy. Each testing session ge
 
 The `player_id` query param on `testing-session.html` binds the browser session to a proxy port.
 
-### Dashboard (`content/dashboard/`)
+### Dashboard (`content/dashboard/` + `content/shared/`)
 
 Static HTML/JS/CSS pages served by nginx:
 - `dashboard.html` — main entry
 - `testing-session.html` + `testing-session-ui.js` — failure injection UI and player characterization
+- `sessions.html` — picker over archived sessions; per-row bad-event chips, bundle download
+- `session-viewer.html` — replays one archived play through the same charts as the live page
 - `player-characterization.js` — ABR ramp sweep logic
 - `grid.html`, `quartet.html`, `playback.html`, `go-monitor.html`, etc.
+
+Shared modules (`content/shared/`):
+- `session-shell.js` — chart rendering core (Chart.js + vis-timeline) used by both live and replay
+- `session-replay.js` — brush + events dropdown + rail markers for the replay page
+- `session-live.js`, `play-id.js` — live/replay glue
+
+### Analytics sidecar (`analytics/`)
+
+- `clickhouse/init.d/01-schema.sql` — `session_snapshots` + `network_requests` schema, 30-day TTL.
+- `go-forwarder/` — Go binary that subscribes to `/api/sessions/stream`, batches inserts into ClickHouse, and serves `/api/sessions`, `/api/snapshots`, `/api/session_events`, `/api/network_requests`, `/api/session_heatmap`, `/api/session_bundle` (ZIP) read-only via parameterized `{name:Type}` SQL placeholders.
+- `grafana/provisioning/` — dashboards-as-code; reload with `make analytics-update`.
+- See [`analytics/README.md`](analytics/README.md) for ops, schema, and the WAN-deploy auth runbook.
+
+Make targets: `make analytics-rebuild-forwarder` (rebuild + recreate forwarder only, no go-server restart), `make analytics-update` (Grafana reload), `make analytics-migrate SQL='ALTER …'` (one-line schema change).
 
 ### Encoding Pipeline (`generate_abr/`)
 

--- a/PRD.md
+++ b/PRD.md
@@ -108,12 +108,11 @@ The system is intended for:
 - Player selector: HLS.js, Shaka, Video.js, Native.
 - Logs player errors and HTTP failure details in the testing UI.
 
-**Incidents**
-- Persistent browser of HAR snapshots captured during testing sessions.
-- Snapshots are auto‑captured on detected stalls (`reason=stall` / `reason=segment_stall`), on player 911 button presses (`reason="user 911"`), or written manually via the testing‑session **Save HAR** button (`reason=manual`).
-- Each row shows reason / source / clipped time window / first stream URL touched / file size.
-- Click any incident to render its waterfall inline using the same renderer the testing session uses; bulk‑delete and per‑row delete supported.
-- Reason filters split auto‑captures from manual saves so triage isn't drowning in 911 backups.
+**Sessions Viewer & Bundle Download**
+- Every session and every network request auto‑archives into the analytics sidecar (ClickHouse + go‑forwarder, 30‑day TTL).
+- The **Sessions** picker page (`/dashboard/sessions.html`) lists every `(session_id, play_id)` pair archived in the last 30 days. Cascading filter UI on player / group / content / play_id; per‑row colored chips flag bad‑event types (🚨 user_marked / ❄️ frozen / ⛔ error / ⏸ segment_stall / 🔄 restart) and a red left bar marks any row carrying a 911, frozen, hard error, master‑manifest failure, or all‑failure event.
+- The **Session Viewer** page (`/dashboard/session-viewer.html?session=…&play_id=…`) replays one play through the same charts the live testing UI uses — bandwidth + variant, buffer depth, FPS, player‑state vis‑timeline, and a HAR network‑log waterfall — scrubbable to any moment via a session‑long brush. Picking an event from the dropdown or rail draws a cyan vertical guide line at that timestamp on every chart and the network log.
+- **Bundle download** (📥 in the picker / banner) streams a `.zip` containing `snapshots.ndjson` (raw per‑second blobs from the proxy SSE stream), `network.har` (HAR 1.2 envelope, opens in Chrome DevTools, custom proxy fields under `_extensions`), `session.json` (at‑a‑glance summary), and `README.md`. Sanitises sensitive headers and credential‑shaped query params server‑side before the bytes leave the forwarder.
 
 ### 7.6 Player Characterization (ABR)
 - A per‑session **Player Characterization** panel is available in the Testing session UI.
@@ -211,8 +210,8 @@ Many platforms already expose their own failure tools (player debug features, br
 - **Network log (HAR)**: every request the proxy serves to the player is captured with full timing (DNS / connect / TLS / TTFB / wait / transfer), method, URL, status, request kind, and fault metadata (`faulted`, `fault_type`, `fault_action`, `fault_category`).
    - The dashboard waterfall renders rows with a flag column whose glyph distinguishes the four "looked like 200, ended badly" categories: `!` (HTTP fault), `!✂` (socket fault inject), `!⏱` (server transfer timeout), `!↩` (client disconnect).
    - Status codes reflect what the *client* observed on the wire: `200` for socket faults that emitted chunked headers before the cut, `0` for connect‑time aborts, the upstream's status for transfer‑timeout / client‑disconnect mid‑body, and `4xx` / `5xx` for HTTP faults.
-- **HAR snapshots**: persistent files written to `$CONTENT_DIR/incidents/`. Triggered automatically on detected player stalls / segment stalls, on a player **911** button press (`user_marked` event), or manually via the dashboard **Save HAR** button. Each snapshot clips to the last 10 minutes of activity and includes every play within that window.
-- **Cross‑layer 911 logging**: the player's 911 button writes a `"911"` log token on the device (Apple device console / `adb logcat`), POSTs a `user_marked` metrics event the server logs with the same `"911"` token, and triggers an immediate HAR snapshot whose lifecycle is logged. Tracing one user complaint across all three layers reduces to `grep 911`.
+- **Auto‑archival**: every session snapshot and every captured request streams into ClickHouse via the analytics sidecar's go‑forwarder (`/api/sessions/stream` SSE → `session_snapshots` + `network_requests` tables, 30‑day TTL). The Sessions picker and Session Viewer read from those tables; the bundle ZIP packages a single play's data for offline / >30‑day preservation.
+- **Cross‑layer 911 logging**: the player's 911 button writes a `"911"` log token on the device (Apple device console / `adb logcat`), POSTs a `user_marked` metrics event the server logs with the same `"911"` token. The event lands in `session_snapshots.last_event = 'user_marked'`, surfaces as a 🚨 chip on the Sessions picker, and as a cyan‑labelled marker on every Session Viewer chart. Tracing one user complaint across device → server → archive reduces to `grep 911`.
 
 ## 10) Security & Access
 - Local development focus; no auth required.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Player bugs are usually environmental — a network blip, a truncated segment, a
 - **Interactive rate shaping with deterministic patterns.** Drag throughput, latency, loss, and pattern-mode sliders and watch the player react in real time. Or build a step-based throughput pattern with a fixed step duration so the same curve replays bit-for-bit on every run — what you saw rebuffer at 09:14 yesterday rebuffers again today.
 - **Per-session isolation.** Each browser session binds to a dedicated proxy port via `player_id`, so concurrent testers don't collide.
 - **Streaming-aware HAR.** The dashboard's network-log waterfall annotates each request with what *actually* happened on the wire. A row that looks like a 200 but ended badly is tagged with `!✂` (proxy-injected body cut), `!⏱` (server transfer-timeout), or `!↩` (client gave up), so the chart tells the truth even when the status code can't.
-- **One-tap incident capture.** A "911" button on every player (iOS / iPadOS / tvOS / Android TV) snapshots the current session's HAR — a 10-minute window of every request, fault, and play, written to the Incidents browser for replay later. No "what did you click before it broke?" debugging.
+- **Auto-archived session forensics.** Every snapshot and every network request streams into a ClickHouse + Grafana sidecar in real time. The dashboard's **Sessions** picker lists every play of every session for the last 30 days; the **Session Viewer** replays one through the same charts the live page uses, scrubbable to any moment. A "911" button on every player (iOS / iPadOS / tvOS / Android TV) drops a `user_marked` event you can see across charts and pick out from the picker. One-click **bundle download** packages a session's snapshots + HAR + README into a portable `.zip` you can attach to a bug report or replay offline after the 30-day TTL expires.
 - **Session grouping for differential testing.** Link two or more independent sessions so fault injection and network shaping apply to all of them simultaneously, while everything else (player engine, codec, live offset, platform, ladder constraints) stays independent per session. One bandwidth collapse, two `live_offset` values, instant apples-to-apples comparison of which setting rebuffers. Or iOS vs Android reacting to the exact same throughput curve. See [Session grouping](#session-grouping-differential-testing).
 - **Side-by-side comparison UI.** Mosaic view for watching multiple players or encodings against the same source simultaneously. Quartet (alpha) extends this to four-panel layouts.
 - **Accessible to non-programmers.** The whole surface is a web UI — click a fault type, drag a throttle slider, flip a Content-tab toggle, watch the bitrate / buffer / FPS charts react in real time. No Python addons, no YAML, no CLI. A QA analyst, a producer, or a support engineer can run real experiments and see cause-and-effect without writing any code.
@@ -131,7 +131,8 @@ That walkthrough exercises the majority of the system. The sections below descri
 - **Quartet** *(alpha)* — four-panel side-by-side comparison across encodings or players.
 - **Live Offset** *(alpha)* — compares live offset, buffer depth, and seekable ranges across variants.
 - **Testing Session** — per-session failure injection, traffic shaping, content manipulation, metrics charts. See below.
-- **Incidents** — browse recorded HAR snapshots from every session. Click any incident to render its waterfall inline; bulk-delete cleanup; reason filters distinguish auto-captures (stall / segment-stall / 911) from manual `Save HAR` clicks.
+- **Sessions** — picker over every archived session for the last 30 days. Per-row colored chips flag bad-event types (🚨 911 / ❄️ frozen / ⛔ error / ⏸ segment stall / 🔄 restart) and a red left bar on critical rows make scanning a folder of sessions a glance, not a click-through. Each row has a 📥 button that downloads the session as a portable bundle ZIP.
+- **Session Viewer** — replays one archived session through the same charts the live Testing Session page uses (bandwidth, buffer, FPS, player-state vis-timeline, network log). A brush across a session-long rail scrubs to any moment; cross-chart event marker draws a cyan vertical line at the picked event's timestamp on every chart and on the network log.
 - **Go-Monitor** — active workers, request counts, last-request time, idle timeout, tick timings.
 - **Upload Content** — web upload + encoding job tracking.
 - **Source Library** — list of `$CONTENT_DIR/originals/`. Click to kick re-encodes.
@@ -260,13 +261,28 @@ Each row is `time | flags | method | path | bytes | Mbps | status | bar`. The **
 
 A row that *looks* like a successful 200 download but has `!↩` or `!⏱` next to its method tells you the player abandoned it or the proxy gave up — exactly the signal you'd otherwise miss.
 
-**Capture controls**:
+**Capture & triage**:
 
-- **Save HAR** — manual snapshot. Writes a HAR file to the Incidents browser with `reason=manual`.
-- **911 button** — every player (iOS / iPadOS / tvOS / Android TV) has a "911" button right of Reload. One tap fires a `user_marked` event the server picks up, which triggers an automatic HAR snapshot of the current session timeline (10-minute clip, includes all plays). Files in the Incidents browser tagged `reason="user 911"`. Cross-layer "911" log lines on Apple device console, `adb logcat`, and docker logs make it grep-friendly across all three layers.
-- **Auto-snapshot** — go-proxy detects extended player stalls / segment-stalls and triggers a HAR snapshot automatically with `reason=stall` / `reason=segment_stall`.
+Every session and every network request auto-archives into the analytics sidecar (ClickHouse + go-forwarder, see [Analytics tier](#analytics-tier)) for 30 days. The dashboard's **Sessions** picker and **Session Viewer** are the triage UI; downloads happen via **bundle ZIP**.
 
-The Incidents page on the dashboard browses every saved HAR; click an incident to render its waterfall inline without leaving the page.
+- **911 button** — every player (iOS / iPadOS / tvOS / Android TV) has a "911" button right of Reload. One tap fires a `user_marked` event that lands as a row in `session_snapshots.last_event` and as a 🚨 chip on the picker row. Cross-layer "911" log lines on Apple device console, `adb logcat`, and docker logs make it grep-friendly across all three layers.
+- **Bundle download** — 📥 button on each picker row and in the session-viewer banner streams a `.zip` containing `snapshots.ndjson` (raw per-second blobs), `network.har` (HAR 1.2 envelope, opens in Chrome DevTools), `session.json` (summary), and `README.md`. Sensitive headers and credential-shaped query params are redacted server-side before the bytes leave the forwarder. See [`analytics/README.md`](analytics/README.md) for the full bundle format.
+
+---
+
+## Analytics tier
+
+A sidecar stack (ClickHouse + Grafana + a small Go forwarder) auto-archives session metrics and per-request HAR for 30 days. Lives entirely under [`analytics/`](analytics/) — operationally independent of the live streaming path: if the forwarder dies, the live UI keeps working, archival just pauses until it restarts.
+
+| Component | Role |
+|---|---|
+| `clickhouse` | Two wide tables (`session_snapshots`, `network_requests`) with 30-day TTL. Hot fields are typed columns; everything else lands in a `session_json` blob. |
+| `go-forwarder` | Subscribes to go-proxy's `/api/sessions/stream` SSE, dedupes by snapshot fingerprint, batches inserts into ClickHouse. Also serves `/api/sessions`, `/api/snapshots`, `/api/session_events`, `/api/network_requests`, `/api/session_heatmap`, `/api/session_bundle` — read-only, parameterized SQL, behind `nginx /analytics/api/`. |
+| `grafana` | Provisioned-as-code dashboards under [`analytics/grafana/provisioning/`](analytics/grafana/provisioning/). Reachable via `nginx /grafana/`. |
+
+**Operating it**: `make analytics-rebuild-forwarder` recreates the forwarder container in-place (live UI untouched); `make analytics-update` reloads Grafana provisioning; `make analytics-migrate SQL='ALTER TABLE …'` runs a schema change. The data is exposed read-only to the dashboard via parameterized ClickHouse queries — no string interpolation, no auth-token leakage.
+
+**Securing for WAN deployment**: opt-in HTTP Basic auth via `INFINITE_STREAM_AUTH_HTPASSWD` gates the dashboard, `/analytics/api/`, and `/grafana/`; player-app endpoints stay public so unattended Apple/Roku/AndroidTV clients keep working. ClickHouse binds to `127.0.0.1` only by default. See [`analytics/README.md`](analytics/README.md) for the docker-compose and k3s runbooks.
 
 ---
 

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -49,7 +49,6 @@ markers =
     regression: Regression tests
     loop: Loop boundary health monitoring tests
     abrchar: ABR player characterization tests
-    har: HAR snapshot endpoint tests (issue #272)
 
 # Logging
 log_cli = true


### PR DESCRIPTION
## Summary

Documentation refresh to match the analytics-tier and bundle-download work that landed in #353 (session bundle), #354 (sessions picker), #355 (tiered retention), #357 (iOS doppleganger fix). Touches \`README.md\`, \`PRD.md\`, \`CLAUDE.md\`, \`AGENTS.md\`:

- Reflect the analytics sidecar architecture (forwarder + ClickHouse + Grafana)
- Drop references to the legacy incidents tier (replaced by tiered retention + bundle-download path)
- Clarify the bundle-download workflow as the persistence escape hatch beyond 30-day TTL
- Update the dashboard topology section

Pure docs change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)