### PR TITLE
feat(forwarder): query SQL tool + OpenAI tool-use loop (#415)

### DIFF
--- a/analytics/go-forwarder/llm_chat.go
+++ b/analytics/go-forwarder/llm_chat.go
@@ -1,0 +1,250 @@
+// Tool-use loop for the AI session-analysis path (epic #412).
+//
+// Implements the standard OpenAI tools loop: model emits tool_calls,
+// the forwarder runs each tool, appends results as role:"tool"
+// messages, re-invokes the model, repeats until the model returns
+// without tool_calls (the final answer).
+//
+// This file is the non-streaming path used by tests + the Analyze
+// button's one-shot mode. The /analytics/api/session_chat endpoint
+// (#416) layers SSE streaming on top by emitting per-tool-call and
+// per-token events as it walks the same loop.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+const (
+	defaultMaxToolCallsPerTurn = 20
+	// Per-iteration deadline: one model call + its tool fan-out. The
+	// 12 s ClickHouse timeout in QueryTool fits inside this comfortably.
+	defaultIterationTimeout = 30 * time.Second
+	// Aggregate deadline for the whole turn — model_call ⨯ N + tool_runs ⨯ M.
+	// Cuts off pathological loops even when each iteration is healthy.
+	defaultTurnTimeout = 120 * time.Second
+)
+
+// ToolDispatcher maps a tool name (the OpenAI Function.Name) to a
+// runner that takes the JSON-string arguments the model emitted.
+// Errors from the runner are not loop-fatal — they round-trip back
+// to the model so it can self-correct. Only context cancellation /
+// upstream model errors stop the loop.
+type ToolDispatcher func(ctx context.Context, name, argumentsJSON string) (resultJSON string)
+
+// ChatTurnResult is the per-turn outcome consumers see.
+type ChatTurnResult struct {
+	FinalText      string                         `json:"final_text"`
+	Messages       []openai.ChatCompletionMessage `json:"messages"`
+	ToolCallsCount int                            `json:"tool_calls_count"`
+	InputTokens    int                            `json:"input_tokens"`
+	OutputTokens   int                            `json:"output_tokens"`
+	Iterations     int                            `json:"iterations"`
+	StoppedReason  string                         `json:"stopped_reason"` // "complete" | "tool_budget" | "timeout" | "error"
+	StoppedDetail  string                         `json:"stopped_detail,omitempty"`
+}
+
+// ChatTurnOptions configures a single chat-completion-with-tools
+// turn. Zero values use sensible defaults.
+type ChatTurnOptions struct {
+	Tools             []openai.Tool
+	Dispatcher        ToolDispatcher
+	MaxToolCallsTotal int           // default 20 (LLM_MAX_TOOL_CALLS_PER_TURN env wins)
+	IterationTimeout  time.Duration // per model+tools pass; default 30s
+	TurnTimeout       time.Duration // whole turn; default 120s
+	Temperature       float32       // default 0 (deterministic-ish)
+	MaxTokens         int           // default 4096
+}
+
+func (c *LLMClient) RunChatTurn(
+	ctx context.Context,
+	profileName string,
+	messages []openai.ChatCompletionMessage,
+	opts ChatTurnOptions,
+) (*ChatTurnResult, error) {
+	prof, err := c.profiles.Resolve(profileName)
+	if err != nil {
+		return nil, err
+	}
+	maxCalls := envIntPositive("LLM_MAX_TOOL_CALLS_PER_TURN", opts.MaxToolCallsTotal, defaultMaxToolCallsPerTurn)
+	iterTO := opts.IterationTimeout
+	if iterTO <= 0 {
+		iterTO = defaultIterationTimeout
+	}
+	turnTO := opts.TurnTimeout
+	if turnTO <= 0 {
+		turnTO = defaultTurnTimeout
+	}
+	maxTok := opts.MaxTokens
+	if maxTok <= 0 {
+		maxTok = 4096
+	}
+
+	turnCtx, cancel := context.WithTimeout(ctx, turnTO)
+	defer cancel()
+
+	res := &ChatTurnResult{
+		Messages: append([]openai.ChatCompletionMessage(nil), messages...),
+	}
+	client := c.clientFor(prof)
+
+	// budgetBlown flips when ToolCallsCount exceeds maxCalls. Once
+	// set, the next iteration sends ToolChoice="none" to force the
+	// model to produce final text instead of more tool calls, and we
+	// break unconditionally after consuming that response. Without
+	// this gate the model can keep emitting tool_calls right up to
+	// the iteration cap and we never get a wrap-up answer.
+	budgetBlown := false
+	// maxCalls + 2: maxCalls tool-emitting iterations, plus one to
+	// receive the model's reply to the final tool result, plus one
+	// forced-no-tool wrap-up if the budget gate fires.
+	for iter := 0; iter < maxCalls+2; iter++ {
+		if err := turnCtx.Err(); err != nil {
+			res.StoppedReason = "timeout"
+			res.StoppedDetail = err.Error()
+			return res, nil
+		}
+		iterCtx, iterCancel := context.WithTimeout(turnCtx, iterTO)
+		req := openai.ChatCompletionRequest{
+			Model:       prof.Model,
+			Messages:    res.Messages,
+			Tools:       opts.Tools,
+			Temperature: opts.Temperature,
+			MaxTokens:   maxTok,
+		}
+		if budgetBlown {
+			req.ToolChoice = "none"
+		}
+		resp, err := client.CreateChatCompletion(iterCtx, req)
+		iterCancel()
+		if err != nil {
+			res.StoppedReason = "error"
+			res.StoppedDetail = err.Error()
+			res.Iterations = iter + 1
+			return res, fmt.Errorf("chat completion (iter %d, profile %q): %w", iter, prof.Name, err)
+		}
+		res.InputTokens += resp.Usage.PromptTokens
+		res.OutputTokens += resp.Usage.CompletionTokens
+		res.Iterations = iter + 1
+
+		if len(resp.Choices) == 0 {
+			res.StoppedReason = "error"
+			res.StoppedDetail = "no choices in response"
+			return res, errors.New("no choices in chat completion response")
+		}
+		assistant := resp.Choices[0].Message
+		res.Messages = append(res.Messages, assistant)
+
+		// Defensive: some providers emit finish_reason="tool_calls"
+		// with an empty array. Treat that the same as the no-tool-
+		// calls branch but flag it so telemetry catches the oddity.
+		if len(assistant.ToolCalls) == 0 && assistant.Content == "" {
+			res.StoppedReason = "error"
+			res.StoppedDetail = "empty assistant message"
+			return res, nil
+		}
+		if len(assistant.ToolCalls) == 0 {
+			res.FinalText = assistant.Content
+			if budgetBlown {
+				res.StoppedReason = "tool_budget"
+			} else {
+				res.StoppedReason = "complete"
+			}
+			return res, nil
+		}
+
+		// If the model returned ToolChoice="none" but still emitted
+		// tool_calls (some providers ignore the directive), bail out
+		// rather than running them — we asked for text, not actions.
+		if budgetBlown {
+			res.StoppedReason = "tool_budget"
+			res.StoppedDetail = "model ignored ToolChoice=none after budget exhaustion"
+			res.FinalText = assistant.Content
+			return res, nil
+		}
+
+		// Note: assistant.Content alongside ToolCalls is preamble
+		// (model "thinking out loud" before invoking tools). It's
+		// preserved in res.Messages for #416's SSE endpoint to
+		// surface; we don't promote it to res.FinalText since this
+		// turn isn't done.
+		for _, tc := range assistant.ToolCalls {
+			res.ToolCallsCount++
+			if res.ToolCallsCount > maxCalls {
+				res.Messages = append(res.Messages, openai.ChatCompletionMessage{
+					Role:       openai.ChatMessageRoleTool,
+					ToolCallID: tc.ID,
+					Content:    `{"error":"tool budget exhausted; reply with a final answer using what you have"}`,
+				})
+				budgetBlown = true
+				continue
+			}
+			// turnCtx deadline dominates if it's sooner than the
+			// 12 s ClickHouse cap inside QueryTool, so a confused
+			// dispatcher can't outlive the request.
+			result := opts.Dispatcher(turnCtx, tc.Function.Name, tc.Function.Arguments)
+			res.Messages = append(res.Messages, openai.ChatCompletionMessage{
+				Role:       openai.ChatMessageRoleTool,
+				ToolCallID: tc.ID,
+				Content:    result,
+			})
+		}
+	}
+
+	if res.StoppedReason == "" {
+		res.StoppedReason = "tool_budget"
+		res.StoppedDetail = "max iterations reached without final answer"
+	}
+	return res, nil
+}
+
+// envIntPositive prefers env over caller-supplied opt over default.
+// Returns the default if both are absent or the env can't parse.
+func envIntPositive(envName string, optVal, defVal int) int {
+	if v := os.Getenv(envName); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	if optVal > 0 {
+		return optVal
+	}
+	return defVal
+}
+
+// MakeQueryDispatcher returns a Dispatcher that routes the `query`
+// tool to a QueryTool and rejects every other name. #424 will fold
+// in the read-only control tools using the same pattern.
+func MakeQueryDispatcher(qt *QueryTool) ToolDispatcher {
+	return func(ctx context.Context, name, args string) string {
+		switch name {
+		case "query":
+			var parsed struct {
+				SQL string `json:"sql"`
+			}
+			if err := json.Unmarshal([]byte(args), &parsed); err != nil {
+				return jsonErr(fmt.Sprintf("malformed args: %s", err.Error()))
+			}
+			if parsed.SQL == "" {
+				return jsonErr("missing required argument: sql")
+			}
+			return qt.Run(ctx, parsed.SQL).MarshalForTool()
+		default:
+			return jsonErr(fmt.Sprintf("unknown tool: %s", name))
+		}
+	}
+}
+
+func jsonErr(msg string) string {
+	b, _ := json.Marshal(map[string]string{"error": msg})
+	return string(b)
+}

--- a/analytics/go-forwarder/llm_chat_test.go
+++ b/analytics/go-forwarder/llm_chat_test.go
@@ -1,0 +1,387 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// scriptedLLM serves chat-completion requests from a pre-loaded
+// FIFO of responses. Each call pops the next entry; running out
+// fails the test. Records the JSON body of each request so tests
+// can verify ToolChoice / Tools / Messages were shaped correctly.
+type scriptedLLM struct {
+	srv       *httptest.Server
+	mu        sync.Mutex
+	responses []openai.ChatCompletionResponse
+	bodies    [][]byte
+}
+
+func (s *scriptedLLM) URL() string { return s.srv.URL }
+
+func (s *scriptedLLM) Bodies() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]byte, len(s.bodies))
+	for i, b := range s.bodies {
+		dup := make([]byte, len(b))
+		copy(dup, b)
+		out[i] = dup
+	}
+	return out
+}
+
+func newScriptedLLM(t *testing.T, responses ...openai.ChatCompletionResponse) *scriptedLLM {
+	s := &scriptedLLM{responses: responses}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		s.mu.Lock()
+		s.bodies = append(s.bodies, body)
+		if len(s.responses) == 0 {
+			s.mu.Unlock()
+			t.Errorf("scriptedLLM: out of scripted responses (call #%d)", len(s.bodies))
+			http.Error(w, "out of scripted responses", 500)
+			return
+		}
+		next := s.responses[0]
+		s.responses = s.responses[1:]
+		s.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(next)
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func textResp(s string, in, out int) openai.ChatCompletionResponse {
+	return openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index:        0,
+			FinishReason: "stop",
+			Message: openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: s,
+			},
+		}},
+		Usage: openai.Usage{PromptTokens: in, CompletionTokens: out},
+	}
+}
+
+func toolCallResp(callID, fnName, fnArgs string, in, out int) openai.ChatCompletionResponse {
+	return openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index:        0,
+			FinishReason: "tool_calls",
+			Message: openai.ChatCompletionMessage{
+				Role: openai.ChatMessageRoleAssistant,
+				ToolCalls: []openai.ToolCall{{
+					ID:   callID,
+					Type: openai.ToolTypeFunction,
+					Function: openai.FunctionCall{
+						Name:      fnName,
+						Arguments: fnArgs,
+					},
+				}},
+			},
+		}},
+		Usage: openai.Usage{PromptTokens: in, CompletionTokens: out},
+	}
+}
+
+func setupChatTest(t *testing.T, baseURL string) (*LLMClient, ChatTurnOptions, *int) {
+	const envName = "LLM_CHAT_TEST_KEY"
+	t.Setenv(envName, "test-key")
+	profile := &LLMProfile{
+		Name:      "test",
+		BaseURL:   baseURL + "/",
+		APIKeyEnv: envName,
+		Model:     "test-model",
+	}
+	profiles := &LLMProfiles{
+		Active:   "test",
+		Profiles: map[string]*LLMProfile{"test": profile},
+	}
+	dispatchCount := 0
+	tools := []openai.Tool{{
+		Type: openai.ToolTypeFunction,
+		Function: &openai.FunctionDefinition{
+			Name:        "echo",
+			Description: "echo back the value field",
+			Parameters: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"value": map[string]any{"type": "string"}},
+				"required":   []string{"value"},
+			},
+		},
+	}}
+	dispatcher := func(ctx context.Context, name, args string) string {
+		dispatchCount++
+		var parsed struct {
+			Value string `json:"value"`
+		}
+		_ = json.Unmarshal([]byte(args), &parsed)
+		return `{"echo":"` + parsed.Value + `"}`
+	}
+	return NewLLMClient(profiles), ChatTurnOptions{
+		Tools:      tools,
+		Dispatcher: dispatcher,
+	}, &dispatchCount
+}
+
+func TestRunChatTurn_NoToolCalls_ReturnsImmediately(t *testing.T) {
+	srv := newScriptedLLM(t, textResp("the answer is 42", 100, 7))
+	client, opts, dispatched := setupChatTest(t, srv.URL())
+
+	res, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "what's the answer"}}, opts)
+	if err != nil {
+		t.Fatalf("RunChatTurn: %v", err)
+	}
+	if res.FinalText != "the answer is 42" {
+		t.Errorf("FinalText = %q", res.FinalText)
+	}
+	if res.ToolCallsCount != 0 {
+		t.Errorf("ToolCallsCount = %d, want 0", res.ToolCallsCount)
+	}
+	if *dispatched != 0 {
+		t.Errorf("dispatcher called %d times, want 0", *dispatched)
+	}
+	if res.StoppedReason != "complete" {
+		t.Errorf("StoppedReason = %q, want complete", res.StoppedReason)
+	}
+	if res.InputTokens != 100 || res.OutputTokens != 7 {
+		t.Errorf("usage = (%d in, %d out)", res.InputTokens, res.OutputTokens)
+	}
+}
+
+func TestRunChatTurn_OneToolCall_RoundTrips(t *testing.T) {
+	srv := newScriptedLLM(t,
+		toolCallResp("call-1", "echo", `{"value":"hello"}`, 50, 10),
+		textResp("you said hello", 60, 5),
+	)
+	client, opts, dispatched := setupChatTest(t, srv.URL())
+
+	res, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "echo hello"}}, opts)
+	if err != nil {
+		t.Fatalf("RunChatTurn: %v", err)
+	}
+	if res.FinalText != "you said hello" {
+		t.Errorf("FinalText = %q", res.FinalText)
+	}
+	if res.ToolCallsCount != 1 {
+		t.Errorf("ToolCallsCount = %d, want 1", res.ToolCallsCount)
+	}
+	if *dispatched != 1 {
+		t.Errorf("dispatcher called %d times, want 1", *dispatched)
+	}
+	if res.StoppedReason != "complete" {
+		t.Errorf("StoppedReason = %q, want complete", res.StoppedReason)
+	}
+	if res.Iterations != 2 {
+		t.Errorf("Iterations = %d, want 2", res.Iterations)
+	}
+	// Token totals accumulate.
+	if res.InputTokens != 110 || res.OutputTokens != 15 {
+		t.Errorf("usage = (%d in, %d out), want (110, 15)", res.InputTokens, res.OutputTokens)
+	}
+	// Final messages should be: user, assistant(tool_call), tool, assistant(text).
+	if got := len(res.Messages); got != 4 {
+		t.Errorf("len(Messages) = %d, want 4", got)
+	}
+	if res.Messages[2].Role != openai.ChatMessageRoleTool {
+		t.Errorf("Messages[2].Role = %q, want tool", res.Messages[2].Role)
+	}
+	if !strings.Contains(res.Messages[2].Content, "hello") {
+		t.Errorf("tool result = %q, expected to contain echoed value", res.Messages[2].Content)
+	}
+}
+
+func TestRunChatTurn_ToolBudgetExhaustion(t *testing.T) {
+	const calls = 4
+	resps := make([]openai.ChatCompletionResponse, 0, calls+2)
+	for i := 0; i < calls+1; i++ {
+		resps = append(resps, toolCallResp("c"+strconv.Itoa(i), "echo", `{"value":"x"}`, 10, 1))
+	}
+	resps = append(resps, textResp("ok, stopping with what I have", 5, 5))
+	srv := newScriptedLLM(t, resps...)
+	client, opts, _ := setupChatTest(t, srv.URL())
+	opts.MaxToolCallsTotal = calls
+
+	res, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "loop"}}, opts)
+	if err != nil {
+		t.Fatalf("RunChatTurn: %v", err)
+	}
+	if res.StoppedReason != "tool_budget" {
+		t.Errorf("StoppedReason = %q, want tool_budget", res.StoppedReason)
+	}
+	if res.FinalText != "ok, stopping with what I have" {
+		t.Errorf("FinalText = %q, want forced wrap-up text", res.FinalText)
+	}
+	if res.ToolCallsCount <= calls {
+		t.Errorf("ToolCallsCount = %d, expected > %d (the over-budget call counts but synthesizes an error)", res.ToolCallsCount, calls)
+	}
+}
+
+// When budget is blown, the next request must include tool_choice:"none"
+// to force a wrap-up text. Verifies by inspecting the recorded bodies.
+func TestRunChatTurn_ToolBudgetForcesToolChoiceNone(t *testing.T) {
+	const calls = 1
+	srv := newScriptedLLM(t,
+		toolCallResp("c0", "echo", `{"value":"x"}`, 10, 1),
+		toolCallResp("c1", "echo", `{"value":"y"}`, 10, 1),
+		textResp("done", 5, 5),
+	)
+	client, opts, _ := setupChatTest(t, srv.URL())
+	opts.MaxToolCallsTotal = calls
+
+	_, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "loop"}}, opts)
+	if err != nil {
+		t.Fatalf("RunChatTurn: %v", err)
+	}
+
+	bodies := srv.Bodies()
+	if len(bodies) < 3 {
+		t.Fatalf("got %d request bodies, expected >= 3", len(bodies))
+	}
+	// First two requests: no tool_choice override (tools allowed).
+	if bytesContains(bodies[0], `"tool_choice"`) {
+		t.Errorf("first request unexpectedly carried tool_choice: %s", bodies[0])
+	}
+	if bytesContains(bodies[1], `"tool_choice"`) {
+		t.Errorf("second request unexpectedly carried tool_choice: %s", bodies[1])
+	}
+	// Third request: budget blown on iter 2 (call #1 emitted by first
+	// response, call #2 by second response → ToolCallsCount = 2 > 1).
+	// The third call must force tool_choice="none".
+	if !bytesContains(bodies[2], `"tool_choice":"none"`) {
+		t.Errorf("third request did not carry tool_choice=\"none\"; body: %s", bodies[2])
+	}
+}
+
+func bytesContains(haystack []byte, needle string) bool {
+	return strings.Contains(string(haystack), needle)
+}
+
+func TestRunChatTurn_TurnTimeout(t *testing.T) {
+	// LLM hangs forever on the first call.
+	hangSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	t.Cleanup(hangSrv.Close)
+	client, opts, _ := setupChatTest(t, hangSrv.URL)
+	opts.TurnTimeout = 100 * time.Millisecond
+	opts.IterationTimeout = 100 * time.Millisecond
+
+	start := time.Now()
+	res, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "hang"}}, opts)
+	elapsed := time.Since(start)
+
+	// We expect a non-nil error from the upstream timeout; the test
+	// asserts we returned within a sane multiple of TurnTimeout
+	// rather than waiting the full 5 s the fake server would have.
+	if elapsed > 1*time.Second {
+		t.Errorf("loop took %v; expected to stop near TurnTimeout", elapsed)
+	}
+	if err == nil && res.StoppedReason != "timeout" && res.StoppedReason != "error" {
+		t.Errorf("expected timeout/error stop; got %q (err=%v)", res.StoppedReason, err)
+	}
+}
+
+func TestRunChatTurn_UpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream boom"}}`))
+	}))
+	t.Cleanup(srv.Close)
+	client, opts, _ := setupChatTest(t, srv.URL)
+
+	_, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "x"}}, opts)
+	if err == nil {
+		t.Fatal("expected error when upstream returns 500")
+	}
+}
+
+func TestRunChatTurn_DispatcherErrorRoundTrips(t *testing.T) {
+	srv := newScriptedLLM(t,
+		toolCallResp("call-1", "echo", `{}`, 5, 5), // missing required value
+		textResp("ok I will not", 10, 3),
+	)
+	client, opts, _ := setupChatTest(t, srv.URL())
+
+	res, err := client.RunChatTurn(context.Background(), "test",
+		[]openai.ChatCompletionMessage{{Role: "user", Content: "do something"}}, opts)
+	if err != nil {
+		t.Fatalf("RunChatTurn: %v", err)
+	}
+	if res.StoppedReason != "complete" {
+		t.Errorf("dispatcher errors should not stop the loop; got %q", res.StoppedReason)
+	}
+	if res.ToolCallsCount != 1 {
+		t.Errorf("ToolCallsCount = %d, want 1", res.ToolCallsCount)
+	}
+}
+
+func TestMakeQueryDispatcher_RejectsUnknownTool(t *testing.T) {
+	qt := NewQueryTool("http://unused")
+	d := MakeQueryDispatcher(qt)
+	out := d(context.Background(), "not_query", `{}`)
+	if !strings.Contains(out, "unknown tool") {
+		t.Errorf("dispatcher should reject unknown tool; got %q", out)
+	}
+}
+
+func TestMakeQueryDispatcher_RejectsMissingSQL(t *testing.T) {
+	qt := NewQueryTool("http://unused")
+	d := MakeQueryDispatcher(qt)
+	out := d(context.Background(), "query", `{}`)
+	if !strings.Contains(out, "missing required argument") {
+		t.Errorf("dispatcher should reject missing sql; got %q", out)
+	}
+}
+
+func TestMakeQueryDispatcher_RejectsMalformedArgs(t *testing.T) {
+	qt := NewQueryTool("http://unused")
+	d := MakeQueryDispatcher(qt)
+	out := d(context.Background(), "query", `not json`)
+	if !strings.Contains(out, "malformed args") {
+		t.Errorf("dispatcher should reject malformed args; got %q", out)
+	}
+}
+
+func TestEnvIntPositive(t *testing.T) {
+	const envName = "LLM_CHAT_ENV_INT_TEST"
+	os.Unsetenv(envName)
+	t.Cleanup(func() { os.Unsetenv(envName) })
+	if got := envIntPositive(envName, 0, 7); got != 7 {
+		t.Errorf("default not used: %d", got)
+	}
+	if got := envIntPositive(envName, 11, 7); got != 11 {
+		t.Errorf("opt not used: %d", got)
+	}
+	t.Setenv(envName, "42")
+	if got := envIntPositive(envName, 11, 7); got != 42 {
+		t.Errorf("env not used: %d", got)
+	}
+	t.Setenv(envName, "garbage")
+	if got := envIntPositive(envName, 11, 7); got != 11 {
+		t.Errorf("malformed env should fall through to opt: %d", got)
+	}
+}

--- a/analytics/go-forwarder/llm_tool_query.go
+++ b/analytics/go-forwarder/llm_tool_query.go
@@ -1,0 +1,200 @@
+// SQL `query` tool for the AI session-analysis path (epic #412).
+//
+// Exposes a single tool to the LLM: query(sql) → rows. All safety is
+// enforced by the ClickHouse `llm_reader` user (#413) at the server
+// level — readonly, time-cap, scan-cap, GRANT scope, no SET. We pass
+// LLM-authored SQL through unchecked.
+//
+// One thing the server does *not* enforce in 24.8 is `max_result_rows`
+// on streaming SELECTs (it's cooperative; see the comment in
+// 02-llm-reader.sql). So this file's runner enforces the response-
+// size cap on read: if ClickHouse hands back more than maxRows or
+// maxBytes, we truncate and flag `truncated=true`. The LLM is
+// expected to react ("got truncated, narrow with WHERE / aggregate").
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// Hard caps the forwarder applies on *response* size. ClickHouse's
+// `max_result_rows` setting is cooperative for streaming SELECTs in
+// 24.8; these kick in regardless and are the real backstop.
+const (
+	queryToolMaxRows  = 10000
+	queryToolMaxBytes = 10 * 1024 * 1024 // 10 MB
+	// 12 s is slightly above the server's 10 s max_execution_time so
+	// we don't race the server's own cutoff. If the server times out
+	// it surfaces as a ClickHouse error, not a Go context cancel.
+	queryToolTimeout = 12 * time.Second
+)
+
+// QueryToolResult is the shape returned to the LLM as a JSON-encoded
+// tool result. Field names are short on purpose — the LLM pays for
+// every input token of these results.
+type QueryToolResult struct {
+	Rows      [][]any  `json:"rows"`
+	Columns   []string `json:"columns"`
+	Truncated bool     `json:"truncated,omitempty"`
+	Error     string   `json:"error,omitempty"`
+	ElapsedMS int      `json:"elapsed_ms"`
+}
+
+// QueryTool runs llm_reader-scoped SQL against ClickHouse via the
+// HTTP interface. The forwarder already posts inserts to the same
+// host; this is a separate user identity over the same transport.
+type QueryTool struct {
+	ClickHouseURL string // e.g. http://clickhouse:8123
+	User          string // llm_reader
+	HTTPClient    *http.Client
+}
+
+func NewQueryTool(clickhouseURL string) *QueryTool {
+	return &QueryTool{
+		ClickHouseURL: strings.TrimRight(clickhouseURL, "/"),
+		User:          "llm_reader",
+		HTTPClient: &http.Client{
+			Timeout: queryToolTimeout,
+		},
+	}
+}
+
+// OpenAITool returns the function-tool schema the LLM uses to invoke
+// this. The description is part of the contract — the LLM reads it
+// and decides when to call. Keep it tight; every word counts.
+func (q *QueryTool) OpenAITool() openai.Tool {
+	return openai.Tool{
+		Type: openai.ToolTypeFunction,
+		Function: &openai.FunctionDefinition{
+			Name: "query",
+			Description: "Run a read-only ClickHouse SQL query against the " +
+				"infinite_streaming database. Returns up to 10000 rows / 10 MB. " +
+				"Server caps: 10s execution, 10M rows scanned, 1 GB memory. " +
+				"Use to answer questions about archived sessions: " +
+				"infinite_streaming.session_snapshots and " +
+				"infinite_streaming.network_requests are the main tables.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"sql": map[string]any{
+						"type":        "string",
+						"description": "ClickHouse SELECT query. SET / INSERT / DDL are rejected.",
+					},
+				},
+				"required": []string{"sql"},
+			},
+		},
+	}
+}
+
+// Run executes a ClickHouse query as `llm_reader` and returns a
+// truncated-on-overflow JSON response shape.
+func (q *QueryTool) Run(ctx context.Context, sql string) *QueryToolResult {
+	started := time.Now()
+	out := &QueryToolResult{}
+
+	// 12 s per-query cap; bounded by the parent ctx if that's sooner,
+	// since context.WithTimeout takes the earlier of the two deadlines.
+	ctx, cancel := context.WithTimeout(ctx, queryToolTimeout)
+	defer cancel()
+
+	url := q.ClickHouseURL + "/?default_format=JSON"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(sql))
+	if err != nil {
+		out.Error = err.Error()
+		out.ElapsedMS = int(time.Since(started).Milliseconds())
+		return out
+	}
+	req.Header.Set("X-ClickHouse-User", q.User)
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+
+	resp, err := q.HTTPClient.Do(req)
+	if err != nil {
+		out.Error = err.Error()
+		out.ElapsedMS = int(time.Since(started).Milliseconds())
+		return out
+	}
+	defer resp.Body.Close()
+
+	// Read up to maxBytes+1 so we can flag truncation. We don't trust
+	// Content-Length — ClickHouse streams without setting it for some
+	// queries.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, queryToolMaxBytes+1))
+	out.ElapsedMS = int(time.Since(started).Milliseconds())
+	if err != nil {
+		out.Error = err.Error()
+		return out
+	}
+	if len(body) > queryToolMaxBytes {
+		body = body[:queryToolMaxBytes]
+		out.Truncated = true
+	}
+	if resp.StatusCode != http.StatusOK {
+		out.Error = fmt.Sprintf("clickhouse %d: %s", resp.StatusCode, sniffError(body))
+		return out
+	}
+
+	var parsed struct {
+		Meta []struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"meta"`
+		Data [][]any `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		// Some malformed cases (e.g. truncated JSON) — pass the raw
+		// body sniff to the LLM so it can adapt.
+		out.Error = fmt.Sprintf("parse json: %s", sniffError(body))
+		return out
+	}
+	for _, m := range parsed.Meta {
+		out.Columns = append(out.Columns, m.Name)
+	}
+	if len(parsed.Data) > queryToolMaxRows {
+		out.Rows = parsed.Data[:queryToolMaxRows]
+		out.Truncated = true
+	} else {
+		out.Rows = parsed.Data
+	}
+	return out
+}
+
+// sniffError takes the first ~200 chars of a body so error messages
+// fed back to the LLM are bounded.
+func sniffError(body []byte) string {
+	const max = 200
+	if len(body) <= max {
+		return strings.TrimSpace(string(body))
+	}
+	return strings.TrimSpace(string(body[:max])) + "…"
+}
+
+// MarshalForTool returns the JSON the assistant role:tool message
+// will carry. Always succeeds — encoding errors collapse to a
+// minimal "{\"error\":\"…\"}" so the loop never gets stuck.
+func (r *QueryToolResult) MarshalForTool() string {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Sprintf(`{"error":%q}`, err.Error())
+	}
+	// Defense in depth: in practice the 10k-row cap upstream keeps
+	// us under maxBytes, but if it ever fires return a clean
+	// truncation marker rather than mid-array junk JSON.
+	if len(b) > queryToolMaxBytes {
+		return fmt.Sprintf(
+			`{"error":"result exceeded %d bytes after row truncation","truncated":true,"elapsed_ms":%d}`,
+			queryToolMaxBytes, r.ElapsedMS,
+		)
+	}
+	return string(b)
+}
+

--- a/analytics/go-forwarder/llm_tool_query_test.go
+++ b/analytics/go-forwarder/llm_tool_query_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeClickHouse impersonates ClickHouse's HTTP interface enough to
+// exercise the QueryTool's parsing + truncation paths.
+func fakeClickHouse(t *testing.T, status int, jsonBody string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the user header is set so the LLM gets the
+		// constrained role-not the privileged default.
+		if got := r.Header.Get("X-ClickHouse-User"); got != "llm_reader" {
+			t.Errorf("X-ClickHouse-User = %q, want llm_reader", got)
+		}
+		// Body should be the SQL.
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "SELECT") {
+			t.Errorf("body did not contain SELECT: %q", string(body))
+		}
+		// Verify default_format=JSON in the URL.
+		if !strings.Contains(r.URL.RawQuery, "default_format=JSON") {
+			t.Errorf("query missing default_format=JSON: %q", r.URL.RawQuery)
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, jsonBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestQueryTool_HappyPath(t *testing.T) {
+	body := `{
+		"meta": [{"name":"n","type":"UInt64"},{"name":"label","type":"String"}],
+		"data": [[1,"a"],[2,"b"]]
+	}`
+	srv := fakeClickHouse(t, http.StatusOK, body)
+	qt := NewQueryTool(srv.URL)
+
+	res := qt.Run(context.Background(), "SELECT n, label FROM t LIMIT 2")
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if !equalStrings(res.Columns, []string{"n", "label"}) {
+		t.Errorf("Columns = %v, want [n label]", res.Columns)
+	}
+	if len(res.Rows) != 2 {
+		t.Errorf("len(Rows) = %d, want 2", len(res.Rows))
+	}
+	if res.Truncated {
+		t.Errorf("Truncated = true, want false")
+	}
+	if res.ElapsedMS < 0 {
+		t.Errorf("ElapsedMS = %d", res.ElapsedMS)
+	}
+}
+
+func TestQueryTool_ErrorStatusFromClickHouse(t *testing.T) {
+	srv := fakeClickHouse(t, http.StatusBadRequest, "Code: 159. DB::Exception: Timeout exceeded")
+	qt := NewQueryTool(srv.URL)
+	res := qt.Run(context.Background(), "SELECT 1")
+	if res.Error == "" {
+		t.Fatal("expected error from non-200 response")
+	}
+	if !strings.Contains(res.Error, "Timeout") {
+		t.Errorf("error did not pass through clickhouse text: %q", res.Error)
+	}
+}
+
+func TestQueryTool_TruncatesAt10kRows(t *testing.T) {
+	// Build a JSON body with > 10k rows so the forwarder applies
+	// its hard cap (server-side max_result_rows is cooperative).
+	const n = 12000
+	rows := make([][]any, n)
+	for i := range rows {
+		rows[i] = []any{i}
+	}
+	bodyMap := map[string]any{
+		"meta": []map[string]string{{"name": "n", "type": "UInt64"}},
+		"data": rows,
+	}
+	bodyBytes, _ := json.Marshal(bodyMap)
+	srv := fakeClickHouse(t, http.StatusOK, string(bodyBytes))
+	qt := NewQueryTool(srv.URL)
+
+	res := qt.Run(context.Background(), "SELECT n FROM huge")
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if len(res.Rows) != queryToolMaxRows {
+		t.Errorf("len(Rows) = %d, want %d (cap)", len(res.Rows), queryToolMaxRows)
+	}
+	if !res.Truncated {
+		t.Errorf("Truncated = false, want true")
+	}
+}
+
+func TestQueryTool_MalformedJSONReturnsErr(t *testing.T) {
+	srv := fakeClickHouse(t, http.StatusOK, "<<not-json>>")
+	qt := NewQueryTool(srv.URL)
+	res := qt.Run(context.Background(), "SELECT 1")
+	if res.Error == "" {
+		t.Fatal("expected parse error for non-JSON body")
+	}
+	if !strings.Contains(res.Error, "parse json") {
+		t.Errorf("error didn't tag as parse error: %q", res.Error)
+	}
+}
+
+func TestQueryTool_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	t.Cleanup(srv.Close)
+	qt := NewQueryTool(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	res := qt.Run(ctx, "SELECT 1")
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("Run did not respect outer ctx; took %v", elapsed)
+	}
+	if res.Error == "" {
+		t.Errorf("expected error from cancelled ctx")
+	}
+}
+
+func TestQueryToolResult_MarshalForTool(t *testing.T) {
+	r := &QueryToolResult{
+		Rows:      [][]any{{1, "a"}},
+		Columns:   []string{"n", "label"},
+		ElapsedMS: 7,
+	}
+	out := r.MarshalForTool()
+	if !strings.Contains(out, `"columns":["n","label"]`) {
+		t.Errorf("output missing columns: %q", out)
+	}
+	if !strings.Contains(out, `"elapsed_ms":7`) {
+		t.Errorf("output missing elapsed_ms: %q", out)
+	}
+}
+
+func TestQueryTool_OpenAIToolSchema(t *testing.T) {
+	qt := NewQueryTool("http://unused")
+	tool := qt.OpenAITool()
+	if tool.Function.Name != "query" {
+		t.Errorf("Name = %q, want query", tool.Function.Name)
+	}
+	params, ok := tool.Function.Parameters.(map[string]any)
+	if !ok {
+		t.Fatalf("Parameters not a map: %T", tool.Function.Parameters)
+	}
+	props, ok := params["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("properties missing or wrong type")
+	}
+	if _, ok := props["sql"]; !ok {
+		t.Errorf("missing sql property")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Adds the SQL `query` tool that the LLM uses to read archived sessions, and the multi-step tool-use loop that drives multi-iteration interactions.
- Sub-issue 3 of epic #412. `Closes #415.`
- **Stacked on #423** (the LLM client + profiles). Once #423 lands, GitHub will retarget this PR's base to `main` automatically.

## What's in the box

- **`llm_tool_query.go`** — `QueryTool` struct + `Run(ctx, sql) *QueryToolResult` + `OpenAITool()` schema. Hits ClickHouse via the same HTTP transport the forwarder already uses for inserts but as the constrained `llm_reader` identity. **Forwarder enforces hard 10k-row / 10MB cap on response read** because ClickHouse 24.8's `max_result_rows` is cooperative for streaming SELECTs (the real server fence is `max_rows_to_read` on input).
- **`llm_chat.go`** — `RunChatTurn(ctx, profile, messages, opts) (*ChatTurnResult, error)`. Implements the OpenAI tool-use loop: model emits `tool_calls` → forwarder runs each via dispatcher → appends `role:"tool"` results → re-invokes → stops when model returns no tool_calls (final answer). Iteration cap from `LLM_MAX_TOOL_CALLS_PER_TURN` env (default 20). Per-iteration timeout 30s, aggregate turn timeout 120s.
- **`MakeQueryDispatcher(qt)`** — maps the `query` tool name through to QueryTool; rejects unknown names. The same dispatcher pattern will pick up the read-only control tools in #424.

## Notable design choice — tool-budget exhaustion

Initial implementation just synthesized a "budget exhausted" tool-result message and let the loop continue. Pre-commit code-reviewer caught that the model could then keep emitting `tool_calls` right up to the iteration cap and never produce text — the wrap-up was aspirational, not enforced.

**Fix:** when the budget is blown, the forwarder sets `ToolChoice: "none"` on the next request, forcing the model to produce final text. If the model still ignores the directive (some providers don't honor it), we bail out with `StoppedReason="tool_budget"` and surface whatever content arrived. New body-inspection test (`TestRunChatTurn_ToolBudgetForcesToolChoiceNone`) verifies the gate actually fires by checking the JSON the scripted LLM received.

## Other pre-commit-review fixes

- Defensive guard for `finish_reason: "tool_calls"` with an empty `ToolCalls` array (known provider bug) — returns `StoppedReason="error"` with `"empty assistant message"` detail.
- `MarshalForTool`'s overflow path produced invalid JSON (`...\"]}`); replaced with a clean `{"error":"result exceeded N bytes","truncated":true,"elapsed_ms":N}` literal. Should never fire in practice (10k-row cap upstream), but if it does the LLM gets parseable data.
- Trimmed several "what" comments per the CLAUDE.md / memory rule. Kept the "why" comments and the cross-issue pointers.
- Test ID generator switched from `'0'+i` (silently breaks past i=9) to `strconv.Itoa(i)`.

## Test plan

- [x] `go test ./...` — 33/33 pass.
- [x] Tool-budget loop terminates with `FinalText` after exhaustion (verified by behavior test).
- [x] `tool_choice: "none"` actually fires on the wrap-up request (verified by body-inspection test).
- [x] QueryTool truncates at exactly 10000 rows when ClickHouse returns more.
- [x] Outer `context.Cancel` propagates into QueryTool (sub-second response).
- [x] Dispatcher errors round-trip back to the model without stopping the loop.
- [ ] Live-network smoke against a real ClickHouse + real LLM — manual / deploy-time, not in unit-test scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
