### PR TITLE
fix(startup): ensure SQLite parent dirs exist (go-proxy + go-upload)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -625,6 +626,15 @@ const (
 func newSessionEventStore(path string) (*SessionEventStore, error) {
 	if strings.TrimSpace(path) == "" {
 		path = defaultSessionEventsDB
+	}
+	// SQLite cannot create the file in a non-existent directory; the
+	// default /tmp path is always present, but operators overriding
+	// GO_PROXY_SESSION_EVENTS_DB to a custom path otherwise hit the
+	// same db.Ping() failure that PR #343 fixed for go-upload.
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create session-events parent dir %s: %w", dir, err)
+		}
 	}
 	db, err := sql.Open("sqlite", path)
 	if err != nil {

--- a/go-upload/internal/store/sqlite.go
+++ b/go-upload/internal/store/sqlite.go
@@ -69,6 +69,15 @@ func DatabasePathFromEnv() string {
 }
 
 func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
+	// Defense in depth: SQLite cannot create the file in a non-existent
+	// directory. main.go already calls app.EnsureDirs(cfg) before reaching
+	// here, but a future caller that forgets that ordering would hit the
+	// same paper-cut PR #343 fixed at the call site. Self-protect.
+	if dir := filepath.Dir(dbPath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create sqlite parent dir %s: %w", dir, err)
+		}
+	}
 	// WAL mode allows concurrent reads alongside a single writer.
 	// busy_timeout makes writers wait briefly on contention instead of failing
 	// immediately with SQLITE_BUSY.


### PR DESCRIPTION
Closes #371. Parallel to #343.

## go-proxy — real bug for custom paths

\`newSessionEventStore\` opens its SQLite session-event store at the configured path (default \`/tmp/go-proxy-session-events.sqlite\`, override via \`GO_PROXY_SESSION_EVENTS_DB\`) without ensuring the parent directory exists. Default works because /tmp always exists; any operator overriding to e.g. \`/var/lib/infinitestream/events.db\` hits the same \`db.Ping()\` failure PR #343 fixed for go-upload.

Fix: \`os.MkdirAll(filepath.Dir(path), 0o755)\` before \`sql.Open\`, returning a wrapped error so the operator sees which path failed.

## go-upload — defense in depth

\`NewSQLiteStore\` is currently safe because \`main.go\` calls \`app.EnsureDirs(cfg)\` first (PR #343). A future caller of the store package that forgets that ordering re-introduces the same bug. Self-protect with the same \`MkdirAll\` pattern.

## Pattern

\`os.MkdirAll(_, 0o755)\` is already established across the codebase:
- \`go-upload/internal/app/app.go:224\` — \`EnsureDirs\`
- \`go-live/internal/api/handlers.go\` — six call sites for variant-output writes
- \`go-live/internal/api/stream_tracker.go:863\` — segment tracker
- \`docker/launch.sh:26\` — TLS cert dir

This PR is a mechanical application of that pattern to two missed sites. No new pattern introduced.

## Test plan

- [x] \`cd go-proxy && go build ./...\` passes
- [x] \`cd go-upload && go build ./...\` passes
- [ ] Override test: \`GO_PROXY_SESSION_EVENTS_DB=/tmp/test-mkdir/events.db\` starts cleanly; \`/tmp/test-mkdir/\` exists after startup
- [ ] Default deploy unchanged: \`make test-deploy-dev\`, server reaches the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)