### PR TITLE
fix: consolidate event_time / last_event_at into single timestamp field

### DIFF
--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -47,7 +47,6 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
     -- Player events (discrete signals embedded in the heartbeat snapshot;
     -- testing.html derives event-lane points from transitions in these).
     last_event            LowCardinality(String)      CODEC(ZSTD(1)),
-    last_event_at         String                      CODEC(ZSTD(1)),
     trigger_type          LowCardinality(String)      CODEC(ZSTD(1)),
     event_time            String                      CODEC(ZSTD(1)),
     player_error          String                      CODEC(ZSTD(1)),
@@ -208,7 +207,6 @@ ALTER TABLE infinite_streaming.session_snapshots
     ADD COLUMN IF NOT EXISTS play_id LowCardinality(String) CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS content_id LowCardinality(String) CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS last_event LowCardinality(String) CODEC(ZSTD(1)),
-    ADD COLUMN IF NOT EXISTS last_event_at String CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS trigger_type LowCardinality(String) CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS event_time String CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS player_error String CODEC(ZSTD(1)),

--- a/analytics/go-forwarder/bundle.go
+++ b/analytics/go-forwarder/bundle.go
@@ -531,7 +531,7 @@ generated:  %s
                       field of every snapshot, e.g.:
                         cat snapshots.ndjson \
                           | jq 'select(.last_event != "" and .last_event != "heartbeat")
-                                | {ts: .last_event_at, type: .last_event,
+                                | {ts: .event_time, type: .last_event,
                                    error: .player_error}'
                       Derived events (paired stall durations, lag-based
                       fault transitions, HAR-derived http_5xx, etc.)

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -97,7 +97,6 @@ type row struct {
 	LoopCountPlayer          uint32  `json:"loop_count_player"`
 	LoopCountServer          uint32  `json:"loop_count_server"`
 	LastEvent                string  `json:"last_event"`
-	LastEventAt              string  `json:"last_event_at"`
 	TriggerType              string  `json:"trigger_type"`
 	EventTime                string  `json:"event_time"`
 	PlayerError              string  `json:"player_error"`
@@ -429,7 +428,6 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		LoopCountPlayer:          uint32(getU64(s, "loop_count_player")),
 		LoopCountServer:          uint32(getU64(s, "loop_count_server")),
 		LastEvent:                getStr(s, "player_metrics_last_event"),
-		LastEventAt:              getStr(s, "player_metrics_last_event_at"),
 		TriggerType:              getStr(s, "player_metrics_trigger_type"),
 		EventTime:                getStr(s, "player_metrics_event_time"),
 		PlayerError:              getStr(s, "player_metrics_error"),

--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
@@ -182,7 +182,6 @@ class PlayerViewModel : ViewModel() {
             "player_metrics_playback_engine" to "exoplayer",
             "player_metrics_last_event" to eventType,
             "player_metrics_trigger_type" to eventType,
-            "player_metrics_last_event_at" to reporter.nowISO(),
             "player_metrics_event_time" to reporter.nowISO(),
             "player_metrics_state" to state,
             "player_metrics_position_s" to round3(positionMs / 1000.0),

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -514,7 +514,6 @@ public final class PlaybackMetrics {
             p.put("player_metrics_source", "android");
             p.put("player_metrics_last_event", event);
             p.put("player_metrics_trigger_type", event);
-            p.put("player_metrics_last_event_at", timestamp);
             p.put("player_metrics_event_time", timestamp);
             p.put("player_metrics_state", mapState());
             p.put("player_metrics_waiting_reason", mapWaitingReason());

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1301,7 +1301,7 @@ extension PlayerViewModel {
         //   1. capture `eventAt = Date()` synchronously
         //   2. build the payload via `buildMetricsPayload(event:at:extra:)`
         //   3. hand the immutable payload into a Task that does only HTTP
-        // This keeps `event_time`, `last_event_at`, `state`, position,
+        // This keeps `event_time`, `state`, position,
         // playhead_wallclock, etc. all anchored to the moment the
         // underlying event fired — not to whenever the Task body
         // happens to run after chaining through `metricsTaskTail`.
@@ -1640,7 +1640,6 @@ extension PlayerViewModel {
             "player_metrics_source": "ios",
             "player_metrics_last_event": event,
             "player_metrics_trigger_type": event,
-            "player_metrics_last_event_at": timestamp,
             "player_metrics_event_time": timestamp,
             "player_metrics_state": diagnostics.state,
             "player_metrics_waiting_reason": diagnostics.waitingReason,

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -649,7 +649,6 @@
                         <div class="session-grid">
                             <div class="session-item"><span class="label">Last Event</span><span class="value" data-field="player_metrics_last_event">${session.player_metrics_last_event || '—'}</span></div>
                             <div class="session-item"><span class="label">trigger_type</span><span class="value" data-field="player_metrics_trigger_type">${session.player_metrics_trigger_type || '—'}</span></div>
-                            <div class="session-item"><span class="label">Last Event At</span><span class="value" data-field="player_metrics_last_event_at">${formatDate(session.player_metrics_last_event_at) || '—'}</span></div>
                             <div class="session-item"><span class="label">Event Time</span><span class="value" data-field="player_metrics_event_time">${formatDate(session.player_metrics_event_time) || '—'}</span></div>
                             <div class="session-item"><span class="label">State</span><span class="value" data-field="player_metrics_state">${session.player_metrics_state || '—'}</span></div>
                             <div class="session-item"><span class="label">Position</span><span class="value" data-field="player_metrics_position_s">${session.player_metrics_position_s ?? '—'}</span></div>

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -1236,7 +1236,6 @@
                 player_metrics_playback_engine: resolvePlayerChoice(currentUrl, getPlayerChoice()),
                 player_metrics_last_event: eventType,
                 player_metrics_trigger_type: eventType,
-                player_metrics_last_event_at: new Date().toISOString(),
                 player_metrics_event_time: new Date().toISOString(),
                 player_metrics_state: video.paused ? 'paused' : 'playing',
                 player_metrics_position_s: toMetricSeconds(current),
@@ -3916,7 +3915,6 @@
 
             setText('[data-field="player_metrics_last_event"]', session.player_metrics_last_event || '—');
             setText('[data-field="player_metrics_trigger_type"]', session.player_metrics_trigger_type || '—');
-            setText('[data-field="player_metrics_last_event_at"]', formatDate(session.player_metrics_last_event_at));
             setText('[data-field="player_metrics_event_time"]', formatDate(session.player_metrics_event_time));
             setText('[data-field="player_metrics_state"]', session.player_metrics_state || '—');
             setText('[data-field="player_metrics_position_s"]', formatSeconds(session.player_metrics_position_s));
@@ -3993,7 +3991,6 @@
 
         function getBandwidthChartEventTimestampMs(session, fallbackMs) {
             const candidates = [
-                session?.player_metrics_last_event_at,
                 session?.player_metrics_event_time,
                 session?.control_revision
             ];
@@ -4640,7 +4637,7 @@
             const eventType = parseBandwidthChartEventType(session.player_metrics_last_event || session.player_metrics_trigger_type);
             if (eventType) {
                 const eventAtMs = getBandwidthChartEventTimestampMs(session, now);
-                const eventStamp = `${eventType}|${session.player_metrics_last_event_at || session.player_metrics_event_time || eventAtMs}`;
+                const eventStamp = `${eventType}|${session.player_metrics_event_time || eventAtMs}`;
                 const lastStamp = lastRecordedPlayerEventBySession.get(String(key));
                 if (eventStamp !== lastStamp) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -1056,7 +1056,6 @@
                 : (Number.isFinite(inferredVideoBitrateMbps) ? `~${formatMetricNumber(inferredVideoBitrateMbps, ' Mbps')}` : '—');
             setText('[data-field="player_metrics_last_event"]', session.player_metrics_last_event || '—');
             setText('[data-field="player_metrics_trigger_type"]', session.player_metrics_trigger_type || '—');
-            setText('[data-field="player_metrics_last_event_at"]', formatDate(session.player_metrics_last_event_at));
             setText('[data-field="player_metrics_event_time"]', formatDate(session.player_metrics_event_time));
             setText('[data-field="player_metrics_state"]', session.player_metrics_state || '—');
             setText('[data-field="player_metrics_position_s"]', formatSeconds(session.player_metrics_position_s));
@@ -1419,7 +1418,6 @@
 
         function getBandwidthChartEventTimestampMs(session, fallbackMs) {
             const candidates = [
-                session?.player_metrics_last_event_at,
                 session?.player_metrics_event_time,
                 session?.control_revision
             ];
@@ -2033,7 +2031,7 @@
             const eventType = parseBandwidthChartEventType(session.player_metrics_last_event || session.player_metrics_trigger_type);
             if (eventType) {
                 const eventAtMs = playerEventAtMs;
-                const eventStamp = `${eventType}|${session.player_metrics_last_event_at || session.player_metrics_event_time || eventAtMs}`;
+                const eventStamp = `${eventType}|${session.player_metrics_event_time || eventAtMs}`;
                 const lastStamp = lastRecordedPlayerEventBySession.get(String(key));
                 if (eventStamp !== lastStamp) {
                     const eventSeries = bandwidthEventHistory.get(key) || [];


### PR DESCRIPTION
## Summary

`buildMetricsPayload` was writing the same ISO-8601 timestamp into two fields on every metrics PATCH — `player_metrics_event_time` and `player_metrics_last_event_at` — which propagated through the analytics pipeline as two ClickHouse columns and surfaced twice in the dashboard session details panel ("Last Event At" / "Event Time").

This was flagged as a follow-up in #385 (sink-time payload snapshot work). Strip `last_event_at` end-to-end and keep `event_time` as the single source of truth.

## Changes

**Wire emitters** — stop setting `player_metrics_last_event_at`:
- `apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift`
- `android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java`
- `android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt`
- `content/dashboard/testing-session.html` (web-engine PATCH builder)

**go-forwarder** — drop the `LastEventAt` row struct field and matching `getStr(s, "player_metrics_last_event_at")` ingestion line. ClickHouse `INSERT … FORMAT JSONEachRow` simply stops writing the column.

**ClickHouse schema** (`analytics/clickhouse/init.d/01-schema.sql`) — drop the column from `CREATE TABLE` and from the idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` block. Fresh installs no longer have the column.

**Bundle ZIP README** (`analytics/go-forwarder/bundle.go`) — switch the jq example from `.last_event_at` → `.event_time` so the snippet still resolves against fresh exports.

**Dashboard rendering** — remove the "Last Event At" row from the session details panel, drop `last_event_at` from the bandwidth-chart event-dedup keys, drop the legacy `data-field="player_metrics_last_event_at"` setText calls.

## What this is NOT

- No destructive `ALTER TABLE … DROP COLUMN last_event_at` against existing ClickHouse deploys. The column will stay (empty for new rows) until natural 30-day TTL purge. Operators can reclaim it eagerly with `make analytics-migrate SQL='ALTER TABLE infinite_streaming.session_snapshots DROP COLUMN IF EXISTS last_event_at'`.
- No rename of `event_time`.
- No Roku change (Roku doesn't carry this field today).

## Test plan

- [x] iOS sim build green (`InfiniteStreamPlayer (iOS)` scheme).
- [x] tvOS sim build green (`InfiniteStreamPlayer (tvOS)` scheme).
- [x] Android `InfiniteStreamPlayer` build green (`./gradlew assembleDebug`).
- [x] go-forwarder `go build ./...` green.
- [x] `make test-deploy-dev` succeeded; forwarder container starts cleanly with the stripped struct field; `/analytics/api/sessions` serves data.
- [x] Repo-wide grep for `last_event_at` / `LastEventAt` across `.swift|.go|.sql|.js|.html|.kt|.java|.brs` returns no matches.
- [ ] Drive a fresh playback through the iOS sim against test-dev and confirm `[METRICS …]` console lines no longer carry `player_metrics_last_event_at` and that the freshly-written ClickHouse row populates `event_time`.
- [ ] Open a fresh session in `testing-session.html` and a recorded session in `session-viewer.html`; confirm one "Event Time" row, no JS console errors.

Pre-existing unrelated breakage in `android/ExoPlayerTestApp` (line 19, `ServerEnvironment.UBUNTU` reference) — not touched here.

Closes #386.