### PR TITLE
feat(dashboard): AI Discuss panel + per-row Analyze button (#419)

### DIFF
--- a/content/dashboard/llm-analyze-modal.js
+++ b/content/dashboard/llm-analyze-modal.js
@@ -1,0 +1,218 @@
+// Per-row Analyze button + modal for sessions.html (epic #412,
+// issue #419).
+//
+// Watches #sessionsContainer for .session-card elements (rendered
+// by session-shell.js) and injects an "Analyze" button into each
+// card's header. Clicking opens a modal that runs a one-shot chat
+// against that session and streams the assistant_message body
+// inline.
+
+(function () {
+    'use strict';
+
+    if (!window.LLMChat) {
+        console.warn('llm-analyze-modal: LLMChat not loaded; modal disabled');
+        return;
+    }
+
+    const STYLE_ID = 'llm-analyze-styles';
+
+    function injectStyles() {
+        if (document.getElementById(STYLE_ID)) return;
+        const css = `
+.llmchat-analyze-btn {
+    background: #4f46e5;
+    color: #fff;
+    border: none;
+    padding: 4px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 600;
+    margin-left: 6px;
+}
+.llmchat-analyze-btn:hover { background: #4338ca; }
+.llmchat-analyze-btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+.llm-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 60px;
+    z-index: 9100;
+}
+.llm-modal {
+    background: #fff;
+    border-radius: 12px;
+    width: min(720px, 92vw);
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.3);
+}
+.llm-modal-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.llm-modal-header h3 { margin: 0; font-size: 15px; flex: 1; }
+.llm-modal-close { background: none; border: none; cursor: pointer; font-size: 22px; color: #64748b; }
+.llm-modal-body {
+    padding: 14px 16px;
+    overflow-y: auto;
+    flex: 1;
+    line-height: 1.55;
+    font-size: 13px;
+    color: #0f172a;
+}
+.llm-modal-status {
+    color: #64748b;
+    font-size: 12px;
+    font-style: italic;
+}
+.llm-modal-meta {
+    padding: 8px 16px;
+    background: #f8fafc;
+    border-top: 1px solid #e5e7eb;
+    font-size: 11px;
+    color: #64748b;
+}
+.llm-modal-error { background: #fef2f2; color: #991b1b; padding: 12px; border-radius: 8px; }
+        `.trim();
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    function openModal(sessionId) {
+        const backdrop = document.createElement('div');
+        backdrop.className = 'llm-modal-backdrop';
+        backdrop.innerHTML = `
+            <div class="llm-modal" role="dialog" aria-modal="true" aria-labelledby="llm-modal-title">
+                <div class="llm-modal-header">
+                    <h3 id="llm-modal-title">Analyzing session ${escapeHTML(sessionId.substring(0, 16))}…</h3>
+                    <button class="llm-modal-close" type="button" aria-label="Close">×</button>
+                </div>
+                <div class="llm-modal-body" data-role="body">
+                    <div class="llm-modal-status">Sending your request…</div>
+                </div>
+                <div class="llm-modal-meta" data-role="meta"></div>
+            </div>
+        `;
+        document.body.appendChild(backdrop);
+        const bodyEl = backdrop.querySelector('[data-role=body]');
+        const metaEl = backdrop.querySelector('[data-role=meta]');
+        const closeBtn = backdrop.querySelector('.llm-modal-close');
+
+        const stream = window.LLMChat.chat({
+            profile: localStorage.getItem('llm-chat-profile') || '',
+            messages: [{
+                role: 'user',
+                content: 'Give me an overview of this session — what happened, anything notable.',
+            }],
+            sessionId,
+            oneShot: true,
+        });
+
+        let assistantText = '';
+        stream.on('tool_call', (data) => {
+            if (!assistantText) {
+                bodyEl.innerHTML = `<div class="llm-modal-status">Running ${escapeHTML(data?.name || 'tool')}…</div>`;
+            }
+        });
+        stream.on('tool_result', (data) => {
+            if (!assistantText) {
+                bodyEl.innerHTML = `<div class="llm-modal-status">Got ${data?.rows ?? 0} rows in ${data?.elapsed_ms ?? 0} ms — thinking…</div>`;
+            }
+        });
+        stream.on('assistant_message', (data) => {
+            assistantText = data?.content || '';
+            bodyEl.innerHTML = window.LLMChat.linkifyTimestamps(assistantText);
+        });
+        stream.on('usage', (data) => {
+            const cost = (data?.cost_usd || 0).toFixed(5);
+            const tokens = (data?.input_tokens || 0) + (data?.output_tokens || 0);
+            metaEl.textContent = `$${cost} · ${tokens} tokens · ${data?.tool_calls_count || 0} tool calls · stopped: ${data?.stopped_reason || '—'}`;
+        });
+        stream.on('error', (data) => {
+            bodyEl.innerHTML = `<div class="llm-modal-error">${escapeHTML(data?.message || data?.kind || 'error')}</div>`;
+        });
+
+        // Track the trigger so focus returns there on close (a11y).
+        const trigger = document.activeElement;
+        const escHandler = (e) => {
+            if (e.key === 'Escape') close();
+        };
+        function close() {
+            stream.cancel();
+            backdrop.remove();
+            document.removeEventListener('keydown', escHandler);
+            if (trigger && typeof trigger.focus === 'function') {
+                try { trigger.focus(); } catch { /* ignore */ }
+            }
+        }
+        closeBtn.addEventListener('click', close);
+        backdrop.addEventListener('click', (e) => {
+            if (e.target === backdrop) close();
+        });
+        document.addEventListener('keydown', escHandler);
+    }
+
+    // Picker rows (sessions.html) carry the session_id on a
+    // <span data-star-cell> in the first cell rather than on the
+    // <tr> directly — see session-replay.js where the table is
+    // rendered. Inject the Analyze button into the same cell as
+    // the star, with z-index above the row's stretched-link
+    // overlay (z-index:0) so clicks reach us, not the row link.
+    function injectAnalyzeButton(starSpan) {
+        const sessionId = starSpan.dataset.sessionId;
+        if (!sessionId) return;
+        const cell = starSpan.parentElement;
+        if (!cell || cell.querySelector('.llmchat-analyze-btn')) return;
+        const btn = document.createElement('button');
+        btn.className = 'llmchat-analyze-btn';
+        btn.type = 'button';
+        btn.textContent = 'Analyze';
+        btn.title = 'Run an AI overview of this session';
+        btn.style.position = 'relative';
+        btn.style.zIndex = '3';
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            openModal(sessionId);
+        });
+        cell.appendChild(btn);
+    }
+
+    function scanAndInject() {
+        document.querySelectorAll('span[data-star-cell][data-session-id]').forEach(injectAnalyzeButton);
+    }
+
+    function escapeHTML(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+        }[c]));
+    }
+
+    function init() {
+        injectStyles();
+        // Initial scan + observer for session-shell.js re-renders.
+        scanAndInject();
+        const container = document.getElementById('sessionsContainer');
+        if (!container) return;
+        const obs = new MutationObserver(() => scanAndInject());
+        obs.observe(container, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/content/dashboard/llm-discuss-panel.js
+++ b/content/dashboard/llm-discuss-panel.js
@@ -1,0 +1,490 @@
+// Discuss panel for session-viewer.html (epic #412, issue #419).
+//
+// Side panel that lets the user chat with the LLM about the
+// currently-loaded session. Conversation history is persisted in
+// localStorage keyed by session_id; closing/reopening a session
+// preserves the chat. Multi-turn — each new message reuses the
+// full prior history. Cancel button stops a stream mid-flight.
+
+(function () {
+    'use strict';
+
+    if (!window.LLMChat) {
+        console.warn('llm-discuss-panel: LLMChat not loaded; panel disabled');
+        return;
+    }
+
+    const STORAGE_PREFIX = 'llm-chat-history:';
+    const STYLE_ID = 'llm-discuss-styles';
+
+    function injectStyles() {
+        if (document.getElementById(STYLE_ID)) return;
+        const css = `
+.llm-discuss-toggle {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: #1e1b4b;
+    color: #fff;
+    border: none;
+    box-shadow: 0 6px 18px rgba(30, 27, 75, 0.35);
+    cursor: pointer;
+    font-size: 22px;
+    z-index: 9000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease;
+}
+.llm-discuss-toggle:hover { transform: translateY(-2px); }
+.llm-discuss-toggle.active { background: #4f46e5; }
+.llm-discuss-toggle[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+.llm-discuss-panel {
+    position: fixed;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: min(440px, 100vw);
+    background: #fff;
+    border-left: 1px solid #c7d2fe;
+    box-shadow: -8px 0 24px rgba(15, 23, 42, 0.12);
+    z-index: 9001;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform 0.18s ease;
+}
+.llm-discuss-panel.open { transform: translateX(0); }
+
+.llm-discuss-header {
+    padding: 14px 16px;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.llm-discuss-header h3 { margin: 0; font-size: 15px; font-weight: 600; flex: 1; }
+.llm-discuss-close { background: none; border: none; cursor: pointer; font-size: 20px; color: #64748b; padding: 4px 8px; }
+.llm-discuss-close:hover { color: #0f172a; }
+
+.llm-discuss-controls {
+    padding: 10px 16px;
+    border-bottom: 1px solid #f1f5f9;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: #475569;
+}
+.llm-discuss-controls select {
+    flex: 1;
+    padding: 4px 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    font-size: 12px;
+}
+.llm-discuss-clear { background: none; border: 1px solid #cbd5e1; border-radius: 6px; padding: 4px 8px; cursor: pointer; font-size: 11px; color: #475569; }
+.llm-discuss-clear:hover { background: #f1f5f9; }
+
+.llm-discuss-budget {
+    padding: 6px 16px;
+    font-size: 11px;
+    color: #64748b;
+    border-bottom: 1px solid #f1f5f9;
+    background: #f8fafc;
+}
+.llm-discuss-budget.over { background: #fef2f2; color: #991b1b; }
+
+.llm-discuss-history {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 16px;
+    background: #fafbff;
+}
+.llmchat-msg { margin-bottom: 14px; line-height: 1.45; font-size: 13px; }
+.llmchat-msg-user { background: #eef2ff; border-radius: 10px; padding: 8px 12px; }
+.llmchat-msg-user .llmchat-msg-role { color: #3730a3; font-weight: 600; font-size: 11px; }
+.llmchat-msg-assistant { padding: 0 4px; color: #0f172a; }
+.llmchat-msg-assistant .llmchat-msg-role { color: #475569; font-weight: 600; font-size: 11px; }
+.llmchat-msg-tool { font-size: 11px; color: #64748b; padding: 4px 8px; background: #f1f5f9; border-radius: 6px; font-family: ui-monospace, monospace; }
+.llmchat-msg-error { background: #fef2f2; color: #991b1b; padding: 8px 12px; border-radius: 8px; font-size: 12px; }
+.llmchat-msg-meta { font-size: 11px; color: #94a3b8; margin-top: 4px; }
+.llmchat-ts { color: #4f46e5; text-decoration: underline dotted; cursor: pointer; }
+.llmchat-ts:hover { color: #312e81; }
+
+.llm-discuss-input {
+    padding: 12px 16px;
+    border-top: 1px solid #e5e7eb;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.llm-discuss-input textarea {
+    width: 100%;
+    min-height: 60px;
+    max-height: 160px;
+    padding: 8px 10px;
+    border: 1px solid #cbd5e1;
+    border-radius: 8px;
+    font-family: inherit;
+    font-size: 13px;
+    resize: vertical;
+}
+.llm-discuss-actions { display: flex; gap: 8px; align-items: center; }
+.llm-discuss-send {
+    flex: 1;
+    background: #4f46e5;
+    color: #fff;
+    border: none;
+    padding: 8px 14px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 600;
+}
+.llm-discuss-send:hover { background: #4338ca; }
+.llm-discuss-send[disabled] { background: #94a3b8; cursor: not-allowed; }
+.llm-discuss-cancel {
+    background: #fef2f2;
+    color: #991b1b;
+    border: 1px solid #fecaca;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 12px;
+}
+.llm-discuss-cancel[disabled] { opacity: 0.5; cursor: not-allowed; }
+        `.trim();
+        const style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.textContent = css;
+        document.head.appendChild(style);
+    }
+
+    function buildPanel() {
+        const panel = document.createElement('aside');
+        panel.className = 'llm-discuss-panel';
+        panel.setAttribute('role', 'dialog');
+        panel.setAttribute('aria-label', 'AI discussion panel');
+        panel.innerHTML = `
+            <div class="llm-discuss-header">
+                <h3>Discuss this session</h3>
+                <button class="llm-discuss-close" type="button" aria-label="Close panel">×</button>
+            </div>
+            <div class="llm-discuss-controls">
+                <label style="font-size:11px;">Model:
+                    <select class="llm-discuss-select" data-role="profile" aria-label="LLM profile"></select>
+                </label>
+                <button class="llm-discuss-clear" type="button">Clear</button>
+            </div>
+            <div class="llm-discuss-budget" data-role="budget">Loading budget…</div>
+            <div class="llm-discuss-history" data-role="history" aria-live="polite"></div>
+            <div class="llm-discuss-input">
+                <textarea data-role="input" placeholder="Ask about this session — e.g. 'what happened around the stall at 0:42?'" aria-label="Message"></textarea>
+                <div class="llm-discuss-actions">
+                    <button class="llm-discuss-send" data-role="send" type="button" disabled>Loading models…</button>
+                    <button class="llm-discuss-cancel" data-role="cancel" type="button" disabled>Cancel</button>
+                </div>
+            </div>
+        `;
+        return panel;
+    }
+
+    function buildToggle() {
+        const btn = document.createElement('button');
+        btn.className = 'llm-discuss-toggle';
+        btn.type = 'button';
+        btn.title = 'Discuss this session with AI';
+        btn.textContent = '💬';
+        return btn;
+    }
+
+    // Persistence: chat history per session_id in localStorage. Keep
+    // it small — last 50 messages per session, drop the rest.
+    function loadHistory(sessionId) {
+        if (!sessionId) return [];
+        try {
+            const raw = localStorage.getItem(STORAGE_PREFIX + sessionId);
+            if (!raw) return [];
+            const arr = JSON.parse(raw);
+            return Array.isArray(arr) ? arr : [];
+        } catch { return []; }
+    }
+    function saveHistory(sessionId, history) {
+        if (!sessionId) return;
+        try {
+            const trimmed = history.slice(-50);
+            localStorage.setItem(STORAGE_PREFIX + sessionId, JSON.stringify(trimmed));
+        } catch { /* quota or disabled — ignore */ }
+    }
+    function clearHistory(sessionId) {
+        if (!sessionId) return;
+        try { localStorage.removeItem(STORAGE_PREFIX + sessionId); } catch { /* ignore */ }
+    }
+
+    function getSessionIdFromURL() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get('session') || params.get('session_id') || '';
+    }
+
+    function renderHistory(historyEl, history) {
+        historyEl.innerHTML = '';
+        for (const msg of history) {
+            historyEl.appendChild(renderMessage(msg));
+        }
+        historyEl.scrollTop = historyEl.scrollHeight;
+    }
+
+    function renderMessage(msg) {
+        const div = document.createElement('div');
+        div.className = `llmchat-msg llmchat-msg-${msg.role}`;
+        if (msg.role === 'user') {
+            div.innerHTML = `<div class="llmchat-msg-role">You</div>${escapeHTML(msg.content)}`;
+        } else if (msg.role === 'assistant') {
+            const meta = msg.meta ? `<div class="llmchat-msg-meta">${escapeHTML(msg.meta)}</div>` : '';
+            div.innerHTML = `<div class="llmchat-msg-role">AI</div>${window.LLMChat.linkifyTimestamps(msg.content)}${meta}`;
+        } else if (msg.role === 'tool') {
+            div.innerHTML = `<div>${escapeHTML(msg.content)}</div>`;
+        } else if (msg.role === 'error') {
+            div.innerHTML = `<div>${escapeHTML(msg.content)}</div>`;
+        }
+        return div;
+    }
+
+    function escapeHTML(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+        }[c]));
+    }
+
+    async function populateProfileSelect(selectEl) {
+        const data = await window.LLMChat.loadProfiles().catch(() => null);
+        selectEl.innerHTML = '';
+        if (!data || !data.enabled) {
+            const opt = document.createElement('option');
+            opt.textContent = '(AI features disabled on this server)';
+            opt.disabled = true;
+            selectEl.appendChild(opt);
+            selectEl.disabled = true;
+            return null;
+        }
+        const profiles = data.profiles || [];
+        const stored = localStorage.getItem('llm-chat-profile') || '';
+        let picked = '';
+        for (const p of profiles) {
+            const opt = document.createElement('option');
+            opt.value = p.name;
+            opt.textContent = `${p.name}${p.available ? '' : ' (no key)'}`;
+            opt.disabled = !p.available;
+            selectEl.appendChild(opt);
+            if (!picked && p.available) picked = p.name;
+            if (stored && p.name === stored && p.available) picked = stored;
+            if (!stored && p.active && p.available) picked = p.name;
+        }
+        selectEl.value = picked;
+        return picked;
+    }
+
+    async function refreshBudget(budgetEl) {
+        const b = await window.LLMChat.loadBudget().catch(() => null);
+        if (!b) {
+            budgetEl.textContent = 'Budget unavailable';
+            return;
+        }
+        const spent = (b.spent_usd || 0).toFixed(4);
+        const cap = (b.cap_usd || 0).toFixed(2);
+        const calls = b.calls_today || 0;
+        const over = (b.spent_usd || 0) >= (b.cap_usd || 0);
+        budgetEl.textContent = `$${spent} of $${cap} used today · ${calls} calls`;
+        budgetEl.classList.toggle('over', over);
+    }
+
+    function init() {
+        injectStyles();
+        const toggle = buildToggle();
+        const panel = buildPanel();
+        document.body.appendChild(toggle);
+        document.body.appendChild(panel);
+
+        const historyEl = panel.querySelector('[data-role=history]');
+        const inputEl = panel.querySelector('[data-role=input]');
+        const sendBtn = panel.querySelector('[data-role=send]');
+        const cancelBtn = panel.querySelector('[data-role=cancel]');
+        const closeBtn = panel.querySelector('.llm-discuss-close');
+        const clearBtn = panel.querySelector('.llm-discuss-clear');
+        const profileSelect = panel.querySelector('[data-role=profile]');
+        const budgetEl = panel.querySelector('[data-role=budget]');
+
+        let sessionId = getSessionIdFromURL();
+        let history = loadHistory(sessionId);
+        let activeStream = null;
+        let budgetTimer = null;
+        let profilesReady = false;
+
+        renderHistory(historyEl, history);
+
+        // Document-level Esc handler is bound only while the panel
+        // is open; close() unbinds it. Avoids the modal-leak issue
+        // the reviewer flagged for the other surface.
+        const escHandler = (e) => {
+            if (e.key === 'Escape' && !activeStream) close();
+        };
+
+        async function open() {
+            panel.classList.add('open');
+            toggle.classList.add('active');
+            document.addEventListener('keydown', escHandler);
+            // Refresh budget when panel opens; poll every 30s while open.
+            refreshBudget(budgetEl);
+            budgetTimer = setInterval(() => refreshBudget(budgetEl), 30000);
+            // Re-load profile list in case server config changed.
+            // Sequential: must finish before sendMessage can fire so
+            // the user doesn't submit with an empty profile.
+            await populateProfileSelect(profileSelect);
+            profilesReady = true;
+            sendBtn.textContent = 'Send';
+            if (!activeStream) sendBtn.disabled = false;
+            inputEl.focus();
+        }
+        function close() {
+            panel.classList.remove('open');
+            toggle.classList.remove('active');
+            document.removeEventListener('keydown', escHandler);
+            if (budgetTimer) {
+                clearInterval(budgetTimer);
+                budgetTimer = null;
+            }
+            if (activeStream) activeStream.cancel();
+            // Return focus to the toggle for keyboard users (a11y).
+            try { toggle.focus(); } catch { /* ignore */ }
+        }
+
+        toggle.addEventListener('click', () => {
+            if (panel.classList.contains('open')) close(); else open();
+        });
+        closeBtn.addEventListener('click', close);
+        clearBtn.addEventListener('click', () => {
+            clearHistory(sessionId);
+            history = [];
+            renderHistory(historyEl, history);
+        });
+        profileSelect.addEventListener('change', () => {
+            try { localStorage.setItem('llm-chat-profile', profileSelect.value); } catch { /* ignore */ }
+        });
+
+        function setStreaming(on) {
+            sendBtn.disabled = on || !profilesReady;
+            cancelBtn.disabled = !on;
+            // readOnly instead of disabled so the user can still
+            // select / copy text from their own pending message.
+            inputEl.readOnly = on;
+        }
+
+        function sendMessage() {
+            if (!profilesReady || !profileSelect.value) return;
+            const content = inputEl.value.trim();
+            if (!content) return;
+            sessionId = sessionId || getSessionIdFromURL();
+            const userMsg = { role: 'user', content };
+            history.push(userMsg);
+            renderHistory(historyEl, history);
+            inputEl.value = '';
+            setStreaming(true);
+
+            // Build the wire-format message list — only user/assistant/tool roles,
+            // never echo a system message back (the forwarder always re-injects).
+            const wireMessages = history
+                .filter((m) => m.role === 'user' || m.role === 'assistant')
+                .map((m) => ({ role: m.role, content: m.content }));
+
+            const partial = { role: 'assistant', content: '', meta: '' };
+            history.push(partial);
+
+            const stream = window.LLMChat.chat({
+                profile: profileSelect.value,
+                messages: wireMessages,
+                sessionId,
+            });
+            activeStream = stream;
+
+            stream.on('tool_call', (data) => {
+                partial.meta = `running ${data?.name || 'tool'}…`;
+                renderHistory(historyEl, history);
+            });
+            stream.on('tool_result', (data) => {
+                const rows = data?.rows ?? 0;
+                const ms = data?.elapsed_ms ?? 0;
+                const trunc = data?.truncated ? ' (truncated)' : '';
+                partial.meta = `tool returned ${rows} rows in ${ms} ms${trunc}`;
+                renderHistory(historyEl, history);
+            });
+            stream.on('assistant_message', (data) => {
+                partial.content = data?.content || '';
+                renderHistory(historyEl, history);
+            });
+            stream.on('usage', (data) => {
+                const cost = (data?.cost_usd || 0).toFixed(5);
+                const tokens = (data?.input_tokens || 0) + (data?.output_tokens || 0);
+                partial.meta = `$${cost} · ${tokens} tokens · ${data?.tool_calls_count || 0} tool calls · ${data?.iterations || 0} iters`;
+                renderHistory(historyEl, history);
+            });
+            stream.on('error', (data) => {
+                history.pop(); // drop the empty assistant placeholder
+                history.push({
+                    role: 'error',
+                    content: data?.kind === 'budget_exceeded'
+                        ? `Daily budget exhausted. Resets in ${data.retryAfterSec || 0} s.`
+                        : `Error: ${data?.message || data?.kind || 'unknown'}`,
+                });
+                renderHistory(historyEl, history);
+                refreshBudget(budgetEl);
+            });
+            stream.on('done', () => {
+                setStreaming(false);
+                activeStream = null;
+                saveHistory(sessionId, history);
+                refreshBudget(budgetEl);
+            });
+            stream.on('cancelled', () => {
+                partial.meta = 'cancelled';
+                renderHistory(historyEl, history);
+            });
+        }
+
+        sendBtn.addEventListener('click', sendMessage);
+        cancelBtn.addEventListener('click', () => {
+            if (activeStream) activeStream.cancel();
+        });
+        inputEl.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+
+        // Click-to-seek on cited timestamps. We dispatch a custom
+        // event the page-level glue can listen for; pages that don't
+        // wire it up just ignore the click (no-op).
+        historyEl.addEventListener('click', (e) => {
+            const a = e.target.closest('.llmchat-ts');
+            if (!a) return;
+            e.preventDefault();
+            const ts = a.dataset.ts || a.textContent;
+            const seconds = window.LLMChat.parseTimestamp(ts);
+            if (!Number.isFinite(seconds)) return;
+            document.dispatchEvent(new CustomEvent('llm:seek', {
+                detail: { sessionId, seconds, ts },
+            }));
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/content/dashboard/session-viewer.html
+++ b/content/dashboard/session-viewer.html
@@ -447,5 +447,7 @@
     <script src="/dashboard/player-characterization.js"></script>
     <script src="/shared/session-shell.js"></script>
     <script src="/shared/session-replay.js"></script>
+    <script src="/shared/llm-chat.js"></script>
+    <script src="/dashboard/llm-discuss-panel.js"></script>
 </body>
 </html>

--- a/content/dashboard/sessions.html
+++ b/content/dashboard/sessions.html
@@ -446,5 +446,7 @@
     <script src="/dashboard/player-characterization.js"></script>
     <script src="/shared/session-shell.js"></script>
     <script src="/shared/session-replay.js"></script>
+    <script src="/shared/llm-chat.js"></script>
+    <script src="/dashboard/llm-analyze-modal.js"></script>
 </body>
 </html>

--- a/content/shared/llm-chat.js
+++ b/content/shared/llm-chat.js
@@ -1,0 +1,224 @@
+// Shared SSE consumer + state for the AI session-analysis path
+// (epic #412, issue #419).
+//
+// Used by:
+//   - dashboard/llm-discuss-panel.js for the multi-turn Discuss panel
+//   - dashboard/llm-analyze-modal.js for the per-row Analyze button
+//
+// DOM-free by design so each consumer wires its own UI. The module
+// surfaces an EventTarget-like API: subscribe to `event:tool_call`,
+// `event:tool_result`, `event:assistant_message`, `event:usage`,
+// `event:error`, `event:done`. Plus a `cancel()` to abort mid-turn.
+
+(function () {
+    'use strict';
+
+    const ANALYTICS_BASE = '/analytics/api';
+
+    function makeEmitter() {
+        const map = new Map();
+        return {
+            on(name, fn) {
+                if (!map.has(name)) map.set(name, new Set());
+                map.get(name).add(fn);
+                return () => map.get(name)?.delete(fn);
+            },
+            emit(name, payload) {
+                map.get(name)?.forEach((fn) => {
+                    try { fn(payload); }
+                    catch (err) { console.error(`llm-chat: handler for ${name} threw`, err); }
+                });
+            },
+        };
+    }
+
+    // parseSSEStream consumes a ReadableStream<Uint8Array> emitting
+    // server-sent events. Yields {event, data} objects via callback.
+    // Tolerant of split events across chunk boundaries.
+    async function parseSSEStream(stream, onEvent, signal) {
+        const reader = stream.getReader();
+        const decoder = new TextDecoder();
+        let buf = '';
+        let cur = { event: '', data: '' };
+        try {
+            while (true) {
+                if (signal?.aborted) return;
+                const { value, done } = await reader.read();
+                if (done) return;
+                buf += decoder.decode(value, { stream: true });
+                let nl;
+                while ((nl = buf.indexOf('\n')) >= 0) {
+                    const line = buf.slice(0, nl).replace(/\r$/, '');
+                    buf = buf.slice(nl + 1);
+                    if (line === '') {
+                        // Blank line terminates one event.
+                        if (cur.event || cur.data) {
+                            let parsed = null;
+                            if (cur.data) {
+                                try { parsed = JSON.parse(cur.data); }
+                                catch { parsed = { raw: cur.data }; }
+                            }
+                            onEvent(cur.event || 'message', parsed);
+                        }
+                        cur = { event: '', data: '' };
+                    } else if (line.startsWith(':')) {
+                        // SSE comment (keepalive). Ignore.
+                    } else {
+                        // Per W3C EventSource: `field:value` with the
+                        // colon optionally followed by a single space.
+                        // Tolerate both `event: foo` and `event:foo`.
+                        const idx = line.indexOf(':');
+                        if (idx <= 0) continue;
+                        const field = line.slice(0, idx);
+                        let value = line.slice(idx + 1);
+                        if (value.startsWith(' ')) value = value.slice(1);
+                        if (field === 'event') {
+                            cur.event = value;
+                        } else if (field === 'data') {
+                            cur.data = (cur.data ? cur.data + '\n' : '') + value;
+                        }
+                        // id: / retry: — ignored for now.
+                    }
+                }
+            }
+        } finally {
+            try { reader.releaseLock(); } catch { /* already released */ }
+        }
+    }
+
+    // chat opens an SSE session against /api/session_chat. Returns
+    // an emitter + cancel(). Caller subscribes to events before
+    // awaiting completion via the `done` event.
+    function chat(opts) {
+        const {
+            profile = '',
+            messages,
+            sessionId = '',
+            sessions = null,
+            range = null,
+            oneShot = false,
+        } = opts || {};
+        if (!Array.isArray(messages) || messages.length === 0) {
+            throw new Error('llm-chat: messages array required');
+        }
+        const emitter = makeEmitter();
+        const ctrl = new AbortController();
+        const body = JSON.stringify({
+            profile,
+            messages,
+            session_id: sessionId,
+            sessions,
+            range,
+            one_shot: oneShot,
+        });
+
+        (async () => {
+            try {
+                const resp = await fetch(`${ANALYTICS_BASE}/session_chat`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body,
+                    signal: ctrl.signal,
+                });
+                if (!resp.ok) {
+                    let detail = '';
+                    try { detail = await resp.text(); } catch { /* ignore */ }
+                    if (resp.status === 429) {
+                        emitter.emit('error', {
+                            kind: 'budget_exceeded',
+                            retryAfterSec: parseInt(resp.headers.get('Retry-After') || '0', 10),
+                            message: detail || 'daily budget exhausted',
+                        });
+                    } else if (resp.status === 413) {
+                        emitter.emit('error', { kind: 'input_too_large', message: detail });
+                    } else {
+                        emitter.emit('error', { kind: 'http', status: resp.status, message: detail });
+                    }
+                    emitter.emit('done', null);
+                    return;
+                }
+                if (!resp.body) {
+                    emitter.emit('error', { kind: 'no_stream', message: 'response had no body' });
+                    emitter.emit('done', null);
+                    return;
+                }
+                await parseSSEStream(resp.body, (event, data) => {
+                    emitter.emit(event, data);
+                }, ctrl.signal);
+            } catch (err) {
+                if (err && err.name === 'AbortError') {
+                    emitter.emit('cancelled', null);
+                    emitter.emit('done', null);
+                    return;
+                }
+                emitter.emit('error', { kind: 'fetch', message: String(err) });
+                emitter.emit('done', null);
+            }
+        })();
+
+        return {
+            on: emitter.on,
+            cancel: () => ctrl.abort(),
+        };
+    }
+
+    async function loadProfiles() {
+        const resp = await fetch(`${ANALYTICS_BASE}/llm_profiles`);
+        if (!resp.ok) throw new Error(`llm_profiles: ${resp.status}`);
+        return resp.json();
+    }
+
+    async function loadBudget() {
+        const resp = await fetch(`${ANALYTICS_BASE}/llm_budget`);
+        if (!resp.ok) throw new Error(`llm_budget: ${resp.status}`);
+        return resp.json();
+    }
+
+    // Format mm:ss.ms from ms / s / number — for citation parsing.
+    // Used when rendering the assistant_message body so timestamps
+    // become click-to-seek anchors.
+    function formatTimestamp(s) {
+        if (typeof s === 'string') {
+            const f = parseFloat(s);
+            if (Number.isFinite(f)) s = f;
+        }
+        if (typeof s !== 'number' || !Number.isFinite(s)) return '';
+        const mm = Math.floor(s / 60);
+        const ss = (s - mm * 60).toFixed(3).padStart(6, '0');
+        return `${mm}:${ss}`;
+    }
+
+    // Linkify timestamps in plain text. Returns an HTML string with
+    // <a class="llmchat-ts" data-ts="0:42.350">0:42.350</a> spans. The
+    // page-level glue listens for clicks on `.llmchat-ts` and routes to
+    // the chart-cursor seek.
+    function linkifyTimestamps(text) {
+        const escaped = text.replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+        }[c]));
+        return escaped.replace(
+            /\b(\d{1,3}:\d{2}(?:\.\d{1,3})?)\b/g,
+            '<a class="llmchat-ts" data-ts="$1" href="javascript:void(0)">$1</a>'
+        );
+    }
+
+    // Parse mm:ss.ms (possibly "1:23" or "1:23.456") to seconds.
+    function parseTimestamp(s) {
+        if (typeof s !== 'string') return NaN;
+        const m = s.match(/^(\d{1,3}):(\d{2})(?:\.(\d{1,3}))?$/);
+        if (!m) return NaN;
+        const minutes = parseInt(m[1], 10);
+        const seconds = parseInt(m[2], 10);
+        const ms = m[3] ? parseInt(m[3].padEnd(3, '0'), 10) : 0;
+        return minutes * 60 + seconds + ms / 1000;
+    }
+
+    window.LLMChat = {
+        chat,
+        loadProfiles,
+        loadBudget,
+        formatTimestamp,
+        linkifyTimestamps,
+        parseTimestamp,
+    };
+})();


### PR DESCRIPTION
## Summary

- The user-facing surface for AI session analysis. Floating 💬 Discuss panel on `session-viewer.html` (multi-turn chat about the loaded session) + per-row Analyze button on `sessions.html` (one-shot overview modal).
- Sub-issue 7 of epic #412 — completes the MVP. `Closes #419.`
- **Stacked on #430**.

## What's new

| File | Role |
|---|---|
| `content/shared/llm-chat.js` | DOM-free SSE consumer + `window.LLMChat` API |
| `content/dashboard/llm-discuss-panel.js` | Discuss panel for `session-viewer.html` |
| `content/dashboard/llm-analyze-modal.js` | Analyze button + modal for `sessions.html` |
| `content/dashboard/session-viewer.html` | +2 script tags |
| `content/dashboard/sessions.html` | +2 script tags |

## Behaviour

**Discuss panel** (session-viewer.html):
- 💬 floating toggle bottom-right; slide-out right-side panel.
- Multi-turn chat tied to the URL's `session=<id>` parameter.
- localStorage persistence (last 50 messages per session).
- Model picker dropdown sourced from `/api/llm_profiles`.
- Budget meter above history; polls `/api/llm_budget` every 30s while open.
- Cmd/Ctrl+Enter sends; Escape closes (when not streaming); focus returns to toggle.
- Cited `mm:ss.ms` timestamps render as click-to-seek anchors that dispatch `document.dispatchEvent(new CustomEvent('llm:seek'))`. Wiring to the chart cursor is a follow-up.

**Analyze button** (sessions.html):
- MutationObserver injects an Analyze button next to each row's star (the canonical `[data-star-cell][data-session-id]` hook).
- Click opens a modal that streams a one-shot overview from the same backend.
- z-index:3 sits above the row's stretched-link overlay so clicks don't navigate away.

## Pre-commit code-review fixes (this is the meaningful section)

The Sonnet pass caught **one critical bug**: my initial implementation queried `.session-card` divs for the picker — but `sessions.html` actually renders rows as `<tr>` with the session_id on a child `<span data-star-cell>`. The button would never have appeared. **Fixed** to target the real DOM shape, with z-index above the row overlay.

Plus important polish:

- **SSE parser** now tolerates spec-conformant `event:foo` (no space) per W3C EventSource. Original required the literal `event: ` (with space). Forwarder happens to emit the spaced form, but a future emit site or rewriting proxy would have silently dropped events.
- **Profile-select race** — Send button starts disabled ("Loading models…"); guards `sendMessage` until the profile fetch resolves. Stops a fast Cmd+Enter from sending with an empty profile.
- **Modal Esc handler** now removes itself on every close path (backdrop click, X button, Escape). Old code only removed on Escape — opening many modals would leak listeners.
- **Discuss panel** — Esc closes (when no stream is active); focus returns to the toggle button after close (WCAG 2.4.3).
- **CSS namespace** tightened: `.llm-msg` / `.llm-ts` → `.llmchat-msg` / `.llmchat-ts` to avoid future collision with generic class names.
- **Duplicate id="llm-profile-select"** removed — label now wraps the select so no id is needed (script-double-load can't create dupes).
- **`readOnly` during streaming** instead of `disabled` so users can still select / copy their own pending text.

## Cross-compare per memory rule

`testing-session.html` (the LIVE control plane) is intentionally NOT touched. Analytical AI is for archived replay; the live-session control AI surface is sub-issues **#424** (read-only inspection tools — `get_session_state`, `get_failure_settings`) and **#425** (HITL mutation tools with propose/apply UX), both planned for after the analytical MVP ships.

## What needs your hands-on browser verification before merge

(I'm a CLI agent — these are the gaps the reviewer + I flagged that only show up in a real browser.)

- [ ] 💬 toggle position vs existing bottom-right chart-expand controls on `session-viewer.html` — visual collision check.
- [ ] Per-row Analyze button placement in the picker's first cell — does it look right next to the star, does the click reach the modal (not the row navigation)?
- [ ] Real session_id end-to-end: pick an archived session, click Analyze, confirm a streamed answer arrives with click-to-seek timestamps.
- [ ] Open Discuss panel, ask a follow-up question, confirm history persists across page reload.
- [ ] Set `LLM_DAILY_BUDGET_USD=0` and confirm the budget meter renders as exhausted + the chat refuses with a 429 message inline.
- [ ] Cancel mid-stream — does the Cancel button actually stop the upstream LLM call (server-side `llm_calls.status='cancelled'`)?

Three files, all `node --check` syntax-clean. The forwarder side is fully covered by the existing 67-test suite (unchanged in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
