### PR TITLE
feat(analytics): ClickHouse llm_reader user with hard server-side caps (#413)

### DIFF
--- a/analytics/clickhouse/init.d/02-llm-reader.sql
+++ b/analytics/clickhouse/init.d/02-llm-reader.sql
@@ -1,0 +1,68 @@
+-- LLM tool-use reader (issue #413, part of epic #412).
+--
+-- ClickHouse runs init.d/*.sql only on first start (when /var/lib/clickhouse
+-- is empty). To apply this to an existing deployment without wiping data:
+--   make analytics-migrate SQL-FILE=analytics/clickhouse/init.d/02-llm-reader.sql
+-- All statements below are idempotent (IF NOT EXISTS), so re-running is safe.
+--
+-- The forwarder's AI-analysis path (`/analytics/api/session_chat`) lets an
+-- LLM author SQL via a `query` tool. We pass that SQL through unchecked
+-- because all safety lives here, in this user's settings profile, enforced
+-- server-side. The LLM literally cannot escape these limits — `readonly = 1`
+-- blocks `SET`, and every cap carries the `READONLY` constraint so the
+-- profile itself is also unchangeable.
+--
+-- Identity: `IDENTIFIED WITH no_password` matches the existing `default`
+-- user. The threat model is "constrain what *our* code can do over this
+-- connection," not "keep network attackers out" — the default user already
+-- accepts unauthenticated connections from the same network, with no
+-- profile constraints. Adding a password here would be theatre: anyone
+-- on the docker bridge / cluster network could just connect as `default`
+-- and bypass every limit.
+
+CREATE SETTINGS PROFILE IF NOT EXISTS llm_readonly SETTINGS
+    -- readonly=1: only SELECT / SHOW / DESCRIBE / EXISTS; SET is rejected.
+    -- readonly=2 would allow SET, defeating the per-setting caps below.
+    readonly = 1 READONLY,
+    -- 10 s wall-clock per query. A wedged or accidentally-cartesian-join
+    -- query gets cut off before it touches anyone else's latency.
+    max_execution_time = 10 READONLY,
+    -- 1 GB peak memory per query. ClickHouse 24.x evaluates this in the
+    -- pipeline, so a streaming aggregate is fine; an in-memory hash join
+    -- of two billion-row tables is not. Verified server-enforced.
+    max_memory_usage = 1000000000 READONLY,
+    -- 10 M rows scanned per query — enforced before aggregation, so
+    -- `SELECT n FROM huge_table` aborts with TOO_MANY_ROWS once the
+    -- pipeline has read 10 M source rows. This is the real input cap.
+    -- Verified server-enforced (Code 158).
+    max_rows_to_read = 10000000 READONLY,
+    -- max_result_rows / max_result_bytes / result_overflow_mode are
+    -- COOPERATIVE in ClickHouse 24.8: the settings are visible and
+    -- READONLY, but plain streaming SELECTs are not truncated server-side
+    -- at the result cap. We document the intent here so any tooling that
+    -- *does* honor them will respect it, and the forwarder's `query` tool
+    -- (#415) enforces a hard 10k-row / 10 MB cap when reading the
+    -- response. The server-side line of defense is `max_rows_to_read`
+    -- above plus `max_execution_time` below.
+    max_result_rows = 10000 READONLY,
+    max_result_bytes = 10485760 READONLY,
+    result_overflow_mode = 'break' READONLY;
+
+CREATE USER IF NOT EXISTS llm_reader
+    IDENTIFIED WITH no_password
+    SETTINGS PROFILE 'llm_readonly';
+
+-- Read access to the analytics tables. Limited to the
+-- infinite_streaming database; the LLM cannot enumerate or read from
+-- system.users, system.zookeeper, etc.
+GRANT SELECT ON infinite_streaming.* TO llm_reader;
+
+-- A handful of system tables are useful for the LLM to introspect its
+-- own environment ("which tables exist", "what's the schema of X",
+-- "how big are the tables") without exposing credentials. system.numbers
+-- and system.one are universally readable in ClickHouse and don't need
+-- an explicit grant.
+GRANT SELECT ON system.tables TO llm_reader;
+GRANT SELECT ON system.columns TO llm_reader;
+GRANT SELECT ON system.parts TO llm_reader;
+GRANT SELECT ON system.parts_columns TO llm_reader;

--- a/k8s-analytics.yaml
+++ b/k8s-analytics.yaml
@@ -13,9 +13,11 @@
 #
 # Schemas + Grafana provisioning are inlined here so the manifest is
 # self-contained — `kubectl apply -f` is enough to bring the analytics
-# tier up. If the source files in analytics/clickhouse/init.d/ or
-# analytics/grafana/provisioning/ change, regenerate this file with
-# `make analytics-regen-k8s-manifest`.
+# tier up. The canonical SQL lives in analytics/clickhouse/init.d/*.sql
+# and the canonical Grafana provisioning in analytics/grafana/; this
+# file is a hand-mirror. There is no regen target — edit both places
+# when changing schemas, users, or dashboards. (A `make analytics-check-
+# mirror` drift check is tracked as a follow-up; not yet wired.)
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -379,6 +381,58 @@ data:
     -- forwarder bumps it on session-end / star / unstar via ALTER UPDATE.
     ALTER TABLE infinite_streaming.network_requests
         ADD COLUMN IF NOT EXISTS classification LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1));
+  02-llm-reader.sql: |
+    -- Mirror of analytics/clickhouse/init.d/02-llm-reader.sql — edit both.
+    -- See that file for the migration runbook (`make analytics-migrate
+    -- SQL-FILE=...` for live clusters) and the full per-cap rationale.
+    --
+    -- LLM tool-use reader (issue #413, part of epic #412).
+    --
+    -- The forwarder's AI-analysis path (`/analytics/api/session_chat`) lets an
+    -- LLM author SQL via a `query` tool. We pass that SQL through unchecked
+    -- because all safety lives here, in this user's settings profile, enforced
+    -- server-side. The LLM literally cannot escape these limits — `readonly = 1`
+    -- blocks `SET`, and every cap carries the `READONLY` constraint so the
+    -- profile itself is also unchangeable.
+    --
+    -- Identity: `IDENTIFIED WITH no_password` matches the existing `default`
+    -- user. The threat model is "constrain what *our* code can do over this
+    -- connection," not "keep network attackers out" — the default user already
+    -- accepts unauthenticated connections from the same network, with no
+    -- profile constraints. Adding a password here would be theatre: anyone
+    -- on the docker bridge / cluster network could just connect as `default`
+    -- and bypass every limit.
+
+    CREATE SETTINGS PROFILE IF NOT EXISTS llm_readonly SETTINGS
+        -- readonly=1: only SELECT / SHOW / DESCRIBE / EXISTS; SET is rejected.
+        readonly = 1 READONLY,
+        -- 10 s wall-clock per query. Verified server-enforced (Code 159).
+        max_execution_time = 10 READONLY,
+        -- 1 GB peak memory per query. Verified server-enforced.
+        max_memory_usage = 1000000000 READONLY,
+        -- 10 M rows scanned per query — the real input cap. Verified
+        -- server-enforced (Code 158, TOO_MANY_ROWS).
+        max_rows_to_read = 10000000 READONLY,
+        -- max_result_rows / max_result_bytes / result_overflow_mode are
+        -- COOPERATIVE in ClickHouse 24.8: settings are visible and
+        -- READONLY but plain streaming SELECTs are not truncated server-
+        -- side. The forwarder's `query` tool (#415) enforces a hard 10k-
+        -- row / 10 MB cap when reading the response. Documented here so
+        -- tooling that respects them does, and so the values stay tied
+        -- to the same intent.
+        max_result_rows = 10000 READONLY,
+        max_result_bytes = 10485760 READONLY,
+        result_overflow_mode = 'break' READONLY;
+
+    CREATE USER IF NOT EXISTS llm_reader
+        IDENTIFIED WITH no_password
+        SETTINGS PROFILE 'llm_readonly';
+
+    GRANT SELECT ON infinite_streaming.* TO llm_reader;
+    GRANT SELECT ON system.tables TO llm_reader;
+    GRANT SELECT ON system.columns TO llm_reader;
+    GRANT SELECT ON system.parts TO llm_reader;
+    GRANT SELECT ON system.parts_columns TO llm_reader;
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
## Summary

- Adds `analytics/clickhouse/init.d/02-llm-reader.sql` creating a dedicated `llm_reader` user behind a locked-down `llm_readonly` settings profile. All safety is server-enforced so the forwarder can pass LLM-authored SQL through unchecked when issue #415 lands.
- Mirrors the same SQL into the `analytics-clickhouse-init` ConfigMap in `k8s-analytics.yaml` for k3d parity, and updates the manifest's header comment to be honest that there is no regen target — the `.sql` file and the ConfigMap block are hand-mirrored.
- Sub-issue 1 of epic #412 (AI-assisted session analysis). `Closes #413.`

## What the lockdown actually achieves

Verified empirically against `clickhouse/clickhouse-server:24.8-alpine`:

| Concern | Mechanism | Outcome |
|---|---|---|
| LLM writes destructive SQL | `GRANT SELECT` only on `infinite_streaming.*` + a small system whitelist | INSERT/DROP/CREATE USER → Code 497 ACCESS_DENIED |
| LLM tries to relax limits | `readonly = 1` (blocks SET) + per-setting `READONLY` constraint | Code 164 READONLY |
| Runaway query | `max_execution_time = 10` | Fires at 10.000s (Code 159 TIMEOUT_EXCEEDED) |
| Massive scan | `max_rows_to_read = 10M` | Fires at 10M source rows (Code 158 TOO_MANY_ROWS) |
| OOM | `max_memory_usage = 1GB` | Pipeline-enforced |
| Massive result set | (cooperative in 24.8 — see note) | Forwarder enforces hard cap at read time in #415 |

`max_result_rows` / `max_result_bytes` / `result_overflow_mode='break'` are cooperative in ClickHouse 24.8: settings are visible and `READONLY`, but plain streaming SELECTs are not truncated server-side. This is documented inline in the SQL. The real server-side input fence is `max_rows_to_read`; the response-side cap will be applied in the forwarder's `query` tool (#415).

## Identity choice

`IDENTIFIED WITH no_password` matches the existing `default` user's posture. The threat model is *"constrain what our code can do over this connection,"* not *"keep network attackers out"* — adding a password while `default` accepts unauthenticated connections on the same network would be theatre. The capability constraint, not the auth, is the load-bearing piece.

## Drift between file and ConfigMap

The two locations contain functionally-identical SQL but are hand-mirrored. The k8s block now starts with a banner pointing back to the `.sql` file as the canonical source plus the `make analytics-migrate SQL-FILE=...` runbook for live clusters. A `make analytics-check-mirror` drift check is a follow-up I'd open separately if drift becomes a problem; not in scope for #413.

## Test plan

- [x] Fresh `clickhouse/clickhouse-server:24.8-alpine` with `analytics/clickhouse/init.d/` mounted: both init scripts run cleanly.
- [x] `SELECT 1` as `llm_reader` works.
- [x] `INSERT`, `DROP TABLE`, `CREATE USER` all denied with Code 497.
- [x] `SET max_execution_time=600` rejected with Code 164.
- [x] `SELECT name FROM system.users` denied (no grant).
- [x] Cartesian-join over a 20k-row real table cut off at exactly 10s.
- [x] `SELECT count() FROM numbers(20M)` fails with Code 158.
- [x] `numbers()` table function and `system.one` work without explicit grants (universally readable).
- [x] `system.parts_columns` grant verified — needed for "what does this table cost" introspection.
- [x] YAML validity of `k8s-analytics.yaml` after edit (yq parses).
- [ ] Apply via `make analytics-migrate SQL-FILE=analytics/clickhouse/init.d/02-llm-reader.sql` against a live `release` cluster — to be exercised when this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
