### PR TITLE
fix: SSE auto-recovery (heartbeat + watchdog + retry) for testing dashboard

### DIFF
--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -739,14 +739,14 @@
         // its 1s polling fallback forever (no path back to SSE).
         let sseReconnectTimer = null;
         const SSE_RETRY_MS = 2000;
-        // Watchdog: server sends a `heartbeat` SSE event every 15 s.
-        // No event of any kind within 30 s ⇒ connection is dead in
+        // Watchdog: server sends a `heartbeat` SSE event every 5 s.
+        // No event of any kind within 12 s ⇒ connection is dead in
         // some way the EventSource state machine hasn't surfaced
         // (browser stuck CONNECTING with silent retry failures, or
-        // similar). Force-close + reopen so we don't go silent.
+        // similar). 12 s allows for one missed heartbeat + jitter.
         let sseLastEventAt = Date.now();
         let sseWatchdogTimer = null;
-        const SSE_WATCHDOG_MS = 30000;
+        const SSE_WATCHDOG_MS = 12000;
         const failureSaveTimers = new Map();
         const failureSaveFields = new Map();
         let playerEstimatedMbps = null;
@@ -6426,6 +6426,8 @@
 
         function ensureSseWatchdog(playerId) {
             if (sseWatchdogTimer !== null) return;
+            // Tick at half the budget so worst-case detection is
+            // one tick + the budget itself.
             sseWatchdogTimer = setInterval(() => {
                 if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
                 console.warn(`SSE silent for ${SSE_WATCHDOG_MS}ms — forcing reconnect`);
@@ -6435,7 +6437,7 @@
                 }
                 sseLastEventAt = Date.now();
                 startSessionStream(playerId);
-            }, 5000);
+            }, 2000);
         }
 
         function startSessionStream(playerId) {

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -734,6 +734,11 @@
         let sessionPollLastAppliedSeq = 0;
         let sessionsStream = null;
         let sessionPollTimer = null;
+        // Same SSE-reconnect plumbing as session-live.js — without
+        // this a server redeploy strands the testing-session page on
+        // its 1s polling fallback forever (no path back to SSE).
+        let sseReconnectTimer = null;
+        const SSE_RETRY_MS = 2000;
         const failureSaveTimers = new Map();
         const failureSaveFields = new Map();
         let playerEstimatedMbps = null;
@@ -6414,8 +6419,25 @@
         function startSessionStream(playerId) {
             if (!window.EventSource) return false;
             if (!playerId) return false;
+            if (sseReconnectTimer !== null) {
+                clearTimeout(sseReconnectTimer);
+                sseReconnectTimer = null;
+            }
             const source = new EventSource('/api/sessions/stream?player_id=' + encodeURIComponent(playerId));
             sessionsStream = source;
+            source.addEventListener('open', () => {
+                // Server-side sessionsBroadcastSeq resets across
+                // container restarts; clear our last-seen revision
+                // so we don't compute a bogus "missed N updates"
+                // gap on the first post-reconnect event.
+                sseLastRevision = 0;
+                // SSE is back — kill any polling fallback we
+                // installed during the outage.
+                if (sessionPollTimer) {
+                    clearInterval(sessionPollTimer);
+                    sessionPollTimer = null;
+                }
+            });
             source.addEventListener('sessions', (event) => {
                 try {
                     const payload = parseSessionsStreamPayload(event);
@@ -6477,11 +6499,20 @@
                 }
             });
             source.addEventListener('error', () => {
-                if (source.readyState === EventSource.CLOSED) {
-                    source.close();
-                    sessionsStream = null;
-                    startSessionPolling(playerId);
-                }
+                // CONNECTING means EventSource is auto-retrying
+                // already — leave it alone. CLOSED means the browser
+                // gave up; start the 1s polling fallback as a safety
+                // net AND queue an SSE retry so we don't get stuck
+                // on polling after a server redeploy.
+                if (source.readyState !== EventSource.CLOSED) return;
+                source.close();
+                sessionsStream = null;
+                startSessionPolling(playerId);
+                if (sseReconnectTimer !== null) return;
+                sseReconnectTimer = setTimeout(() => {
+                    sseReconnectTimer = null;
+                    startSessionStream(playerId);
+                }, SSE_RETRY_MS);
             });
             return true;
         }

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -739,6 +739,14 @@
         // its 1s polling fallback forever (no path back to SSE).
         let sseReconnectTimer = null;
         const SSE_RETRY_MS = 2000;
+        // Watchdog: server sends a `heartbeat` SSE event every 15 s.
+        // No event of any kind within 30 s ⇒ connection is dead in
+        // some way the EventSource state machine hasn't surfaced
+        // (browser stuck CONNECTING with silent retry failures, or
+        // similar). Force-close + reopen so we don't go silent.
+        let sseLastEventAt = Date.now();
+        let sseWatchdogTimer = null;
+        const SSE_WATCHDOG_MS = 30000;
         const failureSaveTimers = new Map();
         const failureSaveFields = new Map();
         let playerEstimatedMbps = null;
@@ -6416,6 +6424,20 @@
             sessionPollTimer = setInterval(() => refreshSession(playerId), 1000);
         }
 
+        function ensureSseWatchdog(playerId) {
+            if (sseWatchdogTimer !== null) return;
+            sseWatchdogTimer = setInterval(() => {
+                if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
+                console.warn(`SSE silent for ${SSE_WATCHDOG_MS}ms — forcing reconnect`);
+                if (sessionsStream) {
+                    try { sessionsStream.close(); } catch (_) { /* ignore */ }
+                    sessionsStream = null;
+                }
+                sseLastEventAt = Date.now();
+                startSessionStream(playerId);
+            }, 5000);
+        }
+
         function startSessionStream(playerId) {
             if (!window.EventSource) return false;
             if (!playerId) return false;
@@ -6425,12 +6447,15 @@
             }
             const source = new EventSource('/api/sessions/stream?player_id=' + encodeURIComponent(playerId));
             sessionsStream = source;
+            sseLastEventAt = Date.now();
+            ensureSseWatchdog(playerId);
             source.addEventListener('open', () => {
                 // Server-side sessionsBroadcastSeq resets across
                 // container restarts; clear our last-seen revision
                 // so we don't compute a bogus "missed N updates"
                 // gap on the first post-reconnect event.
                 sseLastRevision = 0;
+                sseLastEventAt = Date.now();
                 // SSE is back — kill any polling fallback we
                 // installed during the outage.
                 if (sessionPollTimer) {
@@ -6438,7 +6463,11 @@
                     sessionPollTimer = null;
                 }
             });
+            source.addEventListener('heartbeat', () => {
+                sseLastEventAt = Date.now();
+            });
             source.addEventListener('sessions', (event) => {
+                sseLastEventAt = Date.now();
                 try {
                     const payload = parseSessionsStreamPayload(event);
                     const sessions = mergeSessionsBySnapshotVersion(payload.sessions);

--- a/content/dashboard/testing-session.html
+++ b/content/dashboard/testing-session.html
@@ -6438,6 +6438,21 @@
                 sseLastEventAt = Date.now();
                 startSessionStream(playerId);
             }, 2000);
+            // Background tabs throttle setInterval — re-check
+            // liveness on visibility change so a hidden-then-visible
+            // tab catches up immediately instead of waiting for the
+            // next throttled tick.
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState !== 'visible') return;
+                if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
+                console.warn('SSE silent while tab was hidden — forcing reconnect on visibilitychange');
+                if (sessionsStream) {
+                    try { sessionsStream.close(); } catch (_) { /* ignore */ }
+                    sessionsStream = null;
+                }
+                sseLastEventAt = Date.now();
+                startSessionStream(playerId);
+            });
         }
 
         function startSessionStream(playerId) {

--- a/content/shared/session-live.js
+++ b/content/shared/session-live.js
@@ -141,6 +141,21 @@
             sseLastEventAt = Date.now();
             startSessionsStream();
         }, 2000);
+        // Browsers throttle setInterval in background tabs (Chrome
+        // clamps to ≥1Hz, can be much slower under load). When the
+        // tab becomes visible again, immediately check liveness and
+        // force-reconnect if we missed events while throttled.
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState !== 'visible') return;
+            if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
+            console.warn('SSE silent while tab was hidden — forcing reconnect on visibilitychange');
+            if (sessionsStream) {
+                try { sessionsStream.close(); } catch (_) { /* ignore */ }
+                sessionsStream = null;
+            }
+            sseLastEventAt = Date.now();
+            startSessionsStream();
+        });
     }
 
     function start() {

--- a/content/shared/session-live.js
+++ b/content/shared/session-live.js
@@ -25,14 +25,15 @@
     // successful (re)connect.
     let sseReconnectTimer = null;
     const SSE_RETRY_MS = 2000;
-    // Watchdog: server sends a `heartbeat` event every 15 s. If we
-    // don't see ANY event (heartbeat or sessions) within 30 s, the
+    // Watchdog: server sends a `heartbeat` event every 5 s. If we
+    // don't see ANY event (heartbeat or sessions) within 12 s, the
     // connection is dead in some way the EventSource state machine
     // hasn't surfaced (e.g. browser stuck in CONNECTING with silent
-    // retry failures). Force-close + reopen.
+    // retry failures). Force-close + reopen. 12 s allows for one
+    // missed heartbeat plus ~2 s of network jitter.
     let sseLastEventAt = Date.now();
     let sseWatchdogTimer = null;
-    const SSE_WATCHDOG_MS = 30000;
+    const SSE_WATCHDOG_MS = 12000;
 
         function updateSseMissedBadge() {
             if (!sseMissedBadge) return;
@@ -128,6 +129,8 @@
 
     function ensureSseWatchdog() {
         if (sseWatchdogTimer !== null) return;
+        // Tick at half the budget so worst-case detection is one
+        // tick + the budget itself.
         sseWatchdogTimer = setInterval(() => {
             if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
             console.warn(`SSE silent for ${SSE_WATCHDOG_MS}ms — forcing reconnect`);
@@ -137,7 +140,7 @@
             }
             sseLastEventAt = Date.now();
             startSessionsStream();
-        }, 5000);
+        }, 2000);
     }
 
     function start() {

--- a/content/shared/session-live.js
+++ b/content/shared/session-live.js
@@ -25,6 +25,14 @@
     // successful (re)connect.
     let sseReconnectTimer = null;
     const SSE_RETRY_MS = 2000;
+    // Watchdog: server sends a `heartbeat` event every 15 s. If we
+    // don't see ANY event (heartbeat or sessions) within 30 s, the
+    // connection is dead in some way the EventSource state machine
+    // hasn't surfaced (e.g. browser stuck in CONNECTING with silent
+    // retry failures). Force-close + reopen.
+    let sseLastEventAt = Date.now();
+    let sseWatchdogTimer = null;
+    const SSE_WATCHDOG_MS = 30000;
 
         function updateSseMissedBadge() {
             if (!sseMissedBadge) return;
@@ -56,6 +64,8 @@
             }
             const source = new EventSource('/api/sessions/stream');
             sessionsStream = source;
+            sseLastEventAt = Date.now();
+            ensureSseWatchdog();
             source.addEventListener('open', () => {
                 // Server is talking again. Server-side
                 // sessionsBroadcastSeq resets across container
@@ -64,8 +74,13 @@
                 // we don't compute a bogus gap on the first
                 // post-reconnect event.
                 sseLastRevision = 0;
+                sseLastEventAt = Date.now();
+            });
+            source.addEventListener('heartbeat', () => {
+                sseLastEventAt = Date.now();
             });
             source.addEventListener('sessions', (event) => {
+                sseLastEventAt = Date.now();
                 try {
                     const payload = parseSessionsStreamPayload(event);
                     const sessions = payload.sessions;
@@ -110,6 +125,20 @@
             });
             return true;
         }
+
+    function ensureSseWatchdog() {
+        if (sseWatchdogTimer !== null) return;
+        sseWatchdogTimer = setInterval(() => {
+            if (Date.now() - sseLastEventAt < SSE_WATCHDOG_MS) return;
+            console.warn(`SSE silent for ${SSE_WATCHDOG_MS}ms — forcing reconnect`);
+            if (sessionsStream) {
+                try { sessionsStream.close(); } catch (_) { /* ignore */ }
+                sessionsStream = null;
+            }
+            sseLastEventAt = Date.now();
+            startSessionsStream();
+        }, 5000);
+    }
 
     function start() {
         return startSessionsStream();

--- a/content/shared/session-live.js
+++ b/content/shared/session-live.js
@@ -16,6 +16,15 @@
     let sessionsStream = null;
     let sseLastRevision = 0;
     let sseMissedTotal = 0;
+    // Reconnection state — EventSource's built-in auto-retry covers
+    // most transient errors, but in some failure modes (notably
+    // server redeploy when the container is killed mid-response) the
+    // browser sets readyState=CLOSED and gives up. Without an
+    // explicit retry the dashboard goes silent until the user
+    // hits refresh. Retry with a short fixed backoff; reset on
+    // successful (re)connect.
+    let sseReconnectTimer = null;
+    const SSE_RETRY_MS = 2000;
 
         function updateSseMissedBadge() {
             if (!sseMissedBadge) return;
@@ -41,8 +50,21 @@
 
         function startSessionsStream() {
             if (!window.EventSource) return false;
+            if (sseReconnectTimer !== null) {
+                clearTimeout(sseReconnectTimer);
+                sseReconnectTimer = null;
+            }
             const source = new EventSource('/api/sessions/stream');
             sessionsStream = source;
+            source.addEventListener('open', () => {
+                // Server is talking again. Server-side
+                // sessionsBroadcastSeq resets across container
+                // restarts, so the previous revision number is
+                // meaningless on the new connection — clear it so
+                // we don't compute a bogus gap on the first
+                // post-reconnect event.
+                sseLastRevision = 0;
+            });
             source.addEventListener('sessions', (event) => {
                 try {
                     const payload = parseSessionsStreamPayload(event);
@@ -73,11 +95,18 @@
                 }
             });
             source.addEventListener('error', () => {
-                if (source.readyState === EventSource.CLOSED) {
-                    source.close();
-                    sessionsStream = null;
-                    startSessionsPolling();
-                }
+                // CONNECTING state means the browser is auto-retrying
+                // already — leave it alone. CLOSED means the browser
+                // gave up; explicitly retry so a server redeploy
+                // doesn't strand the dashboard until manual refresh.
+                if (source.readyState !== EventSource.CLOSED) return;
+                source.close();
+                sessionsStream = null;
+                if (sseReconnectTimer !== null) return;
+                sseReconnectTimer = setTimeout(() => {
+                    sseReconnectTimer = null;
+                    startSessionsStream();
+                }, SSE_RETRY_MS);
             });
             return true;
         }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1662,10 +1662,24 @@ func (a *App) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	clientID, ch := a.sessionsHub.AddClient(playerIDFilter)
 	defer a.sessionsHub.RemoveClient(clientID)
 
+	// Heartbeat so the client can distinguish "connection alive but
+	// idle" from "connection dead". The dashboard's watchdog
+	// force-reconnects if no event arrives within 30 s, so a 15 s
+	// cadence here keeps the connection comfortably inside the
+	// liveness window. Also keeps middlebox idle timeouts from
+	// silently dropping the SSE TCP connection.
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-r.Context().Done():
 			return
+		case <-heartbeat.C:
+			if _, err := w.Write([]byte("event: heartbeat\ndata: {}\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
 		case event, ok := <-ch:
 			if !ok {
 				return

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1642,6 +1642,14 @@ func (a *App) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
+	// Tell EventSource to retry every 1s (default 3s) on a clean
+	// reconnect path. Combined with the client-side watchdog this
+	// keeps recovery snappy after a server redeploy.
+	if _, err := w.Write([]byte("retry: 1000\n\n")); err != nil {
+		return
+	}
+	flusher.Flush()
+
 	playerIDFilter := r.URL.Query().Get("player_id")
 
 	a.removeInactiveSessions()
@@ -1663,12 +1671,12 @@ func (a *App) handleSessionStream(w http.ResponseWriter, r *http.Request) {
 	defer a.sessionsHub.RemoveClient(clientID)
 
 	// Heartbeat so the client can distinguish "connection alive but
-	// idle" from "connection dead". The dashboard's watchdog
-	// force-reconnects if no event arrives within 30 s, so a 15 s
-	// cadence here keeps the connection comfortably inside the
-	// liveness window. Also keeps middlebox idle timeouts from
+	// idle" from "connection dead". 5 s cadence pairs with the
+	// dashboard's 12 s watchdog (one missed heartbeat + 2 s margin)
+	// so a silent SSE connection recovers within ~12 s instead of
+	// the original 30 s. Also keeps middlebox idle timeouts from
 	// silently dropping the SSE TCP connection.
-	heartbeat := time.NewTicker(15 * time.Second)
+	heartbeat := time.NewTicker(5 * time.Second)
 	defer heartbeat.Stop()
 
 	for {


### PR DESCRIPTION
## Summary

Five-layer recovery so the testing dashboard auto-reconnects within ~10–15s after a server redeploy instead of going silent until a manual page refresh.

- **Bugfix**: removed buggy bare \`startSessionsPolling()\` call in session-live.js's error handler — it threw \`ReferenceError\` because that function lives in session-shell.js's IIFE closure.
- **Server-side heartbeat**: \`event: heartbeat\\ndata: {}\\n\\n\` every 5s in \`handleSessionStream\` (also keeps middlebox idle timeouts at bay).
- **Client watchdog**: 12s budget on \`sseLastEventAt\`; force-close + reopen the EventSource regardless of \`readyState\`. Catches every silent-CONNECTING case the EventSource state machine doesn't surface.
- **Explicit retry on \`readyState === CLOSED\`**: 2s backoff, then recreate the EventSource. Handles HTTP error responses (4xx/5xx during nginx restart) that the browser treats as terminal.
- **\`retry: 1000\` SSE field** so the browser's built-in auto-retry uses 1s instead of default 3s.
- **\`visibilitychange\` hook**: re-check liveness on tab focus to avoid waiting for the next throttled \`setInterval\` tick (Chrome clamps background tabs to ≤1Hz).

Both SSE clients get the same plumbing — session-live.js (testing.html) and the inline script in testing-session.html.

Closes #405.

## Test plan

- [x] \`go vet\` + cross-build (\`go build\` darwin + linux/amd64) on go-proxy clean.
- [x] \`node --check\` on session-live.js clean.
- [x] \`make test-deploy-dev\` — server logs confirm heartbeats firing.
- [x] \`curl -N http://...:21000/api/sessions/stream\` confirms \`retry: 1000\` first frame and \`event: heartbeat\` rows every ~5s.
- [x] In-browser: redeploy server while dashboard tab is open, restart iPad session — new card appears within 8–22s without manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)