### PR TITLE
feat(proxy): server-side RTT chart — TCP_INFO + ICMP path ping (#401, #404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,11 @@ ATS-style transfer timeouts the proxy enforces against the *client* — useful f
 
 When a timeout fires the network-log waterfall renders the row with `!⏱` so you can tell it apart from a fault-injection cut (`!✂`) or a player abort (`!↩`).
 
-### Bitrate chart (with buffer depth and FPS)
+### Bitrate chart (with RTT, buffer depth, and FPS)
 
 ![Playback state chart](docs/screenshots/playback-state-chart.png)
 
-The session card has a collapsible **Bitrate Chart** that stacks an events timeline + up to three time-series charts, all sharing a 10-minute rolling window and unified zoom/pan. Legend entries toggle series, scroll zooms, drag pans, `⏸` pauses live updates. The four panels share an x-axis so a bandwidth dip lines up visually with its buffer / FPS / variant-shift impact.
+The session card has a collapsible **Bitrate Chart** that stacks an events timeline + up to four time-series charts, all sharing a 10-minute rolling window and unified zoom/pan. Legend entries toggle series, scroll zooms, drag pans, `⏸` pauses live updates. The five panels share an x-axis so a bandwidth dip lines up visually with its RTT / buffer / FPS / variant-shift impact.
 
 - **Events timeline** *(top)* — swim-lane visualization of what the player and server are doing right now:
   - **PLAYER variants** — one lane per ladder rung (e.g. `1920×1080:7.1Mbps`, `1280×720:3.5Mbps`). Coloured blocks show which variant the player was on at each moment. The variant shift on a throughput collapse is visible as a downstep across lanes.
@@ -275,10 +275,14 @@ The session card has a collapsible **Bitrate Chart** that stacks an events timel
   - **Reference lines**: `Limit` (shaping ceiling, stepped when a pattern is active), `Server Rendition` (what the server believes it delivered), one line per ladder `Variant` (hidden by default).
   - **Events**: `STALL` and `RESTART` markers annotate player stalls and restarts.
   - **Y-axis**: `Auto` or fixed `5 / 10 / 20 / 30 / 40 / 50 / 100` Mbps — pin the scale when comparing two sessions side by side.
+- **RTT chart** — two independent round-trip-time signals on the same time axis (issues #401 / #404):
+  - **TCP_INFO RTT family** (purple lines, left Y-axis) — what the streaming TCP connection actually experiences. Sampled inside go-proxy via `getsockopt(TCP_INFO)` at 100 Hz, drained into 1 s windows: `RTT avg` (smoothed RFC 6298 SRTT), `RTT max` / `min` (per-window peak/trough envelope), `RTT lifetime min` (sticky path floor, dashed reference), `RTO` (right Y-axis, hidden by default — climbs above RTT during a wedge while smoothed RTT flatlines).
+  - **Path ping** (cyan line, left Y-axis) — out-of-band ICMP echo from go-proxy → `player_ip` at 1 Hz, routed through a high-priority band inside the per-port shaping class. Sees the configured netem delay but jumps the bulk segment queue. The closest thing to "what the path could deliver if you weren't loading it." Zero / gap when ICMP is filtered.
+  - **Why both?** The ping line is the network's contribution; the gap up to the TCP_INFO line is the application stack's contribution (queueing under throttle, delayed ACKs, receiver load). Together they decompose latency under shaping: rising netem moves both lines together; rising throttle inflates only TCP_INFO via bufferbloat. See [`analytics/README.md`](analytics/README.md#reading-the-rtt-chart-issues-401-404) for the deep interpretation guide and per-shaping-knob test recipes.
 - **Buffer depth chart** — player `buffered` TimeRanges (`player_metrics_buffer_depth_s`) on the left axis; **Wall-Clock Offset** (player playhead vs encoder PDT) on the right axis.
 - **FPS chart** — rendered and dropped frames/s from `player_metrics_frames_displayed` / `_dropped_frames`, 2 s sliding window, exponential smoothing (α = 0.15). Series: `FPS (smoothed)`, `Low FPS` (red below threshold), `FPS Baseline` (75th percentile), `Low Threshold` (`0.75 × baseline`), `Dropped Frames/s` (right Y-axis).
 
-The four panels' plot areas all align on the same right edge so vertical x-axis ticks line up across every chart and the events timeline above.
+The five panels' plot areas all align on the same right edge so vertical x-axis ticks line up across every chart and the events timeline above.
 
 ### Network log waterfall (HAR view)
 

--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Sampled inside go-proxy via `getsockopt(TCP_INFO)` on each session's most-recent
 | `client_rtt_min_lifetime_ms` | `tcpi_min_rtt` | Min RTT ever observed on this connection — the path floor |
 | `client_rtt_var_ms` | `tcpi_rttvar` | Smoothed mean deviation (jitter) |
 | `client_rto_ms` | `tcpi_rto` | Current retransmit timeout — rises during a wedge while smoothed RTT flatlines; the gap between `rto` and `rtt` is the canonical "kernel suspects this connection is stalling" signal |
+| `client_path_ping_rtt_ms` | ICMP echo, 1 Hz | **Out-of-band path latency** (issue #404). Independent of the streaming connection's queue contribution — TCP_INFO RTT inflates with throttle, but ICMP packets bypass the application's send queue, so this line stays at the LAN baseline when shaping kicks in. The vertical gap between this line and `client_rtt_ms` is the queueing delay the application is inducing on itself. Zero / gap when ICMP is filtered. |
 
 ### Metric semantics
 

--- a/README.md
+++ b/README.md
@@ -545,6 +545,19 @@ Full API (`/api/content`, `/api/jobs`, `/api/sessions/*`, `/api/nftables/*`, etc
 | `mbps_transfer_rate` | 250 ms | Byte-change-gated rate during segment transfer, aligned to HTB burst edges. Reports at drain/refill boundaries |
 | `mbps_transfer_complete` | per segment | Total bytes / total time for one completed segment transfer (backlog drained to 0) |
 
+### Server-side RTT metrics
+
+Sampled inside go-proxy via `getsockopt(TCP_INFO)` on each session's most-recent connection. The 100 ms sampler folds reads into a 1 s window that drains on every snapshot tick — same cadence as the player-metrics PATCH heartbeat, so the RTT chart shares a time axis with the bitrate chart above it. Linux-only (the kernel option doesn't exist on macOS); the dev build compiles via a stub that emits zeros. All values in milliseconds.
+
+| Metric | Source field | What it measures |
+|---|---|---|
+| `client_rtt_ms` | `tcpi_rtt` (avg of 1 s window) | Smoothed RTT (RFC 6298 SRTT, kernel EWMA) |
+| `client_rtt_max_ms` | window max of `tcpi_rtt` | Peak smoothed RTT in window — catches sub-second spikes the kernel's EWMA would mask |
+| `client_rtt_min_ms` | window min of `tcpi_rtt` | Trough during the same 1 s window |
+| `client_rtt_min_lifetime_ms` | `tcpi_min_rtt` | Min RTT ever observed on this connection — the path floor |
+| `client_rtt_var_ms` | `tcpi_rttvar` | Smoothed mean deviation (jitter) |
+| `client_rto_ms` | `tcpi_rto` | Current retransmit timeout — rises during a wedge while smoothed RTT flatlines; the gap between `rto` and `rtt` is the canonical "kernel suspects this connection is stalling" signal |
+
 ### Metric semantics
 
 - **Limit value** (`nftables` shaping rate): configured ceiling for the session port; a control target, not a measured throughput.

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -77,6 +77,28 @@ docker compose up -d --force-recreate grafana
 - `TTL toDateTime(ts) + INTERVAL 30 DAY` enforces retention; tune via
   `ALTER TABLE ... MODIFY TTL`.
 
+### Reading the RTT chart (issue #401)
+
+Six `client_rtt_*_ms` columns carry server-side TCP_INFO RTT, sampled
+inside go-proxy on a 100 ms ticker and drained into 1 s windows on
+every snapshot tick. Read them like this:
+
+- `client_rtt_ms` is the kernel's smoothed RTT — the *current* path
+  latency, with EWMA so it lags real changes by a fraction of a second.
+- `client_rtt_min_lifetime_ms` is the connection's *path floor* — the
+  best RTT ever seen on that TCP connection. Sticky-low: once observed
+  it doesn't drift back up.
+- The gap between smoothed RTT and lifetime min is *congestion buildup*
+  — queueing on the path beyond the no-load minimum.
+- `client_rto_ms` rising above `client_rtt_ms` means the kernel has
+  doubled its retransmit timeout because ACKs aren't flowing. That gap
+  is the canonical wedge indicator — it's visible even when smoothed
+  RTT goes flat (no fresh ACKs to update the EWMA).
+
+`client_rtt_max_ms` / `client_rtt_min_ms` are the peak/trough of
+smoothed RTT *within the 1 s emit window*, useful for detecting
+sub-second spikes the kernel's EWMA would otherwise mask.
+
 ## Securing a WAN-exposed deployment
 
 Default docker-compose binds ClickHouse to `127.0.0.1` (host-only) and

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -99,6 +99,16 @@ every snapshot tick. Read them like this:
 smoothed RTT *within the 1 s emit window*, useful for detecting
 sub-second spikes the kernel's EWMA would otherwise mask.
 
+`client_path_ping_rtt_ms` (issue #404) is a separate signal entirely
+— an out-of-band ICMP echo from go-proxy → player_ip at 1 Hz. ICMP
+packets are tiny and don't share a queue with the streaming bytes,
+so this line reflects the path's *real* current latency regardless
+of what shaping is doing. The TCP_INFO lines climb under throttle
+(self-loaded measurement); the ping line stays put. The gap between
+ping and `client_rtt_ms` is the queueing delay the application is
+inducing on itself — bufferbloat, made visible. Zero / absent when
+ICMP is filtered on the path between proxy and player.
+
 ## Securing a WAN-exposed deployment
 
 Default docker-compose binds ClickHouse to `127.0.0.1` (host-only) and

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -77,37 +77,217 @@ docker compose up -d --force-recreate grafana
 - `TTL toDateTime(ts) + INTERVAL 30 DAY` enforces retention; tune via
   `ALTER TABLE ... MODIFY TTL`.
 
-### Reading the RTT chart (issue #401)
+### Reading the RTT chart (issues #401, #404)
 
-Six `client_rtt_*_ms` columns carry server-side TCP_INFO RTT, sampled
-inside go-proxy on a 100 ms ticker and drained into 1 s windows on
-every snapshot tick. Read them like this:
+Two independent measurement schemes plotted on the same chart:
 
-- `client_rtt_ms` is the kernel's smoothed RTT — the *current* path
-  latency, with EWMA so it lags real changes by a fraction of a second.
-- `client_rtt_min_lifetime_ms` is the connection's *path floor* — the
-  best RTT ever seen on that TCP connection. Sticky-low: once observed
-  it doesn't drift back up.
-- The gap between smoothed RTT and lifetime min is *congestion buildup*
-  — queueing on the path beyond the no-load minimum.
-- `client_rto_ms` rising above `client_rtt_ms` means the kernel has
-  doubled its retransmit timeout because ACKs aren't flowing. That gap
-  is the canonical wedge indicator — it's visible even when smoothed
-  RTT goes flat (no fresh ACKs to update the EWMA).
+- **TCP_INFO family** (`client_rtt_*_ms`, purple lines) — what the
+  *streaming TCP connection* actually experiences. Self-loaded:
+  every sample includes the application's own queue contribution.
+- **Path ping** (`client_path_ping_rtt_ms`, cyan line) — out-of-band
+  ICMP echo from go-proxy → player_ip at 1 Hz, routed through a
+  high-priority band (TC_PRIO_INTERACTIVE → tc band 0) inside the
+  per-port shaping class. Sees the configured netem delay but jumps
+  the bulk queue. The closest thing to "what the path could deliver
+  if you weren't loading it."
 
-`client_rtt_max_ms` / `client_rtt_min_ms` are the peak/trough of
-smoothed RTT *within the 1 s emit window*, useful for detecting
-sub-second spikes the kernel's EWMA would otherwise mask.
+#### The two probe paths through the kernel
 
-`client_path_ping_rtt_ms` (issue #404) is a separate signal entirely
-— an out-of-band ICMP echo from go-proxy → player_ip at 1 Hz. ICMP
-packets are tiny and don't share a queue with the streaming bytes,
-so this line reflects the path's *real* current latency regardless
-of what shaping is doing. The TCP_INFO lines climb under throttle
-(self-loaded measurement); the ping line stays put. The gap between
-ping and `client_rtt_ms` is the queueing delay the application is
-inducing on itself — bufferbloat, made visible. Zero / absent when
-ICMP is filtered on the path between proxy and player.
+Both probes share the same physical egress (eth0) and the same per-
+port HTB class, but they take different *bands* through the prio
+scheduler that sits inside the class as the leaf qdisc:
+
+```
+egress eth0
+└── HTB root (1:1)
+    └── HTB class 1:<port>     (rate-limited at configured Mbps)
+        └── prio leaf qdisc     (3 bands, default priomap)
+            ├── band 0 (1810:1)  ← PROBE LANE
+            │   └── netem (configured delay/loss + 5% jitter)
+            ├── band 1 (1810:2)  ← BULK DATA LANE
+            │   └── netem (same delay/loss/jitter)
+            └── band 2 (1810:3)  unused
+
+filters at parent 1:0:
+  ip sport <port>           → flowid 1:<port>     (TCP segments → bulk lane via priomap default)
+  ip protocol icmp dst <ip> → flowid 1:<port>     (ICMP probes → probe lane via IP_TOS=0x10 → priomap band 0)
+```
+
+How a packet picks its band:
+
+- **Bulk segment data**: leaves the proxy with `skb->priority = 0`
+  (`TC_PRIO_BESTEFFORT`). Default prio priomap routes that to band 1
+  (the middle band) → classid `1810:2` → bulk netem.
+- **Path-ping ICMP**: socket has `IP_TOS = 0x10` set. Kernel's
+  `rt_tos2priority` table maps that to `TC_PRIO_INTERACTIVE` (priority
+  6). Default priomap routes that to band 0 → classid `1810:1` →
+  probe netem.
+
+Both bands carry **identical netem configuration** — `UpdateNetem`
+writes the same `delay/loss/jitter` to all three bands in lockstep,
+so the configured network conditions apply uniformly regardless of
+priority. The only thing the prio scheduler changes is *queueing
+order* when both bands have eligible packets: strict priority means
+band 0 always drains first.
+
+Net effect:
+
+- **Bulk** sits in band 1's netem queue, gets the configured delay,
+  then waits for HTB's rate-limit token. If the rate is full it
+  queues behind earlier bulk packets too — bufferbloat.
+- **Probe** sits in band 0's netem queue, gets the same configured
+  delay, then jumps every queued bulk packet on the next HTB dequeue.
+  Worst case it waits one MTU's serialization (≈ 12 ms at 1 Mbps,
+  2.4 ms at 5 Mbps) for a bulk packet already on the wire.
+
+So the ping line shows you *path + netem*, almost free of bufferbloat.
+The TCP_INFO lines show you *path + netem + bufferbloat + ACK overhead*
+— what bulk segment data really pays.
+
+#### Why we ship both signals
+
+They answer different questions. Either alone is misleading:
+
+- **Just TCP_INFO** would conflate "the path is bad" with "I'm
+  loading the path" — a player ABR algorithm seeing high RTT can't
+  tell whether to back off or just wait for its own queue to drain.
+  Lifetime min approximates the path floor but is sticky and slow
+  to update during sustained load.
+- **Just ping** would tell you nothing about what the streaming
+  connection actually experiences — the ABR doesn't react to ICMP,
+  it reacts to TCP behavior. A perfectly healthy ping line above a
+  stalling player would be a useless diagnostic.
+
+Together they decompose the latency budget: ping is the *physical
+network's contribution* (path + configured delay), and the gap up
+to TCP_INFO is the *application stack's contribution* (queueing
+under throttle, delayed ACKs, receiver load, reverse-path queuing).
+When bitrate drops or buffer drains, the chart tells you *which
+component* moved — was it the path getting longer, or my own
+queue piling up?
+
+#### Field reference
+
+- `client_rtt_ms` — kernel's smoothed RTT (RFC 6298 SRTT). Current
+  path latency with EWMA, lags real changes by a fraction of a second.
+- `client_rtt_max_ms` / `client_rtt_min_ms` — peak/trough of smoothed
+  RTT *within the 1 s emit window*. Catches sub-second spikes the
+  kernel's EWMA would otherwise mask.
+- `client_rtt_min_lifetime_ms` — connection's *path floor*: the best
+  RTT ever seen on that TCP connection. Sticky-low, never climbs back.
+- `client_rtt_var_ms` — kernel's smoothed mean deviation (jitter).
+- `client_rto_ms` — current retransmit timeout. Rises during a wedge
+  while smoothed RTT flatlines because no fresh ACKs are coming back.
+- `client_path_ping_rtt_ms` — ICMP echo round-trip, 1 Hz cadence.
+  Zero / absent when ICMP is filtered on the path.
+
+#### Why the ping line is *always* lower than TCP_INFO RTT
+
+Even on a perfectly idle, unshaped LAN, expect TCP_INFO RTT to sit
+above the ping line. Sources of inflation, all real, all working as
+designed:
+
+- **Delayed ACKs** — receiver TCP holds ACKs up to 40–200 ms (Linux/iOS
+  default ~40 ms) to coalesce them. ICMP echo replies aren't subject
+  to this; they go out immediately.
+- **TCP_INFO is the smoothed SRTT** — exponentially averaged across
+  recent ACKs, including ACKs generated under load. ICMP samples a
+  single round-trip on the kernel fast path.
+- **Receiver processing latency under load** — at multi-Mbps the
+  player's TCP stack is busy demuxing segment data; ACK generation
+  slips behind. ICMP echo handling skips userspace entirely.
+- **Reverse-path queuing** — the player's egress (ACKs going *back*)
+  has its own tiny outbound queue. ICMP replies skip it.
+
+So `TCP_INFO − ping` on healthy unshaped LAN ≈ delayed-ACK + receiver
+load + reverse queueing. This is the network stack's overhead, not
+a fault.
+
+#### Expected behavior under shaping
+
+The two signals respond differently to the two shaping knobs (netem
+delay and HTB rate limit). Useful test recipes:
+
+| Action | TCP_INFO RTT | Path ping | Why |
+|---|---|---|---|
+| **No shaping** | `path + ACK overhead + receiver load` (typically 5–50 ms LAN) | `~path RTT` (sub-ms LAN) | Baseline. The ping line is the floor; TCP_INFO is everything else the stack adds. |
+| **Set netem delay = 25 ms** | rises by ~25 ms (mean) | rises by ~25 ms (mean) | Both packets traverse the same per-band netem inside the HTB class. Matched movement. Per-packet variance is ±5 % of mean (~1 ms stddev at 25 ms — see jitter note below). |
+| **Set throttle = 1 Mbps** (no netem) | climbs into bufferbloat range (often 100s of ms during downloads) | unchanged from baseline | Bulk segment data fills the HTB queue; each MTU waits for a rate token. The probe escapes via prio band 0 — at most one MTU's serialization (~12 ms at 1 Mbps for 1500 B). |
+| **Throttle + netem combined** | `path + netem + bufferbloat + ACK overhead` (compounded) | `~path + netem + at-most-one-MTU` | Effects stack additively on bulk data. The ping line shows you what's *just* the configured delay so you can subtract bufferbloat by eye. |
+| **Toggle shaping mid-stream** | step changes correlate visibly with bitrate / buffer drops on the chart above | flat through bandwidth changes; steps on netem changes only | Whole point of having both signals. Bitrate dropped because shaping was applied → both lines confirm in different ways. |
+| **Drop packets via fault-injection** | smoothed RTT eventually flatlines (no fresh ACKs); `client_rto_ms` climbs as kernel doubles its timeout | `0` / gap (echo replies dropped too) | RTO − RTT divergence is the canonical wedge indicator. |
+
+Reading the chart in one sentence:
+**ping = network's contribution; (TCP_INFO − ping) = stack + bufferbloat
+contribution.**
+
+#### A note on jitter
+
+`UpdateNetem` adds a fixed 5 % normal-distributed jitter (`stddev =
+delay/20`). For configured 25 ms delay: stddev ≈ 1 ms, so ~99.7 % of
+per-packet delays land in [22, 28] ms. The ping per-window min sits
+at the configured floor; per-window max shows the tight scatter above.
+Configured delays ≤19 ms get zero jitter (integer divide rounds to 0)
+— fine for low-RTT testing where any noise would dominate the signal.
+
+If a future test needs higher jitter (ABR resilience to RTT scatter,
+out-of-order arrivals via wider Gaussian draws), add a separate
+`jitter_ms` parameter to the shaping API rather than re-deriving from
+the delay value. The 5 % default is tuned for "I configured 25 ms,
+the chart should read ~25 ms," not for stress-testing variance.
+
+#### Reading the RTO line (wedge detection)
+
+`client_rto_ms` is hidden by default — toggle it on from the chart
+legend when you suspect a wedge. RTO answers a different question
+than the rest of the chart: not *how long does a round-trip take*
+but *how long is the kernel willing to wait for one before giving
+up and retransmitting*.
+
+What it is. RTO is the kernel's **retransmission timeout** for the
+TCP connection. After sending a segment, the sender starts a timer;
+if no ACK arrives before the timer expires, the segment is
+retransmitted and the timer doubles. RFC 6298 sets the steady-state
+value to roughly `SRTT + 4 × RTTVAR` (smoothed RTT plus four times
+its smoothed deviation), with a kernel floor of 200 ms and ceiling
+of 120 s. So on a quiet, healthy connection RTO sits a small
+multiple of RTT above the smoothed-RTT line — *not* zero.
+
+Why it's the wedge canary. When ACKs stop flowing entirely (transport
+fault, dropped packets, broken middlebox), `tcpi_rtt` flatlines —
+no fresh ACK round-trips means no new samples to update the EWMA.
+Looking at the smoothed-RTT line alone, you can't tell whether the
+connection is healthy-and-idle or wedged-and-silent. RTO has its
+own state machine driven by the kernel's retransmission timer, not
+by ACK arrivals: every retry doubles it (`200ms → 400ms → 800ms →
+1.6s → 3.2s → 6.4s → 12.8s → 25.6s → 51.2s → 102.4s`, capped at
+the kernel max). So when the connection wedges:
+
+```
+RTT (purple) ──flat───────────────────────────────  ← no ACKs, no fresh samples
+RTO  (red) ───────⌐──┘─⌐──┘──⌐──┘──⌐────┘────  ← kernel doubling on each retry
+```
+
+The growing gap between the two is the unambiguous "kernel suspects
+this connection is stalling" signal. It appears within seconds of
+the wedge starting — much faster than a stall on the bitrate chart
+above (which only triggers after the player's buffer drains).
+
+What recovery looks like. Once ACKs start flowing again (fault
+cleared, retry succeeds), the kernel resets RTO to `SRTT + 4×RTTVAR`
+on the very next ACK. The red line snaps back down; the purple
+smoothed-RTT line resumes updating. So a recovered wedge is visible
+as a sawtooth-like RTO climb followed by an instant drop, with the
+RTT line resuming its normal track.
+
+Useful pairing. RTO + the path-ping line together disambiguate the
+wedge cause:
+
+| RTT line | RTO line | Path ping | What it means |
+|---|---|---|---|
+| flat | climbing | also gone (ICMP filtered/dropped) | Wedge or transport fault — entire path is dead from proxy's view. |
+| flat | climbing | still arriving normally | Wedge is TCP-specific — ICMP gets through but TCP is stuck. Likely middlebox dropping the connection or a broken player TCP stack, not a network outage. |
+| climbing slowly | tracking RTT (small multiple above) | climbing the same | Genuine path latency increase, not a wedge — RTO is just following healthy RTT growth. |
 
 ## Securing a WAN-exposed deployment
 

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -45,6 +45,12 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
     client_rtt_min_lifetime_ms Float32                CODEC(ZSTD(1)),
     client_rtt_var_ms          Float32                CODEC(ZSTD(1)),
     client_rto_ms              Float32                CODEC(ZSTD(1)),
+    -- Out-of-band ICMP echo from go-proxy → player_ip at 1 Hz
+    -- (issue #404). Path latency that's independent of the
+    -- streaming TCP connection's queue contribution — the line
+    -- that stays put when shaping kicks in while client_rtt_ms
+    -- climbs from queueing.
+    client_path_ping_rtt_ms    Float32                CODEC(ZSTD(1)),
     display_resolution    LowCardinality(String)      CODEC(ZSTD(1)),
     video_resolution      LowCardinality(String)      CODEC(ZSTD(1)),
     frames_displayed      UInt64                      DEFAULT 0,
@@ -297,6 +303,9 @@ ALTER TABLE infinite_streaming.session_snapshots
     ADD COLUMN IF NOT EXISTS client_rtt_min_lifetime_ms Float32 CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS client_rtt_var_ms Float32 CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS client_rto_ms Float32 CODEC(ZSTD(1)),
+    -- Out-of-band ICMP path-ping (issue #404). See inline comment
+    -- on the CREATE TABLE column above.
+    ADD COLUMN IF NOT EXISTS client_path_ping_rtt_ms Float32 CODEC(ZSTD(1)),
     -- Tiered retention classification (issue #342). One of:
     --   'other'        — default, evicted at 30 d (TTL clause below).
     --   'interesting'  — auto-classified at session-end when any of

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -31,6 +31,20 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
     measured_mbps         Float32                     CODEC(ZSTD(1)),
     mbps_shaper_rate      Float32                     CODEC(ZSTD(1)),
     mbps_shaper_avg       Float32                     CODEC(ZSTD(1)),
+    -- Server-side TCP_INFO RTT (issue #401). 100 ms ticker in
+    -- go-proxy reads getsockopt(TCP_INFO) on each session's most-
+    -- recent connection, folds into a 1 s window, drained on each
+    -- snapshot tick. Units: ms. min_lifetime is the kernel's sticky
+    -- per-connection min RTT (Linux 4.6+); rto rises during wedges
+    -- while smoothed rtt flatlines, and the gap between them is
+    -- the canonical "kernel suspects this connection is stalling"
+    -- signal.
+    client_rtt_ms              Float32                CODEC(ZSTD(1)),
+    client_rtt_max_ms          Float32                CODEC(ZSTD(1)),
+    client_rtt_min_ms          Float32                CODEC(ZSTD(1)),
+    client_rtt_min_lifetime_ms Float32                CODEC(ZSTD(1)),
+    client_rtt_var_ms          Float32                CODEC(ZSTD(1)),
+    client_rto_ms              Float32                CODEC(ZSTD(1)),
     display_resolution    LowCardinality(String)      CODEC(ZSTD(1)),
     video_resolution      LowCardinality(String)      CODEC(ZSTD(1)),
     frames_displayed      UInt64                      DEFAULT 0,
@@ -275,6 +289,14 @@ ALTER TABLE infinite_streaming.session_snapshots
     ADD COLUMN IF NOT EXISTS content_strip_codecs String CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS abrchar_run_lock UInt8 DEFAULT 0,
     ADD COLUMN IF NOT EXISTS control_revision UInt64 DEFAULT 0,
+    -- Server-side TCP_INFO RTT (issue #401). See inline comment on
+    -- the CREATE TABLE columns above.
+    ADD COLUMN IF NOT EXISTS client_rtt_ms Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS client_rtt_max_ms Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS client_rtt_min_ms Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS client_rtt_min_lifetime_ms Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS client_rtt_var_ms Float32 CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS client_rto_ms Float32 CODEC(ZSTD(1)),
     -- Tiered retention classification (issue #342). One of:
     --   'other'        — default, evicted at 30 d (TTL clause below).
     --   'interesting'  — auto-classified at session-end when any of

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -84,6 +84,13 @@ type row struct {
 	MeasuredMbps             float32 `json:"measured_mbps"`
 	MbpsShaperRate           float32 `json:"mbps_shaper_rate"`
 	MbpsShaperAvg            float32 `json:"mbps_shaper_avg"`
+	// Server-side TCP_INFO RTT (issue #401).
+	ClientRTTMs             float32 `json:"client_rtt_ms"`
+	ClientRTTMaxMs          float32 `json:"client_rtt_max_ms"`
+	ClientRTTMinMs          float32 `json:"client_rtt_min_ms"`
+	ClientRTTMinLifetimeMs  float32 `json:"client_rtt_min_lifetime_ms"`
+	ClientRTTVarMs          float32 `json:"client_rtt_var_ms"`
+	ClientRTOMs             float32 `json:"client_rto_ms"`
 	DisplayResolution        string  `json:"display_resolution"`
 	VideoResolution          string  `json:"video_resolution"`
 	FramesDisplayed          uint64  `json:"frames_displayed"`
@@ -441,6 +448,12 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		MeasuredMbps:             getF32(s, "measured_mbps"),
 		MbpsShaperRate:           getF32(s, "mbps_shaper_rate"),
 		MbpsShaperAvg:            getF32(s, "mbps_shaper_avg"),
+		ClientRTTMs:              getF32(s, "client_rtt_ms"),
+		ClientRTTMaxMs:           getF32(s, "client_rtt_max_ms"),
+		ClientRTTMinMs:           getF32(s, "client_rtt_min_ms"),
+		ClientRTTMinLifetimeMs:   getF32(s, "client_rtt_min_lifetime_ms"),
+		ClientRTTVarMs:           getF32(s, "client_rtt_var_ms"),
+		ClientRTOMs:              getF32(s, "client_rto_ms"),
 		DisplayResolution:        getStr(s, "player_metrics_display_resolution"),
 		VideoResolution:          getStr(s, "player_metrics_video_resolution"),
 		FramesDisplayed:          getU64(s, "player_metrics_frames_displayed"),

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -91,6 +91,8 @@ type row struct {
 	ClientRTTMinLifetimeMs  float32 `json:"client_rtt_min_lifetime_ms"`
 	ClientRTTVarMs          float32 `json:"client_rtt_var_ms"`
 	ClientRTOMs             float32 `json:"client_rto_ms"`
+	// Out-of-band ICMP path-ping (issue #404).
+	ClientPathPingRTTMs     float32 `json:"client_path_ping_rtt_ms"`
 	DisplayResolution        string  `json:"display_resolution"`
 	VideoResolution          string  `json:"video_resolution"`
 	FramesDisplayed          uint64  `json:"frames_displayed"`
@@ -454,6 +456,7 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		ClientRTTMinLifetimeMs:   getF32(s, "client_rtt_min_lifetime_ms"),
 		ClientRTTVarMs:           getF32(s, "client_rtt_var_ms"),
 		ClientRTOMs:              getF32(s, "client_rto_ms"),
+		ClientPathPingRTTMs:      getF32(s, "client_path_ping_rtt_ms"),
 		DisplayResolution:        getStr(s, "player_metrics_display_resolution"),
 		VideoResolution:          getStr(s, "player_metrics_video_resolution"),
 		FramesDisplayed:          getU64(s, "player_metrics_frames_displayed"),

--- a/content/dashboard/testing-session-refactored.css
+++ b/content/dashboard/testing-session-refactored.css
@@ -526,7 +526,8 @@
 }
 
 .bandwidth-chart,
-.buffer-depth-chart {
+.buffer-depth-chart,
+.rtt-chart {
     width: 100%;
     height: auto;
 }
@@ -537,6 +538,10 @@
 
 .buffer-depth-chart {
     height: 170px;
+}
+
+.rtt-chart {
+    height: 180px;
 }
 
 /* ============================================================================
@@ -1432,6 +1437,7 @@ button[data-action="reset-bitrate-zoom"].zoom-active::before {
 .chart-wrap.chart-expanded .bandwidth-chart { height: 660px !important; }
 .chart-wrap.chart-expanded .buffer-depth-chart { height: 510px !important; }
 .chart-wrap.chart-expanded .video-fps-chart { height: 510px !important; }
+.chart-wrap.chart-expanded .rtt-chart { height: 510px !important; }
 
 /* ============================================================================
    Live/Pause toggle button (chart-live highlight + pulsing dot).

--- a/content/dashboard/testing-session-ui.js
+++ b/content/dashboard/testing-session-ui.js
@@ -1134,6 +1134,10 @@
                             <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
                             <canvas class="bandwidth-chart" data-field="bandwidth_chart"></canvas>
                         </div>
+                        <div class="chart-wrap">
+                            <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>
+                            <canvas class="rtt-chart" data-field="rtt_chart"></canvas>
+                        </div>
                         ${showBufferDepthChart ? `
                         <div class="chart-wrap">
                             <button type="button" class="chart-expand-btn" data-action="toggle-chart-expanded" title="Toggle expanded chart height" aria-label="Toggle expanded chart height"><span class="chart-expand-icon">⤢</span><span class="chart-expand-label">Expand</span></button>

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -1470,6 +1470,7 @@
             const canvasClassToMap = {
                 'bandwidth-chart': bandwidthCharts,
                 'events-chart': eventsCharts,
+                'rtt-chart': rttCharts,
                 'buffer-depth-chart': bufferDepthCharts,
                 'video-fps-chart': videoFpsCharts
             };
@@ -2438,7 +2439,7 @@
         }
 
         function refreshLegendHoverAll() {
-            const pools = [bandwidthCharts, bufferDepthCharts, videoFpsCharts];
+            const pools = [bandwidthCharts, rttCharts, bufferDepthCharts, videoFpsCharts];
             for (const pool of pools) {
                 if (!pool) continue;
                 pool.forEach((chart) => {
@@ -3076,6 +3077,7 @@
                 const chartsToDestroy = [
                     eventsCharts.get(sessionId),
                     bandwidthCharts.get(sessionId),
+                    rttCharts.get(sessionId),
                     bufferDepthCharts.get(sessionId),
                     videoFpsCharts.get(sessionId)
                 ];
@@ -5369,7 +5371,7 @@
                 eventMarkerBySession.set(key, { tsMs: Number(tsMs), label: markerLabel });
             }
             const marker = eventMarkerBySession.get(key);
-            const pools = [bandwidthCharts, bufferDepthCharts, videoFpsCharts, eventsCharts];
+            const pools = [bandwidthCharts, rttCharts, bufferDepthCharts, videoFpsCharts, eventsCharts];
             for (const pool of pools) {
                 if (!pool) continue;
                 const chart = pool.get(key) || pool.get(sessionId);

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -98,6 +98,12 @@
         const bufferDepthCharts = new Map();
         const videoFpsCharts = new Map();
         const eventsCharts = new Map();
+        // Server-side TCP_INFO RTT chart (issue #401). Mirrors
+        // bandwidthHistory / bandwidthCharts shape; rendered in
+        // renderRTTChart, fed by the six client_rtt_* fields drained
+        // off go-proxy's per-session window each broadcast tick.
+        const rttHistory = new Map();
+        const rttCharts = new Map();
         const eventsTimelines = new Map();
         // Width reserved on the RIGHT side of every chart's plot area
         // so the four Chart.js charts (bandwidth, buffer, fps, events
@@ -1646,6 +1652,7 @@
             return [
                 eventsCharts.get(key),
                 bandwidthCharts.get(key),
+                rttCharts.get(key),
                 bufferDepthCharts.get(key),
                 videoFpsCharts.get(key),
                 eventsTimelines.get(key)
@@ -2170,6 +2177,37 @@
             const cutoff = now - windowMs;
             const filtered = series.filter(point => point.ts >= cutoff);
             bandwidthHistory.set(key, filtered);
+
+            // Server-side RTT (issue #401). Six fields stamped on the
+            // session by go-proxy's normalizeSessionsForResponse →
+            // drainSessionRTT. _stale=true marks a window with no
+            // fresh kernel samples (typically a brief connection
+            // gap) — render avg as null in that case so the line
+            // breaks rather than dragging a stale value forward.
+            const numericIfFinite = (raw) => {
+                const num = Number(raw);
+                return Number.isFinite(num) ? num : null;
+            };
+            const rttAvg = numericIfFinite(session.client_rtt_ms);
+            const rttMax = numericIfFinite(session.client_rtt_max_ms);
+            const rttMin = numericIfFinite(session.client_rtt_min_ms);
+            const rttLifetimeMin = numericIfFinite(session.client_rtt_min_lifetime_ms);
+            const rttVar = numericIfFinite(session.client_rtt_var_ms);
+            const rttRto = numericIfFinite(session.client_rto_ms);
+            const rttStale = session.client_rtt_stale === true;
+            const rttSeries = rttHistory.get(key) || [];
+            rttSeries.push({
+                ts: playerEventAtMs,
+                avg: rttAvg,
+                max: rttMax,
+                min: rttMin,
+                lifetimeMin: rttLifetimeMin,
+                variance: rttVar,
+                rto: rttRto,
+                stale: rttStale
+            });
+            rttHistory.set(key, rttSeries.filter(point => point.ts >= cutoff));
+
             if (key === activeSessionId && !chartRenderSuppressedBySession.has(key)) {
                 renderBandwidthChart(key);
             }
@@ -3048,6 +3086,7 @@
                 }
                 eventsCharts.delete(sessionId);
                 bandwidthCharts.delete(sessionId);
+                rttCharts.delete(sessionId);
                 bufferDepthCharts.delete(sessionId);
                 videoFpsCharts.delete(sessionId);
                 // The events-timeline (vis.Timeline) is preserved by
@@ -3577,6 +3616,13 @@
                 chart.update('none');
             }
 
+            // Server-side TCP_INFO RTT chart (issue #401). Lives
+            // immediately under the bitrate chart, sharing the time
+            // axis / brush / pan via getChartsForSession, so RTT
+            // spikes line up visually with the bitrate / buffer
+            // reactions on the chart above.
+            renderRTTChart(sessionId, windowStart, windowMs);
+
             const bufferCanvas = card.querySelector('canvas.buffer-depth-chart');
             if (!bufferCanvas) return;
             const bufferChartRangeLabel = card.querySelector('[data-field="buffer_depth_chart_range"]');
@@ -4105,6 +4151,216 @@
             }
         }
 
+        // Server-side TCP_INFO RTT chart (issue #401). Sits directly
+        // under the bitrate chart, time-axis-locked to it via
+        // getChartsForSession + buildUnifiedChartZoomOptions. Datasets:
+        //   1. RTT max (transparent line, fills downward to RTT min)
+        //   2. RTT min (transparent line, anchors the band floor)
+        //   3. RTT avg (solid, primary line)
+        //   4. RTT lifetime min (dashed reference — kernel's sticky
+        //      per-connection min RTT, the "path floor")
+        //   5. RTO (thin red, hidden by default — toggleable; rises
+        //      above RTT during a wedge while smoothed RTT flatlines)
+        function renderRTTChart(sessionId, windowStart, windowMs) {
+            if (isChartPaused(sessionId)) return;
+            const card = document.querySelector(`.session-card[data-session-id="${sessionId}"]`);
+            if (!card) return;
+            const canvas = card.querySelector('canvas.rtt-chart');
+            if (!canvas) return;
+            const series = rttHistory.get(sessionId) || [];
+            if (!series.length) return;
+            const points = series
+                .filter(point => point.ts >= windowStart)
+                .map(point => {
+                    const x = (point.ts - windowStart) / 1000;
+                    // Stale points (no fresh kernel samples this 1 s
+                    // window) render as gaps on avg/max/min so the line
+                    // breaks rather than carrying a stale value
+                    // forward; lifetime-min and rto stay populated
+                    // because they're the latest kernel reads, not a
+                    // window aggregate.
+                    return {
+                        x,
+                        avg: point.stale ? null : point.avg,
+                        max: point.stale ? null : point.max,
+                        min: point.stale ? null : point.min,
+                        lifetimeMin: point.lifetimeMin,
+                        rto: point.rto
+                    };
+                });
+            const avgData = points.map(p => ({ x: p.x, y: p.avg }));
+            const maxData = points.map(p => ({ x: p.x, y: p.max }));
+            const minData = points.map(p => ({ x: p.x, y: p.min }));
+            const lifetimeMinData = points.map(p => ({ x: p.x, y: p.lifetimeMin }));
+            const rtoData = points.map(p => ({ x: p.x, y: p.rto }));
+
+            // Auto y-max: max of avg/max/lifetime/rto in window, ceil
+            // to nearest 10 ms with a 5 ms floor and 5000 ms cap (RTOs
+            // can spike to seconds during a wedge — clip rather than
+            // let one outlier flatten the rest of the chart).
+            const numericValues = []
+                .concat(avgData, maxData, lifetimeMinData, rtoData)
+                .map(p => Number(p.y))
+                .filter(v => Number.isFinite(v) && v >= 0);
+            const rawMax = Math.max(5, ...numericValues, 0);
+            const maxY = Math.min(5000, Math.max(5, Math.ceil((rawMax * 1.1) / 10) * 10));
+
+            const datasets = [
+                {
+                    label: '_rtt_max_anchor',
+                    data: maxData,
+                    borderColor: 'rgba(139,92,246,0)',
+                    backgroundColor: 'rgba(139,92,246,0.15)',
+                    borderWidth: 0,
+                    pointRadius: 0,
+                    fill: '+1',
+                    tension: 0.2,
+                    spanGaps: false
+                },
+                {
+                    label: '_rtt_min_anchor',
+                    data: minData,
+                    borderColor: 'rgba(139,92,246,0)',
+                    backgroundColor: 'rgba(139,92,246,0)',
+                    borderWidth: 0,
+                    pointRadius: 0,
+                    fill: false,
+                    tension: 0.2,
+                    spanGaps: false
+                },
+                {
+                    label: 'RTT avg (ms)',
+                    data: avgData,
+                    borderColor: '#8b5cf6',
+                    backgroundColor: 'rgba(139,92,246,0.12)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    fill: false,
+                    spanGaps: false
+                },
+                {
+                    label: 'RTT lifetime min (ms)',
+                    data: lifetimeMinData,
+                    borderColor: '#8b5cf6',
+                    backgroundColor: 'rgba(139,92,246,0)',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0,
+                    borderDash: [8, 4],
+                    fill: false
+                },
+                {
+                    label: 'RTO (ms)',
+                    data: rtoData,
+                    borderColor: '#ef4444',
+                    backgroundColor: 'rgba(239,68,68,0)',
+                    borderWidth: 1,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    borderDash: [4, 2],
+                    fill: false,
+                    hidden: true
+                }
+            ];
+
+            let chart = rttCharts.get(sessionId);
+            if (chart && chart.canvas !== canvas) {
+                chart.destroy();
+                chart = null;
+                rttCharts.delete(sessionId);
+            }
+            if (!chart) {
+                try {
+                    canvas.style.height = '180px';
+                    canvas.style.width = '100%';
+                    canvas.removeAttribute && canvas.removeAttribute('width');
+                    canvas.removeAttribute && canvas.removeAttribute('height');
+                } catch (e) { /* ignore */ }
+                chart = new Chart(canvas, {
+                    type: 'line',
+                    data: { datasets },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        animation: false,
+                        plugins: {
+                            legend: {
+                                display: true,
+                                position: 'bottom',
+                                ...legendHoverCallbacks,
+                                labels: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    filter: (item) => !item.text.startsWith('_')
+                                }
+                            },
+                            tooltip: {
+                                callbacks: {
+                                    title: (items) => {
+                                        const first = Array.isArray(items) && items.length ? items[0] : null;
+                                        if (!first) return '';
+                                        const xValue = Number(first.parsed?.x);
+                                        const startMs = Number(chart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, xValue);
+                                    }
+                                }
+                            },
+                            zoom: buildUnifiedChartZoomOptions(sessionId)
+                        },
+                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
+                        scales: {
+                            x: {
+                                type: 'linear',
+                                min: 0,
+                                max: 600,
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 },
+                                    maxTicksLimit: 8,
+                                    align: 'inner',
+                                    callback: (value) => {
+                                        const startMs = Number(chart?.$windowStartMs || windowStart);
+                                        return formatBitrateChartAbsoluteTick(startMs, Number(value));
+                                    }
+                                }
+                            },
+                            y: {
+                                min: 0,
+                                max: maxY,
+                                afterFit: (axis) => { axis.width = 90; },
+                                grid: { color: '#e5e7eb' },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'RTT (ms)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            }
+                        }
+                    }
+                });
+                chart.$windowStartMs = windowStart;
+                applyStoredChartViewport(sessionId, chart);
+                installRightMousePanHandlers(sessionId, chart);
+                installChartClickPauseHandler(sessionId, chart);
+                ensureChartLiveWheelAnchor();
+                rttCharts.set(sessionId, chart);
+            } else {
+                chart.data.datasets = datasets;
+                chart.$windowStartMs = windowStart;
+                chart.options.scales.y.max = maxY;
+                applyChartXMax(chart, windowMs);
+                applyLegendHover(chart);
+                chart.update('none');
+            }
+        }
+
         function saveSettingsForCard(card) {
             const data = TestingSessionUI.readSessionSettings(card);
             const fields = Object.keys(data || {}).filter(field => field !== 'session_id');
@@ -4493,6 +4749,7 @@
                     }
                     eventsCharts.delete(activeSessionId);
                     bandwidthCharts.delete(activeSessionId);
+                    rttCharts.delete(activeSessionId);
                     bufferDepthCharts.delete(activeSessionId);
                     videoFpsCharts.delete(activeSessionId);
                 }
@@ -5135,6 +5392,8 @@
             bufferDepthCharts: bufferDepthCharts,
             videoFpsCharts: videoFpsCharts,
             eventsCharts: eventsCharts,
+            rttHistory: rttHistory,
+            rttCharts: rttCharts,
             bandwidthVisibility: bandwidthVisibility,
             bitrateAxisMaxBySession: bitrateAxisMaxBySession,
             chartViewportBySession: chartViewportBySession,

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -4332,7 +4332,11 @@
                             },
                             zoom: buildUnifiedChartZoomOptions(sessionId)
                         },
-                        layout: { padding: { right: RIGHT_AXIS_PAD_PX } },
+                        // No layout.padding.right — the y1 axis below
+                        // already reserves RIGHT_AXIS_PAD_PX. Adding
+                        // both stacks them and pushes the plot's right
+                        // edge inward, mis-aligning with the bandwidth
+                        // / buffer / FPS charts above and below.
                         scales: {
                             x: {
                                 type: 'linear',

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -4233,11 +4233,15 @@
                     yAxisID: 'y'
                 },
                 {
-                    label: '_rtt_min_anchor',
+                    label: 'RTT min (ms)',
                     data: minData,
-                    borderColor: 'rgba(139,92,246,0)',
+                    // Same lighter purple as max — both are bounds on
+                    // the avg, just at opposite ends. fill:false so
+                    // the band-fill anchored on max above only paints
+                    // once, not twice.
+                    borderColor: 'rgba(139,92,246,0.55)',
                     backgroundColor: 'rgba(139,92,246,0)',
-                    borderWidth: 0,
+                    borderWidth: 1,
                     pointRadius: 0,
                     fill: false,
                     tension: 0.2,

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -4196,7 +4196,14 @@
                         rto: point.rto,
                         pathPing: point.pathPing
                     };
-                });
+                })
+                // Defensive sort: a Chart.js line chart connects points
+                // in array order. Non-monotonic x (player clock skew,
+                // duplicate snapshots replayed by the SSE pipeline,
+                // re-broadcasts at queue-flush boundaries) would draw
+                // the line backwards and forwards. Sorting by x makes
+                // the line strictly monotonic regardless of push order.
+                .sort((a, b) => a.x - b.x);
             const avgData = points.map(p => ({ x: p.x, y: p.avg }));
             const maxData = points.map(p => ({ x: p.x, y: p.max }));
             const minData = points.map(p => ({ x: p.x, y: p.min }));

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -4194,28 +4194,43 @@
             const lifetimeMinData = points.map(p => ({ x: p.x, y: p.lifetimeMin }));
             const rtoData = points.map(p => ({ x: p.x, y: p.rto }));
 
-            // Auto y-max: max of avg/max/lifetime/rto in window, ceil
-            // to nearest 10 ms with a 5 ms floor and 5000 ms cap (RTOs
-            // can spike to seconds during a wedge — clip rather than
-            // let one outlier flatten the rest of the chart).
-            const numericValues = []
-                .concat(avgData, maxData, lifetimeMinData, rtoData)
+            // Two y-axes: RTT (left, low-millisecond range on a healthy
+            // path) and RTO (right, can spike to seconds during a
+            // wedge). Sharing one axis would flatten the RTT line to
+            // a flat-zero baseline whenever RTO climbs.
+            const rttValues = []
+                .concat(avgData, maxData, lifetimeMinData)
                 .map(p => Number(p.y))
                 .filter(v => Number.isFinite(v) && v >= 0);
-            const rawMax = Math.max(5, ...numericValues, 0);
-            const maxY = Math.min(5000, Math.max(5, Math.ceil((rawMax * 1.1) / 10) * 10));
+            const rtoValues = rtoData
+                .map(p => Number(p.y))
+                .filter(v => Number.isFinite(v) && v >= 0);
+            // RTT axis: floor at 5 ms; cap at 1000 ms (LAN ~1 ms,
+            // shaped 100–500 ms — beyond a second RTT we're in a
+            // pathology that owns the chart anyway).
+            const rttRawMax = Math.max(5, ...rttValues, 0);
+            const maxY = Math.min(1000, Math.max(5, Math.ceil((rttRawMax * 1.1) / 10) * 10));
+            // RTO axis: floor at 50 ms (kernel default); cap at 60000 ms
+            // (kernel ceiling is TCP_RTO_MAX, typically 120 s — clip
+            // hard so a single outlier doesn't dominate).
+            const rtoRawMax = Math.max(50, ...rtoValues, 0);
+            const maxY1 = Math.min(60000, Math.max(50, Math.ceil((rtoRawMax * 1.1) / 50) * 50));
 
             const datasets = [
                 {
-                    label: '_rtt_max_anchor',
+                    label: 'RTT max (ms)',
                     data: maxData,
-                    borderColor: 'rgba(139,92,246,0)',
+                    // Lighter purple than avg so the line reads as a
+                    // bound, not the primary signal. fill:'+1' shades
+                    // the band down to the (transparent) min anchor.
+                    borderColor: 'rgba(139,92,246,0.55)',
                     backgroundColor: 'rgba(139,92,246,0.15)',
-                    borderWidth: 0,
+                    borderWidth: 1,
                     pointRadius: 0,
                     fill: '+1',
                     tension: 0.2,
-                    spanGaps: false
+                    spanGaps: false,
+                    yAxisID: 'y'
                 },
                 {
                     label: '_rtt_min_anchor',
@@ -4226,7 +4241,8 @@
                     pointRadius: 0,
                     fill: false,
                     tension: 0.2,
-                    spanGaps: false
+                    spanGaps: false,
+                    yAxisID: 'y'
                 },
                 {
                     label: 'RTT avg (ms)',
@@ -4237,7 +4253,8 @@
                     pointRadius: 0,
                     tension: 0.2,
                     fill: false,
-                    spanGaps: false
+                    spanGaps: false,
+                    yAxisID: 'y'
                 },
                 {
                     label: 'RTT lifetime min (ms)',
@@ -4248,7 +4265,8 @@
                     pointRadius: 0,
                     tension: 0,
                     borderDash: [8, 4],
-                    fill: false
+                    fill: false,
+                    yAxisID: 'y'
                 },
                 {
                     label: 'RTO (ms)',
@@ -4260,7 +4278,7 @@
                     tension: 0.2,
                     borderDash: [4, 2],
                     fill: false,
-                    hidden: true
+                    yAxisID: 'y1'
                 }
             ];
 
@@ -4327,6 +4345,7 @@
                                 }
                             },
                             y: {
+                                position: 'left',
                                 min: 0,
                                 max: maxY,
                                 afterFit: (axis) => { axis.width = 90; },
@@ -4338,6 +4357,27 @@
                                 title: {
                                     display: true,
                                     text: 'RTT (ms)',
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                }
+                            },
+                            y1: {
+                                position: 'right',
+                                min: 0,
+                                max: maxY1,
+                                // Pin width to RIGHT_AXIS_PAD_PX so the
+                                // plot's right edge matches the bandwidth
+                                // / buffer / FPS charts, keeping x-axis
+                                // ticks aligned across the stack.
+                                afterFit: (axis) => { axis.width = RIGHT_AXIS_PAD_PX; },
+                                grid: { drawOnChartArea: false },
+                                ticks: {
+                                    color: '#6b7280',
+                                    font: { family: 'Courier New, monospace', size: 10 }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'RTO (ms)',
                                     color: '#6b7280',
                                     font: { family: 'Courier New, monospace', size: 10 }
                                 }
@@ -4355,6 +4395,7 @@
                 chart.data.datasets = datasets;
                 chart.$windowStartMs = windowStart;
                 chart.options.scales.y.max = maxY;
+                chart.options.scales.y1.max = maxY1;
                 applyChartXMax(chart, windowMs);
                 applyLegendHover(chart);
                 chart.update('none');

--- a/content/shared/session-shell.js
+++ b/content/shared/session-shell.js
@@ -2195,6 +2195,11 @@
             const rttLifetimeMin = numericIfFinite(session.client_rtt_min_lifetime_ms);
             const rttVar = numericIfFinite(session.client_rtt_var_ms);
             const rttRto = numericIfFinite(session.client_rto_ms);
+            // Out-of-band ICMP path-ping (issue #404). Independent of
+            // the streaming connection's queue contribution — stays
+            // at the LAN baseline when shaping kicks in while the
+            // TCP_INFO lines climb from queueing.
+            const pathPing = numericIfFinite(session.client_path_ping_rtt_ms);
             const rttStale = session.client_rtt_stale === true;
             const rttSeries = rttHistory.get(key) || [];
             rttSeries.push({
@@ -2205,6 +2210,7 @@
                 lifetimeMin: rttLifetimeMin,
                 variance: rttVar,
                 rto: rttRto,
+                pathPing,
                 stale: rttStale
             });
             rttHistory.set(key, rttSeries.filter(point => point.ts >= cutoff));
@@ -4187,7 +4193,8 @@
                         max: point.stale ? null : point.max,
                         min: point.stale ? null : point.min,
                         lifetimeMin: point.lifetimeMin,
-                        rto: point.rto
+                        rto: point.rto,
+                        pathPing: point.pathPing
                     };
                 });
             const avgData = points.map(p => ({ x: p.x, y: p.avg }));
@@ -4195,13 +4202,14 @@
             const minData = points.map(p => ({ x: p.x, y: p.min }));
             const lifetimeMinData = points.map(p => ({ x: p.x, y: p.lifetimeMin }));
             const rtoData = points.map(p => ({ x: p.x, y: p.rto }));
+            const pathPingData = points.map(p => ({ x: p.x, y: p.pathPing }));
 
             // Two y-axes: RTT (left, low-millisecond range on a healthy
             // path) and RTO (right, can spike to seconds during a
             // wedge). Sharing one axis would flatten the RTT line to
             // a flat-zero baseline whenever RTO climbs.
             const rttValues = []
-                .concat(avgData, maxData, lifetimeMinData)
+                .concat(avgData, maxData, lifetimeMinData, pathPingData)
                 .map(p => Number(p.y))
                 .filter(v => Number.isFinite(v) && v >= 0);
             const rtoValues = rtoData
@@ -4272,6 +4280,21 @@
                     tension: 0,
                     borderDash: [8, 4],
                     fill: false,
+                    yAxisID: 'y'
+                },
+                {
+                    // Out-of-band ICMP path-ping (issue #404). Cyan
+                    // to read as "physical path", distinct from the
+                    // purple TCP_INFO family on the same axis.
+                    label: 'Path ping (ms)',
+                    data: pathPingData,
+                    borderColor: '#0891b2',
+                    backgroundColor: 'rgba(8,145,178,0.10)',
+                    borderWidth: 2,
+                    pointRadius: 0,
+                    tension: 0.2,
+                    fill: false,
+                    spanGaps: false,
                     yAxisID: 'y'
                 },
                 {

--- a/docs/API.md
+++ b/docs/API.md
@@ -156,6 +156,21 @@ Network log response shape:
 | GET | `/api/version` | Build version / commit SHA |
 | GET | `/debug` | Internal debug HTML dashboard |
 
+### Server-side RTT fields (issue #401)
+
+Every `/api/sessions` row and SSE snapshot carries six TCP_INFO-derived RTT metrics, in milliseconds. Sampled inside go-proxy by a 100 ms ticker that calls `getsockopt(TCP_INFO)` on each session's most-recent connection and folds the reads into a 1 s window drained on every snapshot tick. Linux-only; the macOS dev build emits zeros.
+
+| Field | Source | Meaning |
+|---|---|---|
+| `client_rtt_ms` | window-avg of `tcpi_rtt` | Smoothed RTT (RFC 6298 SRTT, kernel EWMA) |
+| `client_rtt_max_ms` | window-max of `tcpi_rtt` | Peak smoothed RTT in window — sub-second spike detector |
+| `client_rtt_min_ms` | window-min of `tcpi_rtt` | Trough during the window |
+| `client_rtt_min_lifetime_ms` | `tcpi_min_rtt` | Min RTT ever observed on this connection — path floor |
+| `client_rtt_var_ms` | `tcpi_rttvar` | Smoothed mean deviation (jitter) |
+| `client_rto_ms` | `tcpi_rto` | Current retransmit timeout — rises during a wedge |
+
+If a 1 s window had no fresh kernel samples (typically a short connection gap), the row carries `client_rtt_stale: true` alongside the previous-window values.
+
 ## CORS and caching
 
 All API responses include `Access-Control-Allow-Origin: *` and `Cache-Control: no-cache, no-store, must-revalidate` headers (applied by nginx). Media segments are the exception — they are immutable and served with `expires 1y`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -168,6 +168,7 @@ Every `/api/sessions` row and SSE snapshot carries six TCP_INFO-derived RTT metr
 | `client_rtt_min_lifetime_ms` | `tcpi_min_rtt` | Min RTT ever observed on this connection — path floor |
 | `client_rtt_var_ms` | `tcpi_rttvar` | Smoothed mean deviation (jitter) |
 | `client_rto_ms` | `tcpi_rto` | Current retransmit timeout — rises during a wedge |
+| `client_path_ping_rtt_ms` | ICMP echo, 1 Hz | Out-of-band path latency (issue #404), independent of throttle — zero / absent when ICMP is filtered |
 
 If a 1 s window had no fresh kernel samples (typically a short connection gap), the row carries `client_rtt_stale: true` alongside the previous-window values.
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1258,18 +1258,25 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 	if err := t.ensurePrioLeafForPort(port); err != nil {
 		return err
 	}
-	jitter := delayMs / 2
 	for band := 1; band <= 3; band++ {
 		bandParent := fmt.Sprintf("%s0:%d", portSuffix, band) // e.g. 1810:1
 		bandHandle := fmt.Sprintf("%s%d:", portSuffix, band)  // e.g. 1811:
 		args := []string{"qdisc", "replace", "dev", t.interfaceName,
 			"parent", bandParent, "handle", bandHandle, "netem"}
 		if delayMs > 0 {
-			if jitter > 0 {
-				args = append(args, "delay", fmt.Sprintf("%dms", delayMs), fmt.Sprintf("%dms", jitter), "distribution", "normal")
-			} else {
-				args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
-			}
+			// Exact configured delay — no auto-jitter. Earlier
+			// versions added a normal-distributed `delay/2` jitter
+			// term to "look realistic", but it meant per-packet
+			// delay was sampled from N(mean=delay, stddev=delay/2)
+			// — so a configured 25 ms could yield individual
+			// packets in [13, 37] ms (and below netem-clamp-zero
+			// in the long tail). The path-ping chart's per-window
+			// min then dipped below the configured value, which
+			// surprised users (and is the wrong mental model for
+			// "I set 25 ms of delay"). If we ever expose a jitter
+			// dial in the UI, plumb it through as a separate
+			// param rather than auto-deriving from the delay.
+			args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
 		}
 		if lossPct > 0 {
 			args = append(args, "loss", fmt.Sprintf("%.2f%%", lossPct))

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1487,6 +1487,11 @@ func main() {
 	// snapshot broadcast (issue #401). Linux-only kernel read; the
 	// !linux stub keeps the dev build green on macOS.
 	app.startRTTSampler(context.Background())
+	// 1 Hz out-of-band ICMP probe to each session's player_ip
+	// (issue #404). Surfaces path latency independent of the
+	// streaming connection's queue contribution — the line that
+	// stays put when shaping kicks in, while TCP_INFO RTT climbs.
+	app.startPathPingSampler(context.Background())
 
 	router := mux.NewRouter()
 	router.Use(corsMiddleware)
@@ -4323,6 +4328,11 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionStoreTCPConn(sessionData, tcpConn)
 		sessionGetOrCreateRTTWindow(sessionData)
 	}
+	// Path-ping holder for issue #404 — created here (not in the
+	// sampler) so the snapshot map mutation rides on handleProxy's
+	// normal save path. Sampler reads via the atomic; never writes
+	// to the map itself.
+	sessionGetOrCreatePingRTT(sessionData)
 	log.Printf(
 		"[GO-PROXY][REQUEST] method=%s host=%s port=%s path=%s query=%s session_id=%s player_id_q=%s player_id_h=%s playback_session_h=%s client_ip=%s user_agent=%q",
 		r.Method,
@@ -6681,14 +6691,17 @@ func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData
 		// drainAndReset's stale fallback. Acceptable for a
 		// monitoring tool; flagging it here for future readers.
 		drainSessionRTT(session)
+		// Out-of-band ICMP path-ping (issue #404). Latest 1 Hz
+		// sample stamped here as `client_path_ping_rtt_ms`.
+		stampSessionPathPing(session)
 		// Strip internal session keys that aren't meant for the
-		// SSE / JSON projection — *atomic.Pointer[net.TCPConn]
-		// and *RTTWindow are runtime handles, not metrics. The
-		// authoritative copies live on the snapshot map and are
-		// preserved across cloneSession (cloneInterface's default
-		// arm passes unknown pointer types through).
+		// SSE / JSON projection — runtime handles, not metrics.
+		// The authoritative copies live on the snapshot map and
+		// are preserved across cloneSession (cloneInterface's
+		// default arm passes unknown pointer types through).
 		delete(session, "_lastTCPConn")
 		delete(session, "_rttWindow")
+		delete(session, "_pingRTTUs")
 	}
 	return sessions
 }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1264,19 +1264,23 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 		args := []string{"qdisc", "replace", "dev", t.interfaceName,
 			"parent", bandParent, "handle", bandHandle, "netem"}
 		if delayMs > 0 {
-			// Exact configured delay — no auto-jitter. Earlier
-			// versions added a normal-distributed `delay/2` jitter
-			// term to "look realistic", but it meant per-packet
-			// delay was sampled from N(mean=delay, stddev=delay/2)
-			// — so a configured 25 ms could yield individual
-			// packets in [13, 37] ms (and below netem-clamp-zero
-			// in the long tail). The path-ping chart's per-window
-			// min then dipped below the configured value, which
-			// surprised users (and is the wrong mental model for
-			// "I set 25 ms of delay"). If we ever expose a jitter
-			// dial in the UI, plumb it through as a separate
-			// param rather than auto-deriving from the delay.
-			args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
+			// Tight Gaussian: stddev = 5% of mean. For delay=25 ms
+			// that's ~1 ms stddev, so ~99.7% of per-packet delays
+			// land in [22, 28] ms — variance for ABR/jitter-aware
+			// testing without dominating the configured value.
+			// Earlier `delay/2` was way too wide (a 25 ms config
+			// could draw [13, 37] ms with normal distribution and
+			// dip below netem's clamp-at-zero floor in the long
+			// tail), which violated the "I set 25 ms" mental model.
+			// Integer-divide rounds small delays (≤19 ms) to zero
+			// jitter — fine: those configs are testing low-RTT
+			// paths where jitter noise would be the dominant signal.
+			jitter := delayMs / 20
+			if jitter > 0 {
+				args = append(args, "delay", fmt.Sprintf("%dms", delayMs), fmt.Sprintf("%dms", jitter), "distribution", "normal")
+			} else {
+				args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
+			}
 		}
 		if lossPct > 0 {
 			args = append(args, "loss", fmt.Sprintf("%.2f%%", lossPct))

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -967,6 +967,15 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 	if err := t.ensurePortFilter(port, classid); err != nil {
 		return err
 	}
+	// Make sure the per-port prio+netem-per-band leaf is in place so
+	// the path-ping probe (issue #404) actually jumps the bulk queue
+	// even when shaping was set up via a rate-only call (no netem).
+	// Without this the class falls back to the kernel's default
+	// pfifo leaf and ICMP routed in via ApplyPlayerICMPFilter would
+	// queue behind segment data.
+	if err := t.ensurePrioLeafForPort(port); err != nil {
+		log.Printf("NETSHAPE prio leaf install failed port=%d: %v", port, err)
+	}
 	verifyCmd := exec.Command("tc", "class", "show", "dev", t.interfaceName)
 	verifyOut, _ := verifyCmd.CombinedOutput()
 	afterFilterCmd := exec.Command("tc", "filter", "show", "dev", t.interfaceName)
@@ -1166,27 +1175,63 @@ func (t *TcTrafficManager) EnsureClass(port int, rateMbps float64) error {
 	return t.UpdateRateLimit(port, rateMbps)
 }
 
-// UpdateNetem (re)writes the leaf qdisc inside the per-port HTB class.
+// ensurePrioLeafForPort installs the prio+netem-per-band leaf inside
+// the per-port HTB class if it isn't already there (issue #404).
+// MUST run whenever the class is created/updated — including the
+// rate-limit-only path (UpdateRateLimit) and the netem path
+// (UpdateNetem) — otherwise the class falls back to the default
+// pfifo leaf and the path-ping probe queues behind bulk regardless
+// of what `IP_TOS` the probe socket set.
 //
-// Layout (issue #404):
+// Layout:
 //
-//	HTB class (1:<suffix>, rate-limited)
-//	└── prio (handle <suffix>0:, 3 bands, default priomap)
-//	    ├── band 1 → netem (handle <suffix>1:, delay/loss)
-//	    ├── band 2 → netem (handle <suffix>2:, same delay/loss)
-//	    └── band 3 → netem (handle <suffix>3:, same delay/loss)
+//	HTB class 1:<suffix>
+//	└── prio  <suffix>0:        (3 bands, default priomap)
+//	    ├── netem <suffix>1:    (band 1 — TC_PRIO_INTERACTIVE → probe lane)
+//	    ├── netem <suffix>2:    (band 2 — TC_PRIO_BESTEFFORT → bulk lane)
+//	    └── netem <suffix>3:    (band 3 — unused)
 //
-// Bulk segment traffic (default skb->priority = 0 = TC_PRIO_BESTEFFORT)
-// lands in band 2. The path-ping ICMP socket sets IP_TOS = 0x10
-// (Min Delay → TC_PRIO_INTERACTIVE) so its packets land in band 1,
-// jumping bulk in the HTB drain order. All three bands carry netem
-// with identical delay/loss so the configured shaping applies
-// uniformly regardless of priority.
-//
-// Strict-priority scheduling means the probe is preempt-eligible but
-// not preempt-able mid-packet — the worst-case extra residency is one
-// MTU at the rate limit (≈12 ms at 1 Mbps, ≈2.4 ms at 5 Mbps), vs.
-// hundreds of ms of bufferbloat the bulk lane can accumulate.
+// Initial install gives each band a no-op netem (delay=0, loss=0);
+// UpdateNetem subsequently replaces the per-band netems with user-
+// configured values. Idempotent — exits fast when the prio handle
+// already shows up under `tc qdisc show parent <classid>`.
+func (t *TcTrafficManager) ensurePrioLeafForPort(port int) error {
+	portSuffix := fmt.Sprintf("%03d", port%1000)
+	classid := fmt.Sprintf("1:%s", portSuffix)
+	prioHandle := fmt.Sprintf("%s0:", portSuffix)
+	show := exec.Command("tc", "qdisc", "show", "dev", t.interfaceName, "parent", classid)
+	out, _ := show.CombinedOutput()
+	if strings.Contains(string(out), "qdisc prio "+prioHandle) {
+		return nil
+	}
+	// `replace` is destructive — wipes any existing leaf qdisc
+	// (e.g. the kernel default pfifo) atomically and installs prio
+	// in its place.
+	if installOut, err := exec.Command(
+		"tc", "qdisc", "replace", "dev", t.interfaceName,
+		"parent", classid, "handle", prioHandle,
+		"prio", "bands", "3",
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("tc prio replace failed: %s", strings.TrimSpace(string(installOut)))
+	}
+	for band := 1; band <= 3; band++ {
+		bandParent := fmt.Sprintf("%s0:%d", portSuffix, band)
+		bandHandle := fmt.Sprintf("%s%d:", portSuffix, band)
+		if out, err := exec.Command(
+			"tc", "qdisc", "replace", "dev", t.interfaceName,
+			"parent", bandParent, "handle", bandHandle, "netem",
+		).CombinedOutput(); err != nil {
+			return fmt.Errorf("tc netem (band %d) replace failed: %s", band, strings.TrimSpace(string(out)))
+		}
+	}
+	return nil
+}
+
+// UpdateNetem replaces each band's netem qdisc inside the prio leaf
+// with the new delay/loss params. Issue #404. The leaf itself is
+// installed (or confirmed present) before the netem replacements so
+// this works even when called on a class created by UpdateRateLimit
+// without netem ever previously being touched.
 func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) error {
 	if err := t.EnsureRootQdisc(); err != nil {
 		return err
@@ -1194,30 +1239,25 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 	if err := t.EnsureRootClass(); err != nil {
 		return err
 	}
-	if delayMs > 0 || lossPct > 0 {
+	portSuffix := fmt.Sprintf("%03d", port%1000)
+	classid := fmt.Sprintf("1:%s", portSuffix)
+	if delayMs <= 0 && lossPct <= 0 {
+		// Clearing netem when no class exists is a no-op — don't
+		// create one just to set zero netem on it.
+		showClass := exec.Command("tc", "class", "show", "dev", t.interfaceName)
+		classOut, _ := showClass.CombinedOutput()
+		if !strings.Contains(string(classOut), classid) {
+			t.logTcState("netem_clear", port)
+			return nil
+		}
+	} else {
 		if err := t.EnsureClass(port, 10000); err != nil {
 			return err
 		}
 	}
-	portSuffix := fmt.Sprintf("%03d", port%1000)
-	classid := fmt.Sprintf("1:%s", portSuffix)
-	prioHandle := fmt.Sprintf("%s0:", portSuffix)
-	if delayMs <= 0 && lossPct <= 0 {
-		// Removing the prio leaf cascades to its child netems.
-		_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "parent", classid, "handle", prioHandle).Run()
-		t.logTcState("netem_clear", port)
-		return nil
+	if err := t.ensurePrioLeafForPort(port); err != nil {
+		return err
 	}
-	// Replace leaf with prio (3 bands, default priomap).
-	if out, err := exec.Command(
-		"tc", "qdisc", "replace", "dev", t.interfaceName,
-		"parent", classid, "handle", prioHandle,
-		"prio", "bands", "3",
-	).CombinedOutput(); err != nil {
-		return fmt.Errorf("tc prio failed: %s", strings.TrimSpace(string(out)))
-	}
-	// Attach netem to each band so the configured delay/loss
-	// applies regardless of which band a packet lands in.
 	jitter := delayMs / 2
 	for band := 1; band <= 3; band++ {
 		bandParent := fmt.Sprintf("%s0:%d", portSuffix, band) // e.g. 1810:1
@@ -1238,7 +1278,11 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 			return fmt.Errorf("tc netem band %d failed: %s", band, strings.TrimSpace(string(out)))
 		}
 	}
-	t.logTcState("netem_apply", port)
+	if delayMs <= 0 && lossPct <= 0 {
+		t.logTcState("netem_clear", port)
+	} else {
+		t.logTcState("netem_apply", port)
+	}
 	return nil
 }
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -580,6 +580,13 @@ type TcTrafficManager struct {
 	nlMu          sync.Mutex
 	nlHandle      *netlink.Handle // persistent netlink handle, created lazily
 	nlLink        netlink.Link    // resolved once from interfaceName
+	// Per-port ICMP filter state (issue #404). Tracks the last
+	// player_ip we installed an ICMP-routing filter for so the
+	// path-ping sampler's per-tick ApplyPlayerICMPFilter call
+	// becomes a no-op when nothing changed. Also doubles as the
+	// "is a filter currently installed?" check for cleanup.
+	icmpFilterMu       sync.Mutex
+	icmpFilterIPByPort map[int]string
 }
 
 type ShapeApplyState struct {
@@ -779,7 +786,11 @@ func (s *NftShapeStep) UnmarshalJSON(data []byte) error {
 }
 
 func NewTcTrafficManager(interfaceName string, debug bool) *TcTrafficManager {
-	return &TcTrafficManager{interfaceName: interfaceName, debug: debug}
+	return &TcTrafficManager{
+		interfaceName:      interfaceName,
+		debug:              debug,
+		icmpFilterIPByPort: map[int]string{},
+	}
 }
 
 func (t *TcTrafficManager) IsActive() bool {
@@ -1008,6 +1019,15 @@ func (t *TcTrafficManager) ClearPortShaping(port int) {
 	_ = exec.Command("tc", "filter", "del", "dev", t.interfaceName, "protocol", "ip",
 		"parent", "1:0", "prio", "1", "u32",
 		"match", "ip", "sport", fmt.Sprintf("%d", port), "0xffff").Run()
+	// Also clear the per-port ICMP-to-player_ip filter installed for
+	// the path-ping prio routing (issue #404). Per-port pref makes
+	// this a single by-attribute delete; the tracking map is then
+	// pruned so a future install fires fresh tc commands.
+	_ = exec.Command("tc", "filter", "del", "dev", t.interfaceName,
+		"parent", "1:", "pref", icmpFilterPref(port)).Run()
+	t.icmpFilterMu.Lock()
+	delete(t.icmpFilterIPByPort, port)
+	t.icmpFilterMu.Unlock()
 	_ = exec.Command("tc", "class", "del", "dev", t.interfaceName, "classid", classid).Run()
 }
 
@@ -1146,6 +1166,27 @@ func (t *TcTrafficManager) EnsureClass(port int, rateMbps float64) error {
 	return t.UpdateRateLimit(port, rateMbps)
 }
 
+// UpdateNetem (re)writes the leaf qdisc inside the per-port HTB class.
+//
+// Layout (issue #404):
+//
+//	HTB class (1:<suffix>, rate-limited)
+//	└── prio (handle <suffix>0:, 3 bands, default priomap)
+//	    ├── band 1 → netem (handle <suffix>1:, delay/loss)
+//	    ├── band 2 → netem (handle <suffix>2:, same delay/loss)
+//	    └── band 3 → netem (handle <suffix>3:, same delay/loss)
+//
+// Bulk segment traffic (default skb->priority = 0 = TC_PRIO_BESTEFFORT)
+// lands in band 2. The path-ping ICMP socket sets IP_TOS = 0x10
+// (Min Delay → TC_PRIO_INTERACTIVE) so its packets land in band 1,
+// jumping bulk in the HTB drain order. All three bands carry netem
+// with identical delay/loss so the configured shaping applies
+// uniformly regardless of priority.
+//
+// Strict-priority scheduling means the probe is preempt-eligible but
+// not preempt-able mid-packet — the worst-case extra residency is one
+// MTU at the rate limit (≈12 ms at 1 Mbps, ≈2.4 ms at 5 Mbps), vs.
+// hundreds of ms of bufferbloat the bulk lane can accumulate.
 func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) error {
 	if err := t.EnsureRootQdisc(); err != nil {
 		return err
@@ -1160,29 +1201,104 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)
 	classid := fmt.Sprintf("1:%s", portSuffix)
-	handle := fmt.Sprintf("%s0:", portSuffix)
+	prioHandle := fmt.Sprintf("%s0:", portSuffix)
 	if delayMs <= 0 && lossPct <= 0 {
-		_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "parent", classid, "handle", handle, "netem").Run()
+		// Removing the prio leaf cascades to its child netems.
+		_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "parent", classid, "handle", prioHandle).Run()
 		t.logTcState("netem_clear", port)
 		return nil
 	}
+	// Replace leaf with prio (3 bands, default priomap).
+	if out, err := exec.Command(
+		"tc", "qdisc", "replace", "dev", t.interfaceName,
+		"parent", classid, "handle", prioHandle,
+		"prio", "bands", "3",
+	).CombinedOutput(); err != nil {
+		return fmt.Errorf("tc prio failed: %s", strings.TrimSpace(string(out)))
+	}
+	// Attach netem to each band so the configured delay/loss
+	// applies regardless of which band a packet lands in.
 	jitter := delayMs / 2
-	args := []string{"qdisc", "replace", "dev", t.interfaceName, "parent", classid, "handle", handle, "netem"}
-	if delayMs > 0 {
-		if jitter > 0 {
-			args = append(args, "delay", fmt.Sprintf("%dms", delayMs), fmt.Sprintf("%dms", jitter), "distribution", "normal")
-		} else {
-			args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
+	for band := 1; band <= 3; band++ {
+		bandParent := fmt.Sprintf("%s0:%d", portSuffix, band) // e.g. 1810:1
+		bandHandle := fmt.Sprintf("%s%d:", portSuffix, band)  // e.g. 1811:
+		args := []string{"qdisc", "replace", "dev", t.interfaceName,
+			"parent", bandParent, "handle", bandHandle, "netem"}
+		if delayMs > 0 {
+			if jitter > 0 {
+				args = append(args, "delay", fmt.Sprintf("%dms", delayMs), fmt.Sprintf("%dms", jitter), "distribution", "normal")
+			} else {
+				args = append(args, "delay", fmt.Sprintf("%dms", delayMs))
+			}
+		}
+		if lossPct > 0 {
+			args = append(args, "loss", fmt.Sprintf("%.2f%%", lossPct))
+		}
+		if out, err := exec.Command("tc", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("tc netem band %d failed: %s", band, strings.TrimSpace(string(out)))
 		}
 	}
-	if lossPct > 0 {
-		args = append(args, "loss", fmt.Sprintf("%.2f%%", lossPct))
-	}
-	cmd := exec.Command("tc", args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("tc netem failed: %s", strings.TrimSpace(string(out)))
-	}
 	t.logTcState("netem_apply", port)
+	return nil
+}
+
+// icmpFilterPref returns a unique tc filter pref for the per-port
+// ICMP-to-player_ip filter. Per-port pref means deletion can be
+// done by attribute (no need to parse handles out of `tc filter
+// show` output).
+func icmpFilterPref(port int) string {
+	return fmt.Sprintf("%d", 1000+(port%1000))
+}
+
+// ApplyPlayerICMPFilter installs (install=true) or removes
+// (install=false) a `tc filter` that routes ICMP packets destined
+// for `playerIP` into the per-port HTB class. Issue #404 — combined
+// with the prio+netem leaf installed by UpdateNetem and IP_TOS=0x10
+// on the path-ping socket, this is what lets the probe see the
+// configured netem delay while jumping the bulk queue.
+//
+// Idempotent: tracks the last-installed IP per port and skips the
+// tc invocation when nothing changed. Handles the player-IP-changed
+// case (rare but possible if a player reconnects from a different
+// IP under the same session) by deleting and re-adding.
+func (t *TcTrafficManager) ApplyPlayerICMPFilter(port int, playerIP string, install bool) error {
+	if t == nil {
+		return nil
+	}
+	t.icmpFilterMu.Lock()
+	defer t.icmpFilterMu.Unlock()
+	current := t.icmpFilterIPByPort[port]
+	pref := icmpFilterPref(port)
+	if !install || playerIP == "" {
+		if current == "" {
+			return nil
+		}
+		_ = exec.Command("tc", "filter", "del", "dev", t.interfaceName,
+			"parent", "1:", "pref", pref).Run()
+		delete(t.icmpFilterIPByPort, port)
+		return nil
+	}
+	if current == playerIP {
+		return nil
+	}
+	if current != "" {
+		_ = exec.Command("tc", "filter", "del", "dev", t.interfaceName,
+			"parent", "1:", "pref", pref).Run()
+	}
+	portSuffix := fmt.Sprintf("%03d", port%1000)
+	classid := fmt.Sprintf("1:%s", portSuffix)
+	cmd := exec.Command(
+		"tc", "filter", "add", "dev", t.interfaceName,
+		"protocol", "ip", "parent", "1:", "pref", pref, "u32",
+		"match", "ip", "protocol", "1", "0xff",
+		"match", "ip", "dst", playerIP+"/32",
+		"flowid", classid,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("tc icmp filter add port=%d ip=%s: %s",
+			port, playerIP, strings.TrimSpace(string(out)))
+	}
+	t.icmpFilterIPByPort[port] = playerIP
 	return nil
 }
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1482,6 +1482,11 @@ func main() {
 
 	go app.trackPortThroughput()
 	app.restoreTransportFaultSchedules()
+	// 100 ms TCP_INFO sampler — folds smoothed RTT / jitter / lifetime
+	// min / RTO into per-session windows that get drained on each
+	// snapshot broadcast (issue #401). Linux-only kernel read; the
+	// !linux stub keeps the dev build green on macOS.
+	app.startRTTSampler(context.Background())
 
 	router := mux.NewRouter()
 	router.Use(corsMiddleware)
@@ -1527,6 +1532,11 @@ func main() {
 			srv := &http.Server{
 				Addr:    bind,
 				Handler: router,
+				// Stamp the underlying *net.TCPConn on the per-
+				// connection context so handleProxy can attach
+				// it to its session for the RTT sampler to
+				// read. Issue #401.
+				ConnContext: withTCPConnContext,
 			}
 			errorCh <- srv.ListenAndServe()
 		}(addr)
@@ -4305,6 +4315,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	sessionData["x_forwarded_port"] = internalPort
 	sessionData["x_forwarded_port_external"] = externalPort
+	// Bind the live TCP connection to the session so the 100 ms RTT
+	// sampler can read TCP_INFO off it. Lazily creates the session's
+	// RTT window on first request; subsequent requests just refresh
+	// the conn pointer (atomic). Issue #401.
+	if tcpConn := tcpConnFromContext(r.Context()); tcpConn != nil {
+		sessionStoreTCPConn(sessionData, tcpConn)
+		sessionGetOrCreateRTTWindow(sessionData)
+	}
 	log.Printf(
 		"[GO-PROXY][REQUEST] method=%s host=%s port=%s path=%s query=%s session_id=%s player_id_q=%s player_id_h=%s playback_session_h=%s client_ip=%s user_agent=%q",
 		r.Method,
@@ -6654,6 +6672,23 @@ func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData
 		} else {
 			delete(session, "player_metrics_video_quality_pct")
 		}
+		// Drain the 1 s RTT window onto the snapshot so this
+		// broadcast carries fresh client_rtt_* fields. Issue #401.
+		// NB: this also runs on `/api/sessions` GET requests (which
+		// re-use this normalizer), so a poll racing the SSE flush
+		// can leave one of them with empty `client_rtt_ms` — the
+		// other path gets the previous-window replay via
+		// drainAndReset's stale fallback. Acceptable for a
+		// monitoring tool; flagging it here for future readers.
+		drainSessionRTT(session)
+		// Strip internal session keys that aren't meant for the
+		// SSE / JSON projection — *atomic.Pointer[net.TCPConn]
+		// and *RTTWindow are runtime handles, not metrics. The
+		// authoritative copies live on the snapshot map and are
+		// preserved across cloneSession (cloneInterface's default
+		// arm passes unknown pointer types through).
+		delete(session, "_lastTCPConn")
+		delete(session, "_rttWindow")
 	}
 	return sessions
 }

--- a/go-proxy/cmd/server/ping.go
+++ b/go-proxy/cmd/server/ping.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -85,6 +86,20 @@ func (a *App) startPathPingSampler(ctx context.Context) {
 						continue
 					}
 					ip := strings.TrimSpace(getString(session, "player_ip"))
+					// Keep the per-port ICMP filter in sync with
+					// shaping state (issue #404). When shaping is
+					// active we route ICMP-to-player_ip into the
+					// port's HTB class so the probe sees the
+					// configured netem delay; when shaping is off
+					// we tear the filter down so ICMP travels the
+					// unshaped default class.
+					port, _ := strconv.Atoi(strings.TrimSpace(getString(session, "x_forwarded_port")))
+					shapingActive := getFloat(session, "nftables_bandwidth_mbps") > 0 ||
+						getInt(session, "nftables_delay_ms") > 0 ||
+						getFloat(session, "nftables_packet_loss") > 0
+					if a.traffic != nil && port > 0 {
+						_ = a.traffic.ApplyPlayerICMPFilter(port, ip, shapingActive && ip != "")
+					}
 					if ip == "" {
 						holder.Store(0)
 						continue

--- a/go-proxy/cmd/server/ping.go
+++ b/go-proxy/cmd/server/ping.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Path-ping signal (issue #404). Sampled out-of-band of the streaming
+// TCP connection — ICMP echo from go-proxy → player_ip at 1 Hz so the
+// chart can show "what's the underlying path latency right now"
+// independently of the application's own queue contribution. The
+// TCP_INFO RTT shipped in #401 inflates with throttle because it's
+// always self-loaded; ICMP packets are tiny and don't fight for
+// bandwidth with the segment bytes, so they reflect the path's
+// latency floor in real time, not just at moments when the kernel
+// happened to capture an empty queue.
+
+// sessionGetOrCreatePingRTT installs a per-session *atomic.Uint32
+// (microseconds) holder under SessionData["_pingRTTUs"] if missing.
+// Same survival-across-clone trick as the TCP_INFO conn / window
+// holders — cloneInterface's default arm passes unknown pointer
+// types through, so the holder created in handleProxy persists
+// through every subsequent snapshot.
+func sessionGetOrCreatePingRTT(s SessionData) *atomic.Uint32 {
+	if s == nil {
+		return nil
+	}
+	if h, ok := s["_pingRTTUs"].(*atomic.Uint32); ok && h != nil {
+		return h
+	}
+	h := &atomic.Uint32{}
+	s["_pingRTTUs"] = h
+	return h
+}
+
+func sessionLoadPingRTT(s SessionData) *atomic.Uint32 {
+	if s == nil {
+		return nil
+	}
+	if h, ok := s["_pingRTTUs"].(*atomic.Uint32); ok {
+		return h
+	}
+	return nil
+}
+
+// startPathPingSampler runs a 1 Hz ticker that pings each active
+// session's player_ip via ICMP echo and stamps the round-trip time
+// (microseconds) into the per-session atomic holder. Drained by
+// drainSessionRTT and surfaced as `client_path_ping_rtt_ms` on the
+// snapshot. 1 Hz matches the snapshot emit cadence — no folding
+// needed; the chart line gets one fresh sample per tick.
+//
+// Failures (ICMP filtered, host unreachable, malformed IP) write 0
+// so the chart shows a gap rather than dragging stale values forward.
+// On non-Linux builds newPingSocket returns (nil, nil) and we log a
+// disabled message; the rest of the proxy keeps running.
+func (a *App) startPathPingSampler(ctx context.Context) {
+	sock, err := newPingSocket()
+	if err != nil {
+		log.Printf("path ping sampler disabled: %v", err)
+		return
+	}
+	if sock == nil {
+		log.Printf("path ping sampler disabled: ICMP not supported on this build")
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				snap := a.sessionsSnap.Load()
+				if snap == nil {
+					continue
+				}
+				for _, session := range *snap {
+					holder := sessionLoadPingRTT(session)
+					if holder == nil {
+						continue
+					}
+					ip := strings.TrimSpace(getString(session, "player_ip"))
+					if ip == "" {
+						holder.Store(0)
+						continue
+					}
+					rttUs, perr := sock.ping(ip, 200*time.Millisecond)
+					if perr != nil {
+						holder.Store(0)
+						continue
+					}
+					holder.Store(rttUs)
+				}
+			}
+		}
+	}()
+	log.Printf("path ping sampler started (1Hz)")
+}
+
+// stampSessionPathPing reads the latest per-session ping holder and
+// stamps client_path_ping_rtt_ms onto the session map. Called from
+// normalizeSessionsForResponse alongside drainSessionRTT.
+func stampSessionPathPing(session SessionData) {
+	holder := sessionLoadPingRTT(session)
+	if holder == nil {
+		return
+	}
+	rttUs := holder.Load()
+	if rttUs == 0 {
+		// No fresh ping this tick (timeout, ICMP filtered, no IP).
+		// Delete rather than emitting 0 so the chart renders a gap.
+		delete(session, "client_path_ping_rtt_ms")
+		return
+	}
+	session["client_path_ping_rtt_ms"] = float64(rttUs) / 1000.0
+}

--- a/go-proxy/cmd/server/ping_linux.go
+++ b/go-proxy/cmd/server/ping_linux.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/net/icmp"
+	"golang.org/x/net/ipv4"
+)
+
+// pingSocket is a single shared *icmp.PacketConn shared across all
+// per-session pingers. A receiver goroutine demuxes Echo Replies by
+// (id, seq) into per-call reply channels — so one global socket
+// handles arbitrarily many concurrent ping calls without the lock-
+// hold-during-recv problem of a serial sender.
+//
+// The container runs `privileged: true` (see docker-compose.yml),
+// so raw IPPROTO_ICMP works; we don't need the unprivileged datagram
+// flavour or the ping_group_range sysctl dance.
+type pingSocket struct {
+	conn      *icmp.PacketConn
+	pid       int
+	seq       uint32 // atomic
+	pendingMu sync.Mutex
+	pending   map[uint32]chan time.Time
+}
+
+func newPingSocket() (*pingSocket, error) {
+	c, err := icmp.ListenPacket("ip4:icmp", "0.0.0.0")
+	if err != nil {
+		return nil, err
+	}
+	s := &pingSocket{
+		conn:    c,
+		pid:     os.Getpid() & 0xffff,
+		pending: map[uint32]chan time.Time{},
+	}
+	go s.recvLoop()
+	return s, nil
+}
+
+func (s *pingSocket) recvLoop() {
+	buf := make([]byte, 1500)
+	for {
+		n, _, err := s.conn.ReadFrom(buf)
+		if err != nil {
+			// Socket closed or fatal — bail out; next ping attempt
+			// will surface the error to the sampler which writes 0.
+			return
+		}
+		replyAt := time.Now()
+		msg, perr := icmp.ParseMessage(int(ipv4.ICMPTypeEchoReply.Protocol()), buf[:n])
+		if perr != nil {
+			continue
+		}
+		if msg.Type != ipv4.ICMPTypeEchoReply {
+			continue
+		}
+		echo, ok := msg.Body.(*icmp.Echo)
+		if !ok {
+			continue
+		}
+		key := pingKey(uint16(echo.ID), uint16(echo.Seq))
+		s.pendingMu.Lock()
+		ch, ok := s.pending[key]
+		if ok {
+			delete(s.pending, key)
+		}
+		s.pendingMu.Unlock()
+		if ok {
+			select {
+			case ch <- replyAt:
+			default:
+			}
+		}
+	}
+}
+
+func pingKey(id, seq uint16) uint32 {
+	return (uint32(id) << 16) | uint32(seq)
+}
+
+// ping issues one ICMP Echo Request to addr and returns the round-
+// trip time in microseconds. timeout caps how long we wait for the
+// matching Echo Reply.
+func (s *pingSocket) ping(addr string, timeout time.Duration) (uint32, error) {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return 0, errors.New("invalid ip")
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		// IPv6 not currently supported — player_ip is observed at the
+		// HTTP request layer where the dashboard's testing flow uses
+		// IPv4 throughout. Failing fast here is fine; the chart shows
+		// a gap.
+		return 0, errors.New("ipv6 not supported")
+	}
+	seq := uint16(atomic.AddUint32(&s.seq, 1))
+	body := &icmp.Echo{
+		ID:   s.pid,
+		Seq:  int(seq),
+		Data: []byte("ism-rtt-401"),
+	}
+	msg := &icmp.Message{Type: ipv4.ICMPTypeEcho, Code: 0, Body: body}
+	payload, err := msg.Marshal(nil)
+	if err != nil {
+		return 0, err
+	}
+	key := pingKey(uint16(s.pid), seq)
+	ch := make(chan time.Time, 1)
+	s.pendingMu.Lock()
+	s.pending[key] = ch
+	s.pendingMu.Unlock()
+	cleanup := func() {
+		s.pendingMu.Lock()
+		delete(s.pending, key)
+		s.pendingMu.Unlock()
+	}
+	sentAt := time.Now()
+	if _, err := s.conn.WriteTo(payload, &net.IPAddr{IP: v4}); err != nil {
+		cleanup()
+		return 0, err
+	}
+	select {
+	case replyAt := <-ch:
+		return uint32(replyAt.Sub(sentAt).Microseconds()), nil
+	case <-time.After(timeout):
+		cleanup()
+		return 0, errors.New("ping timeout")
+	}
+}

--- a/go-proxy/cmd/server/ping_linux.go
+++ b/go-proxy/cmd/server/ping_linux.go
@@ -36,6 +36,15 @@ func newPingSocket() (*pingSocket, error) {
 	if err != nil {
 		return nil, err
 	}
+	// IP_TOS = 0x10 (Min Delay) maps to TC_PRIO_INTERACTIVE under the
+	// kernel's default rt_tos2priority table, which the per-port
+	// `prio` qdisc installed by UpdateNetem routes to band 0 — the
+	// high-priority lane that jumps bulk segment data queued in
+	// band 1. Issue #404. SetTOS sets the socket-level IP_TOS option
+	// so all subsequent sends inherit it; no per-packet cmsg dance.
+	if pc := c.IPv4PacketConn(); pc != nil {
+		_ = pc.SetTOS(0x10)
+	}
 	s := &pingSocket{
 		conn:    c,
 		pid:     os.Getpid() & 0xffff,

--- a/go-proxy/cmd/server/ping_other.go
+++ b/go-proxy/cmd/server/ping_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package main
+
+import "time"
+
+// pingSocket / newPingSocket on non-Linux platforms are stubs so the
+// dev build (typically macOS) keeps compiling. Whole feature is gated
+// at the sampler-start path — newPingSocket returns (nil, nil) and
+// the sampler logs "disabled" and exits. Production go-proxy only
+// runs in the Linux container.
+type pingSocket struct{}
+
+func newPingSocket() (*pingSocket, error) {
+	return nil, nil
+}
+
+func (s *pingSocket) ping(addr string, timeout time.Duration) (uint32, error) {
+	return 0, nil
+}

--- a/go-proxy/cmd/server/rtt.go
+++ b/go-proxy/cmd/server/rtt.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// tcpInfoSnapshot is the platform-agnostic subset of struct tcp_info
+// we care about. All values are in microseconds. Populated by
+// readTCPInfo (Linux build) or zeroed by the !linux stub.
+type tcpInfoSnapshot struct {
+	rttUs    uint32 // tcpi_rtt — smoothed RTT (RFC 6298 SRTT)
+	rttVarUs uint32 // tcpi_rttvar — smoothed mean deviation (jitter)
+	minRTTUs uint32 // tcpi_min_rtt — connection-lifetime min (Linux 4.6+)
+	rtoUs    uint32 // tcpi_rto — current retransmit timeout
+}
+
+// tcpConnCtxKey is the context key under which we stash the underlying
+// *net.TCPConn from http.Server.ConnContext. Required because
+// handleProxy otherwise has no way to reach the live TCP connection
+// (Hijacker would tear it out of the server, which we don't want).
+type tcpConnCtxKey struct{}
+
+// withTCPConnContext is the http.Server.ConnContext callback. Down-
+// casts c to *net.TCPConn (true for the stdlib HTTP listener) and
+// stamps it on the per-connection context so handleProxy can pull it
+// off later via tcpConnFromContext.
+func withTCPConnContext(ctx context.Context, c net.Conn) context.Context {
+	if tc, ok := c.(*net.TCPConn); ok {
+		return context.WithValue(ctx, tcpConnCtxKey{}, tc)
+	}
+	return ctx
+}
+
+func tcpConnFromContext(ctx context.Context) *net.TCPConn {
+	if tc, ok := ctx.Value(tcpConnCtxKey{}).(*net.TCPConn); ok {
+		return tc
+	}
+	return nil
+}
+
+// sessionStoreTCPConn updates (or lazily creates) the per-session
+// *atomic.Pointer[net.TCPConn] holder under SessionData["_lastTCPConn"].
+// The same holder pointer is preserved across cloneSession() calls
+// (cloneInterface's default arm passes unknown types through), so the
+// sampler ticker's reads always see the latest connection without
+// allocating a new holder per request.
+func sessionStoreTCPConn(s SessionData, c *net.TCPConn) {
+	if s == nil || c == nil {
+		return
+	}
+	if existing, ok := s["_lastTCPConn"].(*atomic.Pointer[net.TCPConn]); ok && existing != nil {
+		existing.Store(c)
+		return
+	}
+	holder := &atomic.Pointer[net.TCPConn]{}
+	holder.Store(c)
+	s["_lastTCPConn"] = holder
+}
+
+func sessionLoadTCPConn(s SessionData) *net.TCPConn {
+	if s == nil {
+		return nil
+	}
+	if h, ok := s["_lastTCPConn"].(*atomic.Pointer[net.TCPConn]); ok && h != nil {
+		return h.Load()
+	}
+	return nil
+}
+
+// sessionGetOrCreateRTTWindow returns the per-session RTTWindow,
+// allocating one on first call. Same survival-across-clone logic as
+// the conn holder above — created once, then carried forward through
+// every cloneSession.
+func sessionGetOrCreateRTTWindow(s SessionData) *RTTWindow {
+	if s == nil {
+		return nil
+	}
+	if w, ok := s["_rttWindow"].(*RTTWindow); ok && w != nil {
+		return w
+	}
+	w := &RTTWindow{}
+	s["_rttWindow"] = w
+	return w
+}
+
+func sessionLoadRTTWindow(s SessionData) *RTTWindow {
+	if s == nil {
+		return nil
+	}
+	if w, ok := s["_rttWindow"].(*RTTWindow); ok {
+		return w
+	}
+	return nil
+}
+
+// RTTWindow accumulates 100 ms-cadence TCP_INFO samples between
+// snapshot emits (1 s heartbeat). drainAndReset folds the window into
+// a single rttSample and clears the running aggregates so the next
+// 1 s window starts empty.
+type RTTWindow struct {
+	mu                  sync.Mutex
+	sumUs, count        uint64
+	maxUs, minUs        uint32
+	latestRTOUs         uint32
+	latestMinLifetimeUs uint32
+	latestVarUs         uint32
+	// Last successful drain — replayed when count == 0 (no fresh
+	// kernel samples this 1 s window) so the chart line continues
+	// across a brief connection gap with a `stale: true` marker
+	// rather than dropping to zero.
+	lastAvgUs, lastMaxUs, lastMinUs uint32
+	haveLastDrain                   bool
+}
+
+type rttSample struct {
+	avgMs, maxMs, minMs, minLifetimeMs, varMs, rtoMs float32
+	hasData                                          bool
+	stale                                            bool
+}
+
+func (w *RTTWindow) fold(s tcpInfoSnapshot) {
+	if w == nil {
+		return
+	}
+	// All-zero snapshots (macOS stub, or a Linux read where the
+	// kernel hasn't populated fields yet on a brand-new socket) are
+	// no-ops — we don't want to clobber the previous good
+	// rto/var/lifetime values with zeros, since the drain path
+	// replays them on stale windows.
+	if s.rttUs == 0 && s.rtoUs == 0 && s.minRTTUs == 0 && s.rttVarUs == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if s.rttUs > 0 {
+		w.sumUs += uint64(s.rttUs)
+		if w.count == 0 || s.rttUs > w.maxUs {
+			w.maxUs = s.rttUs
+		}
+		if w.count == 0 || s.rttUs < w.minUs {
+			w.minUs = s.rttUs
+		}
+		w.count++
+	}
+	if s.rtoUs > 0 {
+		w.latestRTOUs = s.rtoUs
+	}
+	if s.minRTTUs > 0 {
+		w.latestMinLifetimeUs = s.minRTTUs
+	}
+	if s.rttVarUs > 0 {
+		w.latestVarUs = s.rttVarUs
+	}
+}
+
+func (w *RTTWindow) drainAndReset() rttSample {
+	if w == nil {
+		return rttSample{}
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.count == 0 {
+		if !w.haveLastDrain {
+			return rttSample{}
+		}
+		return rttSample{
+			avgMs:         float32(w.lastAvgUs) / 1000,
+			maxMs:         float32(w.lastMaxUs) / 1000,
+			minMs:         float32(w.lastMinUs) / 1000,
+			minLifetimeMs: float32(w.latestMinLifetimeUs) / 1000,
+			varMs:         float32(w.latestVarUs) / 1000,
+			rtoMs:         float32(w.latestRTOUs) / 1000,
+			hasData:       true,
+			stale:         true,
+		}
+	}
+	avgUs := uint32(w.sumUs / w.count)
+	sample := rttSample{
+		avgMs:         float32(avgUs) / 1000,
+		maxMs:         float32(w.maxUs) / 1000,
+		minMs:         float32(w.minUs) / 1000,
+		minLifetimeMs: float32(w.latestMinLifetimeUs) / 1000,
+		varMs:         float32(w.latestVarUs) / 1000,
+		rtoMs:         float32(w.latestRTOUs) / 1000,
+		hasData:       true,
+	}
+	w.lastAvgUs = avgUs
+	w.lastMaxUs = w.maxUs
+	w.lastMinUs = w.minUs
+	w.haveLastDrain = true
+	w.sumUs = 0
+	w.count = 0
+	w.maxUs = 0
+	w.minUs = 0
+	return sample
+}
+
+// startRTTSampler runs a 100 ms ticker that walks the active session
+// snapshot and folds a fresh getsockopt(TCP_INFO) read into each
+// session's RTTWindow. ~80 syscalls/sec at 8 sessions, negligible
+// CPU cost. Decoupled from the 1 s snapshot emit cadence so the per-
+// window max captures sub-second spikes the kernel's smoothed
+// tcpi_rtt would otherwise mask.
+func (a *App) startRTTSampler(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				snap := a.sessionsSnap.Load()
+				if snap == nil {
+					continue
+				}
+				for _, session := range *snap {
+					conn := sessionLoadTCPConn(session)
+					if conn == nil {
+						continue
+					}
+					window := sessionLoadRTTWindow(session)
+					if window == nil {
+						continue
+					}
+					info, err := readTCPInfo(conn)
+					if err != nil {
+						continue
+					}
+					window.fold(info)
+				}
+			}
+		}
+	}()
+	log.Printf("rtt sampler started (100ms cadence)")
+}
+
+// drainSessionRTT pulls the latest 1 s RTT window for a session and
+// stamps the six metric fields onto the session map. Called from
+// normalizeSessionsForResponse on each broadcast tick.
+func drainSessionRTT(session SessionData) {
+	window := sessionLoadRTTWindow(session)
+	if window == nil {
+		return
+	}
+	sample := window.drainAndReset()
+	if !sample.hasData {
+		return
+	}
+	session["client_rtt_ms"] = float64(sample.avgMs)
+	session["client_rtt_max_ms"] = float64(sample.maxMs)
+	session["client_rtt_min_ms"] = float64(sample.minMs)
+	session["client_rtt_min_lifetime_ms"] = float64(sample.minLifetimeMs)
+	session["client_rtt_var_ms"] = float64(sample.varMs)
+	session["client_rto_ms"] = float64(sample.rtoMs)
+	if sample.stale {
+		session["client_rtt_stale"] = true
+	} else {
+		delete(session, "client_rtt_stale")
+	}
+}

--- a/go-proxy/cmd/server/rtt_tcpinfo_linux.go
+++ b/go-proxy/cmd/server/rtt_tcpinfo_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package main
+
+import (
+	"errors"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// readTCPInfo issues a single getsockopt(TCP_INFO) on the given
+// connection's socket fd via SyscallConn().Control. Returns the four
+// kernel fields we chart (smoothed RTT, jitter, lifetime min RTT,
+// retransmit timeout) in microseconds. ~1 µs per call; the 100 ms
+// sampler ticks at most 8 sessions × 10 Hz ≈ 80 µs/sec total.
+func readTCPInfo(c *net.TCPConn) (tcpInfoSnapshot, error) {
+	if c == nil {
+		return tcpInfoSnapshot{}, errors.New("nil tcp conn")
+	}
+	rc, err := c.SyscallConn()
+	if err != nil {
+		return tcpInfoSnapshot{}, err
+	}
+	var info *unix.TCPInfo
+	var sysErr error
+	ctlErr := rc.Control(func(fd uintptr) {
+		info, sysErr = unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+	})
+	if ctlErr != nil {
+		return tcpInfoSnapshot{}, ctlErr
+	}
+	if sysErr != nil {
+		return tcpInfoSnapshot{}, sysErr
+	}
+	if info == nil {
+		return tcpInfoSnapshot{}, errors.New("tcp_info nil")
+	}
+	return tcpInfoSnapshot{
+		rttUs:    info.Rtt,
+		rttVarUs: info.Rttvar,
+		minRTTUs: info.Min_rtt,
+		rtoUs:    info.Rto,
+	}, nil
+}

--- a/go-proxy/cmd/server/rtt_tcpinfo_other.go
+++ b/go-proxy/cmd/server/rtt_tcpinfo_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package main
+
+import "net"
+
+// readTCPInfo on non-Linux platforms is a no-op stub so the dev build
+// (typically macOS) keeps compiling. The whole RTT chart is empty in
+// that mode — TCP_INFO is a Linux-specific socket option and the
+// production go-proxy only runs in the Linux container anyway.
+func readTCPInfo(c *net.TCPConn) (tcpInfoSnapshot, error) {
+	return tcpInfoSnapshot{}, nil
+}

--- a/go-proxy/go.mod
+++ b/go-proxy/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafov/m3u8 v0.12.1
 	github.com/vishvananda/netlink v1.3.1
-	golang.org/x/sys v0.42.0
+	golang.org/x/net v0.53.0
+	golang.org/x/sys v0.43.0
 	modernc.org/sqlite v1.50.0
 )
 

--- a/go-proxy/go.mod
+++ b/go-proxy/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grafov/m3u8 v0.12.1
 	github.com/vishvananda/netlink v1.3.1
+	golang.org/x/sys v0.42.0
 	modernc.org/sqlite v1.50.0
 )
 
@@ -16,7 +17,6 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go-proxy/go.sum
+++ b/go-proxy/go.sum
@@ -22,13 +22,15 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 modernc.org/cc/v4 v4.27.3 h1:uNCgn37E5U09mTv1XgskEVUJ8ADKpmFMPxzGJ0TSo+U=


### PR DESCRIPTION
## Summary

Two complementary RTT signals on a single chart immediately below the bitrate chart, sharing the time axis with bitrate / buffer / FPS via `getChartsForSession` so spikes line up visually.

**TCP_INFO RTT (#401)** — 100 ms ticker reads `getsockopt(TCP_INFO)` on each session's most-recent connection, folds into a 1 s window drained on every snapshot tick. Six metrics: `client_rtt_ms` (smoothed avg), `_max` / `_min` (per-window peak/trough), `_min_lifetime` (kernel's per-connection floor), `_var` (jitter), `_rto` (retransmit timeout). RTT family on the left axis; RTO on the right axis (kernel default ≥200 ms, can spike to seconds during a wedge — sharing one axis would flatten RTT). Charted with a min/max envelope, dashed lifetime-min reference, hidden-by-default RTO line. Wedge detection is the gap between `rtt` and `rto` — RTO climbs while smoothed RTT flatlines because no fresh ACKs.

**Out-of-band ICMP path ping (#404)** — 1 Hz ICMP echo from go-proxy → `player_ip` via a shared `*icmp.PacketConn` with a receiver goroutine demuxing by (id, seq). Independent of streaming throughput because ICMP packets bypass the application's send queue. New `client_path_ping_rtt_ms` field, cyan line on the same chart's left axis. The line that **stays put when shaping kicks in while TCP_INFO RTT climbs** — the gap between them is the queueing delay the app is inducing on itself. ICMP filtering renders a gap rather than misleading data.

Linux-only kernel reads (`getsockopt(TCP_INFO)`, raw ICMP). `!linux` build tags compile macOS dev with stubs that emit zeros / disabled samplers so `go build ./...` stays green.

Closes #401, closes #404.

## Test plan

- [x] `go vet` + `go build` clean for `go-proxy/...` and `analytics/go-forwarder/...` on darwin and linux/amd64
- [x] `node --check` clean on `session-shell.js` and `testing-session-ui.js`
- [x] Pre-commit Sonnet review pass — surfaced rttCharts cleanup leak (fixed) + fold() zero-overwrite of latest-fields (fixed)
- [x] `make test-deploy-dev` clean: `rtt sampler started (100ms cadence)` + `path ping sampler started (1Hz)` boot logs present, all 9 go-proxy ports listening, no fatals
- [x] `make analytics-migrate` applied seven `ADD COLUMN IF NOT EXISTS` lines (six TCP_INFO + one path-ping); `DESCRIBE session_snapshots` confirms all seven columns
- [x] RTT chart parity with bandwidth/buffer/FPS: in `getChartsForSession`, `ensureChartLiveWheelAnchor`, `refreshLegendHoverAll`, `chartsToDestroy`, event-marker pool. Pause/zoom/pan inherit via DOM and shared zoom options.
- [x] Right-edge alignment: dual-Y chart uses y1 `afterFit` width — no double-counting `layout.padding.right`
- [ ] LAN baseline: drive a session via `testing-session.html`, RTT chart shows `client_rtt_ms < 1 ms`, `client_path_ping_rtt_ms` ≈ same, `client_rtt_min_lifetime_ms` ≈ same, RTO at kernel default
- [ ] Throttle to 1 Mbps mid-stream: TCP_INFO lines climb (queueing); path-ping line **stays at LAN baseline** — that gap is the bufferbloat the chart was built to surface
- [ ] Add `tc netem delay 100ms` on top of throttle: BOTH lines step up by ~100 ms (path itself got longer)
- [ ] Wedge: drop packets via fault-injection UI, toggle RTO visible — RTO rises while RTT flatlines
- [ ] Replay an archived session in `session-viewer.html`: same chart populated from ClickHouse
- [ ] Block ICMP outbound at host firewall: path-ping line shows gap; TCP_INFO lines unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)