### PR TITLE
fix(ios): make metrics PATCH chain pointer update atomic

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1458,19 +1458,18 @@ extension PlayerViewModel {
         // wire — see plan humming-sleeping-squid.md.
         let payload = buildMetricsPayload(event: event, extra: extra)
         if payload.isEmpty { return }
-        // Resolve session ID outside the chain (cached after first
-        // lookup; idempotent and safe to run concurrently).
-        guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }
-        // Serialize the PATCH onto the tail of the in-flight chain so
-        // wire-arrival order matches iOS submission order. URLSession
-        // .shared runs concurrent requests in arbitrary order; without
-        // this, a heartbeat sent 8ms before a rate_shift can arrive
-        // AFTER it and the proxy's last-writer-wins merge stomps the
-        // fresher value. See plan humming-sleeping-squid.md.
+        // CRITICAL: read-tail / set-tail must be synchronous (no
+        // awaits between them) or two concurrent callers can suspend
+        // on a prior await, resume out of FIFO order, and end up
+        // chaining backwards — wire-arrival order then doesn't match
+        // iOS-clock submission order. resolveMetricsSessionId and
+        // patchSessionMetrics live inside the Task so the chain
+        // pointer is updated atomically within one MainActor tick.
         let prev = metricsTaskTail
         let next = Task { [weak self] in
             if let prev { await prev.value }
             guard let self else { return }
+            guard let sessionId = await self.resolveMetricsSessionId(baseURL: baseURL) else { return }
             await self.patchSessionMetrics(sessionId: sessionId, baseURL: baseURL, payload: payload)
         }
         metricsTaskTail = next


### PR DESCRIPTION
Refs #348.

## Background

PR #361 introduced a Task-chain to serialize iOS metrics PATCHes so wire-arrival order matches iOS-clock submission order. Subsequent debugging showed the chain wasn't actually serializing — concurrent callers were chaining backwards.

## Cause

Original code awaited `resolveMetricsSessionId(baseURL:)` BEFORE reading `metricsTaskTail`. That await suspends MainActor; two concurrent callers (heartbeat at T=N, rate_shift at T=N+8ms) both suspend, and Swift Concurrency does NOT guarantee FIFO resumption. When they resume, the *rate_shift* can resume first, read `metricsTaskTail = nil`, set itself as the tail, *then* the heartbeat resumes, sees the rate_shift as `prev`, and chains behind it. Result: wire-arrival order was reversed relative to iOS-clock submission.

## Fix

Move `resolveMetricsSessionId` and `patchSessionMetrics` inside the chained Task body. The enclosing MainActor function now reads `metricsTaskTail` and assigns its successor with no await between them — concurrent callers execute that synchronous block atomically via MainActor's serial queue, and chain order matches iOS-clock order.

\`\`\`swift
// before — race window between read and set:
guard let sessionId = await resolveMetricsSessionId(baseURL: baseURL) else { return }   // ← suspends
let prev = metricsTaskTail   // ← may race with another caller
let next = Task { ... }
metricsTaskTail = next

// after — atomic read/set, no awaits in between:
let prev = metricsTaskTail   // ← atomic on MainActor
let next = Task { [weak self] in
    if let prev { await prev.value }
    guard let self else { return }
    guard let sessionId = await self.resolveMetricsSessionId(baseURL: baseURL) else { return }
    await self.patchSessionMetrics(sessionId: sessionId, baseURL: baseURL, payload: payload)
}
metricsTaskTail = next
await next.value
\`\`\`

## Status as defense in depth

The user-visible flapping bug was actually in the dashboard chart (browser-timestamp vs iOS event-time) and was fixed in #365. With #365 in place this PR is no longer load-bearing for chart correctness, but it remains the right invariant for the wire layer — clients that consume archive rows in server-arrival order will now see them in iOS-submission order rather than URLSession-completion order.

## Test plan

- [ ] Build for iOS + tvOS schemes
- [ ] Run the bandwidth-toggle reproducer with a `[VM-PATCH]` print added to `sendPlayerMetrics`; iOS log should show monotonic submission, archive should reflect that order

🤖 Generated with [Claude Code](https://claude.com/claude-code)