### PR TITLE
fix(dashboard): plot player events at iOS event_time, not browser-receive time

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -4653,11 +4653,19 @@
 
             // PLAYERSTATE: sample state + AVPlayer waiting reason every
             // poll; the renderer coalesces same-label runs.
+            //
+            // All player-attributable events plot at iOS-clock event_time,
+            // not browser-now — pipeline jitter (proxy debounce, SSE
+            // buffering, JS event-loop) can shuffle browser-receive order
+            // vs iOS-clock order → phantom flapping in variant lanes.
+            // Anchoring to player_metrics_event_time pins each event to
+            // its true wall-clock moment.
+            const playerEventAtMs = getBandwidthChartEventTimestampMs(session, now);
             const stateValue = String(session.player_metrics_state || '').trim();
             const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
                 const eventSeries = bandwidthEventHistory.get(key) || [];
-                eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
+                eventSeries.push({ ts: playerEventAtMs, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
                 const eventCutoff = now - windowMs;
                 bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
@@ -4678,7 +4686,7 @@
                 const variantRes = manifestRes || reportedRes;
                 if (variantRes) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    eventSeries.push({ ts: playerEventAtMs, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                 }
@@ -4690,7 +4698,7 @@
             const displayRes = String(session.player_metrics_video_resolution || '').trim();
             if (displayRes) {
                 const eventSeries = bandwidthEventHistory.get(key) || [];
-                eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
+                eventSeries.push({ ts: playerEventAtMs, type: 'DISPLAY_RES', resolution: displayRes });
                 const eventCutoff = now - windowMs;
                 bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
@@ -4705,7 +4713,10 @@
                 }
             }
             series.push({
-                ts: now,
+                // Pin sample to iOS-clock event_time so the bandwidth
+                // line and the variant/state lanes share one timeline
+                // even under pipeline jitter — see session-shell.js.
+                ts: playerEventAtMs,
                 wireActive6s,
                 wireActive1s,
                 segmentWire,

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -2005,13 +2005,21 @@
             // tracks individual transitions like SHIFT_UP/STALL. Fires
             // on the FIRST observation too (prevPlayId === undefined),
             // so opening the page mid-playback still gets a marker.
+            // Single iOS-clock timestamp for every player-attributable
+            // event recorded by this snapshot pass — pins all chart
+            // events to the device-observed wall-clock moment regardless
+            // of pipeline jitter (proxy debounce, SSE buffering, JS
+            // event-loop). Falls back to browser-now only when the
+            // session payload carries no device timestamp.
+            const playerEventAtMs = getBandwidthChartEventTimestampMs(session, now);
+
             const newPlayId = String(session.play_id || '').trim();
             if (newPlayId) {
                 const prevPlayId = lastRecordedPlayIdBySession.get(String(key));
                 if (prevPlayId !== newPlayId) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
                     eventSeries.push({
-                        ts: now,
+                        ts: playerEventAtMs,
                         type: 'PLAYBACK_START',
                         playId: newPlayId,
                         prevPlayId: prevPlayId || ''
@@ -2024,7 +2032,7 @@
 
             const eventType = parseBandwidthChartEventType(session.player_metrics_last_event || session.player_metrics_trigger_type);
             if (eventType) {
-                const eventAtMs = getBandwidthChartEventTimestampMs(session, now);
+                const eventAtMs = playerEventAtMs;
                 const eventStamp = `${eventType}|${session.player_metrics_last_event_at || session.player_metrics_event_time || eventAtMs}`;
                 const lastStamp = lastRecordedPlayerEventBySession.get(String(key));
                 if (eventStamp !== lastStamp) {
@@ -2047,7 +2055,7 @@
             const waitingReason = String(session.player_metrics_waiting_reason || '').trim();
             if (stateValue) {
                 const eventSeries = bandwidthEventHistory.get(key) || [];
-                eventSeries.push({ ts: now, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
+                eventSeries.push({ ts: playerEventAtMs, type: 'PLAYERSTATE', state: stateValue, reason: waitingReason });
                 const eventCutoff = now - windowMs;
                 bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
@@ -2072,7 +2080,7 @@
                 const variantRes = manifestRes || reportedRes;
                 if (variantRes) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];
-                    eventSeries.push({ ts: now, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
+                    eventSeries.push({ ts: playerEventAtMs, type: 'VARIANT', mbps: variantMbps, resolution: variantRes });
                     const eventCutoff = now - windowMs;
                     bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
                 }
@@ -2085,7 +2093,7 @@
             const displayRes = String(session.player_metrics_video_resolution || '').trim();
             if (displayRes) {
                 const eventSeries = bandwidthEventHistory.get(key) || [];
-                eventSeries.push({ ts: now, type: 'DISPLAY_RES', resolution: displayRes });
+                eventSeries.push({ ts: playerEventAtMs, type: 'DISPLAY_RES', resolution: displayRes });
                 const eventCutoff = now - windowMs;
                 bandwidthEventHistory.set(key, eventSeries.filter((event) => Number(event.ts) >= eventCutoff));
             }
@@ -2136,7 +2144,15 @@
                 }
             }
             series.push({
-                ts: now,
+                // Pin sample to iOS-clock event_time so the bandwidth
+                // line and the variant/state lanes share one timeline
+                // even under pipeline jitter. The fields below mix
+                // server-measured (shaperRate, transferRate) and
+                // iOS-reported (bufferDepth, currentRendition) values
+                // — they all relate to the moment iOS emitted this
+                // heartbeat, so anchoring the whole sample to that
+                // instant keeps cross-lane alignment correct.
+                ts: playerEventAtMs,
                 shaperRate,
                 shaperAvg,
                 transferRate,


### PR DESCRIPTION
Closes #364. Refs #348.

## Summary

Variant lanes in the dashboard chart showed phantom flapping at rate-shift transitions despite the player committing monotonically to one variant. Root cause: chart events were timestamped with browser-receive time (`Date.now()`), and pipeline jitter (proxy 250ms SSE debounce, OS SSE buffering, JS event-loop scheduling) shuffled browser-receive order relative to iOS-clock order. Chart painted at the shuffled timestamps.

Fix: plot every player-attributable chart event at `player_metrics_event_time` via the existing `getBandwidthChartEventTimestampMs(session, fallback)` helper. Anchors all events to the iOS-recorded wall-clock moment, immune to pipeline jitter.

## Lanes / events repointed (in both `session-shell.js` and the inline copy in `testing-session.html`)

- `PLAYBACK_START` (play_id rollover)
- `PLAYERSTATE` lane
- `VARIANT` lane
- `DISPLAY_RES` lane
- bandwidth-chart sample point (`series.push`) — keeps the bandwidth line and the variant/state lanes on one shared timeline

Buffer-depth and FPS charts share the bandwidth chart's `points` array, so they pick up the iOS-clock fix transitively. `CONTROL_CHANGE` events stay on browser-now (server-side state changes have no iOS event_time analog).

## Verified all currently-emitting clients include the timestamp

| Client | Where | Timestamp | Format |
|---|---|---|---|
| iOS | `PlayerViewModel.swift:1542-1543` | `Self.metricsTimestampFormatter.string(from: Date())` | ISO8601 with fractional s |
| Android | `PlayerViewModel.kt:185-186` | `reporter.nowISO()` | `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` |
| Web | `testing-session.html:1239-1240` | `new Date().toISOString()` | ISO8601 |
| Roku | — | n/a (no metrics path) | — |

Helper falls back to browser-now if a future client emits malformed/missing timestamps.

## Test plan

- [ ] Reproduce flap conditions: rapid bandwidth toggle 5 Mbps ↔ unlimited a few times. Variant lanes should walk monotonically with no narrow stripes at transitions.
- [ ] Buffer-depth and FPS charts align temporally with the variant lanes (same x-axis).
- [ ] Open `dashboard/sessions.html` for a previously-archived flap session and confirm the historical chart now renders cleanly too (replay path uses the same code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)