### PR TITLE
feat(dashboard): brush-range forensic mode for AI Discuss (#420)

### DIFF
--- a/content/dashboard/llm-discuss-panel.js
+++ b/content/dashboard/llm-discuss-panel.js
@@ -99,6 +99,26 @@
 }
 .llm-discuss-budget.over { background: #fef2f2; color: #991b1b; }
 
+.llm-discuss-focus {
+    padding: 6px 16px;
+    font-size: 11px;
+    color: #312e81;
+    border-bottom: 1px solid #f1f5f9;
+    background: #eef2ff;
+    display: none;
+}
+.llm-discuss-focus.active { display: block; }
+.llm-discuss-focus button {
+    margin-left: 8px;
+    background: none;
+    border: 1px solid #c7d2fe;
+    border-radius: 4px;
+    padding: 2px 6px;
+    cursor: pointer;
+    font-size: 10px;
+    color: #312e81;
+}
+
 .llm-discuss-history {
     flex: 1;
     overflow-y: auto;
@@ -182,6 +202,7 @@
                 <button class="llm-discuss-clear" type="button">Clear</button>
             </div>
             <div class="llm-discuss-budget" data-role="budget">Loading budget…</div>
+            <div class="llm-discuss-focus" data-role="focus"></div>
             <div class="llm-discuss-history" data-role="history" aria-live="polite"></div>
             <div class="llm-discuss-input">
                 <textarea data-role="input" placeholder="Ask about this session — e.g. 'what happened around the stall at 0:42?'" aria-label="Message"></textarea>
@@ -318,12 +339,58 @@
         const clearBtn = panel.querySelector('.llm-discuss-clear');
         const profileSelect = panel.querySelector('[data-role=profile]');
         const budgetEl = panel.querySelector('[data-role=budget]');
+        const focusEl = panel.querySelector('[data-role=focus]');
 
         let sessionId = getSessionIdFromURL();
         let history = loadHistory(sessionId);
         let activeStream = null;
         let budgetTimer = null;
         let profilesReady = false;
+        // Brush range tracked from session-replay.js's
+        // 'replay:brush-changed' CustomEvent. null = no brush
+        // (overview mode); {fromMs, toMs, sessionStartMs} = forensic
+        // mode — the next chat message ships {range:{from,to}} so
+        // the LLM scopes queries to the brushed window.
+        let brushRange = null;
+        let brushOverride = null; // user-suppressed brush focus
+
+        function fmtMs(ms) {
+            if (!Number.isFinite(ms) || ms < 0) return '—';
+            const totalS = Math.floor(ms / 1000);
+            const m = Math.floor(totalS / 60);
+            const s = totalS - m * 60;
+            return `${m}:${s.toString().padStart(2, '0')}`;
+        }
+        function effectiveRange() {
+            if (brushOverride === 'off') return null;
+            return brushRange;
+        }
+        function refreshFocus() {
+            const r = effectiveRange();
+            if (!r) {
+                focusEl.classList.remove('active');
+                focusEl.textContent = '';
+                return;
+            }
+            const startMs = r.sessionStartMs || 0;
+            const span = r.toMs - r.fromMs;
+            focusEl.classList.add('active');
+            focusEl.innerHTML = `Focus: <strong>${escapeHTML(fmtMs(r.fromMs - startMs))}–${escapeHTML(fmtMs(r.toMs - startMs))}</strong> (${escapeHTML(fmtMs(span))} window) <button data-role="focus-clear" type="button">Use full session</button>`;
+            focusEl.querySelector('[data-role=focus-clear]').addEventListener('click', () => {
+                brushOverride = 'off';
+                refreshFocus();
+            });
+        }
+
+        document.addEventListener('replay:brush-changed', (e) => {
+            const detail = e.detail || {};
+            if (detail.sessionId && sessionId && detail.sessionId !== sessionId) return;
+            brushRange = (detail.fromMs && detail.toMs && detail.toMs > detail.fromMs)
+                ? { fromMs: detail.fromMs, toMs: detail.toMs, sessionStartMs: detail.sessionStartMs || 0 }
+                : null;
+            brushOverride = null; // any new brush activity re-enables focus
+            refreshFocus();
+        });
 
         renderHistory(historyEl, history);
 
@@ -404,10 +471,12 @@
             const partial = { role: 'assistant', content: '', meta: '' };
             history.push(partial);
 
+            const focusRange = effectiveRange();
             const stream = window.LLMChat.chat({
                 profile: profileSelect.value,
                 messages: wireMessages,
                 sessionId,
+                range: focusRange ? { from: focusRange.fromMs, to: focusRange.toMs } : null,
             });
             activeStream = stream;
 

--- a/content/shared/session-replay.js
+++ b/content/shared/session-replay.js
@@ -449,6 +449,28 @@
             let brushStart = 0, brushEnd = 0;
             let userMovedBrush = false;
 
+            // publishBrush exposes the current brush window via the
+            // window.SessionReplay.getBrushRange() registry + dispatches
+            // a 'replay:brush-changed' CustomEvent. Used by external
+            // modules (e.g. AI Discuss panel #420) to scope chat
+            // requests to the brushed range. The event detail includes
+            // sessionStartMs so subscribers can format the brush window
+            // relative to play start without re-querying.
+            function publishBrush() {
+                if (!window.SessionReplay || !window.SessionReplay._brushByKey) return;
+                const key = String(sessionId);
+                const range = { fromMs: brushStart, toMs: brushEnd, sessionStartMs };
+                window.SessionReplay._brushByKey.set(key, range);
+                document.dispatchEvent(new CustomEvent('replay:brush-changed', {
+                    detail: {
+                        sessionId: key,
+                        fromMs: brushStart,
+                        toMs: brushEnd,
+                        sessionStartMs,
+                    },
+                }));
+            }
+
             // Brush UI is built once on first batch (when we know session
             // bounds). Subsequent batches just refresh the ticks and
             // bounds without rebuilding the DOM scaffolding.
@@ -486,6 +508,10 @@
                     scrubRow._startLabel.textContent = fmtIsoLocal(sessionStartMs);
                     scrubRow._endLabel.textContent = fmtIsoLocal(sessionEndMs);
                 }
+                // Publish the brush range to external subscribers
+                // (#420 AI Discuss panel scopes chats to the brushed
+                // window). Cheap — just a Map.set + a CustomEvent.
+                publishBrush();
             };
             const updateWindowText = (status) => {
                 if (!windowText) return;
@@ -2863,6 +2889,17 @@
 
     window.SessionReplay = {
         startMode: startReplayMode,
-        startPicker: startReplayPicker
+        startPicker: startReplayPicker,
+        // Brush range registry — populated by publishBrush() inside
+        // a session's brush handlers. Key: String(sessionId).
+        // Value: {fromMs, toMs}. Subscribers also listen for
+        // 'replay:brush-changed' on document for live updates.
+        _brushByKey: new Map(),
+        getBrushRange(sessionId) {
+            const r = window.SessionReplay._brushByKey.get(String(sessionId));
+            if (!r || !Number.isFinite(r.fromMs) || !Number.isFinite(r.toMs)) return null;
+            if (r.toMs <= r.fromMs) return null;
+            return r;
+        },
     };
 })();


### PR DESCRIPTION
## Summary

- When the user brushes a time range on the session-viewer charts, the Discuss panel surfaces a "Focus" banner and the next chat message ships `range:{from,to}` so the LLM scopes queries to that window (forensic mode per the system prompt's mode-hint section).
- Sub-issue 8 of epic #412. `Closes #420.`
- **Stacked on #431.**

## What's in the diff

`content/shared/session-replay.js` — new `publishBrush()` called from `updateBrushVisuals()`. Single hook covers all 10 brush-update sites (every brush mutation already routes through `updateBrushVisuals()` to redraw). Stores `{fromMs, toMs, sessionStartMs}` in `window.SessionReplay._brushByKey` + dispatches `replay:brush-changed` CustomEvent on document. Pull-based consumers can call `window.SessionReplay.getBrushRange(sessionId)`.

`content/dashboard/llm-discuss-panel.js` — listens for `replay:brush-changed`, renders a Focus banner above the chat history with `0:42–1:18 (36 s window)`. "Use full session" button suppresses focus for the next message; any new brush activity re-enables it. `sendMessage()` now passes `range:{from,to}` when active.

No backend changes — `/api/session_chat` already accepts and injects the range field into the system preamble (built in #416, prompt-aware in #418).

## What needs your hands-on browser verification

- [ ] Brush a 30 s window over a known stall, click Send, confirm the panel header shows the right range and the LLM answers with rows from inside that window.
- [ ] Drag the brush, confirm the Focus banner updates live (each drag tick fires a CustomEvent through `updateBrushVisuals`).
- [ ] Click **Use full session**, confirm the next message is overview-mode (no `range` in the request).
- [ ] Brush across the entire session — does the focus banner correctly stay active even when "all" is selected (probably yes; the LLM gets a redundant range that matches the session bounds, harmless).

## Why a single hook in `updateBrushVisuals()`?

`session-replay.js` mutates `brushStart`/`brushEnd` in 10 places (drag handlers, programmatic resets, "snap to end" recovery paths). Adding a `publishBrush()` call to each is mechanical but easy to miss one and silently desync the registry. **Every** brush mutation already routes through `updateBrushVisuals()` to redraw the brush bar — hooking the publish into that one function naturally captures all 10 sites with one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
