### PR TITLE
chore: analytics in every install path + drop test-deploy-run + doc cleanup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,3 +83,47 @@ jobs:
             ${{ steps.meta-server-dh.outputs.tags }}
           labels: ${{ steps.meta-server-ghcr.outputs.labels }}
 
+      # ── Forwarder image ────────────────────────────────────────────────
+      # Published alongside the main image so `make run-ghcr` and the
+      # docker-compose.ghcr.yml install path can pull a complete analytics
+      # stack from GHCR without a source checkout. The forwarder is
+      # cluster-/install-agnostic; the same image works for compose, k3d,
+      # and the various test-deploy variants.
+
+      - name: Extract metadata (forwarder, GHCR)
+        id: meta-forwarder-ghcr
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}-forwarder
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+
+      - name: Extract metadata (forwarder, Docker Hub)
+        if: ${{ vars.DOCKERHUB_NAMESPACE != '' }}
+        id: meta-forwarder-dh
+        uses: docker/metadata-action@v6
+        with:
+          images: docker.io/${{ vars.DOCKERHUB_NAMESPACE }}/infinite-streaming-forwarder
+          tags: |
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+
+      - name: Build and push forwarder
+        uses: docker/build-push-action@v7
+        with:
+          context: ./analytics/go-forwarder
+          push: true
+          tags: |
+            ${{ steps.meta-forwarder-ghcr.outputs.tags }}
+            ${{ steps.meta-forwarder-dh.outputs.tags }}
+          labels: ${{ steps.meta-forwarder-ghcr.outputs.labels }}
+

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,7 @@ export
 
 
 K3S_SSH_HOST ?= user@your-k3s-host
-K3S_KUBECONFIG ?= /home/user/.kube/config
 GO_SERVER_IMAGE ?= ghcr.io/jonathaneoliver/infinite-streaming:latest
-K8S_MANIFESTS ?= k8s-infinite-streaming.yaml
-K8S_DEPLOYMENT ?= infinite-streaming
 IOS_SIM_DEVICE ?= iPad Pro 13-inch (M5)
 IOS_APP_BUNDLE_ID ?= com.jeoliver.InfiniteStreamPlayer
 IOS_API_BASE ?= http://$(K3S_HOST):40000
@@ -304,7 +301,7 @@ test-go:
 	@echo "=== go-upload ==="
 	cd go-upload && go vet ./... && go test -race ./...
 
-test-deploy-all: test-deploy-compose test-deploy-run test-deploy-ghcr test-deploy-registry
+test-deploy-all: test-deploy-compose test-deploy-ghcr test-deploy-registry
 
 test-deploy-dev:
 	@echo "=== Dev: local working tree (port 21000) ==="
@@ -385,7 +382,7 @@ test-clean-dev:
 	ssh $(TEST_SSH) 'docker rm -f test-dev-server 2>/dev/null'
 
 test-clean:
-	ssh $(TEST_SSH) 'docker rm -f test-dev-server test-compose-server test-docker-run test-ghcr-server test-registry-server test-oobe-server 2>/dev/null; docker network prune -f 2>/dev/null'
+	ssh $(TEST_SSH) 'docker rm -f test-dev-server test-compose-server test-ghcr-server test-registry-server test-oobe-server 2>/dev/null; docker network prune -f 2>/dev/null'
 
 test-status:
 	@ssh $(TEST_SSH) 'for p in 21000 22000 23000 24000 25000 26000; do \
@@ -464,16 +461,12 @@ test-deploy-compose:
 	scp tests/deploy/override-compose.yml $(TEST_SSH):~/test-compose/docker-compose.override.yml
 	ssh $(TEST_SSH) 'cd ~/test-compose && docker compose build && docker compose up -d'
 
-test-deploy-run:
-	@echo "=== Option 2: Docker run (port 23000) ==="
-	ssh $(TEST_SSH) 'docker rm -f test-docker-run 2>/dev/null; \
-		docker run -d --name test-docker-run --cap-add NET_ADMIN --privileged \
-		-p 23000:30000 -p 23081:30081 -p 23181:30181 -p 23281:30281 -p 23381:30381 -p 23481:30481 \
-		-p 23581:30581 -p 23681:30681 -p 23781:30781 -p 23881:30881 \
-		-e INFINITE_STREAM_RENDEZVOUS_URL=$(INFINITE_STREAM_RENDEZVOUS_URL) \
-		-e INFINITE_STREAM_ANNOUNCE_URL=http://$(TEST_HOST):23000 \
-		-v $(TEST_MEDIA_DIR):/media \
-		infinite-streaming:latest /sbin/launch.sh 1'
+# `test-deploy-run` (the bare `docker run` of a single container)
+# was removed in #394 — the install method it tested can't support
+# analytics by definition (one image, no sidecars), and analytics is
+# now a baseline expectation in every deploy path. The
+# `test-deploy-{compose,ghcr,registry}` variants cover the actual
+# install methods documented in the README.
 
 test-deploy-ghcr:
 	@echo "=== Option 3: GHCR pre-built (port 24000) ==="

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ From there, **Playback** plays the same clip standalone, **Testing Session** ope
 
 Skipping the seed and uploading your own files via **Open Upload** or by dropping MP4s into `$CONTENT_DIR/originals/` works identically — the seed clip is just a zero-friction "Hello, World" that exercises the full pipeline against content the server generates itself.
 
-Other deployment options (pre-built images, single container, k3s) are in [Advanced deployment](#advanced-deployment) at the bottom.
+Other deployment options (pre-built images from GHCR, k3d clusters) are in [Other ways to run it](#other-ways-to-run-it) at the bottom.
 
 ---
 
@@ -342,7 +342,7 @@ A sidecar stack (ClickHouse + Grafana + a small Go forwarder) auto-archives sess
 
 **Operating it**: `make analytics-rebuild-forwarder` recreates the forwarder container in-place (live UI untouched); `make analytics-update` reloads Grafana provisioning; `make analytics-migrate SQL='ALTER TABLE …'` runs a schema change. The data is exposed read-only to the dashboard via parameterized ClickHouse queries — no string interpolation, no auth-token leakage.
 
-**Securing for WAN deployment**: opt-in HTTP Basic auth via `INFINITE_STREAM_AUTH_HTPASSWD` gates the dashboard, `/analytics/api/`, and `/grafana/`; player-app endpoints stay public so unattended Apple/Roku/AndroidTV clients keep working. ClickHouse binds to `127.0.0.1` only by default. See [`analytics/README.md`](analytics/README.md) for the docker-compose and k3s runbooks.
+**Securing for WAN deployment**: opt-in HTTP Basic auth via `INFINITE_STREAM_AUTH_HTPASSWD` gates the dashboard, `/analytics/api/`, and `/grafana/`; player-app endpoints stay public so unattended Apple/Roku/AndroidTV clients keep working. ClickHouse binds to `127.0.0.1` only by default. See [`analytics/README.md`](analytics/README.md) for the docker-compose and k3d runbooks.
 
 The two pages downstream of this stack — **Sessions view** (the picker) and **Session Viewer** (replay one) — are described in their own sections below.
 
@@ -694,7 +694,7 @@ That's it — no third-party services beyond a Cloudflare account.
 | `INFINITE_STREAM_RENDEZVOUS_URL` | Rendezvous Worker base URL. Required to enable any pairing. |
 | `INFINITE_STREAM_ANNOUNCE_URL` | URL that clients should use to reach this server (e.g. `http://lenovo.local:30000`). When set, this server appears in same-WAN auto-discovery. |
 | `INFINITE_STREAM_ANNOUNCE_LABEL` | Optional friendly label. Defaults to `host:port` from the announce URL. |
-| `INFINITE_STREAM_SERVER_ID` | Optional explicit announce ID (4–64 chars `[A-Za-z0-9_-]`). Defaults to a stable random ID persisted at `<data_dir>/server_id`. Set this when multiple deployments share the same data directory (e.g. dev + release pods on the same k3s node), otherwise their announces overwrite each other on the rendezvous. |
+| `INFINITE_STREAM_SERVER_ID` | Optional explicit announce ID (4–64 chars `[A-Za-z0-9_-]`). Defaults to a stable random ID persisted at `<data_dir>/server_id`. Set this when multiple deployments share the same data directory (e.g. dev + release pods on the same k3d host), otherwise their announces overwrite each other on the rendezvous. |
 
 ### HTTP, HTTPS, and iOS App Transport Security
 
@@ -709,7 +709,7 @@ The server defaults to plain HTTP on its dashboard / API / playback ports. That'
 
 The iOS/tvOS Info.plist files in this repo include an explicit `NSExceptionDomains` entry for `infinitestreaming.jeoliver.com` (the upstream maintainer's public domain). **If you fork and ship apps that talk to a different public-HTTP hostname** (your own server, a Tailscale MagicDNS name like `*.ts.net`, a Tailscale CGNAT IP in `100.64.0.0/10`, etc.) you must add it to both Info.plists or those clients will silently fail to load anything.
 
-The cleaner long-term answer is to terminate TLS at the server so all clients use HTTPS and no per-domain ATS / cleartext exceptions are needed. The k3s manifests already mount a `certs-vol` for this; flipping the nginx template to `listen … ssl` and pointing it at a Let's Encrypt cert (or whichever cert lives in `K3S_CERTS_DIR`) gets you there.
+The cleaner long-term answer is to terminate TLS at the server so all clients use HTTPS and no per-domain ATS / cleartext exceptions are needed. The k3d manifests already mount a `certs-vol` for this; flipping the nginx template to `listen … ssl` and pointing it at a Let's Encrypt cert (or whichever cert lives in `K3S_CERTS_DIR`) gets you there.
 
 ---
 
@@ -717,39 +717,34 @@ The cleaner long-term answer is to terminate TLS at the server so all clients us
 
 Most users should stick with Docker Compose from the [Quick start](#quick-start). These variants are for specific scenarios.
 
-### Docker run (single container, no compose)
-
-```bash
-export CONTENT_DIR=/path/to/your/media
-
-docker run -d --name infinite-streaming \
-  --cap-add NET_ADMIN --privileged \
-  -p 30000:30000 \
-  -p 30081:30081 \
-  -p 30181:30181 -p 30281:30281 -p 30381:30381 -p 30481:30481 \
-  -p 30581:30581 -p 30681:30681 -p 30781:30781 -p 30881:30881 \
-  -v $CONTENT_DIR:/media \
-  ghcr.io/jonathaneoliver/infinite-streaming:latest \
-  /sbin/launch.sh 1
-```
-
-Ports 30181–30881 are the per-session proxy ports that testing sessions get redirected to. Without mapping them, `testing-session.html` works but segments never load because the allocated session port is unreachable from the host.
-
 > **macOS / Docker Desktop note:** Network shaping (TC/nftables) works on Docker Desktop for Mac with `--cap-add NET_ADMIN`, but the TC stats polling (every 100ms per session) spawns processes through the Linux VM layer, which causes significantly higher CPU usage and fan noise compared to native Linux. This is a Docker Desktop VM overhead issue, not a code issue. For sustained testing with shaping, use a native Linux host.
 
 ### Pre-built images from GHCR (no source checkout)
 
+The compose file pulls `infinite-streaming` and `infinite-streaming-forwarder` from GHCR. ClickHouse and Grafana provisioning files are tiny (~30 KB) so the install grabs them via a tarball alongside the compose file:
+
 ```bash
 mkdir infinite-streaming && cd infinite-streaming
+
+# Compose file
 curl -fsSL https://raw.githubusercontent.com/jonathaneoliver/infinite-streaming/main/docker-compose.ghcr.yml \
   -o docker-compose.yml
+
+# Analytics provisioning (ClickHouse schema + Grafana datasources/dashboards)
+mkdir -p analytics
+curl -fsSL https://github.com/jonathaneoliver/infinite-streaming/archive/main.tar.gz | \
+  tar -xzC . --strip-components=1 \
+    infinite-streaming-main/analytics
+
 echo "CONTENT_DIR=/path/to/your/media" > .env
 docker compose up -d
 ```
 
-### k3s, release tagging, GHCR publishing
+Open `http://localhost:30000/`. The dashboard's Sessions / Session Viewer / Grafana features all work in this mode (analytics tier comes up alongside the main image — see [Analytics tier](#analytics-tier)).
 
-See [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for running in a k3s cluster (release + dev side by side), pinning immutable release tags, and configuring GHCR publishing from a fork.
+### k3d, release tagging, GHCR publishing
+
+See [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) for running in two side-by-side k3d clusters (release + dev), pinning immutable release tags, and configuring GHCR publishing from a fork.
 
 ---
 
@@ -773,7 +768,7 @@ Captured from the live dashboard; files live in [`docs/screenshots/`](docs/scree
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — services, routing, port map, request flow
 - [`docs/API.md`](docs/API.md) — HTTP endpoints across go-live, go-upload, go-proxy
 - [`docs/FAULT_INJECTION.md`](docs/FAULT_INJECTION.md) — full fault and shaping reference
-- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) — k3s, release tagging, GHCR publishing
+- [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md) — k3d, release tagging, GHCR publishing
 - [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) — common issues and fixes
 - [`PRD.md`](PRD.md) — product behavior source of truth
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — development workflow

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -37,11 +37,15 @@ Then:
 - Grafana dashboard: <http://localhost:30300/d/is-session-analytics>
 - Replay a session: <http://localhost:30000/testing.html?replay=1&session=SESSION_ID>
 
-## k3s
+## k3d
 
-Apply `k8s-analytics.yaml` alongside the main deployment. Set
-`ANALYTICS_SSE_URL` (default `http://infinite-streaming-dev:30081/api/sessions/stream`)
-and `ANALYTICS_GRAFANA_NODEPORT`.
+`make deploy` and `make deploy-release` apply `k8s-analytics.yaml`
+into the matching k3d cluster automatically — one analytics tier per
+cluster (each cluster has its own ClickHouse PVC, forwarder, and
+Grafana). The forwarder's SSE source is the same in-cluster URL in
+both clusters (`http://infinite-streaming:30081/api/sessions/stream`)
+because each cluster has exactly one `infinite-streaming` Service at
+NodePort 30081.
 
 ## Replay mode
 
@@ -104,18 +108,23 @@ When `INFINITE_STREAM_AUTH_HTPASSWD` is unset (the default), auth is
 disabled — same behaviour as before. With it set, the dashboard pages,
 `/analytics/api/*`, and `/grafana/*` all return 401 without credentials.
 
-### k3s deployment (lenovo)
+### k3d deployment (lenovo)
+
+Both clusters use the same Deployment name (`infinite-streaming`); pick the right kubeconfig per cluster.
 
 ```sh
+# Pick a cluster (dev or release)
+export KUBECONFIG=~/.config/k3d/smashing-release-kubeconfig.yaml
+# (or smashing-dev-kubeconfig.yaml for the dev cluster)
+
 # Generate htpasswd
 docker run --rm httpd:alpine htpasswd -nbB myuser 'mypass' > /tmp/htpasswd
 
-# Create a Secret holding the file
+# Create a Secret holding the file (per-cluster)
 kubectl create secret generic infinite-streaming-auth \
   --from-file=htpasswd=/tmp/htpasswd
 
-# Patch the deployment (use `infinite-streaming` for release,
-# `infinite-streaming-dev` for the dev stack)
+# Patch the deployment (same name in both clusters)
 kubectl patch deployment infinite-streaming --patch '
 spec:
   template:
@@ -143,7 +152,7 @@ curl -s -o /dev/null -w '%{http_code}\n' -u myuser:mypass http://lenovo.local:30
 # → 200
 ```
 
-Rotate the password by re-creating the secret and restarting the rollout:
+Rotate the password by re-creating the secret and restarting the rollout (in the same cluster context):
 
 ```sh
 docker run --rm httpd:alpine htpasswd -nbB myuser 'newpass' > /tmp/htpasswd

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -36,12 +36,82 @@ services:
       - INFINITE_STREAM_UPSTREAM_PORT=30000
       - INFINITE_STREAM_MAX_SESSIONS=8
       - INFINITE_STREAM_TC_INTERFACE=eth0
+      # Wire nginx /analytics/api/* and /grafana/* to the analytics
+      # sidecar services below. Same gating pattern as base compose;
+      # missing/down sidecar yields a 502 from nginx, not a startup
+      # crash (#390).
+      - INFINITE_STREAM_ENABLE_ANALYTICS=1
+      - INFINITE_STREAM_FORWARDER_HOST=forwarder
+      - INFINITE_STREAM_GRAFANA_HOST=grafana
     tmpfs:
       - /go-live:size=4G,mode=755
     networks:
       - app_network
+    depends_on:
+      - clickhouse
+      - forwarder
+      - grafana
     restart: unless-stopped
     stop_grace_period: 1s
+
+  # ── Analytics sidecar (parity with base docker-compose.yml) ──────────
+  # Same shape as the source-build path — only the images come from
+  # GHCR instead of being built locally. ClickHouse + Grafana are
+  # upstream public images either way.
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    container_name: infinite-streaming-clickhouse
+    environment:
+      - CLICKHOUSE_DB=infinite_streaming
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+    # Loopback-only — same posture as base compose. Internal services
+    # reach it via the bridge network; ad-hoc curl from the host uses
+    # 127.0.0.1:30123. Never exposed on the LAN by default.
+    ports:
+      - "127.0.0.1:30123:8123"
+    volumes:
+      - ${CONTENT_DIR:-./sample-content}/analytics:/var/lib/clickhouse
+      - ./analytics/clickhouse/init.d:/docker-entrypoint-initdb.d:ro
+    networks:
+      - app_network
+    restart: unless-stopped
+
+  forwarder:
+    image: ghcr.io/jonathaneoliver/infinite-streaming-forwarder:latest
+    container_name: infinite-streaming-forwarder
+    environment:
+      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_snapshots
+    volumes:
+      - ${CONTENT_DIR:-./sample-content}/logs:/media/logs
+    networks:
+      - app_network
+    depends_on:
+      - clickhouse
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana-oss:11.3.0
+    container_name: infinite-streaming-grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - GF_SERVER_ROOT_URL=http://localhost:30000/grafana/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_LIVE_ALLOWED_ORIGINS=*
+    # No host port — reach Grafana through nginx at /grafana/ where
+    # opt-in basic auth applies uniformly (see CLAUDE.md WAN runbook).
+    volumes:
+      - ./analytics/grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - app_network
+    restart: unless-stopped
 
 networks:
   app_network:

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 The dashboard is a thin client over this API. Every fault-injection action, every shaping change, every session control the UI exposes is available here — so anything you can do in the browser, a test script or CI job can do too. There are no UI-only controls.
 
-All endpoints are exposed through nginx on port `30000` (Docker Compose and k3s release) or `40000` (k3s dev). nginx routes them to the backing service based on path.
+All endpoints are exposed through nginx on port `30000` (Docker Compose and k3d release) or `40000` (k3d dev). nginx routes them to the backing service based on path.
 
 For the **fault-injection** surface (`/api/session/*` patch payloads, `/api/nftables/*` shaping), see [`docs/FAULT_INJECTION.md`](FAULT_INJECTION.md) — this page only summarises those endpoints and points to the full reference.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,15 +64,15 @@ Manifest responses carry `no-cache, no-store, must-revalidate`. Segments are imm
 
 The testing dashboard gives each browser session a dedicated `go-proxy` port. When the player loads `testing-session.html?player_id=<uuid>`, the proxy allocates the session a port in `30181..30881` (internal) — the browser talks to that port for stream requests, not the shared `30081`. All failure injection and traffic shaping applied to that session are scoped to its port.
 
-Internal / external port mapping for k3s:
+Internal / external port mapping:
 
 | Environment | External UI | External session ports | Internal |
 |---|---|---|---|
 | Docker Compose | 30000 | 30181..30881 | same |
-| k3s release | 30000 | 30181..30881 | same |
-| k3s dev | 40000 | 40181..40881 | 30181..30881 |
+| k3d release | 30000 | 30181..30881 | same |
+| k3d dev | 40000 | 40181..40881 | 30181..30881 |
 
-go-proxy maps external → internal using `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, and `PORT_RANGE_COUNT` env vars so dev and release can coexist on one host.
+For k3d, the cluster's `--port` flag does the host→cluster remapping (e.g. host `:40081` → in-cluster NodePort `:30081` for the dev cluster). Inside both clusters the Service NodePorts are stable (30000-30881); the host-port mismatch is purely an external-port concern. go-proxy reads `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, and `PORT_RANGE_COUNT` env vars so the per-session URLs it advertises to clients use the right host port for the cluster's external mapping.
 
 See [`docs/FAULT_INJECTION.md`](FAULT_INJECTION.md) for what go-proxy can do to a session; [`docs/API.md`](API.md) for the full endpoint surface.
 
@@ -135,8 +135,8 @@ Global selection (content, URL, protocol, codec, segment) is kept in `localStora
 | Mode | How | UI | Notes |
 |---|---|---|---|
 | Docker Compose | `make run` or `docker compose up -d` | `localhost:30000` | Simplest, single-host |
-| k3s release | `make deploy-release` | `$K3S_HOST:30000` | 30x port range |
-| k3s dev | `make deploy` | `$K3S_HOST:40000` | 40x port range, coexists with release |
+| k3d release | `make deploy-release` | `$K3S_HOST:30000` | Independent k3d cluster, api `:6544`, 30x port range |
+| k3d dev | `make deploy` | `$K3S_HOST:40000` | Independent k3d cluster, api `:6543`, 40x port range — coexists with release |
 | GHCR compose | Pull `ghcr.io/jonathaneoliver/infinite-streaming:<tag>` | `localhost:30000` | No local build |
 
 All modes mount the same content layout. See [`README.md`](../README.md#quick-start) for commands and [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for common operational issues.
@@ -145,7 +145,7 @@ All modes mount the same content layout. See [`README.md`](../README.md#quick-st
 
 The native client apps (iOS/tvOS, Android TV, Roku) need a way to *find* the server URL on first launch — they can't ship hardcoded addresses. InfiniteStream uses a small **Cloudflare Worker + KV** acting as a public rendezvous, plus a server-side announce loop that publishes its URL there. Clients query the rendezvous and only see servers that share their public IP (the rendezvous filters by `CF-Connecting-IP`), giving same-WAN auto-discovery without LAN multicast.
 
-> **Why not mDNS / Bonjour?** This was the first thing we tried (`_infinitestream._tcp` advertised via `github.com/grandcat/zeroconf` from `go-upload`). Docker's default bridge network filters multicast, so the advertisement never escapes the container — `dns-sd -B` on the host found nothing. Host-network mode is fragile across Linux/macOS/Windows and isn't available on every deployment target (k3s, Docker Desktop). The Cloudflare same-public-IP check delivers the same "servers on my network" semantics without needing multicast to survive the container boundary, so the mDNS advertiser was removed.
+> **Why not mDNS / Bonjour?** This was the first thing we tried (`_infinitestream._tcp` advertised via `github.com/grandcat/zeroconf` from `go-upload`). Docker's default bridge network filters multicast, so the advertisement never escapes the container — `dns-sd -B` on the host found nothing. Host-network mode is fragile across Linux/macOS/Windows and isn't available on every deployment target (k3d, Docker Desktop). The Cloudflare same-public-IP check delivers the same "servers on my network" semantics without needing multicast to survive the container boundary, so the mDNS advertiser was removed.
 
 ```
                                     Cloudflare Worker
@@ -179,8 +179,8 @@ The native client apps (iOS/tvOS, Android TV, Roku) need a way to *find* the ser
 
 **Same-WAN check.** The rendezvous derives a stable hash from `CF-Connecting-IP`; entries are stored under `announce:<ip-hash>:<server_id>`. A `GET /announce` from the client only lists entries with the caller's same IP hash, so the discovery list is automatically scoped to "servers visible from your public IP". Code-based pairing uses the same check (different public IP → 403, with `RENDEZVOUS_ALLOW_CROSS_NETWORK=1` to opt out).
 
-**Distinct `server_id` per deployment.** Multiple deployments sharing a data directory (typical of dev + release pods on the same k3s host that both mount `/media`) end up with the same persisted `<data_dir>/server_id` and overwrite each other on the rendezvous. Set `INFINITE_STREAM_SERVER_ID` explicitly per deployment (e.g. `infinite-streaming-dev` / `infinite-streaming-release`) to make them appear as independent entries in the announce list.
+**Distinct `server_id` per deployment.** Multiple deployments sharing a data directory (typical of dev + release k3d clusters on the same host that both mount `/media`) end up with the same persisted `<data_dir>/server_id` and overwrite each other on the rendezvous. Set `INFINITE_STREAM_SERVER_ID` explicitly per deployment (e.g. `infinite-streaming-dev` / `infinite-streaming-release`) to make them appear as independent entries in the announce list.
 
-**Cleartext HTTP and ATS.** The server defaults to plain HTTP on every listening port. iOS/tvOS' App Transport Security blocks plain HTTP to public hostnames unless the domain is in the app's `NSExceptionDomains`; the iOS/tvOS Info.plists in this repo include an exception for `infinitestreaming.jeoliver.com` so the upstream public deployment is reachable. Forks that ship apps pointing at a different public-HTTP host need to add their own exception (or — better — terminate TLS at the server so HTTPS works without exceptions; the `certs-vol` mount in the k3s manifests is the hook for that). Android has `usesCleartextTraffic="true"` so it isn't affected.
+**Cleartext HTTP and ATS.** The server defaults to plain HTTP on every listening port. iOS/tvOS' App Transport Security blocks plain HTTP to public hostnames unless the domain is in the app's `NSExceptionDomains`; the iOS/tvOS Info.plists in this repo include an exception for `infinitestreaming.jeoliver.com` so the upstream public deployment is reachable. Forks that ship apps pointing at a different public-HTTP host need to add their own exception (or — better — terminate TLS at the server so HTTPS works without exceptions; the `certs-vol` mount in the k3d manifests is the hook for that). Android has `usesCleartextTraffic="true"` so it isn't affected.
 
 See the [Server discovery section in the README](../README.md#server-discovery) for the user-facing summary.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,36 +1,56 @@
 # Deployment
 
-For the standard development / local-use path, Docker Compose (covered in the [README Quick Start](../README.md#quick-start)) is all you need. This page covers the less common paths: running in k3s, side-by-side release and dev stacks, pinning release tags, and publishing images from your own fork.
+For the standard development / local-use path, Docker Compose (covered in the [README Quick Start](../README.md#quick-start)) is all you need. This page covers the less common paths: running in two side-by-side **k3d** clusters (release + dev), pinning immutable release tags, and publishing images from your own fork.
 
-## k3s: release and dev side by side
+## k3d: release and dev as separate clusters
 
-Two manifests, two NodePort ranges, two image tags — so you can run a stable release stack and an active dev stack on the same cluster without conflicts.
+Two independent k3d clusters on the same host — separate kubeconfigs, separate Service namespaces, separate ClickHouse PVCs, separate Grafana state. Stack identity is the cluster context, not a name suffix; one stray `kubectl apply` can't hit the wrong stack.
 
-| Stack | UI | Session ports | Image tag | Manifest | `make` target |
-|---|---|---|---|---|---|
-| Release | `$K3S_HOST:30000` | 30081 (base) + 30181–30881 | `:latest` or pinned | `k8s-infinite-streaming.yaml` | `make deploy-release` |
-| Dev | `$K3S_HOST:40000` | 40081 (base) + 40181–40881 | `:dev` | `k8s-infinite-streaming-dev.yaml` | `make deploy` |
+| Stack | UI | Session ports | API | Image tag | Cluster | `make` target |
+|---|---|---|---|---|---|---|
+| Release | `$K3S_HOST:30000` | 30081 + 30181–30881 | `:6544` | `:latest` or pinned | `release` | `make deploy-release` |
+| Dev | `$K3S_HOST:40000` | 40081 + 40181–40881 | `:6543` | `:dev` | `dev` | `make deploy` |
 
-Configure `.env` with cluster details before deploying:
+Both clusters share the host's local Docker registry (`$K3S_REGISTRY`, HTTP-only — wired via `--registry-config`), and mount the host's `$K3S_MEDIA_DIR` and `$K3S_CERTS_DIR` paths via `--volume`. Per-cluster kubeconfigs are written to `~/.config/k3d/smashing-{dev,release}-kubeconfig.yaml` on the remote host.
+
+### Configure `.env`
 
 ```
-K3S_HOST=<cluster-host>
-K3S_SSH_HOST=user@<cluster-host>
-K3S_REGISTRY=<registry-host:port>      # if using a local registry
-K3S_KUBECONFIG=<path on K3S_SSH_HOST>
+K3S_HOST=<cluster-host>                # bare hostname, used in announce URLs
+K3S_SSH_HOST=user@<cluster-host>       # SSH target for kubectl
+K3S_REGISTRY=<registry-host:port>      # local Docker registry, HTTP
+K3S_MEDIA_DIR=<host path mounted as /media in pods>
+K3S_CERTS_DIR=<host path with localhost.pem/-key.pem>
 ```
 
-Deploy:
+### Bootstrap the clusters (once)
 
 ```bash
-# dev stack
+make k3d-bootstrap
+```
+
+This installs k3d into `~/.local/bin` on `$K3S_SSH_HOST` (no sudo), writes `~/.config/k3d/smashing-registries.yaml` so both clusters can pull from the local HTTP registry, then creates the two clusters with the right host-port mappings, volume mounts, and per-cluster kubeconfigs. Idempotent — re-running is a no-op once both clusters exist.
+
+### Deploy
+
+```bash
+# dev cluster: builds + pushes :dev, applies main app + analytics tier
 make deploy
 
-# release stack (uses K3S_SERVER_IMAGE / K3S_PROXY_IMAGE)
+# release cluster: builds + pushes the release tag, applies main app + analytics tier
 make deploy-release
 ```
 
-go-proxy maps external NodePorts to internal container ports using `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, and `PORT_RANGE_COUNT` env vars in the manifest — that's how release and dev coexist.
+Each `make deploy[-release]` invocation also builds and pushes the analytics forwarder image, applies `k8s-analytics.yaml` (ClickHouse + forwarder + Grafana with inlined schema and Grafana provisioning), and waits for rollout. The single `k8s-infinite-streaming.yaml.tmpl` template renders identically into both clusters; per-stack identity comes from envsubst placeholders (`SERVER_ID`, `ANNOUNCE_URL`, `EXTERNAL_PORT_BASE`) bound by the `make` target.
+
+### Tear down a single cluster
+
+```bash
+make teardown-dev       # k3d cluster delete dev
+make teardown-release   # k3d cluster delete release
+```
+
+Wipes the cluster entirely (analytics + main app + PVC + node containers) so a subsequent `make deploy[-release]` starts clean. The other cluster is untouched.
 
 ## Release tagging
 
@@ -42,29 +62,32 @@ Suggested flow:
    ```bash
    git tag v1.2.3 && git push origin v1.2.3
    ```
-2. Build and push images with that tag:
-   ```bash
-   make build-push-k3s K3S_SERVER_IMAGE=$K3S_REGISTRY/infinite-streaming:v1.2.3
-   ```
-3. Deploy the release pinned to that tag:
+2. The `docker-publish` GitHub Actions workflow publishes to GHCR on tag pushes:
+   - `ghcr.io/<owner>/infinite-streaming:v1.2.3`
+   - `ghcr.io/<owner>/infinite-streaming-forwarder:v1.2.3`
+3. Deploy the release cluster pinned to that tag:
    ```bash
    make deploy-release K3S_SERVER_IMAGE=$K3S_REGISTRY/infinite-streaming:v1.2.3
    ```
 
+`:latest` continues to point at the most recent `main` build; `:v1.2.3` is immutable.
+
 ## GHCR publishing (for forks)
 
-A GitHub Actions workflow builds and publishes to GHCR on pushes to `main`. Tags produced:
+The `docker-publish` GitHub Actions workflow builds and publishes both `infinite-streaming` (main image) and `infinite-streaming-forwarder` (analytics SSE→ClickHouse forwarder) to GHCR on every push to `main` and on tag pushes. Tags produced per image:
 
-- `ghcr.io/<owner>/infinite-streaming:latest`
-- `ghcr.io/<owner>/infinite-streaming:main`
-- `ghcr.io/<owner>/infinite-streaming:sha-<short>`
+- `ghcr.io/<owner>/infinite-streaming:latest` (and `…-forwarder:latest`) — main branch HEAD
+- `ghcr.io/<owner>/infinite-streaming:main`, `:sha-<short>` — branch + sha tags
+- `ghcr.io/<owner>/infinite-streaming:v1.2.3`, `:v1.2`, `:v1` — semver tags from `v*` git tags
 
 To enable in your fork:
 
 1. Set the default branch to `main`.
 2. **Settings → Actions → General** → allow GitHub Actions to write packages.
 
-Consumption (pulling pre-built images) is documented in the [README](../README.md#advanced-deployment).
+Optional Docker Hub mirror: set `vars.DOCKERHUB_NAMESPACE` (e.g. `myuser`) plus `secrets.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN` and the workflow also pushes to Docker Hub. When the namespace is unset (the default for new forks) the Docker Hub steps are skipped entirely.
+
+Consumption (pulling pre-built images) is documented in the [README](../README.md#pre-built-images-from-ghcr-no-source-checkout).
 
 ## Cloud encoding
 
@@ -72,4 +95,4 @@ For offloading ABR ladder encoding to AWS EC2 spot instances, see [`CLOUD_ENCODI
 
 ## Troubleshooting
 
-Deployment-specific issues (image pull failures, port conflicts, NodePort mapping mismatches) are covered in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md#k3s-deployment).
+Deployment-specific issues (image pull failures, port conflicts, NodePort mapping mismatches) are covered in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md#k3d-deployment).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -85,24 +85,27 @@ These require Linux with nftables. On macOS Docker Desktop the proxy container d
 
 Same requirement — Linux + `tc`. Check `GET /api/nftables/capabilities`.
 
-## k3s deployment
+## k3d deployment
 
 ### Pods crash-loop on first deploy
 
 Usually image pull failures:
 
-- If using the local registry (`K3S_REGISTRY`), confirm k3s is configured to trust the insecure registry (`/etc/rancher/k3s/registries.yaml`).
-- If using GHCR, the image must be public or the cluster must have an image pull secret. Pull manually from a worker to confirm: `crictl pull ghcr.io/jonathaneoliver/infinite-streaming:latest`.
+- If using the local registry (`K3S_REGISTRY`), confirm `~/.config/k3d/smashing-registries.yaml` was written by `make k3d-bootstrap` and contains the registry as a mirror with `insecure_skip_verify: true`. The two clusters created via `make k3d-bootstrap` already pass this file via `--registry-config`; only relevant if you re-create a cluster manually.
+- If using GHCR, the image must be public or the cluster must have an image pull secret. Pull manually from a worker to confirm: `kubectl --kubeconfig ~/.config/k3d/smashing-dev-kubeconfig.yaml run pull-test --rm -it --image=ghcr.io/jonathaneoliver/infinite-streaming:latest -- echo ok`.
 
 ### Dev and release fight over ports
 
-They don't — release uses 30xxx, dev uses 40xxx. If you see conflicts:
-- Confirm you deployed `k8s-infinite-streaming-dev.yaml` for dev and `k8s-infinite-streaming.yaml` for release.
-- `kubectl get svc -A` should show both NodePort ranges without overlap.
+They can't — they're separate k3d clusters with disjoint host port mappings (release: 30000-30881; dev: 40000-40881). If you see conflicts on the host:
+- `k3d cluster list` should show both `dev` and `release` running.
+- `docker ps --filter name=k3d-` should show four containers: `k3d-dev-server-0`, `k3d-dev-serverlb`, `k3d-release-server-0`, `k3d-release-serverlb`.
+- Anything else listening on those host ports (e.g. an old k3s install) needs to be stopped first.
 
 ### Session ports work inside the cluster but not from the browser
 
-k3s NodePort maps external → internal via `EXTERNAL_PORT_BASE`, `INTERNAL_PORT_BASE`, `PORT_RANGE_COUNT`. If these don't match between the Service and the Deployment env, the browser hits the proxy on an external port the pod isn't listening for. Redeploy after editing — k3s doesn't pick up env changes without a pod restart.
+The cluster's internal NodePort is stable (`30181-30881` in both clusters). k3d's `--port HOST:NODE@loadbalancer` flag handles the host→cluster remap (e.g. host `:40181` → cluster `:30181` for the dev cluster). If a session port works via `kubectl exec` curl but fails from the browser, the host-side mapping is missing — re-run `make k3d-bootstrap` (idempotent) or check `docker port k3d-{dev,release}-serverlb`.
+
+`go-proxy` separately advertises the *external* host port to clients via `EXTERNAL_PORT_BASE` (set per stack in the Makefile — `40081` for dev, `30081` for release). If the per-session URLs the browser receives have the wrong port, this env var is mismatched between the manifest and the cluster's host-port mapping.
 
 ## Encoding
 
@@ -130,7 +133,7 @@ See [`docs/CLOUD_ENCODING.md`](CLOUD_ENCODING.md#troubleshooting) — common iss
 
 If something isn't covered here, include:
 
-- `docker compose logs infinite-streaming` (or `kubectl logs` for k3s)
+- `docker compose logs infinite-streaming` (or `kubectl logs --kubeconfig ~/.config/k3d/smashing-{dev,release}-kubeconfig.yaml deploy/infinite-streaming` for k3d)
 - `GET /api/version` output
 - For playback issues: `GET /api/session/{id}/network` for the affected session, and the browser's dev-tools network tab
 - For encoding issues: `GET /api/jobs/{job_id}` and the last ~100 lines from the encoder log stream (`/api/jobs/{job_id}/stream`)

--- a/tests/deploy/docker-compose.registry.yml
+++ b/tests/deploy/docker-compose.registry.yml
@@ -23,7 +23,72 @@ services:
     environment:
       - INFINITE_STREAM_MAX_SESSIONS=8
       - INFINITE_STREAM_TC_INTERFACE=eth0
+      - INFINITE_STREAM_ENABLE_ANALYTICS=1
+      - INFINITE_STREAM_FORWARDER_HOST=forwarder
+      - INFINITE_STREAM_GRAFANA_HOST=grafana
     tmpfs:
       - /go-live:size=4G,mode=755
+    networks:
+      - test_registry_net
+    depends_on:
+      - clickhouse
+      - forwarder
+      - grafana
     restart: unless-stopped
     stop_grace_period: 1s
+
+  # Analytics tier — pulled from the same private registry as the main
+  # image, so the registry-pull install path has full feature parity
+  # with `make run`.
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    container_name: test-registry-clickhouse
+    environment:
+      - CLICKHOUSE_DB=infinite_streaming
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      - CLICKHOUSE_SKIP_USER_SETUP=1
+    ports:
+      - "127.0.0.1:25123:8123"
+    volumes:
+      - ${CONTENT_DIR:-./sample-content}/analytics:/var/lib/clickhouse
+      - ../../analytics/clickhouse/init.d:/docker-entrypoint-initdb.d:ro
+    networks:
+      - test_registry_net
+    restart: unless-stopped
+
+  forwarder:
+    image: ${K3S_REGISTRY}/infinite-streaming-forwarder:dev
+    container_name: test-registry-forwarder
+    environment:
+      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_snapshots
+    volumes:
+      - ${CONTENT_DIR:-./sample-content}/logs:/media/logs
+    networks:
+      - test_registry_net
+    depends_on:
+      - clickhouse
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana-oss:11.3.0
+    container_name: test-registry-grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
+      - GF_SERVER_ROOT_URL=http://localhost:25000/grafana/
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_LIVE_ALLOWED_ORIGINS=*
+    volumes:
+      - ../../analytics/grafana/provisioning:/etc/grafana/provisioning:ro
+    networks:
+      - test_registry_net
+    restart: unless-stopped
+
+networks:
+  test_registry_net:
+    driver: bridge


### PR DESCRIPTION
## Why

User direction: "I always want clickhouse etc to work in all targets". Post-#391/#395 audit found three install paths missing analytics + one path that can't ever support it:

| Path | Status before | Status after |
|---|---|---|
| `make run` / Compose Quick start | ✅ analytics | ✅ |
| `make deploy` / `make deploy-release` (k3d) | ✅ analytics (after #395) | ✅ |
| `make test-deploy-{dev,compose,oobe}` | ✅ (base compose + override) | ✅ |
| `make run-ghcr` | ❌ go-server only | ✅ |
| `make test-deploy-ghcr` | ❌ go-server only | ✅ |
| `make test-deploy-registry` | ❌ go-server only | ✅ |
| **`make test-deploy-run`** | ❌ bare docker run, can't have analytics | **dropped** |

Plus `docs/DEPLOYMENT.md` referenced the now-deleted `k8s-infinite-streaming{,-dev}.yaml` and still said "k3s".

## Changes

**Compose files — add analytics services:**
- `docker-compose.ghcr.yml` — adds `clickhouse`, `forwarder`, `grafana`. Forwarder pulls from `ghcr.io/jonathaneoliver/infinite-streaming-forwarder:latest`.
- `tests/deploy/docker-compose.registry.yml` — same set. Forwarder pulls from `${K3S_REGISTRY}/infinite-streaming-forwarder:dev`.

**GHCR workflow — publish the forwarder too:**
- `.github/workflows/docker-publish.yml` — extends the existing `infinite-streaming` build to also build/push `infinite-streaming-forwarder` from `./analytics/go-forwarder`. Same tag pattern (`:latest`, `:main`, `:sha-…`, semver). Docker Hub mirror gated on `vars.DOCKERHUB_NAMESPACE` the same way.

**Drops:**
- `make test-deploy-run` (bare `docker run`) — incompatible with the analytics-everywhere invariant. Removed from the recipe, from `test-deploy-all`, and from the `test-clean` cleanup list.
- README "Docker run (single container, no compose)" section — gone. Macos/Docker-Desktop TC note kept (now under the section preface, applies to all compose-based installs).
- Makefile stale defaults orphaned by #395: `K3S_KUBECONFIG`, `K8S_MANIFESTS`, `K8S_DEPLOYMENT`.

**Doc updates (post-#395 reality):**
- `README.md` — "Other ways to run it" rewritten. GHCR snippet now also fetches `analytics/` via tarball so the bind mounts in `docker-compose.ghcr.yml` resolve. k3s pointer → k3d.
- `docs/DEPLOYMENT.md` — rewritten for two k3d clusters (api ports 6543/6544, kubeconfigs at `~/.config/k3d/`, `make k3d-bootstrap`, `make teardown-{dev,release}`). GHCR-publishing section mentions both images.
- `docs/API.md`, `docs/ARCHITECTURE.md`, `docs/TROUBLESHOOTING.md`, `analytics/README.md` — `s/k3s/k3d/` where the change is real (port mapping, deployment modes, troubleshooting playbook, htpasswd runbook).

## Test plan

- [x] `docker compose -f docker-compose.ghcr.yml config` parses.
- [x] `docker compose -f tests/deploy/docker-compose.registry.yml config` parses.
- [x] `make -n test-deploy-all` parses with no `test-deploy-run` reference.
- [x] No remaining stale references: `grep k3s` across docs returns zero hits in active prose (only the migration-warning sentence in TROUBLESHOOTING).
- [ ] Live verification: `make run-ghcr` / `make test-deploy-{ghcr,registry}` end-to-end against the test-dev host. Deferred until the GHCR forwarder image is first published — that requires this PR to merge so the workflow runs once on `main`. Note in the PR body that the first `make run-ghcr` after merge will hit a 404 on the forwarder image until the workflow completes (~3 min).

## Out of scope

- k3d-equivalent maintenance targets for `analytics-update` / `analytics-rebuild-forwarder` / `analytics-migrate` (currently target the test-dev compose path only). Worth a separate issue if needed.
- Real ClickHouse password hardening (unrelated, came up in #391's CodeQL discussion).

Closes #394.