### PR TITLE
feat(v3): full dashboard + unified timeseries + Live toggle + Sessions picker (#441)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,32 @@ test-go:
 
 test-deploy-all: test-deploy-compose test-deploy-ghcr test-deploy-registry
 
+# Frontend-only hot deploy — rebuild the Vue dashboard locally, push
+# just the static bundle into the running test-dev container WITHOUT
+# rebuilding the image or recreating any service. go-proxy / go-live /
+# go-upload / nginx stay running so in-flight sessions (iPad, Apple
+# TV, etc.) keep their playback path. Use this for any change under
+# content/dashboard-v3/. Use `make test-deploy-dev` only when Go
+# services, the Dockerfile, or analytics binaries actually change.
+#
+# The trick: docker-compose.yml mounts `./content` from the host onto
+# `/content` inside the go-server container (bind mount). rsync-ing
+# files to ~/test-dev/content/dashboard/v3/ on the host therefore
+# appears INSTANTLY inside the container — nginx serves the new
+# bundle on the next request, no docker cp / docker exec / reload
+# needed.
+test-deploy-frontend:
+	@echo "=== Frontend-only hot deploy (no container recreate) ==="
+	@if [ ! -f content/dashboard-v3/package.json ]; then \
+		echo "dashboard-v3 not present — nothing to deploy"; exit 1; \
+	fi
+	@echo "Building dashboard-v3 (Vue)..."
+	@cd content/dashboard-v3 && npm run --silent build
+	@echo "rsync → host:~/test-dev/content/dashboard/v3/ (bind-mounted into container)..."
+	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev/content/dashboard/v3'
+	rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev/content/dashboard/v3/
+	@echo "✓ test-dev frontend updated; sessions untouched."
+
 test-deploy-dev:
 	@echo "=== Dev: local working tree (port 21000) ==="
 	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev'
@@ -374,6 +400,7 @@ test-deploy-dev:
 		--filter=':- .gitignore' \
 		--exclude='.git/' \
 		--exclude='.env' \
+		--exclude='certs/' \
 		./ $(TEST_SSH):~/test-dev/
 	@# The dashboard-v3 Vite build output lives at content/dashboard/v3/
 	@# which is gitignored, so the --filter ':- .gitignore' rule above

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -198,7 +198,13 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_snapshots
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(ts)
-ORDER BY (session_id, ts)
+-- ORDER BY player_id first because the dashboard queries are
+-- always `WHERE player_id = X AND ts BETWEEN ?` (one EventSource
+-- per device per page); leading on player_id gives one primary-
+-- key range scan per query instead of a bloom-filter granule
+-- prune across N session_id chunks. session_id stays bloom-
+-- indexed below for the rare replay-by-session case.
+ORDER BY (player_id, ts)
 -- Tiered retention by classification column (issue #342):
 --   * 'other'       → 30 d (default)
 --   * 'interesting' → 90 d
@@ -333,6 +339,12 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.network_requests
 (
     ts                       DateTime64(3, 'UTC')   CODEC(Delta, ZSTD(1)),
     session_id               String                 CODEC(ZSTD(1)),
+    -- player_id (canonical v2 UUID) on every HAR row so dashboard
+    -- queries can filter by the same identifier as snapshots. Inline
+    -- here (vs the historical post-hoc ALTER below) because it now
+    -- participates in the primary ORDER BY tuple — ALTER-added
+    -- columns can't be in the sort key on first init.
+    player_id                LowCardinality(String) CODEC(ZSTD(1)),
     play_id                  LowCardinality(String) CODEC(ZSTD(1)),
     method                   LowCardinality(String) CODEC(ZSTD(1)),
     url                      String                 CODEC(ZSTD(3)),
@@ -372,7 +384,11 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.network_requests
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(ts)
-ORDER BY (session_id, ts, entry_fingerprint)
+-- ORDER BY player_id first for the same reason as session_snapshots:
+-- the dashboard's network log filter is always WHERE player_id = X
+-- AND ts BETWEEN ?. entry_fingerprint stays as the dedupe component
+-- of the sort tuple so per-request UPSERT semantics still work.
+ORDER BY (player_id, ts, entry_fingerprint)
 -- Tiered retention by classification column — see comment on
 -- session_snapshots above. Both tables share the same retention
 -- policy so paired (snapshots, network) data ages out together.
@@ -385,3 +401,12 @@ SETTINGS index_granularity = 8192;
 -- forwarder bumps it on session-end / star / unstar via ALTER UPDATE.
 ALTER TABLE infinite_streaming.network_requests
     ADD COLUMN IF NOT EXISTS classification LowCardinality(String) DEFAULT 'other' CODEC(ZSTD(1));
+
+-- player_id (canonical v2 UUID) on every HAR row so the v2
+-- /api/v2/network_requests endpoint can filter by the same identifier
+-- the dashboard uses everywhere else (live SSE, snapshots, groups).
+-- Forwarder builds a sessionID→playerID map from incoming session
+-- snapshots and stamps player_id at insert time. Old rows keep the
+-- empty default — they remain queryable by session_id only.
+ALTER TABLE infinite_streaming.network_requests
+    ADD COLUMN IF NOT EXISTS player_id LowCardinality(String) CODEC(ZSTD(1));

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -22,18 +23,82 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/v2translate"
 )
 
+// init: relax TLS verification on every outgoing request. The
+// forwarder only talks to go-server (Docker-internal) and ClickHouse,
+// both reachable on private interfaces with self-signed certs once
+// TS11 flipped go-proxy to TLS. Verification would require shipping
+// the in-container CA into the forwarder image; trusting self-signed
+// for these internal hops is safe and matches `proxy_ssl_verify off`
+// on the nginx side.
+func init() {
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+}
+
+// canonicalV2ID normalises a raw v1 identifier (player_id / play_id) to
+// the same canonical v2 form `v2translate` produces on read: parse as
+// UUID when possible, fall back to the stable v5 derivation otherwise.
+// Empty input → empty output (don't synthesise an id for missing data).
+//
+// Without this step the forwarder stored the raw short-form (e.g.
+// "427a6bf3") on ingest but emitted the v5-derived UUID
+// ("7046b635-…") on read; client-side archive queries built from
+// /api/v2/players (the v2 form) then matched no rows, so the
+// Focus Window came up empty for any non-UUID player.
+func canonicalV2ID(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if u, err := uuid.Parse(raw); err == nil {
+		return u.String()
+	}
+	return v2translate.PlayerUUIDForRawID(raw).String()
+}
+
+// canonicalIDsFor returns the canonical player_id and play_id strings a
+// v3 client will use to look this row up. Routes through
+// v2translate.PlayerFromSession so the forwarder's stored ids stay in
+// lockstep with what `/api/v2/players` emits — including the fallback
+// play_id derivation for sessions whose raw v1 payload doesn't carry
+// `play_id` (web / hls.js / non-Apple devices).
+//
+// Returns empty strings when the session can't be projected (no
+// player_id at all); the caller still inserts the row but the play_id
+// column will be blank and the client won't be able to filter to that
+// row by play_id.
+func canonicalIDsFor(s map[string]interface{}) (string, string) {
+	rec, ok := v2translate.PlayerFromSession(s)
+	if !ok {
+		return canonicalV2ID(getStr(s, "player_id")), canonicalV2ID(getStr(s, "play_id"))
+	}
+	playerID := rec.Id.String()
+	playID := ""
+	if rec.CurrentPlay != nil {
+		playID = rec.CurrentPlay.Id.String()
+	}
+	return playerID, playID
+}
+
 type config struct {
-	sseURL        string
-	clickhouseURL string
-	chDatabase    string
-	chTable       string
-	chUser        string
-	chPassword    string
-	flushEvery    time.Duration
-	flushBatch    int
-	httpListen    string
+	sseURL         string
+	clickhouseURL  string
+	chDatabase     string
+	chTable        string
+	chUser         string
+	chPassword     string
+	flushEvery     time.Duration
+	flushBatch     int
+	httpListen     string
+	ringWindowSecs int // FORWARDER_LIVE_RING_SECONDS; see ring.go
 }
 
 func loadConfig() config {
@@ -51,8 +116,23 @@ func loadConfig() config {
 		flushEvery:    250 * time.Millisecond,
 		flushBatch:    500,
 		httpListen:    getenv("FORWARDER_HTTP_LISTEN", ":8080"),
+		// ring window default 600s (10 min) covers the dashboard's
+		// default focus window so most v3 queries skip ClickHouse
+		// entirely. Tunable down for memory-constrained deployments
+		// or up for "live tail covers more history" use cases.
+		ringWindowSecs: getenvInt("FORWARDER_LIVE_RING_SECONDS", 600),
 	}
 	return c
+}
+
+func getenvInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
+			return n
+		}
+	}
+	return def
 }
 
 func getenv(key, def string) string {
@@ -276,16 +356,25 @@ func main() {
 		cancel()
 	}()
 
+	// In-memory ring covering the recently-ingested rows for both
+	// streams. The v3 /api/v3/timeseries handler reads the ring +
+	// CH and dedupes on the boundary so the dashboard sees fresh
+	// data with no NDJSON-vs-pushLive merge race. Eviction runs
+	// once per second; pending/inserting rows are sticky regardless
+	// of age (they exist nowhere else yet).
+	ring := NewRing(int64(cfg.ringWindowSecs)*1000, 0)
+	ring.StartEvictor(ctx.Done(), time.Second)
+
 	rows := make(chan row, 4096)
-	go batchInserter(ctx, cfg, rows)
-	go serveHTTP(ctx, cfg)
+	go batchInserter(ctx, cfg, ring, rows)
+	go serveHTTP(ctx, cfg, ring)
 
 	// Network log archival: subscribe to go-proxy's /api/network/stream
 	// SSE endpoint and forward each per-request event to ClickHouse so
 	// the session-viewer can replay them after the session is gone.
 	netRows := make(chan netRow, 8192)
 	netSeenSet := newNetSeen(50000)
-	go batchInsertNet(ctx, cfg, netRows)
+	go batchInsertNet(ctx, cfg, ring, netRows)
 	go runNetworkStream(ctx, cfg, netSeenSet, netRows)
 
 	// Auto-classifier: when a snapshot carries an interesting signal
@@ -389,13 +478,13 @@ func handlePayload(data []byte, cache *fingerprintCache, netSeen *netSeen, out c
 		// Stamp the sessionID→playerID map so the network row writer
 		// (runNetworkStream → entryToRow) can carry the v2 player_id
 		// onto every HAR row at insert time.
-		sessionToPlayerID.set(sessionID, getStr(s, "player_id"))
+		sessionToPlayerID.set(sessionID, canonicalV2ID(getStr(s, "player_id")))
 		out <- toRow(ts, payload.Revision, sessionID, s)
 		// Queue auto-classifier if this snapshot carries any of the
 		// "really bad things" signals. Debounced — repeated marks
 		// for the same (session,play) coalesce to one mutation.
 		if classifyQ != nil && hasInterestingSignal(s) {
-			classifyQ.mark(sessionID, getStr(s, "play_id"))
+			classifyQ.mark(sessionID, canonicalV2ID(getStr(s, "play_id")))
 		}
 	}
 	cache.prune(active)
@@ -435,12 +524,19 @@ func snapshotEventTimeAsCHTimestamp(s map[string]interface{}, fallback string) s
 
 func toRow(ts string, revision uint64, sessionID string, s map[string]interface{}) row {
 	full, _ := json.Marshal(s)
+	// Store the v2-canonical ids the v3 client will use to look this
+	// row up. canonicalIDsFor routes through v2translate.PlayerFromSession
+	// so the play_id fallback derivation (used when the raw SSE map
+	// doesn't carry `play_id`, which is most non-Apple clients) matches
+	// what `/api/v2/players` emits. Without that fallback the column
+	// stays empty and the v3 client's play_id filter excludes every row.
+	playerCanonical, playCanonical := canonicalIDsFor(s)
 	return row{
 		Ts:                       ts,
 		Revision:                 revision,
 		SessionID:                sessionID,
-		PlayID:                   getStr(s, "play_id"),
-		PlayerID:                 getStr(s, "player_id"),
+		PlayID:                   playCanonical,
+		PlayerID:                 playerCanonical,
 		GroupID:                  getStr(s, "group_id"),
 		UserAgent:                getStr(s, "user_agent"),
 		ManifestURL:              getStr(s, "manifest_url"),
@@ -656,18 +752,30 @@ func getU64(m map[string]interface{}, key string) uint64 {
 	return 0
 }
 
-func batchInserter(ctx context.Context, cfg config, in <-chan row) {
+func batchInserter(ctx context.Context, cfg config, ring *Ring, in <-chan row) {
 	buf := make([]row, 0, cfg.flushBatch)
+	entries := make([]*ringEntry, 0, cfg.flushBatch)
 	tick := time.NewTicker(cfg.flushEvery)
 	defer tick.Stop()
 	flush := func() {
 		if len(buf) == 0 {
 			return
 		}
+		// State transitions: pending → inserting → confirmed.
+		// On INSERT failure we revert inserting → pending so the
+		// ring's read path keeps surfacing the rows (they exist
+		// nowhere else yet). We don't currently retry the failed
+		// batch — the rows go to /dev/null for CH, which matches
+		// today's behaviour. Follow-up: bounded retry queue.
+		ring.MarkInserting(entries)
 		if err := insert(ctx, cfg, buf); err != nil {
 			log.Printf("insert failed (%d rows dropped): %v", len(buf), err)
+			ring.RevertInserting(entries)
+		} else {
+			ring.MarkConfirmed(entries)
 		}
 		buf = buf[:0]
+		entries = entries[:0]
 	}
 	for {
 		select {
@@ -679,7 +787,16 @@ func batchInserter(ctx context.Context, cfg config, in <-chan row) {
 				flush()
 				return
 			}
-			buf = append(buf, r)
+			// Pin the row in the ring as `pending` before queueing
+			// for INSERT. The pointer we get back lets us flip state
+			// in lockstep with the batch's lifecycle.
+			rowCopy := r
+			e := ring.Add(
+				ringKey{PlayerID: rowCopy.PlayerID},
+				kindSample, nowMs(), rowCopy.Ts, rowCopy.PlayID, &rowCopy,
+			)
+			buf = append(buf, rowCopy)
+			entries = append(entries, e)
 			if len(buf) >= cfg.flushBatch {
 				flush()
 			}
@@ -732,12 +849,13 @@ func insert(ctx context.Context, cfg config, rows []row) error {
 //	GET /api/sessions?since=<rfc3339>
 //	GET /api/snapshots?session=<id>&from=<rfc3339>&to=<rfc3339>&limit=<n>
 //	GET /healthz
-func serveHTTP(ctx context.Context, cfg config) {
+func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("ok"))
 	})
 	mountV2Handlers(mux, cfg)
+	mountV3Handlers(mux, cfg, ring)
 	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
 		since := r.URL.Query().Get("since")
 		until := r.URL.Query().Get("until")
@@ -1092,12 +1210,31 @@ func serveHTTP(ctx context.Context, cfg config) {
 		if session == "" {
 			session = r.URL.Query().Get("session_id")
 		}
-		if session == "" {
-			http.Error(w, "missing session_id", http.StatusBadRequest)
+		// player_id is an alternative way to identify the rows when the
+		// caller doesn't have (or want to plumb) the session_id — the
+		// live testing-session / testing pages drive this path so they
+		// can stop client-side session-id lookups. session_id wins if
+		// both are supplied so explicit deep links keep working.
+		playerID := r.URL.Query().Get("player_id")
+		if session == "" && playerID == "" {
+			http.Error(w, "missing session_id or player_id", http.StatusBadRequest)
 			return
 		}
-		params := map[string]string{"session": session}
-		clauses := []string{"session_id = {session:String}"}
+
+		params := map[string]string{}
+		clauses := []string{}
+		if session != "" {
+			clauses = append(clauses, "session_id = {session:String}")
+			params["session"] = session
+		}
+		if playerID != "" {
+			// Case-insensitive: device-side player_ids often arrive in
+			// the case the player reported (often uppercase) while v2
+			// /api/v2/players normalises to lowercase. lowerUTF8 on both
+			// sides papers over the mismatch.
+			clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+			params["player"] = playerID
+		}
 		// HAR events come from network_requests, which on iOS often
 		// has play_id='' on variant/segment URLs (the iOS player
 		// strips the query param). Filter HAR by time range derived
@@ -1105,26 +1242,42 @@ func serveHTTP(ctx context.Context, cfg config) {
 		// We qualify ts as `nr.ts` because the inner sub-selects
 		// alias `toString(ts) AS ts` and that String alias would
 		// otherwise shadow the column in the WHERE clause.
-		harClauses := []string{"session_id = {session:String}"}
+		harClauses := append([]string{}, clauses...)
 		if v := r.URL.Query().Get("play_id"); v != "" {
 			var pidPred string
 			if v == "—" {
 				pidPred = "play_id = ''"
 			} else {
-				pidPred = "play_id = {play:String}"
+				pidPred = "lowerUTF8(play_id) = lowerUTF8({play:String})"
 				params["play"] = v
 			}
 			clauses = append(clauses, pidPred)
+			// Inner subqueries need an identifying WHERE that mirrors
+			// whichever id(s) the caller supplied.
+			idWhere := []string{}
+			if session != "" {
+				idWhere = append(idWhere, "session_id = {session:String}")
+			}
+			if playerID != "" {
+				idWhere = append(idWhere, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+			}
+			idClause := strings.Join(idWhere, " AND ")
 			harClauses = append(harClauses, fmt.Sprintf(
-				"nr.ts BETWEEN (SELECT min(ts) FROM %s.%s WHERE session_id = {session:String} AND %s) "+
-					"AND (SELECT max(ts) FROM %s.%s WHERE session_id = {session:String} AND %s)",
-				cfg.chDatabase, cfg.chTable, pidPred,
-				cfg.chDatabase, cfg.chTable, pidPred))
+				"nr.ts BETWEEN (SELECT min(ts) FROM %s.%s WHERE %s AND %s) "+
+					"AND (SELECT max(ts) FROM %s.%s WHERE %s AND %s)",
+				cfg.chDatabase, cfg.chTable, idClause, pidPred,
+				cfg.chDatabase, cfg.chTable, idClause, pidPred))
 		}
-		limit := 500
+		// Default 5000 is enough for a quick smoke test; cap 50000
+		// accommodates long sessions where ABR upshift / downshift
+		// noise (often > 60% of events) crowds out rare fault events
+		// at smaller LIMITs. The DESC sort keeps the most-recent N
+		// regardless, so raising the cap is "show more history" not
+		// "fix correctness".
+		limit := 5000
 		if v := r.URL.Query().Get("limit"); v != "" {
 			var n int
-			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 5000 {
+			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 50000 {
 				limit = n
 			}
 		}
@@ -1459,7 +1612,12 @@ func serveHTTP(ctx context.Context, cfg config) {
 			  WHERE prev_url_ts != retry_ts
 			    AND dateDiff('millisecond', prev_url_ts, retry_ts) BETWEEN 1 AND 4000
 			)
-			ORDER BY ts ASC
+			-- DESC so the LIMIT keeps the *most recent* N events. ASC
+			-- caused rare events (HTTP 4xx fault injection, errors) to
+			-- be squeezed out of the result by high-volume ABR upshifts
+			-- / downshifts that dominate the oldest 500 rows on a long
+			-- session. Consumers sort client-side for display.
+			ORDER BY ts DESC
 			LIMIT %d
 			FORMAT JSONEachRow`,
 			// stall_or_buffer_pairs / rate_shifts / base CTEs

--- a/analytics/go-forwarder/net_log.go
+++ b/analytics/go-forwarder/net_log.go
@@ -425,18 +425,24 @@ func parseSSEData(frame []byte) []byte {
 	return nil
 }
 
-func batchInsertNet(ctx context.Context, cfg config, in <-chan netRow) {
+func batchInsertNet(ctx context.Context, cfg config, ring *Ring, in <-chan netRow) {
 	buf := make([]netRow, 0, cfg.flushBatch)
+	entries := make([]*ringEntry, 0, cfg.flushBatch)
 	tick := time.NewTicker(cfg.flushEvery)
 	defer tick.Stop()
 	flush := func() {
 		if len(buf) == 0 {
 			return
 		}
+		ring.MarkInserting(entries)
 		if err := insertNet(ctx, cfg, buf); err != nil {
 			log.Printf("net insert failed (%d rows dropped): %v", len(buf), err)
+			ring.RevertInserting(entries)
+		} else {
+			ring.MarkConfirmed(entries)
 		}
 		buf = buf[:0]
+		entries = entries[:0]
 	}
 	for {
 		select {
@@ -448,7 +454,14 @@ func batchInsertNet(ctx context.Context, cfg config, in <-chan netRow) {
 				flush()
 				return
 			}
-			buf = append(buf, r)
+			rowCopy := r
+			fp := fmt.Sprintf("%d", rowCopy.EntryFingerprint)
+			e := ring.Add(
+				ringKey{PlayerID: rowCopy.PlayerID},
+				kindNetwork, nowMs(), fp, rowCopy.PlayID, &rowCopy,
+			)
+			buf = append(buf, rowCopy)
+			entries = append(entries, e)
 			if len(buf) >= cfg.flushBatch {
 				flush()
 			}

--- a/analytics/go-forwarder/ring.go
+++ b/analytics/go-forwarder/ring.go
@@ -1,0 +1,372 @@
+// Per-(session_id, play_id) in-memory ring buffer that mirrors every
+// row the forwarder ingests until ClickHouse has confirmed the insert.
+// Two purposes:
+//
+//   1. The read side of the v3 /api/v3/timeseries endpoint can answer
+//      "what's the latest sample/network entry?" from RAM without
+//      waiting on the 100–250 ms ingest-to-visible latency that the
+//      JSONEachRow batch path imposes. The ring covers the freshness
+//      gap and, sized larger, can also serve the full default focus
+//      window from RAM so most live queries never touch ClickHouse.
+//
+//   2. Correctness when the read API straddles the visibility seam.
+//      The read path ALWAYS reads ring + ClickHouse and dedupes by
+//      fingerprint. Entries flip ring → ClickHouse-visible via three
+//      states (pending → inserting → confirmed); confirmed entries
+//      are eligible for age-based eviction, pending/inserting are
+//      sticky regardless of age (they exist nowhere else yet, losing
+//      them would be a read-side data loss).
+//
+// Sharded by session_id to bound mutex contention as live-player
+// count grows. Subscribers (the SSE handler) get a fan-out channel
+// per (session, play) so they receive each new entry the moment it's
+// Add()'d without polling.
+package main
+
+import (
+	"hash/fnv"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ringKind discriminates the two stream payloads carried by the ring.
+// session_events are derived at query time (today via ClickHouse SQL
+// multiIf), so they don't pass through the ring.
+type ringKind uint8
+
+const (
+	kindSample ringKind = iota
+	kindNetwork
+)
+
+// ringStatus tracks where a row is in the write pipeline. Eviction is
+// gated on this; only `confirmed` entries are eligible to be dropped
+// from the ring by age, since they live in ClickHouse too.
+type ringStatus uint8
+
+const (
+	statusPending ringStatus = iota
+	statusInserting
+	statusConfirmed
+)
+
+// ringEntry is one item in the ring. Status is read/written via
+// atomic so subscribers and the eviction goroutine don't need the
+// bucket lock to observe state transitions.
+type ringEntry struct {
+	Kind        ringKind
+	TsMs        int64
+	Fingerprint string
+	// PlayID stamped at ingest. The read path can filter by this when
+	// the caller passes an explicit play_id. Empty string is allowed
+	// for rows the proxy hadn't yet stamped.
+	PlayID  string
+	status  atomic.Uint32 // ringStatus
+	Payload interface{}   // *row for samples, *netRow for network
+}
+
+func (e *ringEntry) Status() ringStatus    { return ringStatus(e.status.Load()) }
+func (e *ringEntry) setStatus(s ringStatus) { e.status.Store(uint32(s)) }
+
+// ringKey identifies a per-player_id bucket. play_id is NOT part of
+// the key — it's stored on each ringEntry as a payload field, and the
+// read path filters by it if the caller asked. Keying on player_id
+// only matches the dashboard's "show me this device, follow it across
+// plays" model: a single subscription receives every row for the
+// player, and the play rotates underneath without re-subscription.
+type ringKey struct {
+	PlayerID string
+}
+
+// ringBucket holds the ordered entries for one (session, play). The
+// slice is append-only on Add(); eviction rewrites it in place. We
+// keep it sorted by arrival (which is mostly ts-ascending; out-of-
+// order arrivals are rare enough that the read API resorts).
+type ringBucket struct {
+	mu          sync.RWMutex
+	entries     []*ringEntry
+	subscribers []chan<- *ringEntry
+	// lastActivityMs is the wall-clock ms of the most recent Add or
+	// subscriber registration on this bucket. Buckets idle longer than
+	// the ring's retention window are candidates for full eviction.
+	lastActivityMs int64
+}
+
+// Ring is the global per-forwarder cache. Sharded by session_id so
+// reads/writes of different sessions don't fight a single mutex.
+type Ring struct {
+	windowMs   int64
+	shards     []ringShard
+	subBufSize int
+}
+
+type ringShard struct {
+	mu      sync.RWMutex
+	buckets map[ringKey]*ringBucket
+}
+
+const ringShardCount = 32
+
+// NewRing constructs a Ring with the given retention window.
+//
+// windowMs governs how long confirmed entries linger after CH ingest.
+// Common values:
+//
+//	   30s — closes only the ingest-batch latency gap.
+//	  600s (10m) — covers the dashboard's default focus window so
+//	               most live queries skip ClickHouse entirely.
+//	 1800s (30m) — generous live-tail; CH consulted only on pan-back.
+//
+// subBufSize controls how many entries each subscriber channel
+// buffers before pushes drop. The SSE handler reads in a tight loop
+// so 64 is plenty in practice; sized small to keep slow consumers
+// from holding rows in RAM.
+func NewRing(windowMs int64, subBufSize int) *Ring {
+	if subBufSize <= 0 {
+		subBufSize = 64
+	}
+	r := &Ring{
+		windowMs:   windowMs,
+		shards:     make([]ringShard, ringShardCount),
+		subBufSize: subBufSize,
+	}
+	for i := range r.shards {
+		r.shards[i].buckets = make(map[ringKey]*ringBucket)
+	}
+	return r
+}
+
+func (r *Ring) shardFor(k ringKey) *ringShard {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(k.PlayerID))
+	return &r.shards[h.Sum32()%ringShardCount]
+}
+
+// bucket returns the bucket for k, creating it on demand. The
+// returned bucket is owned by the ring; caller holds no lock.
+func (r *Ring) bucket(k ringKey) *ringBucket {
+	sh := r.shardFor(k)
+	sh.mu.RLock()
+	b, ok := sh.buckets[k]
+	sh.mu.RUnlock()
+	if ok {
+		return b
+	}
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if b, ok := sh.buckets[k]; ok {
+		return b
+	}
+	b = &ringBucket{}
+	sh.buckets[k] = b
+	return b
+}
+
+// Add stores an entry in the bucket for k. Status starts as pending.
+// Returns the stored entry so the ingest pipeline can flip its status
+// later via MarkInserting/MarkConfirmed.
+//
+// Subscribers receive the entry via a non-blocking send; if a
+// subscriber's channel is full, the entry is dropped for that
+// subscriber (the slow consumer is responsible for catching up via a
+// fresh range query). Add never blocks on subscribers.
+func (r *Ring) Add(k ringKey, kind ringKind, tsMs int64, fingerprint, playID string, payload interface{}) *ringEntry {
+	e := &ringEntry{
+		Kind:        kind,
+		TsMs:        tsMs,
+		Fingerprint: fingerprint,
+		PlayID:      playID,
+		Payload:     payload,
+	}
+	e.setStatus(statusPending)
+
+	b := r.bucket(k)
+	// Append and fan out under the bucket's WRITE lock. The fan-out
+	// is bounded (select-default drops on full subscriber channels)
+	// so it doesn't sit on the lock for long. Holding the lock during
+	// the send is what eliminates the race with cancelSubscribe's
+	// close(ch): a closed channel will never be on the subscriber
+	// list when this fan-out runs.
+	b.mu.Lock()
+	b.entries = append(b.entries, e)
+	b.lastActivityMs = nowMs()
+	for _, ch := range b.subscribers {
+		select {
+		case ch <- e:
+		default:
+			// Slow subscriber — drop this push. The subscriber's
+			// reconnect / range-query path will recover the row.
+		}
+	}
+	b.mu.Unlock()
+	return e
+}
+
+// MarkInserting flips a batch of pending entries to inserting just
+// before the ClickHouse INSERT is sent. Idempotent w.r.t. already-
+// confirmed entries (a confirmed entry stays confirmed).
+func (r *Ring) MarkInserting(entries []*ringEntry) {
+	for _, e := range entries {
+		if e.Status() == statusPending {
+			e.setStatus(statusInserting)
+		}
+	}
+}
+
+// MarkConfirmed flips a batch of inserting entries to confirmed after
+// ClickHouse ACKs the INSERT. Confirmed entries are eligible for
+// age-based eviction.
+func (r *Ring) MarkConfirmed(entries []*ringEntry) {
+	for _, e := range entries {
+		e.setStatus(statusConfirmed)
+	}
+}
+
+// RevertInserting flips a batch of inserting entries back to pending
+// when ClickHouse rejects the INSERT. Caller retries the batch.
+func (r *Ring) RevertInserting(entries []*ringEntry) {
+	for _, e := range entries {
+		if e.Status() == statusInserting {
+			e.setStatus(statusPending)
+		}
+	}
+}
+
+// Range returns entries for k whose kind is in `kinds` and whose ts
+// falls within `[fromMs, toMs]` (inclusive). Returned slice is sorted
+// ascending by TsMs.
+//
+// The caller is expected to ALSO query ClickHouse for the same range
+// and dedupe the union by (Kind, Fingerprint). The ring contains
+// every row not-yet-confirmed plus a tail of recently-confirmed rows
+// that haven't been evicted yet; ClickHouse contains every confirmed
+// row. The two overlap; the dedupe is required.
+//
+// Passing `kinds=nil` returns both kinds.
+func (r *Ring) Range(k ringKey, fromMs, toMs int64, kinds []ringKind) []*ringEntry {
+	b := r.bucket(k)
+	b.mu.RLock()
+	out := make([]*ringEntry, 0, len(b.entries))
+	for _, e := range b.entries {
+		if e.TsMs < fromMs || e.TsMs > toMs {
+			continue
+		}
+		if kinds != nil && !kindMatches(kinds, e.Kind) {
+			continue
+		}
+		out = append(out, e)
+	}
+	b.mu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].TsMs < out[j].TsMs })
+	return out
+}
+
+func kindMatches(kinds []ringKind, k ringKind) bool {
+	for _, want := range kinds {
+		if want == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Subscribe registers ch to receive every subsequent ringEntry Add()'d
+// to the bucket for k. The returned func detaches ch when the caller
+// is done (e.g. SSE client disconnect). Buffered channels should be
+// preferred; sends drop on full channel.
+func (r *Ring) Subscribe(k ringKey) (<-chan *ringEntry, func()) {
+	b := r.bucket(k)
+	ch := make(chan *ringEntry, r.subBufSize)
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, ch)
+	b.lastActivityMs = nowMs()
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		for i, sub := range b.subscribers {
+			if sub == ch {
+				// Order doesn't matter; swap-and-truncate.
+				b.subscribers[i] = b.subscribers[len(b.subscribers)-1]
+				b.subscribers = b.subscribers[:len(b.subscribers)-1]
+				break
+			}
+		}
+		b.mu.Unlock()
+		// Drain any stragglers so the sender's select-default doesn't
+		// see a blocked channel that's actually been cancelled.
+		close(ch)
+	}
+	return ch, cancel
+}
+
+// EvictOlderThan trims confirmed entries with TsMs < cutoffMs across
+// all buckets, and drops whole buckets whose lastActivityMs falls
+// before cutoffMs (no activity for a full retention window means the
+// (session, play) is done and won't be queried live again).
+//
+// Called periodically by a background goroutine. Pending/inserting
+// entries are sticky regardless of age — they exist nowhere else.
+func (r *Ring) EvictOlderThan(cutoffMs int64) (evictedEntries, evictedBuckets int) {
+	for sh := range r.shards {
+		shard := &r.shards[sh]
+		shard.mu.Lock()
+		for key, b := range shard.buckets {
+			b.mu.Lock()
+			// Filter entries: keep anything not-yet-confirmed, or
+			// confirmed but young enough. Append-only slice, so we
+			// rebuild it (typical churn keeps the slice short).
+			kept := b.entries[:0]
+			for _, e := range b.entries {
+				if e.Status() == statusConfirmed && e.TsMs < cutoffMs {
+					evictedEntries++
+					continue
+				}
+				kept = append(kept, e)
+			}
+			b.entries = kept
+
+			// If the bucket has been idle past the retention window
+			// AND has no surviving entries AND no subscribers, drop
+			// the whole bucket. Active subscribers keep it alive even
+			// if entries have all been evicted (a fresh play that
+			// just connected before any tick lands).
+			if len(b.entries) == 0 && len(b.subscribers) == 0 && b.lastActivityMs < cutoffMs {
+				b.mu.Unlock()
+				delete(shard.buckets, key)
+				evictedBuckets++
+				continue
+			}
+			b.mu.Unlock()
+		}
+		shard.mu.Unlock()
+	}
+	return evictedEntries, evictedBuckets
+}
+
+// StartEvictor spawns a goroutine that calls EvictOlderThan once per
+// `interval`. Cancel via ctx. Safe to leave running for the life of
+// the forwarder process.
+func (r *Ring) StartEvictor(stop <-chan struct{}, interval time.Duration) {
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				cutoff := nowMs() - r.windowMs
+				r.EvictOlderThan(cutoff)
+			}
+		}
+	}()
+}
+
+// nowMs returns wall-clock now as ms since epoch. Centralised so a
+// test harness can swap it out via a build tag if we ever need to.
+func nowMs() int64 {
+	return time.Now().UnixMilli()
+}

--- a/analytics/go-forwarder/streambundles.go
+++ b/analytics/go-forwarder/streambundles.go
@@ -1,0 +1,388 @@
+// Column-projection bundles for the v3 /api/v3/timeseries endpoint.
+//
+// Each bundle names a curated subset of columns from one of the three
+// underlying stream tables (session_snapshots → samples,
+// network_requests → network, derived → events). Renderers ask for
+// bundles by name so they don't have to enumerate columns; new
+// bundles can be added without client changes.
+//
+// Bundles are versioned ("lanes_v1") so a future server-side
+// pre-derivation (e.g. a materialised view that pre-segments player-
+// state lanes) can ship as `lanes_v2` without disturbing in-flight
+// clients on v1.
+//
+// File is named `streambundles.go` to avoid collision with the
+// existing `bundle.go` (which is the per-session ZIP-bundle exporter
+// — a completely unrelated artifact).
+package main
+
+import (
+	"sort"
+	"strings"
+)
+
+// streamKind names the three top-level data streams the v3 endpoint
+// can emit. Mirrors ringKind for samples/network (events are derived
+// at query time so they don't pass through the ring).
+type streamKind string
+
+const (
+	streamSamples streamKind = "samples"
+	streamNetwork streamKind = "network"
+	streamEvents  streamKind = "events"
+)
+
+func parseStreamKind(s string) (streamKind, bool) {
+	switch s {
+	case "samples":
+		return streamSamples, true
+	case "network":
+		return streamNetwork, true
+	case "events":
+		return streamEvents, true
+	}
+	return "", false
+}
+
+// bundleDef declares the column set a named bundle exposes for one
+// stream. `Columns` is in the order rows are emitted to the wire.
+type bundleDef struct {
+	Name    string
+	Stream  streamKind
+	Columns []string
+}
+
+// bundleRegistry — initial set per the v3 design. Each entry's column
+// list is a curated projection of the underlying CH table. The `all`
+// bundle is an alias that expands to lanes_v1 + network + events.
+//
+// When a renderer asks for `bundles=foo,bar` plus optional
+// `fields=col1,col2`, the resolver below unions all named column sets
+// for each stream, deduplicates, and produces the actual SELECT
+// projection.
+var bundleRegistry = map[string]bundleDef{
+
+	// charts_minimal — what the four line charts (Bandwidth / RTT /
+	// Buffer / FPS) need, nothing more. Roughly an order of magnitude
+	// fewer bytes per sample than the full row, so a long brush
+	// window stays cheap.
+	"charts_minimal": {
+		Name:   "charts_minimal",
+		Stream: streamSamples,
+		Columns: []string{
+			"ts",
+			"session_id", "play_id", "player_id",
+			"event_time",
+			// Bandwidth chart series (server + player side)
+			"video_bitrate_mbps",
+			"network_bitrate_mbps",
+			"avg_network_bitrate_mbps",
+			"measured_mbps",
+			"mbps_shaper_rate",
+			"mbps_shaper_avg",
+			"mbps_transfer_rate",
+			"mbps_transfer_complete",
+			// RTT family
+			"client_rtt_ms",
+			"client_rtt_min_ms",
+			"client_rtt_min_lifetime_ms",
+			"client_rtt_max_ms",
+			"client_path_ping_rtt_ms",
+			"client_rto_ms",
+			// Buffer & offsets
+			"buffer_depth_s",
+			"buffer_end_s",
+			"live_offset_s",
+			"true_offset_s",
+			// FPS-derived counters
+			"frames_displayed",
+			"dropped_frames",
+			"stall_count",
+			"stall_time_s",
+			// Player + manifest identity (used by hover tooltips +
+			// the variant-resolution lookup in EventsTimeline if it
+			// ever re-uses charts_minimal). Keep here so a single
+			// charts_minimal subscription drives every renderer.
+			"video_resolution",
+			"manifest_url",
+			"player_state",
+			"player_error",
+			// Shaper config so BandwidthChart's "Limit (rate_mbps)"
+			// series can be drawn with the same value the user set.
+			// Effective limit at any sample = pattern_rate_runtime_mbps
+			// when a pattern is active, else the static
+			// nftables_bandwidth_mbps. Pattern step index + steps JSON
+			// let the adapter resolve the active step's rate when
+			// pattern_rate_runtime_mbps is zeroed (legacy
+			// "between-steps" fallback). Without these, archived plays
+			// can never reconstruct the Limit line.
+			"nftables_bandwidth_mbps",
+			"nftables_pattern_enabled",
+			"nftables_pattern_rate_runtime_mbps",
+			"nftables_pattern_step",
+			"nftables_pattern_steps",
+			// Server's view of the player's active variant — the
+			// "Server Variant" line that pairs with "Player Variant"
+			// for catching server↔player rendition disagreement.
+			"server_video_rendition_mbps",
+		},
+	},
+
+	// lanes_v1 — what EventsTimeline.vue needs to derive its swim
+	// lanes (PLAYERSTATE / VARIANT / DISPLAY_RES / PLAYBACK /
+	// IMPAIRMENT / CONTROL). A future `lanes_v2` can ship as a
+	// pre-segmented MV without breaking lanes_v1 consumers.
+	"lanes_v1": {
+		Name:   "lanes_v1",
+		Stream: streamSamples,
+		Columns: []string{
+			"ts",
+			"session_id", "play_id", "player_id",
+			"player_state",
+			"waiting_reason",
+			"video_resolution",
+			"video_bitrate_mbps",
+			"display_resolution",
+			"stall_count",
+			"dropped_frames",
+			"player_error",
+			"last_event",
+			"manifest_variants",
+			"master_manifest_consecutive_failures",
+			"manifest_consecutive_failures",
+			"segment_consecutive_failures",
+			"transport_consecutive_failures",
+			"all_consecutive_failures",
+			"fault_count_transfer_active_timeout",
+			"fault_count_transfer_idle_timeout",
+			"control_revision",
+			"video_first_frame_time_s",
+			"video_start_time_s",
+			"loop_count_server",
+		},
+	},
+
+	// session_details — the panel that lists "what is this player /
+	// session". Static-ish fields the user reads, not chart-fed.
+	"session_details": {
+		Name:   "session_details",
+		Stream: streamSamples,
+		Columns: []string{
+			"ts",
+			"session_id", "play_id", "player_id", "group_id",
+			"content_id",
+			"user_agent",
+			"manifest_url",
+			"last_request_url",
+			"player_state",
+			"player_error",
+			"last_event",
+			"classification",
+			"control_revision",
+		},
+	},
+
+	// network — every typed column on network_requests; the table's
+	// JSON-string columns (headers, query_string) are excluded by
+	// default and can be opted in via `fields=`.
+	"network": {
+		Name:   "network",
+		Stream: streamNetwork,
+		Columns: []string{
+			"ts",
+			"session_id", "play_id", "player_id",
+			"method", "url", "upstream_url", "path", "request_kind",
+			"status",
+			"bytes_in", "bytes_out", "content_type",
+			"request_range", "response_content_range",
+			"dns_ms", "connect_ms", "tls_ms",
+			"ttfb_ms", "transfer_ms", "total_ms", "client_wait_ms",
+			"faulted", "fault_type", "fault_action", "fault_category",
+			"entry_fingerprint",
+		},
+	},
+
+	// events — the kind/priority-classified rows from the derived SQL
+	// in main.go (`/api/session_events` taxonomy). Columns here are
+	// the post-projection wire shape, not the raw `session_snapshots`
+	// columns. The timeseries handler delegates to the same SQL.
+	"events": {
+		Name:   "events",
+		Stream: streamEvents,
+		Columns: []string{
+			"ts", "type", "info", "kind", "priority",
+			"play_id", "player_id", "session_id",
+		},
+	},
+}
+
+// bundleAliases — named composites that expand to a set of bundle
+// names. Keeps the wire ergonomic without compounding the resolver.
+var bundleAliases = map[string][]string{
+	// `all` covers the three streams with their primary bundles.
+	"all": {"lanes_v1", "network", "events"},
+}
+
+// streamSelection is the resolved projection for one stream — the
+// distinct set of columns the renderer asked for (via bundles + ad-
+// hoc `fields`), in canonical order.
+type streamSelection struct {
+	Stream  streamKind
+	Columns []string
+}
+
+// resolveSelection turns the raw query params into a per-stream
+// projection. Returns one entry per enabled stream, with columns
+// deduplicated and sorted (sort is stable across calls so SELECT
+// fingerprints don't churn with input order). Unknown bundle names
+// are returned as errors; unknown field names are passed through
+// (CH-side will reject if invalid, surfacing a clean 4xx).
+//
+// `streamsParam` is the comma list from `?streams=…`. Required:
+// callers must opt in to what they want. `bundlesParam` and
+// `fieldsByStream` are optional.
+//
+// `fieldsByStream` maps stream → list of column names, parsed by the
+// caller (since field lists can in principle be per-stream; v3
+// initial cut just splits the flat ?fields= list across all enabled
+// streams as a convenience).
+func resolveSelection(
+	streamsParam string,
+	bundlesParam string,
+	fieldsByStream map[streamKind][]string,
+) ([]streamSelection, error) {
+	wanted := map[streamKind]bool{}
+	for _, s := range splitCSV(streamsParam) {
+		k, ok := parseStreamKind(s)
+		if !ok {
+			return nil, errBadParam("unknown stream: " + s)
+		}
+		wanted[k] = true
+	}
+	if len(wanted) == 0 {
+		return nil, errBadParam("at least one of streams=samples,network,events is required")
+	}
+
+	// Expand bundle aliases.
+	bundleNames := []string{}
+	for _, b := range splitCSV(bundlesParam) {
+		if expanded, ok := bundleAliases[b]; ok {
+			bundleNames = append(bundleNames, expanded...)
+			continue
+		}
+		bundleNames = append(bundleNames, b)
+	}
+
+	colsByStream := map[streamKind]map[string]struct{}{}
+	for _, b := range bundleNames {
+		def, ok := bundleRegistry[b]
+		if !ok {
+			return nil, errBadParam("unknown bundle: " + b)
+		}
+		if !wanted[def.Stream] {
+			// Caller asked for a bundle whose stream they didn't
+			// enable. Treat as a config bug, not a silent no-op —
+			// 400 so the dashboard sees the mismatch loudly.
+			return nil, errBadParam("bundle " + b + " is for stream " + string(def.Stream) + " which is not in streams=")
+		}
+		set, ok := colsByStream[def.Stream]
+		if !ok {
+			set = map[string]struct{}{}
+			colsByStream[def.Stream] = set
+		}
+		for _, c := range def.Columns {
+			set[c] = struct{}{}
+		}
+	}
+
+	for stream, fields := range fieldsByStream {
+		if !wanted[stream] {
+			continue
+		}
+		set, ok := colsByStream[stream]
+		if !ok {
+			set = map[string]struct{}{}
+			colsByStream[stream] = set
+		}
+		for _, c := range fields {
+			if c = strings.TrimSpace(c); c != "" {
+				set[c] = struct{}{}
+			}
+		}
+	}
+
+	// Ensure every enabled stream has at least its minimum identity
+	// columns. Saves callers from having to enumerate them in every
+	// `fields=` list.
+	for stream := range wanted {
+		set, ok := colsByStream[stream]
+		if !ok {
+			set = map[string]struct{}{}
+			colsByStream[stream] = set
+		}
+		for _, c := range mandatoryColumns(stream) {
+			set[c] = struct{}{}
+		}
+	}
+
+	out := []streamSelection{}
+	for stream := range wanted {
+		set := colsByStream[stream]
+		cols := make([]string, 0, len(set))
+		for c := range set {
+			cols = append(cols, c)
+		}
+		sort.Strings(cols)
+		out = append(out, streamSelection{Stream: stream, Columns: cols})
+	}
+	// Stable iteration order: samples, network, events.
+	sort.Slice(out, func(i, j int) bool { return out[i].Stream < out[j].Stream })
+	return out, nil
+}
+
+// mandatoryColumns are forced into every selection for a stream so
+// the timeseries handler doesn't have to special-case them.
+//
+//   - ts identifies position on the timeline (every event must be
+//     placeable).
+//   - session_id / play_id / player_id are the row's keys (used for
+//     fingerprinting + dedup against the ring; also let the client
+//     verify the row is on the expected play after a play_id
+//     rotation).
+//   - entry_fingerprint on network is the stable dedupe key for the
+//     ring/CH boundary.
+func mandatoryColumns(stream streamKind) []string {
+	switch stream {
+	case streamSamples:
+		return []string{"ts", "session_id", "play_id", "player_id"}
+	case streamNetwork:
+		return []string{"ts", "session_id", "play_id", "player_id", "entry_fingerprint"}
+	case streamEvents:
+		return []string{"ts", "play_id", "player_id", "session_id"}
+	}
+	return nil
+}
+
+// splitCSV — comma-list parser tolerating whitespace + empty entries.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// errBadParam tags errors that should surface to the HTTP layer as
+// 400. Plain `error` so the caller doesn't need a custom check.
+type badParamError struct{ msg string }
+
+func (e *badParamError) Error() string { return e.msg }
+func errBadParam(msg string) error     { return &badParamError{msg: msg} }
+func isBadParam(err error) bool        { _, ok := err.(*badParamError); return ok }

--- a/analytics/go-forwarder/timeseries.go
+++ b/analytics/go-forwarder/timeseries.go
@@ -1,0 +1,690 @@
+// v3 timeseries SSE endpoint — see plans/shiny-exploring-jellyfish.md
+// for the architecture writeup.
+//
+// One EventSource per (player_id, play_id). The handler:
+//
+//  1. Resolves liveness (does the (player, play) still have activity
+//     in the ring within the last 30s, or does the row still exist
+//     in CH with no play.ended_at).
+//  2. Subscribes to the ring BEFORE running the backfill, so any
+//     delta that lands during backfill is queued (not dropped).
+//  3. Emits a `meta` event describing the wire shape the caller is
+//     about to receive.
+//  4. Runs per-stream ClickHouse SELECTs for the requested window,
+//     using the column projection from streambundles.resolveSelection.
+//     Rows are emitted as `sample` / `network` SSE events in CH's
+//     ts-ascending order.
+//  5. (live only) Drains the subscription channel, emitting each new
+//     ring entry as it arrives. Periodic heartbeat events keep
+//     proxies from idle-closing the connection.
+//  6. (archive only) Emits `event:complete` and closes.
+//
+// First-cut scope: the `events` stream is accepted by the wire
+// contract but the handler currently returns 501 if requested, since
+// the kind/priority taxonomy needs the multiIf SQL extraction from
+// /api/session_events. That's a follow-up.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// timeseriesParams is the parsed view of the query string. Captured
+// upfront so we can validate before we commit to SSE headers (a 400
+// after `Content-Type: text/event-stream` is harder for the client).
+type timeseriesParams struct {
+	playerID       string
+	sessionID      string // optional alt-key; honoured for v2 callers, but the ring path needs playerID
+	playID         string
+	from           string // ISO-8601 (passed through to CH; CH parses with parseDateTime64BestEffort)
+	to             string
+	limit          int
+	streams        string
+	bundles        string
+	fieldsByStream map[streamKind][]string
+	strideMs       int
+	maxHz          int
+}
+
+// keepaliveInterval — period between SSE heartbeat frames. 15s
+// matches nginx's default proxy_read_timeout of 60s with margin.
+const keepaliveInterval = 15 * time.Second
+
+// initialBackfillCap — server-side ceiling on rows returned per
+// stream during the backfill burst. Surfaced in `meta.server_caps`
+// so the client can adjust its memory budget honestly.
+const (
+	backfillCapSamples = 50000
+	backfillCapNetwork = 5000
+)
+
+// mountV3Handlers wires the v3 timeseries endpoint into mux.
+//
+// Mounted at /api/v3/timeseries; nginx exposes it externally as
+// /analytics/api/v3/timeseries via the same rewrite that handles the
+// existing v1 / v2 endpoints.
+func mountV3Handlers(mux *http.ServeMux, cfg config, ring *Ring) {
+	mux.HandleFunc("/api/v3/timeseries", makeTimeseriesHandler(cfg, ring))
+}
+
+func makeTimeseriesHandler(cfg config, ring *Ring) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params, err := parseTimeseriesParams(r)
+		if err != nil {
+			writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
+			return
+		}
+
+		selections, err := resolveSelection(params.streams, params.bundles, params.fieldsByStream)
+		if err != nil {
+			if isBadParam(err) {
+				writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
+				return
+			}
+			writeProblemv2(w, http.StatusInternalServerError, "resolve error", err.Error())
+			return
+		}
+
+		// First-cut events stub.
+		for _, sel := range selections {
+			if sel.Stream == streamEvents {
+				writeProblemv2(w, http.StatusNotImplemented, "events stream not yet implemented",
+					"the v3 endpoint accepts streams=events but the kind/priority taxonomy SQL is still served via /api/v2/session_events. Follow-up: lift that SQL into a v3 bundle.")
+				return
+			}
+		}
+
+		ctx := r.Context()
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+		setSSEHeaders(w)
+
+		// Ring is keyed by player_id only. play_id (if the caller
+		// passed one) is enforced as an emission filter in
+		// streamLiveDeltas below — entries for OTHER plays of the
+		// same player are dropped on send. This way a subscription
+		// stays valid across play rotations: if no play_id was
+		// requested, every play's rows flow through; if a specific
+		// play_id was requested, the live tail for THAT play does.
+		key := ringKey{PlayerID: params.playerID}
+
+		// Liveness: subscribe BEFORE looking at activity so any deltas
+		// landing during the activity check are queued, not dropped.
+		// If we conclude !live we unsubscribe before returning.
+		subCh, cancelSub := ring.Subscribe(key)
+		defer cancelSub()
+
+		live := isStreamLive(ring, key, params.playerID, params.playID)
+
+		emitMeta(w, flusher, selections, live, ring, params)
+
+		// Track the high-water timestamp emitted during backfill so
+		// the live loop can dedupe against ring entries it already
+		// saw via the backfill scan.
+		emittedIDs := newEmittedSet()
+
+		// Backfill per stream.
+		ringCutoffMs := ring.windowMs
+		for _, sel := range selections {
+			if err := emitBackfill(ctx, w, flusher, cfg, ring, key, sel, params, emittedIDs, ringCutoffMs); err != nil {
+				if ctx.Err() != nil {
+					return // client gone
+				}
+				// Wire an error event then bail. Backfill failures
+				// usually mean CH is down; client will reconnect.
+				emitError(w, flusher, "backfill failed: "+err.Error())
+				return
+			}
+		}
+
+		if !live {
+			emitComplete(w, flusher, "archive_or_play_ended")
+			return
+		}
+
+		streamLiveDeltas(ctx, w, flusher, subCh, selections, emittedIDs, params.playID)
+	}
+}
+
+// parseTimeseriesParams extracts and validates the query params.
+// Returns badParamError for client-fixable problems.
+func parseTimeseriesParams(r *http.Request) (timeseriesParams, error) {
+	q := r.URL.Query()
+	p := timeseriesParams{
+		playerID:       strings.TrimSpace(q.Get("player_id")),
+		sessionID:      strings.TrimSpace(q.Get("session_id")),
+		playID:         strings.TrimSpace(q.Get("play_id")),
+		from:           strings.TrimSpace(q.Get("from")),
+		to:             strings.TrimSpace(q.Get("to")),
+		streams:        strings.TrimSpace(q.Get("streams")),
+		bundles:        strings.TrimSpace(q.Get("bundles")),
+		fieldsByStream: map[streamKind][]string{},
+	}
+
+	// archive:<sessionID>:<playID> prefix shorthand — keeps the v3
+	// endpoint accepting the same id shape getPlayer(archivePlayerId)
+	// uses on the client side.
+	if strings.HasPrefix(p.playerID, "archive:") {
+		rest := strings.TrimPrefix(p.playerID, "archive:")
+		parts := strings.SplitN(rest, ":", 2)
+		if len(parts) == 2 {
+			if p.sessionID == "" {
+				p.sessionID = parts[0]
+			}
+			if p.playID == "" {
+				p.playID = parts[1]
+			}
+			p.playerID = "" // archive ids aren't real player ids
+		}
+	}
+
+	if p.playerID == "" && p.sessionID == "" {
+		return p, errBadParam("one of player_id or session_id is required")
+	}
+	if p.streams == "" {
+		return p, errBadParam("streams=samples,network,... is required")
+	}
+
+	p.limit = parseLimit(q.Get("limit"), 50000, 200000)
+
+	if v := q.Get("stride_ms"); v != "" {
+		if n, err := atoiInRange(v, 1, 60000); err == nil {
+			p.strideMs = n
+		}
+	}
+	if v := q.Get("max_hz"); v != "" {
+		if n, err := atoiInRange(v, 1, 1000); err == nil {
+			p.maxHz = n
+		}
+	}
+
+	// `fields=col1,col2` applies to whichever stream those columns
+	// belong to. For simplicity in this first cut we accept a flat
+	// list and let resolveSelection apply it to ALL enabled streams
+	// (CH will reject unknown columns per-stream — clean 4xx surface).
+	if f := strings.TrimSpace(q.Get("fields")); f != "" {
+		list := splitCSV(f)
+		for _, sk := range []streamKind{streamSamples, streamNetwork, streamEvents} {
+			p.fieldsByStream[sk] = list
+		}
+	}
+
+	return p, nil
+}
+
+func atoiInRange(s string, lo, hi int) (int, error) {
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(s), "%d", &n); err != nil {
+		return 0, err
+	}
+	if n < lo || n > hi {
+		return 0, fmt.Errorf("out of range [%d,%d]", lo, hi)
+	}
+	return n, nil
+}
+
+// isStreamLive returns true if the (player, play) appears to still
+// be actively producing rows. Heuristic: the ring's bucket has been
+// touched within `liveActivityWindow`, OR (if we have no ring data)
+// the most recent CH row for this key is recent.
+//
+// First-cut: ring-only check. CH-fallback for "freshly opened
+// session with no ring history yet" comes once we have the v2
+// proxy-state probe wired. The cost of getting this wrong (returning
+// !live when actually live) is the client closes the SSE early and
+// has to reconnect after the next sample — annoying but recoverable.
+//
+// Note: we read the bucket lastActivityMs without holding any locks
+// the ring exposes; the data race is benign (read of int64 on
+// platforms where Go's memory model permits torn reads is irrelevant
+// here — at worst we mis-classify by one tick and reconnect).
+func isStreamLive(ring *Ring, key ringKey, playerID, playID string) bool {
+	const liveActivityWindow = 30 * 1000 // ms
+	b := ring.bucket(key)
+	b.mu.RLock()
+	last := b.lastActivityMs
+	b.mu.RUnlock()
+	if last == 0 {
+		// No ring activity yet — assume live so the client subscribes
+		// and waits. If the play actually ended before we ever saw
+		// it, the subscription will idle until the SSE timeout cycles
+		// it. Better than wrongly closing early on a fresh play.
+		return true
+	}
+	return nowMs()-last < liveActivityWindow
+}
+
+// emittedSet is a small fingerprint dedupe used to skip ring deltas
+// the backfill scan already covered. Bounded; we expect very few
+// overlaps in practice (the backfill ends roughly at "now" and the
+// next delta lands a few hundred ms later).
+type emittedSet struct {
+	mu    sync.Mutex
+	seen  map[string]struct{}
+	limit int
+}
+
+func newEmittedSet() *emittedSet {
+	return &emittedSet{seen: map[string]struct{}{}, limit: 100000}
+}
+
+func (s *emittedSet) Add(kind streamKind, fp string) bool {
+	if fp == "" {
+		return true
+	}
+	k := string(kind) + "|" + fp
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.seen[k]; ok {
+		return false
+	}
+	if len(s.seen) >= s.limit {
+		// Cheap pressure relief: drop everything. Worst case is
+		// re-emitting a handful of duplicate rows; client dedupes.
+		s.seen = map[string]struct{}{}
+	}
+	s.seen[k] = struct{}{}
+	return true
+}
+
+// emitBackfill runs the per-stream CH SELECT for [from, to] and emits
+// each row as an SSE event. Also pulls ring entries in the same
+// window and emits any that CH hasn't covered (the recently-ingested
+// rows that haven't been INSERTed yet — or just confirmed-but-not-
+// evicted, which CH covers, but the emittedSet dedupes either way).
+//
+// Returns nil even when no rows match — an empty backfill is a valid
+// state (e.g. brand-new play). Returns error only on transport
+// failures the caller should surface.
+func emitBackfill(
+	ctx context.Context,
+	w http.ResponseWriter,
+	flusher http.Flusher,
+	cfg config,
+	ring *Ring,
+	key ringKey,
+	sel streamSelection,
+	params timeseriesParams,
+	seen *emittedSet,
+	ringWindowMs int64,
+) error {
+	switch sel.Stream {
+	case streamSamples:
+		if err := emitBackfillSamples(ctx, w, flusher, cfg, sel, params, seen); err != nil {
+			return err
+		}
+		return emitBackfillFromRing(w, flusher, ring, key, sel.Stream, kindSample, params, seen, ringWindowMs)
+	case streamNetwork:
+		if err := emitBackfillNetwork(ctx, w, flusher, cfg, sel, params, seen); err != nil {
+			return err
+		}
+		return emitBackfillFromRing(w, flusher, ring, key, sel.Stream, kindNetwork, params, seen, ringWindowMs)
+	}
+	return nil
+}
+
+func emitBackfillSamples(ctx context.Context, w http.ResponseWriter, flusher http.Flusher,
+	cfg config, sel streamSelection, params timeseriesParams, seen *emittedSet) error {
+	q, args, err := buildSamplesQuery(cfg, sel, params)
+	if err != nil {
+		return err
+	}
+	rows, err := queryClickHouseRows(ctx, cfg, q, args)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		ts := stringField(row, "ts")
+		if !seen.Add(streamSamples, ts) {
+			continue
+		}
+		writeSSEEvent(w, "sample", ts, row)
+	}
+	flusher.Flush()
+	return nil
+}
+
+func emitBackfillNetwork(ctx context.Context, w http.ResponseWriter, flusher http.Flusher,
+	cfg config, sel streamSelection, params timeseriesParams, seen *emittedSet) error {
+	q, args, err := buildNetworkQuery(cfg, sel, params)
+	if err != nil {
+		return err
+	}
+	rows, err := queryClickHouseRows(ctx, cfg, q, args)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		fp := stringField(row, "entry_fingerprint")
+		if !seen.Add(streamNetwork, fp) {
+			continue
+		}
+		writeSSEEvent(w, "network", fp, row)
+	}
+	flusher.Flush()
+	return nil
+}
+
+// emitBackfillFromRing scans the ring for entries that CH hasn't
+// produced (typically only the unconfirmed tail). Anything CH already
+// emitted is skipped by the seen-set.
+func emitBackfillFromRing(w http.ResponseWriter, flusher http.Flusher,
+	ring *Ring, key ringKey, stream streamKind, kind ringKind,
+	params timeseriesParams, seen *emittedSet, ringWindowMs int64) error {
+	// Window: the SSE backfill ostensibly covers [from, to], but
+	// for the ring overlay we always scan the full ring (cheap, and
+	// guarantees we don't miss a row whose ts falls outside the
+	// caller's coarse from/to but inside our ring's retention).
+	from := nowMs() - ringWindowMs
+	to := nowMs() + 1000 // small lookahead for clock skew
+	for _, e := range ring.Range(key, from, to, []ringKind{kind}) {
+		var payload any
+		var fp string
+		switch stream {
+		case streamSamples:
+			r, ok := e.Payload.(*row)
+			if !ok {
+				continue
+			}
+			payload = r
+			fp = r.Ts
+		case streamNetwork:
+			r, ok := e.Payload.(*netRow)
+			if !ok {
+				continue
+			}
+			payload = r
+			fp = fmt.Sprintf("%d", r.EntryFingerprint)
+		}
+		if !seen.Add(stream, fp) {
+			continue
+		}
+		writeSSEEvent(w, string(streamToEventName(stream)), fp, payload)
+	}
+	flusher.Flush()
+	return nil
+}
+
+// streamLiveDeltas blocks until ctx is canceled (client disconnect)
+// or the subscription channel closes (bucket evicted). Emits each
+// new ring entry as an SSE event; heartbeats every keepaliveInterval.
+//
+// `playIDFilter`, if non-empty, drops entries whose PlayID does not
+// match (case-insensitive). Empty string means "all plays for this
+// player", which is the default the dashboard uses.
+func streamLiveDeltas(ctx context.Context, w http.ResponseWriter, flusher http.Flusher,
+	subCh <-chan *ringEntry, selections []streamSelection, seen *emittedSet, playIDFilter string) {
+
+	enabled := map[streamKind]bool{}
+	for _, s := range selections {
+		enabled[s.Stream] = true
+	}
+	playFilterLower := strings.ToLower(playIDFilter)
+
+	heartbeat := time.NewTicker(keepaliveInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			writeSSEEvent(w, "heartbeat", "", map[string]any{
+				"ts": time.Now().UTC().Format(time.RFC3339Nano),
+			})
+			flusher.Flush()
+		case e, ok := <-subCh:
+			if !ok {
+				return
+			}
+			stream := ringKindToStream(e.Kind)
+			if !enabled[stream] {
+				continue
+			}
+			if playFilterLower != "" && strings.ToLower(e.PlayID) != playFilterLower {
+				// Caller asked for a specific play; this entry is
+				// from a different play of the same player. Drop.
+				continue
+			}
+			var payload any
+			var fp string
+			switch e.Kind {
+			case kindSample:
+				r, _ := e.Payload.(*row)
+				payload = r
+				if r != nil {
+					fp = r.Ts
+				}
+			case kindNetwork:
+				r, _ := e.Payload.(*netRow)
+				payload = r
+				if r != nil {
+					fp = fmt.Sprintf("%d", r.EntryFingerprint)
+				}
+			}
+			if payload == nil {
+				continue
+			}
+			if !seen.Add(stream, fp) {
+				continue
+			}
+			writeSSEEvent(w, string(streamToEventName(stream)), fp, payload)
+			flusher.Flush()
+		}
+	}
+}
+
+func ringKindToStream(k ringKind) streamKind {
+	if k == kindNetwork {
+		return streamNetwork
+	}
+	return streamSamples
+}
+
+func streamToEventName(s streamKind) string {
+	switch s {
+	case streamSamples:
+		return "sample"
+	case streamNetwork:
+		return "network"
+	case streamEvents:
+		return "event"
+	}
+	return "data"
+}
+
+// ---------- CH query builders ----------
+
+func buildSamplesQuery(cfg config, sel streamSelection, params timeseriesParams) (string, map[string]string, error) {
+	args := map[string]string{}
+	clauses := []string{}
+	if params.playerID != "" {
+		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+		args["player"] = params.playerID
+	}
+	if params.sessionID != "" {
+		clauses = append(clauses, "session_id = {sess:String}")
+		args["sess"] = params.sessionID
+	}
+	if params.playID != "" {
+		if params.playID == "—" {
+			clauses = append(clauses, "play_id = ''")
+		} else {
+			clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+			args["play"] = params.playID
+		}
+	}
+	if params.from != "" {
+		clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+		args["from"] = params.from
+	}
+	if params.to != "" {
+		clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
+		args["to"] = params.to
+	}
+	if len(clauses) == 0 {
+		return "", nil, errBadParam("at least one identity clause required")
+	}
+	limit := params.limit
+	if limit <= 0 || limit > backfillCapSamples {
+		limit = backfillCapSamples
+	}
+	// Subquery wrap so WHERE/ORDER BY operate on the native DateTime64
+	// `ts` column. Without the wrap, the outer SELECT's
+	// `toString(ts) AS ts` projection shadows the source column and the
+	// WHERE clause's `ts >= parseDateTime64BestEffort(...)` is then a
+	// String/DateTime64 comparison that CH rejects with
+	// ILLEGAL_TYPE_OF_ARGUMENT. Same pattern v2_handlers.go uses.
+	cols := buildSelectColumns(sel.Columns)
+	q := fmt.Sprintf(`SELECT %s FROM (SELECT * FROM %s.%s WHERE %s ORDER BY ts ASC LIMIT %d) FORMAT JSONEachRow`,
+		cols, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "), limit)
+	return q, args, nil
+}
+
+func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams) (string, map[string]string, error) {
+	args := map[string]string{}
+	clauses := []string{}
+	if params.playerID != "" {
+		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+		args["player"] = params.playerID
+	}
+	if params.sessionID != "" {
+		clauses = append(clauses, "session_id = {sess:String}")
+		args["sess"] = params.sessionID
+	}
+	if params.playID != "" {
+		if params.playID == "—" {
+			clauses = append(clauses, "play_id = ''")
+		} else {
+			clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+			args["play"] = params.playID
+		}
+	}
+	if params.from != "" {
+		clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+		args["from"] = params.from
+	}
+	if params.to != "" {
+		clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
+		args["to"] = params.to
+	}
+	if len(clauses) == 0 {
+		return "", nil, errBadParam("at least one identity clause required")
+	}
+	limit := params.limit
+	if limit <= 0 || limit > backfillCapNetwork {
+		limit = backfillCapNetwork
+	}
+	// Subquery wrap — same DateTime64-vs-String aliasing reason as
+	// buildSamplesQuery above.
+	cols := buildSelectColumns(sel.Columns)
+	q := fmt.Sprintf(`SELECT %s FROM (SELECT * FROM %s.network_requests WHERE %s ORDER BY ts ASC LIMIT %d) FORMAT JSONEachRow`,
+		cols, cfg.chDatabase, strings.Join(clauses, " AND "), limit)
+	return q, args, nil
+}
+
+// buildSelectColumns produces the SELECT projection list. `ts` is
+// emitted as a String for round-trip stability — the CH default for
+// DateTime64 in JSONEachRow is unfortunately locale-affected for
+// some clients, and the dashboard always parses ts via Date.parse.
+func buildSelectColumns(cols []string) string {
+	parts := make([]string, 0, len(cols))
+	for _, c := range cols {
+		switch c {
+		case "ts":
+			parts = append(parts, "toString(ts) AS ts")
+		default:
+			parts = append(parts, c)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stringField pulls a column value out of a JSONEachRow row map and
+// returns it as a string. Used for fingerprinting (event id) only.
+func stringField(row map[string]any, key string) string {
+	v, ok := row[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return fmt.Sprintf("%v", t)
+	default:
+		b, _ := json.Marshal(t)
+		return string(b)
+	}
+}
+
+// ---------- SSE wire helpers ----------
+
+func setSSEHeaders(w http.ResponseWriter) {
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache, no-transform")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no") // disable nginx response buffering
+	w.WriteHeader(http.StatusOK)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// writeSSEEvent emits one SSE frame. Best-effort: write errors mean
+// the client is gone and the caller's next ctx check will return.
+func writeSSEEvent(w io.Writer, event, id string, payload any) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	if event != "" {
+		_, _ = fmt.Fprintf(w, "event: %s\n", event)
+	}
+	if id != "" {
+		_, _ = fmt.Fprintf(w, "id: %s\n", id)
+	}
+	_, _ = fmt.Fprintf(w, "data: %s\n\n", b)
+}
+
+func emitMeta(w http.ResponseWriter, flusher http.Flusher, selections []streamSelection,
+	live bool, ring *Ring, params timeseriesParams) {
+	streams := make([]string, 0, len(selections))
+	cols := map[string][]string{}
+	for _, s := range selections {
+		streams = append(streams, string(s.Stream))
+		cols[string(s.Stream)] = s.Columns
+	}
+	meta := map[string]any{
+		"streams":     streams,
+		"columns":     cols,
+		"live":        live,
+		"server_caps": map[string]int{"samples": backfillCapSamples, "network": backfillCapNetwork},
+		"ring":        map[string]any{"window_seconds": ring.windowMs / 1000},
+		"from":        params.from,
+		"to":          params.to,
+	}
+	writeSSEEvent(w, "meta", "", meta)
+	flusher.Flush()
+}
+
+func emitComplete(w http.ResponseWriter, flusher http.Flusher, reason string) {
+	writeSSEEvent(w, "complete", "", map[string]string{"reason": reason})
+	flusher.Flush()
+}
+
+func emitError(w http.ResponseWriter, flusher http.Flusher, msg string) {
+	writeSSEEvent(w, "stream_error", "", map[string]string{"message": msg})
+	flusher.Flush()
+}

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -104,7 +104,11 @@ func v2SnapshotsHandler(w http.ResponseWriter, r *http.Request, cfg config) {
 	params := map[string]string{}
 	clauses := []string{}
 	if playerID != "" {
-		clauses = append(clauses, "player_id = {player:String}")
+		// Case-insensitive match: device-side UUIDs (iPad, Apple TV,
+		// Roku) often arrive uppercase, but the live v2 /api/v2/players
+		// endpoint hands the dashboard lowercase. Without lowerUTF8 on
+		// both sides the WHERE fails to match either side's case.
+		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
 		params["player"] = playerID
 	}
 	if sessionID != "" {
@@ -116,7 +120,8 @@ func v2SnapshotsHandler(w http.ResponseWriter, r *http.Request, cfg config) {
 		if playID == "—" {
 			clauses = append(clauses, "play_id = ''")
 		} else {
-			clauses = append(clauses, "play_id = {play:String}")
+			// Same case-fold rationale as player_id.
+			clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
 			params["play"] = playID
 		}
 	}
@@ -240,7 +245,8 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 	// no subquery. session_id remains as a transitional bridge for
 	// dashboards that still pass the small numeric port slot.
 	if playerID != "" {
-		clauses = append(clauses, "player_id = {pid:String}")
+		// Case-insensitive match — see snapshots handler comment.
+		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({pid:String})")
 		params["pid"] = playerID
 	}
 	if sessionID != "" {
@@ -252,7 +258,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		if playID == "—" {
 			clauses = append(clauses, "play_id = ''")
 		} else {
-			clauses = append(clauses, "play_id = {play:String}")
+			clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
 			params["play"] = playID
 		}
 	}
@@ -292,7 +298,11 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		    faulted, fault_type, fault_action, fault_category
 		  FROM %s.network_requests
 		  WHERE %s
-		  ORDER BY ts ASC
+		  -- DESC so the LIMIT keeps the most recent N rows. ASC
+		  -- caused rare 4xx / faulted rows to be squeezed out by
+		  -- bulk 200s on long sessions; the NetworkLog table sorts
+		  -- client-side so display order is unaffected.
+		  ORDER BY ts DESC
 		  LIMIT %d
 		)
 		FORMAT JSONEachRow`,

--- a/content/dashboard-v3/session-viewer.html
+++ b/content/dashboard-v3/session-viewer.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Session Viewer — InfiniteStream v3</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 rx=%2210%22 fill=%22%23091929%22/%3E%3Ccircle cx=%2224%22 cy=%2224%22 r=%224%22 fill=%22%230077B6%22/%3E%3C/svg%3E" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/entry-session-viewer.ts"></script>
+  </body>
+</html>

--- a/content/dashboard-v3/sessions.html
+++ b/content/dashboard-v3/sessions.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Archived Sessions — InfiniteStream v3</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 rx=%2210%22 fill=%22%23091929%22/%3E%3Ccircle cx=%2224%22 cy=%2224%22 r=%224%22 fill=%22%230077B6%22/%3E%3C/svg%3E" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/entry-sessions.ts"></script>
+  </body>
+</html>

--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -22,13 +22,17 @@
  * Y-max is controlled by the panel-level BitrateChartPanelToolbar via
  * the shared chart-coordination state.
  */
-import { computed } from 'vue';
+import { computed, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
+import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
-const props = defineProps<{ playerId: string }>();
-const coord = useChartCoordination(props.playerId);
+const props = defineProps<{
+  playerId: string;
+  samplesStream: Stream<Record<string, unknown>>;
+}>();
+const coord = useChartCoordination(toRef(props, 'playerId'));
 const yMax = computed(() => coord.state.bandwidthYMax);
 
 const series: SeriesSpec[] = [
@@ -123,6 +127,7 @@ const series: SeriesSpec[] = [
     title="Bandwidth"
     unit="Mbps"
     :series="series"
+    :samples-stream="samplesStream"
     :y-min="0"
     :y-max="yMax"
   />

--- a/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
+++ b/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
@@ -5,16 +5,16 @@
  * top of the Bitrate Chart panel:
  *
  *   Bitrate Y Max [Auto/5/10/20/30/40/50/100 Mbps]
- *   Reset Zoom   ⏸ Pause / ▶ Live   ⤢ Expand   Alt-zoom hint
+ *   ● Live (toggle)   ⤢ Expand   Alt-zoom hint
  *
  * All controls drive the shared useChartCoordination(playerId) state
  * so a single click affects every chart in the panel in lockstep.
  */
-import { computed } from 'vue';
+import { computed, toRef } from 'vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 
 const props = defineProps<{ playerId: string }>();
-const coord = useChartCoordination(props.playerId);
+const coord = useChartCoordination(toRef(props, 'playerId'));
 
 type YMaxMode = 'auto' | '5' | '10' | '20' | '30' | '40' | '50' | '100';
 const modes: YMaxMode[] = ['auto', '5', '10', '20', '30', '40', '50', '100'];
@@ -30,8 +30,17 @@ function setMode(m: YMaxMode) {
   coord.setBandwidthYMax(m === 'auto' ? undefined : Number(m));
 }
 
-const pauseLabel = computed(() => (coord.state.paused ? '▶ Live' : '⏸ Pause'));
-const zoomActive = computed(() => coord.state.viewport !== null);
+// Live toggle is "checked" when we're currently following live —
+// i.e. no sticky viewport. All four charts in the panel share this
+// coord state so the toolbar's toggle and each chart's toggle stay
+// in lockstep regardless of which one the operator clicked.
+const liveChecked = computed(() => coord.state.viewport === null);
+
+/** Always togglePause — both directions preserve liveSpanMs.
+ *  See MetricsLineChart.onLiveToggleClick for rationale. */
+function onLiveToggleClick() {
+  coord.togglePause();
+}
 </script>
 
 <template>
@@ -52,21 +61,13 @@ const zoomActive = computed(() => coord.state.viewport !== null);
 
     <div class="actions">
       <button
-        class="btn"
         type="button"
-        :class="{ active: zoomActive }"
-        @click="coord.resetZoom()"
-        title="Snap back to live edge"
+        class="btn live-toggle"
+        :class="{ checked: liveChecked }"
+        @click="onLiveToggleClick"
+        :title="liveChecked ? 'Pause at current live edge' : 'Resume following live (drops zoom and pan)'"
       >
-        Reset Zoom
-      </button>
-      <button
-        class="btn"
-        type="button"
-        :class="{ live: coord.state.paused }"
-        @click="coord.togglePause()"
-      >
-        {{ pauseLabel }}
+        {{ liveChecked ? '●' : '○' }} Live
       </button>
       <button
         class="btn"
@@ -78,7 +79,7 @@ const zoomActive = computed(() => coord.state.viewport !== null);
         ⤢
       </button>
       <span class="hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">
-        Alt/⌥+scroll/drag · right-drag pan · click pause
+        Alt/⌥+scroll/drag · right-drag pan
       </span>
     </div>
   </div>
@@ -150,12 +151,22 @@ const zoomActive = computed(() => coord.state.viewport !== null);
   border-color: #818cf8;
   color: #312e81;
 }
-.btn.live {
+/* Live toggle: filled green when checked, muted/outlined when
+ * unchecked. Same scheme as MetricsLineChart / EventsTimeline so
+ * all the toggles in the panel match visually. */
+.btn.live-toggle.checked {
   background: #10b981;
   border-color: #059669;
   color: white;
+  font-weight: 600;
 }
-.btn.live:hover { background: #059669; }
+.btn.live-toggle.checked:hover { background: #059669; }
+.btn.live-toggle:not(.checked) {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #6b7280;
+}
+.btn.live-toggle:not(.checked):hover { background: #e5e7eb; color: #374151; }
 .hint {
   font-size: 10px;
   color: #9aa0a6;

--- a/content/dashboard-v3/src/components/BufferChart.vue
+++ b/content/dashboard-v3/src/components/BufferChart.vue
@@ -7,9 +7,13 @@
  * legacy two-axis layout.
  */
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
+import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
-defineProps<{ playerId: string }>();
+defineProps<{
+  playerId: string;
+  samplesStream: Stream<Record<string, unknown>>;
+}>();
 
 const series: SeriesSpec[] = [
   {
@@ -38,9 +42,9 @@ const series: SeriesSpec[] = [
     title="Buffer & live offset"
     unit="buffer (s)"
     :series="series"
+    :samples-stream="samplesStream"
     :y-min="0"
     y2-title="offset (s)"
     :y2-min="0"
-    :window-seconds="180"
   />
 </template>

--- a/content/dashboard-v3/src/components/CollapsibleSection.vue
+++ b/content/dashboard-v3/src/components/CollapsibleSection.vue
@@ -19,6 +19,13 @@ const props = defineProps<{
   /** Stable id used for localStorage + ?open_folds= deep-linking.
    *  Omit to opt out of persistence (state stays per-tab). */
   persistKey?: string;
+  /** When true, mount the slot eagerly (display: none when collapsed
+   *  instead of removed from the DOM). Required for chart panels in
+   *  the v3 session-viewer so the chart's `watch(player.value)` runs
+   *  during the bulk snapshot replay even if the user has the
+   *  section folded — without this, opening the section after replay
+   *  shows the chart with only the latest sample. */
+  eager?: boolean;
 }>();
 
 const STORAGE_PREFIX = 'testing_session_collapse_';
@@ -78,14 +85,16 @@ const isOpen = ref<boolean>(resolveInitial());
 
 // `<details>` fires a native `toggle` event with `.open` set. Mirror it
 // into our ref and persist.
-function onToggle(e: Event) {
-  const det = e.currentTarget as HTMLDetailsElement;
-  isOpen.value = det.open;
-  if (props.persistKey) {
-    writeStored(props.persistKey, det.open);
-    // eslint-disable-next-line no-console
-    console.debug('[CollapsibleSection] persisted', props.persistKey, '=', det.open);
-  }
+/** Click on the header — flip open state and persist. Owns the state
+ *  in Vue's reactivity rather than delegating to native `<details>`
+ *  toggle: the native event has races (Vue patches `:open` on every
+ *  re-render, the listener attaches AFTER the initial setAttribute,
+ *  etc) that meant the persistence write didn't always run. With a
+ *  plain div + click handler the write is guaranteed for every user
+ *  toggle. */
+function toggle() {
+  isOpen.value = !isOpen.value;
+  if (props.persistKey) writeStored(props.persistKey, isOpen.value);
 }
 
 // If `persistKey` arrives async (rare), re-resolve once it's set.
@@ -103,24 +112,28 @@ watch(
 </script>
 
 <template>
-  <details class="panel" :open="isOpen" @toggle="onToggle">
-    <summary class="head">
+  <div class="panel" :class="{ open: isOpen }">
+    <div class="head" role="button" tabindex="0"
+         @click="toggle"
+         @keydown.enter.prevent="toggle"
+         @keydown.space.prevent="toggle"
+         :aria-expanded="isOpen">
       <span class="icon">▶</span>
       <span class="title">{{ title }}</span>
       <span class="badge"><slot name="badge" /></span>
-    </summary>
-    <div class="body">
+    </div>
+    <div v-if="eager || isOpen" v-show="eager ? isOpen : true" class="body">
       <slot />
     </div>
-  </details>
+  </div>
 </template>
 
 <style scoped>
 .panel {
   background: #fff;
   border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  margin-bottom: 12px;
+  border-radius: 4px;
+  margin-bottom: 2px;
   overflow: hidden;
 }
 .head {
@@ -129,49 +142,51 @@ watch(
   user-select: none;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  font-size: 13px;
+  gap: 6px;
+  padding: 1px 8px;
+  font-size: 11px;
   font-weight: 600;
   color: #1f2937;
   background: #f9fafb;
   border-bottom: 1px solid transparent;
+  line-height: 1.15;
+  min-height: 18px;
 }
-.head::-webkit-details-marker { display: none; }
-.panel[open] > .head {
+.panel.open > .head {
   border-bottom-color: #e5e7eb;
 }
 .head:hover { background: #f3f4f6; }
+.head:focus-visible { outline: 2px solid #3b82f6; outline-offset: -2px; }
 
 .icon {
   display: inline-block;
-  width: 14px;
-  font-size: 10px;
+  width: 10px;
+  font-size: 9px;
   color: #6b7280;
   transition: transform 0.15s ease;
 }
-.panel[open] > .head .icon {
+.panel.open > .head .icon {
   transform: rotate(90deg);
 }
 
 .title {
   flex: 1;
   text-transform: uppercase;
-  letter-spacing: 0.4px;
-  font-size: 12px;
+  letter-spacing: 0.3px;
+  font-size: 11px;
 }
 
 .badge {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 500;
   color: #6b7280;
   background: #f3f4f6;
-  padding: 2px 8px;
-  border-radius: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
 }
 .badge:empty { display: none; }
 
 .body {
-  padding: 16px;
+  padding: 10px 12px;
 }
 </style>

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -28,10 +28,9 @@
  * favour of consuming that.
  */
 import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
-import { usePlayer } from '@/composables/usePlayer';
 import { ensureVisTimeline } from '@/composables/useChartJs';
 import { useChartCoordination } from '@/composables/useChartCoordination';
-import type { PlayerRecord } from '@/repo/v2-repo';
+import type { Stream } from '@/composables/useSessionTimeSeries';
 
 interface LaneCfg { label: string; color: string }
 const EVENT_LANES: Record<string, LaneCfg> = {
@@ -78,9 +77,89 @@ function displayResColor(res: string | null | undefined): string {
   return '#6b7280';
 }
 
-const props = defineProps<{ playerId: string }>();
-const { player } = usePlayer(toRef(props, 'playerId'));
-const coord = useChartCoordination(props.playerId);
+const props = defineProps<{
+  playerId: string;
+  /** Samples stream from SessionDisplay's useSessionTimeSeries model.
+   *  Each row is a CH session_snapshots projection (lanes_v1 bundle).
+   *  EventsTimeline derives swim-lane segments from successive rows. */
+  samplesStream: Stream<Record<string, unknown>>;
+}>();
+const coord = useChartCoordination(toRef(props, 'playerId'));
+
+/** Adapter — map a CH session_snapshots row (wire shape from the v3
+ *  /api/v3/timeseries endpoint) to the small subset of fields ingest()
+ *  reads. Keeps ingest() agnostic to the row shape so the next storage
+ *  layer (materialised lanes_v2) can change column names without
+ *  touching the lane-derivation logic. */
+interface IngestRow {
+  ts: number;
+  state: string;
+  waitingReason: string;
+  videoResolution: string;
+  videoBitrateMbps: number | null;
+  stalls: number | null;
+  droppedFrames: number | null;
+  error: string;
+  firstFrameTimeS: number | null;
+  videoStartTimeS: number | null;
+  loopCountServer: number | null;
+  controlRevision: string | null;
+  playId: string | null;
+  manifestVariants: { bandwidth?: number; resolution?: string }[] | null;
+}
+
+function tsOfRow(row: Record<string, unknown>): number {
+  const v = row.ts;
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string' || !v) return NaN;
+  if (v.length > 10 && v.charAt(10) === ' ') {
+    return Date.parse(v.replace(' ', 'T') + 'Z');
+  }
+  return Date.parse(v);
+}
+
+function num(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') { const n = Number(v); return Number.isFinite(n) ? n : null; }
+  return null;
+}
+
+function chRowToIngest(row: Record<string, unknown>): IngestRow | null {
+  const t = tsOfRow(row);
+  if (!Number.isFinite(t)) return null;
+  // manifest_variants is stored as a JSON string in CH. Parse once
+  // here so the lane resolver below can iterate it like an array.
+  let variants: IngestRow['manifestVariants'] = null;
+  const mv = row.manifest_variants;
+  if (typeof mv === 'string' && mv.length > 0 && mv !== 'null') {
+    try { const parsed = JSON.parse(mv); if (Array.isArray(parsed)) variants = parsed; }
+    catch { /* ignore malformed manifest JSON */ }
+  } else if (Array.isArray(mv)) {
+    variants = mv as IngestRow['manifestVariants'];
+  }
+  // control_revision is UInt64 in CH → JSON string from JSONEachRow.
+  // Stringify defensively so the diff comparator stays stable across
+  // numeric vs. string representations.
+  const rev = row.control_revision;
+  const controlRevision = rev == null ? null : String(rev);
+  return {
+    ts: t,
+    state: String(row.player_state ?? '').trim(),
+    waitingReason: String(row.waiting_reason ?? '').trim(),
+    videoResolution: String(row.video_resolution ?? '').trim(),
+    videoBitrateMbps: num(row.video_bitrate_mbps),
+    stalls: num(row.stall_count),
+    droppedFrames: num(row.dropped_frames),
+    error: String(row.player_error ?? ''),
+    firstFrameTimeS: num(row.video_first_frame_time_s),
+    videoStartTimeS: num(row.video_start_time_s),
+    loopCountServer: num(row.loop_count_server),
+    controlRevision,
+    playId: typeof row.play_id === 'string' ? row.play_id : null,
+    manifestVariants: variants,
+  };
+}
 
 const container = ref<HTMLDivElement | null>(null);
 
@@ -90,6 +169,10 @@ let itemsDS: any = null;
 let groupsDS: any = null;
 let nextId = 1;
 let suppressNextRangeChange = false;
+/** Tolerance for "right edge is at the live sample" — absorbs the gap
+ *  between when a wheel event fires and when the next sample arrives.
+ *  Same 2s tolerance the brush-drop-at-live heuristic uses. */
+const LIVE_EDGE_TOLERANCE_MS = 2000;
 let userInteracted = false;
 
 interface TimelineRangeItem {
@@ -154,7 +237,6 @@ const STATEFUL_LANES = new Set(['PLAYERSTATE', 'DISPLAY_RES']);
 // Sample-tracking memory for diff-based POINT-event detection.
 let prevStalls: number | null = null;
 let prevDropped: number | null = null;
-let prevPlayerRestarts: number | null = null;
 let prevLoopServer: number | null = null;
 let prevControlRev: string | null = null;
 let prevError: string | null = null;
@@ -162,6 +244,10 @@ let prevPlayId: string | null = null;
 let prevFirstFrame: number | null = null;
 let prevVideoStart: number | null = null;
 let prevVariantMbps: number | null = null;
+// Watermark of the latest CH row already fed through `ingest()`. The
+// samples-stream watcher uses this to consume only NEW rows on each
+// version bump (the stream cache holds the full backfill + live tail).
+let lastIngestedMs = -Infinity;
 
 function fmtTime(ms: number): string {
   const d = new Date(ms);
@@ -179,13 +265,12 @@ function variantLabel(mbps: number, resolution: string): string {
  *  tolerant (±max(0.5 Mbps, 5% of the variant's Mbps)) so EWMA drift
  *  doesn't lose the match. Returns '' if no variant is close enough,
  *  so the caller can fall back to the player-reported resolution. */
-function manifestResolutionForBitrate(p: PlayerRecord, targetMbps: number): string {
+function manifestResolutionForBitrate(
+  variants: IngestRow['manifestVariants'],
+  targetMbps: number,
+): string {
   if (!Number.isFinite(targetMbps)) return '';
-  const variants =
-    (p as any)?.current_play?.manifest?.variants ??
-    (p as any)?.raw_session?.manifest_variants ??
-    null;
-  if (!Array.isArray(variants) || variants.length === 0) return '';
+  if (!variants || variants.length === 0) return '';
   let best: string | null = null;
   let bestDelta = Infinity;
   for (const v of variants) {
@@ -201,18 +286,6 @@ function manifestResolutionForBitrate(p: PlayerRecord, targetMbps: number): stri
     }
   }
   return best ?? '';
-}
-
-function tsFor(p: PlayerRecord): number {
-  if (p.player_metrics?.event_time) {
-    const v = Date.parse(p.player_metrics.event_time);
-    if (Number.isFinite(v)) return v;
-  }
-  if (p.last_seen_at) {
-    const v = Date.parse(p.last_seen_at);
-    if (Number.isFinite(v)) return v;
-  }
-  return Date.now();
 }
 
 function laneClose(key: string, t: number) {
@@ -334,28 +407,31 @@ async function ensureTimeline(): Promise<void> {
         start: new Date(vp.min),
         end: new Date(vp.max),
       });
-      // Click on the strip toggles pause / live, matching the
-      // line-chart canvas behaviour (MetricsLineChart). vis-timeline's
-      // 'click' event only fires on a real click — not after a drag —
-      // so panning doesn't accidentally toggle.
-      timeline.on('click', () => {
-        coord.togglePause();
-      });
+      // Pause/live transitions come from the Live toggle button, the
+      // brush rail, and the rangechanged handler below (pan / zoom
+      // auto-pin). Clicks on the strip itself do nothing — earlier
+      // versions toggled pause on click but it produced too many
+      // accidental pauses.
       timeline.on('rangechanged', (rc: any) => {
         if (suppressNextRangeChange) { suppressNextRangeChange = false; return; }
         if (!rc?.byUser) return;
         userInteracted = true;
-        // With the Alt+wheel live-anchor listener below capturing
-        // wheel events in live mode, the only user-driven rangechange
-        // left here is PAN (drag). Pan auto-pauses, mirroring the
-        // chartjs pan handler. In paused mode the Alt+wheel listener
-        // falls through to vis-timeline's mouse-anchored zoom, which
-        // also fires rangechanged → we set the sticky viewport in
-        // both branches.
-        if (!coord.state.paused) coord.setPaused(true);
         const a = rc.start instanceof Date ? rc.start.getTime() : Date.parse(rc.start);
         const b = rc.end instanceof Date ? rc.end.getTime() : Date.parse(rc.end);
-        if (Number.isFinite(a) && Number.isFinite(b)) coord.setViewport({ min: a, max: b });
+        if (!Number.isFinite(a) || !Number.isFinite(b)) return;
+        // Snap-back-to-live: if a mouse-anchored zoom or pan ends with
+        // the right edge at the live sample, return to live tracking
+        // — drop the sticky viewport, preserve the zoom span via
+        // liveSpanMs, and stay unpaused. Any further Alt+wheel will
+        // then take the left-edge-only path.
+        const lastTs = coord.state.lastSampleMs;
+        if (lastTs && b >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
+          coord.setViewport(null);
+          coord.setLiveSpanMs(b - a);
+          return;
+        }
+        if (!coord.state.paused) coord.setPaused(true);
+        coord.setViewport({ min: a, max: b });
       });
       installLiveWheelAnchor();
     } finally {
@@ -367,9 +443,8 @@ async function ensureTimeline(): Promise<void> {
 }
 
 /* ─── Per-tick event derivation ─────────────────────────────────── */
-function ingest(p: PlayerRecord) {
-  const pm = p.player_metrics;
-  const t = tsFor(p);
+function ingest(r: IngestRow) {
+  const t = r.ts;
   coord.noteSample(t);
 
   // Track play_id transitions for the POINT-event diff trackers (so
@@ -379,12 +454,11 @@ function ingest(p: PlayerRecord) {
   // metric ticks, and that flicker would otherwise erase the whole
   // PLAYERSTATE / VARIANT / DISPLAY_RES history (visible as the
   // PLAYERSTATE bar suddenly vanishing). Real "new play" transitions
-  // surface naturally via `player_metrics.state` going through
+  // surface naturally via `player_state` going through
   // idle/loading/playing — that's what drives the lane segmentation.
-  const playId = p.current_play?.id ?? null;
-  if (playId !== prevPlayId) {
-    prevPlayId = playId;
-    prevStalls = prevDropped = prevPlayerRestarts = null;
+  if (r.playId !== prevPlayId) {
+    prevPlayId = r.playId;
+    prevStalls = prevDropped = null;
     prevLoopServer = null;
     prevError = null;
     prevFirstFrame = prevVideoStart = null;
@@ -392,47 +466,23 @@ function ingest(p: PlayerRecord) {
 
   // STATEFUL LANES — push every heartbeat as an event into a flat
   // array. The renderer coalesces runs of same-label entries below.
-  // This is the legacy session-shell.js pattern, robust against the
-  // empty-vs-null / case-flicker / play_id-resync issues that broke
-  // the incremental open-range approach.
-  const stateNorm = String(pm?.state ?? '').trim();
-  const reasonNorm = String(pm?.waiting_reason ?? '').trim();
-  if (stateNorm) {
-    statefulEvents.push({ ts: t, type: 'PLAYERSTATE', state: stateNorm, reason: reasonNorm });
+  if (r.state) {
+    statefulEvents.push({ ts: t, type: 'PLAYERSTATE', state: r.state, reason: r.waitingReason });
   }
 
-  // DISPLAY_RES — the decoded video resolution being displayed (what
-  // the user actually sees on-screen as video content). Sourced from
-  // `pm.video_resolution`, matching the legacy session-shell.js:2352
-  // — the lane label is "DISPLAY RES" but the value is the active
-  // variant's decoded size. (`pm.display_resolution` is the player's
-  // window/viewport size and is reported on its own field, not used
-  // for this lane.)
-  const videoResNorm = String(pm?.video_resolution ?? '').trim();
-  if (videoResNorm) {
-    statefulEvents.push({ ts: t, type: 'DISPLAY_RES', resolution: videoResNorm });
+  // DISPLAY_RES — the decoded video resolution being displayed.
+  if (r.videoResolution) {
+    statefulEvents.push({ ts: t, type: 'DISPLAY_RES', resolution: r.videoResolution });
   }
 
-  // VARIANT — same heartbeat-push pattern. Keyed on the MANIFEST's
-  // canonical resolution for the rung (legacy parity, via
-  // `manifestResolutionForBitrate()`), so iPad's churn through
-  // intermediate `video_resolution` reports during a switch doesn't
-  // create phantom lanes for one rung.
-  const mbpsRaw = pm?.video_bitrate_mbps ?? null;
-  if (mbpsRaw != null && Number.isFinite(mbpsRaw) && mbpsRaw > 0) {
+  // VARIANT — keyed on the MANIFEST's canonical resolution for the
+  // rung so transient `video_resolution` flicker during a switch
+  // doesn't create phantom lanes.
+  const mbpsRaw = r.videoBitrateMbps;
+  if (mbpsRaw != null && mbpsRaw > 0) {
     const mbpsRounded = Math.round(mbpsRaw * 10) / 10;
-    // Only emit when the manifest has a matching variant — that's the
-    // canonical (resolution, bitrate) pair. Falling back to the player's
-    // reported `video_resolution` here would seed phantom lanes during
-    // ABR transitions (player reports an intermediate decoded size like
-    // 2560x1440 while the active rung is actually 3840x2160 · 29.9
-    // Mbps), and those phantom lanes would never collapse even after
-    // the manifest loads. Skip emission until we have the manifest.
-    const variantRes = manifestResolutionForBitrate(p, mbpsRounded);
+    const variantRes = manifestResolutionForBitrate(r.manifestVariants, mbpsRounded);
     if (variantRes) {
-      // Emit PLAYBACK SHIFT_UP / SHIFT_DOWN as POINT events on real
-      // rung changes — incremental tracker is fine here since these
-      // are points, not coalesced ranges.
       if (prevVariantMbps != null) {
         if (mbpsRaw > prevVariantMbps + 0.01) {
           pushPoint('PLAYBACK', t, 'SHIFT UP', '#3b82f6', `\n${prevVariantMbps.toFixed(2)} → ${mbpsRaw.toFixed(2)} Mbps`);
@@ -453,58 +503,78 @@ function ingest(p: PlayerRecord) {
     }
   }
 
-  // IMPAIRMENT — STALL on stall counter increments; ERROR when error
-  // string changes; FROZEN on dropped-frame surge (heuristic).
-  if (pm?.stalls != null && prevStalls != null && pm.stalls > prevStalls) {
-    const delta = pm.stalls - prevStalls;
-    pushPoint('IMPAIRMENT', t, 'STALL', '#000000', `\n+${delta} (total ${pm.stalls})`);
+  // IMPAIRMENT — STALL on counter increments; ERROR on string change;
+  // FROZEN on dropped-frame surge (heuristic).
+  if (r.stalls != null && prevStalls != null && r.stalls > prevStalls) {
+    pushPoint('IMPAIRMENT', t, 'STALL', '#000000', `\n+${r.stalls - prevStalls} (total ${r.stalls})`);
   }
-  if (pm?.dropped_frames != null && prevDropped != null && pm.dropped_frames > prevDropped + 10) {
-    pushPoint('IMPAIRMENT', t, 'FROZEN', '#4c1d95', `\n+${pm.dropped_frames - prevDropped} dropped`);
+  if (r.droppedFrames != null && prevDropped != null && r.droppedFrames > prevDropped + 10) {
+    pushPoint('IMPAIRMENT', t, 'FROZEN', '#4c1d95', `\n+${r.droppedFrames - prevDropped} dropped`);
   }
-  if (pm?.error && pm.error !== prevError) {
-    pushPoint('IMPAIRMENT', t, 'ERROR', '#e11d48', `\n${pm.error}`);
-    prevError = pm.error;
+  if (r.error && r.error !== prevError) {
+    pushPoint('IMPAIRMENT', t, 'ERROR', '#e11d48', `\n${r.error}`);
+    prevError = r.error;
   }
-  if (pm?.stalls != null) prevStalls = pm.stalls;
-  if (pm?.dropped_frames != null) prevDropped = pm.dropped_frames;
+  if (r.stalls != null) prevStalls = r.stalls;
+  if (r.droppedFrames != null) prevDropped = r.droppedFrames;
 
-  // PLAYBACK — RESTART on player_restarts increments; FIRST_FRAME +
-  // PLAYBACK_START once at the play boundary.
-  if (pm?.player_restarts != null && prevPlayerRestarts != null && pm.player_restarts > prevPlayerRestarts) {
-    const delta = pm.player_restarts - prevPlayerRestarts;
-    pushPoint('PLAYBACK', t, 'RESTART', '#a855f7', `\n+${delta}`);
+  // PLAYBACK — FIRST_FRAME + START TIME on first observation per play.
+  // (Legacy RESTART event was driven by `player_restarts`, which isn't
+  // persisted in CH; drop until the schema gains it.)
+  if (r.firstFrameTimeS != null && r.firstFrameTimeS > 0 && prevFirstFrame !== r.firstFrameTimeS) {
+    pushPoint('PLAYBACK', t, 'FIRST FRAME', '#14b8a6', `\n${r.firstFrameTimeS.toFixed(3)}s`);
+    prevFirstFrame = r.firstFrameTimeS;
   }
-  if (pm?.player_restarts != null) prevPlayerRestarts = pm.player_restarts;
-  if (pm?.first_frame_time_s != null && pm.first_frame_time_s > 0 && prevFirstFrame !== pm.first_frame_time_s) {
-    pushPoint('PLAYBACK', t, 'FIRST FRAME', '#14b8a6', `\n${pm.first_frame_time_s.toFixed(3)}s`);
-    prevFirstFrame = pm.first_frame_time_s;
-  }
-  if (pm?.video_start_time_s != null && pm.video_start_time_s > 0 && prevVideoStart !== pm.video_start_time_s) {
-    pushPoint('PLAYBACK', t, 'START TIME', '#15803d', `\n${pm.video_start_time_s.toFixed(3)}s`);
-    prevVideoStart = pm.video_start_time_s;
+  if (r.videoStartTimeS != null && r.videoStartTimeS > 0 && prevVideoStart !== r.videoStartTimeS) {
+    pushPoint('PLAYBACK', t, 'START TIME', '#15803d', `\n${r.videoStartTimeS.toFixed(3)}s`);
+    prevVideoStart = r.videoStartTimeS;
   }
 
-  // SERVER — LOOP increments
-  const loop = p.loop_count_server ?? null;
-  if (loop != null && prevLoopServer != null && loop > prevLoopServer) {
-    const delta = loop - prevLoopServer;
-    pushPoint('LOOP_SERVER', t, 'LOOP', '#84cc16', `\n+${delta} (total ${loop})`);
+  // SERVER — LOOP increments.
+  if (r.loopCountServer != null && prevLoopServer != null && r.loopCountServer > prevLoopServer) {
+    pushPoint('LOOP_SERVER', t, 'LOOP', '#84cc16', `\n+${r.loopCountServer - prevLoopServer} (total ${r.loopCountServer})`);
   }
-  if (loop != null) prevLoopServer = loop;
+  if (r.loopCountServer != null) prevLoopServer = r.loopCountServer;
 
   // CONTROL — record any control_revision change.
-  const rev = p.control_revision ?? null;
-  if (rev && rev !== prevControlRev) {
-    if (prevControlRev != null) {
-      pushPoint('CONTROL', t, 'CONTROL CHANGE', '#7c3aed', `\n${prevControlRev} → ${rev}`);
+  if (r.controlRevision && r.controlRevision !== '0' && r.controlRevision !== prevControlRev) {
+    if (prevControlRev != null && prevControlRev !== '0') {
+      pushPoint('CONTROL', t, 'CONTROL CHANGE', '#7c3aed', `\n${prevControlRev} → ${r.controlRevision}`);
     }
-    prevControlRev = rev;
+    prevControlRev = r.controlRevision;
   }
 
-  // Rebuild stateful-lane items from the events array. Cheap because
-  // events typically number in the hundreds even for hour-long sessions.
-  renderStatefulLanes(t);
+  scheduleStatefulRender(t);
+}
+
+/** Adaptive render throttle — matches the pattern in MetricsLineChart.
+ *  renderStatefulLanes walks `statefulEvents` to coalesce runs into
+ *  vis-timeline items; that walk is O(events). For a 2h archive
+ *  replay we accumulate 5–10k events. At 1 Hz redraw the page burns
+ *  noticeable CPU on the event timeline alone, so back off as the
+ *  event array grows. */
+let pendingRenderTimer: number | null = null;
+let lastRenderAt = 0;
+let pendingRenderTs = 0;
+function pickRenderThrottleMs(): number {
+  const n = statefulEvents.length;
+  if (n >= 10_000) return 10_000;
+  if (n >= 2_500) return 5_000;
+  if (n >= 500) return 2_000;
+  return 1_000;
+}
+function scheduleStatefulRender(ts: number) {
+  pendingRenderTs = ts;
+  if (pendingRenderTimer != null) return;
+  const now = Date.now();
+  const throttleMs = pickRenderThrottleMs();
+  const dueAt = lastRenderAt + throttleMs;
+  const delay = Math.max(0, dueAt - now);
+  pendingRenderTimer = window.setTimeout(() => {
+    pendingRenderTimer = null;
+    lastRenderAt = Date.now();
+    renderStatefulLanes(pendingRenderTs);
+  }, delay);
 }
 
 /* ─── Stateful-lane render (legacy pushRanges pattern) ─────────────
@@ -602,14 +672,95 @@ function renderStatefulLanes(nowMs: number) {
   }
 }
 
+/* ─── Samples-stream consumer ──────────────────────────────────────
+ *
+ * Single feed: drain new rows from the unified time-series cache on
+ * every version bump. `lastIngestedMs` is the high-water mark so we
+ * only feed CH rows we haven't seen yet — the cache holds the full
+ * backfill burst plus every live delta, so a naive re-ingest of the
+ * whole range would re-emit every coalesced range.
+ *
+ * Pause-safe buffer: if the operator paused, hold the new rows in
+ * `pendingLive` and drain on resume. `scheduleStatefulRender`'s
+ * adaptive throttle collapses thousands of ingests into one DataSet
+ * update, so even the initial backfill of 5–10 k rows lands in a
+ * single render pass.
+ */
+const pendingLive: IngestRow[] = [];
+let drainToken = 0;
+async function drainNewRows() {
+  if (lastIngestedMs === Infinity) return; // never happens, defensive
+  const raw = props.samplesStream.inRange(
+    lastIngestedMs === -Infinity ? 0 : lastIngestedMs + 1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (!raw.length) return;
+  await ensureTimeline();
+  const myToken = ++drainToken;
+  const CHUNK = 500;
+  let highWater = lastIngestedMs;
+  for (let start = 0; start < raw.length; start += CHUNK) {
+    if (myToken !== drainToken) return;
+    const end = Math.min(start + CHUNK, raw.length);
+    for (let i = start; i < end; i++) {
+      const row = chRowToIngest(raw[i]);
+      if (!row) continue;
+      if (row.ts <= lastIngestedMs) continue; // belt-and-suspenders
+      if (coord.state.paused) {
+        pendingLive.push(row);
+      } else {
+        ingest(row);
+      }
+      if (row.ts > highWater) highWater = row.ts;
+    }
+    if (end < raw.length) {
+      // Yield to the main thread between chunks so brush/scroll stay
+      // responsive while the backfill drains.
+      await new Promise<void>((r) => setTimeout(r, 0));
+    }
+  }
+  lastIngestedMs = highWater;
+}
+
 watch(
-  () => player.value,
-  async (p) => {
-    if (!p) return;
-    await ensureTimeline();
-    ingest(p);
-  },
+  () => props.samplesStream.version.value,
+  () => { void drainNewRows(); },
   { immediate: true },
+);
+
+// Resume drain — feed any buffered rows through `ingest()` in arrival
+// order so the coalescing logic produces the same lane segments it
+// would have produced live.
+watch(
+  () => coord.state.paused,
+  (paused) => {
+    if (paused || !pendingLive.length) return;
+    const drained = pendingLive.splice(0, pendingLive.length);
+    for (const r of drained) ingest(r);
+  },
+);
+
+// Player swap — reset all per-player state so a picker swap clears
+// the old session's lanes instead of accumulating both. Watching
+// playerId (a string prop) keeps this simple; SessionDisplay's
+// useSessionTimeSeries already re-subscribes the SSE stream.
+watch(
+  () => props.playerId,
+  () => {
+    statefulEvents.length = 0;
+    pendingLive.length = 0;
+    lastIngestedMs = -Infinity;
+    prevStalls = prevDropped = null;
+    prevLoopServer = null;
+    prevControlRev = null;
+    prevError = null;
+    prevPlayId = null;
+    prevFirstFrame = prevVideoStart = null;
+    prevVariantMbps = null;
+    if (itemsDS) {
+      try { itemsDS.clear(); } catch { /* ignore */ }
+    }
+  },
 );
 
 watch(
@@ -623,19 +774,22 @@ watch(
 );
 
 /**
- * Live-edge wheel zoom anchor — port of legacy session-shell.js
- * `ensureVisTimelineLiveWheelAnchor`. Same rule as the chartjs charts:
+ * Alt+wheel — handled entirely here so the wheel direction + zoom
+ * speed match every other surface (line charts, focus bar). We never
+ * fall through to vis-timeline's native zoom because its delta /
+ * factor curve differs from ours and the result felt inconsistent.
  *
- *   - LIVE  (not paused): Alt+wheel updates `coord.liveSpanMs`, the
- *     timeline tracks the live edge with the new span (cursor position
- *     ignored). preventDefault + stopPropagation so vis-timeline's own
- *     wheel handler doesn't double-zoom.
- *   - PAUSED: fall through to vis-timeline's default mouse-anchored
- *     wheel zoom (which fires `rangechanged` and refreshes the sticky
- *     viewport).
+ * Convention everywhere: wheel UP (`deltaY < 0`) → zoom IN (smaller
+ * span, factor 0.9).
  *
- * Capture-phase listener on the timeline container so we run before
- * vis-timeline's own handler. */
+ *   - AT LIVE (`viewport == null`): grow/shrink the span by moving
+ *     the LEFT edge only — right stays glued to the live sample.
+ *     Updates `coord.liveSpanMs`.
+ *   - OFF LIVE (`viewport != null`): mouse-anchored zoom. The
+ *     timestamp under the cursor stays fixed while both edges move.
+ *     If the new right edge reaches live, snap back to live tracking.
+ *
+ * Capture-phase listener so we run before vis-timeline's own handler. */
 function installLiveWheelAnchor() {
   const el = container.value;
   if (!el) return;
@@ -643,27 +797,89 @@ function installLiveWheelAnchor() {
     'wheel',
     (e: WheelEvent) => {
       if (!e.altKey) return;
-      if (coord.state.paused) return;
       e.preventDefault();
       e.stopPropagation();
       const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
-      const windowMs = coord.state.windowMs;
-      const currentSpan =
-        coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
       const MIN_SPAN_MS = 1_000;
-      const nextSpan = Math.max(
-        MIN_SPAN_MS,
-        Math.min(windowMs, currentSpan * factor),
-      );
-      coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+      const MAX_SPAN_MS = 24 * 3600 * 1000;
+      const lastTs = coord.state.lastSampleMs;
+      const vp = coord.state.viewport;
+
+      if (vp == null) {
+        const windowMs = coord.state.windowMs;
+        const currentSpan = coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
+        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
+        coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+        return;
+      }
+
+      const currentSpan = vp.max - vp.min;
+      const nextSpan = Math.max(MIN_SPAN_MS, Math.min(MAX_SPAN_MS, currentSpan * factor));
+      const rect = el.getBoundingClientRect();
+      const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0.5;
+      const anchorTime = vp.min + frac * currentSpan;
+      let newStart = anchorTime - frac * nextSpan;
+      let newEnd = newStart + nextSpan;
+      if (lastTs && newEnd >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
+        coord.setViewport(null);
+        coord.setLiveSpanMs(nextSpan);
+        if (coord.state.paused) coord.setPaused(false);
+        return;
+      }
+      if (!coord.state.paused) coord.setPaused(true);
+      coord.setViewport({ min: newStart, max: newEnd });
     },
     { capture: true, passive: false },
   );
 }
 
 const expandedClass = computed(() => (coord.state.expanded ? 'expanded' : ''));
-const pauseLabel = computed(() => (coord.state.paused ? '▶ Live' : '⏸ Pause'));
-const zoomActive = computed(() => coord.state.viewport !== null || userInteracted);
+// Live toggle is "checked" when we're currently following live —
+// i.e. no sticky viewport. Reacts to all transitions (click, brush
+// drag, pan, zoom-snap-to-live) because every reader binds against
+// the shared `coord.state.viewport`.
+const liveChecked = computed(() => coord.state.viewport === null);
+
+/** Always togglePause — both directions preserve liveSpanMs.
+ *  See MetricsLineChart.onLiveToggleClick for rationale. */
+function onLiveToggleClick() {
+  userInteracted = false;
+  coord.togglePause();
+}
+
+/**
+ * "Selected event" cursor — synchronized vertical marker matching
+ * the line charts. vis-timeline ships an addCustomTime/setCustomTime
+ * API that draws a labelled vertical line; we add it once and
+ * shuffle position via setCustomTime, removing only when the cursor
+ * is cleared so the timeline doesn't accumulate stray markers across
+ * scope changes.
+ */
+const NAV_CURSOR_ID = 'nav-cursor';
+let navCursorAdded = false;
+watch(
+  () => coord.state.cursorMs,
+  async (ms) => {
+    await ensureTimeline();
+    if (!timeline) return;
+    if (ms == null || !Number.isFinite(ms)) {
+      if (navCursorAdded) {
+        try { timeline.removeCustomTime(NAV_CURSOR_ID); } catch { /* ignore */ }
+        navCursorAdded = false;
+      }
+      return;
+    }
+    if (!navCursorAdded) {
+      try {
+        timeline.addCustomTime(new Date(ms), NAV_CURSOR_ID);
+        navCursorAdded = true;
+      } catch { /* ignore */ }
+    } else {
+      try { timeline.setCustomTime(new Date(ms), NAV_CURSOR_ID); } catch { /* ignore */ }
+    }
+  },
+  { immediate: true },
+);
 
 onBeforeUnmount(() => {
   try { timeline?.destroy(); } catch { /* ignore */ }
@@ -678,25 +894,30 @@ onBeforeUnmount(() => {
     <div class="bar">
       <div class="title">Events</div>
       <div class="actions">
-        <button class="btn btn-expand" type="button" :class="{ active: coord.state.expanded }"
-          @click="coord.toggleExpanded()"
-          :title="coord.state.expanded ? 'Restore default chart height' : 'Double this chart\'s height for a closer look'">
-          <span class="chart-expand-icon">⤢</span>
-          {{ coord.state.expanded ? 'Collapse' : 'Expand' }}
-        </button>
-        <button class="btn" type="button" :class="{ active: zoomActive }"
-          @click="coord.resetZoom(); userInteracted = false" title="Snap back to live edge">
-          Reset Zoom
-        </button>
-        <button class="btn" type="button" :class="{ live: coord.state.paused }"
-          @click="coord.togglePause()">
-          {{ pauseLabel }}
+        <!-- No expand/collapse: swim-lane heights are content-defined
+             so doubling the chart height just adds empty space below
+             the lanes. The line charts (bandwidth/RTT/buffer/FPS)
+             get the toggle because their y-axes have meaningful
+             vertical scale. -->
+        <button
+          type="button"
+          class="btn live-toggle"
+          :class="{ checked: liveChecked }"
+          @click="coord.togglePause(); userInteracted = false"
+          :title="liveChecked ? 'Pause at current live edge' : 'Resume following live (drops zoom and pan)'"
+        >
+          {{ liveChecked ? '●' : '○' }} Live
         </button>
         <span class="hint">Alt+scroll · drag pan</span>
       </div>
     </div>
 
-    <!-- Static legend strip — every section's colour key. -->
+    <div class="strip-wrap" :class="expandedClass">
+      <div ref="container" class="strip" />
+    </div>
+
+    <!-- Colour key — placed BELOW the chart so the eye reads the
+         swim lanes first and consults the legend only as needed. -->
     <div class="legend">
       <span class="key"><span class="sw" style="background:#16a34a"/>Playing</span>
       <span class="key"><span class="sw" style="background:#f59e0b"/>Buffering</span>
@@ -708,11 +929,6 @@ onBeforeUnmount(() => {
       <span class="key"><span class="sw" style="background:#e11d48"/>Error</span>
       <span class="key"><span class="sw" style="background:#7c3aed"/>Control</span>
       <span class="key"><span class="sw" style="background:#84cc16"/>Loop</span>
-    </div>
-
-    <div class="strip-wrap" :class="expandedClass">
-      <div ref="container" class="strip" />
-      <div v-if="coord.state.paused" class="paused-badge">PAUSED</div>
     </div>
   </div>
 </template>
@@ -744,8 +960,21 @@ onBeforeUnmount(() => {
 }
 .btn:hover { background: #e5e7eb; }
 .btn.active { background: #e0e7ff; border-color: #818cf8; color: #312e81; }
-.btn.live { background: #10b981; border-color: #059669; color: white; }
-.btn.live:hover { background: #059669; }
+/* Live toggle: filled green when checked (following live), muted/
+ * outlined when unchecked (pinned). Mirrors MetricsLineChart. */
+.btn.live-toggle.checked {
+  background: #10b981;
+  border-color: #059669;
+  color: white;
+  font-weight: 600;
+}
+.btn.live-toggle.checked:hover { background: #059669; }
+.btn.live-toggle:not(.checked) {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #6b7280;
+}
+.btn.live-toggle:not(.checked):hover { background: #e5e7eb; color: #374151; }
 .hint { font-size: 10px; color: #9ca3af; }
 
 .legend {
@@ -789,20 +1018,30 @@ onBeforeUnmount(() => {
   border-radius: 4px;
   min-height: inherit;
 }
-.paused-badge {
-  position: absolute;
-  top: 4px;
-  /* `right: 6px` would place it past the reserved gutter — shift in
-   * by 60+6 so it sits inside the plot area instead. */
-  right: 66px;
-  background: rgba(31, 41, 55, 0.85);
-  color: #fde68a;
-  padding: 1px 6px;
-  border-radius: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 1px;
+/* "Selected event" custom-time line — full visual parity with the
+ * line-chart cursor: 1.5 px dashed blue line + a small filled
+ * triangle at the top. vis-timeline renders <div class="vis-custom-time">
+ * as a 1 px wide div spanning the full chart height; we hide its
+ * own background and use the left border to draw the dashed line.
+ * The down-arrow is a ::before pseudo-element absolute-positioned
+ * just above the chart area. */
+.events-timeline :deep(.vis-custom-time) {
+  background: transparent !important;
+  border-left: 1.5px dashed #1d4ed8 !important;
+  width: 0 !important;
   pointer-events: none;
+  z-index: 5;
+}
+.events-timeline :deep(.vis-custom-time::before) {
+  content: '';
+  position: absolute;
+  left: -5px;
+  top: 0;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid #1d4ed8;
 }
 
 /* vis-timeline label panel + labelset pinned to the SAME 60px width

--- a/content/dashboard-v3/src/components/FPSChart.vue
+++ b/content/dashboard-v3/src/components/FPSChart.vue
@@ -6,14 +6,23 @@
  * The frames_displayed counter is monotonically non-decreasing per
  * play; we keep the previous (count, time) pair and divide by elapsed
  * wall time. Resets to zero on a new play (counter goes down).
+ *
+ * Reads from the unified samples stream rather than usePlayer so the
+ * chart is fed by the same backfill+live source as every other chart;
+ * the per-row delta state below mirrors what the stream watcher inside
+ * MetricsLineChart does, but here it's exposed via a `__derived` field
+ * the synthetic PlayerRecord adapter passes through.
  */
-import { computed, ref, toRef, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
-import { usePlayer } from '@/composables/usePlayer';
+import type { Stream } from '@/composables/useSessionTimeSeries';
+import { tsOfRow } from '@/composables/chRowAdapter';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
-const props = defineProps<{ playerId: string }>();
-const { player } = usePlayer(toRef(props, 'playerId'));
+const props = defineProps<{
+  playerId: string;
+  samplesStream: Stream<Record<string, unknown>>;
+}>();
 
 // per-instance state: previous frame counters + the derived rate to
 // surface to MetricsLineChart through the synthetic accessor below.
@@ -24,49 +33,66 @@ let prevFrames: number | null = null;
 let prevDropped: number | null = null;
 let prevTs: number | null = null;
 let prevPlayId: string | null = null;
+let lastSeenMs = -Infinity;
+
+function num(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') { const n = Number(v); return Number.isFinite(n) ? n : null; }
+  return null;
+}
 
 watch(
-  () => player.value,
-  (p) => {
-    if (!p) return;
-    const pm = p.player_metrics;
-    if (!pm) return;
-    const t = (() => {
-      if (pm.event_time) {
-        const v = Date.parse(pm.event_time);
-        if (Number.isFinite(v)) return v;
+  () => props.samplesStream.version.value,
+  () => {
+    const raw = props.samplesStream.inRange(
+      lastSeenMs === -Infinity ? 0 : lastSeenMs + 1,
+      Number.MAX_SAFE_INTEGER,
+    );
+    if (!raw.length) return;
+    for (const row of raw) {
+      const t = tsOfRow(row);
+      if (!Number.isFinite(t) || t <= lastSeenMs) continue;
+      lastSeenMs = t;
+      const fr = num(row.frames_displayed);
+      const dr = num(row.dropped_frames);
+      const playId = typeof row.play_id === 'string' ? row.play_id : null;
+      if (playId !== prevPlayId) {
+        prevPlayId = playId;
+        prevFrames = fr;
+        prevDropped = dr;
+        prevTs = t;
+        displayedFps.value = null;
+        droppedFps.value = null;
+        continue;
       }
-      if (p.last_seen_at) {
-        const v = Date.parse(p.last_seen_at);
-        if (Number.isFinite(v)) return v;
+      if (prevTs != null && prevFrames != null && fr != null && t > prevTs) {
+        const dt = (t - prevTs) / 1000;
+        displayedFps.value = dt > 0 ? Math.max(0, (fr - prevFrames) / dt) : null;
       }
-      return Date.now();
-    })();
-    const playId = p.current_play?.id ?? null;
-    if (playId !== prevPlayId) {
-      prevPlayId = playId;
-      prevFrames = pm.frames_displayed ?? null;
-      prevDropped = pm.dropped_frames ?? null;
+      if (prevTs != null && prevDropped != null && dr != null && t > prevTs) {
+        const dt = (t - prevTs) / 1000;
+        droppedFps.value = dt > 0 ? Math.max(0, (dr - prevDropped) / dt) : null;
+      }
+      prevFrames = fr;
+      prevDropped = dr;
       prevTs = t;
-      displayedFps.value = null;
-      droppedFps.value = null;
-      return;
     }
-    const fr = pm.frames_displayed ?? null;
-    const dr = pm.dropped_frames ?? null;
-    if (prevTs != null && prevFrames != null && fr != null && t > prevTs) {
-      const dt = (t - prevTs) / 1000;
-      displayedFps.value = dt > 0 ? Math.max(0, (fr - prevFrames) / dt) : null;
-    }
-    if (prevTs != null && prevDropped != null && dr != null && t > prevTs) {
-      const dt = (t - prevTs) / 1000;
-      droppedFps.value = dt > 0 ? Math.max(0, (dr - prevDropped) / dt) : null;
-    }
-    prevFrames = fr;
-    prevDropped = dr;
-    prevTs = t;
   },
   { immediate: true },
+);
+
+// Reset on player swap so the next play's counters don't get a
+// spurious huge delta against the previous player's last frame count.
+watch(
+  () => props.playerId,
+  () => {
+    prevFrames = prevDropped = prevTs = null;
+    prevPlayId = null;
+    lastSeenMs = -Infinity;
+    displayedFps.value = null;
+    droppedFps.value = null;
+  },
 );
 
 const series = computed<SeriesSpec[]>(() => [
@@ -88,6 +114,7 @@ const series = computed<SeriesSpec[]>(() => [
     axis: 'y2',
   },
 ]);
+
 </script>
 
 <template>
@@ -96,7 +123,7 @@ const series = computed<SeriesSpec[]>(() => [
     title="Frame rate (derived)"
     unit="fps"
     :series="series"
-    :window-seconds="180"
+    :samples-stream="samplesStream"
     :y-min="0"
     y2-title="dropped (count)"
     :y2-min="0"

--- a/content/dashboard-v3/src/components/FaultRules.vue
+++ b/content/dashboard-v3/src/components/FaultRules.vue
@@ -127,8 +127,13 @@ function patchSurface(surface: Exclude<Surface, 'transport'>, partial: Partial<F
     : ({
         id: 'v1-' + surface,
         type: (partial.type as FaultRule['type']) ?? 'none',
-        mode: (partial.mode as FaultRule['mode']) ?? 'requests',
-        consecutive: partial.consecutive ?? 1,
+        // Default mode = "every N seconds". Operators reach for the
+        // time-based cadence first ("inject a fault every 5 s") far
+        // more often than the request-counter mode, so make that the
+        // happy-path default everywhere. Matches transport's existing
+        // default below.
+        mode: (partial.mode as FaultRule['mode']) ?? 'failures_per_seconds',
+        consecutive: partial.consecutive ?? 0,
         frequency: partial.frequency ?? 0,
         filter: surface === 'all' ? undefined : { request_kind: [surface as any] },
         ...partial,
@@ -142,7 +147,7 @@ function patchTransport(partial: { type?: string; mode?: string; frequency?: num
     type: (partial.type ?? cur?.type ?? 'drop') as 'drop' | 'reject',
     mode: (partial.mode ?? cur?.mode ?? 'failures_per_seconds') as
       | 'failures_per_seconds' | 'failures_per_packets' | 'seconds' | 'requests',
-    consecutive: partial.consecutive ?? cur?.consecutive ?? 1,
+    consecutive: partial.consecutive ?? cur?.consecutive ?? 0,
     frequency: partial.frequency ?? cur?.frequency ?? 0,
   };
   setTransportFault(next);
@@ -182,8 +187,8 @@ function getFreq(surface: Surface): number {
 }
 function getCons(surface: Surface): number {
   if (localCons.value[surface] !== null) return localCons.value[surface]!;
-  if (surface === 'transport') return transportFault.value?.consecutive ?? 1;
-  return ruleFor(surface)?.consecutive ?? 1;
+  if (surface === 'transport') return transportFault.value?.consecutive ?? 0;
+  return ruleFor(surface)?.consecutive ?? 0;
 }
 function getType(surface: Surface): string {
   if (surface === 'transport') {
@@ -194,7 +199,10 @@ function getType(surface: Surface): string {
 }
 function getMode(surface: Surface): string {
   if (surface === 'transport') return transportFault.value?.mode ?? 'failures_per_seconds';
-  return ruleFor(surface)?.mode ?? 'requests';
+  // Same "every N seconds" default as patchSurface, so the dropdown
+  // matches the value we'd write if the operator nudges any other
+  // control on this surface.
+  return ruleFor(surface)?.mode ?? 'failures_per_seconds';
 }
 
 function onTypeChange(surface: Surface, e: Event) {

--- a/content/dashboard-v3/src/components/GroupBanner.vue
+++ b/content/dashboard-v3/src/components/GroupBanner.vue
@@ -15,22 +15,33 @@ import { computed, toRef } from 'vue';
 import { usePlayer } from '@/composables/usePlayer';
 import { useGroups } from '@/composables/useGroups';
 import { usePlayers } from '@/composables/usePlayers';
+import { deviceFromUA, groupNameFor } from '@/composables/useSessionLabels';
 import * as repo from '@/repo/v2-repo';
 
 const props = defineProps<{ playerId: string }>();
 const { player } = usePlayer(toRef(props, 'playerId'));
-const { groups, link, disband } = useGroups();
+const { groups, disband, updateMembers } = useGroups();
 const { players } = usePlayers();
 
-const groupId = computed<string | null>(() => {
-  const raw = (player.value as any)?.raw_session;
-  const gid = raw?.group_id;
-  return typeof gid === 'string' && gid.length ? gid : null;
+// Identify the active player's group via membership rather than by
+// matching raw_session.group_id against PlayerGroup.id. The server
+// derives `g.id` as a stable v5 UUID under a fixed namespace
+// (v2translate.StableGroupUUID), so g.id never equals the raw v1
+// group_id string — comparing them gave a null groupInfo and the
+// banner fell through to "(only you)" even when peers were present.
+const groupInfo = computed(() => {
+  return (
+    (groups.value ?? []).find((g) =>
+      Array.isArray(g.member_player_ids) && g.member_player_ids.includes(props.playerId),
+    ) ?? null
+  );
 });
 
-const groupInfo = computed(() => {
-  if (!groupId.value) return null;
-  return (groups.value ?? []).find((g) => g.id === groupId.value) ?? null;
+const groupId = computed<string | null>(() => {
+  // Surface the v2 PlayerGroup id (v5 derivation) for the "Ungroup"
+  // call + chip label. raw_session.group_id is the v1 tag; we don't
+  // need it directly now that membership drives groupInfo.
+  return groupInfo.value ? String(groupInfo.value.id) : null;
 });
 
 const memberNames = computed(() => {
@@ -39,31 +50,51 @@ const memberNames = computed(() => {
     .filter((id) => id !== props.playerId)
     .map((id) => {
       const p = (players.value ?? []).find((x) => x.id === id);
-      return p?.display_id ? `#${p.display_id}` : id.slice(0, 8);
+      if (!p) return id.slice(0, 8);
+      const num = p.display_id != null ? `#${p.display_id}` : id.slice(0, 8);
+      const device = deviceFromUA(p.user_agent ?? null);
+      return device ? `${num} ${device}` : num;
     });
 });
 
-const candidates = computed(() => {
-  return (players.value ?? [])
-    .filter((p) => p.id !== props.playerId)
-    .filter((p) => {
-      const raw = (p as any).raw_session;
-      const otherGid = raw?.group_id;
-      return !otherGid || otherGid === groupId.value;
-    });
+/** Group name shared with the pill badge in Testing.vue. */
+const groupName = computed<string>(() => {
+  if (!groupInfo.value) return '';
+  return groupNameFor(
+    {
+      id: String(groupInfo.value.id),
+      member_player_ids: groupInfo.value.member_player_ids,
+    },
+    players.value ?? [],
+  );
 });
 
-import { ref } from 'vue';
-const groupWith = ref<string>('');
+/** Member count drives the Leave vs Disband split.
+ *  - 2 members: only "Ungroup" makes sense (the surviving 1 is a
+ *    degenerate group, so leaving == disbanding).
+ *  - 3+ members: surface both Leave (only this session exits) and
+ *    Disband (drop the whole group). */
+const memberCount = computed<number>(
+  () => groupInfo.value?.member_player_ids?.length ?? 0,
+);
 
-function linkSelected() {
-  if (!groupWith.value) return;
-  link([props.playerId, groupWith.value]);
-  groupWith.value = '';
+function disbandGroup() {
+  if (groupId.value) disband(groupId.value);
 }
 
-function ungroup() {
-  if (groupId.value) disband(groupId.value);
+function leaveGroup() {
+  const g = groupInfo.value;
+  if (!g) return;
+  const rev = g.control_revision;
+  if (!rev) {
+    // No revision means the listGroups poll hasn't caught up to the
+    // most recent membership write; ask the user to retry rather
+    // than racing the PATCH without an If-Match.
+    window.alert('Group revision not yet known — try again in a moment.');
+    return;
+  }
+  const remaining = (g.member_player_ids ?? []).filter((id) => id !== props.playerId);
+  updateMembers(String(g.id), remaining, rev);
 }
 
 async function deleteSession() {
@@ -79,29 +110,31 @@ async function deleteSession() {
 </script>
 
 <template>
+  <!-- Group banner now exists only to surface grouped state + Delete
+       Session. Linking happens in the pill rail (Testing.vue's
+       Group(N) trigger), so the "Group with…" select form is gone. -->
   <div v-if="player" class="group-controls-row">
     <div class="row">
       <template v-if="groupId">
         <span class="banner grouped">
           🔗 Grouped with: <strong>{{ memberNames.join(', ') || '(only you)' }}</strong>
-          <span class="chip">{{ groupInfo?.label || groupId.slice(0, 8) }}</span>
+          <span class="chip">{{ groupName }}</span>
         </span>
-        <button type="button" class="btn btn-warn" @click="ungroup">Ungroup</button>
-      </template>
-      <template v-else>
-        <label class="link-form">
-          Group with
-          <select v-model="groupWith">
-            <option value="">— select session —</option>
-            <option v-for="p in candidates" :key="p.id" :value="p.id">
-              #{{ p.display_id }} {{ p.player_ip || p.origination_ip || '' }}
-            </option>
-          </select>
-        </label>
-        <button type="button" class="btn btn-primary" :disabled="!groupWith" @click="linkSelected">
-          Group
+        <!-- "Ungroup" = this session leaves; "Delete Group" = drop the
+             whole group. With only 2 members, leaving leaves a
+             degenerate 1-member group, so we surface only "Delete
+             Group" in that case. -->
+        <button
+          v-if="memberCount >= 3"
+          type="button"
+          class="btn btn-secondary"
+          @click="leaveGroup"
+        >
+          Ungroup
         </button>
-        <span v-if="!candidates.length" class="hint">No other sessions available to group with.</span>
+        <button type="button" class="btn btn-warn" @click="disbandGroup">
+          Delete Group
+        </button>
       </template>
 
       <button type="button" class="btn btn-danger ml-auto" @click="deleteSession">
@@ -148,21 +181,6 @@ async function deleteSession() {
   font-weight: 500;
 }
 
-.link-form {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: #5f6368;
-}
-.link-form select {
-  background: #fff;
-  border: 1px solid #dadce0;
-  border-radius: 6px;
-  padding: 4px 8px;
-  font-size: 13px;
-  min-width: 220px;
-}
-
 .btn {
   background: #f1f3f4;
   border: 1px solid #dadce0;
@@ -175,13 +193,14 @@ async function deleteSession() {
 }
 .btn:hover { background: #e8eaed; }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-.btn-primary { background: #1a73e8; color: white; border-color: #1a73e8; }
-.btn-primary:hover { background: #1765cc; }
+/* "Ungroup" = neutral, this session leaves; visually muted so it
+ * doesn't read as destructive next to "Delete Group". */
+.btn-secondary { background: #e5e7eb; color: #1f2937; border-color: #d1d5db; font-size: 11px; padding: 4px 10px; }
+.btn-secondary:hover { background: #d1d5db; }
 .btn-warn { background: #ef4444; color: white; border-color: #ef4444; font-size: 11px; padding: 4px 10px; }
 .btn-warn:hover { background: #dc2626; }
 .btn-danger { background: #fee2e2; color: #991b1b; border-color: #fca5a5; }
 .btn-danger:hover { background: #fecaca; }
 
-.hint { color: #9aa0a6; font-size: 12px; font-style: italic; }
 .ml-auto { margin-left: auto; }
 </style>

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -3,7 +3,7 @@
  * MetricsLineChart.vue — streaming line chart with the same UX the
  * legacy session-shell.js charts had:
  *
- *   - Toolbar: Reset Zoom · Pause/Live · Expand · zoom hint
+ *   - Toolbar: Live toggle · Expand · zoom hint
  *   - Alt + wheel / drag = zoom (x-axis only)
  *   - Right-click drag = pan
  *   - Left click (no drag) = toggle pause
@@ -17,9 +17,10 @@
  * has data to show. The chart never holds more than ~2× window worth.
  */
 import { computed, onBeforeUnmount, ref, toRef, watch, type PropType } from 'vue';
-import { usePlayer } from '@/composables/usePlayer';
 import { ensureChartJs } from '@/composables/useChartJs';
 import { useChartCoordination, fmtTickHMSms, type ChartViewport } from '@/composables/useChartCoordination';
+import type { Stream } from '@/composables/useSessionTimeSeries';
+import { tsOfRow, chRowToPlayerRecord } from '@/composables/chRowAdapter';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 export type SeriesAccessor = (p: PlayerRecord) => number | null | undefined;
@@ -47,36 +48,45 @@ const props = defineProps({
   y2Title: { type: String, default: '' },
   y2Min: { type: Number, default: 0 },
   y2Max: { type: Number, default: undefined },
+  /** Samples stream from SessionDisplay's useSessionTimeSeries model.
+   *  Each row is one CH session_snapshots projection (charts_minimal
+   *  bundle); the chart adapts it to the synthetic PlayerRecord shape
+   *  the per-series accessors expect. */
+  samplesStream: { type: Object as PropType<Stream<Record<string, unknown>>>, required: true },
 });
 
 const canvas = ref<HTMLCanvasElement | null>(null);
 const wrap = ref<HTMLDivElement | null>(null);
 const canvasWrap = ref<HTMLDivElement | null>(null);
-const { player } = usePlayer(toRef(props, 'playerId'));
-const coord = useChartCoordination(props.playerId);
+const coord = useChartCoordination(toRef(props, 'playerId'));
 
 let chart: any = null;
-let lastSampleKey: string | null = null;
 let dataset: Array<Array<{ x: number; y: number }>> = [];
-let clickStartX = 0;
-let clickStartY = 0;
-let clickDragged = false;
+// Watermark of the latest CH row already pushed through the chart.
+// Read by the samples-stream watcher to drain only NEW rows on each
+// version bump (the cache holds the full backfill + live tail).
+let lastIngestedMs = -Infinity;
 
-function tsFor(p: PlayerRecord): number {
-  if (p.player_metrics?.event_time) {
-    const v = Date.parse(p.player_metrics.event_time);
-    if (Number.isFinite(v)) return v;
+/** Tolerance for "right edge is at the live sample" — matches the
+ *  brush-drop-at-live heuristic in SessionDisplay. */
+const LIVE_EDGE_TOLERANCE_MS = 2000;
+
+/** Pan- / zoom-complete handler: pin the new range as a sticky
+ *  viewport UNLESS the right edge has reached the live sample, in
+ *  which case return to live tracking — drop viewport, preserve the
+ *  span via liveSpanMs, stay unpaused. Mirrors the EventsTimeline
+ *  rangechanged path so chart / lane behave identically. */
+function applyViewportOrSnapToLive(min: number, max: number) {
+  const lastTs = coord.state.lastSampleMs;
+  if (lastTs && max >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
+    coord.setViewport(null);
+    coord.setLiveSpanMs(max - min);
+    if (coord.state.paused) coord.setPaused(false);
+    return;
   }
-  if (p.last_seen_at) {
-    const v = Date.parse(p.last_seen_at);
-    if (Number.isFinite(v)) return v;
-  }
-  return Date.now();
+  coord.setViewport({ min, max });
 }
 
-function sampleKey(p: PlayerRecord): string {
-  return `${p.control_revision}|${p.last_seen_at ?? ''}|${p.player_metrics?.event_time ?? ''}`;
-}
 
 /** Pick a "nice" tick interval based on the visible span. Snaps to
  *  one of the wall-clock-friendly steps so gridlines land on real
@@ -178,7 +188,11 @@ function createChartInstance(Chart: any): any {
         borderColor: s.color,
         backgroundColor: s.color + '22',
         data: dataset[i],
-        tension: s.stepped ? 0 : 0.25,
+        // Straight line segments between samples — no curve fitting.
+        // Stepped series (player state) keep tension 0 too. Smoothing
+        // implies measurements that weren't taken; for instrumentation
+        // data, straight-line is the truthful representation.
+        tension: 0,
         stepped: !!s.stepped,
         pointRadius: 0,
         borderWidth: 2,
@@ -186,6 +200,46 @@ function createChartInstance(Chart: any): any {
         yAxisID: s.axis === 'y2' ? 'y2' : 'y',
       })),
     },
+    /**
+     * Inline plugin: vertical "selected event" cursor.
+     * Reads `coord.state.cursorMs` (set from SessionViewer prev/next)
+     * and draws a single dashed line at that x-position so the
+     * operator can see exactly where the selected event lines up
+     * across every chart in the card. Drawn after the datasets so it
+     * sits on top of the lines, but below the tooltip/legend.
+     */
+    plugins: [{
+      id: 'navCursorLine',
+      afterDatasetsDraw(c: any) {
+        const ms = coord.state.cursorMs;
+        if (ms == null || !Number.isFinite(ms)) return;
+        const sx = c.scales?.x;
+        const sy = c.scales?.y;
+        if (!sx || !sy) return;
+        if (ms < sx.min || ms > sx.max) return;
+        const x = sx.getPixelForValue(ms);
+        const ctx = c.ctx;
+        ctx.save();
+        ctx.beginPath();
+        ctx.moveTo(x, sy.top);
+        ctx.lineTo(x, sy.bottom);
+        ctx.lineWidth = 1.5;
+        ctx.strokeStyle = '#1d4ed8';
+        ctx.setLineDash([4, 3]);
+        ctx.stroke();
+        // Tiny down-arrow at the top of the line so the eye finds
+        // the cursor immediately on dense charts.
+        ctx.beginPath();
+        ctx.setLineDash([]);
+        ctx.moveTo(x - 4, sy.top);
+        ctx.lineTo(x + 4, sy.top);
+        ctx.lineTo(x, sy.top + 5);
+        ctx.closePath();
+        ctx.fillStyle = '#1d4ed8';
+        ctx.fill();
+        ctx.restore();
+      },
+    }],
     options: {
       responsive: true,
       maintainAspectRatio: false,
@@ -261,17 +315,32 @@ function createChartInstance(Chart: any): any {
             mode: 'x',
             threshold: 2,
             modifierKey: undefined,
-            onPanStart: () => {
+            onPanStart: ({ chart: c }: any) => {
+              // Pre-seed coord.viewport with the chart's CURRENT visible
+              // range before setPaused fires. setPaused → snapshotLive‑
+              // Viewport would otherwise overwrite viewport with
+              // `[lastSample − liveSpanMs, lastSample]` (the live‑edge
+              // window), flashing the chart back to live mid‑pan. The
+              // snapshot helper now skips when a viewport already
+              // exists, so seeding it here is enough.
+              const sx = c?.scales?.x;
+              if (sx && Number.isFinite(sx.min) && Number.isFinite(sx.max)) {
+                coord.setViewport({ min: sx.min, max: sx.max });
+              }
               if (!coord.state.paused) coord.setPaused(true);
             },
             onPanComplete: ({ chart: c }: any) => {
               const sx = c.scales?.x;
               if (!sx) return;
-              coord.setViewport({ min: sx.min, max: sx.max });
+              applyViewportOrSnapToLive(sx.min, sx.max);
             },
           },
           zoom: {
-            wheel: { enabled: true, modifierKey: 'alt' },
+            // Wheel disabled here — `installLiveWheelAnchor` handles
+            // Alt+wheel itself with a unified mouse-anchored math
+            // shared across the player state lane and focus bar so
+            // direction + speed are identical across all three.
+            wheel: { enabled: false },
             drag: {
               enabled: true,
               modifierKey: 'alt',
@@ -289,7 +358,7 @@ function createChartInstance(Chart: any): any {
             onZoomComplete: ({ chart: c }: any) => {
               const sx = c.scales?.x;
               if (!sx) return;
-              coord.setViewport({ min: sx.min, max: sx.max });
+              applyViewportOrSnapToLive(sx.min, sx.max);
             },
           },
         },
@@ -344,7 +413,6 @@ function createChartInstance(Chart: any): any {
   // panes from a left-button drag. We swap the underlying pointerdown
   // event so right-drag triggers pan and suppresses contextmenu.
   installRightDragPan();
-  installClickPause();
   installLiveWheelAnchor();
   installContextMenuSuppress();
   return chart;
@@ -354,66 +422,6 @@ function installContextMenuSuppress() {
   const c = canvas.value;
   if (!c) return;
   c.addEventListener('contextmenu', (e) => e.preventDefault());
-}
-
-function installClickPause() {
-  // Bind on the WRAPPER, not the canvas. The legend area is drawn on
-  // the canvas by Chart.js, but the zoom plugin attaches its own
-  // listeners directly on the canvas element and can swallow the click
-  // before our handler runs. The wrapper sits one level up so the
-  // event always bubbles to us.
-  const el = canvasWrap.value;
-  if (!el) return;
-
-  /** Is `(clientX,clientY)` inside the Chart.js legend hit-box? Chart
-   *  v4 exposes `chart.legend.{top,bottom,left,right}` in canvas-local
-   *  pixel coordinates. We translate the click into the same space and
-   *  test the rectangle. Clicking legend items toggles series
-   *  visibility (Chart.js handles that internally); we must NOT also
-   *  toggle pause when the user is just hiding a line. */
-  function pointInLegend(clientX: number, clientY: number): boolean {
-    const c = canvas.value;
-    if (!c || !chart?.legend) return false;
-    const r = c.getBoundingClientRect();
-    // Translate to CSS-pixel canvas coords. Chart.js uses devicePixelRatio
-    // internally; legend.{top,…} is reported in CSS pixels matching the
-    // bounding rect, no extra scaling needed.
-    const x = clientX - r.left;
-    const y = clientY - r.top;
-    const l = chart.legend;
-    return (
-      typeof l.top === 'number' &&
-      typeof l.bottom === 'number' &&
-      typeof l.left === 'number' &&
-      typeof l.right === 'number' &&
-      x >= l.left && x <= l.right && y >= l.top && y <= l.bottom
-    );
-  }
-
-  // Same heuristic for the chart title / panel toolbar widgets that
-  // sit ABOVE the plot area. Currently we only have the legend below
-  // the chart, so just the legend check is needed.
-
-  el.addEventListener('mousedown', (e) => {
-    if (e.button !== 0) return;
-    clickStartX = e.clientX;
-    clickStartY = e.clientY;
-    clickDragged = false;
-  });
-  el.addEventListener('mousemove', (e) => {
-    if (e.buttons === 0) return;
-    if (Math.abs(e.clientX - clickStartX) > 3 || Math.abs(e.clientY - clickStartY) > 3) {
-      clickDragged = true;
-    }
-  });
-  el.addEventListener('click', (e) => {
-    if (e.altKey) return;
-    if (clickDragged) return;
-    // Don't toggle pause when the user is interacting with the Chart.js
-    // legend (show/hide a series) or the chart's toolbar/title area.
-    if (pointInLegend(e.clientX, e.clientY)) return;
-    coord.togglePause();
-  });
 }
 
 let dragState: { startX: number; startMin: number; startMax: number } | null = null;
@@ -464,32 +472,83 @@ function installLiveWheelAnchor() {
     'wheel',
     (e: WheelEvent) => {
       if (!e.altKey) return;
-      if (coord.state.paused) return; // plugin handles mouse-anchored zoom
       e.preventDefault();
       e.stopPropagation();
       const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
-      const windowMs = coord.state.windowMs;
-      const currentSpan =
-        coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
       const MIN_SPAN_MS = 1_000;
-      const nextSpan = Math.max(
-        MIN_SPAN_MS,
-        Math.min(windowMs, currentSpan * factor),
-      );
-      // Clearing the override (back to full window) when we'd otherwise
-      // pin at windowMs lets future "no override" callers (e.g. reset)
-      // observe a clean state.
-      coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+      const MAX_SPAN_MS = 24 * 3600 * 1000;
+      const vp = coord.state.viewport;
+
+      // LIVE — left-edge-only via liveSpanMs.
+      if (vp == null) {
+        const windowMs = coord.state.windowMs;
+        const currentSpan = coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
+        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
+        coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+        return;
+      }
+
+      // OFF-LIVE — mouse-anchored zoom on the chartArea. Pin to
+      // viewport, snap back to live if the new right edge reaches
+      // the live sample.
+      const currentSpan = vp.max - vp.min;
+      const nextSpan = Math.max(MIN_SPAN_MS, Math.min(MAX_SPAN_MS, currentSpan * factor));
+      const chartArea = chart?.chartArea;
+      let frac = 0.5;
+      if (chartArea && chartArea.right > chartArea.left) {
+        const rect = c.getBoundingClientRect();
+        const xInArea = e.clientX - rect.left - chartArea.left;
+        const widthPx = chartArea.right - chartArea.left;
+        frac = Math.max(0, Math.min(1, xInArea / widthPx));
+      }
+      const anchorTime = vp.min + frac * currentSpan;
+      const newStart = anchorTime - frac * nextSpan;
+      const newEnd = newStart + nextSpan;
+      applyViewportOrSnapToLive(newStart, newEnd);
     },
     { capture: true, passive: false },
   );
 }
 
-function pushSample(p: PlayerRecord) {
+/** Binary-insert a {x,y} point into `data` so the array stays sorted
+ *  ascending by x. Mirrors legacy session-shell.js `insertByTsAsc` —
+ *  needed because samples can arrive out of order in two scenarios:
+ *
+ *    1. v3 session-viewer's bulk replay fires N async watcher
+ *       callbacks that resolve concurrently — without sorting the
+ *       line zigzags ("scribble") even though the source data is in
+ *       order
+ *    2. Live mode with SSE jitter where a delayed metrics frame
+ *       arrives after a fresher one
+ *
+ *  Duplicate x values overwrite — last write wins for that timestamp.
+ *  O(log n) lookup + O(n) shift; chart pushSample is dominated by
+ *  Chart.js update() cost anyway. */
+function insertByX(data: { x: number; y: number }[], point: { x: number; y: number }) {
+  if (!data.length || point.x >= data[data.length - 1].x) {
+    if (data.length && data[data.length - 1].x === point.x) {
+      data[data.length - 1] = point;
+    } else {
+      data.push(point);
+    }
+    return;
+  }
+  let lo = 0; let hi = data.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (data[mid].x < point.x) lo = mid + 1; else hi = mid;
+  }
+  if (lo < data.length && data[lo].x === point.x) {
+    data[lo] = point;
+  } else {
+    data.splice(lo, 0, point);
+  }
+}
+
+
+function pushSample(p: PlayerRecord, x: number) {
   if (!chart || !chart.data?.datasets) return;
-  const x = tsFor(p);
   coord.noteSample(x);
-  const cutoff = x - coord.state.windowMs * 2;
   let mutated = false;
   for (let i = 0; i < props.series.length; i++) {
     const s = props.series[i];
@@ -498,10 +557,16 @@ function pushSample(p: PlayerRecord) {
     if (y == null || !Number.isFinite(y)) continue;
     const data = dataset[i];
     if (!data) continue;
-    data.push({ x, y: Number(y) });
-    while (data.length && data[0].x < cutoff) data.shift();
+    insertByX(data, { x, y: Number(y) });
     mutated = true;
   }
+  // Retention is the time-series cache's job (SOFT_CAP_SAMPLES) —
+  // the chart used to trim at `x - windowMs * 2` to bound memory,
+  // but `windowMs` is the *visible* window, not retention. When the
+  // operator zooms in (focusSpan shrinks → setWindowMs shrinks) the
+  // trim was killing older points the PLAYERSTATE lane still had,
+  // producing a chart-vs-lane time-axis mismatch. Chart.js with
+  // `animation: false` handles tens of thousands of points fine.
   if (mutated) {
     if (!coord.state.paused && !coord.state.viewport) {
       applyViewport({ min: x - coord.state.windowMs, max: x });
@@ -515,26 +580,143 @@ function pushSample(p: PlayerRecord) {
 // and can leave Chart.js in a half-applied state. The chart will
 // catch up on the next reactive tick anyway, so swallowing transient
 // failures is safe.
+//
+// Updates are coalesced to a max of one per second via setTimeout.
+// Two reasons setTimeout beats requestAnimationFrame here:
+//   1. requestAnimationFrame is throttled / paused when the tab is
+//      backgrounded — during a bulk archive replay the rAF callback
+//      can hold off indefinitely, and the queued chart.update never
+//      fires, so the canvas stays blank
+//   2. Even at 60 Hz, the session-viewer bulk replay (17k+ snapshots
+//      pushed through one watcher each) needs only "the chart catches
+//      up periodically so the operator sees progress"; 60× per second
+//      is wasted work, 1× per second is plenty
+// Live (testing-session) mode also benefits — at 1 Hz the cadence
+// matches the server's metrics emit rate, so no work is wasted re-
+// rendering a chart that hasn't changed.
+/** Adaptive update throttle. Chart.js's render cost grows roughly
+ *  linearly with `totalPoints × series`, so a fixed 1 s cadence
+ *  becomes the dominant cost once the chart has thousands of points
+ *  (a 2 h archive replay can sit at ~30 k points across all series).
+ *  Tier the throttle to keep redraws bounded while live mode stays
+ *  responsive at the metrics emit cadence:
+ *
+ *     <   500 pts → 1 s   (live testing-session, fresh)
+ *     <  5000 pts → 2 s   (live after ~30 minutes)
+ *     <  20000 pts → 5 s  (archive replay or very long live)
+ *     >= 20000 pts → 10 s (very long archive)
+ *
+ *  Picked from observed paint times on test-dev: a 30k-point chart
+ *  takes ~80 ms per update — at 1 Hz that's 8 % CPU just for one
+ *  chart, with 4 charts on the page that's already 32 %. 10 s drops
+ *  that to ~3 % even for the worst case. */
+let pendingUpdateTimer: number | null = null;
+let lastUpdateAt = 0;
+function pickThrottleMs(): number {
+  const n = (chart?.data?.datasets ?? []).reduce(
+    (acc: number, d: any) => acc + (Array.isArray(d?.data) ? d.data.length : 0), 0);
+  if (n >= 20_000) return 10_000;
+  if (n >= 5_000) return 5_000;
+  if (n >= 500) return 2_000;
+  return 1_000;
+}
 function safeChartUpdate() {
   if (!chart) return;
-  try { chart.update('none'); } catch (err) { console.warn('chart update skipped:', err); }
+  if (pendingUpdateTimer != null) return;
+  const now = Date.now();
+  const throttleMs = pickThrottleMs();
+  const dueAt = lastUpdateAt + throttleMs;
+  const delay = Math.max(0, dueAt - now);
+  pendingUpdateTimer = window.setTimeout(() => {
+    pendingUpdateTimer = null;
+    lastUpdateAt = Date.now();
+    if (!chart) return;
+    try { chart.update('none'); } catch (err) { console.warn('chart update skipped:', err); }
+  }, delay);
+}
+
+/* ─── Samples-stream consumer ──────────────────────────────────────
+ *
+ * Single feed: drain new CH rows from the time-series cache on every
+ * version bump. `lastIngestedMs` is the watermark — only NEW rows
+ * (ts > watermark) get pushed. Backfill burst lands in one drain
+ * pass; live tail is one extra row per flush.
+ *
+ * Pause buffer: while paused, queued rows hold in `pendingLive` so
+ * the chart's trim cutoff (`pushSample` removes points older than
+ * `x - windowMs * 2`) can't advance and silently drop pre-pause
+ * archive history off the left edge.
+ */
+const pendingLive: { p: PlayerRecord; x: number }[] = [];
+let drainToken = 0;
+
+async function drainNewRows() {
+  if (!chart) {
+    try { await ensure(); }
+    catch (err) { console.warn('chart ensure failed:', err); return; }
+  }
+  if (!chart) return;
+  const raw = props.samplesStream.inRange(
+    lastIngestedMs === -Infinity ? 0 : lastIngestedMs + 1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (!raw.length) return;
+  const myToken = ++drainToken;
+  // Chunked iteration with main-thread yields keeps brush + scroll
+  // responsive when the initial backfill hits (5–10 k rows).
+  const CHUNK = 500;
+  let highWater = lastIngestedMs;
+  for (let start = 0; start < raw.length; start += CHUNK) {
+    if (myToken !== drainToken) return;
+    const end = Math.min(start + CHUNK, raw.length);
+    for (let i = start; i < end; i++) {
+      const row = raw[i];
+      const x = tsOfRow(row);
+      if (!Number.isFinite(x)) continue;
+      if (x <= lastIngestedMs) continue; // belt-and-suspenders
+      const p = chRowToPlayerRecord(row);
+      if (coord.state.paused) {
+        pendingLive.push({ p, x });
+      } else {
+        pushSample(p, x);
+      }
+      if (x > highWater) highWater = x;
+    }
+    if (end < raw.length) {
+      await new Promise<void>((r) => setTimeout(r, 0));
+    }
+  }
+  lastIngestedMs = highWater;
 }
 
 watch(
-  () => player.value,
-  async (p) => {
-    if (!p) return;
-    const k = sampleKey(p);
-    if (k === lastSampleKey) return;
-    lastSampleKey = k;
-    try {
-      await ensure();
-      pushSample(p);
-    } catch (err) {
-      console.warn('chart sample push failed:', err);
-    }
+  () => props.samplesStream.version.value,
+  () => { void drainNewRows(); },
+  { immediate: true },
+);
+
+// Resume drain — flush any samples that arrived during pause in
+// chronological order, so the chart catches up to the live edge in
+// one pass. insertByX dedupes by x so re-runs stay safe.
+watch(
+  () => coord.state.paused,
+  (paused) => {
+    if (paused || !pendingLive.length) return;
+    const drained = pendingLive.splice(0, pendingLive.length);
+    for (const { p, x } of drained) pushSample(p, x);
   },
-  { immediate: true, deep: false },
+);
+
+// Player swap — reset all per-player state so a picker swap clears
+// the old chart instead of accumulating both.
+watch(
+  () => props.playerId,
+  () => {
+    pendingLive.length = 0;
+    lastIngestedMs = -Infinity;
+    for (const arr of dataset) arr.length = 0;
+    safeChartUpdate();
+  },
 );
 
 // React to coordinated state changes (other charts in the same session
@@ -548,7 +730,13 @@ watch(
     } catch (err) {
       console.warn('chart viewport apply skipped:', err);
     }
-    safeChartUpdate();
+    // Viewport / pause changes are axis-only updates — render
+    // directly so brush drag feels as smooth as the vis-timeline
+    // events panel. safeChartUpdate's adaptive throttle exists for
+    // data-arrival churn (pushSample / drainNewRows insert many
+    // points per second); applying it here would delay pan response
+    // up to several seconds when a dataset has thousands of points.
+    try { chart.update('none'); } catch (err) { console.warn('chart pan render skipped:', err); }
   },
 );
 
@@ -561,23 +749,47 @@ watch(
   },
 );
 
+
 // Per-chart-instance expand toggle. The legacy let the operator double
 // a single chart's vertical resolution without disturbing the others,
 // so they could eyeball a specific signal closely. Local ref, not
 // shared via `coord` — each of bandwidth / RTT / buffer / FPS toggles
-// independently.
-const expandedLocal = ref(false);
+// independently. Persisted to localStorage under a per-title key so
+// the operator's chosen tall layout survives reloads.
+const EXPAND_STORAGE_PREFIX = 'dashboard_v3_chart_expand_';
+function expandStorageKey() {
+  return EXPAND_STORAGE_PREFIX + String(props.title || 'chart').toLowerCase().replace(/\s+/g, '-');
+}
+function readExpandStored(): boolean {
+  try { return localStorage.getItem(expandStorageKey()) === 'true'; } catch { return false; }
+}
+function writeExpandStored(v: boolean) {
+  try { localStorage.setItem(expandStorageKey(), v ? 'true' : 'false'); } catch { /* ignore */ }
+}
+const expandedLocal = ref<boolean>(readExpandStored());
 const expandedClass = computed(() => (expandedLocal.value ? 'expanded' : ''));
 function toggleExpand() {
   expandedLocal.value = !expandedLocal.value;
+  writeExpandStored(expandedLocal.value);
   // Chart.js with maintainAspectRatio:false honours the new container
   // height via its ResizeObserver. The 150ms CSS transition can race
   // the observer's settled-callback though, so call resize() after the
   // transition completes to make sure the plot fills the new box.
   setTimeout(() => { try { chart?.resize(); } catch { /* ignore */ } }, 200);
 }
-const pauseLabel = computed(() => (coord.state.paused ? '▶ Live' : '⏸ Pause'));
-const zoomActive = computed(() => coord.state.viewport !== null);
+// Live toggle is "checked" when we're currently following live —
+// i.e. no sticky viewport. Reactive across all charts because every
+// MetricsLineChart instance reads from the shared `coord.state`.
+const liveChecked = computed(() => coord.state.viewport === null);
+
+/** Click handler — always togglePause. Both directions preserve the
+ *  current `liveSpanMs` so going PINNED → LIVE doesn't reset the zoom
+ *  span the user dialed in. (The earlier asymmetric "go to default
+ *  span on the way back" was rejected — kept ripping the focus bar
+ *  away from the zoom the user picked.) */
+function onLiveToggleClick() {
+  coord.togglePause();
+}
 
 onBeforeUnmount(() => {
   try { chart?.destroy(); } catch { /* ignore */ }
@@ -602,30 +814,20 @@ onBeforeUnmount(() => {
         </button>
         <button
           type="button"
-          class="btn"
-          :class="{ active: zoomActive }"
-          @click="coord.resetZoom()"
-          title="Snap back to live edge and clear any zoom"
+          class="btn live-toggle"
+          :class="{ checked: liveChecked }"
+          @click="onLiveToggleClick"
+          :title="liveChecked ? 'Pause at current live edge' : 'Resume following live (drops zoom and pan)'"
         >
-          Reset Zoom
-        </button>
-        <button
-          type="button"
-          class="btn"
-          :class="{ live: coord.state.paused }"
-          @click="coord.togglePause()"
-          title="Freeze the chart at the current view"
-        >
-          {{ pauseLabel }}
+          {{ liveChecked ? '●' : '○' }} Live
         </button>
         <span class="hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">
-          Alt/⌥+scroll/drag · right-drag pan · click pause
+          Alt/⌥+scroll/drag · right-drag pan
         </span>
       </div>
     </div>
     <div ref="canvasWrap" class="canvas-wrap" :class="expandedClass">
       <canvas ref="canvas" />
-      <div v-if="coord.state.paused" class="paused-badge">PAUSED</div>
     </div>
   </div>
 </template>
@@ -670,12 +872,22 @@ onBeforeUnmount(() => {
   border-color: #818cf8;
   color: #312e81;
 }
-.btn.live {
+/* Live toggle: filled green when checked (following live), muted/
+ * outlined when unchecked (pinned). The hollow vs filled dot in the
+ * label reinforces the state at a glance. */
+.btn.live-toggle.checked {
   background: #10b981;
   border-color: #059669;
   color: white;
+  font-weight: 600;
 }
-.btn.live:hover { background: #059669; }
+.btn.live-toggle.checked:hover { background: #059669; }
+.btn.live-toggle:not(.checked) {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #6b7280;
+}
+.btn.live-toggle:not(.checked):hover { background: #e5e7eb; color: #374151; }
 
 .hint {
   font-size: 10px;
@@ -700,18 +912,4 @@ onBeforeUnmount(() => {
   color: #ffffff;
 }
 .btn-expand.active:hover { background: #1d4ed8; }
-
-.paused-badge {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: rgba(31, 41, 55, 0.85);
-  color: #fde68a;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 1px;
-  pointer-events: none;
-}
 </style>

--- a/content/dashboard-v3/src/components/NetworkLog.vue
+++ b/content/dashboard-v3/src/components/NetworkLog.vue
@@ -15,16 +15,82 @@
  *
  * Polled at 2 Hz; SSE-driven feed lands in a follow-up.
  */
-import { computed, nextTick, ref, toRef, watch } from 'vue';
-import { useQuery } from '@tanstack/vue-query';
-import * as repo from '@/repo/v2-repo';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue';
 import type { NetworkLogEntry } from '@/repo/v2-repo';
 import { usePlayer } from '@/composables/usePlayer';
-import NetworkLogBrush, { type BrushTick } from './NetworkLogBrush.vue';
+import { useChartCoordination } from '@/composables/useChartCoordination';
+import type { Stream } from '@/composables/useSessionTimeSeries';
 
-const props = defineProps<{ playerId: string }>();
+const props = defineProps<{
+  playerId: string;
+  /** Network stream from the parent SessionDisplay's
+   *  useSessionTimeSeries model. Supplies every per-request row for
+   *  this (player, play), server-filtered to the current play_id,
+   *  with the ring + CH boundary already deduplicated. */
+  networkStream: Stream<Record<string, unknown>>;
+}>();
 const playerIdRef = toRef(props, 'playerId');
 const { sseState } = usePlayer(playerIdRef);
+const coord = useChartCoordination(playerIdRef);
+
+/** Rows to highlight for the synchronized "selected event" cursor.
+ *
+ *  Three-tier fallback so SOMETHING always lights up when a cursor
+ *  is set, since events rarely line up with a request's lifetime
+ *  (player-side stalls, downshifts, etc. happen between requests):
+ *
+ *    1. Containing requests — any rows whose [ts, ts+duration]
+ *       interval includes the cursor time. Multiple can match
+ *       (overlapping partial-segment fetches); highlight all.
+ *    2. Predecessor — the most recent request that started at or
+ *       before the cursor. Maps "where in the request stream did
+ *       this event happen?" to the obvious answer "right after this
+ *       last request started."
+ *    3. Successor — first row after the cursor, only when the
+ *       cursor sits before any logged request (e.g. cursor at
+ *       session start before traffic began).
+ */
+const currentRowKeys = computed<Set<string>>(() => {
+  const ms = coord.state.cursorMs;
+  const out = new Set<string>();
+  if (ms == null || !Number.isFinite(ms)) return out;
+  const arr = allRows.value;
+  if (!arr.length) return out;
+
+  let foundContaining = false;
+  for (const r of arr) {
+    if (r.ts <= ms && ms <= r.ts + Math.max(1, r.duration)) {
+      out.add(rowKey(r));
+      foundContaining = true;
+    }
+  }
+  if (foundContaining) return out;
+
+  // Predecessor — largest ts ≤ cursorMs. allRows isn't guaranteed
+  // sorted by ts (depends on the forwarder's ORDER BY), so scan.
+  let bestPred: typeof arr[number] | null = null;
+  let bestPredTs = -Infinity;
+  let bestSucc: typeof arr[number] | null = null;
+  let bestSuccTs = Infinity;
+  for (const r of arr) {
+    if (r.ts <= ms) {
+      if (r.ts > bestPredTs) { bestPredTs = r.ts; bestPred = r; }
+    } else {
+      if (r.ts < bestSuccTs) { bestSuccTs = r.ts; bestSucc = r; }
+    }
+  }
+  if (bestPred) out.add(rowKey(bestPred));
+  else if (bestSucc) out.add(rowKey(bestSucc));
+  return out;
+});
+function rowKey(r: { ts: number; entry: NetworkLogEntry }): string {
+  // Same join key as the v-for :key so the class application lines up
+  // with the rendered row. URL alone isn't unique (retries), so we
+  // pair with ts. (sortedRows :key is the array index, but mapping by
+  // index requires the computed to know the current sort order — far
+  // simpler to key by ts+url and check Set.has() in the template.)
+  return r.ts + '|' + (r.entry.url ?? r.entry.path ?? '');
+}
 
 type SortCol = 'time' | 'method' | 'path' | 'bytes' | 'mbps' | 'duration' | 'status';
 type SortDir = 'asc' | 'desc';
@@ -41,48 +107,46 @@ const paused = ref(false);
 
 const rowsScrollRef = ref<HTMLDivElement | null>(null);
 
-const brushStartMs = ref<number | null>(null);
-const brushEndMs = ref<number | null>(null);
-function onBrushChange(v: { startMs: number; endMs: number } | null) {
-  if (v) {
-    brushStartMs.value = v.startMs;
-    brushEndMs.value = v.endMs;
-  } else {
-    brushStartMs.value = null;
-    brushEndMs.value = null;
-  }
+/** Adapt a raw row from the v3 /api/v3/timeseries stream (CH row
+ *  shape — `ts` string in CH format, Int64 fields as JSON strings,
+ *  `faulted` as 0/1) to the NetworkLogEntry shape the renderer
+ *  expects. The wire shape is intentionally kept close to CH's
+ *  storage; the dashboard does the conversion once on read. */
+function chRowToEntry(raw: Record<string, unknown>): NetworkLogEntry {
+  const tsRaw = raw.ts as string | undefined;
+  const timestamp = tsRaw && tsRaw.length > 10 && tsRaw.charAt(10) === ' '
+    ? tsRaw.replace(' ', 'T') + 'Z'
+    : (tsRaw ?? '');
+  const toNum = (v: unknown): number => {
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') return Number(v);
+    return 0;
+  };
+  return {
+    timestamp,
+    method: (raw.method as string) ?? '',
+    url: (raw.url as string) ?? '',
+    upstream_url: (raw.upstream_url as string) ?? '',
+    path: (raw.path as string) ?? '',
+    request_kind: (raw.request_kind as string) ?? '',
+    status: toNum(raw.status),
+    bytes_in: toNum(raw.bytes_in),
+    bytes_out: toNum(raw.bytes_out),
+    content_type: (raw.content_type as string) ?? '',
+    play_id: (raw.play_id as string) ?? '',
+    ttfb_ms: toNum(raw.ttfb_ms),
+    total_ms: toNum(raw.total_ms),
+    dns_ms: toNum(raw.dns_ms),
+    connect_ms: toNum(raw.connect_ms),
+    tls_ms: toNum(raw.tls_ms),
+    transfer_ms: toNum(raw.transfer_ms),
+    client_wait_ms: toNum(raw.client_wait_ms),
+    faulted: !!raw.faulted && raw.faulted !== 0,
+    fault_type: (raw.fault_type as string) ?? '',
+    fault_action: (raw.fault_action as string) ?? '',
+    fault_category: (raw.fault_category as string) ?? '',
+  } as NetworkLogEntry;
 }
-
-const query = useQuery({
-  queryKey: computed(() => ['network', playerIdRef.value] as const),
-  queryFn: () => repo.getPlayerNetworkLog(playerIdRef.value, 500),
-  // Stop polling once the server has rejected this player_id outright
-  // (400 / 404). Otherwise refetch every 2s while not paused.
-  refetchInterval: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    if (typeof s === 'number' && s >= 400 && s < 500) return false;
-    return paused.value ? false : 2_000;
-  },
-  refetchIntervalInBackground: false,
-  staleTime: 1_000,
-  retry: (n, err: any) => {
-    const s = err?.status;
-    if (typeof s === 'number' && s >= 400 && s < 500) return false;
-    return n < 1;
-  },
-  refetchOnMount: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-  refetchOnWindowFocus: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-  refetchOnReconnect: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-});
 
 interface Row {
   entry: NetworkLogEntry;
@@ -123,12 +187,24 @@ function isSuccessful(e: NetworkLogEntry): boolean {
 }
 
 /** All rows, before brush + toggles — used to feed the overview rail
- *  so the user always sees every request regardless of current filter. */
+ *  so the user always sees every request regardless of current filter.
+ *
+ *  Sourced from the parent SessionDisplay's unified time-series
+ *  model (`networkStream`). The stream is server-filtered by play_id
+ *  and merges ring + CH on the boundary, so the table no longer
+ *  needs to dedupe or worry about stale-play leakage. Reading the
+ *  stream's `version` ref registers the computed as a dep so it
+ *  re-runs on every delta. */
 const allRows = computed<Row[]>(() => {
-  const items = (query.data.value ?? []) as NetworkLogEntry[];
+  // Touch `version` so Vue tracks deltas; inRange() ALSO touches
+  // the underlying array ref via tsOf, but reading version is a
+  // belt-and-suspenders guarantee against shallowRef quirks.
+  void props.networkStream.version.value;
+  const raw = props.networkStream.inRange(0, Number.MAX_SAFE_INTEGER);
   const built: Row[] = [];
-  for (const e of items) {
-    const r = buildRow(e);
+  for (const obj of raw) {
+    const entry = chRowToEntry(obj);
+    const r = buildRow(entry);
     if (!r) continue;
     built.push(r);
   }
@@ -139,24 +215,9 @@ const rows = computed<Row[]>(() => {
   return allRows.value.filter((r) => {
     if (faultedOnly.value && !r.entry.faulted) return false;
     if (hideSuccessful.value && isSuccessful(r.entry)) return false;
-    if (brushStartMs.value != null && brushEndMs.value != null) {
-      const reqStart = r.ts;
-      const reqEnd = r.ts + r.duration;
-      // Keep any row whose extent overlaps the brush range.
-      if (reqEnd < brushStartMs.value) return false;
-      if (reqStart > brushEndMs.value) return false;
-    }
     return true;
   });
 });
-
-const brushTicks = computed<BrushTick[]>(() =>
-  allRows.value.map((r) => ({
-    ts: r.ts,
-    status: Number(r.entry.status ?? 0),
-    faulted: !!r.entry.faulted,
-  })),
-);
 
 /** Summary line: total request count + breakdowns by kind / fault /
  *  slow + lifetime bytes-in. Matches the legacy `.netwf-summary`. */
@@ -368,12 +429,14 @@ function phaseStyle(r: Row): PhaseStyle | null {
 }
 
 function refresh() {
-  query.refetch();
+  // Refresh is a no-op on the streaming model — new deltas arrive
+  // via SSE automatically. We keep the button for muscle memory;
+  // a future iteration could expose a reconnect() that re-opens
+  // the EventSource if the operator wants to force a re-backfill.
 }
 
 function togglePause() {
   paused.value = !paused.value;
-  if (!paused.value) refresh();
 }
 
 // Follow-latest: when on, scroll the row list to the latest row each
@@ -392,6 +455,69 @@ watch(
     });
   },
 );
+
+// Position the highlighted row inside the .rows scroll container
+// without touching the OUTER page scroll. scrollIntoView() would
+// walk up every scroll ancestor (panel → CollapsibleSection → page)
+// and yank the page to the network log — annoying when the operator
+// is mid-scroll elsewhere. Instead, set scrollTop directly so only
+// the inner container moves; if the row is already inside the
+// visible band, do nothing (scrollIntoView's `block: 'nearest'`
+// equivalent without the side effect).
+watch(
+  () => coord.state.cursorMs,
+  () => {
+    if (currentRowKeys.value.size === 0) return;
+    nextTick(() => {
+      const el = rowsScrollRef.value;
+      if (!el) return;
+      const target = el.querySelector('.row.cursor-current') as HTMLElement | null;
+      if (!target) return;
+      const containerTop = el.scrollTop;
+      const containerBottom = containerTop + el.clientHeight;
+      const rowTop = target.offsetTop;
+      const rowBottom = rowTop + target.offsetHeight;
+      if (rowTop < containerTop) {
+        // Above the viewport — scroll up so the row sits at the top.
+        el.scrollTop = rowTop;
+      } else if (rowBottom > containerBottom) {
+        // Below — scroll down just enough to land the row at bottom.
+        el.scrollTop = rowBottom - el.clientHeight;
+      }
+      // Otherwise it's already visible; leave scrollTop alone.
+    });
+  },
+);
+
+/* ─── Wheel hijack ─────────────────────────────────────────────────
+ *
+ * Plain mouse-wheel inside the network-log row container should scroll
+ * the PAGE, not the inner overflow box. Trapping wheel events on a
+ * long inner-scroll region is the legacy session-shell.js parity
+ * behaviour — operators expect the page to keep scrolling when they
+ * roll past the rail, and only opt into row scrolling explicitly.
+ *
+ *   - plain wheel  → preventDefault + window.scrollBy (page moves)
+ *   - Alt+wheel    → native overflow scroll inside the rows container
+ *
+ * Capture-phase listener so we run before the browser's default
+ * overflow handler, with `passive: false` so preventDefault is allowed.
+ */
+onMounted(() => {
+  const el = rowsScrollRef.value;
+  if (!el) return;
+  el.addEventListener('wheel', onRowsWheel, { capture: true, passive: false });
+});
+onBeforeUnmount(() => {
+  const el = rowsScrollRef.value;
+  if (!el) return;
+  el.removeEventListener('wheel', onRowsWheel, { capture: true } as EventListenerOptions);
+});
+function onRowsWheel(e: WheelEvent) {
+  if (e.altKey) return; // operator opted in — let the rows scroll
+  e.preventDefault();
+  window.scrollBy({ top: e.deltaY, left: e.deltaX, behavior: 'auto' });
+}
 </script>
 
 <template>
@@ -419,13 +545,11 @@ watch(
       <span class="sse" :data-state="sseState">{{ sseState }}</span>
     </div>
 
-    <NetworkLogBrush
-      v-if="brushTicks.length"
-      :ticks="brushTicks"
-      :brush-start-ms="brushStartMs"
-      :brush-end-ms="brushEndMs"
-      @update:brush="onBrushChange"
-    />
+    <!-- In-panel brush retired in the timeseries migration —
+         SessionDisplay's page-level focus bar is the single brush
+         surface. NetworkLog now shows whatever the network stream
+         delivers for the current play. -->
+
 
     <!-- Summary line: count breakdown + lifetime bytes (matches legacy
          .netwf-summary). Shown beneath the brush so it picks up the
@@ -471,7 +595,7 @@ watch(
           v-for="(r, i) in sortedRows"
           :key="i"
           class="row"
-          :class="rowFaultClass(r)"
+          :class="[rowFaultClass(r), { 'cursor-current': currentRowKeys.has(rowKey(r)) }]"
           :title="tooltipFor(r)"
         >
           <div class="cell c-time">{{ fmtTime(r.ts) }}</div>
@@ -645,6 +769,25 @@ watch(
 }
 
 .row:hover { background: #f9fafb; }
+
+/* "Selected event" cursor — synchronized with the chart cursor. A
+ * row is highlighted when its [ts, ts+duration] interval contains
+ * cursorMs. Visual treatment is intentionally loud: a 2px dashed
+ * blue line top + bottom, saturated blue background tint, a 4px
+ * left-edge gutter in solid blue, and z-index lift so the borders
+ * aren't visually cropped by the next row's top-border. Multiple
+ * rows can light up simultaneously (overlapping partial fetches),
+ * which correctly conveys "everything in flight at that moment." */
+.row.cursor-current {
+  position: relative;
+  background: rgba(29, 78, 216, 0.14);
+  border-top: 2px dashed #1d4ed8;
+  border-bottom: 2px dashed #1d4ed8;
+  box-shadow: inset 4px 0 0 #1d4ed8;
+  z-index: 2;
+}
+.row.cursor-current:hover { background: rgba(29, 78, 216, 0.20); }
+
 .row-faulted { background: #fef2f2; }
 .row-faulted:hover { background: #fee2e2; }
 .row-slow { background: #fffbeb; }

--- a/content/dashboard-v3/src/components/RTTChart.vue
+++ b/content/dashboard-v3/src/components/RTTChart.vue
@@ -7,9 +7,13 @@
  * readable. Matches the legacy chart layout.
  */
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
+import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
-defineProps<{ playerId: string }>();
+defineProps<{
+  playerId: string;
+  samplesStream: Stream<Record<string, unknown>>;
+}>();
 
 const series: SeriesSpec[] = [
   {
@@ -47,9 +51,9 @@ const series: SeriesSpec[] = [
     title="Round-trip time"
     unit="ms"
     :series="series"
+    :samples-stream="samplesStream"
     :y-min="0"
     y2-title="RTO (ms)"
     :y2-min="0"
-    :window-seconds="180"
   />
 </template>

--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -54,6 +54,11 @@ const fields = computed(() => {
   const sm = p.server_metrics ?? null;
   const raw = (p as any).raw_session ?? null;
   const port = raw?.x_forwarded_port_external ?? raw?.x_forwarded_port ?? null;
+  // Group ID lives on the v1 session passthrough (the v2 PlayerRecord
+  // doesn't model it as a first-class field yet). Show "—" when
+  // ungrouped so the operator can confirm linking actually landed.
+  const gid = raw?.group_id;
+  const groupValue = typeof gid === 'string' && gid.length ? gid : '—';
   // Master URL is the manifest entry the player loaded; the legacy
   // page also showed the "Last Request URL" (the most-recent network
   // log entry's URL); we don't track that here yet so omit it.
@@ -61,6 +66,7 @@ const fields = computed(() => {
     { label: 'Player ID', value: p.id ?? '—' },
     { label: 'Display ID', value: String(p.display_id ?? '—') },
     { label: 'Play ID', value: cp?.id ?? '—' },
+    { label: 'Group ID', value: groupValue },
     { label: 'Origination IP', value: p.origination_ip ?? '—' },
     { label: 'Player IP', value: p.player_ip ?? '—' },
     { label: 'Port', value: port != null ? String(port) : '—' },

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1,0 +1,1705 @@
+<script setup lang="ts">
+/**
+ * SessionDisplay.vue — shared display layout for both the live
+ * testing-session page and the archive session-viewer page.
+ *
+ * Owns:
+ *   - Display panels (Session Details, Player Metrics, Player State,
+ *     Bandwidth/RTT/Buffer/FPS charts, Network Log)
+ *   - Brush rail (skip buttons, focus window, drag-pan, click-recenter)
+ *   - Event filter accordion (Effects/Causes pills + priority tier
+ *     groups + per-tier and per-type eye toggles + instance drilldown)
+ *   - Synchronized "selected event" cursor across all charts
+ *   - Prev/next nav with scope locking (tier / type) and keyboard ,/.
+ *
+ * Mode-driven behaviour:
+ *   - mode='archive' — brush + accordion + nav always visible. Bulk-feed
+ *     drives chart history; setArchivePlayer + setQueryData prime the
+ *     TanStack cache so the same display panels render archive data
+ *     with no per-component refactor.
+ *   - mode='live'    — brush + accordion + nav HIDDEN until the operator
+ *     pauses (clicks a chart, drags the brush, or hits ⏸). Live SSE
+ *     fills the chart per-sample via MetricsLineChart's player.value
+ *     watcher; this component's bulk-feed only fires on initial
+ *     historical preload (when sessionId+playId are known).
+ *
+ * Composables run unconditionally; if sessionId is empty (live mode
+ * before historical resolution), they short-circuit and return empty.
+ */
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { useQueryClient } from '@tanstack/vue-query';
+import CollapsibleSection from '@/components/CollapsibleSection.vue';
+import SessionDetails from '@/components/SessionDetails.vue';
+import PlayerMetrics from '@/components/PlayerMetrics.vue';
+import EventsTimeline from '@/components/EventsTimeline.vue';
+import BandwidthChart from '@/components/BandwidthChart.vue';
+import RTTChart from '@/components/RTTChart.vue';
+import BufferChart from '@/components/BufferChart.vue';
+import FPSChart from '@/components/FPSChart.vue';
+import NetworkLog from '@/components/NetworkLog.vue';
+import BitrateChartPanelToolbar from '@/components/BitrateChartPanelToolbar.vue';
+import { useChartCoordination } from '@/composables/useChartCoordination';
+import { useArchivedSessionEvents, type SessionEvent } from '@/composables/useArchivedSessionEvents';
+import { usePlayer } from '@/composables/usePlayer';
+import { useSessionTimeSeries } from '@/composables/useSessionTimeSeries';
+import { chRowToPlayerRecord, tsOfRow } from '@/composables/chRowAdapter';
+import {
+  setArchivePlayer,
+  type PlayerRecord,
+} from '@/repo/v2-repo';
+
+const props = defineProps<{
+  /** Canonical player UUID. Used identically in live and archive
+   *  modes — SSE registration, v3 timeseries subscription, panel cache
+   *  keying. (session_id retired: SSE keys by player_id only and the
+   *  v3 endpoint resolves rows by player_id.) */
+  playerId: string;
+  /** Play id. In live mode usually null (subscribe across plays); in
+   *  archive mode the specific play being replayed. */
+  playId: string | null;
+  /** archive = sticky brush + replay banner visible; live = brush
+   *  hidden until paused. The v3 timeseries server decides actual
+   *  liveness via its `meta.live` event regardless of this prop. */
+  mode: 'live' | 'archive';
+  /** Suppress the internal Session Details panel. The live testing
+   *  pages mount their own Session Details right before Fault Injection
+   *  (above the control panels), so they pass this flag and SessionDisplay
+   *  omits the duplicate panel from its stack. */
+  hideSessionDetails?: boolean;
+}>();
+
+/** Live vs archive switches the brush-rail visibility default and
+ *  whether to extend timeRange.max with `coord.lastSampleMs` for the
+ *  live edge. Driven by the `mode` prop — the page knows which one
+ *  it's rendering. The v3 stream subscription works the same in both
+ *  modes (player_id + optional play_id). */
+const isLive = computed(() => props.mode !== 'archive');
+
+const playIdRef = computed(() => props.playId);
+
+// usePlayer subscribes to live SSE + the all-pool stream. In live
+// mode the TanStack cache is fed by SSE; in archive mode usePlayer's
+// GET will 404 (player isn't in the proxy roster) — that's fine,
+// nothing reads `livePlayer.value` in archive mode.
+const livePlayerIdRef = computed(() => (isLive.value ? props.playerId : ''));
+const { player: livePlayer } = usePlayer(livePlayerIdRef);
+
+// Defensive: only adopt usePlayer's canonical-case id when it
+// matches props.playerId case-insensitively. The shared TanStack
+// cache + all-pool SSE pool can briefly leak a record from a
+// DIFFERENT player during cache invalidation/refetch races; passing
+// that wrong UUID into useSessionTimeSeries would re-subscribe the
+// SSE to a foreign player. Fall back to props.playerId whenever the
+// live record disagrees.
+const apiPlayerIdRef = computed(() => {
+  const fromLive = livePlayer.value?.id;
+  if (fromLive && fromLive.toLowerCase() === props.playerId.toLowerCase()) {
+    return fromLive;
+  }
+  return props.playerId;
+});
+
+// Internal cache key for the side-channel archive store (v2-repo).
+// In archive mode we synthesize an `archive:<player_id>:<play_id>`
+// key so the panel cursor (set by the windowEndMs watcher below)
+// doesn't collide with the live cache for the same player_id. In
+// live mode the raw player_id IS the cache key.
+const archivePlayerId = computed(() =>
+  isLive.value
+    ? props.playerId
+    : `archive:${props.playerId}:${props.playId ?? 'all'}`,
+);
+
+// Event accordion source. The events stream isn't on the v3 timeseries
+// endpoint yet (out of scope for TS6); kept here so the brush-rail
+// tick markers, the priority/tier filter UI, and the prev/next nav
+// keep functioning unchanged. Filters by player_id + play_id only —
+// session_id retired.
+const { events: sessionEvents } = useArchivedSessionEvents(apiPlayerIdRef, playIdRef);
+
+// v3 unified time-series model. Single subscription per
+// SessionDisplay drives:
+//   - Bandwidth / RTT / Buffer / FPS charts (samples)
+//   - EventsTimeline swim lanes (samples → ingest)
+//   - NetworkLog waterfall (network)
+//   - Focus bar / brush rail bounds (rangeBounds + coord.lastSampleMs)
+//   - PlayerMetrics / SessionDetails panels in archive mode
+//     (lastAt(windowEndMs) + chRowToPlayerRecord adapter feeding
+//     setArchivePlayer)
+// session_details bundle is requested so the snapshot-cursor row
+// carries enough identity (manifest_url etc.) for the panels.
+//
+// Identity refs:
+//   - apiPlayerIdRef is defensively stable against the shared
+//     TanStack cache race (see its definition above).
+//   - playIdRef is null in live mode (server returns rows across all
+//     plays so the brush handles boundary moves naturally) and the
+//     specific archived play in archive mode.
+const timeseriesPlayId = computed<string | null>(() => isLive.value ? null : props.playId);
+const timeseries = useSessionTimeSeries(
+  apiPlayerIdRef,
+  timeseriesPlayId,
+  {
+    streams: ['samples', 'network'],
+    bundles: ['charts_minimal', 'lanes_v1', 'session_details', 'network'],
+  },
+);
+
+// coord declared up-front so the `timeRange` computed below can read
+// `coord.state.lastSampleMs` (live edge) without a temporal dead zone
+// — and so any earlier reactive code (window watcher, brush clamps)
+// sees a coord instance even though it gets consumed mostly later.
+const coord = useChartCoordination(archivePlayerId);
+
+/** Effective time range for the brush rail. Reads the cached
+ *  rangeBounds of the samples stream as the historical span; in live
+ *  mode extend `max` with `coord.lastSampleMs` so the rail's right
+ *  edge tracks the live tail even when the cache hasn't received the
+ *  freshest CH backfill yet. */
+const timeRange = computed<{ min: number; max: number } | null>(() => {
+  const ar = timeseries.samples.rangeBounds.value;
+  const live = isLive.value ? (coord.state.lastSampleMs || 0) : 0;
+  if (!ar && !live) return null;
+  if (!ar) return { min: live, max: live };
+  if (!live) return ar;
+  return { min: ar.min, max: Math.max(ar.max, live) };
+});
+
+const loading = computed(() => timeseries.samples.loading.value);
+const error = computed(() => timeseries.samples.error.value);
+const progressLabel = computed(() => loading.value ? 'Streaming snapshots…' : '');
+// Approximate count of rendered samples — used in the brush-rail
+// status line. The cache only grows; reading via inRange touches
+// `version` so this stays reactive on every flush.
+const samplesCount = computed(() => {
+  void timeseries.samples.version.value;
+  return timeseries.samples.inRange(0, Number.MAX_SAFE_INTEGER).length;
+});
+
+/* ─── Event filter ──────────────────────────────────────────────── */
+
+function eventMs(ev: SessionEvent): number {
+  const raw = ev.ts ?? ev.event_time;
+  if (!raw) return NaN;
+  const iso = typeof raw === 'string' && !raw.includes('T')
+    ? raw.replace(' ', 'T') + 'Z'
+    : String(raw);
+  const v = Date.parse(iso);
+  return Number.isFinite(v) ? v : NaN;
+}
+
+// L0 — Kind toggle (orthogonal: effect vs cause)
+const enabledKind = ref<Record<'effect' | 'cause', boolean>>({
+  effect: true,
+  cause: false,
+});
+
+// L1 — Priority tier
+type Priority = 1 | 2 | 3 | 4;
+const PRIORITY_ORDER: Priority[] = [1, 2, 3, 4];
+const PRIORITY_META: Record<Priority, { label: string; color: string; bg: string; border: string }> = {
+  1: { label: 'Critical', color: '#dc2626', bg: '#fee2e2', border: '#fca5a5' },
+  2: { label: 'High',     color: '#b45309', bg: '#fef3c7', border: '#fcd34d' },
+  3: { label: 'Medium',   color: '#1d4ed8', bg: '#dbeafe', border: '#93c5fd' },
+  4: { label: 'Low',      color: '#4b5563', bg: '#e5e7eb', border: '#9ca3af' },
+};
+
+const expandedTiers = ref<Record<Priority, boolean>>({
+  1: true, 2: true, 3: false, 4: false,
+});
+function toggleTier(p: Priority) {
+  expandedTiers.value[p] = !expandedTiers.value[p];
+}
+
+const visiblePriority = ref<Record<Priority, boolean>>({
+  1: true, 2: true, 3: true, 4: false,
+});
+function togglePriorityVisibility(p: Priority, e: MouseEvent) {
+  e.stopPropagation();
+  const willBeVisible = !visiblePriority.value[p];
+  visiblePriority.value[p] = willBeVisible;
+  // Cascade to type-level eyes.
+  const next = new Set(hiddenTypeKeys.value);
+  for (const t of tierTypes.value[p]) {
+    const k = typeKey(t.type, p);
+    if (willBeVisible) next.delete(k);
+    else next.add(k);
+  }
+  hiddenTypeKeys.value = next;
+}
+
+const hiddenTypeKeys = ref<Set<string>>(new Set());
+function isTypeVisible(t: string, p: Priority): boolean {
+  return !hiddenTypeKeys.value.has(typeKey(t, p));
+}
+function toggleTypeVisibility(t: string, p: Priority, e: MouseEvent) {
+  e.stopPropagation();
+  const k = typeKey(t, p);
+  const next = new Set(hiddenTypeKeys.value);
+  if (next.has(k)) next.delete(k); else next.add(k);
+  hiddenTypeKeys.value = next;
+}
+
+const lockedPriority = ref<Priority | null>(null);
+const lockedType = ref<string | null>(null);
+function selectTier(p: Priority) {
+  if (lockedPriority.value === p && !lockedType.value) {
+    lockedPriority.value = null;
+  } else {
+    lockedPriority.value = p;
+    lockedType.value = null;
+    navCursor.value = 0;
+    expandedTiers.value[p] = true;
+  }
+}
+function selectType(t: string, p: Priority) {
+  if (lockedType.value === t && lockedPriority.value === p) {
+    lockedType.value = null;
+  } else {
+    lockedPriority.value = p;
+    lockedType.value = t;
+    navCursor.value = 0;
+    expandedTypeKey.value = typeKey(t, p);
+  }
+}
+function clearScope() {
+  lockedPriority.value = null;
+  lockedType.value = null;
+}
+
+const expandedTypeKey = ref<string | null>(null);
+function typeKey(t: string, p: Priority): string { return `${p}|${t}`; }
+function toggleTypeExpand(t: string, p: Priority) {
+  const k = typeKey(t, p);
+  expandedTypeKey.value = expandedTypeKey.value === k ? null : k;
+}
+
+function eventPriority(ev: SessionEvent): Priority {
+  const p = ev.priority;
+  return (p === 1 || p === 2 || p === 3 || p === 4) ? p : 3;
+}
+function eventKindCE(ev: SessionEvent): 'effect' | 'cause' {
+  return ev.kind === 'cause' ? 'cause' : 'effect';
+}
+
+interface AnnotatedEvent extends SessionEvent {
+  _ts: number;
+  _p: Priority;
+}
+
+const kindFilteredEvents = computed<AnnotatedEvent[]>(() =>
+  sessionEvents.value
+    .filter((ev) => enabledKind.value[eventKindCE(ev)])
+    .map((ev) => ({ ...ev, _ts: eventMs(ev), _p: eventPriority(ev) }))
+    .filter((ev) => Number.isFinite(ev._ts))
+    .sort((a, b) => a._ts - b._ts),
+);
+
+const filteredEvents = computed<AnnotatedEvent[]>(
+  () => kindFilteredEvents.value.filter((ev) => {
+    if (!visiblePriority.value[ev._p]) return false;
+    const k = `${ev._p}|${ev.type ?? 'event'}`;
+    if (hiddenTypeKeys.value.has(k)) return false;
+    return true;
+  }),
+);
+
+const tierCounts = computed<Record<Priority, number>>(() => {
+  const c: Record<Priority, number> = { 1: 0, 2: 0, 3: 0, 4: 0 };
+  for (const ev of kindFilteredEvents.value) c[ev._p]++;
+  return c;
+});
+
+function kindCount(k: 'effect' | 'cause'): number {
+  let n = 0;
+  for (const ev of sessionEvents.value) if (eventKindCE(ev) === k) n++;
+  return n;
+}
+
+const tierTypes = computed<Record<Priority, Array<{ type: string; count: number }>>>(() => {
+  const buckets: Record<Priority, Map<string, number>> = {
+    1: new Map(), 2: new Map(), 3: new Map(), 4: new Map(),
+  };
+  for (const ev of kindFilteredEvents.value) {
+    const t = String(ev.type ?? 'event');
+    buckets[ev._p].set(t, (buckets[ev._p].get(t) ?? 0) + 1);
+  }
+  const out = {} as Record<Priority, Array<{ type: string; count: number }>>;
+  for (const p of PRIORITY_ORDER) {
+    out[p] = [...buckets[p].entries()]
+      .map(([type, count]) => ({ type, count }))
+      .sort((a, b) => a.count - b.count);
+  }
+  return out;
+});
+
+const tierTypeInstances = computed<Record<string, AnnotatedEvent[]>>(() => {
+  const out: Record<string, AnnotatedEvent[]> = {};
+  for (const ev of kindFilteredEvents.value) {
+    const k = `${ev._p}|${ev.type ?? 'event'}`;
+    (out[k] ??= []).push(ev);
+  }
+  return out;
+});
+
+function selectInstance(ev: AnnotatedEvent, t: string, p: Priority) {
+  if (lockedType.value !== t || lockedPriority.value !== p) {
+    lockedPriority.value = p;
+    lockedType.value = t;
+    expandedTiers.value[p] = true;
+    expandedTypeKey.value = typeKey(t, p);
+  }
+  const idx = navEvents.value.findIndex(
+    (e) => e._ts === ev._ts && e.type === ev.type,
+  );
+  if (idx >= 0) {
+    navCursor.value = idx;
+    recenterOnNav();
+  }
+}
+
+function tierPreview(p: Priority): Array<{ type: string; count: number }> {
+  return tierTypes.value[p].slice(0, 5);
+}
+function tierPreviewMore(p: Priority): number {
+  return Math.max(0, tierTypes.value[p].length - 5);
+}
+function pickPreviewType(t: string, p: Priority) {
+  expandedTiers.value[p] = true;
+  selectType(t, p);
+}
+
+const scopeLabel = computed<string>(() => {
+  if (lockedType.value && lockedPriority.value) {
+    return `${lockedType.value} (in ${PRIORITY_META[lockedPriority.value].label})`;
+  }
+  if (lockedPriority.value) {
+    return `All ${PRIORITY_META[lockedPriority.value].label} events`;
+  }
+  return `All events (${filteredEvents.value.length})`;
+});
+
+/* ─── Prev/next navigation ──────────────────────────────────────── */
+
+const navEvents = computed<AnnotatedEvent[]>(() => {
+  let arr = filteredEvents.value;
+  if (lockedPriority.value) arr = arr.filter((e) => e._p === lockedPriority.value);
+  if (lockedType.value)     arr = arr.filter((e) => e.type === lockedType.value);
+  return arr;
+});
+const navCursor = ref(0);
+const navCurrent = computed<AnnotatedEvent | null>(
+  () => navEvents.value[navCursor.value] ?? null,
+);
+watch(navEvents, (arr) => {
+  if (navCursor.value >= arr.length) navCursor.value = Math.max(0, arr.length - 1);
+});
+function navPrev() {
+  const n = navEvents.value.length; if (n === 0) return;
+  navCursor.value = (navCursor.value - 1 + n) % n;
+  recenterOnNav();
+}
+function navNext() {
+  const n = navEvents.value.length; if (n === 0) return;
+  navCursor.value = (navCursor.value + 1) % n;
+  recenterOnNav();
+}
+function recenterOnNav() {
+  const ev = navCurrent.value; if (!ev) return;
+  const half = (windowEndMs.value - windowStartMs.value) / 2;
+  windowStartMs.value = clampStart(ev._ts - half);
+  windowEndMs.value = clampEnd(ev._ts + half);
+  userMovedBrush.value = true;
+}
+
+watch(navCurrent, (ev) => {
+  coord.setCursorMs(ev ? ev._ts : null);
+});
+
+function onKey(e: KeyboardEvent) {
+  const t = e.target as HTMLElement | null;
+  if (t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+  if (e.key === ',') { e.preventDefault(); navPrev(); }
+  else if (e.key === '.') { e.preventDefault(); navNext(); }
+  else if (e.key === 'Escape') {
+    if (lockedType.value) lockedType.value = null;
+    else if (lockedPriority.value) lockedPriority.value = null;
+  }
+}
+
+const railMarkers = computed(() => {
+  const r = timeRange.value;
+  if (!r || !filteredEvents.value.length) return [] as Array<{ leftPct: number; color: string; opacity: number; isCurrent: boolean; title: string; ts: number; ev: AnnotatedEvent }>;
+  const span = Math.max(1, r.max - r.min);
+  const cur = navCurrent.value;
+  return filteredEvents.value.map((ev) => {
+    const pct = Math.max(0, Math.min(100, ((ev._ts - r.min) / span) * 100));
+    const isCurrent = !!cur && cur._ts === ev._ts && cur.type === ev.type;
+    return {
+      leftPct: pct,
+      color: PRIORITY_META[ev._p].color,
+      opacity: eventKindCE(ev) === 'effect' ? 1 : 0.4,
+      isCurrent,
+      ts: ev._ts,
+      ev,
+      title: `${ev.type ?? 'event'} · p${ev._p} · ${fmtTime(ev._ts)}${ev.info ? ' · ' + ev.info : ''}`,
+    };
+  });
+});
+
+/* ─── Brush + focus window ──────────────────────────────────────── */
+
+const windowStartMs = ref<number>(0);
+const windowEndMs = ref<number>(0);
+const windowSpanMs = computed(() => Math.max(1, windowEndMs.value - windowStartMs.value));
+
+const DEFAULT_FOCUS_MS = 10 * 60 * 1000;
+const userMovedBrush = ref(false);
+
+/** Same checked rule as the chart-toolbar Live toggles — the brush
+ *  rail's Live button reflects the shared `coord.state.viewport`. */
+const brushLiveChecked = computed(() => coord.state.viewport === null);
+watch(timeRange, (r) => {
+  if (!r) return;
+  const fullSpan = r.max - r.min;
+  // When the brush is tracking the live edge (!userMovedBrush) we
+  // preserve whatever WIDTH it already has — so if the operator
+  // resized to 3 min and then dropped at live, the live-tracking
+  // window stays 3 min wide. Only fall back to DEFAULT_FOCUS_MS on
+  // the very first paint when no width exists yet.
+  if (!userMovedBrush.value) {
+    // Live-tracking: span is driven by coord.liveSpanMs (set by chart
+    // Alt+wheel) or DEFAULT_FOCUS_MS. Never carry forward the previous
+    // tick's currentSpan — that's what got the brush stuck at 30 s
+    // when a fresh session started narrow and we never grew past it.
+    // Capped at fullSpan so a very young session (1 s of data) doesn't
+    // try to show empty area before r.min.
+    const liveSpan = coord.state.liveSpanMs;
+    const targetSpan = liveSpan != null
+      ? Math.min(liveSpan, fullSpan)
+      : Math.min(DEFAULT_FOCUS_MS, fullSpan);
+    const newStart = Math.max(r.min, r.max - targetSpan);
+    windowStartMs.value = newStart;
+    windowEndMs.value = r.max;
+    return;
+  }
+  if (windowStartMs.value < r.min) windowStartMs.value = r.min;
+  if (windowEndMs.value > r.max) windowEndMs.value = r.max;
+  if (windowStartMs.value >= windowEndMs.value) {
+    const span = Math.min(DEFAULT_FOCUS_MS, fullSpan);
+    windowStartMs.value = Math.max(r.min, r.max - span);
+    windowEndMs.value = r.max;
+  }
+});
+
+// Chart Alt+wheel updates coord.liveSpanMs to narrow the visible
+// span around the live edge. The brush width tracks chart zoom
+// unconditionally — zooming on a chart IS a request to resize the
+// focus rail, regardless of whether the brush is currently pinned.
+// Position-pinning (userMovedBrush) governs WHERE the window lives,
+// not how wide it is.
+watch(
+  () => coord.state.liveSpanMs,
+  (span) => {
+    const r = timeRange.value;
+    if (!r) return;
+    const targetSpan = span ?? Math.min(DEFAULT_FOCUS_MS, r.max - r.min);
+    // Anchor at the CURRENT right edge when the user has parked the
+    // brush off live — Alt+wheel on a chart should only resize the
+    // span, not rip the window back to "now". When at live (or never
+    // moved off), anchor at r.max so the live-tracking semantics hold.
+    const anchorRight = userMovedBrush.value ? windowEndMs.value : r.max;
+    console.log('[BR] liveSpanMs watch span=' + (span ?? 'null') + ' → brush ' + Math.round(targetSpan/1000) + 's, anchor=' + (userMovedBrush.value ? 'current' : 'live'));
+    windowStartMs.value = Math.max(r.min, anchorRight - targetSpan);
+    windowEndMs.value = anchorRight;
+  },
+);
+
+function clampStart(v: number) {
+  const r = timeRange.value; if (!r) return v;
+  return Math.max(r.min, Math.min(v, windowEndMs.value - 1000));
+}
+function clampEnd(v: number) {
+  const r = timeRange.value; if (!r) return v;
+  return Math.min(r.max, Math.max(v, windowStartMs.value + 1000));
+}
+
+/* ─── Brush drag handling ───────────────────────────────────────── */
+
+const railRef = ref<HTMLElement | null>(null);
+const dragState = ref<{ mode: 'pan' | 'resize-left' | 'resize-right'; startX: number; startStart: number; startEnd: number } | null>(null);
+
+function railFracToMs(frac: number): number {
+  const r = timeRange.value; if (!r) return 0;
+  return r.min + Math.max(0, Math.min(1, frac)) * (r.max - r.min);
+}
+function pxToMs(px: number): number {
+  const w = railRef.value?.clientWidth ?? 1;
+  const r = timeRange.value; if (!r || w <= 0) return 0;
+  return (px / w) * (r.max - r.min);
+}
+
+function onBrushMouseDown(e: MouseEvent, mode: 'pan' | 'resize-left' | 'resize-right') {
+  e.preventDefault();
+  e.stopPropagation();
+  userMovedBrush.value = true;
+  dragState.value = {
+    mode,
+    startX: e.clientX,
+    startStart: windowStartMs.value,
+    startEnd: windowEndMs.value,
+  };
+  window.addEventListener('mousemove', onDragMove);
+  window.addEventListener('mouseup', onDragEnd, { once: true });
+}
+function onDragMove(e: MouseEvent) {
+  const d = dragState.value; if (!d) return;
+  const r = timeRange.value; if (!r) return;
+  const dms = pxToMs(e.clientX - d.startX);
+  const MIN_WINDOW_MS = 1000;
+  if (d.mode === 'pan') {
+    const span = d.startEnd - d.startStart;
+    let s = d.startStart + dms;
+    let f = s + span;
+    if (s < r.min) { s = r.min; f = s + span; }
+    if (f > r.max) { f = r.max; s = f - span; }
+    windowStartMs.value = s;
+    windowEndMs.value = f;
+  } else if (d.mode === 'resize-left') {
+    let s = d.startStart + dms;
+    if (s < r.min) s = r.min;
+    if (s > d.startEnd - MIN_WINDOW_MS) s = d.startEnd - MIN_WINDOW_MS;
+    windowStartMs.value = s;
+  } else if (d.mode === 'resize-right') {
+    let f = d.startEnd + dms;
+    if (f > r.max) f = r.max;
+    if (f < d.startStart + MIN_WINDOW_MS) f = d.startStart + MIN_WINDOW_MS;
+    windowEndMs.value = f;
+  }
+}
+function onDragEnd() {
+  dragState.value = null;
+  window.removeEventListener('mousemove', onDragMove);
+  const r = timeRange.value;
+  // RIGHT EDGE position determines the pinned-vs-following state.
+  // Drop within 2 s of the live sample → following live (charts and
+  // brush re-anchor at r.max via the watchers below).
+  // Drop away from live → pinned to the brush window.
+  const atLiveEdge =
+    !!r
+    && props.mode !== 'archive'
+    && !coord.state.paused
+    && r.max - windowEndMs.value <= 2000;
+  const dropSpan = windowEndMs.value - windowStartMs.value;
+  if (atLiveEdge) userMovedBrush.value = false;
+
+  // BRUSH WIDTH on release becomes the new liveSpanMs — operator's
+  // intent regardless of where the right edge ended up. Pinned drops
+  // store the span so it survives the round trip when they later
+  // click Live to return; live drops update the span immediately so
+  // every other chart's live-tracker uses the same width.
+  if (isLive.value && dropSpan > 0 && coord.state.liveSpanMs !== dropSpan) {
+    coord.setLiveSpanMs(dropSpan);
+  }
+
+  // Reconcile viewport with the new brush window. !userMovedBrush →
+  // clears viewport (charts follow live). userMovedBrush → pins
+  // viewport to the brush range.
+  applyWindowToViewport();
+}
+/** Alt+wheel on the brush rail zooms the focus-window duration.
+ *
+ *   - AT LIVE (right edge ≈ r.max): left-edge-only — right stays
+ *     glued to live, span shrinks/grows from the left.
+ *   - OFF LIVE: mouse-anchored — the time under the cursor stays
+ *     fixed while both edges move. If the resulting right edge
+ *     reaches live, snap the brush back to live tracking
+ *     (userMovedBrush=false) so further zooms take the left-only
+ *     path.
+ *
+ *  Plain wheel falls through to native page scroll. */
+function onRailWheel(e: WheelEvent) {
+  if (!e.altKey) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const rail = railRef.value;
+  const r = timeRange.value;
+  if (!rail || !r) return;
+  const fullSpan = Math.max(1, r.max - r.min);
+  const currentSpan = Math.max(1, windowEndMs.value - windowStartMs.value);
+  const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
+  const MIN_SPAN_MS = 1_000;
+  const nextSpan = Math.max(MIN_SPAN_MS, Math.min(fullSpan, currentSpan * factor));
+  if (nextSpan === currentSpan) return;
+  const atLive = isLive.value && r.max - windowEndMs.value <= 2000;
+
+  let newStart: number;
+  let newEnd: number;
+  if (atLive) {
+    newEnd = r.max;
+    newStart = Math.max(r.min, newEnd - nextSpan);
+  } else {
+    // Mouse-anchored: keep the timestamp under the cursor at the same
+    // x position in the rail after the zoom.
+    const rect = rail.getBoundingClientRect();
+    const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0.5;
+    const anchorTime = r.min + frac * fullSpan;
+    const anchorFracInWindow = (anchorTime - windowStartMs.value) / currentSpan;
+    newStart = anchorTime - anchorFracInWindow * nextSpan;
+    newEnd = newStart + nextSpan;
+    if (newStart < r.min) { newStart = r.min; newEnd = newStart + nextSpan; }
+    if (newEnd > r.max) { newEnd = r.max; newStart = newEnd - nextSpan; }
+  }
+
+  windowStartMs.value = newStart;
+  windowEndMs.value = newEnd;
+  // Snap back to live tracking if the zoom landed at the live edge.
+  const endedAtLive = isLive.value && r.max - newEnd <= 2000;
+  userMovedBrush.value = !endedAtLive;
+}
+
+function onRailMouseDown(e: MouseEvent) {
+  if (e.defaultPrevented) return;
+  if (!(e.target instanceof HTMLElement)) return;
+  if (e.target.closest('.brush-window, .brush-tick')) return;
+  const rail = railRef.value; if (!rail) return;
+  const rect = rail.getBoundingClientRect();
+  if (rect.width <= 0) return;
+  const frac = (e.clientX - rect.left) / rect.width;
+  const target = railFracToMs(frac);
+  const span = windowEndMs.value - windowStartMs.value;
+  const r = timeRange.value; if (!r) return;
+  let s = target - span / 2;
+  let f = s + span;
+  if (s < r.min) { s = r.min; f = s + span; }
+  if (f > r.max) { f = r.max; s = f - span; }
+  windowStartMs.value = s;
+  windowEndMs.value = f;
+  userMovedBrush.value = true;
+}
+
+/* ─── Brush-driven panel cursor ─────────────────────────────────── */
+
+const qc = useQueryClient();
+function playerKey(id: string) {
+  return ['player', id] as const;
+}
+
+watch([windowStartMs, windowEndMs], () => {
+  // Brush WIDTH drives coord.liveSpanMs in live-tracking mode so
+  // chart Alt+wheel zoom and brush drag stay in sync. We do NOT feed
+  // back into coord.windowMs anymore — doing so capped the wheel
+  // anchor's zoom-out at the current brush width and trips the
+  // "snap to null" branch, jumping from e.g. 1 min straight back to
+  // 10 min. windowMs stays the slow-changing "max default rolling
+  // window" (10 min); liveSpanMs is the active zoom span.
+  //
+  // Auto-feedback to liveSpanMs only when we're NOT actively dragging
+  // — the brush watcher fires on every windowStart/End change, and
+  // mid-drag the right edge can briefly be within the 2 s live
+  // tolerance even when the operator is on their way OFF live. That
+  // would flip userMovedBrush back to false and the liveSpanMs
+  // watcher would yank the brush right edge to r.max, fighting the
+  // drag. onDragEnd handles the "released AT live → update span"
+  // case explicitly instead.
+  const focusSpan = windowEndMs.value - windowStartMs.value;
+  if (
+    focusSpan > 0
+    && isLive.value
+    && !userMovedBrush.value
+    && coord.state.liveSpanMs !== focusSpan
+  ) {
+    coord.setLiveSpanMs(focusSpan);
+  }
+  applyWindowToViewport();
+});
+
+function applyWindowToViewport() {
+  // Three states for the chart viewport:
+  //  1. Operator has explicitly moved the brush — pin charts to that
+  //     window (frozen view, even on live mode).
+  //  2. Paused — same: pin charts to the window the operator pinned
+  //     by hitting pause.
+  //  3. Neither, AND we're in live mode — hand the viewport back to
+  //     coord by clearing it. `effectiveViewport` then follows the
+  //     live edge with the coord's `windowMs` span, so the charts
+  //     keep advancing as new samples arrive. This is what `>>` and
+  //     drag-to-live-edge both want.
+  //
+  // Archive mode never falls into the "hand back to coord" branch —
+  // there is no live edge to follow, and `effectiveViewport`'s
+  // live-edge fallback would snap the charts to `[lastSample -
+  // windowMs, lastSample]`, throwing away the brush window.
+  if (props.mode !== 'archive' && !userMovedBrush.value && !coord.state.paused) {
+    if (coord.state.viewport != null) coord.setViewport(null);
+    return;
+  }
+  if (windowStartMs.value && windowEndMs.value && windowStartMs.value < windowEndMs.value) {
+    coord.setViewport({ min: windowStartMs.value, max: windowEndMs.value });
+  }
+}
+
+watch(
+  () => coord.state.viewport,
+  (v) => {
+    console.log('[BR] coord.viewport watch', v ? `[span=${Math.round((v.max-v.min)/1000)}s]` : 'null', 'userMoved=' + userMovedBrush.value);
+    if (v) {
+      if (windowStartMs.value === v.min && windowEndMs.value === v.max) return;
+      console.log('[BR] coord.viewport set → brush ' + Math.round((v.max-v.min)/1000) + 's, userMovedBrush=true');
+      windowStartMs.value = v.min;
+      windowEndMs.value = v.max;
+      userMovedBrush.value = true;
+      return;
+    }
+    // viewport=null = explicit return to following live (via the Live
+    // toggle's checked → unchecked path or snap-back-to-live on zoom).
+    // Snap brush right edge to live and ALWAYS clear userMovedBrush
+    // so charts AND brush move together. Span preference order:
+    //   1. liveSpanMs — set by chart Alt+wheel; the operator picked it
+    //   2. currentSpan — whatever the brush was when pinned (e.g. a
+    //      manual 5-min drag); preserves their inspection width
+    //   3. DEFAULT_FOCUS_MS — last-resort fallback on a fresh session
+    //      where neither has ever been set
+    if (!isLive.value) return;
+    const r = timeRange.value; if (!r) return;
+    const fullSpan = r.max - r.min;
+    const liveSpan = coord.state.liveSpanMs;
+    const currentSpan = windowEndMs.value - windowStartMs.value;
+    let targetSpan: number;
+    if (liveSpan != null) targetSpan = Math.min(liveSpan, fullSpan);
+    else if (currentSpan > 0) targetSpan = Math.min(currentSpan, fullSpan);
+    else targetSpan = Math.min(DEFAULT_FOCUS_MS, fullSpan);
+    const newStart = Math.max(r.min, r.max - targetSpan);
+    windowStartMs.value = newStart;
+    windowEndMs.value = r.max;
+    userMovedBrush.value = false;
+  },
+);
+
+// Panel-cursor sync: the SessionDetails / PlayerMetrics panels read
+// from the v2-archive store (or live cache in live mode). For archive
+// mode we project the row at the brush's right edge — adapted from
+// CH via chRowToPlayerRecord — into the archive store so panels stay
+// in sync with the focus window.
+watch(
+  [windowEndMs, () => timeseries.samples.version.value],
+  () => {
+    if (isLive.value) return;
+    const row = timeseries.samples.lastAt(windowEndMs.value);
+    if (!row) return;
+    const adapted = chRowToPlayerRecord(row);
+    setArchivePlayer(archivePlayerId.value, adapted);
+    qc.setQueryData(playerKey(archivePlayerId.value), { player: adapted, etag: undefined });
+  },
+);
+
+onMounted(() => window.addEventListener('keydown', onKey));
+onBeforeUnmount(() => window.removeEventListener('keydown', onKey));
+
+/* ─── Misc helpers ──────────────────────────────────────────────── */
+
+function fmtTime(ms: number): string {
+  if (!Number.isFinite(ms) || !ms) return '—';
+  const d = new Date(ms);
+  return d.toLocaleString('en-US', { hour12: false }) + '.' +
+    String(d.getMilliseconds()).padStart(3, '0');
+}
+function fmtDur(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '—';
+  const s = Math.floor(ms / 1000);
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  return hh ? `${hh}h ${mm}m ${ss}s` : `${mm}m ${ss}s`;
+}
+function fmtDurShort(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '—';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+const scrubMin = computed(() => timeRange.value?.min ?? 0);
+const scrubMax = computed(() => timeRange.value?.max ?? 0);
+
+function skipToStart() {
+  const r = timeRange.value; if (!r) return;
+  const span = Math.max(1000, windowEndMs.value - windowStartMs.value);
+  windowStartMs.value = r.min;
+  windowEndMs.value = Math.min(r.max, r.min + span);
+  userMovedBrush.value = true;
+}
+function skipToEnd() {
+  const r = timeRange.value; if (!r) return;
+  const span = Math.max(1000, windowEndMs.value - windowStartMs.value);
+  windowEndMs.value = r.max;
+  windowStartMs.value = Math.max(r.min, r.max - span);
+  userMovedBrush.value = false;
+}
+
+</script>
+
+<template>
+  <div class="session-display">
+    <!-- Brush + event filter + nav-bar live in a persistent fold so
+         the operator can collapse them out of the way without losing
+         the live view to a pause-state toggle. Pause-gated visibility
+         was disruptive — the section appearing / disappearing under
+         the panels caused layout jumps. Now always rendered; operator
+         hides via the fold chevron. -->
+    <CollapsibleSection title="Focus Window" :open="true" persist-key="focus-window">
+    <!-- Empty-state placeholder: a fresh session has no archived
+         snapshots until the forwarder ingests a few seconds of SSE
+         data. The brush rail without any rows is a misleading
+         full-width green bar with `—` time labels, so swap it out
+         for a short status message until rows arrive. -->
+    <div v-if="!samplesCount" class="brush-empty">
+      <span class="brush-empty-title">No archived snapshots yet</span>
+      <span class="brush-empty-detail">
+        <template v-if="loading">streaming history…</template>
+        <template v-else-if="error">error: {{ error }}</template>
+        <template v-else>Live samples stream into the charts below; the focus rail will fill in as the forwarder ingests.</template>
+      </span>
+    </div>
+    <div v-else class="brush">
+      <div class="brush-row">
+        <button
+          type="button"
+          class="brush-skip"
+          @click="skipToStart"
+          :disabled="!timeRange"
+          title="Jump focus window to start"
+        >⏮</button>
+
+        <div
+          class="brush-rail"
+          ref="railRef"
+          @mousedown="onRailMouseDown"
+          @wheel="onRailWheel"
+        >
+          <button
+            v-for="(m, i) in railMarkers"
+            :key="i"
+            type="button"
+            class="brush-tick"
+            :class="{ current: m.isCurrent }"
+            :style="{
+              left: m.leftPct + '%',
+              background: m.color,
+              opacity: m.opacity,
+              '--tick-color': m.color,
+            }"
+            :data-title="m.title"
+            :title="m.title"
+            @click.stop="selectInstance(m.ev, String(m.ev.type ?? 'event'), m.ev._p)"
+          />
+          <div
+            v-if="timeRange"
+            class="brush-window"
+            :class="{ dragging: dragState }"
+            :style="{
+              left: ((windowStartMs - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              right: ((scrubMax - windowEndMs) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            }"
+            @mousedown.stop="onBrushMouseDown($event, 'pan')"
+          >
+            <div class="brush-handle left" @mousedown.stop="onBrushMouseDown($event, 'resize-left')" />
+            <div class="brush-handle right" @mousedown.stop="onBrushMouseDown($event, 'resize-right')" />
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="brush-skip"
+          @click="skipToEnd"
+          :disabled="!timeRange"
+          title="Jump focus window to end"
+        >⏭</button>
+      </div>
+
+      <div class="brush-labels-row">
+        <span class="rail-edge-label">{{ fmtTime(scrubMin) }}</span>
+        <span
+          v-if="timeRange"
+          class="rail-focus-label"
+          :style="{
+            left: ((windowStartMs - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            right: ((scrubMax - windowEndMs) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+          }"
+        >
+          <span class="focus-pill">{{ fmtDurShort(windowSpanMs) }} · at end</span>
+          <span class="focus-pill subtle">{{ samplesCount.toLocaleString() }} rendered</span>
+        </span>
+        <span class="rail-edge-label">{{ fmtTime(scrubMax) }}</span>
+      </div>
+
+      <div class="event-filter" v-if="sessionEvents.length">
+        <div class="kind-row">
+          <span class="chips-label">Show:</span>
+          <button
+            type="button"
+            class="kind-pill effect"
+            :class="{ off: !enabledKind.effect }"
+            @click="enabledKind.effect = !enabledKind.effect"
+            title="Effects — what the player or user saw"
+          >
+            {{ enabledKind.effect ? '✓' : '○' }} Effects · {{ kindCount('effect') }}
+          </button>
+          <button
+            type="button"
+            class="kind-pill cause"
+            :class="{ off: !enabledKind.cause }"
+            @click="enabledKind.cause = !enabledKind.cause"
+            title="Causes — proxy/system actions"
+          >
+            {{ enabledKind.cause ? '✓' : '○' }} Causes · {{ kindCount('cause') }}
+          </button>
+        </div>
+
+        <div
+          v-for="p in PRIORITY_ORDER"
+          :key="p"
+          class="tier-group"
+          :class="{
+            expanded: expandedTiers[p],
+            dim: !tierCounts[p],
+            'tier-active': lockedPriority === p && !lockedType,
+          }"
+          :style="{
+            '--tier-bg': PRIORITY_META[p].bg,
+            '--tier-border': PRIORITY_META[p].border,
+            '--tier-color': PRIORITY_META[p].color,
+          }"
+        >
+          <div class="tier-header">
+            <button
+              type="button"
+              class="tier-chevron-btn"
+              @click="toggleTier(p)"
+              :title="expandedTiers[p] ? 'Collapse' : 'Expand'"
+            >
+              {{ expandedTiers[p] ? '▾' : '▸' }}
+            </button>
+            <button
+              type="button"
+              class="tier-name-btn"
+              @click="selectTier(p); expandedTiers[p] = true"
+              :title="`Walk all ${tierCounts[p]} ${PRIORITY_META[p].label} event(s) with prev/next`"
+              :disabled="!tierCounts[p]"
+            >
+              <span class="tier-dot" />
+              <span class="tier-name">{{ PRIORITY_META[p].label }}</span>
+              <span class="tier-count-pill">{{ tierCounts[p] }}</span>
+            </button>
+            <button
+              type="button"
+              class="tier-eye-btn"
+              :class="{ off: !visiblePriority[p] }"
+              @click="togglePriorityVisibility(p, $event)"
+              :title="visiblePriority[p] ? `Hide ${PRIORITY_META[p].label} events from the rail` : `Show ${PRIORITY_META[p].label} events on the rail`"
+              :disabled="!tierCounts[p]"
+            >
+              <svg v-if="visiblePriority[p]" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
+                <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
+              </svg>
+              <svg v-else viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
+                <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
+              </svg>
+            </button>
+            <div class="tier-preview-chips" v-if="!expandedTiers[p] && tierCounts[p]">
+              <button
+                v-for="t in tierPreview(p)"
+                :key="t.type"
+                type="button"
+                class="preview-chip"
+                @click="pickPreviewType(t.type, p)"
+                :title="`Walk ${t.count} ${t.type} event(s)`"
+              >
+                {{ t.type }} · {{ t.count }}
+              </button>
+              <span v-if="tierPreviewMore(p)" class="preview-more">
+                +{{ tierPreviewMore(p) }} more
+              </span>
+            </div>
+          </div>
+
+          <div class="tier-body" v-if="expandedTiers[p] && tierCounts[p]">
+            <div
+              v-for="t in tierTypes[p]"
+              :key="t.type"
+              class="type-row-wrap"
+            >
+              <div
+                class="type-row"
+                :class="{
+                  active: lockedPriority === p && lockedType === t.type,
+                  'instances-open': expandedTypeKey === typeKey(t.type, p),
+                  hidden: !isTypeVisible(t.type, p),
+                }"
+              >
+                <button
+                  type="button"
+                  class="type-chevron-btn"
+                  @click="toggleTypeExpand(t.type, p)"
+                  :title="expandedTypeKey === typeKey(t.type, p) ? 'Hide instances' : 'Show instances'"
+                >
+                  {{ expandedTypeKey === typeKey(t.type, p) ? '▾' : '▸' }}
+                </button>
+                <button
+                  type="button"
+                  class="type-name-btn-row"
+                  @click="selectType(t.type, p)"
+                  :title="`Walk ${t.count} ${t.type} event(s) with prev/next`"
+                >
+                  <span class="type-name">{{ t.type }}</span>
+                  <span class="type-count">{{ t.count }}</span>
+                </button>
+                <button
+                  type="button"
+                  class="type-eye-btn"
+                  :class="{ off: !isTypeVisible(t.type, p) }"
+                  @click="toggleTypeVisibility(t.type, p, $event)"
+                  :title="isTypeVisible(t.type, p) ? `Hide ${t.type} events from the rail` : `Show ${t.type} events on the rail`"
+                >
+                  <svg v-if="isTypeVisible(t.type, p)" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
+                    <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
+                  </svg>
+                  <svg v-else viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clip-rule="evenodd"/>
+                    <path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.065 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/>
+                  </svg>
+                </button>
+              </div>
+              <div class="instances" v-if="expandedTypeKey === typeKey(t.type, p)">
+                <button
+                  v-for="(ev, idx) in tierTypeInstances[typeKey(t.type, p)] ?? []"
+                  :key="idx"
+                  type="button"
+                  class="instance-row"
+                  :class="{
+                    current: navCurrent
+                      && lockedPriority === p
+                      && lockedType === t.type
+                      && navCurrent._ts === ev._ts,
+                  }"
+                  @click="selectInstance(ev, t.type, p)"
+                  :title="`Jump to this event at ${fmtTime(ev._ts)}`"
+                >
+                  <span class="instance-marker">▸</span>
+                  <span class="instance-time">{{ fmtTime(ev._ts) }}</span>
+                  <span class="instance-info" v-if="ev.info">{{ ev.info }}</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="nav-bar" v-if="navEvents.length">
+        <span class="nav-scope">
+          Showing: <strong>{{ scopeLabel }}</strong>
+          <span class="nav-detail" v-if="navCurrent">
+            · current {{ fmtTime(navCurrent._ts) }}<template v-if="navCurrent.info"> · {{ navCurrent.info }}</template>
+          </span>
+        </span>
+        <button class="nav-btn" type="button" @click="navPrev" :disabled="navEvents.length < 2" title="Previous (,)">‹ prev</button>
+        <span class="nav-counter">{{ navCursor + 1 }} / {{ navEvents.length }}</span>
+        <button class="nav-btn" type="button" @click="navNext" :disabled="navEvents.length < 2" title="Next (.)">next ›</button>
+        <button
+          v-if="lockedPriority || lockedType"
+          class="btn-mini"
+          type="button"
+          @click="clearScope"
+          title="Clear scope — walk every event"
+        >Clear scope</button>
+      </div>
+
+      <div class="brush-actions">
+        <button
+          type="button"
+          class="btn live-toggle"
+          :class="{ checked: brushLiveChecked }"
+          @click="coord.togglePause()"
+          :title="brushLiveChecked ? 'Pause at current live edge' : 'Resume following live'"
+        >
+          {{ brushLiveChecked ? '●' : '○' }} Live
+        </button>
+        <span class="brush-status">
+          <template v-if="loading">streaming · {{ samplesCount.toLocaleString() }} snapshots</template>
+          <template v-else-if="error"><span class="brush-status-err">error: {{ error }}</span></template>
+          <template v-else>complete · {{ samplesCount.toLocaleString() }} snapshots</template>
+        </span>
+      </div>
+
+      <div v-if="loading" class="thin-progress">
+        <div class="thin-progress-shimmer" />
+      </div>
+    </div>
+    </CollapsibleSection>
+
+    <!-- Display panels — same components in both modes; data routes
+         through usePlayer/getPlayer per the playerId prefix. -->
+    <CollapsibleSection v-if="!hideSessionDetails" title="Session Details" persist-key="session-details">
+      <SessionDetails :player-id="archivePlayerId" />
+    </CollapsibleSection>
+
+    <CollapsibleSection title="Player Metrics" persist-key="player-metrics">
+      <PlayerMetrics :player-id="archivePlayerId" />
+    </CollapsibleSection>
+
+    <CollapsibleSection title="Player State" :open="true" eager persist-key="player-state">
+      <EventsTimeline :player-id="archivePlayerId" :samples-stream="timeseries.samples" />
+    </CollapsibleSection>
+
+    <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">
+      <BitrateChartPanelToolbar :player-id="archivePlayerId" />
+      <div class="chart-stack">
+        <BandwidthChart :player-id="archivePlayerId" :samples-stream="timeseries.samples" />
+        <RTTChart :player-id="archivePlayerId" :samples-stream="timeseries.samples" />
+        <BufferChart :player-id="archivePlayerId" :samples-stream="timeseries.samples" />
+        <FPSChart :player-id="archivePlayerId" :samples-stream="timeseries.samples" />
+      </div>
+    </CollapsibleSection>
+
+    <CollapsibleSection title="Network Log" persist-key="network-log">
+      <!-- The page-level brush in SessionDisplay is the only scrub
+           surface — archive shows it always, live shows it once
+           paused. NetworkLog's own in-panel brush would duplicate it
+           (or worse, show a brush in live-not-paused when nothing
+           else does), so always opt out of it here. -->
+      <NetworkLog :player-id="archivePlayerId" :network-stream="timeseries.network" />
+    </CollapsibleSection>
+  </div>
+</template>
+
+<style scoped>
+.session-display { display: contents; }
+
+/* Empty-state for the Focus Window before archive snapshots land. */
+.brush-empty {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.brush-empty-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+.brush-empty-detail {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+/* Brush block — joins onto the page header above (no gap, shared
+ * borders) for a single unified top panel. */
+.brush {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0 0 8px 8px;
+  padding: 12px 14px 10px;
+  margin-bottom: 14px;
+  position: relative;
+}
+.brush-row { display: flex; align-items: stretch; gap: 8px; }
+
+.brush-skip {
+  width: 32px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #4b5563;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.brush-skip:hover:not(:disabled) { background: #f3f4f6; color: #111827; }
+.brush-skip:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.brush-rail {
+  flex: 1;
+  position: relative;
+  height: 30px;
+  background: #d1fae5;
+  border-radius: 6px;
+  overflow: visible;
+  cursor: crosshair;
+}
+.brush-rail .brush-tick {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  border: 0;
+  padding: 0;
+  transform: translateX(-1px);
+  border-radius: 1px;
+  opacity: 0.9;
+  z-index: 3;
+  cursor: pointer;
+}
+.brush-rail .brush-tick:hover {
+  opacity: 1;
+  width: 5px;
+  top: -3px;
+  bottom: -3px;
+  box-shadow: 0 0 0 1px #fff, 0 1px 4px rgba(0,0,0,0.25);
+}
+.brush-rail .brush-tick:hover::after {
+  content: attr(data-title);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1f2937;
+  color: #fff;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.25);
+}
+.brush-rail .brush-tick.current {
+  width: 5px;
+  top: -3px;
+  bottom: -3px;
+  outline: 2px solid #fff;
+  outline-offset: -1px;
+  box-shadow: 0 0 0 1px var(--tick-color, #1d4ed8), 0 0 0 3px rgba(29,78,216,0.25);
+  z-index: 3;
+}
+
+.brush-window {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(29, 78, 216, 0.18);
+  border: 0;
+  border-radius: 6px;
+  box-shadow:
+    inset 0 0 0 1px rgba(29, 78, 216, 0.45),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.4);
+  cursor: grab;
+  box-sizing: border-box;
+  z-index: 2;
+}
+.brush-window.dragging { cursor: grabbing; }
+.brush-handle {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  width: 8px;
+  background: #1d4ed8;
+  border-radius: 3px;
+  cursor: ew-resize;
+  box-shadow: 0 1px 3px rgba(29, 78, 216, 0.4);
+}
+.brush-handle.left  { left: -4px; }
+.brush-handle.right { right: -4px; }
+
+.brush-labels-row {
+  position: relative;
+  margin: 4px 40px 0;
+  height: 16px;
+  font-size: 10.5px;
+  color: #6b7280;
+  font-family: ui-monospace, monospace;
+}
+.rail-edge-label { position: absolute; top: 0; }
+.rail-edge-label:first-child { left: 0; }
+.rail-edge-label:last-child  { right: 0; }
+.rail-focus-label {
+  position: absolute;
+  top: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  justify-content: center;
+  min-width: 60px;
+  pointer-events: none;
+}
+.focus-pill {
+  background: rgba(29, 78, 216, 0.08);
+  color: #1d4ed8;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+.focus-pill.subtle { background: transparent; color: #6b7280; font-weight: 500; padding: 1px 0; }
+
+/* Event filter ─── L0 / L1 / L2 / L3 */
+.chips-label { font-size: 11px; color: #6b7280; font-weight: 500; margin-right: 2px; }
+.kind-row { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin: 10px 0 0; }
+.kind-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.kind-pill.effect { background: #dbeafe; border-color: #93c5fd; color: #1d4ed8; }
+.kind-pill.cause  { background: #fed7aa; border-color: #fdba74; color: #7c2d12; }
+.kind-pill.off    { opacity: 0.4; background: #f3f4f6; border-color: #d1d5db; color: #6b7280; }
+
+.event-filter {
+  margin: 10px 0 0;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.tier-group {
+  --tier-bg: #f3f4f6;
+  --tier-border: #d1d5db;
+  --tier-color: #4b5563;
+  border-top: 1px solid #e5e7eb;
+}
+.tier-group:first-of-type { border-top: none; }
+.tier-group.dim { opacity: 0.5; }
+.tier-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px 4px 4px;
+  background: transparent;
+  font-size: 12px;
+}
+.tier-group.expanded .tier-header { background: var(--tier-bg); }
+.tier-group.tier-active .tier-header { background: var(--tier-bg); }
+.tier-chevron-btn {
+  width: 22px;
+  height: 22px;
+  font-size: 10px;
+  color: var(--tier-color);
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.tier-chevron-btn:hover { background: rgba(0,0,0,0.05); }
+.tier-name-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 10px;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+  cursor: pointer;
+  text-align: left;
+  flex-shrink: 0;
+}
+.tier-name-btn:hover:not(:disabled) { background: rgba(0,0,0,0.05); }
+.tier-name-btn:disabled { cursor: default; opacity: 0.5; }
+.tier-group.tier-active .tier-name-btn { box-shadow: inset 0 0 0 2px var(--tier-color); }
+.tier-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tier-color);
+  flex-shrink: 0;
+}
+.tier-name { color: var(--tier-color); }
+.tier-count-pill {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--tier-color);
+  background: rgba(255,255,255,0.7);
+  border-radius: 999px;
+  padding: 0 7px;
+  min-width: 22px;
+  text-align: center;
+  font-size: 11px;
+}
+
+.tier-eye-btn {
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--tier-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  opacity: 0.75;
+}
+.tier-eye-btn svg { width: 16px; height: 16px; display: block; }
+.tier-eye-btn:hover:not(:disabled) { background: rgba(0,0,0,0.06); opacity: 1; }
+.tier-eye-btn.off { opacity: 0.45; color: #6b7280; }
+.tier-eye-btn:disabled { opacity: 0.2; cursor: not-allowed; }
+
+.type-eye-btn {
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--tier-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  margin-right: 6px;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+.type-eye-btn svg { width: 14px; height: 14px; display: block; }
+.type-row:hover .type-eye-btn,
+.type-row .type-eye-btn.off { opacity: 0.75; }
+.type-row .type-eye-btn:hover { background: rgba(0,0,0,0.06); opacity: 1; }
+.type-row .type-eye-btn.off { color: #6b7280; }
+.type-row.hidden .type-name-btn-row { opacity: 0.45; }
+
+.tier-preview-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+  flex: 1;
+  min-width: 0;
+}
+.preview-chip {
+  font-size: 10.5px;
+  font-family: ui-monospace, monospace;
+  font-weight: 500;
+  padding: 1px 8px;
+  border: 1px solid var(--tier-border);
+  background: #fff;
+  color: var(--tier-color);
+  border-radius: 999px;
+  cursor: pointer;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+.preview-chip:hover { background: var(--tier-color); color: #fff; border-color: var(--tier-color); }
+.preview-more { font-size: 10px; color: #6b7280; font-style: italic; margin-left: 2px; }
+
+.tier-body { max-height: 240px; overflow-y: auto; border-top: 1px solid #e5e7eb; background: #fff; }
+.type-row-wrap {}
+.type-row {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background: transparent;
+  font-family: ui-monospace, monospace;
+  border-left: 3px solid transparent;
+}
+.type-row.active { background: var(--tier-bg); border-left-color: var(--tier-color); }
+.type-row.instances-open { background: rgba(0,0,0,0.02); }
+.type-chevron-btn {
+  width: 28px;
+  background: transparent;
+  border: 0;
+  font-size: 10px;
+  color: var(--tier-color);
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.type-chevron-btn:hover { background: rgba(0,0,0,0.05); }
+.type-name-btn-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  padding: 4px 10px 4px 4px;
+  background: transparent;
+  border: 0;
+  font-size: 11.5px;
+  color: #374151;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+.type-name-btn-row:hover { background: #f9fafb; }
+.type-row.active .type-name-btn-row { font-weight: 700; color: var(--tier-color); }
+.type-name { flex: 1; }
+.type-count { font-variant-numeric: tabular-nums; color: #6b7280; font-size: 10.5px; }
+.type-row.active .type-count { color: var(--tier-color); }
+
+.instances {
+  background: #fafafa;
+  border-top: 1px dashed #e5e7eb;
+  border-bottom: 1px dashed #e5e7eb;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.instance-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 3px 10px 3px 60px;
+  background: transparent;
+  border: 0;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  color: #4b5563;
+  cursor: pointer;
+  text-align: left;
+}
+.instance-row:hover { background: rgba(29, 78, 216, 0.06); }
+.instance-row.current {
+  background: rgba(29, 78, 216, 0.12);
+  color: #1d4ed8;
+  font-weight: 700;
+  box-shadow: inset 3px 0 0 #1d4ed8;
+}
+.instance-marker { width: 10px; font-size: 9px; color: #9ca3af; text-align: center; }
+.instance-row.current .instance-marker { color: #1d4ed8; }
+.instance-time { font-variant-numeric: tabular-nums; flex-shrink: 0; }
+.instance-info {
+  color: #6b7280;
+  font-size: 10.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.instance-row.current .instance-info { color: #1d4ed8; }
+
+.nav-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0 0;
+  padding: 6px 10px;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #374151;
+  flex-wrap: wrap;
+}
+.nav-scope { flex: 1; min-width: 0; }
+.nav-scope strong { color: #111827; }
+.nav-detail { color: #1d4ed8; font-family: ui-monospace, monospace; font-size: 10.5px; }
+.nav-btn {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #1f2937;
+}
+.nav-btn:hover:not(:disabled) { background: #f3f4f6; }
+.nav-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.nav-counter {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: #6b7280;
+  padding: 0 4px;
+  min-width: 60px;
+  text-align: center;
+}
+
+.brush-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: #4b5563;
+}
+.btn-mini {
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.btn-mini:hover { background: #f3f4f6; }
+/* Live toggle in the brush rail — matches the chart-toolbar style
+ * (filled green when checked, muted when unchecked) so all four
+ * Live toggles on the page look the same and update in lockstep. */
+.brush-actions .btn.live-toggle {
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #f3f4f6;
+  color: #6b7280;
+  cursor: pointer;
+}
+.brush-actions .btn.live-toggle:hover { background: #e5e7eb; color: #374151; }
+.brush-actions .btn.live-toggle.checked {
+  background: #10b981;
+  border-color: #059669;
+  color: #fff;
+  font-weight: 600;
+}
+.brush-actions .btn.live-toggle.checked:hover { background: #059669; }
+.brush-status {
+  margin-left: auto;
+  font-size: 11px;
+  color: #6b7280;
+  font-family: ui-monospace, monospace;
+}
+.brush-status-err { color: #b91c1c; }
+
+.thin-progress {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  overflow: hidden;
+  border-radius: 0 0 8px 8px;
+}
+.thin-progress-shimmer {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(90deg,
+    transparent 0 6px,
+    rgba(59, 130, 246, 0.6) 6px 12px);
+  animation: viewer-shimmer 0.8s linear infinite;
+}
+@keyframes viewer-shimmer {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(12px); }
+}
+
+.chart-stack { display: grid; gap: 12px; }
+</style>

--- a/content/dashboard-v3/src/components/ShapeSliders.vue
+++ b/content/dashboard-v3/src/components/ShapeSliders.vue
@@ -41,8 +41,22 @@ const patternRunning = computed(() => {
   return !!(p && Array.isArray(p.steps) && p.steps.length);
 });
 
-// What the slider displays. Local wins during drag; model wins otherwise.
-const dispRate = computed(() => localRate.value ?? player.value?.shape?.rate_mbps ?? 0);
+// What the slider displays. Local wins during drag; model wins
+// otherwise. When a pattern is running we display the kernel-
+// enforced runtime rate (`pattern_rate_runtime_mbps`) instead of the
+// static `rate_mbps` so the slider tracks the pattern as it steps,
+// matching the legacy behaviour the operator expects. Slider is
+// disabled in that mode (see `patternRunning`) so the moving handle
+// is read-only.
+const dispRate = computed(() => {
+  if (localRate.value !== null) return localRate.value;
+  const sh = player.value?.shape;
+  if (patternRunning.value) {
+    const rt = sh?.pattern_rate_runtime_mbps;
+    if (rt != null && Number.isFinite(rt)) return rt;
+  }
+  return sh?.rate_mbps ?? 0;
+});
 const dispDelay = computed(() => localDelay.value ?? player.value?.shape?.delay_ms ?? 0);
 const dispLoss = computed(() => localLoss.value ?? player.value?.shape?.loss_pct ?? 0);
 

--- a/content/dashboard-v3/src/components/ShellLayout.vue
+++ b/content/dashboard-v3/src/components/ShellLayout.vue
@@ -46,7 +46,7 @@ interface NavSection {
  *  has a valid origin to work from. v3 pages stay on localhost so HMR
  *  keeps working there. */
 const DEV_PORT = '5173';
-const DEV_BACKEND = 'http://jonathanoliver-ubuntu.local:21000';
+const DEV_BACKEND = 'https://jonathanoliver-ubuntu.local:21000';
 
 function rewriteHrefForDev(href: string): string {
   if (typeof window === 'undefined') return href;
@@ -81,7 +81,7 @@ const sections: NavSection[] = [
       { id: 'playback',      icon: '▶️', text: 'Playback',        href: '/dashboard/playback.html' },
       { id: 'test-playback', icon: '🧭', text: 'Testing Playback',href: '/dashboard/v3/testing-session.html?nav=1' },
       { id: 'testing',       icon: '🧪', text: 'Testing Monitor', href: '/dashboard/v3/testing.html' },
-      { id: 'sessions',      icon: '⏪', text: 'Sessions',         href: '/dashboard/sessions.html' },
+      { id: 'sessions',      icon: '⏪', text: 'Sessions',         href: '/dashboard/v3/sessions.html' },
       { id: 'quartet',       icon: '🎬', text: 'Quartet',          href: '/dashboard/quartet.html', alpha: true },
       { id: 'segment-duration', icon: '⏱️', text: 'Live Offset',   href: '/dashboard/segment-duration-comparison.html', alpha: true },
     ],

--- a/content/dashboard-v3/src/components/VideoPlayerFrame.vue
+++ b/content/dashboard-v3/src/components/VideoPlayerFrame.vue
@@ -67,6 +67,32 @@ function normalizeStreamUrl(url: string): string {
   }
 }
 
+/** Web-minted play_id for this playback. Apple/Roku clients self-report
+ *  a play_id; the v3 web player previously relied on the server-side
+ *  v5 fallback derivation, which made archive lookups fragile. Minting
+ *  here and surfacing via `?play_id=<uuid>` lets the proxy store the
+ *  same id the dashboard later queries by.
+ *  Bumped on Retry / Restart via mintPlayId() so each new playback gets
+ *  a fresh row in the archive. */
+function mintPlayId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID (mirrors the
+  // Grid.vue helper). Hand-assembled UUIDv4 with proper version bits.
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+const webPlayId = ref<string>(mintPlayId());
+
 const masterUrl = computed<string | null>(() => {
   // Explicit override beats whatever the player record says.
   let raw: string | null = null;
@@ -81,7 +107,18 @@ const masterUrl = computed<string | null>(() => {
   if (!raw) return null;
   const normalized = normalizeStreamUrl(raw);
   if (normalized !== raw) console.log('[VPF] masterUrl normalized to shaper port', normalized);
-  return normalized;
+  // Attach our minted play_id so the proxy records it on session
+  // creation; this is what shows up in /api/v2/players.current_play.id
+  // and in the forwarder's session_snapshots.play_id column.
+  try {
+    const u = new URL(normalized, window.location.href);
+    if (!u.searchParams.get('play_id') && webPlayId.value) {
+      u.searchParams.set('play_id', webPlayId.value);
+    }
+    return u.toString();
+  } catch {
+    return normalized;
+  }
 });
 
 type Engine = 'auto' | 'hlsjs' | 'shaka' | 'videojs' | 'native';

--- a/content/dashboard-v3/src/composables/chRowAdapter.ts
+++ b/content/dashboard-v3/src/composables/chRowAdapter.ts
@@ -1,0 +1,118 @@
+/**
+ * chRowAdapter — adapter from a CH session_snapshots row (wire shape
+ * from /api/v3/timeseries) to the v2 PlayerRecord shape the rest of
+ * the dashboard expects (nested player_metrics / server_metrics, with
+ * a couple of fields renamed).
+ *
+ * Lives outside the renderers because both MetricsLineChart and
+ * SessionDisplay read CH rows now (TS5+TS6) and shouldn't each carry
+ * their own copy of the mapping. Mirrors the inverse direction in
+ * go-forwarder/v2translate.go.
+ */
+import type { PlayerRecord } from '@/repo/v2-repo';
+
+export function tsOfRow(row: Record<string, unknown>): number {
+  const v = row.ts;
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string' || !v) return NaN;
+  if (v.length > 10 && v.charAt(10) === ' ') {
+    return Date.parse(v.replace(' ', 'T') + 'Z');
+  }
+  return Date.parse(v);
+}
+
+function num(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') { const n = Number(v); return Number.isFinite(n) ? n : null; }
+  return null;
+}
+
+/** Adapter — synthesize a PlayerRecord-shaped object from one CH row.
+ *  CH stores flat columns; the v2 wire shape nests them under
+ *  player_metrics.* and server_metrics.*. Map here so per-series
+ *  accessors and panel templates don't need to know the storage
+ *  shape. */
+export function chRowToPlayerRecord(row: Record<string, unknown>): PlayerRecord {
+  const playerMetrics = {
+    event_time: typeof row.event_time === 'string' ? row.event_time
+      : (typeof row.ts === 'string' ? row.ts : ''),
+    state: typeof row.player_state === 'string' ? row.player_state : '',
+    waiting_reason: typeof row.waiting_reason === 'string' ? row.waiting_reason : '',
+    error: typeof row.player_error === 'string' ? row.player_error : '',
+    video_resolution: typeof row.video_resolution === 'string' ? row.video_resolution : '',
+    display_resolution: typeof row.display_resolution === 'string' ? row.display_resolution : '',
+    video_bitrate_mbps: num(row.video_bitrate_mbps),
+    network_bitrate_mbps: num(row.network_bitrate_mbps),
+    avg_network_bitrate_mbps: num(row.avg_network_bitrate_mbps),
+    buffer_depth_s: num(row.buffer_depth_s),
+    buffer_end_s: num(row.buffer_end_s),
+    live_offset_s: num(row.live_offset_s),
+    true_offset_s: num(row.true_offset_s),
+    frames_displayed: num(row.frames_displayed),
+    dropped_frames: num(row.dropped_frames),
+    // CH stores `stall_count`; v2 wire uses `stalls`.
+    stalls: num(row.stall_count),
+    stall_time_s: num(row.stall_time_s),
+    first_frame_time_s: num(row.video_first_frame_time_s),
+    video_start_time_s: num(row.video_start_time_s),
+  } as PlayerRecord['player_metrics'];
+
+  const serverMetrics = {
+    measured_mbps: num(row.measured_mbps),
+    mbps_shaper_rate: num(row.mbps_shaper_rate),
+    mbps_shaper_avg: num(row.mbps_shaper_avg),
+    mbps_transfer_rate: num(row.mbps_transfer_rate),
+    mbps_transfer_complete: num(row.mbps_transfer_complete),
+    // CH `client_*` columns map to v2 `server_metrics.*` (TCP_INFO at
+    // the proxy's socket, server-side from the player's POV).
+    rtt_ms: num(row.client_rtt_ms),
+    rtt_min_ms: num(row.client_rtt_min_ms),
+    rtt_max_ms: num(row.client_rtt_max_ms),
+    rto_ms: num(row.client_rto_ms),
+    path_ping_rtt_ms: num(row.client_path_ping_rtt_ms),
+    // Server's view of the player's active variant — pairs with
+    // player_metrics.video_bitrate_mbps so BandwidthChart can draw
+    // both "Player Variant" and "Server Variant" for archived plays.
+    rendition_mbps: num(row.server_video_rendition_mbps),
+  } as PlayerRecord['server_metrics'];
+
+  // Reconstruct the per-snapshot shaper config the BandwidthChart's
+  // "Limit (rate_mbps)" accessor reads via `p.shape.*`. The proxy's
+  // pattern_rate_runtime_mbps is the effective enforced rate when a
+  // pattern is active; static `nftables_bandwidth_mbps` is the
+  // baseline when no pattern is running. pattern_steps is stored as
+  // a JSON string in CH — parsed lazily here so the accessor can
+  // walk `steps[stepIdx-1].rate_mbps` for the legacy "between
+  // pattern_rate_runtime updates" fallback.
+  let patternSteps: { rate_mbps?: number }[] | null = null;
+  const stepsRaw = row.nftables_pattern_steps;
+  if (typeof stepsRaw === 'string' && stepsRaw.length > 0 && stepsRaw !== 'null') {
+    try { const parsed = JSON.parse(stepsRaw); if (Array.isArray(parsed)) patternSteps = parsed; }
+    catch { /* malformed pattern JSON — leave null */ }
+  }
+  const patternEnabled = Number(row.nftables_pattern_enabled ?? 0) === 1;
+  const shape = {
+    rate_mbps: num(row.nftables_bandwidth_mbps),
+    pattern: patternEnabled && patternSteps && patternSteps.length
+      ? { steps: patternSteps }
+      : null,
+    pattern_rate_runtime_mbps: num(row.nftables_pattern_rate_runtime_mbps),
+    pattern_step: num(row.nftables_pattern_step),
+    pattern_step_runtime: num(row.nftables_pattern_step),
+  };
+
+  return {
+    id: typeof row.player_id === 'string' ? row.player_id : '',
+    last_seen_at: typeof row.event_time === 'string' ? row.event_time
+      : (typeof row.ts === 'string' ? row.ts : ''),
+    player_metrics: playerMetrics,
+    server_metrics: serverMetrics,
+    current_play: typeof row.play_id === 'string' ? { id: row.play_id } : null,
+    loop_count_server: num(row.loop_count_server),
+    control_revision: row.control_revision == null ? undefined : String(row.control_revision),
+    shape,
+    // current_play.manifest.* isn't persisted per-snapshot; EventsTimeline
+    // reads manifest_variants directly out of the raw CH row.
+  } as unknown as PlayerRecord;
+}

--- a/content/dashboard-v3/src/composables/sessionTimeSeriesUtils.ts
+++ b/content/dashboard-v3/src/composables/sessionTimeSeriesUtils.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure helpers shared between useSessionTimeSeries and consumers
+ * that want to do their own range queries against the same data
+ * (e.g. compare-charts overlays in the future).
+ *
+ * No Vue imports — keep this side-effect-free so it can be unit-
+ * tested without a Vue runtime.
+ */
+
+/**
+ * tsOf — coerces a row's timestamp field to ms-since-epoch.
+ *
+ * Accepts:
+ *   - DateTime64(3) string from CH JSONEachRow ("YYYY-MM-DD HH:MM:SS.fff")
+ *   - ISO-8601 string ("2026-05-15T13:17:15.375Z")
+ *   - number (already ms)
+ *
+ * Returns NaN for unparseable inputs; callers filter these out.
+ *
+ * The CH-format string lacks a trailing 'Z' but represents UTC; we
+ * append 'Z' to force Date.parse to treat it as UTC instead of the
+ * browser's local TZ.
+ */
+export function tsOf(row: unknown): number {
+  if (row == null) return NaN;
+  const r = row as Record<string, unknown>;
+  const v = r.ts ?? r.timestamp;
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string' || !v) return NaN;
+  // CH format "YYYY-MM-DD HH:MM:SS.fff" — replace the space with 'T'
+  // and append 'Z'. ISO format already parses correctly.
+  if (v.length > 10 && v.charAt(10) === ' ') {
+    return Date.parse(v.replace(' ', 'T') + 'Z');
+  }
+  return Date.parse(v);
+}
+
+/**
+ * binarySearch — index of greatest element ≤ target by `keyOf`.
+ * Returns -1 if every element is greater than target.
+ *
+ * Used by lastAt(t) for chart cursor positioning ("what's the most
+ * recent sample at time t?") — O(log n) on a sorted-asc array.
+ */
+export function binarySearchLE<T>(arr: T[], target: number, keyOf: (e: T) => number): number {
+  let lo = 0;
+  let hi = arr.length - 1;
+  let best = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const k = keyOf(arr[mid]);
+    if (k <= target) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}
+
+/**
+ * insertSortedDedup — splice `entry` into `arr` (sorted asc by
+ * keyOf) so the result stays sorted. If an existing element shares
+ * the dedup fingerprint with `entry`, replace it in place. Returns
+ * true if the array was modified.
+ *
+ * Used to merge SSE deltas into the cache as they arrive. O(log n)
+ * search + O(n) shift; chart render cost dominates.
+ */
+export function insertSortedDedup<T>(
+  arr: T[],
+  entry: T,
+  keyOf: (e: T) => number,
+  fpOf: (e: T) => string,
+): boolean {
+  const targetK = keyOf(entry);
+  const targetFP = fpOf(entry);
+  // Binary search for the first index whose key > targetK.
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (keyOf(arr[mid]) <= targetK) lo = mid + 1;
+    else hi = mid;
+  }
+  // Sweep backward from lo-1 to check for an existing fingerprint
+  // match at the same key (multiple rows can share a ts in network
+  // streams). Bounded sweep — if we don't find a match within the
+  // same-key cluster, splice.
+  for (let i = lo - 1; i >= 0 && keyOf(arr[i]) === targetK; i--) {
+    if (fpOf(arr[i]) === targetFP) {
+      arr[i] = entry;
+      return true;
+    }
+  }
+  arr.splice(lo, 0, entry);
+  return true;
+}
+
+/**
+ * inRangeAsc — slice the rows in [t1, t2] inclusive from a sorted-
+ * asc array. Binary-searches both ends for O(log n + k).
+ */
+export function inRangeAsc<T>(arr: T[], t1: number, t2: number, keyOf: (e: T) => number): T[] {
+  if (!arr.length || t1 > t2) return [];
+  // Find first index whose key ≥ t1.
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (keyOf(arr[mid]) < t1) lo = mid + 1;
+    else hi = mid;
+  }
+  const startIdx = lo;
+  // Find first index whose key > t2.
+  lo = startIdx;
+  hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (keyOf(arr[mid]) <= t2) lo = mid + 1;
+    else hi = mid;
+  }
+  return arr.slice(startIdx, lo);
+}
+
+/**
+ * evictOutsideViewport — drop entries whose ts is outside the
+ * eviction window `[viewport.t1 − 2·span, viewport.t2 + 2·span]`.
+ * Mutates `arr` in place; returns the number of entries removed.
+ *
+ * Caller calls this when the cache exceeds its soft memory budget;
+ * the 2·span guardband keeps adjacent panning cheap (no immediate
+ * re-fetch when the operator nudges the brush a few seconds).
+ */
+export function evictOutsideViewport<T>(
+  arr: T[],
+  viewportMin: number,
+  viewportMax: number,
+  keyOf: (e: T) => number,
+): number {
+  if (!arr.length) return 0;
+  const span = Math.max(0, viewportMax - viewportMin);
+  const lo = viewportMin - 2 * span;
+  const hi = viewportMax + 2 * span;
+  const kept: T[] = [];
+  for (const e of arr) {
+    const k = keyOf(e);
+    if (k >= lo && k <= hi) kept.push(e);
+  }
+  const removed = arr.length - kept.length;
+  if (removed > 0) {
+    // Replace contents in place so existing references stay valid.
+    arr.length = 0;
+    Array.prototype.push.apply(arr, kept);
+  }
+  return removed;
+}

--- a/content/dashboard-v3/src/composables/ssePool.ts
+++ b/content/dashboard-v3/src/composables/ssePool.ts
@@ -1,22 +1,25 @@
 /**
- * ssePool — shared singleton EventSource for `/api/v2/events?include=raw`
- * (no player_id filter, gets every player event). Used by both:
+ * ssePool — shared subscription to `/api/v2/events?include=raw` (the
+ * proxy's all-players control-plane stream). Used by both:
  *
  *   - usePlayers()    — the picker. Wants every player's events.
- *   - usePlayerSSE()  — per-player. Auto-detects this pool and
- *                       piggybacks on it (filtering by player_id in
- *                       JS) rather than opening a duplicate socket.
+ *   - usePlayerSSE()  — per-player. Filters by player_id in JS.
  *
- * The motivation is twofold:
- *   1. Chrome caps per-origin connections at 6 — when testing.html
- *      opened one filtered SSE per player_id plus one unfiltered, it
- *      blew the cap and got `ERR_ABORTED`d.
- *   2. Even under the cap, any open EventSource keeps the tab in the
- *      "loading" state. Fewer sockets = spinner stops sooner.
- *
- * Pool semantics: created on first subscriber, closed when the last
- * subscriber releases.
+ * One EventSource per page, fanned out to local subscribers. With
+ * the dashboard now served over TLS + HTTP/2 (TS11), multiple tabs
+ * multiplex onto a single TCP connection per origin — the
+ * SharedWorker indirection from TS10 was removed because the
+ * per-origin connection cap that motivated it disappears under h2.
  */
+
+const ALL_POOL_URL = '/api/v2/events?include=raw';
+const ALL_POOL_EVENT_TYPES = [
+  'heartbeat',
+  'player.created',
+  'player.updated',
+  'player.controls.updated',
+  'player.deleted',
+];
 
 export type ConnectionState = 'connecting' | 'open' | 'closed';
 
@@ -62,7 +65,7 @@ function fanOut(
 
 function ensureSocket() {
   if (allEs) return;
-  const es = new EventSource('/api/v2/events?include=raw');
+  const es = new EventSource(ALL_POOL_URL);
   allEs = es;
   setAllState('connecting');
   es.addEventListener('open', () => setAllState('open'));
@@ -106,11 +109,7 @@ export function subscribeAllPlayers(sub: AllPlayersSubscriber): { release: () =>
     release() {
       allSubs.delete(sub);
       if (allSubs.size === 0 && allEs) {
-        try {
-          allEs.close();
-        } catch {
-          /* ignore */
-        }
+        try { allEs.close(); } catch { /* ignore */ }
         allEs = null;
         allState = 'connecting';
       }

--- a/content/dashboard-v3/src/composables/useArchivedSessionEvents.ts
+++ b/content/dashboard-v3/src/composables/useArchivedSessionEvents.ts
@@ -1,0 +1,156 @@
+/**
+ * useArchivedSessionEvents(playerId, playId)
+ *
+ * Fetches the notable-events list for the SessionViewer's rail markers
+ * and jump-to-event dropdown. Mirrors the legacy session-replay.js
+ * call to /analytics/api/v2/session_events (NDJSON) — one record per
+ * notable thing (STALL, ERROR, SHIFT_UP/DOWN, FROZEN, LOOP, USER_MARK,
+ * RESTART, etc).
+ *
+ * Each event has at minimum: { event_time, type, severity? }. Some
+ * carry payload fields (e.g. STALL → stall_seconds, SHIFT_UP →
+ * previous/next bitrate). The dropdown groups by priority (error /
+ * warn / info) and chip colors come from the legacy palette.
+ */
+import { onScopeDispose, ref, watch, type Ref } from 'vue';
+
+export interface SessionEvent {
+  // Forwarder NDJSON stamps each row with `ts` (ClickHouse string
+  // format "YYYY-MM-DD HH:MM:SS.fff"); `event_time` is the legacy
+  // alias kept around for forwarder versions that still emit it.
+  ts?: string;
+  event_time?: string;
+  type?: string;
+  info?: string;
+  // Two-dimensional taxonomy from the forwarder's session_events
+  // handler (analytics/go-forwarder/main.go ~1143-1272):
+  //   - kind: 'effect' (user-visible outcome) vs 'cause' (proxy/
+  //           system action that may or may not have produced one)
+  //   - priority: 1=Critical, 2=High, 3=Medium, 4=Low — computed
+  //           server-side via a multiIf() on event type
+  // Both are present on every row; this UI consumes them directly
+  // rather than re-classifying client-side.
+  kind?: 'effect' | 'cause';
+  priority?: 1 | 2 | 3 | 4;
+  // Legacy `severity` field — kept as fallback for old forwarder
+  // builds that haven't been redeployed yet.
+  severity?: string;
+  [k: string]: unknown;
+}
+
+function buildQuery(p: Record<string, string | number | undefined>): string {
+  const parts: string[] = [];
+  for (const k of Object.keys(p)) {
+    const v = p[k];
+    if (v == null || v === '') continue;
+    parts.push(encodeURIComponent(k) + '=' + encodeURIComponent(String(v)));
+  }
+  return parts.length ? '?' + parts.join('&') : '';
+}
+
+export function useArchivedSessionEvents(
+  playerId: Ref<string>,
+  playId: Ref<string | null>,
+) {
+  const events = ref<SessionEvent[]>([]);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  // Re-fetch trigger sources:
+  //  1. Identity refs (playerId / playId) change → wipe + full
+  //     re-fetch (watch below).
+  //  2. Periodic poll while the page is open → re-fetch in place so
+  //     new server-derived events (HTTP 4xx/5xx, faults, stalls,
+  //     downshifts) show up on the Focus Window within a few seconds
+  //     of the forwarder ingesting them.
+  // In-flight guard: skip a poll tick when the previous request
+  // hasn't finished. Cancelling an almost-done fetch wastes the
+  // server-side work AND surfaces as a "(canceled)" entry in the
+  // DevTools network panel. Letting the previous one finish gives
+  // the user the most recent successful response; the next 3 s tick
+  // picks up any newer events. The AbortController is still wired
+  // up so an identity change (player_id / play_id swap) can hard-
+  // abort the previous query — that one IS worth cancelling.
+  let abort: AbortController | null = null;
+  let inFlight = false;
+  // 10 s ceiling so a stuck request (e.g. browser connection coalesced
+  // with a dead socket) doesn't pin the in-flight guard forever and
+  // freeze all subsequent polls. Server query is ~200 ms typically;
+  // 10 s is comfortably above the legitimate slow path.
+  const REQUEST_TIMEOUT_MS = 10_000;
+  async function fetchEvents(): Promise<void> {
+    if (!playerId.value) {
+      events.value = [];
+      return;
+    }
+    if (inFlight) return; // skip; previous still running
+    abort = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      try { abort?.abort(); } catch { /* ignore */ }
+    }, REQUEST_TIMEOUT_MS);
+    inFlight = true;
+    loading.value = true;
+    try {
+      const qs = buildQuery({
+        player_id: playerId.value,
+        play_id: playId.value ?? undefined,
+        // Match the forwarder's expanded cap so long sessions get
+        // full event history. With ABR adaptation accounting for
+        // ~67% of events on a thrashing player, capping at 5000
+        // historically squeezed out rare faults / errors.
+        limit: 50000,
+      });
+      const resp = await fetch('/analytics/api/v2/session_events' + qs, {
+        headers: { Accept: 'application/x-ndjson' },
+        signal: abort.signal,
+      });
+      if (!resp.ok) throw new Error(`session_events ${resp.status}`);
+      const text = await resp.text();
+      const out: SessionEvent[] = [];
+      for (const line of text.split('\n')) {
+        if (!line) continue;
+        try {
+          const ev = JSON.parse(line);
+          if (ev && !ev._error) out.push(ev as SessionEvent);
+        } catch { /* skip */ }
+      }
+      // Reassign whole array rather than mutating in place — the
+      // brush rail / accordion watch this ref and need identity
+      // change to react.
+      events.value = out;
+      error.value = null;
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') error.value = String(e?.message ?? e);
+    } finally {
+      window.clearTimeout(timeoutId);
+      loading.value = false;
+      inFlight = false;
+    }
+  }
+
+  // Identity-change trigger: wipe + re-fetch on player / play swap.
+  // Hard-abort any in-flight query first — it would return data for
+  // the OLD player which we'd then immediately discard.
+  watch(
+    [playerId, playId],
+    () => {
+      if (abort) { abort.abort(); abort = null; inFlight = false; }
+      events.value = [];
+      error.value = null;
+      void fetchEvents();
+    },
+    { immediate: true },
+  );
+
+  // Periodic poll. 3 s lines up with the forwarder's batched ingest
+  // (network rows + snapshots arrive in ~1-2 s batches), so a fresh
+  // event lands on the Focus Window within ~3-5 s of injection.
+  const POLL_MS = 3000;
+  const timer = window.setInterval(() => { void fetchEvents(); }, POLL_MS);
+  onScopeDispose(() => {
+    window.clearInterval(timer);
+    if (abort) abort.abort();
+  });
+
+  return { events, loading, error };
+}

--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -8,15 +8,22 @@
  *   - One window length: changing the rolling window length once
  *     applies everywhere.
  *
- * The state lives in a module-level Map keyed by playerId so it
- * survives component remount (e.g. when a section collapses + reopens)
- * and is shared across charts that mount independently of one another.
+ * Backing store: module-level Map keyed by playerId so the state
+ * survives component remount AND is shared across charts on the same
+ * session card.
+ *
+ * Reactivity model: callers may pass either a plain string (legacy) or
+ * a `Ref<string>` (TS12 — picker swap without :key remount). When a
+ * ref is supplied, the `state` getter + every computed + every mutator
+ * re-read `playerIdRef.value` on access, so switching the active
+ * player in Testing.vue's picker propagates to every chart in the
+ * same SessionDisplay instance without forcing a remount.
  *
  * Matches the legacy session-shell.js semantics: 10-minute default
  * window, viewport in ms relative to the latest sample's wall clock,
  * paused freezes the viewport.
  */
-import { computed, reactive } from 'vue';
+import { computed, isRef, reactive, ref, type Ref } from 'vue';
 
 export interface ChartViewport {
   /** ms-since-epoch start of the visible range */
@@ -45,28 +52,63 @@ export interface ChartCoordinationState {
   version: number;
   /** Y-axis upper bound for the bandwidth chart (undefined = auto). */
   bandwidthYMax: number | undefined;
+  /** Synchronized "selected event" cursor — ms-since-epoch.
+   *  When non-null every member chart (line charts + events
+   *  timeline) draws a vertical marker at this x position so the
+   *  operator can see exactly where the prev/next-selected event
+   *  sits across all panels. null = no cursor (default). */
+  cursorMs: number | null;
 }
 
 const states = new Map<string, ChartCoordinationState>();
 
-export function useChartCoordination(playerId: string) {
-  let state = states.get(playerId);
-  if (!state) {
-    state = reactive<ChartCoordinationState>({
-      paused: false,
-      expanded: false,
-      viewport: null,
-      lastSampleMs: 0,
-      windowMs: 10 * 60 * 1000,
-      liveSpanMs: null,
-      version: 0,
-      bandwidthYMax: undefined,
-    });
-    states.set(playerId, state);
+const EXPANDED_STORAGE_KEY = 'dashboard_v3_events_timeline_expanded';
+function readExpandedStored(): boolean {
+  try { return localStorage.getItem(EXPANDED_STORAGE_KEY) === 'true'; } catch { return false; }
+}
+function writeExpandedStored(v: boolean) {
+  try { localStorage.setItem(EXPANDED_STORAGE_KEY, v ? 'true' : 'false'); } catch { /* ignore */ }
+}
+
+function freshState(): ChartCoordinationState {
+  return reactive<ChartCoordinationState>({
+    paused: false,
+    expanded: readExpandedStored(),
+    viewport: null,
+    lastSampleMs: 0,
+    windowMs: 10 * 60 * 1000,
+    liveSpanMs: null,
+    version: 0,
+    bandwidthYMax: undefined,
+    cursorMs: null,
+  });
+}
+
+function ensureState(pid: string): ChartCoordinationState {
+  let s = states.get(pid);
+  if (!s) {
+    s = freshState();
+    states.set(pid, s);
   }
-  const s = state;
+  return s;
+}
+
+export function useChartCoordination(playerIdInput: string | Ref<string>) {
+  // Normalise input — accept both a plain string (legacy callers) and
+  // a reactive ref (new picker-swap-aware callers). When a ref is
+  // provided, every getter + computed + mutator below threads through
+  // `playerIdRef.value` so changes propagate to the consumer's
+  // reactive context without a component remount.
+  const playerIdRef: Ref<string> = isRef(playerIdInput)
+    ? playerIdInput
+    : ref(playerIdInput);
+
+  function cur(): ChartCoordinationState {
+    return ensureState(playerIdRef.value);
+  }
 
   const effectiveViewport = computed<ChartViewport>(() => {
+    const s = cur();
     if (s.viewport) return s.viewport;
     const end = s.lastSampleMs || Date.now();
     // When live (no sticky viewport) and the user has chosen a tighter
@@ -103,10 +145,15 @@ export function useChartCoordination(playerId: string) {
   });
 
   function noteSample(ts: number) {
+    const s = cur();
     if (ts > s.lastSampleMs) s.lastSampleMs = ts;
   }
 
   function setViewport(v: ChartViewport | null) {
+    const s = cur();
+    const span = v ? Math.round((v.max - v.min) / 1000) : 'null';
+    const trace = new Error().stack?.split('\n').slice(2, 5).join(' | ').slice(0, 200) ?? '';
+    console.log('[CC] setViewport span=' + span + 's | ' + trace);
     s.viewport = v;
     s.version++;
   }
@@ -122,12 +169,22 @@ export function useChartCoordination(playerId: string) {
    *  exactly what they were watching, not a snap-out to the full
    *  window. */
   function snapshotLiveViewport() {
+    const s = cur();
+    // If there's already an explicit viewport (set by a brush drag
+    // or an Alt+drag-zoom on a chart), DON'T overwrite it. The whole
+    // point of pausing is to freeze whatever the operator was looking
+    // at; if they had a custom range it IS the visible window. The
+    // legacy "snapshot to [lastSample - liveSpanMs, ...]" path runs
+    // only when no sticky viewport exists — i.e. we're live-tracking
+    // and need to freeze at the live edge.
+    if (s.viewport) return;
     const end = s.lastSampleMs || Date.now();
     const span = s.liveSpanMs != null ? s.liveSpanMs : s.windowMs;
     s.viewport = { min: end - span, max: end };
   }
 
   function togglePause() {
+    const s = cur();
     s.paused = !s.paused;
     if (s.paused) {
       snapshotLiveViewport();
@@ -140,6 +197,7 @@ export function useChartCoordination(playerId: string) {
   }
 
   function setPaused(p: boolean) {
+    const s = cur();
     if (s.paused === p) return;
     s.paused = p;
     if (p) snapshotLiveViewport();
@@ -147,65 +205,58 @@ export function useChartCoordination(playerId: string) {
     s.version++;
   }
 
-  /** Snap charts back to the full-window extent. Crucially, this does
-   *  NOT touch `paused` — legacy session-shell.js parity: Reset Zoom
-   *  is a viewport-only operation. If the user is paused and wants to
-   *  resume streaming, they click the Pause / Live button (which
-   *  reads "Live" while paused).
-   *
-   *  Live → viewport stays null AND any Alt+wheel live-span gets
-   *  cleared so `effectiveViewport` follows the full live window.
-   *
-   *  Paused → viewport must be re-snapshotted at the current frozen
-   *  time to the full window. We can't leave it null because
-   *  `effectiveViewport` would otherwise fall back to
-   *  `[lastSampleMs - windowMs, lastSampleMs]` which keeps sliding
-   *  with each new tick — defeating the pause. */
-  function resetZoom() {
-    s.liveSpanMs = null;
-    if (s.paused) {
-      snapshotLiveViewport();
-    } else {
-      s.viewport = null;
-    }
-    s.version++;
-  }
-
   /** Set the live-edge zoom span. Bumps the version so charts react.
    *  Pass null to clear (revert to full `windowMs`). Has no effect on
    *  the paused branch — paused mode uses sticky `viewport`. */
   function setLiveSpanMs(ms: number | null) {
+    const s = cur();
     s.liveSpanMs = ms;
     s.version++;
   }
 
   function toggleExpanded() {
+    const s = cur();
     s.expanded = !s.expanded;
+    writeExpandedStored(s.expanded);
   }
 
   function setWindowMs(ms: number) {
+    const s = cur();
     s.windowMs = Math.max(5_000, ms);
     s.viewport = null;
     s.version++;
   }
 
   function setBandwidthYMax(v: number | undefined) {
-    s.bandwidthYMax = v;
+    cur().bandwidthYMax = v;
+  }
+
+  /** Move the synchronized "selected event" cursor. Pass null to
+   *  hide it. Bumps version so chart watchers re-render the marker
+   *  layer in lock-step. */
+  function setCursorMs(ms: number | null) {
+    const s = cur();
+    s.cursorMs = ms;
+    s.version++;
   }
 
   return {
-    state: s,
+    // `state` is a getter so each property read flows through cur(),
+    // which reads playerIdRef.value. Vue templates / computeds that
+    // touch `coord.state.X` therefore depend on playerIdRef and
+    // re-evaluate when the active player switches.
+    get state(): ChartCoordinationState { return cur(); },
     effectiveViewport,
     tickPositions,
     noteSample,
     setViewport,
     togglePause,
     setPaused,
-    resetZoom,
     setLiveSpanMs,
     toggleExpanded,
     setWindowMs,
     setBandwidthYMax,
+    setCursorMs,
   };
 }
 

--- a/content/dashboard-v3/src/composables/useGroups.ts
+++ b/content/dashboard-v3/src/composables/useGroups.ts
@@ -25,12 +25,25 @@ export function useGroups() {
     refetchOnWindowFocus: true,
   });
 
+  // Surface mutation failures — without an onError handler the
+  // TanStack Query mutation just logs to its internal state and the
+  // UI never moves, which is exactly how the earlier
+  // `{player_ids: ...}` POST regression slipped through.
+  function reportMutationError(action: string, err: unknown) {
+    const msg = (err as any)?.message ?? String(err);
+    console.error(`[useGroups] ${action} failed`, err);
+    if (typeof window !== 'undefined') {
+      window.alert(`${action} failed: ${msg}`);
+    }
+  }
+
   const link = useMutation({
     mutationFn: (playerIds: string[]) => repo.linkGroup(playerIds),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: key() });
       qc.invalidateQueries({ queryKey: ['players'] });
     },
+    onError: (err) => reportMutationError('Group sessions', err),
   });
 
   const disband = useMutation({
@@ -39,6 +52,19 @@ export function useGroups() {
       qc.invalidateQueries({ queryKey: key() });
       qc.invalidateQueries({ queryKey: ['players'] });
     },
+    onError: (err) => reportMutationError('Disband group', err),
+  });
+
+  /** Update a group's membership wholesale. Caller provides the
+   *  desired final list; handler diffs against the current set. */
+  const updateMembers = useMutation({
+    mutationFn: (args: { groupId: string; memberPlayerIds: string[]; ifMatch: string }) =>
+      repo.updateGroupMembers(args.groupId, args.memberPlayerIds, args.ifMatch),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: key() });
+      qc.invalidateQueries({ queryKey: ['players'] });
+    },
+    onError: (err) => reportMutationError('Update group membership', err),
   });
 
   return {
@@ -46,5 +72,7 @@ export function useGroups() {
     isLoading: query.isLoading,
     link: (playerIds: string[]) => link.mutate(playerIds),
     disband: (groupId: string) => disband.mutate(groupId),
+    updateMembers: (groupId: string, memberPlayerIds: string[], ifMatch: string) =>
+      updateMembers.mutate({ groupId, memberPlayerIds, ifMatch }),
   };
 }

--- a/content/dashboard-v3/src/composables/usePlayer.ts
+++ b/content/dashboard-v3/src/composables/usePlayer.ts
@@ -27,6 +27,7 @@
 import { computed, ref, watch, type Ref } from 'vue';
 import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/vue-query';
 import * as repo from '@/repo/v2-repo';
+import { isLivePlayerId } from '@/repo/v2-repo';
 import type {
   PlayerRecord,
   Shape,
@@ -89,6 +90,11 @@ export function usePlayer(playerId: Ref<string>) {
     // the cached state is a permanent 4xx — no point polling for a
     // player_id the server has already said is malformed/missing.
     refetchInterval: (q: any) => {
+      // Archive playerIds (v3 session-viewer) are static historical
+      // data — no point polling. The SSE chain is also skipped for
+      // these (see usePlayerSSE.ts); polling would just re-fire the
+      // chart watcher with the same archived record every 5s.
+      if (!isLivePlayerId(playerId.value)) return false;
       const errStatus = (q?.state?.error as any)?.status;
       if (typeof errStatus === 'number' && errStatus >= 400 && errStatus < 500) return false;
       return sseState.value === 'closed' ? 5_000 : false;
@@ -170,11 +176,18 @@ export function usePlayer(playerId: Ref<string>) {
   // the canonical casing (via the case-insensitive lookup in v2-repo)
   // we switch the SSE filter to that, so events flow even when the
   // user pasted a URL with the wrong case.
+  //
+  // For `archive:` ids (v3 session-viewer) we MUST NOT do the canonical
+  // swap: the cached PlayerRecord's `id` field is the original live
+  // player UUID, NOT the synthetic archive id. Swapping would subscribe
+  // SSE to that live UUID and pour current-time events into the chart,
+  // which then trims away the archived history on every push.
   const sseId = ref<string>(playerId.value);
   watch(playerId, (v) => { sseId.value = v; });
   watch(
     () => player.value?.id,
     (canonicalId) => {
+      if (!isLivePlayerId(playerId.value)) return;
       if (canonicalId && canonicalId !== sseId.value) sseId.value = canonicalId;
     },
   );

--- a/content/dashboard-v3/src/composables/usePlayerSSE.ts
+++ b/content/dashboard-v3/src/composables/usePlayerSSE.ts
@@ -30,8 +30,8 @@
  *   - onHeartbeat:        SSE keep-alive (no payload)
  */
 import { onScopeDispose, ref, watch, type Ref } from 'vue';
+import { isLivePlayerId } from '@/repo/v2-repo';
 import {
-  isAllPoolActive,
   subscribeAllPlayers,
   type AllPlayersSubscriber,
   type ConnectionState as PoolState,
@@ -47,143 +47,44 @@ type Handlers = {
 
 export type ConnectionState = PoolState;
 
-/* ─── Per-player-id pool (fallback when all-pool not active) ────── */
-
-interface PerPlayerEntry {
-  es: EventSource;
-  state: ConnectionState;
-  subscribers: Set<Handlers>;
-  stateRefs: Set<Ref<ConnectionState>>;
-}
-
-const perPlayerPool = new Map<string, PerPlayerEntry>();
-
-function parsePayload(e: MessageEvent): any {
-  try {
-    return JSON.parse((e as MessageEvent).data).data;
-  } catch {
-    return null;
-  }
-}
-
-function getOrCreatePerPlayer(pid: string): PerPlayerEntry {
-  const cached = perPlayerPool.get(pid);
-  if (cached) return cached;
-  const url = `/api/v2/events?include=raw&player_id=${encodeURIComponent(pid)}`;
-  const es = new EventSource(url);
-  const entry: PerPlayerEntry = {
-    es,
-    state: 'connecting',
-    subscribers: new Set(),
-    stateRefs: new Set(),
-  };
-
-  function setState(s: ConnectionState) {
-    entry.state = s;
-    for (const r of entry.stateRefs) r.value = s;
-  }
-  function fan(method: keyof Handlers, payload?: any) {
-    for (const h of entry.subscribers) {
-      try {
-        const fn = h[method];
-        if (typeof fn === 'function') (fn as any)(payload);
-      } catch (err) {
-        console.warn('[usePlayerSSE] subscriber threw', err);
-      }
-    }
-  }
-
-  es.addEventListener('open', () => setState('open'));
-  es.addEventListener('error', () => {
-    if (es.readyState === EventSource.CLOSED) setState('closed');
-  });
-  es.addEventListener('heartbeat', () => fan('onHeartbeat'));
-  es.addEventListener('player.created', (e) => {
-    const d = parsePayload(e as MessageEvent);
-    if (d) fan('onCreated', d);
-  });
-  es.addEventListener('player.updated', (e) => {
-    const d = parsePayload(e as MessageEvent);
-    if (d) fan('onUpdated', d);
-  });
-  es.addEventListener('player.controls.updated', (e) => {
-    const d = parsePayload(e as MessageEvent);
-    if (d) fan('onControlsUpdated', d);
-  });
-  es.addEventListener('player.deleted', (e) => {
-    const d = parsePayload(e as MessageEvent);
-    if (d) fan('onDeleted', d);
-  });
-
-  perPlayerPool.set(pid, entry);
-  return entry;
-}
-
-function releasePerPlayer(pid: string, handlers: Handlers, stateRef: Ref<ConnectionState>) {
-  const entry = perPlayerPool.get(pid);
-  if (!entry) return;
-  entry.subscribers.delete(handlers);
-  entry.stateRefs.delete(stateRef);
-  if (entry.subscribers.size === 0) {
-    try {
-      entry.es.close();
-    } catch {
-      /* ignore */
-    }
-    perPlayerPool.delete(pid);
-  }
-}
-
 /* ─── Public composable ─────────────────────────────────────────── */
 
 export function usePlayerSSE(playerId: Ref<string | null | undefined>, handlers: Handlers) {
   const state = ref<ConnectionState>('connecting');
 
-  // Active subscription handle. Tagged union so cleanup picks the
-  // right release path.
-  type Sub =
-    | { kind: 'all'; pid: string; release: () => void }
-    | { kind: 'per'; pid: string }
-    | null;
+  // Active subscription handle — always the all-pool path now.
+  type Sub = { pid: string; release: () => void } | null;
   let sub: Sub = null;
 
   function attach(pid: string) {
-    if (isAllPoolActive()) {
-      // Filter events from the shared all-players socket by player_id.
-      const filtered: AllPlayersSubscriber = {
-        onCreated: (d) => {
-          if (d?.id === pid) handlers.onCreated?.(d);
-        },
-        onUpdated: (d) => {
-          if (d?.id === pid) handlers.onUpdated?.(d);
-        },
-        onControlsUpdated: (d) => {
-          if (d?.id === pid) handlers.onControlsUpdated?.(d);
-        },
-        onDeleted: (d) => {
-          if (d?.id === pid || d?.player_id === pid) handlers.onDeleted?.(d);
-        },
-        onHeartbeat: () => handlers.onHeartbeat?.(),
-        onStateChange: (s) => { state.value = s; },
-      };
-      const handle = subscribeAllPlayers(filtered);
-      sub = { kind: 'all', pid, release: handle.release };
-    } else {
-      const entry = getOrCreatePerPlayer(pid);
-      entry.subscribers.add(handlers);
-      entry.stateRefs.add(state);
-      state.value = entry.state;
-      sub = { kind: 'per', pid };
-    }
+    // Always go through the shared all-players SSE — opening a per-
+    // player SSE in parallel doubles the EventSource count per page,
+    // which (under HTTP/1.1's 6-per-origin cap) starves the second
+    // browser tab's REST polls. The all-pool socket is server-side
+    // unfiltered; we filter client-side by player_id.
+    const filtered: AllPlayersSubscriber = {
+      onCreated: (d) => {
+        if (d?.id === pid) handlers.onCreated?.(d);
+      },
+      onUpdated: (d) => {
+        if (d?.id === pid) handlers.onUpdated?.(d);
+      },
+      onControlsUpdated: (d) => {
+        if (d?.id === pid) handlers.onControlsUpdated?.(d);
+      },
+      onDeleted: (d) => {
+        if (d?.id === pid || d?.player_id === pid) handlers.onDeleted?.(d);
+      },
+      onHeartbeat: () => handlers.onHeartbeat?.(),
+      onStateChange: (s) => { state.value = s; },
+    };
+    const handle = subscribeAllPlayers(filtered);
+    sub = { pid, release: handle.release };
   }
 
   function detach() {
     if (!sub) return;
-    if (sub.kind === 'all') {
-      sub.release();
-    } else {
-      releasePerPlayer(sub.pid, handlers, state);
-    }
+    sub.release();
     sub = null;
     state.value = 'closed';
   }
@@ -192,6 +93,17 @@ export function usePlayerSSE(playerId: Ref<string | null | undefined>, handlers:
     playerId,
     (pid) => {
       detach();
+      // Skip SSE entirely for archive playerIds. The v3 session-viewer
+      // uses synthetic ids like `archive:<sid>:<pid>` to reuse the
+      // live-mode usePlayer chain over historical data. Subscribing
+      // those to /api/v2/events would either 404 (no live player) or
+      // — worse — feed unrelated live events into the chart's
+      // pushSample loop, where the current-time `event_time` on those
+      // events triggers the trim cutoff and wipes the archived history.
+      if (pid && !isLivePlayerId(pid)) {
+        state.value = 'closed';
+        return;
+      }
       if (pid) attach(pid);
     },
     { immediate: true },

--- a/content/dashboard-v3/src/composables/useSessionLabels.ts
+++ b/content/dashboard-v3/src/composables/useSessionLabels.ts
@@ -1,0 +1,120 @@
+/**
+ * useSessionLabels.ts — pure helpers for turning a PlayerRecord into
+ * human-readable pill / banner labels. No reactivity, no fetches —
+ * just string munging on fields the v2 API already returns.
+ *
+ * Used by Testing.vue's pillLabel + group-badge and by GroupBanner's
+ * peer list + chip so the at-a-glance UX shows "iPad · sintel-6s-hls"
+ * instead of a hex slice of a UUID. Raw UUIDs still live in
+ * SessionDetails.vue for the "show me the IDs" surface.
+ */
+import type { PlayerRecord } from '@/repo/v2-repo';
+
+interface DeviceRule {
+  re: RegExp;
+  label: string;
+}
+
+// Match order matters — first hit wins. Apple TV must come before
+// generic iOS/Mac patterns because tvOS reports `AppleTV` in the UA
+// but its underlying engine string also matches Mac patterns.
+const DEVICE_RULES: DeviceRule[] = [
+  { re: /AppleTV|tvOS/i,            label: 'Apple TV' },
+  { re: /iPad/i,                    label: 'iPad' },
+  { re: /iPhone/i,                  label: 'iPhone' },
+  { re: /iPod/i,                    label: 'iPod' },
+  { re: /Roku/i,                    label: 'Roku' },
+  { re: /AFTM|FireTV|AFT[A-Z]/i,    label: 'Fire TV' },
+  { re: /ExoPlayer|Android/i,       label: 'Android' },
+  { re: /Tizen/i,                   label: 'Samsung TV' },
+  { re: /Web0?OS/i,                 label: 'LG TV' },
+  { re: /SmartTV|HbbTV/i,           label: 'Smart TV' },
+  { re: /Macintosh|Mac OS X/i,      label: 'Mac' },
+  { re: /Windows/i,                 label: 'Windows' },
+  { re: /CrOS/i,                    label: 'ChromeOS' },
+  { re: /Linux/i,                   label: 'Linux' },
+  { re: /Edg\//i,                   label: 'Edge' },
+  { re: /Chrome\//i,                label: 'Chrome' },
+  { re: /Firefox\//i,               label: 'Firefox' },
+  { re: /Safari\//i,                label: 'Safari' },
+];
+
+export function deviceFromUA(ua: string | null | undefined): string {
+  if (!ua) return '';
+  for (const rule of DEVICE_RULES) {
+    if (rule.re.test(ua)) return rule.label;
+  }
+  return 'Web';
+}
+
+// The content slug lives in the segment right after `go-live` in
+// every master URL the proxy generates (e.g. `/go-live/sintel-6s-hls/
+// master.m3u8`). The basename and any deeper path components (variant
+// playlists, partial segments) are not human-friendly, so we anchor
+// off `go-live` rather than walking from the tail.
+//
+// Uploaded slugs from the encoding pipeline look like
+//   INSANE_FPV_SHOTS_Hydrofoil_Windsurfing_p200_h264_20260423_212139
+// — title + profile + codec + YYYYMMDD + HHMMSS — which is unusable
+// in a pill. prettifyContentSlug strips that tail and visually caps
+// the remainder so even verbose titles fit.
+const PILL_SLUG_MAX = 22;
+
+function prettifyContentSlug(raw: string): string {
+  if (!raw) return '';
+  let s = raw;
+  // _<YYYYMMDD>_<HHMMSS> at the end (with or without preceding tokens).
+  s = s.replace(/_\d{8}_\d{6}$/i, '');
+  // _p<digits> profile and/or _<codec> trailing tokens. Repeat in case
+  // both are present (e.g. `..._p200_h264`).
+  for (let i = 0; i < 3; i++) {
+    const next = s.replace(/_(p\d{2,4}|h264|h265|hevc|av1|vp9|vvc)$/i, '');
+    if (next === s) break;
+    s = next;
+  }
+  if (s.length > PILL_SLUG_MAX) s = s.slice(0, PILL_SLUG_MAX - 1) + '…';
+  return s;
+}
+
+export function contentFromMasterUrl(url: string | null | undefined): string {
+  if (!url) return '';
+  let pathname = '';
+  try {
+    pathname = new URL(url, 'http://placeholder.local').pathname;
+  } catch {
+    return '';
+  }
+  const segments = pathname.split('/').filter(Boolean);
+  const i = segments.indexOf('go-live');
+  if (i < 0 || i + 1 >= segments.length) return '';
+  return prettifyContentSlug(segments[i + 1]);
+}
+
+export function deviceContentLabel(p: PlayerRecord): string {
+  const device = deviceFromUA(p.user_agent ?? null);
+  const content = contentFromMasterUrl(p.current_play?.manifest?.master_url ?? null);
+  if (device && content) return `${device} · ${content}`;
+  return device || content || '';
+}
+
+/**
+ * Group name derivation. Both the pill badge and the banner chip
+ * should read "Group #<lowest-display_id>" so the two surfaces agree.
+ * Falls back to a 6-char UUID slice only when none of the group's
+ * members are currently in the players list (transient state during
+ * tear-down).
+ */
+export function groupNameFor(
+  group: { id: string; member_player_ids?: string[] | null },
+  players: PlayerRecord[],
+): string {
+  const memberIds = group.member_player_ids ?? [];
+  let lowest: number | null = null;
+  for (const pid of memberIds) {
+    const m = players.find((p) => p.id === pid);
+    if (m?.display_id == null) continue;
+    if (lowest == null || m.display_id < lowest) lowest = m.display_id;
+  }
+  if (lowest != null) return `Group #${lowest}`;
+  return `Group ${group.id.slice(0, 6)}`;
+}

--- a/content/dashboard-v3/src/composables/useSessionMetrics.ts
+++ b/content/dashboard-v3/src/composables/useSessionMetrics.ts
@@ -91,18 +91,13 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
 
   async function resolveSessionId(): Promise<string | null> {
     if (sessionId.value) return sessionId.value;
-    if (!opts.playerId.value) {
-      console.log('[USM] resolveSessionId: no playerId, skipping');
-      return null;
-    }
+    if (!opts.playerId.value) return null;
     if (!lookupInFlight) {
-      console.log('[USM] resolveSessionId: starting GET for', opts.playerId.value);
       lookupInFlight = (async () => {
         try {
           const { player } = await repo.getPlayer(opts.playerId.value);
           const raw = (player as any).raw_session;
           const sid = raw?.session_id;
-          console.log('[USM] resolveSessionId: GET ok, session_id =', sid);
           if (sid != null) sessionId.value = String(sid);
         } catch (e: any) {
           console.warn('[USM] resolveSessionId: GET failed', e?.status, e?.message);
@@ -110,8 +105,6 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
           lookupInFlight = null;
         }
       })();
-    } else {
-      console.log('[USM] resolveSessionId: lookup already in flight');
     }
     await lookupInFlight;
     return sessionId.value;
@@ -227,32 +220,21 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
   let postEnabled = true;
 
   function send(eventType: string, extra: Record<string, unknown> = {}): void {
-    if (!postEnabled) {
-      console.log('[USM] send skipped: postEnabled=false', eventType);
-      return;
-    }
+    if (!postEnabled) return;
     const payload = buildPayload(eventType, extra);
     const fields = Object.keys(payload).filter((k) => payload[k] !== undefined);
-    if (!fields.length) {
-      console.log('[USM] send skipped: empty payload', eventType, 'videoEl=', !!opts.videoEl.value);
-      return;
-    }
-    console.log('[USM] send queued', eventType, 'fields=', fields.length, 'sessionId=', sessionId.value);
+    if (!fields.length) return;
     tail = tail
       .catch(() => {})
       .then(async () => {
         const sid = await resolveSessionId();
-        if (!sid) {
-          console.log('[USM] send dropped: sessionId still null after resolve', eventType);
-          return; // not yet registered; next heartbeat will retry
-        }
+        if (!sid) return; // not yet registered; next heartbeat will retry
         try {
-          const r = await fetch(`/api/session/${encodeURIComponent(sid)}/metrics`, {
+          await fetch(`/api/session/${encodeURIComponent(sid)}/metrics`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ set: payload, fields }),
           });
-          console.log('[USM] POST', eventType, '→', r.status, 'sid=', sid);
         } catch (err) {
           console.warn('[USM] POST failed', eventType, err);
         }
@@ -395,7 +377,6 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
   watch(
     opts.videoEl,
     (v, old) => {
-      console.log('[USM] videoEl watcher fired — was=', !!old, 'now=', !!v);
       if (old) detachVideo();
       if (v) attachVideo(v);
     },
@@ -405,7 +386,6 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
   watch(
     opts.hlsInst,
     (h, old) => {
-      console.log('[USM] hlsInst watcher fired — was=', !!old, 'now=', !!h);
       if (old) detachHls();
       if (h) attachHls(h);
     },
@@ -419,11 +399,8 @@ export function useSessionMetrics(opts: UseSessionMetricsOptions) {
   });
 
   /* ─── 1Hz heartbeat ───────────────────────────────────────────────── */
-  console.log('[USM] composable initialised, heartbeat every', heartbeatMs, 'ms — playerId=', opts.playerId.value);
   heartbeatTimer = setInterval(() => {
-    const has = !!opts.videoEl.value;
-    console.log('[USM] heartbeat tick — hasVideoEl=', has, 'sessionId=', sessionId.value);
-    if (has) send('heartbeat');
+    if (opts.videoEl.value) send('heartbeat');
   }, heartbeatMs);
 
   /* ─── Cleanup ─────────────────────────────────────────────────────── */

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -1,0 +1,502 @@
+/**
+ * useSessionTimeSeries — single client-side consumer of the v3
+ * /api/v3/timeseries SSE endpoint. One subscription per
+ * (player_id, play_id); exposes per-stream caches with the same
+ * range-query API for every renderer (line charts, events
+ * timeline, network log, focus-bar rail).
+ *
+ * The endpoint emits typed events:
+ *   - meta:        wire shape of the connection (streams, columns, live)
+ *   - sample:      one row from session_snapshots
+ *   - network:     one row from network_requests
+ *   - event:       (future) one kind/priority-classified event
+ *   - heartbeat:   keepalive (no data)
+ *   - complete:    archive replay finished, server is closing
+ *   - stream_error: server-side error; client may want to reconnect
+ *
+ * Reconnect via the standard EventSource Last-Event-ID mechanism —
+ * each row's `id:` is its stable fingerprint (entry_fingerprint for
+ * network, ts string for samples) so the server resumes from where
+ * we left off without dupes.
+ *
+ * Throughput: incoming rows are queued and flushed in 1 s buckets so
+ * the renderer chain (allRows recompute, chart insert, vis-timeline
+ * DataSet diff, Vue patch) re-runs at most once per second per
+ * stream regardless of arrival rate. Keeps the JS thread responsive
+ * even when the forwarder bursts a backfill of thousands of rows.
+ */
+import { ref, shallowRef, triggerRef, watch, onScopeDispose, type Ref } from 'vue';
+import {
+  tsOf,
+  binarySearchLE,
+  insertSortedDedup,
+  inRangeAsc,
+  evictOutsideViewport,
+} from './sessionTimeSeriesUtils';
+const V3_EVENT_TYPES = ['meta', 'sample', 'network', 'event', 'heartbeat', 'complete', 'stream_error'];
+
+/**
+ * Stream<T> — the per-stream surface every renderer consumes. Read
+ * `version` to know when to re-query; range-query via inRange or
+ * lastAt; consult `rangeBounds` for the brush rail's left/right
+ * edges; show `loading` / `error` in the UI.
+ */
+export interface Stream<T> {
+  inRange(t1: number, t2: number): T[];
+  lastAt(t: number): T | null;
+  /** Bumped whenever the underlying cache changes shape. Use as a
+   *  trigger source in computed() / watch() — read it to subscribe. */
+  version: Ref<number>;
+  /** Min/max ts cached client-side. Lazy-fill: caller can request
+   *  ranges outside these bounds to trigger a backfill. */
+  rangeBounds: Ref<{ min: number; max: number } | null>;
+  loading: Ref<boolean>;
+  error: Ref<string | null>;
+}
+
+export interface UseSessionTimeSeriesOpts {
+  /** Comma list of streams to subscribe to. Default: all three. */
+  streams?: ('samples' | 'network' | 'events')[];
+  /** Bundle names. Default: charts_minimal,lanes_v1,network for samples+network. */
+  bundles?: string[];
+  /** Ad-hoc field list — applied to every enabled stream as a
+   *  convenience. CH rejects unknown columns per stream → caller
+   *  sees a 400 cleanly. */
+  fields?: string[];
+  /** Initial backfill window. Defaults to last 10 minutes when
+   *  unset; the brush rail will then drive subsequent fetches via
+   *  range queries. */
+  fromMs?: number;
+  toMs?: number;
+  /** Per-(samples) downsample bucket. Live deltas always full-res. */
+  strideMs?: number;
+  /** Per-stream max delta rate hint. Server coalesces above this. */
+  maxHz?: number;
+}
+
+export interface UseSessionTimeSeriesReturn {
+  samples: Stream<Record<string, unknown>>;
+  network: Stream<Record<string, unknown>>;
+  events: Stream<Record<string, unknown>>;
+  /** True if the server is actively tailing this stream. False once
+   *  it sends `event:complete` (archive replay or play ended). */
+  live: Ref<boolean>;
+  /** SSE connection state — useful for the reconnect badge in UI. */
+  connectionState: Ref<'connecting' | 'open' | 'closed'>;
+  /** Force a reconnect (e.g. after an explicit "refresh" button). */
+  reconnect: () => void;
+  /** Detach the EventSource and free resources. */
+  close: () => void;
+}
+
+const DEFAULT_BACKFILL_MS = 10 * 60 * 1000;
+const FLUSH_INTERVAL_MS = 1000;
+
+/**
+ * fpOf — stable per-row fingerprint. Used by insertSortedDedup to
+ * collapse duplicates (re-emitted backfill rows or an SSE retry that
+ * replays via Last-Event-ID). Preference order:
+ *   1. explicit entry_fingerprint (network rows; ID-stable in CH)
+ *   2. ts string (samples; one snapshot per ts per session)
+ *   3. ms-since-epoch fallback for anything else
+ *
+ * Critically this MUST read from the argument — closing over a
+ * specific row's fingerprint and returning that for every call
+ * causes insertSortedDedup to think every existing element matches
+ * and overwrite the tail. (See the 2026-05-15 fix in drainQueue.)
+ */
+function fpOf(row: Record<string, unknown>): string {
+  return String(
+    (row.entry_fingerprint as string | undefined) ??
+    (row.ts as string | undefined) ??
+    tsOf(row),
+  );
+}
+
+/**
+ * useSessionTimeSeries — main entry point. Pass reactive refs for
+ * playerId + playId; the composable re-subscribes whenever either
+ * changes (so picker-swap on testing.html works without a key= hack).
+ */
+export function useSessionTimeSeries(
+  playerId: Ref<string>,
+  playId: Ref<string | null>,
+  opts: UseSessionTimeSeriesOpts = {},
+): UseSessionTimeSeriesReturn {
+
+  const samplesArr = shallowRef<Record<string, unknown>[]>([]);
+  const networkArr = shallowRef<Record<string, unknown>[]>([]);
+  const eventsArr = shallowRef<Record<string, unknown>[]>([]);
+
+  const samplesVersion = ref(0);
+  const networkVersion = ref(0);
+  const eventsVersion = ref(0);
+
+  const samplesBounds = ref<{ min: number; max: number } | null>(null);
+  const networkBounds = ref<{ min: number; max: number } | null>(null);
+  const eventsBounds = ref<{ min: number; max: number } | null>(null);
+
+  const samplesLoading = ref(false);
+  const networkLoading = ref(false);
+  const eventsLoading = ref(false);
+
+  const samplesError = ref<string | null>(null);
+  const networkError = ref<string | null>(null);
+  const eventsError = ref<string | null>(null);
+
+  const live = ref(true);
+  const connectionState = ref<'connecting' | 'open' | 'closed'>('closed');
+
+  let es: EventSource | null = null;
+  let lastEventId = '';
+
+  // Per-stream pending queues. Rows arrive on the SSE event
+  // listeners and are appended here without touching reactivity.
+  // The flush timer drains all three queues every FLUSH_INTERVAL_MS,
+  // sorts/dedupes them into the main arrays in a single pass, then
+  // bumps version + triggerRef once per stream that received rows.
+  // This caps re-render cost at one pass per stream per second
+  // regardless of upstream burst rate.
+  const samplesPending: Record<string, unknown>[] = [];
+  const networkPending: Record<string, unknown>[] = [];
+  const eventsPending: Record<string, unknown>[] = [];
+  let flushTimer: ReturnType<typeof setInterval> | null = null;
+
+  function teardown() {
+    if (es) {
+      try { es.close(); } catch { /* ignore */ }
+      es = null;
+    }
+    if (flushTimer) {
+      clearInterval(flushTimer);
+      flushTimer = null;
+    }
+    connectionState.value = 'closed';
+  }
+
+  function resetCaches() {
+    samplesArr.value = [];
+    networkArr.value = [];
+    eventsArr.value = [];
+    samplesPending.length = 0;
+    networkPending.length = 0;
+    eventsPending.length = 0;
+    samplesVersion.value++;
+    networkVersion.value++;
+    eventsVersion.value++;
+    samplesBounds.value = null;
+    networkBounds.value = null;
+    eventsBounds.value = null;
+    samplesLoading.value = false;
+    networkLoading.value = false;
+    eventsLoading.value = false;
+    samplesError.value = null;
+    networkError.value = null;
+    eventsError.value = null;
+    lastEventId = '';
+  }
+
+  /** Build the SSE URL from current opts + identity refs. */
+  function buildUrl(): string | null {
+    const pid = playerId.value;
+    if (!pid) return null;
+    const params = new URLSearchParams();
+    params.set('player_id', pid);
+    if (playId.value) params.set('play_id', playId.value);
+    const streams = opts.streams ?? ['samples', 'network'];
+    params.set('streams', streams.join(','));
+    if (opts.bundles && opts.bundles.length) {
+      params.set('bundles', opts.bundles.join(','));
+    } else {
+      // Default bundle picks per stream; keeps the wire ergonomic.
+      const defaults: string[] = [];
+      if (streams.includes('samples')) defaults.push('charts_minimal', 'lanes_v1');
+      if (streams.includes('network')) defaults.push('network');
+      if (streams.includes('events')) defaults.push('events');
+      if (defaults.length) params.set('bundles', defaults.join(','));
+    }
+    if (opts.fields && opts.fields.length) {
+      params.set('fields', opts.fields.join(','));
+    }
+    if (opts.fromMs && opts.fromMs > 0) {
+      params.set('from', new Date(opts.fromMs).toISOString());
+    } else if (!playId.value) {
+      // Live mode (no specific play_id): default backfill is the last
+      // 10 minutes so a fresh page load doesn't drag down a 24h
+      // history. Archive replay (playId set) gets no default `from`
+      // so the server returns ALL rows for that play (the play's
+      // bounded range naturally caps the row count below the
+      // server's per-stream limit).
+      params.set('from', new Date(Date.now() - DEFAULT_BACKFILL_MS).toISOString());
+    }
+    if (opts.toMs && opts.toMs > 0) {
+      params.set('to', new Date(opts.toMs).toISOString());
+    }
+    if (opts.strideMs && opts.strideMs > 0) params.set('stride_ms', String(opts.strideMs));
+    if (opts.maxHz && opts.maxHz > 0) params.set('max_hz', String(opts.maxHz));
+    return '/analytics/api/v3/timeseries?' + params.toString();
+  }
+
+  function connect() {
+    teardown();
+    resetCaches();
+    const url = buildUrl();
+    if (!url) return;
+    connectionState.value = 'connecting';
+    samplesLoading.value = true;
+    networkLoading.value = true;
+
+    es = new EventSource(url);
+    es.onopen = () => { connectionState.value = 'open'; };
+    es.onerror = () => {
+      // EventSource auto-reconnects on transient network blips; we
+      // only flip to 'closed' once the browser gives up. Surface
+      // connecting/closed states for the SSE badge in the UI.
+      if (es && es.readyState === EventSource.CLOSED) connectionState.value = 'closed';
+      else connectionState.value = 'connecting';
+    };
+    for (const t of V3_EVENT_TYPES) {
+      es.addEventListener(t, (ev: MessageEvent) => {
+        handleStreamEvent(t, ev.data, ev.lastEventId);
+      });
+    }
+
+    flushTimer = setInterval(flushAll, FLUSH_INTERVAL_MS);
+  }
+
+  /** Dispatch one SSE event by type. Same shape regardless of the
+   *  event source so adding a new event type only requires adding
+   *  a case below + listing it in V3_EVENT_TYPES. */
+  function handleStreamEvent(eventType: string, data: string, evtLastEventId: string) {
+    if (evtLastEventId) lastEventId = evtLastEventId;
+    switch (eventType) {
+      case 'meta':
+        try {
+          const m = JSON.parse(data);
+          if (typeof m?.live === 'boolean') live.value = m.live;
+        } catch { /* ignore malformed meta */ }
+        return;
+      case 'sample':
+        enqueueRow(data, samplesPending);
+        return;
+      case 'network':
+        enqueueRow(data, networkPending);
+        return;
+      case 'event':
+        enqueueRow(data, eventsPending);
+        return;
+      case 'heartbeat':
+        return;
+      case 'complete':
+        // Drain anything queued before signalling done so the final
+        // archive rows make it into the cache.
+        flushAll();
+        live.value = false;
+        samplesLoading.value = false;
+        networkLoading.value = false;
+        eventsLoading.value = false;
+        teardown();
+        return;
+      case 'stream_error':
+        try {
+          const m = JSON.parse(data);
+          const msg = String(m?.message ?? 'stream error');
+          samplesError.value = msg;
+          networkError.value = msg;
+          eventsError.value = msg;
+        } catch {
+          samplesError.value = 'stream error';
+        }
+        return;
+    }
+  }
+
+  /** Append one parsed row to the named pending queue. Cheap: no
+   *  reactive writes happen here. */
+  function enqueueRow(data: string, queue: Record<string, unknown>[]) {
+    let row: Record<string, unknown>;
+    try { row = JSON.parse(data); } catch { return; }
+    queue.push(row);
+  }
+
+  /** Drain all three pending queues into their backing arrays in one
+   *  pass per stream. Bumps version + triggerRef once per stream
+   *  that actually received rows. */
+  function flushAll() {
+    drainQueue(samplesPending, samplesArr, samplesVersion, samplesBounds, samplesLoading);
+    drainQueue(networkPending, networkArr, networkVersion, networkBounds, networkLoading);
+    drainQueue(eventsPending, eventsArr, eventsVersion, eventsBounds, eventsLoading);
+  }
+
+  function drainQueue(
+    pending: Record<string, unknown>[],
+    arr: Ref<Record<string, unknown>[]>,
+    versionRef: Ref<number>,
+    boundsRef: Ref<{ min: number; max: number } | null>,
+    loadingRef: Ref<boolean>,
+  ) {
+    if (pending.length === 0) return;
+    const list = arr.value;
+    let curMin = boundsRef.value?.min ?? Infinity;
+    let curMax = boundsRef.value?.max ?? -Infinity;
+    for (const row of pending) {
+      const ms = tsOf(row);
+      if (!Number.isFinite(ms)) continue;
+      // keyOf / fpOf must inspect the element passed in, not close
+      // over the new row — insertSortedDedup calls them on existing
+      // arr[i] entries to find dedupe candidates. If they ignore the
+      // argument and return the new row's values, every insert
+      // overwrites the last existing row and the cache stays at
+      // length 1. (Bug fixed 2026-05-15.)
+      insertSortedDedup(list, row, tsOf, fpOf);
+      if (ms < curMin) curMin = ms;
+      if (ms > curMax) curMax = ms;
+    }
+    pending.length = 0;
+    // shallowRef + triggerRef: avoid Vue's deep proxy overhead on the
+    // potentially-large row array; downstream watchers re-fire.
+    triggerRef(arr);
+    versionRef.value++;
+    if (curMin !== Infinity) {
+      const cur = boundsRef.value;
+      if (!cur || cur.min !== curMin || cur.max !== curMax) {
+        boundsRef.value = { min: curMin, max: curMax };
+      }
+    }
+    if (loadingRef.value) loadingRef.value = false;
+  }
+
+  // Re-subscribe ONLY when the (playerId, playId) string values
+  // actually change AND only after they've been stable for at
+  // least RECONNECT_DEBOUNCE_MS. The upstream usePlayer cache
+  // absorbs all-pool SSE updates that occasionally cause our
+  // identity refs to ping-pong; without debouncing, the EventSource
+  // tears down and re-opens every 100–300 ms, each reconnect
+  // spawning a fresh CH backfill SELECT that piles up faster than
+  // ClickHouse can drain (TOO_MANY_SIMULTANEOUS_QUERIES). 500 ms
+  // is enough to absorb the typical churn without being
+  // user-noticeable on a genuine player swap.
+  const RECONNECT_DEBOUNCE_MS = 500;
+  let lastPid = '';
+  let lastPlayid: string | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(
+    [playerId, playId],
+    ([pid, plyid]) => {
+      const newPid = pid ?? '';
+      const newPlayid = plyid ?? null;
+      if (newPid === lastPid && newPlayid === lastPlayid) return;
+      lastPid = newPid;
+      lastPlayid = newPlayid;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      // Immediate teardown + resetCaches so the OLD player's EventSource
+      // stops streaming and the cache doesn't leak stale samples into
+      // the next subscriber's drain. Without this, the 500 ms debounce
+      // below leaves the old stream open AND the cache populated;
+      // EventsTimeline + the charts then ingest old-player rows as if
+      // they belonged to the new player_id (lane "freeze" bug observed
+      // 2026-05-16 — picker switch sometimes showed previous player's
+      // VARIANT shifts). connect() runs after the debounce; it will
+      // teardown+reset again, idempotently.
+      teardown();
+      resetCaches();
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        const finalPid = playerId.value ?? '';
+        const finalPlayid = playId.value ?? null;
+        if (finalPid !== lastPid || finalPlayid !== lastPlayid) {
+          lastPid = finalPid;
+          lastPlayid = finalPlayid;
+        }
+        connect();
+      }, RECONNECT_DEBOUNCE_MS);
+    },
+    { immediate: true },
+  );
+
+  onScopeDispose(() => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    teardown();
+  });
+
+  // Stream<T> facade builders.
+  function makeStream<T extends Record<string, unknown>>(
+    arr: Ref<T[]>,
+    versionRef: Ref<number>,
+    boundsRef: Ref<{ min: number; max: number } | null>,
+    loadingRef: Ref<boolean>,
+    errorRef: Ref<string | null>,
+  ): Stream<T> {
+    return {
+      inRange(t1, t2) { return inRangeAsc(arr.value, t1, t2, tsOf); },
+      lastAt(t) {
+        const idx = binarySearchLE(arr.value, t, tsOf);
+        return idx >= 0 ? arr.value[idx] : null;
+      },
+      version: versionRef,
+      rangeBounds: boundsRef,
+      loading: loadingRef,
+      error: errorRef,
+    };
+  }
+
+  // Periodic eviction guard: if any stream balloons past its soft
+  // cap, drop entries outside the current viewport guardband. The
+  // viewport hint is (samples ∪ network ∪ events) bounds so we
+  // never throw away data the brush is actively showing. Renderers
+  // that pan past the cache trigger a fresh fetch — handled at
+  // the upper layer (TS6).
+  const SOFT_CAP_SAMPLES = 50000;
+  const SOFT_CAP_NETWORK = 5000;
+  const SOFT_CAP_EVENTS = 50000;
+  watch(
+    [samplesVersion, networkVersion, eventsVersion],
+    () => {
+      const bounds = mergedBounds(samplesBounds.value, networkBounds.value, eventsBounds.value);
+      if (!bounds) return;
+      if (samplesArr.value.length > SOFT_CAP_SAMPLES) {
+        evictOutsideViewport(samplesArr.value, bounds.min, bounds.max, tsOf);
+        triggerRef(samplesArr);
+      }
+      if (networkArr.value.length > SOFT_CAP_NETWORK) {
+        evictOutsideViewport(networkArr.value, bounds.min, bounds.max, tsOf);
+        triggerRef(networkArr);
+      }
+      if (eventsArr.value.length > SOFT_CAP_EVENTS) {
+        evictOutsideViewport(eventsArr.value, bounds.min, bounds.max, tsOf);
+        triggerRef(eventsArr);
+      }
+    },
+  );
+
+  return {
+    samples: makeStream(samplesArr, samplesVersion, samplesBounds, samplesLoading, samplesError),
+    network: makeStream(networkArr, networkVersion, networkBounds, networkLoading, networkError),
+    events: makeStream(eventsArr, eventsVersion, eventsBounds, eventsLoading, eventsError),
+    live,
+    connectionState,
+    reconnect: connect,
+    close: teardown,
+  };
+}
+
+function mergedBounds(
+  a: { min: number; max: number } | null,
+  b: { min: number; max: number } | null,
+  c: { min: number; max: number } | null,
+): { min: number; max: number } | null {
+  let min = Infinity;
+  let max = -Infinity;
+  let any = false;
+  for (const x of [a, b, c]) {
+    if (!x) continue;
+    if (x.min < min) min = x.min;
+    if (x.max > max) max = x.max;
+    any = true;
+  }
+  if (!any) return null;
+  return { min, max };
+}

--- a/content/dashboard-v3/src/entry-session-viewer.ts
+++ b/content/dashboard-v3/src/entry-session-viewer.ts
@@ -1,0 +1,4 @@
+import { mountPage } from './main';
+import SessionViewer from './pages/SessionViewer.vue';
+
+mountPage(SessionViewer);

--- a/content/dashboard-v3/src/entry-sessions.ts
+++ b/content/dashboard-v3/src/entry-sessions.ts
@@ -1,0 +1,4 @@
+import { mountPage } from './main';
+import Sessions from './pages/Sessions.vue';
+
+mountPage(Sessions);

--- a/content/dashboard-v3/src/pages/Grid.vue
+++ b/content/dashboard-v3/src/pages/Grid.vue
@@ -66,12 +66,27 @@ const menu = ref({
 });
 
 function mintPlayerId(): string {
-  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
-    const bytes = new Uint8Array(6);
-    crypto.getRandomValues(bytes);
-    return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 8);
+  // Mint a canonical v4 UUID so the player_id is already in the v2
+  // form everywhere (URL, v1 shaper register, /api/v2/players, archive
+  // lookup). Previously this returned an 8-char hex short form, which
+  // the v2 layer transparently v5-derived to a UUID on read — but the
+  // forwarder then stored the raw short form and the v3 archive
+  // queries (built from /api/v2/players.id) missed every row.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
   }
-  return Math.random().toString(36).slice(2, 10);
+  // Fallback for ancient environments without crypto.randomUUID:
+  // hand-assemble a UUIDv4 with proper version/variant bits.
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant
+  const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 /** Rewrite the tile URL to the shaper port (last 3 digits → `081`) and
@@ -94,6 +109,10 @@ function buildTestingUrl(url: string, playerId: string): string {
   if (currentPort !== '5173' && currentPort.length >= 4) {
     absolute.hostname = window.location.hostname;
     absolute.port = currentPort.slice(0, -3) + '081';
+    // Inherit the page's protocol — go-proxy now serves TLS on the
+    // shaper ports so the dashboard's HTTPS page can embed playback
+    // without mixed-content blocking. `window.location.protocol`
+    // includes the trailing colon, exactly what URL.protocol expects.
     absolute.protocol = window.location.protocol;
   }
   absolute.searchParams.set('player_id', playerId);
@@ -164,10 +183,14 @@ const rows = computed(() => clampInt(params.rows, DEFAULT_ROWS, 1, 6));
 const total = computed(() => cols.value * rows.value);
 const gridStyle = computed(() => ({ gridTemplateColumns: `repeat(${cols.value}, 1fr)` }));
 
-const protocol = computed(() => params.protocol || 'all'); // hls | dash | both | all
-const codec    = computed(() => params.codec    || 'all'); // h264 | hevc | av1 | all
+// Default filters target the most common test combo (HLS + H264 + 6 s
+// segments) so a fresh page load lands on a useful slice without the
+// operator picking from "all" each time. URL params still win — drop
+// `?protocol=…&codec=…&segs=…` to override.
+const protocol = computed(() => params.protocol || 'hls'); // hls | dash | both | all
+const codec    = computed(() => params.codec    || 'h264'); // h264 | hevc | av1 | all
 const segs     = computed<'2' | '6' | 'll' | 'all'>(() => {
-  const v = params.segs;
+  const v = params.segs ?? '6';
   if (v === '2' || v === '6' || v === 'll') return v;
   return 'all';
 });

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+/**
+ * SessionViewer.vue — v3 archive replay page.
+ *
+ * Replaces the legacy /dashboard/session-viewer.html for sessions
+ * archived in ClickHouse (forwarder). Reads `session_id` (and
+ * optional `play_id`) from the URL.
+ *
+ * The display half (panels + brush + accordion + cursor sync) lives
+ * in SessionDisplay.vue, shared with the live testing-session page.
+ * This page just owns the REPLAY banner (Star / Download bundle /
+ * Back to sessions) plus the synthetic `archive:` cache key that
+ * routes display panels to the side-channel store in v2-repo instead
+ * of the live `/api/v2/players` fetch.
+ */
+import { ref, computed, onMounted } from 'vue';
+import ShellLayout from '@/components/ShellLayout.vue';
+import SessionDisplay from '@/components/SessionDisplay.vue';
+
+const qs = new URLSearchParams(window.location.search);
+// v3 canonical: identify an archived play by (player_id, play_id).
+// session_id was the legacy proxy-port handle — not needed here since
+// the v3 timeseries endpoint and the SSE pool both key by player_id.
+const playerId = ref<string>(qs.get('player_id') ?? '');
+const playId = ref<string | null>(qs.get('play_id'));
+
+// Starred state. Optimistically toggled on click, then synced from
+// the server response. Initial fetch in onMounted below.
+const starred = ref<boolean>(false);
+async function toggleStarred() {
+  if (!playerId.value || !playId.value) return;
+  const next = !starred.value;
+  starred.value = next; // optimistic
+  try {
+    const url = `/analytics/api/sessions/${encodeURIComponent(playerId.value)}/${encodeURIComponent(playId.value)}/star`;
+    const resp = await fetch(url, { method: next ? 'POST' : 'DELETE' });
+    if (!resp.ok) throw new Error(`star ${resp.status}`);
+  } catch {
+    starred.value = !next; // rollback on failure
+  }
+}
+
+const bundleHref = computed(() => {
+  if (!playerId.value) return '#';
+  const p = new URLSearchParams();
+  p.set('player_id', playerId.value);
+  if (playId.value) p.set('play_id', playId.value);
+  return '/analytics/api/session_bundle?' + p.toString();
+});
+// Back-link points at the LEGACY picker — v3 sessions picker isn't
+// ready as the default yet. Flip to /dashboard/v3/sessions.html once
+// it is.
+const backHref = '/dashboard/sessions.html';
+
+onMounted(async () => {
+  // Look up the current starred state. The endpoint returns
+  // {"starred": true|false} (or 404 if the play hasn't been touched).
+  if (playerId.value && playId.value) {
+    try {
+      const url = `/analytics/api/sessions/${encodeURIComponent(playerId.value)}/${encodeURIComponent(playId.value)}/star`;
+      const resp = await fetch(url);
+      if (resp.ok) {
+        const j = await resp.json();
+        starred.value = !!j.starred;
+      }
+    } catch {
+      // Star lookup is non-essential; the toggle still works.
+    }
+  }
+});
+
+</script>
+
+<template>
+  <ShellLayout active-page="sessions">
+    <template #header>
+      <div class="header-title">Session Viewer</div>
+    </template>
+
+    <div class="page">
+      <main class="content">
+        <div v-if="!playerId" class="empty">
+          <p>No <code>player_id</code> in the URL.</p>
+          <p>Open <code>/dashboard/v3/session-viewer.html?player_id=&lt;uuid&gt;&amp;play_id=&lt;uuid&gt;</code></p>
+        </div>
+
+        <template v-else>
+          <!-- REPLAY banner — page-specific (SessionDisplay's brush
+               block joins flush below it via shared border styling). -->
+          <header class="meta-banner">
+            <div class="meta-line">
+              <span class="replay-badge">REPLAY</span>
+              <span class="meta-label">play</span>
+              <code class="id-pill" :title="playId ?? '(all plays)'">{{ playId ?? '(all plays)' }}</code>
+            </div>
+            <div class="banner-actions">
+              <button
+                type="button"
+                class="banner-btn"
+                :class="{ active: starred }"
+                @click="toggleStarred"
+                :disabled="!playId"
+                :title="starred ? 'Unstar — TTL applies again' : 'Star — keep this play forever'"
+              >
+                {{ starred ? '★ Starred' : '☆ Star' }}
+              </button>
+              <a class="banner-btn" :href="bundleHref" :class="{ disabled: !playId }" download>⬇ Download bundle</a>
+              <a class="banner-btn" :href="backHref">← Back to sessions</a>
+            </div>
+          </header>
+
+          <SessionDisplay
+            :player-id="playerId"
+            :play-id="playId"
+            mode="archive"
+          />
+        </template>
+      </main>
+    </div>
+  </ShellLayout>
+</template>
+
+<style scoped>
+.page { display: flex; }
+.content {
+  padding: 14px 20px;
+  margin: 0 auto;
+  flex: 1;
+}
+.header-title { font-size: 16px; font-weight: 600; }
+
+.meta-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  background: linear-gradient(90deg, #fff7ed, #fffbeb);
+  border: 1px solid #fcd34d;
+  border-radius: 8px 8px 0 0;
+  border-bottom: none;
+  flex-wrap: wrap;
+}
+.meta-line {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 13px;
+  color: #374151;
+}
+.replay-badge {
+  background: #fde68a;
+  color: #92400e;
+  padding: 2px 10px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+.meta-label { font-weight: 600; color: #4b5563; }
+.id-pill {
+  background: #e5e7eb;
+  color: #374151;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+.banner-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #1f2937;
+  cursor: pointer;
+  text-decoration: none;
+}
+.banner-btn:hover { background: #f9fafb; }
+.banner-btn.active {
+  background: #f59e0b;
+  border-color: #d97706;
+  color: #fff;
+}
+.banner-btn.disabled { opacity: 0.4; pointer-events: none; }
+
+.empty {
+  text-align: center;
+  padding: 64px 24px;
+  color: #6b7280;
+}
+.empty code {
+  background: #1f2937;
+  color: #e5e7eb;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: ui-monospace, monospace;
+}
+</style>

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -1,0 +1,886 @@
+<script setup lang="ts">
+/**
+ * Sessions.vue — Vue port of the legacy session picker
+ * (content/shared/session-replay.js `startReplayPicker`). The data
+ * source, derived health metrics, column set, badge styling, sort
+ * + filter semantics, star bookmark, bundle download and auto-refresh
+ * cadence all match the legacy implementation 1:1 so the v3 page
+ * looks identical to /dashboard/sessions.html.
+ */
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import ShellLayout from '@/components/ShellLayout.vue';
+
+interface SessionRow {
+  session_id: string;
+  play_id?: string;
+  player_id?: string;
+  group_id?: string;
+  content_id?: string;
+  started?: string;
+  last_seen?: string;
+  classification?: string;
+  last_state?: string;
+  last_player_error?: string;
+  metric_events?: number | string;
+  net_events?: number | string;
+  stalls?: number;
+  dropped_frames?: number;
+  downshifts?: number;
+  upshifts?: number;
+  resolution_changes?: number;
+  master_manifest_failures?: number;
+  manifest_failures?: number;
+  segment_failures?: number;
+  all_failures?: number;
+  transport_failures?: number;
+  active_timeouts?: number;
+  idle_timeouts?: number;
+  user_marked_count?: number;
+  frozen_count?: number;
+  segment_stall_count?: number;
+  restart_count?: number;
+  error_event_count?: number;
+  avg_quality_pct?: number;
+  bitrate_shifts?: number;
+  // derived in deriveHealth
+  duration_ms?: number;
+  errors_count?: number;
+  faults_count?: number;
+  downshifts_count?: number;
+  upshifts_count?: number;
+  issues_count?: number;
+  health_score?: number;
+  is_critical?: boolean;
+  issues_breakdown?: Record<string, any>;
+  health_breakdown?: Record<string, any>;
+}
+
+const RANGES = [
+  { id: '15m',    label: 'Last 15 minutes', ms: 15 * 60 * 1000 },
+  { id: '1h',     label: 'Last hour',       ms: 60 * 60 * 1000 },
+  { id: '4h',     label: 'Last 4 hours',    ms: 4 * 60 * 60 * 1000 },
+  { id: '24h',    label: 'Last 24 hours',   ms: 24 * 60 * 60 * 1000 },
+  { id: '7d',     label: 'Last 7 days',     ms: 7 * 24 * 60 * 60 * 1000 },
+  { id: '30d',    label: 'Last 30 days',    ms: 30 * 24 * 60 * 60 * 1000 },
+  { id: 'all',    label: 'All time',        ms: 0 },
+  { id: 'custom', label: 'Custom range…', ms: -1 },
+] as const;
+type RangeId = typeof RANGES[number]['id'];
+
+const RANGE_KEY = 'ismSessionsRange';
+const RANGE_CUSTOM_KEY = 'ismSessionsRangeCustom';
+
+const activeRangeId = ref<RangeId>(readStoredRange());
+const customFrom = ref(readStoredCustom().from);
+const customTo = ref(readStoredCustom().to);
+
+function readStoredRange(): RangeId {
+  try {
+    const v = localStorage.getItem(RANGE_KEY) as RangeId | null;
+    if (v && RANGES.some((r) => r.id === v)) return v;
+  } catch { /* ignore */ }
+  return '24h';
+}
+function readStoredCustom(): { from: string; to: string } {
+  try {
+    const raw = localStorage.getItem(RANGE_CUSTOM_KEY);
+    if (raw) {
+      const v = JSON.parse(raw);
+      return { from: v?.from ?? '', to: v?.to ?? '' };
+    }
+  } catch { /* ignore */ }
+  return { from: '', to: '' };
+}
+
+const filters = ref<{
+  player_id: string;
+  group_id: string;
+  content_id: string;
+  play_id: string;
+  classification: 'all' | 'starred' | 'interesting' | 'other';
+}>({
+  player_id: '', group_id: '', content_id: '', play_id: '',
+  classification: 'all',
+});
+
+const rows = ref<SessionRow[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const sortKey = ref('started');
+const sortDir = ref<'asc' | 'desc'>('desc');
+// Force-bump on auto-refresh so `fmtRelTime` re-renders even if the
+// underlying row's `last_seen` string is unchanged but the wall clock
+// moved.
+const tick = ref(0);
+
+const rangeLabel = computed(() => RANGES.find((r) => r.id === activeRangeId.value)?.label ?? '');
+
+function computeRange(): { since: string; until: string } {
+  if (activeRangeId.value === 'custom') {
+    return { since: customFrom.value || '', until: customTo.value || '' };
+  }
+  const meta = RANGES.find((r) => r.id === activeRangeId.value);
+  if (!meta || meta.ms === 0) return { since: '1970-01-01T00:00:00Z', until: '' };
+  return { since: new Date(Date.now() - meta.ms).toISOString(), until: '' };
+}
+
+function deriveHealth(r: SessionRow): void {
+  const n = (k: keyof SessionRow) => Number((r as any)[k]) || 0;
+  const stalls = n('stalls');
+  const drops = n('dropped_frames');
+  const downshifts = n('downshifts');
+  const upshifts = n('upshifts');
+  const resChanges = n('resolution_changes');
+  const errors = r.last_player_error && r.last_player_error.length > 0 ? 1 : 0;
+  const faults = n('master_manifest_failures') + n('manifest_failures') + n('segment_failures')
+    + n('all_failures') + n('transport_failures')
+    + n('active_timeouts') + n('idle_timeouts');
+  const dropBlocks = Math.ceil(drops / 100);
+
+  r.errors_count = errors;
+  r.faults_count = faults;
+  r.downshifts_count = downshifts;
+  r.upshifts_count = upshifts;
+
+  r.user_marked_count = n('user_marked_count');
+  r.frozen_count = n('frozen_count');
+  r.segment_stall_count = n('segment_stall_count');
+  r.restart_count = n('restart_count');
+  r.error_event_count = n('error_event_count');
+  r.is_critical = (r.user_marked_count > 0)
+    || (r.frozen_count > 0)
+    || (r.error_event_count > 0)
+    || (errors > 0)
+    || (n('master_manifest_failures') > 0)
+    || (n('all_failures') > 0);
+
+  r.issues_count = stalls + errors * 5 + faults + downshifts + dropBlocks;
+  r.issues_breakdown = {
+    stalls, errors, faults, downshifts, drops, dropBlocks,
+    resolution_changes: resChanges,
+    upshifts, player_error: r.last_player_error || '',
+  };
+
+  const deductStalls = stalls * 2;
+  const deductErrors = errors * 25;
+  const deductFaults = Math.min(faults * 1, 10);
+  const deductDrops = Math.min(dropBlocks, 20);
+  const deductShifts = downshifts * 1;
+  r.health_score = Math.max(0, 100 - (deductStalls + deductErrors + deductFaults + deductDrops + deductShifts));
+  r.health_breakdown = {
+    stalls: deductStalls, errors: deductErrors,
+    faults: deductFaults, drops: deductDrops, downshifts: deductShifts,
+  };
+}
+
+let reloadInFlight = false;
+async function loadRows(silent = false) {
+  if (reloadInFlight) return;
+  reloadInFlight = true;
+  if (!silent) loading.value = true;
+  error.value = null;
+  try {
+    const { since, until } = computeRange();
+    const qs = new URLSearchParams();
+    if (since) qs.set('since', since);
+    if (until) qs.set('until', until);
+    const resp = await fetch('/analytics/api/sessions' + (qs.toString() ? '?' + qs : ''));
+    if (!resp.ok) throw new Error(`HTTP ${resp.status} (analytics forwarder reachable?)`);
+    const body = await resp.text();
+    const fresh: SessionRow[] = [];
+    for (const line of body.split('\n')) {
+      if (!line) continue;
+      try { fresh.push(JSON.parse(line)); } catch { /* skip */ }
+    }
+    for (const r of fresh) {
+      const t0 = Date.parse(r.started ?? '');
+      const t1 = Date.parse(r.last_seen ?? '');
+      r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;
+      deriveHealth(r);
+    }
+    rows.value = fresh;
+  } catch (e: any) {
+    error.value = String(e?.message ?? e);
+  } finally {
+    if (!silent) loading.value = false;
+    reloadInFlight = false;
+  }
+}
+
+const isInterestingRow = (r: SessionRow): boolean =>
+  Number(r.user_marked_count) > 0
+  || Number(r.frozen_count) > 0
+  || Number(r.error_event_count) > 0
+  || Number(r.segment_stall_count) > 0
+  || Number(r.restart_count) > 0;
+
+function matchesClassification(r: SessionRow): boolean {
+  switch (filters.value.classification) {
+    case 'all': return true;
+    case 'starred': return String(r.classification || '') === 'favourite';
+    case 'interesting': return isInterestingRow(r) || String(r.classification || '') === 'favourite';
+    case 'other': return !isInterestingRow(r) && String(r.classification || '') !== 'favourite';
+  }
+}
+
+function matches(r: SessionRow): boolean {
+  const f = filters.value;
+  return (!f.player_id || r.player_id === f.player_id)
+    && (!f.group_id || r.group_id === f.group_id)
+    && (!f.content_id || r.content_id === f.content_id)
+    && (!f.play_id || r.play_id === f.play_id)
+    && matchesClassification(r);
+}
+
+const filtered = computed(() => rows.value.filter(matches));
+
+const sorted = computed(() => {
+  const list = filtered.value.slice();
+  const key = sortKey.value;
+  const dir = sortDir.value === 'asc' ? 1 : -1;
+  const isNumberCol = COLUMNS.find((c) => c.key === key)?.type === 'number';
+  list.sort((a, b) => {
+    const av = (a as any)[key];
+    const bv = (b as any)[key];
+    if (isNumberCol) {
+      return ((Number(av) || 0) - (Number(bv) || 0)) * dir;
+    }
+    const as = String(av || '');
+    const bs = String(bv || '');
+    if (as < bs) return -1 * dir;
+    if (as > bs) return 1 * dir;
+    return 0;
+  });
+  return list;
+});
+
+// Cascading distinct-values for the four selects: each select's
+// option set is filtered by the SELECTIONS to its left.
+function distinctFor(key: 'player_id' | 'group_id' | 'content_id' | 'play_id'): string[] {
+  const f = filters.value;
+  const pool = rows.value.filter((r) => {
+    if (key === 'player_id') return true;
+    if (!f.player_id || r.player_id === f.player_id) {
+      if (key === 'group_id') return true;
+      if (!f.group_id || r.group_id === f.group_id) {
+        if (key === 'content_id') return true;
+        return !f.content_id || r.content_id === f.content_id;
+      }
+    }
+    return false;
+  });
+  return Array.from(new Set(pool.map((r) => (r as any)[key] || '').filter(Boolean))).sort();
+}
+const playerOptions = computed(() => distinctFor('player_id'));
+const groupOptions = computed(() => distinctFor('group_id'));
+const contentOptions = computed(() => distinctFor('content_id'));
+const playOptions = computed(() => distinctFor('play_id'));
+
+// When a parent filter narrows enough that the current value is no
+// longer in the visible set, clear it. Mirrors `fillSelect` in the
+// legacy code.
+watch(playerOptions, (opts) => { if (filters.value.player_id && !opts.includes(filters.value.player_id)) filters.value.player_id = ''; });
+watch(groupOptions, (opts) => { if (filters.value.group_id && !opts.includes(filters.value.group_id)) filters.value.group_id = ''; });
+watch(contentOptions, (opts) => { if (filters.value.content_id && !opts.includes(filters.value.content_id)) filters.value.content_id = ''; });
+watch(playOptions, (opts) => { if (filters.value.play_id && !opts.includes(filters.value.play_id)) filters.value.play_id = ''; });
+
+function clearFilters() {
+  filters.value.player_id = '';
+  filters.value.group_id = '';
+  filters.value.content_id = '';
+  filters.value.play_id = '';
+  filters.value.classification = 'all';
+}
+
+function onRangeChange() {
+  try { localStorage.setItem(RANGE_KEY, activeRangeId.value); } catch { /* ignore */ }
+  if (activeRangeId.value !== 'custom') void loadRows();
+}
+function applyCustomRange() {
+  customFrom.value = localToIso(customFromInput.value);
+  customTo.value = localToIso(customToInput.value);
+  try {
+    localStorage.setItem(RANGE_CUSTOM_KEY, JSON.stringify({ from: customFrom.value, to: customTo.value }));
+  } catch { /* ignore */ }
+  void loadRows();
+}
+
+const customFromInput = ref(isoToLocal(customFrom.value));
+const customToInput = ref(isoToLocal(customTo.value));
+
+function localToIso(v: string): string {
+  if (!v) return '';
+  const d = new Date(v);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : '';
+}
+function isoToLocal(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function viewerHref(r: SessionRow): string {
+  if (!r.player_id) return '#';
+  const qs = new URLSearchParams({ player_id: r.player_id });
+  if (r.play_id && r.play_id !== '—') qs.set('play_id', r.play_id);
+  return '/dashboard/v3/session-viewer.html?' + qs.toString();
+}
+function bundleHref(r: SessionRow): string {
+  if (!r.player_id) return '#';
+  const qs = new URLSearchParams({ player_id: r.player_id });
+  if (r.play_id && r.play_id !== '—') qs.set('play_id', r.play_id);
+  return '/analytics/api/session_bundle?' + qs.toString();
+}
+
+function fmtDur(ms?: number): string {
+  if (!ms) return '—';
+  const s = Math.round(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h) return `${h}h ${m}m ${sec}s`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
+function fmtStarted(iso?: string): string {
+  if (!iso) return '—';
+  const t = Date.parse(iso.includes('T') ? iso : iso.replace(' ', 'T') + 'Z');
+  if (!Number.isFinite(t)) return iso;
+  const d = new Date(t);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} `
+    + `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${String(d.getMilliseconds()).padStart(3, '0')}`;
+}
+interface RelTime { label: string; tip: string; recent: boolean; medium: boolean }
+function fmtRelTime(iso?: string): RelTime {
+  // Touch tick so this re-evaluates on auto-refresh.
+  void tick.value;
+  if (!iso) return { label: '—', tip: '', recent: false, medium: false };
+  const t = Date.parse(iso.includes('T') ? iso : iso.replace(' ', 'T') + 'Z');
+  if (!Number.isFinite(t)) return { label: '—', tip: '', recent: false, medium: false };
+  const ageSec = Math.max(0, (Date.now() - t) / 1000);
+  let label: string;
+  if (ageSec < 60) label = `${Math.round(ageSec)}s ago`;
+  else if (ageSec < 3600) label = `${Math.round(ageSec / 60)}m ago`;
+  else if (ageSec < 86400) label = `${Math.round(ageSec / 3600)}h ago`;
+  else label = `${Math.round(ageSec / 86400)}d ago`;
+  return { label, tip: iso, recent: ageSec < 30, medium: ageSec >= 30 && ageSec < 300 };
+}
+interface IssueBadge { count: number; cls: 'ok' | 'warn' | 'bad'; tip: string }
+function fmtIssuesBadge(r: SessionRow): IssueBadge {
+  const c = Number(r.issues_count) || 0;
+  const cls: IssueBadge['cls'] = c === 0 ? 'ok' : c <= 4 ? 'warn' : 'bad';
+  const b = r.issues_breakdown || {};
+  const parts: string[] = [];
+  if (b.stalls) parts.push(`${b.stalls} stall${b.stalls === 1 ? '' : 's'}`);
+  if (b.errors) parts.push(`player error: ${b.player_error || 'yes'}`);
+  if (b.faults) parts.push(`${b.faults} injected fault${b.faults === 1 ? '' : 's'}`);
+  if (b.downshifts) parts.push(`${b.downshifts} ABR downshift${b.downshifts === 1 ? '' : 's'}`);
+  if (b.drops) parts.push(`${b.drops} dropped frames (~${b.dropBlocks} blocks)`);
+  if (b.resolution_changes) parts.push(`${b.resolution_changes} resolution changes`);
+  return { count: c, cls, tip: parts.join(' · ') || 'no noteworthy events' };
+}
+interface HealthBadge { score: number; cls: 'ok' | 'warn' | 'bad'; tip: string }
+function fmtHealthBadge(r: SessionRow): HealthBadge {
+  const s = Number(r.health_score) || 0;
+  const cls: HealthBadge['cls'] = s >= 90 ? 'ok' : s >= 70 ? 'warn' : 'bad';
+  const b = r.health_breakdown || {};
+  const tip = `100 − stalls:${b.stalls || 0} − errors:${b.errors || 0} − faults:${b.faults || 0} − drops:${b.drops || 0} − downshifts:${b.downshifts || 0}`;
+  return { score: s, cls, tip };
+}
+interface CountCell { n: number; color: string; bold: boolean }
+function fmtCount(v: number | undefined, warn: number, bad: number): CountCell {
+  const n = Number(v) || 0;
+  let color = '#065f46';
+  if (n >= bad) color = '#991b1b';
+  else if (n >= warn) color = '#92400e';
+  else if (n === 0) color = '#9ca3af';
+  return { n, color, bold: n !== 0 };
+}
+interface PctCell { label: string; color: string }
+function fmtPct(v?: number): PctCell {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n === 0) return { label: '—', color: '#9ca3af' };
+  let color = '#065f46';
+  if (n < 60) color = '#991b1b';
+  else if (n < 85) color = '#92400e';
+  return { label: `${n.toFixed(1)}%`, color };
+}
+
+const FLAG_DEFS = [
+  { key: 'user_marked_count' as const,   icon: '🚨', label: '911 / user flag',  color: '#dc2626' },
+  { key: 'frozen_count' as const,        icon: '❄️',  label: 'frozen',           color: '#7c3aed' },
+  { key: 'error_event_count' as const,   icon: '⛔',        label: 'error event',      color: '#b91c1c' },
+  { key: 'segment_stall_count' as const, icon: '⏸',         label: 'segment stall',    color: '#c2410c' },
+  { key: 'restart_count' as const,       icon: '🔄', label: 'restart',          color: '#b45309' },
+];
+function flagChips(r: SessionRow): { icon: string; label: string; tip: string; color: string; count: number }[] {
+  const out: { icon: string; label: string; tip: string; color: string; count: number }[] = [];
+  for (const f of FLAG_DEFS) {
+    const c = Number((r as any)[f.key]) || 0;
+    if (c <= 0) continue;
+    out.push({ icon: f.icon, label: f.label, color: f.color, count: c, tip: `${c} ${f.label}${c === 1 ? '' : 's'}` });
+  }
+  return out;
+}
+
+// Column metadata drives header rendering + sort.
+const COLUMNS = [
+  { key: '__star',           label: '',           type: 'string' as const,  sortable: false },
+  { key: 'started',          label: 'Started',    type: 'string' as const,  sortable: true },
+  { key: 'last_seen',        label: 'Last updated', type: 'string' as const, sortable: true },
+  { key: 'duration_ms',      label: 'Duration',   type: 'number' as const,  sortable: true },
+  { key: 'player_id',        label: 'Player',     type: 'string' as const,  sortable: true },
+  { key: 'content_id',       label: 'Content',    type: 'string' as const,  sortable: true },
+  { key: 'play_id',          label: 'Play ID',    type: 'string' as const,  sortable: true },
+  { key: 'last_state',       label: 'State',      type: 'string' as const,  sortable: true },
+  { key: 'issues_count',     label: 'Issues',     type: 'number' as const,  sortable: true },
+  { key: '__flags',          label: 'Flags',      type: 'string' as const,  sortable: false },
+  { key: 'health_score',     label: 'Health',     type: 'number' as const,  sortable: true },
+  { key: 'stalls',           label: 'Stalls',     type: 'number' as const,  sortable: true },
+  { key: 'errors_count',     label: 'Errors',     type: 'number' as const,  sortable: true },
+  { key: 'faults_count',     label: 'Faults',     type: 'number' as const,  sortable: true },
+  { key: 'downshifts_count', label: 'Downshifts', type: 'number' as const,  sortable: true },
+  { key: 'dropped_frames',   label: 'Drops',      type: 'number' as const,  sortable: true },
+  { key: 'avg_quality_pct',  label: 'Avg Q%',     type: 'number' as const,  sortable: true },
+  { key: 'metric_events',    label: 'Metrics',    type: 'number' as const,  sortable: true },
+  { key: 'net_events',       label: 'HAR',        type: 'number' as const,  sortable: true },
+  { key: '__bundle',         label: '',           type: 'string' as const,  sortable: false },
+];
+
+function onHeaderClick(col: typeof COLUMNS[number]) {
+  if (!col.sortable) return;
+  if (sortKey.value === col.key) {
+    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortKey.value = col.key;
+    sortDir.value = col.type === 'number' ? 'desc' : 'asc';
+  }
+}
+
+async function toggleStar(r: SessionRow, ev: MouseEvent) {
+  ev.stopPropagation();
+  ev.preventDefault();
+  const wasStarred = String(r.classification || '') === 'favourite';
+  const pid = (r.play_id && r.play_id !== '—') ? r.play_id : '—';
+  const url = `/analytics/api/sessions/${encodeURIComponent(r.session_id)}/${encodeURIComponent(pid)}/star`;
+  const method = wasStarred ? 'DELETE' : 'POST';
+  // Optimistic flip.
+  r.classification = wasStarred ? '' : 'favourite';
+  try {
+    const resp = await fetch(url, { method });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  } catch (err: any) {
+    r.classification = wasStarred ? 'favourite' : '';
+    window.alert(`Star toggle failed: ${err?.message ?? err}`);
+  }
+}
+
+function onRowClick(r: SessionRow, ev: MouseEvent) {
+  const tgt = ev.target as HTMLElement | null;
+  // Star, bundle and explicit anchors handle themselves.
+  if (tgt?.closest('[data-star-cell]')) return;
+  if (tgt?.closest('[data-bundle-link]')) return;
+  if (tgt?.closest('a:not([data-row-fallback])')) return;
+  if (ev.metaKey || ev.ctrlKey || ev.shiftKey) return;
+  const href = viewerHref(r);
+  if (href !== '#') window.location.href = href;
+}
+
+let autoRefreshTimer: number | undefined;
+let clockTimer: number | undefined;
+onMounted(() => {
+  void loadRows();
+  // Auto-refresh every 5s (silent).
+  autoRefreshTimer = window.setInterval(() => void loadRows(true), 5000);
+  // 1s clock tick so "1s ago" → "2s ago" updates without a fetch.
+  clockTimer = window.setInterval(() => { tick.value++; }, 1000);
+});
+onBeforeUnmount(() => {
+  if (autoRefreshTimer) clearInterval(autoRefreshTimer);
+  if (clockTimer) clearInterval(clockTimer);
+});
+
+const heading = computed(() =>
+  `${rows.value.length} playback episodes archived (${rangeLabel.value.toLowerCase()}). Filter then pick one to replay.`,
+);
+const matchCount = computed(() => `${filtered.value.length} matching`);
+const showCustomInputs = computed(() => activeRangeId.value === 'custom');
+</script>
+
+<template>
+  <ShellLayout active-page="sessions">
+    <template #header>
+      <div class="page-title-bar">Sessions</div>
+    </template>
+
+    <main class="ism-content-wide">
+      <div class="page-header">
+        <div class="page-title">Sessions</div>
+        <div class="page-subtitle">Browse archived streaming sessions. Click one to open it in the Session Viewer.</div>
+      </div>
+
+      <div class="panel">
+        <div class="panel-header">
+          <div class="panel-title">Active Sessions <span v-if="loading" class="status-message">loading…</span></div>
+        </div>
+
+        <div class="picker-wrap">
+          <div class="picker-heading">{{ heading }}</div>
+
+          <div class="range-row">
+            <label class="ctrl-label">
+              <span>Time range:</span>
+              <select v-model="activeRangeId" @change="onRangeChange" class="ctrl-input">
+                <option v-for="r in RANGES" :key="r.id" :value="r.id">{{ r.label }}</option>
+              </select>
+            </label>
+            <span v-if="showCustomInputs" class="custom-range">
+              <span>from</span>
+              <input type="datetime-local" v-model="customFromInput" class="ctrl-input" />
+              <span>to</span>
+              <input type="datetime-local" v-model="customToInput" class="ctrl-input" />
+              <button type="button" class="btn btn-secondary" @click="applyCustomRange">Apply</button>
+            </span>
+            <span v-if="error" class="error">{{ error }}</span>
+          </div>
+
+          <div class="filter-row">
+            <label class="ctrl-label">
+              <span>Player:</span>
+              <select v-model="filters.player_id" class="ctrl-input">
+                <option value="">all ({{ playerOptions.length }})</option>
+                <option v-for="v in playerOptions" :key="v" :value="v">{{ v }}</option>
+              </select>
+            </label>
+            <label class="ctrl-label">
+              <span>Group:</span>
+              <select v-model="filters.group_id" class="ctrl-input">
+                <option value="">all ({{ groupOptions.length }})</option>
+                <option v-for="v in groupOptions" :key="v" :value="v">{{ v }}</option>
+              </select>
+            </label>
+            <label class="ctrl-label">
+              <span>Content:</span>
+              <select v-model="filters.content_id" class="ctrl-input">
+                <option value="">all ({{ contentOptions.length }})</option>
+                <option v-for="v in contentOptions" :key="v" :value="v">{{ v }}</option>
+              </select>
+            </label>
+            <label class="ctrl-label">
+              <span>Play:</span>
+              <select v-model="filters.play_id" class="ctrl-input">
+                <option value="">all ({{ playOptions.length }})</option>
+                <option v-for="v in playOptions" :key="v" :value="v">{{ v }}</option>
+              </select>
+            </label>
+
+            <div class="class-chip-wrap">
+              <span class="ctrl-label-text">Show:</span>
+              <button
+                v-for="c in ([
+                  { value: 'all',         label: 'All' },
+                  { value: 'starred',     label: '★ Starred' },
+                  { value: 'interesting', label: 'Interesting' },
+                  { value: 'other',       label: 'Other' }
+                ] as const)"
+                :key="c.value"
+                type="button"
+                class="class-chip"
+                :class="{ active: filters.classification === c.value }"
+                @click="filters.classification = c.value"
+              >{{ c.label }}</button>
+            </div>
+
+            <button type="button" class="btn btn-secondary" @click="clearFilters">Clear filters</button>
+            <span class="match-count">{{ matchCount }}</span>
+          </div>
+
+          <div class="table-wrap">
+            <table class="picker-table">
+              <thead>
+                <tr>
+                  <th
+                    v-for="col in COLUMNS"
+                    :key="col.key"
+                    :class="{ sortable: col.sortable }"
+                    :title="col.sortable ? `Sort by ${col.label}` : ''"
+                    @click="onHeaderClick(col)"
+                  >
+                    {{ col.label }}<template v-if="col.sortable">
+                      <span v-if="sortKey === col.key">{{ sortDir === 'asc' ? ' ▲' : ' ▼' }}</span>
+                      <span v-else class="sort-idle"> ⇅</span>
+                    </template>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-if="sorted.length === 0">
+                  <td :colspan="COLUMNS.length" class="empty">No sessions match the current filters.</td>
+                </tr>
+                <tr
+                  v-for="r in sorted"
+                  :key="r.session_id + ':' + (r.play_id ?? '')"
+                  :class="{ 'row-critical': r.is_critical }"
+                  @click="onRowClick(r, $event)"
+                >
+                  <td class="cell-star">
+                    <span
+                      data-star-cell
+                      class="star"
+                      :class="{ starred: r.classification === 'favourite' }"
+                      :title="r.classification === 'favourite'
+                        ? 'Starred — kept forever (click to unstar)'
+                        : 'Click to star — kept forever and exempt from TTL'"
+                      @click="toggleStar(r, $event)"
+                    >{{ r.classification === 'favourite' ? '★' : '☆' }}</span>
+                  </td>
+                  <td>{{ fmtStarted(r.started) }}</td>
+                  <td>
+                    <span
+                      :class="{ 'rel-recent': fmtRelTime(r.last_seen).recent, 'rel-medium': fmtRelTime(r.last_seen).medium, 'rel-old': !fmtRelTime(r.last_seen).recent && !fmtRelTime(r.last_seen).medium }"
+                      :title="fmtRelTime(r.last_seen).tip"
+                    >
+                      <span v-if="fmtRelTime(r.last_seen).recent" class="rel-dot"></span>
+                      {{ fmtRelTime(r.last_seen).label }}
+                    </span>
+                  </td>
+                  <td>{{ fmtDur(r.duration_ms) }}</td>
+                  <td>{{ r.player_id || '' }}</td>
+                  <td>{{ r.content_id || '' }}</td>
+                  <td class="cell-play-id">
+                    <a v-if="r.play_id && r.player_id" :href="viewerHref(r)" class="play-id-link">{{ r.play_id }}</a>
+                    <template v-else>{{ r.play_id || '' }}</template>
+                  </td>
+                  <td>{{ r.last_state || '' }}</td>
+                  <td>
+                    <span class="issue-badge" :class="'issue-' + fmtIssuesBadge(r).cls" :title="fmtIssuesBadge(r).tip">{{ fmtIssuesBadge(r).count }}</span>
+                  </td>
+                  <td>
+                    <span v-for="(f, i) in flagChips(r)" :key="i" class="flag-chip" :style="{ background: f.color }" :title="f.tip">{{ f.icon }} {{ f.count }}</span>
+                    <span v-if="flagChips(r).length === 0" class="dash">—</span>
+                  </td>
+                  <td>
+                    <span class="health-badge" :class="'issue-' + fmtHealthBadge(r).cls" :title="fmtHealthBadge(r).tip">{{ fmtHealthBadge(r).score }}</span>
+                  </td>
+                  <td><span :style="{ color: fmtCount(r.stalls, 1, 5).color, fontWeight: fmtCount(r.stalls, 1, 5).bold ? 600 : 400 }">{{ fmtCount(r.stalls, 1, 5).n }}</span></td>
+                  <td><span :style="{ color: fmtCount(r.errors_count, 1, 1).color, fontWeight: fmtCount(r.errors_count, 1, 1).bold ? 600 : 400 }">{{ fmtCount(r.errors_count, 1, 1).n }}</span></td>
+                  <td><span :style="{ color: fmtCount(r.faults_count, 1, 10).color, fontWeight: fmtCount(r.faults_count, 1, 10).bold ? 600 : 400 }">{{ fmtCount(r.faults_count, 1, 10).n }}</span></td>
+                  <td><span :style="{ color: fmtCount(r.downshifts_count, 1, 5).color, fontWeight: fmtCount(r.downshifts_count, 1, 5).bold ? 600 : 400 }">{{ fmtCount(r.downshifts_count, 1, 5).n }}</span></td>
+                  <td><span :style="{ color: fmtCount(r.dropped_frames, 100, 1000).color, fontWeight: fmtCount(r.dropped_frames, 100, 1000).bold ? 600 : 400 }">{{ fmtCount(r.dropped_frames, 100, 1000).n }}</span></td>
+                  <td><span :style="{ color: fmtPct(r.avg_quality_pct).color }">{{ fmtPct(r.avg_quality_pct).label }}</span></td>
+                  <td>{{ r.metric_events || 0 }}</td>
+                  <td>{{ r.net_events || 0 }}</td>
+                  <td>
+                    <a
+                      v-if="r.player_id"
+                      data-bundle-link
+                      :href="bundleHref(r)"
+                      download
+                      title="Download session bundle (.zip)"
+                      class="bundle-btn"
+                    >📥</a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </main>
+  </ShellLayout>
+</template>
+
+<style scoped>
+.page-title-bar { font-size: 16px; font-weight: 600; }
+.ism-content-wide { width: 100%; padding: 16px 24px; box-sizing: border-box; }
+.page-header { margin-bottom: 20px; }
+.page-title { font-size: 32px; font-weight: 400; margin-bottom: 8px; color: var(--text-primary); }
+.page-subtitle { font-size: 14px; color: var(--text-secondary); }
+
+.panel {
+  background: var(--bg-primary);
+  border-radius: 12px;
+  box-shadow: var(--shadow-md);
+  padding: 16px;
+  margin-bottom: 18px;
+}
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.panel-title { font-size: 16px; font-weight: 600; color: var(--text-primary); }
+.status-message { font-size: 12px; color: var(--text-secondary); font-weight: 400; margin-left: 8px; }
+
+.picker-wrap { display: flex; flex-direction: column; gap: 10px; }
+.picker-heading { font-size: 13px; color: var(--text-secondary); }
+
+.range-row, .filter-row {
+  display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+}
+.ctrl-label {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--text-secondary); font-weight: 500;
+}
+.ctrl-label-text {
+  font-size: 12px; color: var(--text-secondary); font-weight: 500;
+}
+.ctrl-input {
+  padding: 4px 8px;
+  font: 13px system-ui;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color, #d1d5db);
+  border-radius: 4px;
+}
+.custom-range { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); }
+.error { color: #b91c1c; font-size: 12px; }
+.match-count { margin-left: auto; font-size: 12px; color: var(--text-secondary); }
+
+.class-chip-wrap { display: flex; align-items: center; gap: 6px; }
+.class-chip {
+  padding: 4px 10px;
+  border-radius: 14px;
+  border: 1px solid var(--border-color, #d1d5db);
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+  font: 500 12px system-ui;
+  cursor: pointer;
+}
+.class-chip.active {
+  background: #1d4ed8;
+  color: #fff;
+  font-weight: 700;
+  border-color: #1d4ed8;
+}
+
+.btn {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #1f2937;
+  cursor: pointer;
+}
+.btn:hover { background: #f3f4f6; }
+.btn-secondary { background: var(--bg-secondary, #f9fafb); }
+
+.table-wrap {
+  max-height: 60vh;
+  overflow: auto;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+}
+.picker-table {
+  width: 100%;
+  border-collapse: collapse;
+  font: 12px ui-monospace, Menlo, monospace;
+}
+.picker-table thead tr {
+  background: var(--bg-secondary, #f5f5f5);
+  position: sticky;
+  top: 0;
+  z-index: 3;
+}
+.picker-table th {
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  user-select: none;
+}
+.picker-table th.sortable { cursor: pointer; }
+.sort-idle { color: #9ca3af; }
+.picker-table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border-color, #f3f4f6);
+  position: relative;
+}
+.picker-table tbody tr {
+  cursor: pointer;
+  border-left: 4px solid transparent;
+}
+.picker-table tbody tr:hover { background: var(--bg-hover, #f9fafb); }
+.picker-table tbody tr.row-critical { border-left: 4px solid #dc2626; }
+.picker-table tbody tr.row-critical:hover { background: #fef2f2; }
+.empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.cell-star { width: 28px; padding-left: 6px; padding-right: 0; }
+.star {
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  color: #9ca3af;
+  display: inline-block;
+  padding: 0 6px;
+  user-select: none;
+}
+.star.starred { color: #f59e0b; }
+
+.cell-play-id { font-weight: 600; color: #1d4ed8; }
+.play-id-link { color: #1d4ed8; text-decoration: none; font-weight: 600; }
+.play-id-link:hover { text-decoration: underline; }
+
+.issue-badge, .health-badge {
+  display: inline-block;
+  min-width: 28px;
+  text-align: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 700;
+  font-family: system-ui;
+}
+.health-badge { border-radius: 4px; min-width: 36px; }
+.issue-ok { background: #d1fae5; color: #065f46; }
+.issue-warn { background: #fef3c7; color: #92400e; }
+.issue-bad { background: #fee2e2; color: #991b1b; }
+
+.flag-chip {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 2px 0 0;
+  border-radius: 10px;
+  color: #fff;
+  font: 600 11px system-ui;
+  line-height: 1.4;
+}
+.dash { color: #9ca3af; }
+
+.rel-recent { color: #16a34a; font-weight: 600; display: inline-flex; align-items: center; gap: 6px; }
+.rel-medium { color: var(--text-primary); }
+.rel-old { color: var(--text-secondary); }
+.rel-dot {
+  display: inline-block; width: 6px; height: 6px;
+  border-radius: 50%; background: #16a34a;
+  animation: rel-pulse 1.2s ease-in-out infinite;
+}
+@keyframes rel-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+.bundle-btn {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--bg-secondary, #f3f4f6);
+  color: var(--text-primary, #111827);
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.2;
+}
+.bundle-btn:hover { background: var(--bg-hover, #e5e7eb); }
+</style>

--- a/content/dashboard-v3/src/pages/Testing.vue
+++ b/content/dashboard-v3/src/pages/Testing.vue
@@ -25,6 +25,7 @@
 import { computed, ref, watch } from 'vue';
 import { usePlayers } from '@/composables/usePlayers';
 import { useGroups } from '@/composables/useGroups';
+import { deviceContentLabel, groupNameFor } from '@/composables/useSessionLabels';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import * as repo from '@/repo/v2-repo';
 import ShapeSliders from '@/components/ShapeSliders.vue';
@@ -32,19 +33,16 @@ import NetworkShapingPattern from '@/components/NetworkShapingPattern.vue';
 import TransferTimeouts from '@/components/TransferTimeouts.vue';
 import ContentManipulation from '@/components/ContentManipulation.vue';
 import FaultRules from '@/components/FaultRules.vue';
-import SessionDetails from '@/components/SessionDetails.vue';
-import PlayerMetrics from '@/components/PlayerMetrics.vue';
-import NetworkLog from '@/components/NetworkLog.vue';
 import GroupBanner from '@/components/GroupBanner.vue';
-import BandwidthChart from '@/components/BandwidthChart.vue';
-import RTTChart from '@/components/RTTChart.vue';
-import BufferChart from '@/components/BufferChart.vue';
-import FPSChart from '@/components/FPSChart.vue';
-import EventsTimeline from '@/components/EventsTimeline.vue';
+import SessionDetails from '@/components/SessionDetails.vue';
 import CollapsibleSection from '@/components/CollapsibleSection.vue';
 import ShellLayout from '@/components/ShellLayout.vue';
-import BitrateChartPanelToolbar from '@/components/BitrateChartPanelToolbar.vue';
 import StatusBanners from '@/components/StatusBanners.vue';
+// Shared display half — same component testing-session.html and
+// session-viewer.html mount. Brings historical preload + brush +
+// accordion + cursor sync along automatically. Brush stays hidden
+// while live-following; appears once the operator pauses.
+import SessionDisplay from '@/components/SessionDisplay.vue';
 
 const { players, isLoading, isError, error, sseState, refetch, deletePlayer } = usePlayers();
 const { groups, link, disband } = useGroups();
@@ -85,6 +83,11 @@ const activePlayer = computed<PlayerRecord | null>(() => {
   if (!activeId.value) return null;
   return players.value.find((p) => p.id === activeId.value) ?? null;
 });
+
+// play_id comes straight off the active PlayerRecord; SessionDisplay
+// passes player_id (the live UUID) to the forwarder for archive
+// lookups, no client-side session resolution needed.
+const activePlayIdRef = computed<string | null>(() => activePlayer.value?.current_play?.id ?? null);
 
 /** Per-player group_id lookup (sourced from PlayerGroup.member_player_ids). */
 const groupIdOf = computed(() => {
@@ -157,11 +160,6 @@ async function releaseAll() {
   }
 }
 
-async function releaseOne(id: string) {
-  if (!confirm(`Release session ${id}?`)) return;
-  try { await deletePlayer(id); } catch (e) { console.error(e); }
-}
-
 function portOf(p: PlayerRecord): string {
   const raw = (p as any).raw_session ?? {};
   const port = raw.x_forwarded_port_external ?? raw.x_forwarded_port ?? null;
@@ -170,9 +168,22 @@ function portOf(p: PlayerRecord): string {
 
 function pillLabel(p: PlayerRecord): string {
   const port = portOf(p);
-  const idShort = p.id.slice(0, 8);
   const portSuffix = port ? ` (Port ${port})` : '';
-  return `Session #${p.display_id ?? '?'}${portSuffix} · ${idShort}`;
+  const tail = deviceContentLabel(p);
+  // Drop the trailing " · …" entirely if we can't infer device or
+  // content — a hex UUID slice doesn't help a human, so don't show
+  // anything rather than fall back to it.
+  const tailSuffix = tail ? ` · ${tail}` : '';
+  return `Session #${p.display_id ?? '?'}${portSuffix}${tailSuffix}`;
+}
+
+/** Stable group-badge text shared with the GroupBanner chip. */
+function groupBadgeFor(playerId: string): string {
+  const gid = groupIdOf.value.get(playerId);
+  if (!gid) return '';
+  const g = (groups.value ?? []).find((x) => x.id === gid);
+  if (!g) return `Group ${gid.slice(0, 6)}`;
+  return groupNameFor(g, players.value ?? []);
 }
 
 const sortedPlayers = computed<PlayerRecord[]>(() => {
@@ -183,19 +194,6 @@ const sortedPlayers = computed<PlayerRecord[]>(() => {
   });
 });
 
-const linkStatus = computed<string>(() => {
-  if (selected.value.size < 2) return 'Select 2+ sessions to group';
-  return `${selected.value.size} sessions selected`;
-});
-
-const showBufferChart = computed(() => {
-  const pm = activePlayer.value?.player_metrics;
-  return pm != null && (pm.buffer_depth_s != null || pm.live_offset_s != null);
-});
-const showFpsChart = computed(() => {
-  const pm = activePlayer.value?.player_metrics;
-  return pm != null && (pm.frames_displayed != null || pm.dropped_frames != null);
-});
 </script>
 
 <template>
@@ -215,9 +213,9 @@ const showFpsChart = computed(() => {
 
       <StatusBanners />
 
-      <div class="panel">
-        <div class="panel-header">
-          <div class="panel-title">
+      <div class="page-card">
+        <div class="page-card-header">
+          <div class="page-card-title">
             Active Sessions
             <span v-if="players.length" class="count-badge">{{ players.length }}</span>
           </div>
@@ -227,20 +225,6 @@ const showFpsChart = computed(() => {
               Release All Sessions
             </button>
           </div>
-        </div>
-
-        <!-- Group-controls bar — only meaningful with 2+ sessions, same
-             as legacy renderSessionTabs gating. -->
-        <div v-if="sortedPlayers.length > 1" class="group-controls">
-          <button
-            class="btn btn-sm btn-secondary"
-            type="button"
-            :disabled="selected.size < 2"
-            @click="linkSelected"
-          >
-            Group Selected Sessions
-          </button>
-          <span class="status-message">{{ linkStatus }}</span>
         </div>
 
         <div v-if="isLoading" class="empty">Loading sessions…</div>
@@ -276,8 +260,21 @@ const showFpsChart = computed(() => {
               />
               {{ pillLabel(p) }}
               <span v-if="groupIdOf.get(p.id)" class="group-badge">
-                {{ groupIdOf.get(p.id)?.slice(0, 6) }}
+                {{ groupBadgeFor(p.id) }}
               </span>
+            </button>
+            <!-- "Group" appears at the tail of the pill rail once the
+                 operator has ticked 2+ checkboxes. This replaces the
+                 separate group-controls bar — the action lives where the
+                 selection happens. -->
+            <button
+              v-if="selected.size >= 2"
+              class="group-trigger"
+              type="button"
+              @click="linkSelected"
+              :title="`Group ${selected.size} selected sessions`"
+            >
+              Group ({{ selected.size }})
             </button>
           </div>
 
@@ -286,56 +283,51 @@ const showFpsChart = computed(() => {
           <template v-if="activePlayer">
             <GroupBanner :player-id="activePlayer.id" />
 
-            <h3 class="session-controls-heading">
-              Session Controls
-              <button class="btn btn-sm btn-text" type="button" @click="releaseOne(activePlayer.id)">
-                Release this session
-              </button>
-            </h3>
-
-            <CollapsibleSection title="Session Details">
+            <!-- Session Details sits above the control panels for
+                 quick "what am I looking at" reference. SessionDisplay
+                 below suppresses its duplicate via :hide-session-details. -->
+            <CollapsibleSection title="Session Details" persist-key="session-details">
               <SessionDetails :player-id="activePlayer.id" />
             </CollapsibleSection>
 
-            <CollapsibleSection title="Player Metrics">
-              <PlayerMetrics :player-id="activePlayer.id" />
-            </CollapsibleSection>
+            <h3 class="session-controls-heading">Session Controls</h3>
 
-            <CollapsibleSection title="Fault Injection" :open="true">
+            <!-- Control panels — same as testing-session.html. These
+                 mutate live server state so they stay outside
+                 SessionDisplay (which is read-only). The Delete
+                 Session affordance lives on GroupBanner above, so no
+                 inline release button is needed here. -->
+            <CollapsibleSection title="Fault Injection" :open="true" persist-key="fault-injection">
               <FaultRules :player-id="activePlayer.id" />
             </CollapsibleSection>
 
-            <CollapsibleSection title="Content Manipulation">
+            <CollapsibleSection title="Content Manipulation" persist-key="content-manipulation">
               <ContentManipulation :player-id="activePlayer.id" />
             </CollapsibleSection>
 
-            <CollapsibleSection title="Server Timeouts">
+            <CollapsibleSection title="Server Timeouts" persist-key="server-timeouts">
               <TransferTimeouts :player-id="activePlayer.id" />
             </CollapsibleSection>
 
-            <CollapsibleSection title="Network Shaping" :open="true">
+            <CollapsibleSection title="Network Shaping" :open="true" persist-key="network-shaping">
               <ShapeSliders :player-id="activePlayer.id" />
               <h3 class="subhead">Pattern</h3>
               <NetworkShapingPattern :player-id="activePlayer.id" />
             </CollapsibleSection>
 
-            <CollapsibleSection title="Player State">
-              <EventsTimeline :player-id="activePlayer.id" />
-            </CollapsibleSection>
+            <h3 class="session-controls-heading">Session Display</h3>
 
-            <CollapsibleSection title="Bitrate Chart etc">
-              <BitrateChartPanelToolbar :player-id="activePlayer.id" />
-              <div class="chart-stack">
-                <BandwidthChart :player-id="activePlayer.id" />
-                <RTTChart :player-id="activePlayer.id" />
-                <BufferChart v-if="showBufferChart" :player-id="activePlayer.id" />
-                <FPSChart v-if="showFpsChart" :player-id="activePlayer.id" />
-              </div>
-            </CollapsibleSection>
-
-            <CollapsibleSection title="Network Log">
-              <NetworkLog :player-id="activePlayer.id" />
-            </CollapsibleSection>
+            <!-- Display half — historical preload + Focus Window fold
+                 + cursor sync, shared with testing-session.html and
+                 session-viewer.html. Brush + event filter + nav-bar
+                 live inside the Focus Window fold (collapse via its
+                 chevron to hide). -->
+            <SessionDisplay
+              :player-id="activePlayer.id"
+              :play-id="activePlayIdRef"
+              mode="live"
+              hide-session-details
+            />
           </template>
         </template>
       </div>
@@ -346,7 +338,6 @@ const showFpsChart = computed(() => {
 <style scoped>
 .page {
   padding: 24px;
-  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -364,14 +355,14 @@ const showFpsChart = computed(() => {
   margin-top: 2px;
 }
 
-.panel {
+.page-card {
   background: #fff;
   border: 1px solid #e5e7eb;
   border-radius: 12px;
   padding: 16px;
   box-shadow: 0 1px 3px rgba(60, 64, 67, 0.05);
 }
-.panel-header {
+.page-card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -379,7 +370,7 @@ const showFpsChart = computed(() => {
   gap: 12px;
   flex-wrap: wrap;
 }
-.panel-title {
+.page-card-title {
   font-size: 16px;
   font-weight: 600;
   color: #202124;
@@ -447,23 +438,32 @@ const showFpsChart = computed(() => {
 .sse[data-state='open']       { background: #d1fae5; color: #065f46; }
 .sse[data-state='closed']     { background: #fee2e2; color: #991b1b; }
 
-.group-controls {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  margin-bottom: 12px;
-  padding: 6px 0;
-}
-.status-message {
-  font-size: 12px;
-  color: #5f6368;
-}
-
 .session-tabs {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
   margin-bottom: 16px;
+}
+
+/* Tail-of-rail "Group (N)" trigger — appears only when ≥2 pills are
+ * ticked. Visually adjacent to the last pill so the action reads as
+ * "and now group these N". */
+.group-trigger {
+  background: #10b981;
+  color: white;
+  border: 1px solid #059669;
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 4px 10px rgba(16, 185, 129, 0.25);
+}
+.group-trigger:hover {
+  background: #059669;
+  box-shadow: 0 6px 14px rgba(5, 150, 105, 0.32);
 }
 .session-tab {
   display: inline-flex;

--- a/content/dashboard-v3/src/pages/TestingSession.vue
+++ b/content/dashboard-v3/src/pages/TestingSession.vue
@@ -15,20 +15,18 @@ import NetworkShapingPattern from '@/components/NetworkShapingPattern.vue';
 import TransferTimeouts from '@/components/TransferTimeouts.vue';
 import ContentManipulation from '@/components/ContentManipulation.vue';
 import FaultRules from '@/components/FaultRules.vue';
-import SessionDetails from '@/components/SessionDetails.vue';
-import PlayerMetrics from '@/components/PlayerMetrics.vue';
 import GroupBanner from '@/components/GroupBanner.vue';
-import NetworkLog from '@/components/NetworkLog.vue';
 import VideoPlayerFrame from '@/components/VideoPlayerFrame.vue';
-import BandwidthChart from '@/components/BandwidthChart.vue';
-import RTTChart from '@/components/RTTChart.vue';
-import BufferChart from '@/components/BufferChart.vue';
-import FPSChart from '@/components/FPSChart.vue';
-import EventsTimeline from '@/components/EventsTimeline.vue';
+import SessionDetails from '@/components/SessionDetails.vue';
 import CollapsibleSection from '@/components/CollapsibleSection.vue';
 import ShellLayout from '@/components/ShellLayout.vue';
-import BitrateChartPanelToolbar from '@/components/BitrateChartPanelToolbar.vue';
 import StatusBanners from '@/components/StatusBanners.vue';
+// Display half (Session Details / Player Metrics / Player State /
+// Bitrate charts / Network Log + Focus Window fold) is shared with
+// SessionViewer via SessionDisplay.vue. SessionDisplay resolves
+// historical via player_id directly against the forwarder — no
+// client-side session lookup needed.
+import SessionDisplay from '@/components/SessionDisplay.vue';
 
 const params = useUrlSearchParams<{ player_id?: string; url?: string }>('history');
 const playerId = computed(() => params.player_id ?? '');
@@ -81,69 +79,17 @@ console.log('[TS] page boot', {
 
 const { player, isLoading, isError, error, sseState } = usePlayer(playerId);
 
+// play_id falls out of the live PlayerRecord directly; the forwarder
+// accepts player_id alongside play_id, so SessionDisplay can query
+// archive data without a session_id lookup.
+const playIdRef = computed<string | null>(() => player.value?.current_play?.id ?? null);
+
 const masterUrl = computed<string>(() => player.value?.current_play?.manifest?.master_url ?? 'Loading…');
 const displayId = computed<string>(() => {
   const n = player.value?.display_id;
   return typeof n === 'number' ? `#${n}` : '';
 });
 
-// Lightweight request-kind tallies fed by the network log query.
-// Used as a CollapsibleSection badge on Session Details — matches the
-// legacy `M:{master}/Man:{manifest}/Seg:{segment}` count.
-import { useQuery } from '@tanstack/vue-query';
-import * as repo from '@/repo/v2-repo';
-const netQuery = useQuery({
-  queryKey: computed(() => ['network', playerId.value, 'tally'] as const),
-  queryFn: () => repo.getPlayerNetworkLog(playerId.value, 500),
-  enabled: computed(() => playerId.value.length > 0),
-  refetchInterval: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    if (typeof s === 'number' && s >= 400 && s < 500) return false;
-    return 5_000;
-  },
-  refetchIntervalInBackground: false,
-  retry: (n, err: any) => {
-    const s = err?.status;
-    if (typeof s === 'number' && s >= 400 && s < 500) return false;
-    return n < 1;
-  },
-  refetchOnMount: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-  refetchOnWindowFocus: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-  refetchOnReconnect: (q: any) => {
-    const s = (q?.state?.error as any)?.status;
-    return !(typeof s === 'number' && s >= 400 && s < 500);
-  },
-});
-// Buffer + FPS charts only render once the player has reported a
-// usable sample (matches legacy `showBufferDepthChart`). The Bandwidth
-// + RTT charts always render because the server can report them even
-// before the player ever ticks.
-const showBufferChart = computed(() => {
-  const pm = player.value?.player_metrics;
-  return pm != null && (pm.buffer_depth_s != null || pm.live_offset_s != null);
-});
-const showFpsChart = computed(() => {
-  const pm = player.value?.player_metrics;
-  return pm != null && (pm.frames_displayed != null || pm.dropped_frames != null);
-});
-
-const kindTally = computed(() => {
-  const items = (netQuery.data.value ?? []) as { request_kind?: string }[];
-  let m = 0, mn = 0, sg = 0;
-  for (const e of items) {
-    const k = (e.request_kind ?? '').toLowerCase();
-    if (k === 'master_manifest') m++;
-    else if (k === 'manifest' || k === 'audio_manifest') mn++;
-    else if (k === 'segment' || k === 'partial' || k === 'init' || k === 'audio_segment') sg++;
-  }
-  return { master: m, manifest: mn, segment: sg };
-});
 </script>
 
 <template>
@@ -192,26 +138,28 @@ const kindTally = computed(() => {
              CollapsibleSection component reads/writes
              `testing_session_collapse_<key>` to localStorage (matches
              legacy) and honours `?open_folds=<key>,<key>` deep links. -->
-        <CollapsibleSection title="Playback" :open="true" persist-key="playback">
+        <!-- persist-key bumped to playback-v2 — older "playback" key
+             may have been stored collapsed; reset to default-open so
+             returning operators see the video frame on landing. New
+             toggles still persist under the v2 key normally. -->
+        <CollapsibleSection title="Playback" :open="true" persist-key="playback-v2">
           <VideoPlayerFrame :player-id="playerId" :url-override="urlOverride" />
+        </CollapsibleSection>
+
+        <!-- Session Details sits above the control panels on live
+             pages: it's the "what am I looking at" summary the
+             operator reads before adjusting fault rules / shaping.
+             SessionDisplay below omits its internal duplicate via
+             :hide-session-details. -->
+        <CollapsibleSection title="Session Details" persist-key="session-details">
+          <SessionDetails :player-id="playerId" />
         </CollapsibleSection>
 
         <h3 class="session-controls-heading">Session Controls</h3>
 
-        <!-- Panel order below mirrors legacy testing-session.html so
-             muscle memory carries over. Default-open flags match the
-             legacy resolveSectionDefault(...) values. -->
-        <CollapsibleSection title="Session Details" persist-key="session-details">
-          <template #badge>
-            M:{{ kindTally.master }} / Man:{{ kindTally.manifest }} / Seg:{{ kindTally.segment }}
-          </template>
-          <SessionDetails :player-id="playerId" />
-        </CollapsibleSection>
-
-        <CollapsibleSection title="Player Metrics" persist-key="player-metrics">
-          <PlayerMetrics :player-id="playerId" />
-        </CollapsibleSection>
-
+        <!-- Control panels — order mirrors legacy testing-session.html.
+             These mutate server state and so are LIVE-only; the
+             archive session-viewer omits them. -->
         <CollapsibleSection title="Fault Injection" :open="true" persist-key="fault-injection">
           <FaultRules :player-id="playerId" />
         </CollapsibleSection>
@@ -230,28 +178,22 @@ const kindTally = computed(() => {
           <NetworkShapingPattern :player-id="playerId" />
         </CollapsibleSection>
 
-        <CollapsibleSection title="Player State" :open="true" persist-key="player-state">
-          <EventsTimeline :player-id="playerId" />
-        </CollapsibleSection>
+        <h3 class="session-controls-heading">Session Display</h3>
 
-        <CollapsibleSection title="Bitrate Chart etc" :open="true" persist-key="bitrate-chart">
-          <BitrateChartPanelToolbar :player-id="playerId" />
-          <div class="chart-stack">
-            <BandwidthChart :player-id="playerId" />
-            <RTTChart :player-id="playerId" />
-            <BufferChart v-if="showBufferChart" :player-id="playerId" />
-            <FPSChart v-if="showFpsChart" :player-id="playerId" />
-          </div>
-        </CollapsibleSection>
-
-        <CollapsibleSection title="Network Log" persist-key="network-log">
-          <template #badge>
-            <span v-if="player?.fault_counters">
-              {{ Object.values(player.fault_counters).reduce((a, n) => a + Number(n || 0), 0) }} faults
-            </span>
-          </template>
-          <NetworkLog :player-id="playerId" />
-        </CollapsibleSection>
+        <!-- Display half — same component the archive session-viewer
+             mounts. The brush + accordion + nav-bar live inside the
+             Focus Window fold (collapse via its chevron to hide).
+             SessionDisplay queries archive history with player_id
+             (no session lookup); play_id comes straight from the
+             live PlayerRecord. Empty until forwarder ingest catches
+             up — display panels still render via the live SSE path
+             during that window. -->
+        <SessionDisplay
+          :player-id="playerId"
+          :play-id="playIdRef"
+          mode="live"
+          hide-session-details
+        />
 
       </template>
       </main>
@@ -315,7 +257,6 @@ const kindTally = computed(() => {
 
 .content {
   padding: 24px;
-  max-width: 1200px;
   margin: 0 auto;
 }
 

--- a/content/dashboard-v3/src/repo/v2-repo.ts
+++ b/content/dashboard-v3/src/repo/v2-repo.ts
@@ -20,6 +20,22 @@ export type ContentManipulation = components['schemas']['ContentManipulation'];
 export type Labels = components['schemas']['Labels'];
 export type NetworkLogEntry = components['schemas']['NetworkLogEntry'];
 
+/**
+ * Single source of truth for the "is this id pointing at a live
+ * server-managed player vs. a finished play served from the
+ * ClickHouse archive" branch. Archive ids are minted by the
+ * session-viewer page as `archive:<sessionId>:<playId>` so getPlayer
+ * et al. can route to the local snapshot store instead of HTTP, and
+ * SessionDisplay can skip live-only behaviours (SSE subscription,
+ * 1 Hz cache patches, live-edge brush chase).
+ *
+ * Use this helper instead of inlining `id.startsWith('archive:')` so
+ * that future renaming of the prefix happens in one place.
+ */
+export function isLivePlayerId(id: string): boolean {
+  return !id.startsWith('archive:');
+}
+
 export class RepoError extends Error {
   constructor(
     public readonly status: number,
@@ -104,7 +120,36 @@ async function resolveCanonicalId(id: string): Promise<string | null> {
   return canonicalIdCache.get(id.toLowerCase()) ?? null;
 }
 
+// Side-channel store for archive/replay PlayerRecord objects. The v3
+// session-viewer page primes this map as it scrubs through historical
+// snapshots, then calls qc.setQueryData/invalidate so the standard
+// usePlayer() chain reads from cache without going to the network.
+// Archive ids carry an `archive:` prefix; anything else falls through
+// to the live `/api/v2/players/<id>` fetch path.
+const archiveStore = new Map<string, PlayerRecord>();
+const archiveNetworkStore = new Map<string, NetworkLogEntry[]>();
+export function setArchivePlayer(id: string, p: PlayerRecord) {
+  archiveStore.set(id, p);
+}
+export function setArchiveNetworkLog(id: string, rows: NetworkLogEntry[]) {
+  archiveNetworkStore.set(id, rows);
+}
+export function clearArchivePlayer(id: string) {
+  archiveStore.delete(id);
+  archiveNetworkStore.delete(id);
+}
+
 export async function getPlayer(playerId: string): Promise<{ player: PlayerRecord; etag?: string }> {
+  if (!isLivePlayerId(playerId)) {
+    const cached = archiveStore.get(playerId);
+    if (cached) return { player: cached, etag: undefined };
+    // Throw a 4xx so usePlayer's refetchOnMount guard treats it as a
+    // permanent miss and stops re-firing. The session-viewer page
+    // primes the cache *before* mounting the child components, so the
+    // first call should already find the entry — this branch only
+    // fires if the page mounts before the snapshot stream resolves.
+    throw Object.assign(new Error('archive snapshot not yet loaded'), { status: 404 });
+  }
   const id = canonicalIdFor(playerId);
   try {
     const { data, etag } = await request<PlayerRecord>(
@@ -215,10 +260,24 @@ export async function getPlayerNetworkLog(
   playerId: string,
   limit = 200,
 ): Promise<NetworkLogEntry[]> {
-  const { data } = await request<{ items: NetworkLogEntry[] }>(
-    `/api/v2/players/${encodeURIComponent(canonicalIdFor(playerId))}/network?limit=${limit}`,
-  );
-  return data.items ?? [];
+  if (!isLivePlayerId(playerId)) {
+    return archiveNetworkStore.get(playerId) ?? [];
+  }
+  try {
+    const { data } = await request<{ items: NetworkLogEntry[] }>(
+      `/api/v2/players/${encodeURIComponent(canonicalIdFor(playerId))}/network?limit=${limit}`,
+    );
+    return data.items ?? [];
+  } catch (err) {
+    // Treat 404 as "player no longer exists" rather than an error.
+    // When a session is released, SSE-driven cache invalidations can
+    // race a refetch for the just-deleted player_id, producing a
+    // noisy console 404 that's already correct behaviour on the
+    // server. Return empty so the UI just shows an empty log instead
+    // of an error state.
+    if ((err as any)?.status === 404) return [];
+    throw err;
+  }
 }
 
 // ----- Player groups -----
@@ -229,9 +288,14 @@ export async function listGroups(): Promise<PlayerGroup[]> {
 }
 
 export async function linkGroup(playerIds: string[]): Promise<PlayerGroup> {
+  // The v2 spec names the field `member_player_ids` (matches
+  // PlayerGroup.member_player_ids on read). The earlier `player_ids`
+  // payload was a v1-ism — the handler rejected it with 400
+  // "member_player_ids required" and the useMutation swallowed the
+  // error, which is why bulk-link in Testing.vue silently no-op'd.
   const { data } = await request<PlayerGroup>('/api/v2/player-groups', {
     method: 'POST',
-    body: JSON.stringify({ player_ids: playerIds }),
+    body: JSON.stringify({ member_player_ids: playerIds }),
   });
   return data;
 }
@@ -241,6 +305,26 @@ export async function disbandGroup(groupId: string, ifMatch?: string): Promise<v
     method: 'DELETE',
     ifMatch,
   });
+}
+
+/** PATCH a group's membership. The handler diffs against the current
+ *  set and removes/adds via the v1 store accordingly. If-Match comes
+ *  from the group's `control_revision`. */
+export async function updateGroupMembers(
+  groupId: string,
+  memberPlayerIds: string[],
+  ifMatch: string,
+): Promise<PlayerGroup> {
+  const { data } = await request<PlayerGroup>(
+    `/api/v2/player-groups/${encodeURIComponent(groupId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      body: JSON.stringify({ member_player_ids: memberPlayerIds }),
+      ifMatch,
+    },
+  );
+  return data;
 }
 
 // ----- Diagnostics -----

--- a/content/dashboard-v3/vite.config.ts
+++ b/content/dashboard-v3/vite.config.ts
@@ -34,7 +34,16 @@ export default defineConfig({
         // and right-clicking a tile deep-links into v3 testing-session
         // (the legacy /dashboard/grid.html still works and opens the
         // legacy testing-session.html; this is the parallel path).
-        grid: resolve(__dirname, 'grid.html')
+        grid: resolve(__dirname, 'grid.html'),
+        // Stage 6 — v3-native archive replay page. Parallel to legacy
+        // /dashboard/session-viewer.html (which uses session-shell.js +
+        // session-replay.js); this build reuses the live page's
+        // composables in replay mode driven by archived snapshots.
+        'session-viewer': resolve(__dirname, 'session-viewer.html'),
+        // Stage 6 (cont.) — archived-sessions picker. The session-viewer
+        // entry above expects a deep-link with session_id; this is the
+        // browse page that lists every play.
+        sessions: resolve(__dirname, 'sessions.html')
       }
     }
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,14 @@ services:
     restart: unless-stopped
 
   forwarder:
-    build: ./analytics/go-forwarder
+    # Build context is the repo root so the Dockerfile can COPY both
+    # analytics/go-forwarder/ AND go-proxy/ — the forwarder's go.mod
+    # uses a `replace` directive (../../go-proxy) to share the v2
+    # translator + oapigen types with the proxy module. Without the
+    # wider context that path doesn't exist inside the build container.
+    build:
+      context: .
+      dockerfile: analytics/go-forwarder/Dockerfile
     image: infinite-streaming-forwarder
     container_name: infinite-streaming-forwarder
     volumes:

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -45,8 +45,17 @@ upstream go_proxy {
 # Normal server
 server {
 
-    listen ${INFINITE_STREAM_LISTEN_PORT} default_server;
-    listen [::]:${INFINITE_STREAM_LISTEN_PORT} default_server;
+    # TLS + HTTP/2 for browsers (external traffic). Browsers refuse
+    # cleartext h2 so the port must be HTTPS for multiplexing to
+    # apply — eliminates Chrome's 6-per-origin HTTP/1.1 cap so SSE
+    # streams + REST polls share one TCP connection per tab.
+    listen ${INFINITE_STREAM_LISTEN_PORT} ssl http2 default_server;
+    listen [::]:${INFINITE_STREAM_LISTEN_PORT} ssl http2 default_server;
+    # Cleartext loopback listener for in-container internal calls
+    # (go-proxy → nginx → go-live). go-proxy's UPSTREAM_PORT env
+    # points here so it can speak plain HTTP without negotiating
+    # TLS against the same nginx instance.
+    listen 127.0.0.1:30005;
 
     ssl_certificate /etc/nginx/certs/localhost.pem;
     ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
@@ -138,6 +147,15 @@ server {
         add_header Expires "0" always;
     }
 
+    # NOTE: No legacy→v3 URL rewrites here. v3 source links go to
+    # /dashboard/v3/*.html paths directly (see ShellLayout.vue) so
+    # new clicks land at v3 naturally. Keeping the legacy URLs as-is
+    # lets the operator manually edit a v3 URL down to its legacy
+    # equivalent in the browser to A/B-compare behaviour. Per-file
+    # cutover happens by changing source links + the underlying
+    # /dashboard/v3/<file>.html → /dashboard/<file>.html mapping at
+    # the page level, not via nginx rewrites.
+
     location /dashboard/ {
         ${INFINITE_STREAM_AUTH_DIRECTIVES}
         alias /content/dashboard/;
@@ -192,7 +210,8 @@ server {
     include /etc/nginx/snippets/analytics-*.conf;
 
     location = /api/sessions {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -204,7 +223,8 @@ server {
     }
 
     location = /api/version {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -216,7 +236,8 @@ server {
     }
 
     location = /api/sessions/stream {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -232,7 +253,8 @@ server {
     }
 
     location = /api/clear-sessions {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -244,7 +266,8 @@ server {
     }
 
     location = /api/external-ips {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -256,7 +279,8 @@ server {
     }
 
     location ~ ^/api/session/ {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -268,7 +292,8 @@ server {
     }
 
     location ~ ^/api/failure-settings/ {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -280,7 +305,8 @@ server {
     }
 
     location ~ ^/api/session-group/ {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -292,7 +318,8 @@ server {
     }
 
     location ~ ^/api/nftables/ {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -307,7 +334,8 @@ server {
     # is SSE — needs the same buffering/timeout overrides as /api/sessions/stream
     # but the location regex below covers the non-stream paths first.
     location = /api/v2/events {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -321,7 +349,8 @@ server {
     }
 
     location ~ ^/api/v2/ {
-        proxy_pass http://go_proxy;
+        proxy_pass https://go_proxy;
+            proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1706,11 +1706,19 @@ func main() {
 
 	ports := []int{30081, 30181, 30281, 30381, 30481, 30581, 30681, 30781, 30881}
 
+	// TLS + HTTP/2 on every listener so the dashboard (served HTTPS
+	// by nginx at port 21000/30000) can embed HLS playback URLs
+	// pointing here without browsers blocking mixed content. Cert
+	// is the same self-signed pair launch.sh writes for nginx; we
+	// reuse it so there's exactly one identity to trust per dev
+	// machine. h2 turns on automatically once TLS is in play.
+	const tlsCertFile = "/etc/nginx/certs/localhost.pem"
+	const tlsKeyFile = "/etc/nginx/certs/localhost-key.pem"
 	errorCh := make(chan error, len(ports))
 	for _, port := range ports {
 		addr := fmt.Sprintf(":%d", port)
 		go func(bind string) {
-			log.Printf("go-proxy listening on %s", bind)
+			log.Printf("go-proxy listening on %s (TLS)", bind)
 			srv := &http.Server{
 				Addr:    bind,
 				Handler: router,
@@ -1720,7 +1728,7 @@ func main() {
 				// read. Issue #401.
 				ConnContext: withTCPConnContext,
 			}
-			errorCh <- srv.ListenAndServe()
+			errorCh <- srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
 		}(addr)
 	}
 
@@ -2953,6 +2961,24 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, delayMs int, los
 			"nftables_pattern_enabled": false,
 			"nftables_pattern_steps":   []NftShapeStep{},
 		}, "")
+		// Disarming the pattern loop leaves the kernel at whatever
+		// rate the last pattern step applied. Reassert the session's
+		// static shape so the user-visible "Limit" matches reality —
+		// without this the proxy reports pattern_enabled=false +
+		// bandwidth=N but the kernel keeps shaping at the old pattern
+		// rate (issue: ramp-pattern → sliders=0 didn't tear down the
+		// shaper). Walks every session bound to this port so a port
+		// hosting a group still drops the rate cleanly. Runs after
+		// the session update above so applySessionShaping sees the
+		// freshly cleared pattern_enabled flag and doesn't no-op via
+		// its "pattern owns the rate" guard.
+		for _, sess := range a.getSessionList() {
+			if portStr := getString(sess, "x_forwarded_port"); portStr != "" {
+				if p, err := strconv.Atoi(portStr); err == nil && p == port {
+					a.applySessionShaping(sess, port)
+				}
+			}
+		}
 		return nil
 	}
 	if err := a.traffic.UpdateNetem(port, delayMs, loss); err != nil {
@@ -4254,7 +4280,12 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				assignedNum, _ := strconv.Atoi(assigned)
 				newPort := replaceThirdFromLastDigit(externalPort, assignedNum)
 				host := hostWithoutPort(r.Host)
-				newURL := fmt.Sprintf("http://%s:%s/%s", host, newPort, escapedPath)
+				// Preserve the request's scheme — go-proxy now serves
+				// TLS on every shaper port (issue TS11), so an HTTPS
+				// dashboard must redirect to https:// to avoid mixed
+				// content. Plain HTTP requests redirect to http://.
+				scheme := requestScheme(r)
+				newURL := fmt.Sprintf("%s://%s:%s/%s", scheme, host, newPort, escapedPath)
 				if r.URL.RawQuery != "" {
 					newURL = newURL + "?" + r.URL.RawQuery
 				}
@@ -4303,11 +4334,18 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			log.Printf("PORT_MAP_DERIVE external=%s internal=%s allocated=%d", assignedExternalPort, assignedInternalPort, allocated)
 		}
 		groupID := extractGroupId(playerID)
+		// Optional play_id from the client. iOS/tvOS/Roku don't mint one
+		// (the v2 read path derives a stable fallback), but the v3 web
+		// player (VideoPlayerFrame) does — surfacing it here lets the
+		// forwarder archive each web play under its operator-known id
+		// instead of the server-side derivation.
+		playID := r.URL.Query().Get("play_id")
 		sessionData := SessionData{
 			"session_number":                           fmt.Sprintf("%d", allocated),
 			"sid":                                      fmt.Sprintf("%d", allocated),
 			"session_id":                               fmt.Sprintf("%d", allocated),
 			"player_id":                                playerID,
+			"play_id":                                  playID,
 			"group_id":                                 groupID,
 			"control_revision":                         newControlRevision(),
 			"headers_player_id":                        playerHeader,
@@ -4440,7 +4478,8 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		}
 		a.recordSessionStart(sessionData, manifestURL)
 		host := hostWithoutPort(r.Host)
-		newURL := fmt.Sprintf("http://%s:%s/%s", host, assignedExternalPort, escapedPath)
+		scheme := requestScheme(r)
+		newURL := fmt.Sprintf("%s://%s:%s/%s", scheme, host, assignedExternalPort, escapedPath)
 		if r.URL.RawQuery != "" {
 			newURL = newURL + "?" + r.URL.RawQuery
 		}
@@ -7560,6 +7599,23 @@ func countActiveSessionsForIP(sessions []SessionData, requesterIP string) int {
 		}
 	}
 	return count
+}
+
+// requestScheme returns "https" or "http" for the incoming request.
+// Used by redirect handlers so the per-session port URL in the
+// Location header matches the dashboard's origin and the browser
+// doesn't block the hop as mixed content. r.TLS is non-nil when the
+// request arrived over TLS directly; falling back to
+// X-Forwarded-Proto handles a future TLS-terminating reverse proxy
+// upstream of go-proxy.
+func requestScheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return proto
+	}
+	return "http"
 }
 
 func hostWithoutPort(hostport string) string {

--- a/go-proxy/cmd/server/rtt.go
+++ b/go-proxy/cmd/server/rtt.go
@@ -115,7 +115,22 @@ type RTTWindow struct {
 	// rather than dropping to zero.
 	lastAvgUs, lastMaxUs, lastMinUs uint32
 	haveLastDrain                   bool
+	// Multi-consumer dedup: every broadcast tick now fans out to
+	// several normalize callers (v1 SSE, v1 REST, v2 SSE source, v2
+	// SessionList, v2 SessionByPlayerID). Without dedup, the first
+	// caller drains and the rest see count=0 and get stale=true
+	// replay even though fresh samples exist. lastDrainAt lets a
+	// drain within mergeWindow re-use the prior sample without
+	// resetting the window.
+	lastDrainAt time.Time
 }
+
+// mergeWindow is the dedup span: any drain within this much time of
+// the previous successful drain returns the previous sample without
+// touching the running aggregator. Set comfortably larger than the
+// longest realistic same-tick consumer fanout (~tens of ms) and
+// comfortably smaller than the broadcast cadence (250ms).
+const rttMergeWindow = 100 * time.Millisecond
 
 type rttSample struct {
 	avgMs, maxMs, minMs, minLifetimeMs, varMs, rtoMs float32
@@ -164,10 +179,27 @@ func (w *RTTWindow) drainAndReset() rttSample {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	// Multi-consumer dedup: a same-tick re-read returns the previous
+	// sample without resetting state, so all consumers in one
+	// broadcast tick see identical fresh values instead of one fresh
+	// + N stale.
+	if w.haveLastDrain && !w.lastDrainAt.IsZero() && time.Since(w.lastDrainAt) < rttMergeWindow {
+		return rttSample{
+			avgMs:         float32(w.lastAvgUs) / 1000,
+			maxMs:         float32(w.lastMaxUs) / 1000,
+			minMs:         float32(w.lastMinUs) / 1000,
+			minLifetimeMs: float32(w.latestMinLifetimeUs) / 1000,
+			varMs:         float32(w.latestVarUs) / 1000,
+			rtoMs:         float32(w.latestRTOUs) / 1000,
+			hasData:       true,
+			// Not stale — same-tick re-read of a fresh drain.
+		}
+	}
 	if w.count == 0 {
 		if !w.haveLastDrain {
 			return rttSample{}
 		}
+		w.lastDrainAt = time.Now()
 		return rttSample{
 			avgMs:         float32(w.lastAvgUs) / 1000,
 			maxMs:         float32(w.lastMaxUs) / 1000,
@@ -193,6 +225,7 @@ func (w *RTTWindow) drainAndReset() rttSample {
 	w.lastMaxUs = w.maxUs
 	w.lastMinUs = w.minUs
 	w.haveLastDrain = true
+	w.lastDrainAt = time.Now()
 	w.sumUs = 0
 	w.count = 0
 	w.maxUs = 0

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -678,10 +678,18 @@ func (a *v2Adapter) LinkGroup(groupID string, playerIDs []string) []string {
 	if a == nil || a.app == nil || groupID == "" || len(playerIDs) == 0 {
 		return nil
 	}
-	wanted := map[string]struct{}{}
+	// Match each wanted player_id via matchesPlayerID rather than a
+	// plain string-equality map. Devices report their player_id in
+	// whatever case they like (iPad reports the UUID uppercase), but
+	// oapigen canonicalises incoming UUIDs to lowercase, so a raw
+	// `wanted[pid]` lookup misses every time and link returns 0 → 409
+	// "no eligible members". matchesPlayerID handles UUID equality
+	// (case-insensitive) AND the v1 short-form → v5(playerUUIDNamespace)
+	// derivation that every other v2 mutation path uses.
+	wantedRaw := make([]string, 0, len(playerIDs))
 	for _, p := range playerIDs {
 		if p != "" {
-			wanted[p] = struct{}{}
+			wantedRaw = append(wantedRaw, p)
 		}
 	}
 	current := a.app.getSessionList()
@@ -689,7 +697,14 @@ func (a *v2Adapter) LinkGroup(groupID string, playerIDs []string) []string {
 	var linked []string
 	for i, s := range updated {
 		pid := getString(s, "player_id")
-		if _, ok := wanted[pid]; !ok {
+		matched := false
+		for _, want := range wantedRaw {
+			if matchesPlayerID(pid, want) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			continue
 		}
 		updated[i]["group_id"] = groupID

--- a/go-proxy/internal/v2/server/handlers_groups.go
+++ b/go-proxy/internal/v2/server/handlers_groups.go
@@ -237,7 +237,13 @@ func buildGroupRecord(gid string, label *string, labels *oapigen.Labels, memberI
 	for _, p := range memberIDs {
 		if u, err := uuid.Parse(p); err == nil {
 			members = append(members, u)
+			continue
 		}
+		// v1 short-form pids (not parseable as UUID directly) round-trip
+		// via the same v5 derivation the read path uses — without this
+		// the response member list silently drops members the adapter
+		// just linked.
+		members = append(members, v2translate.PlayerUUIDForRawID(p))
 	}
 	return oapigen.PlayerGroup{
 		Id:              groupUUID,

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -789,13 +789,33 @@ func GroupsFromSessions(sessions []map[string]any) []oapigen.PlayerGroup {
 		}
 		playerUUID, err := uuid.Parse(pid)
 		if err != nil {
-			continue
+			// v1 short-form (e.g. "427a6bf3") never parses as UUID, but
+			// PlayerFromSession surfaces the same session under the
+			// stable v5 derivation. Mirror that here so the group's
+			// member list lines up with /api/v2/players — without this
+			// the picker's groupIdOf map never resolves the short-form
+			// pill back to its group, so only the natively-UUID member
+			// gets the grouped highlight.
+			playerUUID = derivePlayerUUID(pid)
 		}
 		g, exists := byID[gid]
 		if !exists {
-			groupUUID, err := StableGroupUUID(gid)
-			if err != nil {
-				continue
+			// v2-created groups store the v1 tag as a canonical UUIDv4
+			// (handlers_groups.PostApiV2PlayerGroups uses uuid.New()),
+			// so when the tag parses we use it directly — this keeps
+			// POST's `id` and GET's `id` identical, which is what the
+			// v3 client relies on for disband/lookup. Legacy v1 tags
+			// (e.g. "G1234") aren't parseable and fall through to the
+			// stable v5 derivation as before.
+			var groupUUID openapi_types.UUID
+			if u, perr := uuid.Parse(gid); perr == nil {
+				groupUUID = u
+			} else {
+				var err error
+				groupUUID, err = StableGroupUUID(gid)
+				if err != nil {
+					continue
+				}
 			}
 			label := gid
 			g = &oapigen.PlayerGroup{

--- a/tests/deploy/override-dev.yml
+++ b/tests/deploy/override-dev.yml
@@ -1,6 +1,20 @@
 services:
   go-server:
     container_name: test-dev-server
+    # Mount mkcert-signed certs over the auto-generated self-signed
+    # pair so Chrome / Safari trust them without per-port click-through.
+    # Drop localhost.pem + localhost-key.pem in ./certs/ on the host
+    # (`scp` from a Mac that ran `mkcert -install` + `mkcert
+    # jonathanoliver-ubuntu.local localhost 127.0.0.1`). launch.sh
+    # skips its self-signed fallback when the files already exist at
+    # /media/certs/, so the mounted cert wins.
+    volumes:
+      - ./certs:/media/certs:ro
+    environment:
+      # nginx's external listen on 30000 is now TLS-only. Internal
+      # in-container calls from go-proxy → nginx use the cleartext
+      # loopback listener on 30005 (see nginx-content.conf.template).
+      - INFINITE_STREAM_UPSTREAM_PORT=30005
     ports:
       !override
       - "21000:30000"
@@ -34,7 +48,7 @@ services:
   forwarder:
     container_name: test-dev-forwarder
     environment:
-      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_SSE_URL=https://go-server:30081/api/sessions/stream
       - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
       - FORWARDER_CLICKHOUSE_DB=infinite_streaming
       - FORWARDER_CLICKHOUSE_TABLE=session_snapshots


### PR DESCRIPTION
## Summary

Theme 5 of the organized landing — **the mega-squash** that absorbs 13 messy commits of v3 iteration so the live+ClickHouse merge round-trips vanish (Option C from the plan).

## Folded commits

`725ed44, 2d8e8ef, 91046f6, 8ba60e5, c5daba8, adc391e, b6d0b89, e21be65, 5f37948, 157048f, ea52489, 5bb82ab, 9203c62`

## Round-trips eaten by squash

- `useArchivedNetworkRequests.ts` (151 LOC) — added in early commits, removed in `9203c62` cleanup. **Never appears in this diff.**
- `useArchivedSnapshots.ts` (326 LOC) — same pattern. **Never appears.**
- `usePlayerSSE.ts` bulk-channel branches — transiently added then removed. **Final form is the simpler one.**

## Highlights

**v3 archive replay**: SessionViewer.vue with accordion event filter + synchronized cursor; Sessions.vue (886 LOC) full port of legacy sessions.html picker — time range, cascading filters, classification chips, 20-col table, bookmarks, bundle download, 5s auto-refresh.

**Shared SessionDisplay** (1705 LOC): extracted so live testing pages AND archive replay mount the same panels. Live pages preload historical via player_id (case-insensitive forwarder lookup).

**Unified v3 timeseries pipeline**:
- `analytics/go-forwarder/ring.go` (372 LOC) — per-(player, play) ring with pending/inserting/confirmed status
- `analytics/go-forwarder/streambundles.go` (388 LOC) — bundle catalogue + column projections
- `analytics/go-forwarder/timeseries.go` (690 LOC) — `/api/v3/timeseries` SSE handler with CH backfill + ring overlay + live deltas + dedupe at the seam
- `useSessionTimeSeries.ts` (502 LOC) — single client consumer with sorted dedupe caches, viewport-anchored eviction, Last-Event-ID reconnect
- Renderer migrations: NetworkLog, MetricsLineChart, EventsTimeline, SessionDisplay all read from `model.samples`/`model.network`

**Unified Live toggle + brush-driven span**: single checkable Live toggle replaces Pause/Live + Reset Zoom across all chart toolbars; brush drag-end is source of truth for focus span; right-edge-within-2s = pinned/following toggle. Click-to-pause dropped. PAUSED badge dropped.

**TLS + HTTP/2** on dashboard + shaper ports; ClickHouse `shaper_limit_mbps` + `rendition_mbps` columns persisted for v3 Limit/Server-Variant line parity (TS9); various v3 polish (Grid defaults, fault mode defaults, grouping, isLive).

## Skipped

22 legacy files (content/dashboard/*.html, content/shared/session-*.js, v2-*.js) — all deleted in Theme 6.

## Test plan

- [x] `go build ./go-proxy/... ./analytics/go-forwarder/...` clean
- [x] `cd content/dashboard-v3 && npm run build` clean (vue-tsc + vite both green; 7 v3 entry HTMLs)
- [ ] Live + archive smoke after Theme 6 cleans the legacy paths

Part of the organized landing per `/Users/jonathanoliver/.claude/plans/shiny-exploring-jellyfish.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
