### PR TITLE
fix: main image boots without the analytics sidecar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN mkdir -p /tmp/uploads /data /data/sources && \
 # Copy config and scripts (rarely change)
 COPY docker/mime.types /etc/nginx/mime.types
 COPY docker/nginx-content.conf.template /etc/nginx/http.d/
+COPY docker/nginx-analytics.conf.template /etc/nginx/snippets/nginx-analytics.conf.template
 COPY docker/launch.sh /sbin/
 COPY generate_abr/parse_fmp4_fragments.py /sbin/
 COPY --from=go-builder /out/go-live /usr/local/bin/go-live

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,16 @@ status-k3s:
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get nodes; echo; kubectl get pods -A"
 
 # `make deploy` and `make deploy-release` are end-to-end — they build +
-# push the main image, apply the main app manifest, AND apply the
-# analytics sidecar (ClickHouse + forwarder + Grafana) in one shot.
-# The analytics apply is idempotent (configmap apply uses --dry-run +
-# kubectl apply, manifest apply is `kubectl apply -f -`), so running
-# either deploy target multiple times is safe and re-converges state.
+# push the main image, apply the main app manifest, AND apply that
+# stack's analytics tier (ClickHouse + forwarder + Grafana — separate
+# pods, Services, and PVCs per stack so dev and release share nothing).
+# Each stack picks its own `ANALYTICS_STACK` and `ANALYTICS_SSE_URL`
+# via target-specific variables below.
+
+deploy: ANALYTICS_STACK=dev
+# Dev's go-proxy is reachable via the dev Service at port 40081
+# (the NodePort's `port` value, mapped to container :30081).
+deploy: ANALYTICS_SSE_URL=http://infinite-streaming-dev:40081/api/sessions/stream
 deploy: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev --push .
 	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K8S_MANIFESTS=k8s-infinite-streaming-dev.yaml K8S_DEPLOYMENT=infinite-streaming-dev K3S_SERVER_IMAGE=$(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev
@@ -140,6 +145,8 @@ deploy: analytics-deploy-k3s
 logs:
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl logs deploy/infinite-streaming-dev --all-containers -f"
 
+deploy-release: ANALYTICS_STACK=release
+deploy-release: ANALYTICS_SSE_URL=http://infinite-streaming:30081/api/sessions/stream
 deploy-release: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 \
 		--build-arg VERSION=$(shell cat VERSION) \
@@ -149,65 +156,72 @@ deploy-release: analytics-deploy-k3s
 	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K3S_SERVER_IMAGE=$(K3S_SERVER_IMAGE)
 
 # ── Analytics tier deployment to k3s ───────────────────────────────────
-# Brings up the analytics sidecar (ClickHouse + forwarder + Grafana)
-# alongside the main app. Run once after `make deploy` / `make
-# deploy-release` so the dashboard's session-archive features
-# (/analytics/api/* and /grafana/*) work — the main image stays
-# bootable without this (#390).
-#
-# SSE source URL the forwarder subscribes to. Default points at the
-# release stack on the cluster. Override for the dev stack:
-#   make analytics-deploy-k3s ANALYTICS_SSE_URL=http://infinite-streaming-dev:30081/api/sessions/stream
-ANALYTICS_SSE_URL ?= http://infinite-streaming:30081/api/sessions/stream
+# Per-stack analytics: dev and release each get their own ClickHouse,
+# forwarder, and Grafana. Resources are named with `-${ANALYTICS_STACK}`
+# suffix so both can coexist in the same namespace. Schemas + Grafana
+# provisioning are inlined in k8s-analytics.yaml — no separate
+# ConfigMap-from-file step.
 
-# Build + push the forwarder image into the cluster's registry. Mirrors
-# the `make build` flow that exists for the main image, but for the
-# Go forwarder under analytics/go-forwarder/.
+# Build + push the forwarder image into the cluster's registry. Same
+# image is shared across stacks (it's stack-agnostic); only the
+# Deployment env vars differ.
 analytics-build-forwarder-k3s:
 	docker buildx build --platform linux/amd64 \
 		-t $(K3S_REGISTRY)/infinite-streaming-forwarder:dev \
 		--push ./analytics/go-forwarder
 
-# Apply the analytics manifest, packaging the Grafana provisioning
-# (datasources + dashboards) as ConfigMaps so the InfiniteStreaming
-# dashboard auto-loads (parity with compose's bind-mount flow). The
-# `kubectl create … --dry-run=client -o yaml | kubectl apply -f -`
-# pattern is idempotent: it diffs against the live ConfigMap rather
-# than failing on already-exists.
+# Apply the analytics manifest for the `${ANALYTICS_STACK}` stack.
+# Idempotent: `kubectl apply` re-converges on every run.
 analytics-deploy-k3s: analytics-build-forwarder-k3s
-	@echo "=== Staging provisioning + schema files on $(K3S_SSH_HOST) ==="
-	ssh $(K3S_SSH_HOST) "rm -rf ~/.cache/infinite-streaming-analytics && mkdir -p ~/.cache/infinite-streaming-analytics/grafana ~/.cache/infinite-streaming-analytics/clickhouse"
-	rsync -az analytics/grafana/provisioning/ $(K3S_SSH_HOST):.cache/infinite-streaming-analytics/grafana/
-	rsync -az analytics/clickhouse/init.d/ $(K3S_SSH_HOST):.cache/infinite-streaming-analytics/clickhouse/
-	@echo "=== Provisioning ConfigMaps (clickhouse-init schema, grafana datasources + dashboards) ==="
-	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); \
-		kubectl create configmap analytics-clickhouse-init \
-			--from-file=01-schema.sql=\$$HOME/.cache/infinite-streaming-analytics/clickhouse/01-schema.sql \
-			--dry-run=client -o yaml | kubectl apply -f -; \
-		kubectl create configmap analytics-grafana-datasources \
-			--from-file=\$$HOME/.cache/infinite-streaming-analytics/grafana/datasources/ \
-			--dry-run=client -o yaml | kubectl apply -f -; \
-		kubectl create configmap analytics-grafana-dashboards \
-			--from-file=\$$HOME/.cache/infinite-streaming-analytics/grafana/dashboards/ \
-			--dry-run=client -o yaml | kubectl apply -f -"
-	@echo "=== Applying k8s-analytics.yaml ==="
-	ANALYTICS_SSE_URL='$(ANALYTICS_SSE_URL)' K3S_REGISTRY='$(K3S_REGISTRY)' \
+	@if [ -z "$(ANALYTICS_STACK)" ]; then echo "ANALYTICS_STACK must be set (dev|release)"; exit 1; fi
+	@if [ -z "$(ANALYTICS_SSE_URL)" ]; then echo "ANALYTICS_SSE_URL must be set"; exit 1; fi
+	@echo "=== Applying analytics tier (stack=$(ANALYTICS_STACK)) ==="
+	ANALYTICS_STACK='$(ANALYTICS_STACK)' \
+	ANALYTICS_SSE_URL='$(ANALYTICS_SSE_URL)' \
+	K3S_REGISTRY='$(K3S_REGISTRY)' \
 		envsubst < k8s-analytics.yaml | \
 		ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl apply -f -"
-	@echo "=== Waiting for analytics rollout ==="
+	@echo "=== Waiting for $(ANALYTICS_STACK) analytics rollout ==="
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); \
-		kubectl rollout status statefulset/clickhouse --timeout=120s; \
-		kubectl rollout status deployment/forwarder --timeout=120s; \
-		kubectl rollout status deployment/grafana --timeout=120s"
-	@echo "=== Re-applying canonical schema to clickhouse-0 ==="
-	@# docker-entrypoint-initdb.d only runs on first startup, so column
-	@# adds in the canonical schema never reach an existing cluster. The
-	@# schema is fully idempotent (CREATE … IF NOT EXISTS, ADD COLUMN IF
-	@# NOT EXISTS), so piping it through clickhouse-client every deploy
-	@# converges drift without breaking existing data.
-	cat analytics/clickhouse/init.d/01-schema.sql | \
-		ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl exec -i clickhouse-0 -- clickhouse-client --multiquery"
-	@echo "Analytics deployed. Main app needs INFINITE_STREAM_ENABLE_ANALYTICS=1 (already wired in k8s-infinite-streaming*.yaml) so its nginx routes /analytics/api/* and /grafana/* to the new services."
+		kubectl rollout status statefulset/clickhouse-$(ANALYTICS_STACK) --timeout=120s; \
+		kubectl rollout status deployment/forwarder-$(ANALYTICS_STACK) --timeout=120s; \
+		kubectl rollout status deployment/grafana-$(ANALYTICS_STACK) --timeout=120s"
+
+# Tear down a single stack (analytics + main app) so the other stack
+# can be exercised in isolation. Removes Deployments, Services,
+# StatefulSets, ConfigMaps, AND the PVC (so a subsequent
+# `make deploy[-release]` starts from empty ClickHouse data — matches
+# the user's "no data migration needed" model).
+#
+# Usage:
+#   make teardown-k3s-dev        # wipes the dev stack
+#   make teardown-k3s-release    # wipes the release stack
+#
+# Both targets also delete the main app deployment for that stack so
+# you get a fully empty namespace slot.
+teardown-k3s-dev:
+	$(MAKE) teardown-k3s-stack ANALYTICS_STACK=dev MAIN_APP=infinite-streaming-dev
+teardown-k3s-release:
+	$(MAKE) teardown-k3s-stack ANALYTICS_STACK=release MAIN_APP=infinite-streaming
+
+# Internal worker. Don't invoke directly; use the dev/release wrappers.
+teardown-k3s-stack:
+	@if [ -z "$(ANALYTICS_STACK)" ]; then echo "ANALYTICS_STACK required"; exit 1; fi
+	@echo "=== Tearing down $(ANALYTICS_STACK) analytics + main app ==="
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); \
+		kubectl delete --ignore-not-found=true \
+			deployment/grafana-$(ANALYTICS_STACK) \
+			deployment/forwarder-$(ANALYTICS_STACK) \
+			statefulset/clickhouse-$(ANALYTICS_STACK) \
+			service/grafana-$(ANALYTICS_STACK) \
+			service/forwarder-$(ANALYTICS_STACK) \
+			service/clickhouse-$(ANALYTICS_STACK) \
+			configmap/analytics-grafana-dashboards-$(ANALYTICS_STACK) \
+			configmap/analytics-grafana-datasources-$(ANALYTICS_STACK) \
+			configmap/analytics-clickhouse-init-$(ANALYTICS_STACK); \
+		kubectl delete pvc --ignore-not-found=true -l app=clickhouse-$(ANALYTICS_STACK); \
+		kubectl delete --ignore-not-found=true deployment/$(MAIN_APP) service/$(MAIN_APP)"
+	@echo "Stack $(ANALYTICS_STACK) torn down. Run \`make deploy$(if $(filter release,$(ANALYTICS_STACK)),-release,)\` to bring it back."
 
 # ── Remote deployment testing ──────────────────────────────────────────
 # Deploy all 4 installation methods to a remote Docker host for parallel testing.

--- a/Makefile
+++ b/Makefile
@@ -127,20 +127,87 @@ deploy-k3s: deploy-k3s-local
 status-k3s:
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl get nodes; echo; kubectl get pods -A"
 
-deploy:
+# `make deploy` and `make deploy-release` are end-to-end — they build +
+# push the main image, apply the main app manifest, AND apply the
+# analytics sidecar (ClickHouse + forwarder + Grafana) in one shot.
+# The analytics apply is idempotent (configmap apply uses --dry-run +
+# kubectl apply, manifest apply is `kubectl apply -f -`), so running
+# either deploy target multiple times is safe and re-converges state.
+deploy: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev --push .
 	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K8S_MANIFESTS=k8s-infinite-streaming-dev.yaml K8S_DEPLOYMENT=infinite-streaming-dev K3S_SERVER_IMAGE=$(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev
 
 logs:
 	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl logs deploy/infinite-streaming-dev --all-containers -f"
 
-deploy-release:
+deploy-release: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 \
 		--build-arg VERSION=$(shell cat VERSION) \
 		-t $(K3S_SERVER_IMAGE) \
 		-t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):$(shell cat VERSION) \
 		--push .
 	$(MAKE) deploy-k3s K3S_KUBECONFIG=$(K3S_KUBECONFIG) K3S_SERVER_IMAGE=$(K3S_SERVER_IMAGE)
+
+# ── Analytics tier deployment to k3s ───────────────────────────────────
+# Brings up the analytics sidecar (ClickHouse + forwarder + Grafana)
+# alongside the main app. Run once after `make deploy` / `make
+# deploy-release` so the dashboard's session-archive features
+# (/analytics/api/* and /grafana/*) work — the main image stays
+# bootable without this (#390).
+#
+# SSE source URL the forwarder subscribes to. Default points at the
+# release stack on the cluster. Override for the dev stack:
+#   make analytics-deploy-k3s ANALYTICS_SSE_URL=http://infinite-streaming-dev:30081/api/sessions/stream
+ANALYTICS_SSE_URL ?= http://infinite-streaming:30081/api/sessions/stream
+
+# Build + push the forwarder image into the cluster's registry. Mirrors
+# the `make build` flow that exists for the main image, but for the
+# Go forwarder under analytics/go-forwarder/.
+analytics-build-forwarder-k3s:
+	docker buildx build --platform linux/amd64 \
+		-t $(K3S_REGISTRY)/infinite-streaming-forwarder:dev \
+		--push ./analytics/go-forwarder
+
+# Apply the analytics manifest, packaging the Grafana provisioning
+# (datasources + dashboards) as ConfigMaps so the InfiniteStreaming
+# dashboard auto-loads (parity with compose's bind-mount flow). The
+# `kubectl create … --dry-run=client -o yaml | kubectl apply -f -`
+# pattern is idempotent: it diffs against the live ConfigMap rather
+# than failing on already-exists.
+analytics-deploy-k3s: analytics-build-forwarder-k3s
+	@echo "=== Staging provisioning + schema files on $(K3S_SSH_HOST) ==="
+	ssh $(K3S_SSH_HOST) "rm -rf ~/.cache/infinite-streaming-analytics && mkdir -p ~/.cache/infinite-streaming-analytics/grafana ~/.cache/infinite-streaming-analytics/clickhouse"
+	rsync -az analytics/grafana/provisioning/ $(K3S_SSH_HOST):.cache/infinite-streaming-analytics/grafana/
+	rsync -az analytics/clickhouse/init.d/ $(K3S_SSH_HOST):.cache/infinite-streaming-analytics/clickhouse/
+	@echo "=== Provisioning ConfigMaps (clickhouse-init schema, grafana datasources + dashboards) ==="
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); \
+		kubectl create configmap analytics-clickhouse-init \
+			--from-file=01-schema.sql=\$$HOME/.cache/infinite-streaming-analytics/clickhouse/01-schema.sql \
+			--dry-run=client -o yaml | kubectl apply -f -; \
+		kubectl create configmap analytics-grafana-datasources \
+			--from-file=\$$HOME/.cache/infinite-streaming-analytics/grafana/datasources/ \
+			--dry-run=client -o yaml | kubectl apply -f -; \
+		kubectl create configmap analytics-grafana-dashboards \
+			--from-file=\$$HOME/.cache/infinite-streaming-analytics/grafana/dashboards/ \
+			--dry-run=client -o yaml | kubectl apply -f -"
+	@echo "=== Applying k8s-analytics.yaml ==="
+	ANALYTICS_SSE_URL='$(ANALYTICS_SSE_URL)' K3S_REGISTRY='$(K3S_REGISTRY)' \
+		envsubst < k8s-analytics.yaml | \
+		ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl apply -f -"
+	@echo "=== Waiting for analytics rollout ==="
+	ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); \
+		kubectl rollout status statefulset/clickhouse --timeout=120s; \
+		kubectl rollout status deployment/forwarder --timeout=120s; \
+		kubectl rollout status deployment/grafana --timeout=120s"
+	@echo "=== Re-applying canonical schema to clickhouse-0 ==="
+	@# docker-entrypoint-initdb.d only runs on first startup, so column
+	@# adds in the canonical schema never reach an existing cluster. The
+	@# schema is fully idempotent (CREATE … IF NOT EXISTS, ADD COLUMN IF
+	@# NOT EXISTS), so piping it through clickhouse-client every deploy
+	@# converges drift without breaking existing data.
+	cat analytics/clickhouse/init.d/01-schema.sql | \
+		ssh $(K3S_SSH_HOST) "export KUBECONFIG=$(K3S_KUBECONFIG); kubectl exec -i clickhouse-0 -- clickhouse-client --multiquery"
+	@echo "Analytics deployed. Main app needs INFINITE_STREAM_ENABLE_ANALYTICS=1 (already wired in k8s-infinite-streaming*.yaml) so its nginx routes /analytics/api/* and /grafana/* to the new services."
 
 # ── Remote deployment testing ──────────────────────────────────────────
 # Deploy all 4 installation methods to a remote Docker host for parallel testing.

--- a/analytics/grafana/provisioning/datasources/clickhouse.yml
+++ b/analytics/grafana/provisioning/datasources/clickhouse.yml
@@ -13,6 +13,9 @@ datasources:
       defaultDatabase: infinite_streaming
       tlsSkipVerify: true
       username: default
-    secureJsonData:
-      password: ""
+    # secureJsonData.password is intentionally omitted — ClickHouse's
+    # default user has no password (CLICKHOUSE_SKIP_USER_SETUP=1 in
+    # docker-compose / k8s manifest), and Grafana skips the field
+    # upstream when not set. Setting an empty literal here would trip
+    # CodeQL without changing behavior.
     editable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,12 @@ services:
       # standalone /pair page lists it. Optional label overrides hostname.
       - INFINITE_STREAM_ANNOUNCE_URL=${INFINITE_STREAM_ANNOUNCE_URL:-}
       - INFINITE_STREAM_ANNOUNCE_LABEL=${INFINITE_STREAM_ANNOUNCE_LABEL:-}
+      # Compose ships the analytics sidecar alongside (forwarder + ClickHouse
+      # + Grafana), so wire the nginx /analytics/api/* and /grafana/* routes.
+      # k3s deployments default this to 0 (off) until k8s-analytics.yaml is
+      # also applied; the main image must boot regardless of the sidecar's
+      # existence (#390).
+      - INFINITE_STREAM_ENABLE_ANALYTICS=1
     tmpfs:
       - /go-live:size=4G,mode=755
     networks:

--- a/docker/launch.sh
+++ b/docker/launch.sh
@@ -10,6 +10,14 @@ export INFINITE_STREAM_LISTEN_PORT="${INFINITE_STREAM_LISTEN_PORT:-${INFINITE_LI
 # Generate nginx config from template with environment variable substitution
 export INFINITE_STREAM_OUTPUT_DIR="${INFINITE_STREAM_OUTPUT_DIR:-${INFINITE_OUTPUT_DIR:-/media/dynamic_content}}"
 
+# Pre-create /media subdirectories the services log into. In docker-compose
+# the `init-permissions` sidecar handles this; in k3s there's no
+# equivalent, so a fresh PVC starts empty and nginx + the tee pipelines
+# below blow up on missing /media/logs. Same pattern as #343 / #372 which
+# pre-created SQLite parent dirs in the go services. Idempotent: `-p` is a
+# no-op when the directory already exists.
+mkdir -p /media/logs /media/data "$INFINITE_STREAM_OUTPUT_DIR"
+
 # Auto-generate self-signed TLS certs if missing
 certdir="/media/certs"
 if [ -f "$certdir/localhost.pem" ] && [ -f "$certdir/localhost-key.pem" ]; then
@@ -27,8 +35,25 @@ mkdir -p /etc/nginx/certs
 ln -sf "$certdir/localhost.pem" /etc/nginx/certs/localhost.pem
 ln -sf "$certdir/localhost-key.pem" /etc/nginx/certs/localhost-key.pem
 export INFINITE_STREAM_PROXY_HOST="${INFINITE_STREAM_PROXY_HOST:-127.0.0.1}"
+
+# Analytics sidecar (forwarder + Grafana) is OPT-IN. Compose sets
+# INFINITE_STREAM_ENABLE_ANALYTICS=1 so /analytics/api/* and /grafana/*
+# route to the sibling services. k3s deployments leave it off until
+# k8s-analytics.yaml is also applied — the main image must boot
+# regardless (per CLAUDE.md: "the live streaming path is independent
+# of the sidecar"). When off, the analytics location blocks aren't
+# rendered, and /analytics/api/* + /grafana/* simply 404.
+export INFINITE_STREAM_ENABLE_ANALYTICS="${INFINITE_STREAM_ENABLE_ANALYTICS:-0}"
 export INFINITE_STREAM_FORWARDER_HOST="${INFINITE_STREAM_FORWARDER_HOST:-forwarder}"
 export INFINITE_STREAM_GRAFANA_HOST="${INFINITE_STREAM_GRAFANA_HOST:-grafana}"
+
+# DNS resolver for runtime upstream resolution in the analytics
+# fragment. nginx's `resolver` directive doesn't read /etc/resolv.conf
+# automatically — extract the first nameserver from the OS resolver
+# config so this works in both docker-compose (Docker embedded DNS at
+# 127.0.0.11) and k3s (CoreDNS at the cluster's nameserver IP).
+INFINITE_STREAM_DNS_RESOLVER="$(awk '/^nameserver/ { print $2; exit }' /etc/resolv.conf 2>/dev/null)"
+export INFINITE_STREAM_DNS_RESOLVER="${INFINITE_STREAM_DNS_RESOLVER:-127.0.0.11}"
 
 # Opt-in basic-auth on dashboard pages, /analytics/api/, and /grafana/.
 # When INFINITE_STREAM_AUTH_HTPASSWD points at a readable htpasswd file,
@@ -48,7 +73,21 @@ else
   export INFINITE_STREAM_AUTH_DIRECTIVES="auth_basic off;"
   echo "Basic auth disabled (set INFINITE_STREAM_AUTH_HTPASSWD to a htpasswd file path to enable)."
 fi
-envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_FORWARDER_HOST} ${INFINITE_STREAM_GRAFANA_HOST} ${INFINITE_STREAM_LISTEN_PORT} ${INFINITE_STREAM_AUTH_DIRECTIVES}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
+envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_LISTEN_PORT} ${INFINITE_STREAM_AUTH_DIRECTIVES}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
+
+# Analytics fragment: emitted only when the sidecar is enabled.
+# /etc/nginx/snippets/ is glob-included from inside the main config's
+# server block, so a missing file is a clean no-op (locations 404).
+mkdir -p /etc/nginx/snippets
+rm -f /etc/nginx/snippets/analytics-locations.conf
+if [ "$INFINITE_STREAM_ENABLE_ANALYTICS" = "1" ]; then
+  envsubst '${INFINITE_STREAM_DNS_RESOLVER} ${INFINITE_STREAM_FORWARDER_HOST} ${INFINITE_STREAM_GRAFANA_HOST} ${INFINITE_STREAM_AUTH_DIRECTIVES}' \
+    < /etc/nginx/snippets/nginx-analytics.conf.template \
+    > /etc/nginx/snippets/analytics-locations.conf
+  echo "Analytics ENABLED — /analytics/api/* → $INFINITE_STREAM_FORWARDER_HOST:8080, /grafana/* → $INFINITE_STREAM_GRAFANA_HOST:3000 (resolver=$INFINITE_STREAM_DNS_RESOLVER)."
+else
+  echo "Analytics disabled (set INFINITE_STREAM_ENABLE_ANALYTICS=1 to wire /analytics/api/* and /grafana/* to a forwarder + Grafana sidecar)."
+fi
 
 # Mirror service stdout/stderr to /media/logs/ so logs are inspectable from
 # the host (tail -f, rsync, attach to bug bundle) without losing the docker

--- a/docker/nginx-analytics.conf.template
+++ b/docker/nginx-analytics.conf.template
@@ -63,8 +63,13 @@ location ^~ /grafana/ {
 # prefix so the forwarder sees its native /api/ path.
 location ^~ /analytics/api/ {
     ${INFINITE_STREAM_AUTH_DIRECTIVES}
-    rewrite ^/analytics(/api/.*)$ $1 break;
+    # CRITICAL: `set` must come BEFORE `rewrite … break`. `break` halts
+    # the rewrite-module phase, and `set` is also a rewrite-module
+    # directive — putting `set` after `rewrite … break` leaves the
+    # variable uninitialized at proxy_pass time and yields
+    #   "using uninitialized $forwarder_host variable" → 500.
     set $forwarder_host "${INFINITE_STREAM_FORWARDER_HOST}";
+    rewrite ^/analytics(/api/.*)$ $1 break;
     proxy_pass http://$forwarder_host:8080;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;

--- a/docker/nginx-analytics.conf.template
+++ b/docker/nginx-analytics.conf.template
@@ -1,0 +1,81 @@
+# ============================================================
+# Analytics location blocks — included from inside server {}
+# in nginx-content.conf.template via:
+#   include /etc/nginx/snippets/analytics-*.conf;
+# launch.sh writes this snippet to
+# /etc/nginx/snippets/analytics-locations.conf only when
+# INFINITE_STREAM_ENABLE_ANALYTICS=1, so the glob matches zero
+# files cleanly when analytics is off.
+# ============================================================
+
+# Runtime DNS resolver — defers upstream hostname resolution to
+# request time instead of nginx config-load time. A missing or
+# unreachable forwarder/grafana yields a per-request 502 instead
+# of taking down the entire main image at startup.
+#
+# In docker-compose this is the embedded Docker DNS (127.0.0.11);
+# in k3s it's CoreDNS at the cluster's nameserver IP. launch.sh
+# extracts the first nameserver from /etc/resolv.conf so this
+# works in both environments without per-environment overrides.
+resolver ${INFINITE_STREAM_DNS_RESOLVER} valid=10s ipv6=off;
+
+# Bare /grafana → /grafana/ — the prefix-match `location ^~
+# /grafana/` requires the trailing slash, so without this redirect
+# /grafana would fall through to the catch-all and 404.
+# Use $http_host (the client's Host header) instead of $host:$server_port
+# so the redirect preserves the port the client actually connected
+# on (e.g. 21000 on test-dev) — nginx's default would otherwise
+# build the URL with its own listen port (30000 inside the container).
+location = /grafana {
+    return 301 $scheme://$http_host/grafana/;
+}
+
+# Grafana, routed through nginx so basic-auth applies uniformly.
+# Set GF_SERVER_ROOT_URL in the grafana service to match this prefix
+# (e.g. http://localhost:30000/grafana/) so dashboard URLs resolve.
+location ^~ /grafana/ {
+    ${INFINITE_STREAM_AUTH_DIRECTIVES}
+    # Variable proxy_pass — DNS happens per-request via the resolver
+    # above. The `$request_uri` suffix is required when the proxy_pass
+    # value is variable-only (no path), otherwise nginx treats it as
+    # ambiguous. Grafana expects to receive requests at /grafana/* and
+    # serves them via its sub-path config (GF_SERVER_SERVE_FROM_SUB_PATH=true).
+    set $grafana_host "${INFINITE_STREAM_GRAFANA_HOST}";
+    proxy_pass http://$grafana_host:3000$request_uri;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_buffering off;
+    # WebSocket upgrade for Grafana Live (/grafana/api/live/ws).
+    # Headers are harmless on non-upgrade requests — $http_upgrade
+    # is empty for plain HTTP, so $connection_upgrade evaluates to
+    # `close` and behaves as a normal proxy.
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 1h;
+}
+
+# Analytics: read-only proxy to the SSE→ClickHouse forwarder, which
+# exposes /api/snapshots and /api/sessions for historical replay and
+# cross-session queries. The `rewrite ... break` strips the /analytics
+# prefix so the forwarder sees its native /api/ path.
+location ^~ /analytics/api/ {
+    ${INFINITE_STREAM_AUTH_DIRECTIVES}
+    rewrite ^/analytics(/api/.*)$ $1 break;
+    set $forwarder_host "${INFINITE_STREAM_FORWARDER_HOST}";
+    proxy_pass http://$forwarder_host:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 60s;
+    # Stream NDJSON to the browser line-by-line so the replay UI
+    # can paint snapshots as they arrive instead of waiting for
+    # the entire response to buffer.
+    proxy_buffering off;
+    proxy_request_buffering off;
+    add_header X-Accel-Buffering "no" always;
+    add_header Access-Control-Allow-Origin * always;
+    add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+}

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -34,19 +34,13 @@ upstream go_proxy {
     keepalive 4;
 }
 
-# Upstream to analytics forwarder (read-only ClickHouse query proxy)
-upstream analytics_forwarder {
-    server ${INFINITE_STREAM_FORWARDER_HOST}:8080;
-    keepalive 4;
-}
-
-# Upstream to Grafana. Routed through nginx so that basic-auth and the
-# host firewall rules apply uniformly — Grafana is no longer reachable
-# directly via its container port from outside the docker network.
-upstream analytics_grafana {
-    server ${INFINITE_STREAM_GRAFANA_HOST}:3000;
-    keepalive 4;
-}
+# Analytics upstreams (forwarder, grafana) are no longer declared at
+# http-level. They live in /etc/nginx/snippets/analytics-*.conf and use
+# variable-based `proxy_pass` with a runtime resolver, so the main
+# image boots cleanly when the analytics sidecar isn't deployed (the
+# documented "live streaming path is independent of the sidecar"
+# guarantee — see CLAUDE.md). launch.sh writes the snippet only when
+# INFINITE_STREAM_ENABLE_ANALYTICS=1.
 
 # Normal server
 server {
@@ -176,61 +170,13 @@ server {
         add_header Access-Control-Allow-Origin * always;
     }
 
-    # Analytics: read-only proxy to the SSE→ClickHouse forwarder, which
-    # exposes /api/snapshots and /api/sessions for historical replay and
-    # cross-session queries. Failing closed (502) when the forwarder is
-    # not running keeps the live UI unaffected.
-    # Bare /grafana → /grafana/ — the prefix-match `location ^~
-    # /grafana/` requires the trailing slash, so without this redirect
-    # /grafana would fall through to the catch-all and 404.
-    # Use $http_host (the client's Host header) instead of $host:$server_port
-    # so the redirect preserves the port the client actually connected
-    # on (e.g. 21000 on test-dev) — nginx's default would otherwise
-    # build the URL with its own listen port (30000 inside the container).
-    location = /grafana {
-        return 301 $scheme://$http_host/grafana/;
-    }
-
-    # Grafana, routed through nginx so basic-auth applies uniformly.
-    # Set GF_SERVER_ROOT_URL in the grafana service to match this prefix
-    # (e.g. http://localhost:30000/grafana/) so dashboard URLs resolve.
-    location ^~ /grafana/ {
-        ${INFINITE_STREAM_AUTH_DIRECTIVES}
-        # No trailing slash on proxy_pass — Grafana expects to receive
-        # requests at /grafana/* and serves them via its sub-path
-        # config (GF_SERVER_SERVE_FROM_SUB_PATH=true).
-        proxy_pass http://analytics_grafana;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_buffering off;
-        # WebSocket upgrade for Grafana Live (/grafana/api/live/ws).
-        # Headers are harmless on non-upgrade requests — $http_upgrade
-        # is empty for plain HTTP, so Connection: "upgrade" only takes
-        # effect when the client actually sent Upgrade: websocket.
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_read_timeout 1h;
-    }
-
-    location ^~ /analytics/api/ {
-        ${INFINITE_STREAM_AUTH_DIRECTIVES}
-        proxy_pass http://analytics_forwarder/api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_read_timeout 60s;
-        # Stream NDJSON to the browser line-by-line so the replay UI
-        # can paint snapshots as they arrive instead of waiting for
-        # the entire response to buffer.
-        proxy_buffering off;
-        proxy_request_buffering off;
-        add_header X-Accel-Buffering "no" always;
-        add_header Access-Control-Allow-Origin * always;
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-    }
+    # Analytics + Grafana location blocks live in a glob-included
+    # snippet, written by launch.sh only when
+    # INFINITE_STREAM_ENABLE_ANALYTICS=1. The glob matches zero files
+    # cleanly when analytics is off, so /analytics/api/* and /grafana/*
+    # simply 404 instead of crashing nginx at startup with an
+    # "host not found in upstream" error.
+    include /etc/nginx/snippets/analytics-*.conf;
 
     location = /api/sessions {
         proxy_pass http://go_proxy;

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -1,36 +1,398 @@
-# Analytics sidecar: ClickHouse + Grafana + SSE→ClickHouse forwarder.
-# Apply alongside k8s-infinite-streaming-dev.yaml or k8s-infinite-streaming.yaml.
-# Uses envsubst at apply time for ${K3S_REGISTRY} and the SSE source URL
-# (${ANALYTICS_SSE_URL}). The forwarder defaults to the dev stack
-# (infinite-streaming-dev:30081); override ANALYTICS_SSE_URL for release.
+# Analytics tier — ClickHouse + forwarder + Grafana, parametrized for
+# dev/release split. Apply per-stack: each `make deploy` /
+# `make deploy-release` invokes this manifest with a stack-specific
+# `${ANALYTICS_STACK}` so the two stacks share nothing — separate
+# pods, separate Services, separate PVCs, separate Grafana state.
 #
-# The `analytics-clickhouse-init` ConfigMap is NOT defined inline here.
-# `make analytics-deploy-k3s` generates it from the canonical schema at
-# analytics/clickhouse/init.d/01-schema.sql via:
-#   kubectl create configmap analytics-clickhouse-init \
-#       --from-file=01-schema.sql=analytics/clickhouse/init.d/01-schema.sql \
-#       --dry-run=client -o yaml | kubectl apply -f -
-# This keeps a single source of truth for the schema across compose
-# (which bind-mounts the file into ClickHouse) and k3s. The same
-# Makefile target also re-applies the canonical schema against the
-# running clickhouse-0 pod after rollout, so column-add migrations
-# land on existing clusters even though docker-entrypoint-initdb.d/
-# only runs on first startup.
+# Three placeholders are envsubst'd at apply time:
+#   - ${ANALYTICS_STACK}      — "dev" or "release" (stack identifier)
+#   - ${ANALYTICS_SSE_URL}    — the forwarder's session-stream source
+#   - ${K3S_REGISTRY}         — host:port for the forwarder image
+#
+# Schemas + Grafana provisioning are inlined here so the manifest is
+# self-contained — `kubectl apply -f` is enough to bring the stack up,
+# no separate ConfigMap-from-file step in the Makefile. If the source
+# files in analytics/clickhouse/init.d/ or
+# analytics/grafana/provisioning/ change, regenerate this file with
+# `make analytics-regen-k8s-manifest`.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-clickhouse-init-${ANALYTICS_STACK}
+data:
+  01-schema.sql: |
+    -- Analytics schema for InfiniteStream session snapshots.
+    --
+    -- One row per session per SSE broadcast tick. The forwarder dedupes by
+    -- payload fingerprint, so an unchanging session does not generate rows.
+    -- Grafana, ad-hoc SQL, and testing.html replay mode all read from here.
+    
+    CREATE DATABASE IF NOT EXISTS infinite_streaming;
+    
+    CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
+    (
+        ts                    DateTime64(3, 'UTC')        CODEC(DoubleDelta, ZSTD(1)),
+        revision              UInt64                      CODEC(DoubleDelta, ZSTD(1)),
+        session_id            String                      CODEC(ZSTD(1)),
+        play_id               LowCardinality(String)      CODEC(ZSTD(1)),
+        player_id             LowCardinality(String)      CODEC(ZSTD(1)),
+        group_id              LowCardinality(String)      CODEC(ZSTD(1)),
+        user_agent            String                      CODEC(ZSTD(1)),
+    
+        -- Content / manifest
+        manifest_url          String                      CODEC(ZSTD(1)),
+        manifest_variants     String                      CODEC(ZSTD(3)),
+        last_request_url      String                      CODEC(ZSTD(1)),
+        content_id            LowCardinality(String)      CODEC(ZSTD(1)),
+    
+        -- Player state (hot path for charts)
+        player_state          LowCardinality(String)      CODEC(ZSTD(1)),
+        waiting_reason        LowCardinality(String)      CODEC(ZSTD(1)),
+        buffer_depth_s        Float32                     CODEC(ZSTD(1)),
+        network_bitrate_mbps  Float32                     CODEC(ZSTD(1)),
+        video_bitrate_mbps    Float32                     CODEC(ZSTD(1)),
+        measured_mbps         Float32                     CODEC(ZSTD(1)),
+        mbps_shaper_rate      Float32                     CODEC(ZSTD(1)),
+        mbps_shaper_avg       Float32                     CODEC(ZSTD(1)),
+        display_resolution    LowCardinality(String)      CODEC(ZSTD(1)),
+        video_resolution      LowCardinality(String)      CODEC(ZSTD(1)),
+        frames_displayed      UInt64                      DEFAULT 0,
+        dropped_frames        UInt32                      DEFAULT 0,
+        stall_count           UInt32                      DEFAULT 0,
+        stall_time_s          Float32                     CODEC(ZSTD(1)),
+        position_s            Float32                     CODEC(ZSTD(1)),
+        live_edge_s           Float32                     CODEC(ZSTD(1)),
+        true_offset_s         Float32                     CODEC(ZSTD(1)),
+        playback_rate         Float32                     CODEC(ZSTD(1)),
+        loop_count_player     UInt32                      DEFAULT 0,
+        loop_count_server     UInt32                      DEFAULT 0,
+    
+        -- Player events (discrete signals embedded in the heartbeat snapshot;
+        -- testing.html derives event-lane points from transitions in these).
+        last_event            LowCardinality(String)      CODEC(ZSTD(1)),
+        trigger_type          LowCardinality(String)      CODEC(ZSTD(1)),
+        event_time            String                      CODEC(ZSTD(1)),
+        player_error          String                      CODEC(ZSTD(1)),
+    
+        -- Player metrics (extended)
+        avg_network_bitrate_mbps     Float32 CODEC(ZSTD(1)),
+        buffer_end_s                 Float32 CODEC(ZSTD(1)),
+        last_stall_time_s            Float32 CODEC(ZSTD(1)),
+        live_offset_s                Float32 CODEC(ZSTD(1)),
+        playhead_wallclock_ms        Int64   CODEC(ZSTD(1)),
+        seekable_end_s               Float32 CODEC(ZSTD(1)),
+        metrics_source               LowCardinality(String) CODEC(ZSTD(1)),
+        video_first_frame_time_s     Float32 CODEC(ZSTD(1)),
+        video_quality_pct            Float32 CODEC(ZSTD(1)),
+        video_start_time_s           Float32 CODEC(ZSTD(1)),
+    
+        -- Network / transfer
+        mbps_transfer_complete       Float32 CODEC(ZSTD(1)),
+        mbps_transfer_rate           Float32 CODEC(ZSTD(1)),
+        player_ip                    LowCardinality(String) CODEC(ZSTD(1)),
+        server_received_at_ms        Int64   CODEC(ZSTD(1)),
+        x_forwarded_port             UInt16  DEFAULT 0,
+        x_forwarded_port_external    UInt16  DEFAULT 0,
+    
+        -- Master manifest failure injection
+        master_manifest_url               String                 CODEC(ZSTD(1)),
+        master_manifest_failure_type      LowCardinality(String) CODEC(ZSTD(1)),
+        master_manifest_failure_mode      LowCardinality(String) CODEC(ZSTD(1)),
+        master_manifest_failure_frequency Float32                CODEC(ZSTD(1)),
+        master_manifest_consecutive_failures UInt32              DEFAULT 0,
+        master_manifest_requests_count    UInt32                 DEFAULT 0,
+    
+        -- Manifest failure injection (extended)
+        manifest_failure_frequency      Float32 CODEC(ZSTD(1)),
+        manifest_failure_urls           String  CODEC(ZSTD(3)),
+        manifest_consecutive_failures   UInt32  DEFAULT 0,
+        manifest_requests_count         UInt32  DEFAULT 0,
+    
+        -- Segment failure injection (extended)
+        segment_failure_frequency       Float32 CODEC(ZSTD(1)),
+        segment_failure_urls            String  CODEC(ZSTD(3)),
+        segment_consecutive_failures    UInt32  DEFAULT 0,
+        segments_count                  UInt32  DEFAULT 0,
+    
+        -- "All" (cross-cutting) failure injection
+        all_failure_type                LowCardinality(String) CODEC(ZSTD(1)),
+        all_failure_mode                LowCardinality(String) CODEC(ZSTD(1)),
+        all_failure_frequency           Float32                CODEC(ZSTD(1)),
+        all_failure_urls                String                 CODEC(ZSTD(3)),
+        all_consecutive_failures        UInt32                 DEFAULT 0,
+    
+        -- Transport failure / fault details
+        transport_failure_frequency     Float32                CODEC(ZSTD(1)),
+        transport_failure_mode          LowCardinality(String) CODEC(ZSTD(1)),
+        transport_failure_units         LowCardinality(String) CODEC(ZSTD(1)),
+        transport_consecutive_failures  UInt32                 DEFAULT 0,
+        transport_consecutive_seconds   Float32                CODEC(ZSTD(1)),
+        transport_consecutive_units     UInt32                 DEFAULT 0,
+        transport_frequency_seconds     Float32                CODEC(ZSTD(1)),
+        transport_fault_drop_packets    UInt8                  DEFAULT 0,
+        transport_fault_reject_packets  UInt8                  DEFAULT 0,
+        transport_fault_off_seconds     Float32                CODEC(ZSTD(1)),
+        transport_fault_on_seconds      Float32                CODEC(ZSTD(1)),
+        transport_fault_type            LowCardinality(String) CODEC(ZSTD(1)),
+        fault_count_transfer_active_timeout  UInt32            DEFAULT 0,
+        fault_count_transfer_idle_timeout    UInt32            DEFAULT 0,
+    
+        -- Transfer timeouts
+        transfer_active_timeout_seconds   Float32 CODEC(ZSTD(1)),
+        transfer_idle_timeout_seconds     Float32 CODEC(ZSTD(1)),
+        transfer_timeout_applies_manifests UInt8  DEFAULT 0,
+        transfer_timeout_applies_master    UInt8  DEFAULT 0,
+        transfer_timeout_applies_segments  UInt8  DEFAULT 0,
+    
+        -- nftables (extended)
+        nftables_pattern_step               UInt32  DEFAULT 0,
+        nftables_pattern_step_runtime       UInt32  DEFAULT 0,
+        nftables_pattern_steps              String  CODEC(ZSTD(3)),
+        nftables_pattern_rate_runtime_mbps  Float32 CODEC(ZSTD(1)),
+        nftables_pattern_margin_pct         Float32 CODEC(ZSTD(1)),
+        nftables_pattern_template_mode      LowCardinality(String) CODEC(ZSTD(1)),
+    
+        -- Content config
+        content_allowed_variants    String                 CODEC(ZSTD(3)),
+        content_live_offset         Float32                CODEC(ZSTD(1)),
+        content_strip_codecs        String                 CODEC(ZSTD(1)),
+    
+        -- Misc
+        abrchar_run_lock            UInt8                  DEFAULT 0,
+        control_revision            UInt64                 DEFAULT 0,
+    
+        -- Server-side variant
+        server_video_rendition       LowCardinality(String) CODEC(ZSTD(1)),
+        server_video_rendition_mbps  Float32                CODEC(ZSTD(1)),
+    
+        -- Failure injection (categorical hot fields)
+        manifest_failure_type    LowCardinality(String)   CODEC(ZSTD(1)),
+        manifest_failure_mode    LowCardinality(String)   CODEC(ZSTD(1)),
+        segment_failure_type     LowCardinality(String)   CODEC(ZSTD(1)),
+        segment_failure_mode     LowCardinality(String)   CODEC(ZSTD(1)),
+        transport_failure_type   LowCardinality(String)   CODEC(ZSTD(1)),
+        transport_fault_active   UInt8                    DEFAULT 0,
+    
+        -- Network shaping
+        nftables_bandwidth_mbps  Float32                  CODEC(ZSTD(1)),
+        nftables_delay_ms        UInt32                   DEFAULT 0,
+        nftables_packet_loss     Float32                  CODEC(ZSTD(1)),
+        nftables_pattern_enabled UInt8                    DEFAULT 0,
+    
+        -- Lifecycle
+        first_request_time   String                       CODEC(ZSTD(1)),
+        last_request         String                       CODEC(ZSTD(1)),
+        session_duration     Float32                      CODEC(ZSTD(1)),
+    
+        -- Long tail: full session map as JSON, for fields not promoted to columns.
+        session_json         String                       CODEC(ZSTD(3)),
+    
+        -- Tiered retention classification (issue #342). One of:
+        --   'other'        — default, evicted at 30 d (TTL clause below).
+        --   'interesting'  — auto-classified at session-end when any bad-event
+        --                    signal appears in the session. Evicted at 90 d.
+        --   'favourite'    — explicitly starred by the user. Never evicted.
+        -- Set by the forwarder via ALTER UPDATE on session-end + on star /
+        -- unstar API calls. Must be declared inline (not via post-create
+        -- ALTER) because the TTL clause below references it. The redundant
+        -- ADD COLUMN IF NOT EXISTS further down is a no-op for fresh hosts
+        -- but keeps the upgrade path alive for hosts created before #342.
+        classification       LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1))
+    )
+    ENGINE = MergeTree
+    PARTITION BY toYYYYMMDD(ts)
+    ORDER BY (session_id, ts)
+    -- Tiered retention by classification column (issue #342):
+    --   * 'other'       → 30 d (default)
+    --   * 'interesting' → 90 d
+    --   * 'favourite'   → no clause matches → kept forever
+    -- Per-row TTL is computed against the row's own ts. For long sessions
+    -- the front of the session may evict before the end (#347 tracks the
+    -- session_end_ts polish that would make eviction strictly all-or-
+    -- nothing). For typical hour-scale sessions the trim window is too
+    -- small to care about.
+    TTL toDateTime(ts) + INTERVAL 30 DAY DELETE WHERE classification = 'other',
+        toDateTime(ts) + INTERVAL 90 DAY DELETE WHERE classification = 'interesting'
+    SETTINGS index_granularity = 8192;
+    
+    -- Bloom filter on session_id for fast point lookups in replay mode.
+    ALTER TABLE infinite_streaming.session_snapshots
+        ADD INDEX IF NOT EXISTS idx_session_id session_id TYPE bloom_filter(0.01) GRANULARITY 4;
+    
+    ALTER TABLE infinite_streaming.session_snapshots
+        ADD INDEX IF NOT EXISTS idx_player_id player_id TYPE bloom_filter(0.01) GRANULARITY 4;
+    
+    ALTER TABLE infinite_streaming.session_snapshots
+        ADD INDEX IF NOT EXISTS idx_play_id play_id TYPE bloom_filter(0.01) GRANULARITY 4;
+    
+    -- Bring older deployments up to date if the column predates this column.
+    ALTER TABLE infinite_streaming.session_snapshots
+        ADD COLUMN IF NOT EXISTS play_id LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS content_id LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS last_event LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS trigger_type LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS event_time String CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS player_error String CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS avg_network_bitrate_mbps Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS buffer_end_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS last_stall_time_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS live_offset_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS playhead_wallclock_ms Int64 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS seekable_end_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS metrics_source LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS video_first_frame_time_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS video_quality_pct Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS video_start_time_s Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS mbps_transfer_complete Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS mbps_transfer_rate Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS player_ip LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS server_received_at_ms Int64 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS x_forwarded_port UInt16 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS x_forwarded_port_external UInt16 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS master_manifest_url String CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS master_manifest_failure_type LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS master_manifest_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS master_manifest_failure_frequency Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS master_manifest_consecutive_failures UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS master_manifest_requests_count UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS manifest_failure_frequency Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS manifest_failure_urls String CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS manifest_consecutive_failures UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS manifest_requests_count UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS segment_failure_frequency Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS segment_failure_urls String CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS segment_consecutive_failures UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS segments_count UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS all_failure_type LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS all_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS all_failure_frequency Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS all_failure_urls String CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS all_consecutive_failures UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transport_failure_frequency Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_failure_mode LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_failure_units LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_consecutive_failures UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transport_consecutive_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_consecutive_units UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transport_frequency_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_fault_drop_packets UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transport_fault_reject_packets UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transport_fault_off_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_fault_on_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transport_fault_type LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS fault_count_transfer_active_timeout UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS fault_count_transfer_idle_timeout UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transfer_active_timeout_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transfer_idle_timeout_seconds Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS transfer_timeout_applies_manifests UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transfer_timeout_applies_master UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS transfer_timeout_applies_segments UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS nftables_pattern_step UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS nftables_pattern_step_runtime UInt32 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS nftables_pattern_steps String CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS nftables_pattern_rate_runtime_mbps Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS nftables_pattern_margin_pct Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS nftables_pattern_template_mode LowCardinality(String) CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS content_allowed_variants String CODEC(ZSTD(3)),
+        ADD COLUMN IF NOT EXISTS content_live_offset Float32 CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS content_strip_codecs String CODEC(ZSTD(1)),
+        ADD COLUMN IF NOT EXISTS abrchar_run_lock UInt8 DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS control_revision UInt64 DEFAULT 0,
+        -- Tiered retention classification (issue #342). One of:
+        --   'other'        — default, evicted at 30 d (TTL clause below).
+        --   'interesting'  — auto-classified at session-end when any of
+        --                    user_marked / frozen / segment_stall / restart /
+        --                    error / non-empty player_error / fault counters
+        --                    appear in the session. Evicted at 90 d.
+        --   'favourite'    — explicitly starred by the user. Never evicted.
+        -- Set by the forwarder via ALTER UPDATE on session-end + on star /
+        -- unstar API calls. Lives on every row of (session_id, play_id) so
+        -- ClickHouse TTL can evaluate it without joining a side table.
+        ADD COLUMN IF NOT EXISTS classification LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1));
+    
+    -- Convert legacy manifest_variants UInt16 (broken: always stored 0 because
+    -- the SSE field is an array, not a number) to String (JSON of the variant
+    -- ladder). Safe MODIFY since the only existing values are zero.
+    ALTER TABLE infinite_streaming.session_snapshots
+        MODIFY COLUMN IF EXISTS manifest_variants String CODEC(ZSTD(3));
+    
+    -- Per-request HAR-style log so the session-viewer's network log fold
+    -- can replay archived sessions whose go-proxy buffer is gone. Forwarder
+    -- polls /api/session/<id>/network for live sessions and dedupes rows
+    -- via entry_fingerprint. Headers/query are stored as JSON strings —
+    -- almost never queried column-by-column and often empty.
+    CREATE TABLE IF NOT EXISTS infinite_streaming.network_requests
+    (
+        ts                       DateTime64(3, 'UTC')   CODEC(Delta, ZSTD(1)),
+        session_id               String                 CODEC(ZSTD(1)),
+        play_id                  LowCardinality(String) CODEC(ZSTD(1)),
+        method                   LowCardinality(String) CODEC(ZSTD(1)),
+        url                      String                 CODEC(ZSTD(3)),
+        upstream_url             String                 CODEC(ZSTD(3)),
+        path                     String                 CODEC(ZSTD(3)),
+        request_kind             LowCardinality(String) CODEC(ZSTD(1)),
+        status                   UInt16                 DEFAULT 0,
+        bytes_in                 Int64                  DEFAULT 0,
+        bytes_out                Int64                  DEFAULT 0,
+        content_type             LowCardinality(String) CODEC(ZSTD(1)),
+        request_range            String                 CODEC(ZSTD(1)),
+        response_content_range   String                 CODEC(ZSTD(1)),
+        dns_ms                   Float32                CODEC(ZSTD(1)),
+        connect_ms               Float32                CODEC(ZSTD(1)),
+        tls_ms                   Float32                CODEC(ZSTD(1)),
+        ttfb_ms                  Float32                CODEC(ZSTD(1)),
+        transfer_ms              Float32                CODEC(ZSTD(1)),
+        total_ms                 Float32                CODEC(ZSTD(1)),
+        client_wait_ms           Float32                CODEC(ZSTD(1)),
+        faulted                  UInt8                  DEFAULT 0,
+        fault_type               LowCardinality(String) CODEC(ZSTD(1)),
+        fault_action             LowCardinality(String) CODEC(ZSTD(1)),
+        fault_category           LowCardinality(String) CODEC(ZSTD(1)),
+        request_headers          String                 CODEC(ZSTD(3)),
+        response_headers         String                 CODEC(ZSTD(3)),
+        query_string             String                 CODEC(ZSTD(3)),
+        -- Fingerprint over the immutable identity (ts ms, path, method,
+        -- status, play_id) so re-polling go-proxy doesn't double-insert.
+        entry_fingerprint        UInt64                 CODEC(ZSTD(1)),
+        -- Tiered retention classification (issue #342) — must be inline
+        -- because the TTL clause below references it. See full comment on
+        -- session_snapshots. The post-create ALTER ADD COLUMN IF NOT EXISTS
+        -- below is a no-op on fresh hosts but covers the upgrade path.
+        classification           LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1)),
+        INDEX idx_play_id play_id TYPE bloom_filter GRANULARITY 4,
+        INDEX idx_status status TYPE minmax GRANULARITY 4
+    )
+    ENGINE = MergeTree
+    PARTITION BY toYYYYMMDD(ts)
+    ORDER BY (session_id, ts, entry_fingerprint)
+    -- Tiered retention by classification column — see comment on
+    -- session_snapshots above. Both tables share the same retention
+    -- policy so paired (snapshots, network) data ages out together.
+    TTL toDateTime(ts) + INTERVAL 30 DAY DELETE WHERE classification = 'other',
+        toDateTime(ts) + INTERVAL 90 DAY DELETE WHERE classification = 'interesting'
+    SETTINGS index_granularity = 8192;
+    
+    -- Same classification column on the per-request table so HAR rows
+    -- track their session's retention tier. Defaults to 'other' on insert;
+    -- forwarder bumps it on session-end / star / unstar via ALTER UPDATE.
+    ALTER TABLE infinite_streaming.network_requests
+        ADD COLUMN IF NOT EXISTS classification LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1));
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: clickhouse
+  name: clickhouse-${ANALYTICS_STACK}
 spec:
-  serviceName: clickhouse
+  serviceName: clickhouse-${ANALYTICS_STACK}
   replicas: 1
   selector:
     matchLabels:
-      app: clickhouse
+      app: clickhouse-${ANALYTICS_STACK}
   template:
     metadata:
       labels:
-        app: clickhouse
+        app: clickhouse-${ANALYTICS_STACK}
     spec:
       containers:
       - name: clickhouse
@@ -53,7 +415,7 @@ spec:
       volumes:
       - name: init
         configMap:
-          name: analytics-clickhouse-init
+          name: analytics-clickhouse-init-${ANALYTICS_STACK}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -66,10 +428,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: clickhouse
+  name: clickhouse-${ANALYTICS_STACK}
 spec:
   selector:
-    app: clickhouse
+    app: clickhouse-${ANALYTICS_STACK}
   ports:
   - name: http
     port: 8123
@@ -81,16 +443,16 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: forwarder
+  name: forwarder-${ANALYTICS_STACK}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: forwarder
+      app: forwarder-${ANALYTICS_STACK}
   template:
     metadata:
       labels:
-        app: forwarder
+        app: forwarder-${ANALYTICS_STACK}
     spec:
       containers:
       - name: forwarder
@@ -102,7 +464,7 @@ spec:
         - name: FORWARDER_SSE_URL
           value: "${ANALYTICS_SSE_URL}"
         - name: FORWARDER_CLICKHOUSE_URL
-          value: "http://clickhouse:8123"
+          value: "http://clickhouse-${ANALYTICS_STACK}:8123"
         - name: FORWARDER_CLICKHOUSE_DB
           value: infinite_streaming
         - name: FORWARDER_CLICKHOUSE_TABLE
@@ -111,28 +473,199 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: forwarder
+  name: forwarder-${ANALYTICS_STACK}
 spec:
   selector:
-    app: forwarder
+    app: forwarder-${ANALYTICS_STACK}
   ports:
   - name: http
     port: 8080
     targetPort: 8080
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-grafana-datasources-${ANALYTICS_STACK}
+data:
+  clickhouse.yml: |
+    apiVersion: 1
+    datasources:
+      - name: ClickHouse
+        type: grafana-clickhouse-datasource
+        uid: ch_infinite_streaming
+        access: proxy
+        isDefault: true
+        jsonData:
+          host: clickhouse-${ANALYTICS_STACK}
+          port: 9000
+          protocol: native
+          defaultDatabase: infinite_streaming
+          tlsSkipVerify: true
+          username: default
+        secureJsonData:
+          password: ""
+        editable: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: analytics-grafana-dashboards-${ANALYTICS_STACK}
+data:
+  default.yml: |
+    apiVersion: 1
+    providers:
+      - name: infinite-streaming
+        orgId: 1
+        folder: ""
+        type: file
+        disableDeletion: false
+        updateIntervalSeconds: 30
+        allowUiUpdates: true
+        options:
+          path: /etc/grafana/provisioning/dashboards
+  infinite-streaming.json: |
+    {
+      "title": "InfiniteStream Storage",
+      "uid": "is-session-analytics",
+      "schemaVersion": 39,
+      "editable": true,
+      "tags": ["infinite-streaming"],
+      "time": { "from": "now-24h", "to": "now" },
+      "refresh": "30s",
+      "timepicker": {
+        "refresh_intervals": ["10s", "30s", "1m", "5m", "15m", "1h"],
+        "quick_ranges": [
+          { "from": "now-15m",  "to": "now",     "display": "Last 15 minutes" },
+          { "from": "now-1h",   "to": "now",     "display": "Last hour"       },
+          { "from": "now-6h",   "to": "now",     "display": "Last 6 hours"    },
+          { "from": "now-24h",  "to": "now",     "display": "Last 24 hours"   },
+          { "from": "now-7d",   "to": "now",     "display": "Last 7 days"     },
+          { "from": "now-30d",  "to": "now",     "display": "Last 30 days"    },
+          { "from": "now-90d",  "to": "now",     "display": "Last 90 days"    }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "type": "timeseries",
+          "title": "Messages by retention tier",
+          "description": "Per-minute row count grouped by classification across both session_snapshots and network_requests. Time scope follows the dashboard time picker. Tiers: 'other' (gray, TTL 30 d), 'interesting' (amber, TTL 90 d), 'favourite' (green, kept forever). Eyeballing the gray slice tells you how much of the visible window will be gone in a month.",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "gridPos": { "x": 0, "y": 0, "w": 24, "h": 10 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "fillOpacity": 100,
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": { "mode": "normal", "group": "A" }
+              }
+            },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "other" },
+                "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#6b7280" } }] },
+              { "matcher": { "id": "byName", "options": "interesting" },
+                "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#f59e0b" } }] },
+              { "matcher": { "id": "byName", "options": "favourite" },
+                "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "#10b981" } }] }
+            ]
+          },
+          "options": {
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["sum"] },
+            "tooltip": { "mode": "multi", "sort": "none" }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+              "rawSql": "SELECT time, tier, sum(messages) AS messages FROM ( SELECT $__timeInterval(ts) AS time, classification AS tier, count() AS messages FROM infinite_streaming.session_snapshots WHERE $__timeFilter(ts) GROUP BY time, classification UNION ALL SELECT $__timeInterval(ts) AS time, classification AS tier, count() AS messages FROM infinite_streaming.network_requests WHERE $__timeFilter(ts) GROUP BY time, classification ) GROUP BY time, tier ORDER BY time ASC, tier ASC",
+              "format": 0
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Total storage",
+          "description": "On-disk bytes across all active parts in the infinite_streaming database.",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "gridPos": { "x": 0, "y": 10, "w": 8, "h": 6 },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "decbytes",
+              "color": { "mode": "thresholds" },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 5368709120 },
+                  { "color": "red", "value": 21474836480 }
+                ]
+              }
+            }
+          },
+          "options": {
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "colorMode": "value",
+            "graphMode": "area",
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+              "rawSql": "SELECT sum(bytes_on_disk) AS bytes FROM system.parts WHERE database = 'infinite_streaming' AND active",
+              "format": 1
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "type": "table",
+          "title": "Storage by table × tier",
+          "description": "Per-table on-disk bytes and row counts split by retention tier. Bytes are proportional: total table bytes from system.parts × (tier_rows / total_table_rows). Compression is part-level, not row-level, so this is an estimate — accurate to within a few percent for typical mixes.",
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+          "gridPos": { "x": 8, "y": 10, "w": 16, "h": 6 },
+          "fieldConfig": {
+            "defaults": { "unit": "short" },
+            "overrides": [
+              { "matcher": { "id": "byName", "options": "bytes" }, "properties": [{ "id": "unit", "value": "decbytes" }] },
+              { "matcher": { "id": "byName", "options": "rows" },  "properties": [{ "id": "unit", "value": "short" }] }
+            ]
+          },
+          "options": {
+            "showHeader": true,
+            "footer": { "show": false }
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": { "type": "grafana-clickhouse-datasource", "uid": "ch_infinite_streaming" },
+              "rawSql": "WITH part_sizes AS ( SELECT table, sum(rows) AS table_rows, sum(bytes_on_disk) AS table_bytes FROM system.parts WHERE database = 'infinite_streaming' AND active GROUP BY table ), class_counts AS ( SELECT 'session_snapshots' AS table, classification, count() AS class_rows FROM infinite_streaming.session_snapshots GROUP BY classification UNION ALL SELECT 'network_requests', classification, count() FROM infinite_streaming.network_requests GROUP BY classification ) SELECT c.table AS table, c.classification AS tier, c.class_rows AS rows, toUInt64(p.table_bytes * (c.class_rows / nullIf(p.table_rows, 0))) AS bytes FROM class_counts c LEFT JOIN part_sizes p ON c.table = p.table ORDER BY c.table ASC, c.classification ASC",
+              "format": 1
+            }
+          ]
+        }
+      ]
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: grafana
+  name: grafana-${ANALYTICS_STACK}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: grafana
+      app: grafana-${ANALYTICS_STACK}
   template:
     metadata:
       labels:
-        app: grafana
+        app: grafana-${ANALYTICS_STACK}
     spec:
       containers:
       - name: grafana
@@ -142,33 +675,19 @@ spec:
         env:
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
-        # Viewer (not Editor) — anonymous visitors can read dashboards
-        # but can't edit them. Log in via the form (admin/admin on
-        # first login, Grafana forces a password change) to edit. UI
-        # edits are per-instance only; the source of truth is the
-        # provisioned JSON in analytics/grafana/provisioning/.
         - name: GF_AUTH_ANONYMOUS_ORG_ROLE
           value: "Viewer"
         - name: GF_AUTH_DISABLE_LOGIN_FORM
           value: "false"
         - name: GF_INSTALL_PLUGINS
           value: "grafana-clickhouse-datasource"
-        # Grafana is served behind the go-server nginx at /grafana/,
-        # so it must build URLs relative to that prefix.
         - name: GF_SERVER_ROOT_URL
           value: "%(protocol)s://%(domain)s:%(http_port)s/grafana/"
         - name: GF_SERVER_SERVE_FROM_SUB_PATH
           value: "true"
-        # Grafana Live origin check — wildcard so WebSocket works
-        # when the cluster is reached via multiple hostnames
-        # (.local, IP, Tailscale, etc.). See docker-compose.yml note.
         - name: GF_LIVE_ALLOWED_ORIGINS
           value: "*"
         volumeMounts:
-        # Datasources + dashboards come from ConfigMaps populated by
-        # `make analytics-deploy-k3s` from analytics/grafana/provisioning/.
-        # Same content compose mounts via bind-mount; in k3s we package
-        # it as ConfigMaps so the cluster has its own copy.
         - name: datasources
           mountPath: /etc/grafana/provisioning/datasources
         - name: dashboards
@@ -176,22 +695,19 @@ spec:
       volumes:
       - name: datasources
         configMap:
-          name: analytics-grafana-datasources
+          name: analytics-grafana-datasources-${ANALYTICS_STACK}
       - name: dashboards
         configMap:
-          name: analytics-grafana-dashboards
+          name: analytics-grafana-dashboards-${ANALYTICS_STACK}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: grafana
+  name: grafana-${ANALYTICS_STACK}
 spec:
-  # ClusterIP, not NodePort — Grafana is reached via the go-server
-  # nginx at /grafana/ where basic-auth (when enabled) gates access.
-  # Exposing it directly on a node port would bypass that gate.
   type: ClusterIP
   selector:
-    app: grafana
+    app: grafana-${ANALYTICS_STACK}
   ports:
   - name: http
     port: 3000

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -3,138 +3,19 @@
 # Uses envsubst at apply time for ${K3S_REGISTRY} and the SSE source URL
 # (${ANALYTICS_SSE_URL}). The forwarder defaults to the dev stack
 # (infinite-streaming-dev:30081); override ANALYTICS_SSE_URL for release.
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: analytics-clickhouse-init
-data:
-  01-schema.sql: |
-    CREATE DATABASE IF NOT EXISTS infinite_streaming;
-    CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
-    (
-        ts DateTime64(3, 'UTC'),
-        revision UInt64,
-        session_id String,
-        play_id LowCardinality(String),
-        player_id LowCardinality(String),
-        group_id LowCardinality(String),
-        user_agent String,
-        manifest_url String,
-        manifest_variants String,
-        last_request_url String,
-        content_id LowCardinality(String),
-        player_state LowCardinality(String),
-        waiting_reason LowCardinality(String),
-        buffer_depth_s Float32,
-        network_bitrate_mbps Float32,
-        video_bitrate_mbps Float32,
-        measured_mbps Float32,
-        mbps_shaper_rate Float32,
-        mbps_shaper_avg Float32,
-        display_resolution LowCardinality(String),
-        video_resolution LowCardinality(String),
-        frames_displayed UInt64 DEFAULT 0,
-        dropped_frames UInt32 DEFAULT 0,
-        stall_count UInt32 DEFAULT 0,
-        stall_time_s Float32,
-        position_s Float32,
-        live_edge_s Float32,
-        true_offset_s Float32,
-        playback_rate Float32,
-        loop_count_player UInt32 DEFAULT 0,
-        loop_count_server UInt32 DEFAULT 0,
-        last_event LowCardinality(String),
-        last_event_at String,
-        trigger_type LowCardinality(String),
-        event_time String,
-        player_error String,
-        avg_network_bitrate_mbps Float32,
-        buffer_end_s Float32,
-        last_stall_time_s Float32,
-        live_offset_s Float32,
-        playhead_wallclock_ms Int64,
-        seekable_end_s Float32,
-        metrics_source LowCardinality(String),
-        video_first_frame_time_s Float32,
-        video_quality_pct Float32,
-        video_start_time_s Float32,
-        mbps_transfer_complete Float32,
-        mbps_transfer_rate Float32,
-        player_ip LowCardinality(String),
-        server_received_at_ms Int64,
-        x_forwarded_port UInt16 DEFAULT 0,
-        x_forwarded_port_external UInt16 DEFAULT 0,
-        master_manifest_url String,
-        master_manifest_failure_type LowCardinality(String),
-        master_manifest_failure_mode LowCardinality(String),
-        master_manifest_failure_frequency Float32,
-        master_manifest_consecutive_failures UInt32 DEFAULT 0,
-        master_manifest_requests_count UInt32 DEFAULT 0,
-        manifest_failure_frequency Float32,
-        manifest_failure_urls String,
-        manifest_consecutive_failures UInt32 DEFAULT 0,
-        manifest_requests_count UInt32 DEFAULT 0,
-        segment_failure_frequency Float32,
-        segment_failure_urls String,
-        segment_consecutive_failures UInt32 DEFAULT 0,
-        segments_count UInt32 DEFAULT 0,
-        all_failure_type LowCardinality(String),
-        all_failure_mode LowCardinality(String),
-        all_failure_frequency Float32,
-        all_failure_urls String,
-        all_consecutive_failures UInt32 DEFAULT 0,
-        transport_failure_frequency Float32,
-        transport_failure_mode LowCardinality(String),
-        transport_failure_units LowCardinality(String),
-        transport_consecutive_failures UInt32 DEFAULT 0,
-        transport_consecutive_seconds Float32,
-        transport_consecutive_units UInt32 DEFAULT 0,
-        transport_frequency_seconds Float32,
-        transport_fault_drop_packets UInt8 DEFAULT 0,
-        transport_fault_reject_packets UInt8 DEFAULT 0,
-        transport_fault_off_seconds Float32,
-        transport_fault_on_seconds Float32,
-        transport_fault_type LowCardinality(String),
-        fault_count_transfer_active_timeout UInt32 DEFAULT 0,
-        fault_count_transfer_idle_timeout UInt32 DEFAULT 0,
-        transfer_active_timeout_seconds Float32,
-        transfer_idle_timeout_seconds Float32,
-        transfer_timeout_applies_manifests UInt8 DEFAULT 0,
-        transfer_timeout_applies_master UInt8 DEFAULT 0,
-        transfer_timeout_applies_segments UInt8 DEFAULT 0,
-        nftables_pattern_step UInt32 DEFAULT 0,
-        nftables_pattern_step_runtime UInt32 DEFAULT 0,
-        nftables_pattern_steps String,
-        nftables_pattern_rate_runtime_mbps Float32,
-        nftables_pattern_margin_pct Float32,
-        nftables_pattern_template_mode LowCardinality(String),
-        content_allowed_variants String,
-        content_live_offset Float32,
-        content_strip_codecs String,
-        abrchar_run_lock UInt8 DEFAULT 0,
-        control_revision UInt64 DEFAULT 0,
-        server_video_rendition LowCardinality(String),
-        server_video_rendition_mbps Float32,
-        manifest_failure_type LowCardinality(String),
-        manifest_failure_mode LowCardinality(String),
-        segment_failure_type LowCardinality(String),
-        segment_failure_mode LowCardinality(String),
-        transport_failure_type LowCardinality(String),
-        transport_fault_active UInt8 DEFAULT 0,
-        nftables_bandwidth_mbps Float32,
-        nftables_delay_ms UInt32 DEFAULT 0,
-        nftables_packet_loss Float32,
-        nftables_pattern_enabled UInt8 DEFAULT 0,
-        first_request_time String,
-        last_request String,
-        session_duration Float32,
-        session_json String CODEC(ZSTD(3))
-    )
-    ENGINE = MergeTree
-    PARTITION BY toYYYYMMDD(ts)
-    ORDER BY (session_id, ts)
-    TTL toDateTime(ts) + INTERVAL 30 DAY;
+#
+# The `analytics-clickhouse-init` ConfigMap is NOT defined inline here.
+# `make analytics-deploy-k3s` generates it from the canonical schema at
+# analytics/clickhouse/init.d/01-schema.sql via:
+#   kubectl create configmap analytics-clickhouse-init \
+#       --from-file=01-schema.sql=analytics/clickhouse/init.d/01-schema.sql \
+#       --dry-run=client -o yaml | kubectl apply -f -
+# This keeps a single source of truth for the schema across compose
+# (which bind-mounts the file into ClickHouse) and k3s. The same
+# Makefile target also re-applies the canonical schema against the
+# running clickhouse-0 pod after rollout, so column-add migrations
+# land on existing clusters even though docker-entrypoint-initdb.d/
+# only runs on first startup.
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -283,6 +164,22 @@ spec:
         # (.local, IP, Tailscale, etc.). See docker-compose.yml note.
         - name: GF_LIVE_ALLOWED_ORIGINS
           value: "*"
+        volumeMounts:
+        # Datasources + dashboards come from ConfigMaps populated by
+        # `make analytics-deploy-k3s` from analytics/grafana/provisioning/.
+        # Same content compose mounts via bind-mount; in k3s we package
+        # it as ConfigMaps so the cluster has its own copy.
+        - name: datasources
+          mountPath: /etc/grafana/provisioning/datasources
+        - name: dashboards
+          mountPath: /etc/grafana/provisioning/dashboards
+      volumes:
+      - name: datasources
+        configMap:
+          name: analytics-grafana-datasources
+      - name: dashboards
+        configMap:
+          name: analytics-grafana-dashboards
 ---
 apiVersion: v1
 kind: Service

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -502,8 +502,11 @@ data:
           defaultDatabase: infinite_streaming
           tlsSkipVerify: true
           username: default
-        secureJsonData:
-          password: ""
+        # secureJsonData.password is intentionally omitted — ClickHouse's
+        # default user has no password (CLICKHOUSE_SKIP_USER_SETUP=1 in
+        # the StatefulSet env below), and Grafana skips the field
+        # upstream when not set. Setting an empty literal here would
+        # trip CodeQL without changing behavior.
         editable: true
 ---
 apiVersion: v1

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -69,6 +69,12 @@ spec:
           value: "9"
         - name: INFINITE_STREAM_TC_DEBUG
           value: "1"
+        # Wire nginx /analytics/api/* and /grafana/* to the analytics
+        # sidecar Services (forwarder, grafana). See #390 for the gating
+        # mechanism. The analytics tier is applied alongside this
+        # deployment by the same `make deploy` target.
+        - name: INFINITE_STREAM_ENABLE_ANALYTICS
+          value: "1"
         # Pairing rendezvous (substituted by envsubst at deploy time).
         - name: INFINITE_STREAM_RENDEZVOUS_URL
           value: "${INFINITE_STREAM_RENDEZVOUS_URL}"

--- a/k8s-infinite-streaming-dev.yaml
+++ b/k8s-infinite-streaming-dev.yaml
@@ -69,12 +69,21 @@ spec:
           value: "9"
         - name: INFINITE_STREAM_TC_DEBUG
           value: "1"
-        # Wire nginx /analytics/api/* and /grafana/* to the analytics
-        # sidecar Services (forwarder, grafana). See #390 for the gating
-        # mechanism. The analytics tier is applied alongside this
-        # deployment by the same `make deploy` target.
+        # Wire nginx /analytics/api/* and /grafana/* to the dev-stack
+        # analytics Services. See #390 for the gating mechanism. Each
+        # stack (dev/release) has its own forwarder + ClickHouse +
+        # Grafana so their archives don't mix.
         - name: INFINITE_STREAM_ENABLE_ANALYTICS
           value: "1"
+        # FQDNs (not bare service names): nginx's runtime `resolver`
+        # directive sends queries with no search-domain expansion, so
+        # CoreDNS only answers for the fully-qualified form. Bare
+        # `forwarder-dev` resolves fine for in-cluster shells (which
+        # walk /etc/resolv.conf's search list) but not for nginx.
+        - name: INFINITE_STREAM_FORWARDER_HOST
+          value: "forwarder-dev.default.svc.cluster.local"
+        - name: INFINITE_STREAM_GRAFANA_HOST
+          value: "grafana-dev.default.svc.cluster.local"
         # Pairing rendezvous (substituted by envsubst at deploy time).
         - name: INFINITE_STREAM_RENDEZVOUS_URL
           value: "${INFINITE_STREAM_RENDEZVOUS_URL}"

--- a/k8s-infinite-streaming.yaml
+++ b/k8s-infinite-streaming.yaml
@@ -61,6 +61,12 @@ spec:
           value: "8"
         - name: INFINITE_STREAM_TC_INTERFACE
           value: "eth0"
+        # Wire nginx /analytics/api/* and /grafana/* to the analytics
+        # sidecar Services (forwarder, grafana). See #390 for the gating
+        # mechanism. The analytics tier is applied alongside this
+        # deployment by the same `make deploy-release` target.
+        - name: INFINITE_STREAM_ENABLE_ANALYTICS
+          value: "1"
         # Pairing rendezvous (substituted by envsubst at deploy time).
         - name: INFINITE_STREAM_RENDEZVOUS_URL
           value: "${INFINITE_STREAM_RENDEZVOUS_URL}"

--- a/k8s-infinite-streaming.yaml
+++ b/k8s-infinite-streaming.yaml
@@ -61,12 +61,21 @@ spec:
           value: "8"
         - name: INFINITE_STREAM_TC_INTERFACE
           value: "eth0"
-        # Wire nginx /analytics/api/* and /grafana/* to the analytics
-        # sidecar Services (forwarder, grafana). See #390 for the gating
-        # mechanism. The analytics tier is applied alongside this
-        # deployment by the same `make deploy-release` target.
+        # Wire nginx /analytics/api/* and /grafana/* to the release-stack
+        # analytics Services. See #390 for the gating mechanism. Each
+        # stack (dev/release) has its own forwarder + ClickHouse +
+        # Grafana so their archives don't mix.
         - name: INFINITE_STREAM_ENABLE_ANALYTICS
           value: "1"
+        # FQDNs (not bare service names): nginx's runtime `resolver`
+        # directive sends queries with no search-domain expansion, so
+        # CoreDNS only answers for the fully-qualified form. Bare
+        # `forwarder-release` resolves fine for in-cluster shells (which
+        # walk /etc/resolv.conf's search list) but not for nginx.
+        - name: INFINITE_STREAM_FORWARDER_HOST
+          value: "forwarder-release.default.svc.cluster.local"
+        - name: INFINITE_STREAM_GRAFANA_HOST
+          value: "grafana-release.default.svc.cluster.local"
         # Pairing rendezvous (substituted by envsubst at deploy time).
         - name: INFINITE_STREAM_RENDEZVOUS_URL
           value: "${INFINITE_STREAM_RENDEZVOUS_URL}"


### PR DESCRIPTION
## Why

Three problems on lenovo, each downstream of the previous:

1. **Main image crash-looped on k3s** with `nginx: [emerg] host not found in upstream "forwarder:8080"`. nginx resolved `upstream {}` hostnames at config-load time and refused to boot when any were unresolvable. CLAUDE.md says the live streaming path is independent of the sidecar — nginx was making it a hard dependency.
2. **Dashboard's session-archive features 404'd** even after the main image stayed up, because the analytics tier itself was never deployed to lenovo.
3. **Dev and release sessions would have mixed** in a single ClickHouse/forwarder/Grafana — per user direction, "nothing should be shared between the dev and release images".

This PR ships the full lenovo fix.

## Layered fixes

**1. Standalone-image contract** — extract analytics location blocks into `docker/nginx-analytics.conf.template`, glob-included via `include /etc/nginx/snippets/analytics-*.conf;`. `launch.sh` writes the snippet only when `INFINITE_STREAM_ENABLE_ANALYTICS=1`; otherwise the glob matches zero files cleanly and analytics routes 404. Compose sets the env var to `1`.

**2. Runtime DNS resolver** — when analytics IS on, the snippet uses `resolver` + variable-based `proxy_pass` so DNS happens per-request. A missing/transient forwarder yields a per-request 502 instead of taking down nginx at startup. `launch.sh` extracts the first nameserver from `/etc/resolv.conf` so this works in compose (Docker DNS at 127.0.0.11) and k3s (CoreDNS) without per-environment overrides.

**3. Per-stack analytics on k3s** — `k8s-analytics.yaml` is now parametrized by `${ANALYTICS_STACK}`; each `make deploy` (dev) and `make deploy-release` (release) applies the manifest with its own stack identifier. Dev gets `clickhouse-dev`/`forwarder-dev`/`grafana-dev`; release gets the `-release` suffix. Separate pods, Services, PVCs, Grafana state. The manifest is fully self-contained — schemas (ClickHouse + Grafana datasources + dashboards) inlined as ConfigMaps so `kubectl apply -f` is enough. No Makefile glue for ConfigMap generation, no post-deploy migration.

**4. Teardown targets** — `make teardown-k3s-dev` and `make teardown-k3s-release` wipe a single stack (analytics + main app + PVC) so the other can be exercised in isolation, or so a clean reinstall starts from empty.

## Bug fixes exposed by exercising the path end-to-end

- nginx `set $var` must come BEFORE `rewrite ... break;` — `break` halts the rewrite-module phase, and `set` is also rewrite-module. Wrong order leaves the variable uninitialized, → 500.
- nginx's runtime `resolver` doesn't honor `/etc/resolv.conf` search domains. Main app manifests now use fully-qualified `forwarder-${stack}.default.svc.cluster.local`.
- Dev's go-proxy is reachable in-cluster via the dev Service at port 40081 (the NodePort's `port` value), not 30081 directly. Forwarder-dev's SSE source URL corrected.
- Latent k3s issue once nginx stopped crashing first: `launch.sh` now `mkdir -p /media/logs /media/data $INFINITE_STREAM_OUTPUT_DIR` so a fresh PVC doesn't break the nginx access/error_log directives. Same pattern as #343 / #372.

## Files

- `docker/nginx-content.conf.template` — drop analytics `upstream {}` + `location` blocks; replace with `include /etc/nginx/snippets/analytics-*.conf;`.
- `docker/nginx-analytics.conf.template` — **new** — analytics fragment with `resolver` + variable proxy_pass, `set` before `rewrite`.
- `docker/launch.sh` — `INFINITE_STREAM_ENABLE_ANALYTICS` gate, DNS resolver detection, `/media/logs` mkdir.
- `Dockerfile` — `COPY docker/nginx-analytics.conf.template /etc/nginx/snippets/`.
- `docker-compose.yml` — `INFINITE_STREAM_ENABLE_ANALYTICS=1`.
- `Makefile` — new targets `analytics-build-forwarder-k3s`, `analytics-deploy-k3s`, `teardown-k3s-dev`, `teardown-k3s-release`. `deploy:` and `deploy-release:` set their stack via target-specific variables.
- `k8s-analytics.yaml` — parametrized by `${ANALYTICS_STACK}`; schemas + Grafana provisioning inlined.
- `k8s-infinite-streaming.yaml` + `k8s-infinite-streaming-dev.yaml` — `INFINITE_STREAM_ENABLE_ANALYTICS=1`, FQDN forwarder/grafana hosts.

## Test plan (verified on lenovo)

- [x] `nginx -t` passes inside the container in **both** modes (analytics on and off).
- [x] All 8 pods 1/1 Running: `clickhouse-{dev,release}`, `forwarder-{dev,release}`, `grafana-{dev,release}`, `infinite-streaming{,-dev}`.
- [x] `/analytics/api/sessions` returns **HTTP 200** on both stacks (was 502 → 404 → 500 before this PR series).
- [x] Stacks are independent: dev's forwarder writes to `clickhouse-dev`, release's writes to `clickhouse-release`.
- [x] `make teardown-k3s-dev` removes only dev resources; release stays up.
- [ ] `/grafana/` end-to-end dashboard render — left for spot-check.

Closes #390. Folded #392 into this PR per direction.