### PR TITLE
feat(clients): on-device Diagnostic HUD

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -609,6 +609,14 @@ public final class PlaybackMetrics {
         return p;
     }
 
+    /** Read-only counters surfaced for the on-device DiagnosticHud. */
+    public int getStallCount() { return stallCount; }
+    public double getLastStallSeconds() { return lastStallDurationS; }
+    public long getDroppedFrames() { return droppedFramesTotal; }
+    public int getProfileShiftCount() { return profileShiftCount; }
+    public String currentMappedState() { return mapState(); }
+    public String currentMappedWaitingReason() { return mapWaitingReason(); }
+
     private String mapState() {
         // Lowercase canonical names — matches Apple PlaybackDiagnostics,
         // Android-test ExoPlayerTestApp, web embed, and Roku, so the

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -91,6 +91,9 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
 
     private var metrics: PlaybackMetrics? = null
 
+    /** Read-only view of the metrics pipeline for the on-device DiagnosticHud. */
+    val metricsRef: PlaybackMetrics? get() = metrics
+
     /**
      * Count of "decoder leases" currently held by tile / hero ExoPlayer
      * instances on Home (or any other surface that decodes video). Each

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/PlaybackScreen.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/PlaybackScreen.kt
@@ -184,33 +184,29 @@ fun PlaybackScreen(
             )
         }
 
-        // Top-right corner stack: shortcut hint sits on top, developer
-        // diagnostics sits below it. Stacking (vs. overlapping) means the
-        // hint stays visible when dev mode is on — otherwise the user
-        // loses the only signpost telling them how to get back into
-        // settings. (Top-left is reserved for source-video burnt-in
-        // overlays we don't control.)
-        Column(
+        // Top-right shortcut hint — the only signpost telling the user
+        // how to reveal the HUD. (Top-left is reserved for source-video
+        // burnt-in overlays we don't control.)
+        AnimatedVisibility(
+            visible = !state.hudVisible && !state.settingsOpen,
+            enter = fadeIn(), exit = fadeOut(),
             modifier = Modifier.align(Alignment.TopEnd).padding(Space.s5),
-            horizontalAlignment = Alignment.End,
         ) {
-            AnimatedVisibility(
-                visible = !state.hudVisible && !state.settingsOpen,
-                enter = fadeIn(), exit = fadeOut(),
-            ) {
-                Text(
-                    "▼ HUD",
-                    style = AppType.monoSm.copy(color = Tokens.fg.copy(alpha = 0.55f)),
-                )
-            }
-            AnimatedVisibility(
-                visible = state.developerMode && !state.settingsOpen,
-                enter = fadeIn(), exit = fadeOut(),
-            ) {
-                Box(modifier = Modifier.padding(top = Space.s2)) {
-                    DeveloperHud(vm)
-                }
-            }
+            Text(
+                "▼ HUD",
+                style = AppType.monoSm.copy(color = Tokens.fg.copy(alpha = 0.55f)),
+            )
+        }
+
+        // Mid-right diagnostic readout — gated on Developer mode. Same
+        // field list and units as the Apple DiagnosticHUD so an operator
+        // can read either readout during a cross-platform soak run.
+        AnimatedVisibility(
+            visible = state.developerMode && !state.settingsOpen,
+            enter = fadeIn(), exit = fadeOut(),
+            modifier = Modifier.align(Alignment.CenterEnd).padding(end = Space.s4),
+        ) {
+            DiagnosticHud(vm)
         }
 
         // Bottom HUD overlay — gradient + transport.
@@ -451,34 +447,127 @@ private fun Scrubber(player: ExoPlayer) {
     }
 }
 
+/**
+ * Mid-right semi-transparent diagnostic readout. Gated on Developer
+ * mode in [PlaybackScreen]. Pure formatting over `vm.player`,
+ * `vm.bandwidthMeter`, and the read-only accessors on [PlaybackMetrics].
+ *
+ * Companion to the Apple `DiagnosticHUD` SwiftUI view; field list,
+ * labels, and units must stay in lockstep so an operator can read
+ * either readout during a cross-platform soak run.
+ */
 @Composable
-private fun DeveloperHud(vm: PlayerViewModel) {
-    val resolution = remember { mutableStateOf("") }
-    val bitrate = remember { mutableStateOf("") }
-    val leases by vm.decoderLeases.collectAsStateWithLifecycle()
+private fun DiagnosticHud(vm: PlayerViewModel) {
+    var stateText by remember { mutableStateOf("—") }
+    // NET is the iOS-only LocalHTTPProxy per-chunk wire rate; we PATCH
+    // null for it on Android, so the row stays at "—".
+    val netText = "—"
+    var avgNetText by remember { mutableStateOf("—") }
+    var videoText by remember { mutableStateOf("—") }
+    var resText by remember { mutableStateOf("—") }
+    var bufferText by remember { mutableStateOf("—") }
+    var offsetText by remember { mutableStateOf("—") }
+    var shiftsText by remember { mutableStateOf("0") }
+    var stallsText by remember { mutableStateOf("0") }
+    var droppedText by remember { mutableStateOf("—") }
+
     LaunchedEffect(vm.player) {
         while (true) {
-            val f = vm.player.videoFormat
-            resolution.value = if (f != null && f.width > 0) "${f.width}x${f.height}" else "—"
-            val mbps = f?.bitrate?.takeIf { it > 0 }?.let { it / 1_000_000.0 }
-            val avg = vm.bandwidthMeter.bitrateEstimate.takeIf { it > 0 }?.let { it / 1_000_000.0 }
-            bitrate.value = buildString {
-                append("AVG ")
-                append(avg?.let { String.format("%.1f", it) } ?: "—")
-                append(" | PEAK ")
-                append(mbps?.let { String.format("%.1f", it) } ?: "—")
+            val player = vm.player
+            val metrics = vm.metricsRef
+
+            // STATE (+ waiting reason in parens when non-empty).
+            val s = (metrics?.currentMappedState() ?: "idle").uppercase()
+            val reason = metrics?.currentMappedWaitingReason().orEmpty()
+            stateText = if (reason.isEmpty()) s else "$s ($reason)"
+
+            // AVG NET = ExoPlayer's session-wide bandwidth estimate, the
+            // analogue of AVPlayer's observedBitrate that the iOS HUD
+            // reads. This is the same value we PATCH as
+            // `player_metrics_avg_network_bitrate_mbps`.
+            val avg = vm.bandwidthMeter.bitrateEstimate.takeIf { it > 0 }
+            avgNetText = avg?.let { String.format("%.2f Mbps", it / 1_000_000.0) } ?: "—"
+            val format = player.videoFormat
+            val videoBps = format?.bitrate?.takeIf { it > 0 }
+            videoText = videoBps?.let { String.format("%.2f Mbps", it / 1_000_000.0) } ?: "—"
+
+            // RES: video stream native resolution.
+            val vs = player.videoSize
+            resText = if (vs.width > 0 && vs.height > 0) "${vs.width}×${vs.height}" else "—"
+
+            // BUFFER: seconds of video ahead of playhead.
+            val bufMs = (player.bufferedPosition - player.currentPosition).coerceAtLeast(0)
+            bufferText = String.format("%.1fs", bufMs / 1000.0)
+
+            // OFFSET: ground-truth seconds behind live edge, derived from
+            // PROGRAM-DATE-TIME at the playhead. Falls back to ExoPlayer's
+            // getCurrentLiveOffset when the timeline doesn't carry a wall-
+            // clock origin.
+            offsetText = run {
+                val tl = player.currentTimeline
+                if (!tl.isEmpty) {
+                    val idx = player.currentMediaItemIndex
+                    if (idx in 0 until tl.windowCount) {
+                        val w = androidx.media3.common.Timeline.Window()
+                        tl.getWindow(idx, w)
+                        if (w.windowStartTimeMs != androidx.media3.common.C.TIME_UNSET) {
+                            val pdtMs = w.windowStartTimeMs + player.currentPosition
+                            return@run String.format("%.1fs", (System.currentTimeMillis() - pdtMs) / 1000.0)
+                        }
+                    }
+                }
+                val live = player.currentLiveOffset
+                if (live != androidx.media3.common.C.TIME_UNSET) String.format("%.1fs", live / 1000.0) else "—"
             }
+
+            // SHIFTS / STALLS / DROPPED — pulled from PlaybackMetrics counters.
+            shiftsText = (metrics?.profileShiftCount ?: 0).toString()
+            val stalls = metrics?.stallCount ?: 0
+            stallsText = if (stalls == 0) "0"
+                else String.format("%d (last %.1fs)", stalls, metrics?.lastStallSeconds ?: 0.0)
+            droppedText = metrics?.droppedFrames?.toString() ?: "—"
+
             delay(1000)
         }
     }
-    Column(horizontalAlignment = Alignment.End) {
-        Text(bitrate.value, style = AppType.monoSm.copy(color = Tokens.fgDim))
-        Text(resolution.value, style = AppType.monoSm.copy(color = Tokens.fgDim))
-        // Live count of preview-tile decoder leases that the main player
-        // gates on during Home → Playback navigation. 0 on the playback
-        // screen unless something is leaking; non-zero briefly during
-        // the transition window.
-        Text("DECODE LEASES $leases", style = AppType.monoSm.copy(color = Tokens.fgDim))
+
+    Column(
+        modifier = Modifier
+            .width(240.dp)
+            .clip(RoundedCornerShape(Radius.row))
+            .background(Color.Black.copy(alpha = 0.45f))
+            .padding(horizontal = Space.s3, vertical = Space.s2),
+    ) {
+        DiagnosticRow("STATE", stateText)
+        DiagnosticRow("NET", netText)
+        DiagnosticRow("AVG NET", avgNetText)
+        DiagnosticRow("VIDEO", videoText)
+        DiagnosticRow("RES", resText)
+        DiagnosticRow("BUFFER", bufferText)
+        DiagnosticRow("OFFSET", offsetText)
+        DiagnosticRow("SHIFTS", shiftsText)
+        DiagnosticRow("STALLS", stallsText)
+        DiagnosticRow("DROPPED", droppedText)
+    }
+}
+
+@Composable
+private fun DiagnosticRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            label,
+            style = AppType.monoSm.copy(color = Tokens.diag),
+            modifier = Modifier.width(72.dp),
+        )
+        Spacer(Modifier.width(Space.s1))
+        Text(
+            value,
+            style = AppType.monoSm.copy(color = Tokens.fg),
+            maxLines = 1,
+        )
     }
 }
 

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -272,7 +272,7 @@ private fun MainList(
                 focusRequester = codecFocus)
         }
         item {
-            RowView(SettingRow("Advanced", if (state.developerMode) "Developer mode on" else "Default") {
+            RowView(SettingRow("Advanced", if (state.developerMode) "HUD on" else "Default") {
                 onPick(PickerKind.Advanced)
             }, focusRequester = advancedFocus)
         }
@@ -415,7 +415,7 @@ private fun PickerList(
                     }
                     item {
                         PickerItem(
-                            label = "Developer mode (AVG/PEAK overlay)",
+                            label = "HUD",
                             selected = state.developerMode,
                             onClick = { vm.setDeveloperMode(!state.developerMode) },
                         )

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/theme/Tokens.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/theme/Tokens.kt
@@ -36,6 +36,11 @@ object Tokens {
     // LIVE badge: coral red (oklch(0.70 0.18 25) ≈ #EC5E4A).
     val live    = Color(0xFFEC5E4A)
 
+    // Cool blue used exclusively for diagnostic / dev-mode overlays.
+    // Matches Apple Tokens.diag so the HUD palette is consistent
+    // across platforms.
+    val diag    = Color(0xFF5BBDF2)
+
     // Online status (green).
     val ok      = Color(0xFF4ADE80)
     val offline = Color(0xFF6B6F77)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.pbxproj
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		A1A1A1A1A1A1A1A1A1A10057 /* LivePreviewTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11057 /* LivePreviewTile.swift */; };
 		A1A1A1A1A1A1A1A1A1A10058 /* PlaybackDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11058 /* PlaybackDiagnostics.swift */; };
 		A1A1A1A1A1A1A1A1A1A10059 /* DecodeBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11059 /* DecodeBudget.swift */; };
+		A1A1A1A1A1A1A1A1A1A10060 /* DiagnosticHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11060 /* DiagnosticHUD.swift */; };
 		A1A1A1A1A1A1A1A1A1A1000D /* RequestTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */; };
 		A1A1A1A1A1A1A1A1A1A1000F /* LocalHTTPProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */; };
 		A1A1A1A1A1A1A1A1A1A10020 /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11030 /* QRScannerView.swift */; };
@@ -45,6 +46,7 @@
 		A2A2A2A2A2A2A2A2A2A20057 /* LivePreviewTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11057 /* LivePreviewTile.swift */; };
 		A2A2A2A2A2A2A2A2A2A20058 /* PlaybackDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11058 /* PlaybackDiagnostics.swift */; };
 		A2A2A2A2A2A2A2A2A2A20059 /* DecodeBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11059 /* DecodeBudget.swift */; };
+		A2A2A2A2A2A2A2A2A2A20060 /* DiagnosticHUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11060 /* DiagnosticHUD.swift */; };
 		A2A2A2A2A2A2A2A2A2A2000D /* RequestTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */; };
 		A2A2A2A2A2A2A2A2A2A2000F /* LocalHTTPProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */; };
 		A2A2A2A2A2A2A2A2A2A20020 /* QRScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1A1A1A1A1A1A11030 /* QRScannerView.swift */; };
@@ -71,6 +73,7 @@
 		A1A1A1A1A1A1A1A1A1A11057 /* LivePreviewTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePreviewTile.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11058 /* PlaybackDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackDiagnostics.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11059 /* DecodeBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeBudget.swift; sourceTree = "<group>"; };
+		A1A1A1A1A1A1A1A1A1A11060 /* DiagnosticHUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticHUD.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTracker.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalHTTPProxy.swift; sourceTree = "<group>"; };
 		A1A1A1A1A1A1A1A1A1A11030 /* QRScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerView.swift; sourceTree = "<group>"; };
@@ -133,6 +136,7 @@
 				A1A1A1A1A1A1A1A1A1A11057 /* LivePreviewTile.swift */,
 				A1A1A1A1A1A1A1A1A1A11058 /* PlaybackDiagnostics.swift */,
 				A1A1A1A1A1A1A1A1A1A11059 /* DecodeBudget.swift */,
+				A1A1A1A1A1A1A1A1A1A11060 /* DiagnosticHUD.swift */,
 				A1A1A1A1A1A1A1A1A1A1100D /* RequestTracker.swift */,
 				A1A1A1A1A1A1A1A1A1A1100F /* LocalHTTPProxy.swift */,
 				A1A1A1A1A1A1A1A1A1A11030 /* QRScannerView.swift */,
@@ -282,6 +286,7 @@
 				A1A1A1A1A1A1A1A1A1A10057 /* LivePreviewTile.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A10058 /* PlaybackDiagnostics.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A10059 /* DecodeBudget.swift in Sources */,
+				A1A1A1A1A1A1A1A1A1A10060 /* DiagnosticHUD.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A1000D /* RequestTracker.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A1000F /* LocalHTTPProxy.swift in Sources */,
 				A1A1A1A1A1A1A1A1A1A10020 /* QRScannerView.swift in Sources */,
@@ -309,6 +314,7 @@
 				A2A2A2A2A2A2A2A2A2A20057 /* LivePreviewTile.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A20058 /* PlaybackDiagnostics.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A20059 /* DecodeBudget.swift in Sources */,
+				A2A2A2A2A2A2A2A2A2A20060 /* DiagnosticHUD.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A2000D /* RequestTracker.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A2000F /* LocalHTTPProxy.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A20020 /* QRScannerView.swift in Sources */,

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DiagnosticHUD.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DiagnosticHUD.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// Mid-right semi-transparent diagnostic readout. Gated on Developer
+/// mode in `PlaybackScreen`. Pure formatting over the live `@Published`
+/// fields on `PlaybackDiagnostics` — no new collection, no polling.
+///
+/// Companion to the Android `DiagnosticHud` composable; field list and
+/// units must stay in lockstep so an operator can read either readout
+/// during a cross-platform soak run.
+struct DiagnosticHUD: View {
+    @ObservedObject var vm: PlayerViewModel
+    // SwiftUI's @ObservedObject only tracks changes on the top-level
+    // object, not nested ObservableObjects. Most HUD fields live on
+    // PlaybackDiagnostics (nested), so we observe it explicitly here
+    // — without this, the HUD only redraws when one of vm's own
+    // @Published fields (e.g. profileShiftCount) ticks, leaving live
+    // counters like buffer / offset / bitrates frozen between events.
+    @ObservedObject var diagnostics: PlaybackDiagnostics
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            row("STATE", stateText)
+            // NET / AVG NET / VIDEO source fields match what we PATCH:
+            //   NET     → player_metrics_network_bitrate_mbps     (LocalHTTPProxy per-chunk wire rate; nil during idle)
+            //   AVG NET → player_metrics_avg_network_bitrate_mbps (AVPlayer session-wide observed throughput)
+            //   VIDEO   → player_metrics_video_bitrate_mbps       (variant's indicated bitrate)
+            row("NET", mbpsText(diagnostics.networkBitrate))
+            row("AVG NET", mbpsText(diagnostics.observedBitrate))
+            row("VIDEO", mbpsText(diagnostics.indicatedBitrate))
+            row("RES", resolutionText)
+            row("BUFFER", secondsText(diagnostics.bufferDepth))
+            row("OFFSET", offsetText)
+            row("SHIFTS", String(vm.profileShiftCount))
+            row("STALLS", stallText)
+            row("DROPPED", framesText(diagnostics.droppedVideoFrames))
+        }
+        .padding(.horizontal, Space.s3)
+        .padding(.vertical, Space.s2)
+        .frame(width: 240, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Radius.row, style: .continuous)
+                .fill(Color.black.opacity(0.45))
+        )
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack(spacing: Space.s2) {
+            Text(label)
+                .font(AppType.monoSm())
+                .foregroundColor(Tokens.diag)
+                .frame(width: 72, alignment: .leading)
+            Text(value)
+                .font(AppType.monoSm())
+                .foregroundColor(Tokens.fg)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Field formatters
+
+    private var stateText: String {
+        let s = diagnostics.state.uppercased()
+        let reason = diagnostics.waitingReason
+        return reason.isEmpty ? s : "\(s) (\(reason))"
+    }
+
+    private var resolutionText: String {
+        sizeText(diagnostics.videoWidth, diagnostics.videoHeight)
+    }
+
+    private var offsetText: String {
+        if let wallClock = diagnostics.playheadWallClock {
+            let trueOffset = Date().timeIntervalSince(wallClock)
+            return String(format: "%.1fs", trueOffset)
+        }
+        return secondsText(diagnostics.liveOffset)
+    }
+
+    private var stallText: String {
+        let n = diagnostics.stallCount
+        if n == 0 { return "0" }
+        return String(format: "%d (last %.1fs)", n, diagnostics.lastStallDurationSeconds)
+    }
+
+    private func mbpsText(_ bps: Double?) -> String {
+        guard let bps, bps > 0 else { return "—" }
+        return String(format: "%.2f Mbps", bps / 1_000_000)
+    }
+
+    private func secondsText(_ s: Double?) -> String {
+        guard let s else { return "—" }
+        return String(format: "%.1fs", s)
+    }
+
+    private func framesText(_ f: Double?) -> String {
+        guard let f else { return "—" }
+        return String(format: "%.0f", f)
+    }
+
+    private func sizeText(_ w: Double?, _ h: Double?) -> String {
+        guard let w, let h, w > 0, h > 0 else { return "—" }
+        return "\(Int(w))×\(Int(h))"
+    }
+}

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackScreen.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackScreen.swift
@@ -27,6 +27,14 @@ struct PlaybackScreen: View {
             .id(vm.playerEpoch)
             .ignoresSafeArea()
             .background(Color.black.ignoresSafeArea())
+            .overlay(alignment: .trailing) {
+                if vm.developerMode && !vm.settingsOpen {
+                    DiagnosticHUD(vm: vm, diagnostics: vm.diagnostics)
+                        .padding(.trailing, Space.s4)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+            }
 
             #if !os(tvOS)
             VStack {

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
@@ -348,7 +348,7 @@ private struct PickerList: View {
                 vm.setPreviewVideoSlots($0)
             }
             .focused($itemIdx, equals: 7)
-            ToggleRow(label: "Developer mode",
+            ToggleRow(label: "HUD",
                       isOn: vm.developerMode, compact: compact) { vm.setDeveloperMode($0) }
                 .focused($itemIdx, equals: 8)
             DestructiveRow(label: "Reset All Settings", compact: compact) {


### PR DESCRIPTION
On-device diagnostic readout for the Apple (iOS / iPadOS / tvOS) and Android TV playback views. Closes #373.

## Summary

Semi-transparent mid-right HUD over the playback surface showing live player metrics — STATE / NET / AVG NET / VIDEO / RES / BUFFER / OFFSET / SHIFTS / STALLS / DROPPED. Gated on the existing Advanced flag, which has been re-labelled in the Settings UI from "Developer mode" to "HUD" (the persisted symbol stays as `developerMode` / `developer_mode` to preserve user state across upgrade).

- **Apple** — new SwiftUI `DiagnosticHUD` reading both `PlayerViewModel` and `PlaybackDiagnostics` as `@ObservedObject`s so SwiftUI propagates the nested-diagnostics `@Published` mutations. Mounted as a trailing-aligned overlay in `PlaybackScreen`.
- **Android** — replaces the prior small top-right `DeveloperHud` with a mid-right composable. `PlaybackMetrics` exposes read-only counters (stalls, dropped frames, profile shifts) so the HUD can render them without leaking internals into the UI layer.
- Field sources match the metrics PATCH on both platforms: `NET` reads `networkBitrate` (iOS LocalHTTPProxy per-chunk wire rate, idle-gated; "—" on Android by design), `AVG NET` reads `observedBitrate` (AVPlayer / ExoPlayer session-wide empirical throughput), `VIDEO` reads `indicatedBitrate`.

## Test plan

- [x] Apple iOS / iPadOS / tvOS sims build green
- [x] Android `assembleDebug` green
- [x] Deployed on iPad sim — HUD appears with HUD = ON, fields populate live (NET, AVG NET, VIDEO, RES, BUFFER, OFFSET, SHIFTS, STALLS, DROPPED)
- [x] Deployed on Google TV Streamer (Android TV) via `make deploy-androidtv` — HUD + Settings toggle both visible
- [x] Pre-PR Sonnet code review run on the diff
- [ ] Persistence: kill + relaunch the app, confirm HUD toggle state survives
- [ ] tvOS focus: D-pad walks every Advanced row including the new "HUD" entry

## Follow-ups (not in this PR)

- #374 — "Disable analytics" Advanced toggle (deferred while the related dashboard-rendering UX is resolved)
- #376 — bitrate chart goes blank during quiet stretches; two fix options captured for later

🤖 Generated with [Claude Code](https://claude.com/claude-code)