### PR TITLE
feat(forwarder): system prompt for session chat (#418)

### DIFF
--- a/analytics/go-forwarder/Dockerfile
+++ b/analytics/go-forwarder/Dockerfile
@@ -7,9 +7,13 @@ RUN CGO_ENABLED=0 GOFLAGS=-trimpath go build -o /out/forwarder .
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/forwarder /forwarder
-# Default LLM_PROFILES_PATH points to /config/llm_profiles.yaml. Mount
-# a ConfigMap / bind-mount over /config to override per environment
-# without rebuilding the image.
+# Default LLM_PROFILES_PATH points to /config/llm_profiles.yaml.
+# Default SESSION_CHAT_PROMPT_PATH points to /config/prompts/session_chat.md.
+# Mount a ConfigMap / bind-mount over /config to override per
+# environment without rebuilding the image; the prompt file
+# specifically can be edited live and the next request picks it up
+# (mtime-cached re-read).
 COPY config/ /config/
+COPY prompts/ /config/prompts/
 USER nonroot:nonroot
 ENTRYPOINT ["/forwarder"]

--- a/analytics/go-forwarder/llm_prompt.go
+++ b/analytics/go-forwarder/llm_prompt.go
@@ -1,0 +1,150 @@
+// System-prompt loader for the AI session-analysis path
+// (epic #412, issue #418).
+//
+// Prompts live as markdown files under analytics/go-forwarder/prompts/
+// and are mounted into the image at /config/prompts/. Each prompt has
+// optional YAML frontmatter for default model params + a version
+// label that flows into the llm_calls ledger so prompt iterations
+// correlate with output quality over time.
+//
+// Loaded at request time with mtime caching: re-read only when the
+// file changes on disk. This lets operators iterate on a prompt with
+// a kubectl rollout / docker compose reload of the config volume —
+// no forwarder restart needed. Falls back to a built-in stub when
+// the file is missing so AI features keep working out of the box.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PromptFrontmatter is the YAML block at the top of a prompt file.
+// Frontmatter is delimited by '---' lines per common markdown
+// convention (Hugo / Jekyll / Obsidian / etc.).
+type PromptFrontmatter struct {
+	Version            string  `yaml:"prompt_version"`
+	DefaultMaxTokens   int     `yaml:"default_max_tokens"`
+	DefaultTemperature float32 `yaml:"default_temperature"`
+}
+
+type Prompt struct {
+	Path        string
+	Frontmatter PromptFrontmatter
+	Body        string
+	mtime       time.Time
+}
+
+type PromptCache struct {
+	mu      sync.Mutex
+	entries map[string]*Prompt
+}
+
+var defaultPromptCache = &PromptCache{entries: map[string]*Prompt{}}
+
+// LoadPrompt returns the parsed prompt for the given path, re-reading
+// only if the file's mtime has changed. nil + error when the file is
+// missing or malformed; callers fall back to the built-in stub below.
+func (c *PromptCache) Load(path string) (*Prompt, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	cached, ok := c.entries[path]
+	c.mu.Unlock()
+	if ok && cached.mtime.Equal(stat.ModTime()) {
+		return cached, nil
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	p, err := parsePrompt(string(body))
+	if err != nil {
+		return nil, fmt.Errorf("parse prompt %s: %w", path, err)
+	}
+	p.Path = path
+	p.mtime = stat.ModTime()
+	c.mu.Lock()
+	c.entries[path] = p
+	c.mu.Unlock()
+	return p, nil
+}
+
+func parsePrompt(text string) (*Prompt, error) {
+	p := &Prompt{}
+	r := bufio.NewReader(strings.NewReader(text))
+	first, err := r.ReadString('\n')
+	if err != nil {
+		// Empty or near-empty file → no frontmatter, body is the
+		// whole text.
+		p.Body = text
+		return p, nil
+	}
+	if strings.TrimSpace(first) != "---" {
+		// No frontmatter delimiter — entire text is body.
+		p.Body = text
+		return p, nil
+	}
+	// Read until the closing '---' line, accumulating frontmatter.
+	var fm strings.Builder
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("frontmatter not terminated by '---'")
+		}
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		fm.WriteString(line)
+	}
+	if err := yaml.Unmarshal([]byte(fm.String()), &p.Frontmatter); err != nil {
+		return nil, fmt.Errorf("yaml: %w", err)
+	}
+	body, _ := readRest(r)
+	p.Body = body
+	return p, nil
+}
+
+func readRest(r *bufio.Reader) (string, error) {
+	var b strings.Builder
+	for {
+		chunk, err := r.ReadString('\n')
+		b.WriteString(chunk)
+		if err != nil {
+			return strings.TrimLeft(b.String(), "\n"), nil
+		}
+	}
+}
+
+// builtinSessionChatPrompt is the stub used when the on-disk prompt
+// is missing. It must be enough to make /api/session_chat work end-
+// to-end so test harnesses don't depend on the file being present.
+const builtinSessionChatPrompt = `You are an expert in adaptive video streaming and ClickHouse analytics. Use the query tool to read from infinite_streaming.session_snapshots and infinite_streaming.network_requests. Cite timestamps in mm:ss.ms form. If data is missing, say so explicitly.`
+
+// SessionChatPrompt loads /config/prompts/session_chat.md (overridable
+// via SESSION_CHAT_PROMPT_PATH) or falls back to the built-in stub.
+// Returns the body and the version string for ledger correlation.
+func SessionChatPrompt() (body, version string) {
+	path := os.Getenv("SESSION_CHAT_PROMPT_PATH")
+	if path == "" {
+		path = "/config/prompts/session_chat.md"
+	}
+	p, err := defaultPromptCache.Load(path)
+	if err != nil {
+		return builtinSessionChatPrompt, "builtin-fallback"
+	}
+	v := p.Frontmatter.Version
+	if v == "" {
+		v = "unversioned"
+	}
+	return p.Body, v
+}

--- a/analytics/go-forwarder/llm_prompt_test.go
+++ b/analytics/go-forwarder/llm_prompt_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writePromptTemp(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "session_chat.md")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tmp prompt: %v", err)
+	}
+	return p
+}
+
+func TestParsePrompt_NoFrontmatter(t *testing.T) {
+	p, err := parsePrompt("just a plain prompt body\nno frontmatter\n")
+	if err != nil {
+		t.Fatalf("parsePrompt: %v", err)
+	}
+	if !strings.Contains(p.Body, "plain prompt body") {
+		t.Errorf("Body = %q", p.Body)
+	}
+	if p.Frontmatter.Version != "" {
+		t.Errorf("expected empty version when no frontmatter")
+	}
+}
+
+func TestParsePrompt_WithFrontmatter(t *testing.T) {
+	src := `---
+prompt_version: v3
+default_max_tokens: 8000
+default_temperature: 0.5
+---
+the prompt body
+goes here
+`
+	p, err := parsePrompt(src)
+	if err != nil {
+		t.Fatalf("parsePrompt: %v", err)
+	}
+	if p.Frontmatter.Version != "v3" {
+		t.Errorf("Version = %q, want v3", p.Frontmatter.Version)
+	}
+	if p.Frontmatter.DefaultMaxTokens != 8000 {
+		t.Errorf("DefaultMaxTokens = %d, want 8000", p.Frontmatter.DefaultMaxTokens)
+	}
+	if !strings.HasPrefix(p.Body, "the prompt body") {
+		t.Errorf("Body = %q (frontmatter not stripped?)", p.Body)
+	}
+}
+
+func TestParsePrompt_UnterminatedFrontmatter(t *testing.T) {
+	_, err := parsePrompt("---\nprompt_version: v1\nbody never reached")
+	if err == nil {
+		t.Fatal("expected error for unterminated frontmatter")
+	}
+}
+
+func TestPromptCache_ReReadOnMtimeChange(t *testing.T) {
+	cache := &PromptCache{entries: map[string]*Prompt{}}
+	path := writePromptTemp(t, "first body\n")
+	first, err := cache.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !strings.Contains(first.Body, "first") {
+		t.Fatalf("Body = %q", first.Body)
+	}
+	// Bump mtime by sleeping briefly (filesystem mtime resolution is
+	// sometimes 1 s on older FSes; 1.1 s is safe everywhere we run).
+	time.Sleep(1100 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("second body\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	second, err := cache.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !strings.Contains(second.Body, "second") {
+		t.Errorf("cache didn't refresh on mtime change; got %q", second.Body)
+	}
+}
+
+func TestPromptCache_HitsCache(t *testing.T) {
+	cache := &PromptCache{entries: map[string]*Prompt{}}
+	path := writePromptTemp(t, "stable body\n")
+	a, _ := cache.Load(path)
+	b, _ := cache.Load(path)
+	if a != b {
+		t.Errorf("cache should return same pointer for unchanged file")
+	}
+}
+
+func TestPromptCache_MissingFile(t *testing.T) {
+	cache := &PromptCache{entries: map[string]*Prompt{}}
+	_, err := cache.Load("/nonexistent/prompt.md")
+	if err == nil {
+		t.Fatal("expected error for missing prompt file")
+	}
+}
+
+func TestSessionChatPrompt_FallsBackToBuiltin(t *testing.T) {
+	// Override path to a missing file.
+	t.Setenv("SESSION_CHAT_PROMPT_PATH", "/definitely/not/here.md")
+	body, version := SessionChatPrompt()
+	if !strings.Contains(body, "expert in adaptive video streaming") {
+		t.Errorf("fallback body wrong: %q", body)
+	}
+	if version != "builtin-fallback" {
+		t.Errorf("version = %q, want builtin-fallback", version)
+	}
+}
+
+func TestSessionChatPrompt_LoadsFromDisk(t *testing.T) {
+	src := `---
+prompt_version: test-v1
+---
+# Custom prompt
+test body
+`
+	path := writePromptTemp(t, src)
+	t.Setenv("SESSION_CHAT_PROMPT_PATH", path)
+	// Reset cache so previous tests don't shadow this one.
+	defaultPromptCache = &PromptCache{entries: map[string]*Prompt{}}
+	body, version := SessionChatPrompt()
+	if !strings.Contains(body, "Custom prompt") || !strings.Contains(body, "test body") {
+		t.Errorf("body wrong: %q", body)
+	}
+	if version != "test-v1" {
+		t.Errorf("version = %q, want test-v1", version)
+	}
+}
+
+func TestSessionChatPrompt_UnversionedFrontmatter(t *testing.T) {
+	src := `---
+default_max_tokens: 1000
+---
+body
+`
+	path := writePromptTemp(t, src)
+	t.Setenv("SESSION_CHAT_PROMPT_PATH", path)
+	defaultPromptCache = &PromptCache{entries: map[string]*Prompt{}}
+	_, version := SessionChatPrompt()
+	if version != "unversioned" {
+		t.Errorf("version = %q, want unversioned", version)
+	}
+}

--- a/analytics/go-forwarder/llm_session_chat.go
+++ b/analytics/go-forwarder/llm_session_chat.go
@@ -220,7 +220,8 @@ func handleSessionChat(w http.ResponseWriter, r *http.Request, client *LLMClient
 	stopHeartbeat := startSSEHeartbeat(chatCtx, sw, heartbeatIntervalForTest)
 	defer stopHeartbeat()
 
-	messages := buildMessagesWithContext(req)
+	systemPrompt, promptVersion := SessionChatPrompt()
+	messages := buildMessagesWithContext(req, systemPrompt)
 	tools := []openai.Tool{queryTool.OpenAITool()}
 	dispatcher := MakeQueryDispatcher(queryTool)
 
@@ -266,6 +267,7 @@ func handleSessionChat(w http.ResponseWriter, r *http.Request, client *LLMClient
 		SessionID:      req.SessionID,
 		Profile:        prof.Name,
 		Model:          prof.Model,
+		PromptVersion:  promptVersion,
 		OneShot:        boolToU8(req.OneShot),
 		DurationMS:     dur,
 		Iterations:     uint16(res.Iterations),
@@ -368,39 +370,44 @@ func serveLLMBudget(w http.ResponseWriter, r *http.Request, ledger *LLMLedger, c
 	_ = json.NewEncoder(w).Encode(out)
 }
 
-// buildMessagesWithContext prepends a focus-context system message
-// when session_id / sessions / range are set. Contract for multi-turn
-// chat: the client must NOT echo system messages from prior turns
-// back in `messages` — it should send the user/assistant/tool history
-// only and re-supply session_id / range / sessions on each turn. We
-// always re-inject so prompt-cacheable backends see a byte-identical
-// prefix (sessions slice is sorted for that reason).
-func buildMessagesWithContext(req chatRequest) []openai.ChatCompletionMessage {
-	messages := req.Messages
-	if req.SessionID == "" && len(req.Sessions) == 0 && req.Range == nil {
-		return messages
+// buildMessagesWithContext prepends the system prompt + a focus-
+// context system message when session_id / sessions / range are set.
+// Contract for multi-turn chat: the client must NOT echo system
+// messages from prior turns back in `messages` — it should send the
+// user/assistant/tool history only and re-supply session_id / range
+// / sessions on each turn. We always re-inject so prompt-cacheable
+// backends see a byte-identical prefix (sessions slice is sorted
+// for that reason). System prompt comes first (largest, cacheable);
+// focus context second (small, varies per call).
+func buildMessagesWithContext(req chatRequest, systemPrompt string) []openai.ChatCompletionMessage {
+	out := make([]openai.ChatCompletionMessage, 0, len(req.Messages)+2)
+	if systemPrompt != "" {
+		out = append(out, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleSystem,
+			Content: systemPrompt,
+		})
 	}
-	parts := []string{}
-	if req.SessionID != "" {
-		parts = append(parts, fmt.Sprintf("Focus session_id: %s", req.SessionID))
+	if req.SessionID != "" || len(req.Sessions) > 0 || req.Range != nil {
+		parts := []string{}
+		if req.SessionID != "" {
+			parts = append(parts, fmt.Sprintf("Focus session_id: %s", req.SessionID))
+		}
+		if len(req.Sessions) > 0 {
+			// Sort for stable cache key — Anthropic prefix caching
+			// needs a byte-identical prefix across calls.
+			sorted := append([]string(nil), req.Sessions...)
+			sort.Strings(sorted)
+			parts = append(parts, fmt.Sprintf("Compare sessions: %v", sorted))
+		}
+		if req.Range != nil {
+			parts = append(parts, fmt.Sprintf("Focus range (ms): %d to %d", req.Range.From, req.Range.To))
+		}
+		out = append(out, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleSystem,
+			Content: "Session-chat preamble:\n- " + strings.Join(parts, "\n- "),
+		})
 	}
-	if len(req.Sessions) > 0 {
-		// Sort for stable cache key — Anthropic prefix caching needs
-		// a byte-identical prefix across calls.
-		sorted := append([]string(nil), req.Sessions...)
-		sort.Strings(sorted)
-		parts = append(parts, fmt.Sprintf("Compare sessions: %v", sorted))
-	}
-	if req.Range != nil {
-		parts = append(parts, fmt.Sprintf("Focus range (ms): %d to %d", req.Range.From, req.Range.To))
-	}
-	preamble := openai.ChatCompletionMessage{
-		Role:    openai.ChatMessageRoleSystem,
-		Content: "Session-chat preamble:\n- " + strings.Join(parts, "\n- "),
-	}
-	out := make([]openai.ChatCompletionMessage, 0, len(messages)+1)
-	out = append(out, preamble)
-	out = append(out, messages...)
+	out = append(out, req.Messages...)
 	return out
 }
 

--- a/analytics/go-forwarder/llm_session_chat_test.go
+++ b/analytics/go-forwarder/llm_session_chat_test.go
@@ -336,6 +336,40 @@ func TestRegisterLLMHandlers_DisabledWhenNoProfiles(t *testing.T) {
 	}
 }
 
+// Verifies the system prompt loaded by SessionChatPrompt() reaches
+// the LLM as the first message — this is what links the rest of the
+// epic (style rules, tool docs, schema) to actual model behavior.
+func TestSessionChat_InjectsSystemPrompt(t *testing.T) {
+	src := `---
+prompt_version: test-v9
+---
+SUPER UNIQUE PROMPT MARKER do not match elsewhere
+`
+	path := writePromptTemp(t, src)
+	t.Setenv("SESSION_CHAT_PROMPT_PATH", path)
+	defaultPromptCache = &PromptCache{entries: map[string]*Prompt{}}
+
+	s := newChatTestSetup(t,
+		[]openai.ChatCompletionResponse{textResp("ok", 5, 5)},
+		`{"meta":[],"data":[]}`,
+	)
+	body := `{"profile":"test","messages":[{"role":"user","content":"hi"}]}`
+	resp, err := http.Post(s.muxServer.URL+"/api/session_chat", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	bodies := s.llmServer.Bodies()
+	if len(bodies) == 0 {
+		t.Fatal("LLM saw no bodies")
+	}
+	if !bytes.Contains(bodies[0], []byte("SUPER UNIQUE PROMPT MARKER")) {
+		t.Errorf("system prompt body not injected; bodies[0]=%s", bodies[0])
+	}
+}
+
 func TestSessionChat_InjectsSessionContext(t *testing.T) {
 	s := newChatTestSetup(t,
 		[]openai.ChatCompletionResponse{textResp("ok", 5, 5)},

--- a/analytics/go-forwarder/prompts/session_chat.md
+++ b/analytics/go-forwarder/prompts/session_chat.md
@@ -1,0 +1,121 @@
+---
+prompt_version: v1
+default_max_tokens: 4096
+default_temperature: 0.2
+---
+
+# Role
+
+You are an expert in adaptive video streaming (HLS, DASH, LL-HLS, LL-DASH) and ClickHouse analytics. You help the user understand what happened during recorded video playback sessions captured by the InfiniteStream test harness.
+
+You have one tool: `query(sql)`. Use it to read from `infinite_streaming.session_snapshots` and `infinite_streaming.network_requests`. Hard limits enforced server-side: 10 second execution, 10 million rows scanned per query, 1 GB memory, 10000 rows / 10 MB returned. The user's chat panel can run for up to 20 tool calls per turn.
+
+# How playback sessions are recorded
+
+A "session" is one continuous testing session bound to a `session_id` and a player. Within a session, each restart of playback gets its own `play_id`. Snapshots are emitted once per second while the player is active. Each row in `session_snapshots` is one tick: it carries the player's current state (`player_state`, `waiting_reason`), the buffer depth (`buffer_depth_s`), the bitrate the player is rendering (`video_bitrate_mbps`), the network throughput (`measured_mbps`), the server-side TCP RTT (`client_rtt_ms`), and the path RTT (`client_path_ping_rtt_ms`).
+
+`network_requests` is the per-HTTP-request HAR-style log: one row per manifest / segment / init-section fetch with `total_ms`, `ttfb_ms`, `transfer_ms`, `bytes_in`, `status`, `request_kind`, and any `fault_type` if the test proxy injected a failure on that request.
+
+# Key tables (subset of columns; query `system.columns` if you need more)
+
+## `infinite_streaming.session_snapshots`
+
+```
+ts                          DateTime64(3, 'UTC')
+session_id                  String
+play_id                     LowCardinality(String)
+player_id                   LowCardinality(String)
+content_id                  LowCardinality(String)
+player_state                LowCardinality(String)  -- 'playing' | 'paused' | 'buffering' | ...
+waiting_reason              LowCardinality(String)  -- buffer underrun classification
+buffer_depth_s              Float32
+network_bitrate_mbps        Float32                  -- player-reported throughput
+video_bitrate_mbps          Float32                  -- selected variant bitrate (live)
+measured_mbps               Float32                  -- player-side measured throughput
+mbps_shaper_rate            Float32                  -- shaped target (if traffic-shaping active)
+client_rtt_ms               Float32                  -- server-side TCP_INFO smoothed RTT
+client_rtt_min_lifetime_ms  Float32                  -- kernel sticky min RTT
+client_rto_ms               Float32                  -- kernel TCP retransmit timeout (rises in wedges)
+client_path_ping_rtt_ms     Float32                  -- out-of-band ICMP RTT (independent of throttle)
+stall_count                 UInt32
+stall_time_s                Float32
+position_s                  Float32
+playback_rate               Float32
+last_event                  LowCardinality(String)
+trigger_type                LowCardinality(String)
+player_error                String
+mbps_transfer_complete      Float32
+mbps_transfer_rate          Float32
+classification              LowCardinality(String)   -- 'other' | 'interesting' | 'favourite'
+```
+
+Plus failure-injection columns for manifest/segment/master/transport faults (e.g. `manifest_failure_frequency`, `segment_failure_urls`, `transport_fault_active`, `nftables_bandwidth_mbps`, etc.). Query the schema if you need them.
+
+## `infinite_streaming.network_requests`
+
+```
+ts                       DateTime64(3, 'UTC')
+session_id               String
+play_id                  LowCardinality(String)
+method                   LowCardinality(String)
+url                      String
+path                     String
+request_kind             LowCardinality(String)   -- 'manifest' | 'segment' | 'init' | ...
+status                   UInt16
+bytes_in                 Int64
+bytes_out                Int64
+content_type             LowCardinality(String)
+dns_ms / connect_ms / tls_ms / ttfb_ms / transfer_ms / total_ms   Float32
+faulted                  UInt8                    -- 1 if test proxy injected a fault
+fault_type               LowCardinality(String)
+fault_action             LowCardinality(String)
+classification           LowCardinality(String)
+```
+
+## `infinite_streaming.llm_calls` (your own spend ledger; read only via system if granted)
+
+# Response style
+
+When you produce text answers:
+
+1. **Anchor every claim to a timestamp** in `mm:ss.ms` form (e.g. `0:42.350`). The dashboard auto-links these to the chart's seek cursor — so always cite, even for one-claim answers.
+2. **Show the data, briefly.** Quote the row count from your query, plus the metric value (e.g. "buffer dropped to 1.2 s at 0:42.350; over the 5 s before the stall, `client_rtt_ms` rose from 35 ms to 220 ms").
+3. **Forensic answers (when the user gives a `range:` or asks "what happened at"):**
+   - Open with **Observation** — the symptom you confirmed in the data.
+   - **Mechanism** — the immediate technical cause (e.g. "TCP wedged: `client_rto_ms` climbed past `client_rtt_ms` × 4").
+   - **Evidence** — the rows / metrics that support the mechanism.
+4. **Compare answers (when `sessions:` is multiple):**
+   - **Similarities** — what's identical across sessions.
+   - **Differences** — what diverges, with side-tagged citations like `(A@0:42.350, B@0:42.350)`.
+   - **Hypotheses** — ranked by what the data most directly supports. Say so when a hypothesis is speculative.
+5. **No padding.** No "let me investigate", no "I'll start by querying", no closing summary. Just lead with the finding.
+6. **No code blocks of SQL** in the answer unless the user asked. Cite the query inline if it adds value, but assume the user can read the tool-call summary.
+7. **When data is sparse**, say so explicitly: "I see only 3 rows in this window; can't confidently say more than X." Don't reach.
+
+# Mode hints
+
+The user message may include scope info via the request body, surfaced as a system preamble before the user message:
+
+- `Focus session_id: <id>` — single-session analysis. Default to **overview** unless the user asks for forensics.
+- `Focus range (ms): <from> to <to>` — forensic mode. Treat the range as the focus window; pull raw events / requests within it; use coarser aggregates outside it for context.
+- `Compare sessions: [A, B]` — comparison mode. Always investigate both sides symmetrically; never analyze one before the other.
+
+If none are present, ask the user which session to focus on rather than guessing.
+
+# Tool-use guidance
+
+- **Start narrow.** Your first query should pin down the session (`SELECT count(), min(ts), max(ts) FROM session_snapshots WHERE session_id = {id}`) so you know the time window before sweeping.
+- **Use `groupArray` and aggregates** rather than returning thousands of raw rows. The 10000-row cap means the LLM can't ask for "everything"; aggregate or filter first.
+- **Use `argMin` / `argMax`** for "the row at the time of X" patterns instead of materializing rows.
+- **For stall analysis**, look at `(player_state, waiting_reason)` transitions and the rows immediately before. Buffer underruns usually show as `buffer_depth_s` collapsing toward 0 over the prior 3–5 seconds.
+- **For ABR shifts**, watch `video_bitrate_mbps` changes vs `measured_mbps` — a downshift right after `measured_mbps` collapses is healthy; a downshift with stable `measured_mbps` suggests the player misread headroom.
+- **For "is the network actually slow?"** compare `client_rtt_ms` (current connection, queue-sensitive) against `client_path_ping_rtt_ms` (out-of-band path latency). Divergence = queueing. Both rising = path slow.
+- **Errors first.** If the user asks "what went wrong," start with `WHERE last_event = 'error' OR player_error != ''` and `WHERE status >= 400` on `network_requests`.
+- **Don't run `SELECT *`** — it wastes tokens. Project only the columns you need.
+
+# Failure modes for you (the assistant)
+
+- If a query errors, **read the error message** and adjust. ClickHouse errors are precise (`Code: 158. TOO_MANY_ROWS`). Don't retry the same query.
+- If a query returns empty, **check the time window first** before assuming the data isn't there. The `ts` clause is the most common cause of unexpected emptiness.
+- If you've made 3 tool calls and still don't have a clear picture, **ask the user for guidance** rather than burning more tool budget on speculation.
+- **Never invent metric values.** If you didn't query for it, don't cite it.


### PR DESCRIPTION
## Summary

- Authors `prompts/session_chat.md` — the system prompt that drives every AI session-analysis interaction (overview, forensic, compare). Covers role, schema, tool docs, response style, mode hints, and failure-mode language.
- Adds a small mtime-cached loader so operators can edit the prompt live (no forwarder restart) and the next request picks it up.
- Sub-issue 6 of epic #412. `Closes #418.`
- **Stacked on #429**.

## What's in the prompt

- Role + how sessions are recorded (session_id ⨯ play_id, 1Hz snapshots, HAR-style network_requests).
- Schema of `session_snapshots` + `network_requests` + `llm_calls` with the columns analyses actually reach for.
- Response-style rules — **anchor every claim to `mm:ss.ms` timestamps** (the dashboard auto-links these to seek), structure forensic answers as **Observation / Mechanism / Evidence**, comparison answers as **Similarities / Differences / Hypotheses**, no padding, no SQL in answers unless asked.
- Mode hints triggered by the focus-context preamble (`Focus session_id` / `Focus range` / `Compare sessions`).
- Tool-use guidance — start narrow, aggregate before materializing, errors-first.
- Failure-mode language so a confused or data-sparse model stops cleanly instead of hallucinating.

## Loader behaviour

- `SessionChatPrompt()` reads `/config/prompts/session_chat.md` (overridable via `SESSION_CHAT_PROMPT_PATH`).
- `PromptCache.Load` re-reads only on mtime change — edit the file in production, next chat picks it up automatically.
- Built-in stub fallback keeps `/api/session_chat` working when the file is missing or malformed.
- Frontmatter parser handles standard `---` delimiters; missing or unversioned frontmatter logs `unversioned` into the ledger.

## Ledger correlation

`llm_calls.prompt_version` now carries the version from the loaded prompt's frontmatter, so A/B iterations on the prompt correlate with response quality (e.g. cost per turn, average iterations, error rate) over time.

## Test plan

- [x] `go test ./...` 67/67 pass.
- [x] `docker build` clean; image contains `/config/prompts/session_chat.md` (8.5 KB).
- [x] `TestSessionChat_InjectsSystemPrompt` — uses a unique marker string to verify the on-disk prompt body actually reaches the LLM as the first message.
- [x] Frontmatter parsing covers: no frontmatter, with frontmatter, unterminated frontmatter, unversioned frontmatter.
- [x] `PromptCache` covers: re-read on mtime change, hit cache when unchanged, missing-file fallback to builtin.
- [ ] Live-network smoke against a real LLM with the new prompt — manual / deploy-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
