### PR TITLE
feat(probe): nginx /healthz + readinessProbe on the main image

### DIFF
--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -67,6 +67,19 @@ server {
 
     include /etc/nginx/mime.types;
 
+    # Liveness/readiness probe endpoint — purely "is nginx accepting
+    # connections?", no upstream dependencies. `auth_basic off` so probes
+    # don't 401 when INFINITE_STREAM_AUTH_HTPASSWD is set.
+    # `access_log off` so probe traffic doesn't dominate the access log.
+    # See #397 — a probe pointed here would have caught the #390 nginx
+    # config-load crash at deploy-time instead of leaving the pod marked
+    # Running but serving 502s on every request.
+    location = /healthz {
+        auth_basic off;
+        access_log off;
+        return 200 "ok\n";
+    }
+
     # Go-live location must come BEFORE catch-all .m3u8/.mpd to take precedence
     # Routes /go-live/ URLs to Go LL-HLS service (port 8010) for playlists
     # Serves segments directly from source files

--- a/k8s-infinite-streaming.yaml.tmpl
+++ b/k8s-infinite-streaming.yaml.tmpl
@@ -116,6 +116,20 @@ spec:
         # when both stacks announce themselves to the rendezvous.
         - name: INFINITE_STREAM_SERVER_ID
           value: "${SERVER_ID}"
+        # Readiness only — no liveness probe, intentionally. The
+        # underlying failure modes we've actually hit (nginx config-load
+        # crash on missing upstream, missing /media/logs dir) all
+        # surface at startup; a readiness probe holds the pod NotReady
+        # until nginx is actually serving, which fails the rolling-
+        # update cleanly. Restart-on-wedge (livenessProbe) is deferred
+        # to #399 — too easy to false-positive on a transient blip.
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 30000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
         securityContext:
           privileged: true
           capabilities:


### PR DESCRIPTION
## Why

Today, when nginx fails at config-load — missing upstream, bad include, the kind of thing that bit us in #390 — the pod looks `Running` to k8s because `launch.sh` (PID 1) hasn't exited. The Service routes traffic to the broken pod; users hit 502; rollouts that should have failed silently succeed. We lost ~40 min of debugging during the analytics-decouple work to exactly this failure mode.

A single readiness probe on the nginx port catches it cleanly: pod stays `0/1 Ready=False`, Deployment's rolling-update strategy holds the OLD pod in service, `kubectl rollout status` exits non-zero, `make deploy` fails the build instead of leaving you with a quietly-broken cluster.

## What this PR does

**`docker/nginx-content.conf.template`** — one location:

```nginx
location = /healthz {
    auth_basic off;
    access_log off;
    return 200 "ok\n";
}
```

- `auth_basic off;` so probes don't 401 when `INFINITE_STREAM_AUTH_HTPASSWD` is set.
- `access_log off;` so probe traffic (~6 hits/min per pod) doesn't drown the access log.
- Static body, no upstream dependencies — purely "is nginx accepting connections?".

**`k8s-infinite-streaming.yaml.tmpl`** — readiness probe on the Deployment:

```yaml
readinessProbe:
  httpGet: { path: /healthz, port: 30000 }
  initialDelaySeconds: 5
  periodSeconds: 10
  failureThreshold: 3
```

Conservative thresholds — three consecutive 30-second windows of failure mark the pod NotReady. Avoids false-positives on transient blips. No `livenessProbe` (no restart-on-wedge) — that's a separate decision tracked in #399.

## What this PR deliberately doesn't do

- No probes on go-proxy / forwarder / ClickHouse / Grafana
- No `livenessProbe` — restart-on-wedge has more risk than reward today (we haven't actually hit a wedge-without-crash failure mode in this codebase)
- No `healthcheck:` blocks in `docker-compose.yml` / `docker-compose.ghcr.yml` / `tests/deploy/docker-compose.registry.yml`
- No "deep" probe that exercises downstream dependencies — cascade-failure surface needs design

All of the above are tracked in **#399** (production-readiness probes + Marketplace prep). Pulling them out keeps this PR small and immediately useful, and keeps the larger scope decision separate.

## Test plan

- [x] `kubectl apply --dry-run=client` validates the rendered template.
- [ ] `make deploy` to lenovo dev: pod still rolls out 1/1 Ready (the green path is unaffected).
- [ ] Reproduce #390 by deploying a build whose nginx fails to bind: pod stays `0/1 Ready=False`, `kubectl rollout status` exits non-zero. Today the same scenario silently leaves a "Running" pod.
- [ ] `curl http://lenovo:30000/healthz` returns `200 ok`. Probe traffic doesn't appear in the nginx access log.

Closes #397.