### PR TITLE
feat(forwarder): OpenAI-compatible LLM client + profile registry (#414)

### DIFF
--- a/analytics/go-forwarder/Dockerfile
+++ b/analytics/go-forwarder/Dockerfile
@@ -1,10 +1,15 @@
 FROM golang:1.25-alpine AS build
 WORKDIR /src
-COPY go.mod ./
+COPY go.mod go.sum ./
+RUN go mod download
 COPY *.go ./
 RUN CGO_ENABLED=0 GOFLAGS=-trimpath go build -o /out/forwarder .
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/forwarder /forwarder
+# Default LLM_PROFILES_PATH points to /config/llm_profiles.yaml. Mount
+# a ConfigMap / bind-mount over /config to override per environment
+# without rebuilding the image.
+COPY config/ /config/
 USER nonroot:nonroot
 ENTRYPOINT ["/forwarder"]

--- a/analytics/go-forwarder/config/llm_profiles.yaml
+++ b/analytics/go-forwarder/config/llm_profiles.yaml
@@ -1,0 +1,82 @@
+# LLM profiles for the AI session-analysis path (epic #412).
+#
+# Each profile selects a backend by setting `base_url` to an
+# OpenAI-compatible endpoint. The same Go client (llm_client.go) talks
+# to all of them. Routing options:
+#
+#   - HF Inference Providers: https://router.huggingface.co/v1
+#   - Anthropic OpenAI-compat: https://api.anthropic.com/v1/openai/
+#   - OpenAI:                 https://api.openai.com/v1
+#   - Local Ollama:           http://ollama:11434/v1
+#   - OpenRouter:             https://openrouter.ai/api/v1
+#
+# `api_key_env` names the env var the client reads at request time. A
+# missing env var means the profile is `available: false` in the
+# /analytics/api/llm_profiles listing — UIs should grey it out.
+# Empty string means no auth is needed (local Ollama).
+#
+# `pricing` is per-million-tokens USD; used to compute cost_usd in the
+# llm_calls ledger (#417). Set both to 0 for free / locally-hosted
+# models so they don't count against the daily budget.
+#
+# `supports_tools` and `supports_caching` are advisory hints — the
+# session_chat endpoint (#416) reads them to decide whether to send
+# a `tools` array and to set `cache_control` markers respectively.
+# Models that lie about their capabilities will simply produce worse
+# results, not crash.
+
+active: hf-llama-70b
+
+profiles:
+  hf-llama-70b:
+    base_url: https://router.huggingface.co/v1
+    api_key_env: HF_TOKEN
+    # The :together suffix pins the upstream provider for reproducibility —
+    # without it, HF picks an underlying provider that can shift between
+    # calls and produce inconsistent tool-use behavior.
+    model: meta-llama/Llama-3.3-70B-Instruct:together
+    supports_tools: true
+    supports_caching: false
+    pricing:
+      input_per_mtok: 0.88
+      output_per_mtok: 0.88
+
+  hf-qwen-72b:
+    base_url: https://router.huggingface.co/v1
+    api_key_env: HF_TOKEN
+    model: Qwen/Qwen2.5-72B-Instruct:fireworks
+    supports_tools: true
+    supports_caching: false
+    pricing:
+      input_per_mtok: 0.90
+      output_per_mtok: 0.90
+
+  opus:
+    base_url: https://api.anthropic.com/v1/openai/
+    api_key_env: ANTHROPIC_API_KEY
+    model: claude-opus-4-7
+    supports_tools: true
+    supports_caching: true
+    pricing:
+      input_per_mtok: 15.00
+      output_per_mtok: 75.00
+
+  gpt4o:
+    base_url: https://api.openai.com/v1
+    api_key_env: OPENAI_API_KEY
+    model: gpt-4o
+    supports_tools: true
+    supports_caching: true
+    pricing:
+      input_per_mtok: 2.50
+      output_per_mtok: 10.00
+
+  local-llama:
+    base_url: http://ollama:11434/v1
+    api_key_env: ""
+    model: llama3.1:70b
+    supports_tools: true
+    supports_caching: false
+    pricing:
+      input_per_mtok: 0
+      output_per_mtok: 0

--- a/analytics/go-forwarder/go.mod
+++ b/analytics/go-forwarder/go.mod
@@ -1,3 +1,8 @@
 module github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder
 
 go 1.25.0
+
+require (
+	github.com/sashabaranov/go-openai v1.41.2
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/analytics/go-forwarder/go.sum
+++ b/analytics/go-forwarder/go.sum
@@ -1,0 +1,6 @@
+github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
+github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/analytics/go-forwarder/llm_client.go
+++ b/analytics/go-forwarder/llm_client.go
@@ -1,0 +1,80 @@
+// OpenAI-compatible chat client for the AI session-analysis path
+// (epic #412). The same client talks to every backend the profiles
+// support — HF Inference Providers, Anthropic OpenAI-compat, OpenAI,
+// local Ollama — by overriding base URL + API key per call.
+//
+// This file deliberately exposes a thin Chat() surface that's enough
+// for the smoke-test acceptance of #414. Streaming + tool_calls
+// support arrives in #415 (tool-use loop) and #416 (SSE endpoint).
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+type LLMClient struct {
+	profiles *LLMProfiles
+}
+
+func NewLLMClient(profiles *LLMProfiles) *LLMClient {
+	return &LLMClient{profiles: profiles}
+}
+
+// clientFor builds a per-profile go-openai client. We construct it
+// per call rather than caching: profiles are few, and the cost is a
+// struct allocation. Caching would force us to invalidate when env
+// vars change in tests, which isn't worth it.
+func (c *LLMClient) clientFor(prof *LLMProfile) *openai.Client {
+	cfg := openai.DefaultConfig(prof.APIKey())
+	cfg.BaseURL = prof.BaseURL
+	return openai.NewClientWithConfig(cfg)
+}
+
+// PingResult is the smoke-test return shape — what the issue
+// acceptance criteria need to verify ("returns a non-empty response
+// with usage populated").
+type PingResult struct {
+	Profile      string
+	Model        string
+	Reply        string
+	InputTokens  int
+	OutputTokens int
+}
+
+// Ping sends a one-shot "say 'pong'" message and returns the reply
+// plus token counts. Used by the smoke test in CI / local; not on the
+// session_chat hot path.
+func (c *LLMClient) Ping(ctx context.Context, profileName string) (*PingResult, error) {
+	prof, err := c.profiles.Resolve(profileName)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.clientFor(prof).CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: prof.Model,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: "Reply with exactly the single word: pong",
+			},
+		},
+		MaxTokens: 16,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("chat completion against profile %q (%s): %w", prof.Name, prof.Model, err)
+	}
+	if len(resp.Choices) == 0 {
+		return nil, errors.New("no choices in chat completion response")
+	}
+	return &PingResult{
+		Profile:      prof.Name,
+		Model:        prof.Model,
+		Reply:        resp.Choices[0].Message.Content,
+		InputTokens:  resp.Usage.PromptTokens,
+		OutputTokens: resp.Usage.CompletionTokens,
+	}, nil
+}

--- a/analytics/go-forwarder/llm_client_test.go
+++ b/analytics/go-forwarder/llm_client_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeOpenAI minimally impersonates an OpenAI-compatible chat endpoint
+// so we can test client wiring (URL routing, auth header, model field,
+// usage parsing) without any live network call.
+func fakeOpenAI(t *testing.T, expectModel, replyText string, inTok, outTok int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/chat/completions") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization header = %q, want Bearer test-key", got)
+		}
+		var req struct {
+			Model    string `json:"model"`
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode req: %v (body=%s)", err, body)
+		}
+		if req.Model != expectModel {
+			t.Errorf("Model = %q, want %q", req.Model, expectModel)
+		}
+		resp := map[string]any{
+			"id":      "test-id",
+			"object":  "chat.completion",
+			"created": 0,
+			"model":   expectModel,
+			"choices": []any{
+				map[string]any{
+					"index": 0,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": replyText,
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]any{
+				"prompt_tokens":     inTok,
+				"completion_tokens": outTok,
+				"total_tokens":      inTok + outTok,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestLLMClient_Ping_RoutesAndParses(t *testing.T) {
+	srv := fakeOpenAI(t, "test-model", "pong", 7, 1)
+	defer srv.Close()
+
+	const envName = "LLM_TEST_PING_KEY"
+	t.Setenv(envName, "test-key")
+
+	profile := &LLMProfile{
+		Name:      "fake",
+		BaseURL:   srv.URL + "/",
+		APIKeyEnv: envName,
+		Model:     "test-model",
+	}
+	profiles := &LLMProfiles{
+		Active:   "fake",
+		Profiles: map[string]*LLMProfile{"fake": profile},
+	}
+	client := NewLLMClient(profiles)
+	res, err := client.Ping(context.Background(), "fake")
+	if err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if res.Reply != "pong" {
+		t.Errorf("Reply = %q, want %q", res.Reply, "pong")
+	}
+	if res.InputTokens != 7 || res.OutputTokens != 1 {
+		t.Errorf("usage = (%d in, %d out), want (7, 1)", res.InputTokens, res.OutputTokens)
+	}
+	if res.Model != "test-model" {
+		t.Errorf("Model = %q, want test-model", res.Model)
+	}
+}
+
+func TestLLMClient_Ping_UnavailableProfile(t *testing.T) {
+	const envName = "LLM_TEST_PING_UNAVAIL"
+	profile := &LLMProfile{
+		Name:      "no-creds",
+		BaseURL:   "http://unused/",
+		APIKeyEnv: envName,
+		Model:     "m",
+	}
+	profiles := &LLMProfiles{
+		Active:   "no-creds",
+		Profiles: map[string]*LLMProfile{"no-creds": profile},
+	}
+	_, err := NewLLMClient(profiles).Ping(context.Background(), "no-creds")
+	if err == nil {
+		t.Fatal("expected error when profile API key env missing")
+	}
+}
+
+func TestLLMClient_Ping_PropagatesUpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"message":"boom"}}`)
+	}))
+	defer srv.Close()
+
+	const envName = "LLM_TEST_PING_BOOM"
+	t.Setenv(envName, "k")
+
+	profile := &LLMProfile{
+		Name:      "boom",
+		BaseURL:   srv.URL + "/",
+		APIKeyEnv: envName,
+		Model:     "m",
+	}
+	profiles := &LLMProfiles{
+		Active:   "boom",
+		Profiles: map[string]*LLMProfile{"boom": profile},
+	}
+	_, err := NewLLMClient(profiles).Ping(context.Background(), "boom")
+	if err == nil {
+		t.Fatal("expected error when upstream returns 500")
+	}
+}

--- a/analytics/go-forwarder/llm_profiles.go
+++ b/analytics/go-forwarder/llm_profiles.go
@@ -1,0 +1,134 @@
+// LLM profile loader for the AI session-analysis path (epic #412).
+//
+// A profile pairs an OpenAI-compatible base URL + model + API-key env
+// var. Profiles are loaded once at startup; live reload is intentionally
+// out of scope (restart the forwarder to pick up new profiles).
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"slices"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Pricing is per-million-tokens USD; consumed by the llm_calls ledger
+// (#417) to compute cost_usd. Zero means free (local models) and is
+// honored by the daily-budget guard.
+type Pricing struct {
+	InputPerMTok  float64 `yaml:"input_per_mtok"`
+	OutputPerMTok float64 `yaml:"output_per_mtok"`
+}
+
+type LLMProfile struct {
+	Name            string  `yaml:"-"`
+	BaseURL         string  `yaml:"base_url"`
+	APIKeyEnv       string  `yaml:"api_key_env"`
+	Model           string  `yaml:"model"`
+	SupportsTools   bool    `yaml:"supports_tools"`
+	SupportsCaching bool    `yaml:"supports_caching"`
+	Pricing         Pricing `yaml:"pricing"`
+}
+
+// Available means the API key env var is set (or none required).
+// We surface this via /analytics/api/llm_profiles in #416 so the UI
+// can grey out profiles instead of letting requests fail with 401.
+func (p *LLMProfile) Available() bool {
+	if p.APIKeyEnv == "" {
+		return true
+	}
+	return os.Getenv(p.APIKeyEnv) != ""
+}
+
+func (p *LLMProfile) APIKey() string {
+	if p.APIKeyEnv == "" {
+		return ""
+	}
+	return os.Getenv(p.APIKeyEnv)
+}
+
+type LLMProfiles struct {
+	Active   string                 `yaml:"active"`
+	Profiles map[string]*LLMProfile `yaml:"profiles"`
+}
+
+func LoadLLMProfiles(path string) (*LLMProfiles, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read llm profiles %s: %w", path, err)
+	}
+	var p LLMProfiles
+	if err := yaml.Unmarshal(b, &p); err != nil {
+		return nil, fmt.Errorf("parse llm profiles %s: %w", path, err)
+	}
+	if len(p.Profiles) == 0 {
+		return nil, fmt.Errorf("llm profiles %s: no profiles defined", path)
+	}
+	for name, prof := range p.Profiles {
+		prof.Name = name
+		if prof.BaseURL == "" {
+			return nil, fmt.Errorf("llm profile %q: base_url is required", name)
+		}
+		if prof.Model == "" {
+			return nil, fmt.Errorf("llm profile %q: model is required", name)
+		}
+	}
+	// Map iteration order would otherwise make the default Active vary
+	// across restarts. Pick lexicographically-smallest as a stable fallback.
+	if p.Active == "" {
+		names := make([]string, 0, len(p.Profiles))
+		for n := range p.Profiles {
+			names = append(names, n)
+		}
+		p.Active = slices.Min(names)
+	}
+	if _, ok := p.Profiles[p.Active]; !ok {
+		return nil, fmt.Errorf("llm profiles %s: active profile %q not in profiles", path, p.Active)
+	}
+	return &p, nil
+}
+
+// loadLLMProfilesAtStartup is non-fatal by design: a misconfigured
+// profiles file or a missing config volume must not stop session
+// snapshot archival. session_chat handlers (#416) report 503 when
+// llmProfiles is nil so the UI can grey out the AI features cleanly.
+func loadLLMProfilesAtStartup(path string) {
+	p, err := LoadLLMProfiles(path)
+	if err != nil {
+		log.Printf("llm profiles unavailable (%v); AI features disabled", err)
+		llmProfiles = nil
+		return
+	}
+	llmProfiles = p
+	var avail, total int
+	var names []string
+	for _, prof := range p.Profiles {
+		total++
+		if prof.Available() {
+			avail++
+		}
+		names = append(names, prof.Name)
+	}
+	log.Printf("llm profiles loaded: %d total, %d available, active=%q (%v)",
+		total, avail, p.Active, names)
+}
+
+// Resolve picks the named profile, falling back to Active when name
+// is empty. Errors if the profile doesn't exist or its key env is
+// missing — callers translate this to the appropriate HTTP status.
+func (p *LLMProfiles) Resolve(name string) (*LLMProfile, error) {
+	if name == "" {
+		name = p.Active
+	}
+	prof, ok := p.Profiles[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown llm profile %q", name)
+	}
+	if !prof.Available() {
+		return nil, fmt.Errorf("llm profile %q unavailable: env %s not set", name, prof.APIKeyEnv)
+	}
+	return prof, nil
+}

--- a/analytics/go-forwarder/llm_profiles_test.go
+++ b/analytics/go-forwarder/llm_profiles_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "profiles.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tmp yaml: %v", err)
+	}
+	return p
+}
+
+func TestLoadLLMProfiles_HappyPath(t *testing.T) {
+	p := writeTempYAML(t, `
+active: opus
+profiles:
+  opus:
+    base_url: https://api.anthropic.com/v1/openai/
+    api_key_env: ANTHROPIC_API_KEY
+    model: claude-opus-4-7
+    supports_tools: true
+    supports_caching: true
+    pricing:
+      input_per_mtok: 15.0
+      output_per_mtok: 75.0
+  local:
+    base_url: http://ollama:11434/v1
+    api_key_env: ""
+    model: llama3.1:70b
+    supports_tools: true
+    supports_caching: false
+    pricing:
+      input_per_mtok: 0
+      output_per_mtok: 0
+`)
+	profiles, err := LoadLLMProfiles(p)
+	if err != nil {
+		t.Fatalf("LoadLLMProfiles: %v", err)
+	}
+	if got := profiles.Active; got != "opus" {
+		t.Errorf("Active = %q, want %q", got, "opus")
+	}
+	if profiles.Profiles["opus"].Name != "opus" {
+		t.Errorf("Name not populated from map key")
+	}
+	if !profiles.Profiles["local"].Available() {
+		t.Errorf("local profile (no api_key_env) should be available")
+	}
+}
+
+func TestLoadLLMProfiles_DefaultsActiveLexicographically(t *testing.T) {
+	p := writeTempYAML(t, `
+profiles:
+  zebra:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m1
+  alpha:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m2
+  middle:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m3
+`)
+	for i := 0; i < 5; i++ {
+		profiles, err := LoadLLMProfiles(p)
+		if err != nil {
+			t.Fatalf("LoadLLMProfiles: %v", err)
+		}
+		if profiles.Active != "alpha" {
+			t.Errorf("iter %d: Active = %q, want %q (lexicographic min)", i, profiles.Active, "alpha")
+		}
+	}
+}
+
+func TestLoadLLMProfiles_MissingFile(t *testing.T) {
+	_, err := LoadLLMProfiles("/nonexistent/path.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadLLMProfiles_MalformedYAML(t *testing.T) {
+	p := writeTempYAML(t, "this is not: yaml: {{{ broken")
+	_, err := LoadLLMProfiles(p)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+func TestLoadLLMProfiles_EmptyProfiles(t *testing.T) {
+	p := writeTempYAML(t, "active: foo\nprofiles: {}\n")
+	_, err := LoadLLMProfiles(p)
+	if err == nil {
+		t.Fatal("expected error for empty profiles map")
+	}
+}
+
+func TestLoadLLMProfiles_MissingBaseURL(t *testing.T) {
+	p := writeTempYAML(t, `
+profiles:
+  bad:
+    api_key_env: FOO
+    model: m
+`)
+	_, err := LoadLLMProfiles(p)
+	if err == nil {
+		t.Fatal("expected error for missing base_url")
+	}
+}
+
+func TestLoadLLMProfiles_MissingModel(t *testing.T) {
+	p := writeTempYAML(t, `
+profiles:
+  bad:
+    base_url: http://x/v1
+    api_key_env: FOO
+`)
+	_, err := LoadLLMProfiles(p)
+	if err == nil {
+		t.Fatal("expected error for missing model")
+	}
+}
+
+func TestLoadLLMProfiles_ActiveNotInProfiles(t *testing.T) {
+	p := writeTempYAML(t, `
+active: notreal
+profiles:
+  real:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m
+`)
+	_, err := LoadLLMProfiles(p)
+	if err == nil {
+		t.Fatal("expected error when active points to missing profile")
+	}
+}
+
+func TestProfile_AvailableTracksEnv(t *testing.T) {
+	const envName = "LLM_TEST_KEY_DO_NOT_SET_IN_CI"
+	os.Unsetenv(envName)
+	t.Cleanup(func() { os.Unsetenv(envName) })
+
+	p := writeTempYAML(t, `
+profiles:
+  paid:
+    base_url: http://x/v1
+    api_key_env: `+envName+`
+    model: m
+`)
+	profiles, err := LoadLLMProfiles(p)
+	if err != nil {
+		t.Fatalf("LoadLLMProfiles: %v", err)
+	}
+	prof := profiles.Profiles["paid"]
+	if prof.Available() {
+		t.Errorf("expected unavailable when env unset")
+	}
+	t.Setenv(envName, "secret-value")
+	if !prof.Available() {
+		t.Errorf("expected available after env set")
+	}
+	if prof.APIKey() != "secret-value" {
+		t.Errorf("APIKey() = %q, want %q", prof.APIKey(), "secret-value")
+	}
+}
+
+func TestResolve_FallsBackToActive(t *testing.T) {
+	p := writeTempYAML(t, `
+active: free
+profiles:
+  free:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m
+`)
+	profiles, err := LoadLLMProfiles(p)
+	if err != nil {
+		t.Fatalf("LoadLLMProfiles: %v", err)
+	}
+	prof, err := profiles.Resolve("")
+	if err != nil {
+		t.Fatalf("Resolve(\"\"): %v", err)
+	}
+	if prof.Name != "free" {
+		t.Errorf("Resolve(\"\").Name = %q, want %q", prof.Name, "free")
+	}
+}
+
+func TestResolve_UnknownProfile(t *testing.T) {
+	p := writeTempYAML(t, `
+profiles:
+  free:
+    base_url: http://x/v1
+    api_key_env: ""
+    model: m
+`)
+	profiles, _ := LoadLLMProfiles(p)
+	_, err := profiles.Resolve("nope")
+	if err == nil {
+		t.Fatal("expected error for unknown profile")
+	}
+}
+
+func TestResolve_UnavailableProfile(t *testing.T) {
+	const envName = "LLM_TEST_KEY_RESOLVE_UNAVAIL"
+	os.Unsetenv(envName)
+	t.Cleanup(func() { os.Unsetenv(envName) })
+	p := writeTempYAML(t, `
+profiles:
+  paid:
+    base_url: http://x/v1
+    api_key_env: `+envName+`
+    model: m
+`)
+	profiles, _ := LoadLLMProfiles(p)
+	_, err := profiles.Resolve("paid")
+	if err == nil {
+		t.Fatal("expected error when API key env missing")
+	}
+}

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -34,6 +34,8 @@ type config struct {
 	flushEvery    time.Duration
 	flushBatch    int
 	httpListen    string
+
+	llmProfilesPath string
 }
 
 func loadConfig() config {
@@ -48,9 +50,14 @@ func loadConfig() config {
 		// inserter empties whichever happens first (timer or batch
 		// fills). 250ms keeps the picker's "x seconds ago" honest
 		// without significantly raising ClickHouse insert pressure.
-		flushEvery:    250 * time.Millisecond,
-		flushBatch:    500,
-		httpListen:    getenv("FORWARDER_HTTP_LISTEN", ":8080"),
+		flushEvery: 250 * time.Millisecond,
+		flushBatch: 500,
+		httpListen: getenv("FORWARDER_HTTP_LISTEN", ":8080"),
+
+		// /config is the in-image path Dockerfile copies analytics/go-
+		// forwarder/config/ to. Override via env when running outside
+		// Docker or to point at a custom override file.
+		llmProfilesPath: getenv("LLM_PROFILES_PATH", "/config/llm_profiles.yaml"),
 	}
 	return c
 }
@@ -260,10 +267,21 @@ func setupLogFile() {
 	log.Printf("forwarder log file: %s", path)
 }
 
+// llmProfiles is the parsed AI-analysis profile registry (epic #412).
+// nil when LLM_PROFILES_PATH is missing or unreadable; the analytics
+// archive path is independent of this and must keep working without it.
+// session_chat handlers (#416) will check for nil and 503 if absent.
+//
+// Set once in main() before any goroutine starts, then read-only.
+// If a future PR adds /api/llm_profiles/reload or hot-reload, swap
+// this for an atomic.Pointer[LLMProfiles] to avoid the race.
+var llmProfiles *LLMProfiles
+
 func main() {
 	setupLogFile()
 	cfg := loadConfig()
 	log.Printf("forwarder starting: sse=%s ch=%s/%s.%s", cfg.sseURL, cfg.clickhouseURL, cfg.chDatabase, cfg.chTable)
+	loadLLMProfilesAtStartup(cfg.llmProfilesPath)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

- Adds an OpenAI-compatible Go client to `analytics/go-forwarder/` plus a YAML profile registry (`config/llm_profiles.yaml`) so the same code path talks to HF Inference Providers, Anthropic OpenAI-compat, OpenAI, local Ollama, or OpenRouter just by switching profile.
- Foundation for the AI session-analysis epic (#412); the actual session_chat HTTP endpoint, tool-use loop, and budget ledger arrive in #415/#416/#417.
- Sub-issue 2 of epic #412. `Closes #414.`

## What's in the box

- `llm_profiles.go` — YAML loader + `Resolve()` + `Available()` + non-fatal `loadLLMProfilesAtStartup()`. Loaders fail soft: misconfiguration logs `AI features disabled` and the analytics archive path keeps running.
- `llm_client.go` — `LLMClient.Ping(ctx, profileName)` smoke method built on `sashabaranov/go-openai`. Streaming + tool_calls support arrives in #415/#416 — this PR keeps it tight.
- `config/llm_profiles.yaml` — seed profiles for the five backends listed above. Per-profile `pricing` (per-million-tokens USD) feeds the future ledger; `supports_tools` / `supports_caching` are advisory hints for #416.
- `llm_profiles_test.go` (12 tests) and `llm_client_test.go` (3 tests, `httptest.NewServer` fake OpenAI). 15 tests total, all pass.
- `Dockerfile` — proper Go-build cache layering (`go.mod`/`go.sum` → `go mod download` → `*.go`), copies `config/` into the image.
- `main.go` — adds `llmProfilesPath` config (env `LLM_PROFILES_PATH`, default `/config/llm_profiles.yaml`), wires startup load, declares `var llmProfiles *LLMProfiles` for #416 handlers.

## Provider choice — why not OpenRouter exclusively?

Most modern providers expose **native OpenAI-compatible endpoints**, so the same Go client talks to all of them by switching `base_url`. Direct profiles avoid a third-party hop, the markup, and the privacy footprint. OpenRouter remains a *one-line addition* if you ever want unified billing or a model that lives only there. The seed profile list reflects this — direct providers + HF for open-source.

## Threat model + secrets

- API keys are read from env vars named in each profile (`api_key_env`); never logged, never echoed.
- Profiles flagged unavailable when the env is missing → the future `/analytics/api/llm_profiles` endpoint will mark them grey rather than letting requests fail with 401.
- `loadLLMProfilesAtStartup` is non-fatal so a leaked / misconfigured profiles file can't take down the live SSE → ClickHouse pipeline that everyone else depends on.

## A footnote on `main.go` formatting

The pre-existing `row` struct alignment is wider than gofmt would naturally produce. Left untouched to keep this diff surgical. My new field (`llmProfilesPath`) sits in its own column-group separated by a blank line, so it doesn't drag the existing struct into a re-align. Unrelated drift; tightenable in a separate cleanup PR if anyone cares.

## Test plan

- [x] `cd analytics/go-forwarder && go test ./...` — 15/15 tests pass.
- [x] `docker build` — image builds clean with new Dockerfile cache layering.
- [x] Image runs with profiles present: logs `llm profiles loaded: 5 total, 1 available, active="hf-llama-70b" (...)`.
- [x] Image runs with `LLM_PROFILES_PATH=/nonexistent`: logs `llm profiles unavailable (...); AI features disabled`, forwarder otherwise runs normally.
- [ ] Live smoke test against each profile — gated on credentials being set in the deploy env; out of unit-test scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
