### PR TITLE
docs: drop phantom memcached references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,7 @@ Default server target for tests is `$K3S_HOST:30000/30081`. Override with `--hos
 |---------|------|------|
 | `go-live` | 8010 | LL-HLS + LL-DASH generator (2s/6s/LL variants) |
 | `go-upload` | 8003 | Upload API, encoding job orchestration, content discovery |
-| `go-proxy` | 30081 | Per-session testing proxy — failure injection, traffic shaping (nftables), SSE session stream |
-| `memcached` | 11211 | Session state storage (embedded in container) |
+| `go-proxy` | 30081 | Per-session testing proxy — failure injection, traffic shaping (nftables), SSE session stream, in-process session-state map |
 | nginx | 30000 | Routing, static dashboard |
 
 Plus the optional **analytics sidecar** (separate compose services): `clickhouse` (archive, 30-day TTL), `forwarder` (SSE → ClickHouse + read API), `grafana` (provisioned dashboards). All under [`analytics/`](analytics/). The live streaming path is independent of the sidecar — if the forwarder dies, the live UI keeps working, archival just pauses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ go build ./...
 go test ./...
 ```
 
-Running a service outside the container is possible but needs careful env setup — memcached, the media volume layout, and nginx upstreams all have to be reachable. For most work, rebuilding the full container (`make build && make run`) is faster to reason about.
+Running a service outside the container is possible but needs careful env setup — the media volume layout and nginx upstreams have to be reachable. For most work, rebuilding the full container (`make build && make run`) is faster to reason about.
 
 ### Iterating on the dashboard
 

--- a/PRD.md
+++ b/PRD.md
@@ -166,7 +166,7 @@ Many platforms already expose their own failure tools (player debug features, br
 - Keeps test setup **documented and portable** with the content itself.
 
 ### 7.5 Session Data Distribution & Shaping Control
-- **Session store**: all session state is stored in memcache under `session_list` and broadcast on change.
+- **Session store**: go-proxy holds the per-session state map in-process under a `session_list` key and broadcasts the full snapshot on change.
 - **SSE updates**: `/api/sessions/stream` emits full session snapshots (no 10‑session cap). UI should treat each event as authoritative.
 - **Polling fallback**: when SSE is unavailable, the UI polls `/api/sessions` and applies the same normalization logic.
 - **Control vs data**: UI control widgets sync only when `control_revision` changes; data metrics update every tick.

--- a/README.md
+++ b/README.md
@@ -487,9 +487,8 @@ Point at any of them as a starting template for a new platform.
 |---|---|---|
 | `go-live` | 8010 | LL-HLS + LL-DASH generator (2s / 6s / LL segment variants) |
 | `go-upload` | 8003 | Upload API, encoding job orchestration, content discovery |
-| `go-proxy` | 30081 (+ per-session ports) | Failure injection, traffic shaping, SSE session stream |
+| `go-proxy` | 30081 (+ per-session ports) | Failure injection, traffic shaping, SSE session stream, in-process session-state map |
 | `nginx` | 30000 | Routing, static dashboard |
-| `memcached` | 11211 | Session state (internal) |
 
 ### Live stream generation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,11 +8,10 @@ InfiniteStream runs as a **single Docker container** with four cooperating proce
 |---|---|---|
 | `go-live` | 8010 | Dynamic HLS/DASH manifest generation (LL + 2s + 6s segment variants) from short VOD content |
 | `go-upload` | 8003 | Upload API, encoding job orchestration, content discovery |
-| `go-proxy` | 30081 (base) + per-session ports | Failure-injection proxy and traffic shaping |
+| `go-proxy` | 30081 (base) + per-session ports | Failure-injection proxy + traffic shaping; holds the per-session state map in-process and broadcasts changes via SSE |
 | `nginx` | 30000 | Static dashboard + routing to the three Go services |
-| `memcached` | 11211 (internal only) | Session state for go-proxy |
 
-All four run in the same container. The only optional external dependency at runtime is a Cloudflare Worker for client-side server discovery (see [Server discovery](#server-discovery) below) — disable it by leaving `INFINITE_STREAM_RENDEZVOUS_URL` unset.
+All three Go services + nginx run in the same container. The only optional external dependency at runtime is a Cloudflare Worker for client-side server discovery (see [Server discovery](#server-discovery) below) — disable it by leaving `INFINITE_STREAM_RENDEZVOUS_URL` unset.
 
 ## High-level flow
 


### PR DESCRIPTION
## Why

Audit triggered by user question "are we actually still using memcached anywhere?" — the answer is no:

- **Zero code references**: no `gomemcache` import in `go-proxy`, `go-upload`, or `go-live` (`go.mod` and `go.sum` contain nothing memcache-related); no `:11211` connections.
- **Not in the image**: `Dockerfile` doesn't install memcached and `launch.sh` doesn't start it.
- **Not in any deployment**: zero references in `docker-compose.yml`, `docker-compose.ghcr.yml`, `tests/deploy/docker-compose.registry.yml`, `k8s-infinite-streaming.yaml.tmpl`, or `k8s-analytics.yaml`.

The session store lives in **go-proxy's in-process state map** and is broadcast via SSE. Memcached was once part of the design but was removed without updating the docs.

## Files

- `CLAUDE.md` — drop services-table row; fold the in-process state-map detail into the go-proxy row.
- `README.md` — same.
- `docs/ARCHITECTURE.md` — same; also fix "All four run in the same container" → "All three Go services + nginx".
- `PRD.md` §7.5 — rewrite "all session state is stored in memcache" → "go-proxy holds the per-session state map in-process".
- `CONTRIBUTING.md` — drop the "memcached must be reachable" caveat for out-of-container development.

## Background

Originally folded into PR #396 but that PR merged before this commit was associated. Carrying it across as its own one-commit PR.