### PR TITLE
refactor(v3): brush-as-source-of-truth chart coordination

### DIFF
--- a/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
+++ b/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
@@ -39,7 +39,7 @@ const liveChecked = computed(() => coord.state.range === null);
 /** Always togglePause — both directions preserve liveSpanMs.
  *  See MetricsLineChart.onLiveToggleClick for rationale. */
 function onLiveToggleClick() {
-  coord.togglePause();
+  coord.toggleLive();
 }
 </script>
 

--- a/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
+++ b/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
@@ -34,7 +34,7 @@ function setMode(m: YMaxMode) {
 // i.e. no sticky viewport. All four charts in the panel share this
 // coord state so the toolbar's toggle and each chart's toggle stay
 // in lockstep regardless of which one the operator clicked.
-const liveChecked = computed(() => coord.state.viewport === null);
+const liveChecked = computed(() => coord.state.range === null);
 
 /** Always togglePause — both directions preserve liveSpanMs.
  *  See MetricsLineChart.onLiveToggleClick for rationale. */

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -399,7 +399,7 @@ async function ensureTimeline(): Promise<void> {
       itemsDS = new vis.DataSet([]);
       groupsDS = new vis.DataSet([]);
       rebuildGroups();
-      const vp = coord.effectiveViewport.value;
+      const vp = coord.effectiveRange.value;
       timeline = new vis.Timeline(container.value, itemsDS, groupsDS, {
         stack: false,
         showCurrentTime: true,
@@ -728,7 +728,7 @@ async function drainNewRows() {
       const row = chRowToIngest(raw[i]);
       if (!row) continue;
       if (row.ts <= lastIngestedMs) continue; // belt-and-suspenders
-      if (coord.state.paused) {
+      if (coord.state.range !== null) {
         pendingLive.push(row);
       } else {
         ingest(row);
@@ -754,9 +754,9 @@ watch(
 // order so the coalescing logic produces the same lane segments it
 // would have produced live.
 watch(
-  () => coord.state.paused,
-  (paused) => {
-    if (paused || !pendingLive.length) return;
+  () => coord.state.range,
+  (range) => {
+    if (range !== null || !pendingLive.length) return;
     const drained = pendingLive.splice(0, pendingLive.length);
     for (const r of drained) ingest(r);
   },
@@ -786,7 +786,7 @@ watch(
 );
 
 watch(
-  () => [coord.state.version, coord.state.paused, coord.state.lastSampleMs] as const,
+  () => coord.effectiveRange.value,
   () => {
     if (!timeline) return;
     // Skip while the operator is mid-pan — a live sample arriving
@@ -794,7 +794,7 @@ watch(
     // visibly fighting the drag (and breaking the final rangechanged
     // event's intent).
     if (userInteracting) return;
-    const vp = coord.effectiveViewport.value;
+    const vp = coord.effectiveRange.value;
     suppressNextRangeChange = true;
     timeline.setWindow(vp.min, vp.max, { animation: false });
   },
@@ -830,11 +830,11 @@ function installLiveWheelAnchor() {
       const MIN_SPAN_MS = 1_000;
       const MAX_SPAN_MS = 24 * 3600 * 1000;
       const lastTs = coord.state.lastSampleMs;
-      const vp = coord.state.viewport;
+      const vp = coord.state.range;
 
       if (vp == null) {
         const windowMs = coord.state.windowMs;
-        const currentSpan = coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
+        const currentSpan = coord.state.liveSpan;
         const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
         coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
         return;
@@ -862,10 +862,10 @@ function installLiveWheelAnchor() {
 
 const expandedClass = computed(() => (coord.state.expanded ? 'expanded' : ''));
 // Live toggle is "checked" when we're currently following live —
-// i.e. no sticky viewport. Reacts to all transitions (click, brush
+// i.e. no sticky range. Reacts to all transitions (click, brush
 // drag, pan, zoom-snap-to-live) because every reader binds against
-// the shared `coord.state.viewport`.
-const liveChecked = computed(() => coord.state.viewport === null);
+// the shared `coord.state.range`.
+const liveChecked = computed(() => coord.state.range === null);
 
 /** Always togglePause — both directions preserve liveSpanMs.
  *  See MetricsLineChart.onLiveToggleClick for rationale. */

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -446,14 +446,12 @@ async function ensureTimeline(): Promise<void> {
         // — drop the sticky viewport, preserve the zoom span via
         // liveSpanMs, and stay unpaused. Any further Alt+wheel will
         // then take the left-edge-only path.
-        const lastTs = coord.state.lastSampleMs;
-        if (lastTs && b >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
-          coord.setViewport(null);
-          coord.setLiveSpanMs(b - a);
+        if (coord.isAtLiveEdge(b)) {
+          coord.setLiveSpan(b - a);
+          coord.setRange(null);
           return;
         }
-        if (!coord.state.paused) coord.setPaused(true);
-        coord.setViewport({ min: a, max: b });
+        coord.setRange({ min: a, max: b });
       });
       installLiveWheelAnchor();
     } finally {
@@ -829,14 +827,13 @@ function installLiveWheelAnchor() {
       const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
       const MIN_SPAN_MS = 1_000;
       const MAX_SPAN_MS = 24 * 3600 * 1000;
-      const lastTs = coord.state.lastSampleMs;
       const vp = coord.state.range;
 
       if (vp == null) {
         const windowMs = coord.state.windowMs;
         const currentSpan = coord.state.liveSpan;
         const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
-        coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+        coord.setLiveSpan(nextSpan);
         return;
       }
 
@@ -847,14 +844,12 @@ function installLiveWheelAnchor() {
       const anchorTime = vp.min + frac * currentSpan;
       let newStart = anchorTime - frac * nextSpan;
       let newEnd = newStart + nextSpan;
-      if (lastTs && newEnd >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
-        coord.setViewport(null);
-        coord.setLiveSpanMs(nextSpan);
-        if (coord.state.paused) coord.setPaused(false);
+      if (coord.isAtLiveEdge(newEnd)) {
+        coord.setLiveSpan(nextSpan);
+        coord.setRange(null);
         return;
       }
-      if (!coord.state.paused) coord.setPaused(true);
-      coord.setViewport({ min: newStart, max: newEnd });
+      coord.setRange({ min: newStart, max: newEnd });
     },
     { capture: true, passive: false },
   );
@@ -871,7 +866,7 @@ const liveChecked = computed(() => coord.state.range === null);
  *  See MetricsLineChart.onLiveToggleClick for rationale. */
 function onLiveToggleClick() {
   userInteracted = false;
-  coord.togglePause();
+  coord.toggleLive();
 }
 
 /**
@@ -930,7 +925,7 @@ onBeforeUnmount(() => {
           type="button"
           class="btn live-toggle"
           :class="{ checked: liveChecked }"
-          @click="coord.togglePause(); userInteracted = false"
+          @click="coord.toggleLive(); userInteracted = false"
           :title="liveChecked ? 'Pause at current live edge' : 'Resume following live (drops zoom and pan)'"
         >
           {{ liveChecked ? '●' : '○' }} Live

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -821,6 +821,19 @@ function installLiveWheelAnchor() {
   el.addEventListener(
     'wheel',
     (e: WheelEvent) => {
+      // Horizontal scroll → pan. Same semantics as MetricsLineChart;
+      // see gh#461.
+      if (!e.altKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        e.preventDefault();
+        e.stopPropagation();
+        const widthPx = el.clientWidth;
+        if (widthPx <= 0) return;
+        const current = coord.effectiveRange.value;
+        const span = current.max - current.min;
+        const dms = (e.deltaX / widthPx) * span;
+        coord.setRange({ min: current.min + dms, max: current.max + dms });
+        return;
+      }
       if (!e.altKey) return;
       e.preventDefault();
       e.stopPropagation();

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -29,7 +29,7 @@
  */
 import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import { ensureVisTimeline } from '@/composables/useChartJs';
-import { useChartCoordination } from '@/composables/useChartCoordination';
+import { useChartCoordination, DEFAULT_FOCUS_MS } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 
 interface LaneCfg { label: string; color: string }
@@ -830,9 +830,8 @@ function installLiveWheelAnchor() {
       const vp = coord.state.range;
 
       if (vp == null) {
-        const windowMs = coord.state.windowMs;
         const currentSpan = coord.state.liveSpan;
-        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
+        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(DEFAULT_FOCUS_MS, currentSpan * factor));
         coord.setLiveSpan(nextSpan);
         return;
       }

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -77,14 +77,12 @@ const LIVE_EDGE_TOLERANCE_MS = 2000;
  *  span via liveSpanMs, stay unpaused. Mirrors the EventsTimeline
  *  rangechanged path so chart / lane behave identically. */
 function applyViewportOrSnapToLive(min: number, max: number) {
-  const lastTs = coord.state.lastSampleMs;
-  if (lastTs && max >= lastTs - LIVE_EDGE_TOLERANCE_MS) {
-    coord.setViewport(null);
-    coord.setLiveSpanMs(max - min);
-    if (coord.state.paused) coord.setPaused(false);
+  if (coord.isAtLiveEdge(max)) {
+    coord.setLiveSpan(max - min);
+    coord.setRange(null);
     return;
   }
-  coord.setViewport({ min, max });
+  coord.setRange({ min, max });
 }
 
 
@@ -317,17 +315,13 @@ function createChartInstance(Chart: any): any {
             modifierKey: undefined,
             onPanStart: ({ chart: c }: any) => {
               // Pre-seed coord.viewport with the chart's CURRENT visible
-              // range before setPaused fires. setPaused → snapshotLive‑
-              // Viewport would otherwise overwrite viewport with
-              // `[lastSample − liveSpanMs, lastSample]` (the live‑edge
-              // window), flashing the chart back to live mid‑pan. The
-              // snapshot helper now skips when a viewport already
-              // exists, so seeding it here is enough.
+              // Pin the range to the chart's current visible window so
+              // effectiveRange stops following live mid-pan. setRange
+              // collapses what used to be setViewport + setPaused.
               const sx = c?.scales?.x;
               if (sx && Number.isFinite(sx.min) && Number.isFinite(sx.max)) {
-                coord.setViewport({ min: sx.min, max: sx.max });
+                coord.setRange({ min: sx.min, max: sx.max });
               }
-              if (!coord.state.paused) coord.setPaused(true);
             },
             onPanComplete: ({ chart: c }: any) => {
               const sx = c.scales?.x;
@@ -435,7 +429,9 @@ function installRightDragPan() {
     const sx = chart.scales?.x;
     if (!sx) return;
     dragState = { startX: e.clientX, startMin: sx.min, startMax: sx.max };
-    if (!coord.state.paused) coord.setPaused(true);
+    // Pin from the start so effectiveRange stops sliding while the
+    // user is dragging (setRange handles both range + paused mirror).
+    coord.setRange({ min: sx.min, max: sx.max });
   });
   window.addEventListener('mousemove', (e) => {
     if (!dragState || !chart) return;
@@ -445,7 +441,7 @@ function installRightDragPan() {
     const span = dragState.startMax - dragState.startMin;
     const dx = e.clientX - dragState.startX;
     const dv = (dx / widthPx) * span;
-    coord.setViewport({ min: dragState.startMin - dv, max: dragState.startMax - dv });
+    coord.setRange({ min: dragState.startMin - dv, max: dragState.startMax - dv });
   });
   window.addEventListener('mouseup', (e) => {
     if (e.button === 2) dragState = null;
@@ -484,7 +480,7 @@ function installLiveWheelAnchor() {
         const windowMs = coord.state.windowMs;
         const currentSpan = coord.state.liveSpan;
         const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
-        coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
+        coord.setLiveSpan(nextSpan);
         return;
       }
 
@@ -792,7 +788,7 @@ const liveChecked = computed(() => coord.state.range === null);
  *  span on the way back" was rejected — kept ripping the focus bar
  *  away from the zoom the user picked.) */
 function onLiveToggleClick() {
-  coord.togglePause();
+  coord.toggleLive();
 }
 
 onBeforeUnmount(() => {

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -18,7 +18,7 @@
  */
 import { computed, onBeforeUnmount, ref, toRef, watch, type PropType } from 'vue';
 import { ensureChartJs } from '@/composables/useChartJs';
-import { useChartCoordination, fmtTickHMSms, type ChartViewport } from '@/composables/useChartCoordination';
+import { useChartCoordination, fmtTickHMSms, DEFAULT_FOCUS_MS, type ChartViewport } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow, chRowToPlayerRecord } from '@/composables/chRowAdapter';
 import type { PlayerRecord } from '@/repo/v2-repo';
@@ -477,9 +477,8 @@ function installLiveWheelAnchor() {
 
       // LIVE — left-edge-only via liveSpan.
       if (vp == null) {
-        const windowMs = coord.state.windowMs;
         const currentSpan = coord.state.liveSpan;
-        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
+        const nextSpan = Math.max(MIN_SPAN_MS, Math.min(DEFAULT_FOCUS_MS, currentSpan * factor));
         coord.setLiveSpan(nextSpan);
         return;
       }
@@ -565,7 +564,7 @@ function pushSample(p: PlayerRecord, x: number) {
   // `animation: false` handles tens of thousands of points fine.
   if (mutated) {
     if (coord.state.range === null) {
-      applyViewport({ min: x - coord.state.windowMs, max: x });
+      applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
     safeChartUpdate();
   }

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -467,6 +467,23 @@ function installLiveWheelAnchor() {
   c.addEventListener(
     'wheel',
     (e: WheelEvent) => {
+      // Horizontal scroll (trackpad two-finger swipe left/right or
+      // mouse horizontal scroll) → pan the chart by deltaX scaled
+      // against the chart's plot-area width. No Alt required; plain
+      // vertical scroll still falls through to page scroll. See
+      // gh#461.
+      if (!e.altKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        e.preventDefault();
+        e.stopPropagation();
+        const chartArea = chart?.chartArea;
+        if (!chartArea || chartArea.right <= chartArea.left) return;
+        const widthPx = chartArea.right - chartArea.left;
+        const current = coord.effectiveRange.value;
+        const span = current.max - current.min;
+        const dms = (e.deltaX / widthPx) * span;
+        coord.setRange({ min: current.min + dms, max: current.max + dms });
+        return;
+      }
       if (!e.altKey) return;
       e.preventDefault();
       e.stopPropagation();

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -167,7 +167,7 @@ async function ensure(): Promise<any> {
 
 function createChartInstance(Chart: any): any {
   dataset = props.series.map(() => []);
-  const initialViewport = coord.effectiveViewport.value;
+  const initialViewport = coord.effectiveRange.value;
   const usesY2 = props.series.some((s) => s.axis === 'y2');
 
   // Pin chart plot-area edges across every chart in the panel so the
@@ -477,12 +477,12 @@ function installLiveWheelAnchor() {
       const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
       const MIN_SPAN_MS = 1_000;
       const MAX_SPAN_MS = 24 * 3600 * 1000;
-      const vp = coord.state.viewport;
+      const vp = coord.state.range;
 
-      // LIVE — left-edge-only via liveSpanMs.
+      // LIVE — left-edge-only via liveSpan.
       if (vp == null) {
         const windowMs = coord.state.windowMs;
-        const currentSpan = coord.state.liveSpanMs != null ? coord.state.liveSpanMs : windowMs;
+        const currentSpan = coord.state.liveSpan;
         const nextSpan = Math.max(MIN_SPAN_MS, Math.min(windowMs, currentSpan * factor));
         coord.setLiveSpanMs(nextSpan >= windowMs ? null : nextSpan);
         return;
@@ -568,7 +568,7 @@ function pushSample(p: PlayerRecord, x: number) {
   // producing a chart-vs-lane time-axis mismatch. Chart.js with
   // `animation: false` handles tens of thousands of points fine.
   if (mutated) {
-    if (!coord.state.paused && !coord.state.viewport) {
+    if (coord.state.range === null) {
       applyViewport({ min: x - coord.state.windowMs, max: x });
     }
     safeChartUpdate();
@@ -675,7 +675,7 @@ async function drainNewRows() {
       if (!Number.isFinite(x)) continue;
       if (x <= lastIngestedMs) continue; // belt-and-suspenders
       const p = chRowToPlayerRecord(row);
-      if (coord.state.paused) {
+      if (coord.state.range !== null) {
         pendingLive.push({ p, x });
       } else {
         pushSample(p, x);
@@ -695,13 +695,13 @@ watch(
   { immediate: true },
 );
 
-// Resume drain — flush any samples that arrived during pause in
+// Resume drain — flush any samples that arrived while pinned in
 // chronological order, so the chart catches up to the live edge in
 // one pass. insertByX dedupes by x so re-runs stay safe.
 watch(
-  () => coord.state.paused,
-  (paused) => {
-    if (paused || !pendingLive.length) return;
+  () => coord.state.range,
+  (range) => {
+    if (range !== null || !pendingLive.length) return;
     const drained = pendingLive.splice(0, pendingLive.length);
     for (const { p, x } of drained) pushSample(p, x);
   },
@@ -719,14 +719,18 @@ watch(
   },
 );
 
-// React to coordinated state changes (other charts in the same session
-// zooming / panning / pausing).
+// React to the coordinated visible range. `effectiveRange` collapses
+// the old (version, paused, lastSampleMs) tuple — it changes whenever
+// the range pin shifts (chart pan, brush drag, Live toggle) AND when
+// lastSampleMs advances (only while in live-tracking mode; when pinned
+// the new sample doesn't move the effective range, so the chart
+// correctly stays parked).
 watch(
-  () => [coord.state.version, coord.state.paused, coord.state.lastSampleMs] as const,
+  () => coord.effectiveRange.value,
   () => {
     if (!chart) return;
     try {
-      applyViewport(coord.effectiveViewport.value);
+      applyViewport(coord.effectiveRange.value);
     } catch (err) {
       console.warn('chart viewport apply skipped:', err);
     }
@@ -780,7 +784,7 @@ function toggleExpand() {
 // Live toggle is "checked" when we're currently following live —
 // i.e. no sticky viewport. Reactive across all charts because every
 // MetricsLineChart instance reads from the shared `coord.state`.
-const liveChecked = computed(() => coord.state.viewport === null);
+const liveChecked = computed(() => coord.state.range === null);
 
 /** Click handler — always togglePause. Both directions preserve the
  *  current `liveSpanMs` so going PINNED → LIVE doesn't reset the zoom

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -405,10 +405,11 @@ function navNext() {
 }
 function recenterOnNav() {
   const ev = navCurrent.value; if (!ev) return;
-  const half = (windowEndMs.value - windowStartMs.value) / 2;
-  windowStartMs.value = clampStart(ev._ts - half);
-  windowEndMs.value = clampEnd(ev._ts + half);
-  userMovedBrush.value = true;
+  const current = brushRange.value;
+  const half = (current.max - current.min) / 2;
+  const newStart = clampStart(ev._ts - half);
+  const newEnd = clampEnd(ev._ts + half);
+  coord.setRange({ min: newStart, max: newEnd });
 }
 
 watch(navCurrent, (ev) => {
@@ -448,79 +449,30 @@ const railMarkers = computed(() => {
 
 /* ─── Brush + focus window ──────────────────────────────────────── */
 
-const windowStartMs = ref<number>(0);
-const windowEndMs = ref<number>(0);
-const windowSpanMs = computed(() => Math.max(1, windowEndMs.value - windowStartMs.value));
+/** Brush position derives directly from `coord.effectiveRange`. Drag
+ *  handlers compute new ranges from mouse deltas and write via
+ *  `coord.setRange`; there are no local windowStart/windowEnd refs,
+ *  no userMovedBrush flag. "Paused / pinned" IS `coord.state.range
+ *  !== null`. "Live edge" IS `coord.isAtLiveEdge(brushRange.max)`.
+ *
+ *  Fresh-session auto-grow happens automatically: as samples land,
+ *  `coord.state.lastSampleMs` advances, so `effectiveRange.max`
+ *  advances, so the brush widens up to `coord.state.liveSpan`
+ *  (default 10 min) without any auto-feedback watcher that could get
+ *  stuck. */
+const brushRange = computed(() => coord.effectiveRange.value);
+const windowSpanMs = computed(() => Math.max(1, brushRange.value.max - brushRange.value.min));
 
-const DEFAULT_FOCUS_MS = 10 * 60 * 1000;
-const userMovedBrush = ref(false);
-
-/** Same checked rule as the chart-toolbar Live toggles — the brush
- *  rail's Live button reflects the shared `coord.state.viewport`. */
-const brushLiveChecked = computed(() => coord.state.viewport === null);
-watch(timeRange, (r) => {
-  if (!r) return;
-  const fullSpan = r.max - r.min;
-  // When the brush is tracking the live edge (!userMovedBrush) we
-  // preserve whatever WIDTH it already has — so if the operator
-  // resized to 3 min and then dropped at live, the live-tracking
-  // window stays 3 min wide. Only fall back to DEFAULT_FOCUS_MS on
-  // the very first paint when no width exists yet.
-  if (!userMovedBrush.value) {
-    // Live-tracking: span is driven by coord.liveSpanMs (set by chart
-    // Alt+wheel) or DEFAULT_FOCUS_MS. Never carry forward the previous
-    // tick's currentSpan — that's what got the brush stuck at 30 s
-    // when a fresh session started narrow and we never grew past it.
-    // Capped at fullSpan so a very young session (1 s of data) doesn't
-    // try to show empty area before r.min.
-    const liveSpan = coord.state.liveSpanMs;
-    const targetSpan = liveSpan != null
-      ? Math.min(liveSpan, fullSpan)
-      : Math.min(DEFAULT_FOCUS_MS, fullSpan);
-    const newStart = Math.max(r.min, r.max - targetSpan);
-    windowStartMs.value = newStart;
-    windowEndMs.value = r.max;
-    return;
-  }
-  if (windowStartMs.value < r.min) windowStartMs.value = r.min;
-  if (windowEndMs.value > r.max) windowEndMs.value = r.max;
-  if (windowStartMs.value >= windowEndMs.value) {
-    const span = Math.min(DEFAULT_FOCUS_MS, fullSpan);
-    windowStartMs.value = Math.max(r.min, r.max - span);
-    windowEndMs.value = r.max;
-  }
-});
-
-// Chart Alt+wheel updates coord.liveSpanMs to narrow the visible
-// span around the live edge. The brush width tracks chart zoom
-// unconditionally — zooming on a chart IS a request to resize the
-// focus rail, regardless of whether the brush is currently pinned.
-// Position-pinning (userMovedBrush) governs WHERE the window lives,
-// not how wide it is.
-watch(
-  () => coord.state.liveSpanMs,
-  (span) => {
-    const r = timeRange.value;
-    if (!r) return;
-    const targetSpan = span ?? Math.min(DEFAULT_FOCUS_MS, r.max - r.min);
-    // Anchor at the CURRENT right edge when the user has parked the
-    // brush off live — Alt+wheel on a chart should only resize the
-    // span, not rip the window back to "now". When at live (or never
-    // moved off), anchor at r.max so the live-tracking semantics hold.
-    const anchorRight = userMovedBrush.value ? windowEndMs.value : r.max;
-    console.log('[BR] liveSpanMs watch span=' + (span ?? 'null') + ' → brush ' + Math.round(targetSpan/1000) + 's, anchor=' + (userMovedBrush.value ? 'current' : 'live'));
-    windowStartMs.value = Math.max(r.min, anchorRight - targetSpan);
-    windowEndMs.value = anchorRight;
-  },
-);
+/** Live toggle checked rule — same across every surface. */
+const brushLiveChecked = computed(() => coord.state.range === null);
 
 function clampStart(v: number) {
   const r = timeRange.value; if (!r) return v;
-  return Math.max(r.min, Math.min(v, windowEndMs.value - 1000));
+  return Math.max(r.min, Math.min(v, brushRange.value.max - 1000));
 }
 function clampEnd(v: number) {
   const r = timeRange.value; if (!r) return v;
-  return Math.min(r.max, Math.max(v, windowStartMs.value + 1000));
+  return Math.min(r.max, Math.max(v, brushRange.value.min + 1000));
 }
 
 /* ─── Brush drag handling ───────────────────────────────────────── */
@@ -541,13 +493,17 @@ function pxToMs(px: number): number {
 function onBrushMouseDown(e: MouseEvent, mode: 'pan' | 'resize-left' | 'resize-right') {
   e.preventDefault();
   e.stopPropagation();
-  userMovedBrush.value = true;
+  // Snapshot the start range BEFORE pinning — if the brush was
+  // following live, effectiveRange was advancing with each sample.
+  // Pinning stops that so the drag operates on a stable baseline.
+  const start = brushRange.value;
   dragState.value = {
     mode,
     startX: e.clientX,
-    startStart: windowStartMs.value,
-    startEnd: windowEndMs.value,
+    startStart: start.min,
+    startEnd: start.max,
   };
+  coord.setRange({ min: start.min, max: start.max });
   window.addEventListener('mousemove', onDragMove);
   window.addEventListener('mouseup', onDragEnd, { once: true });
 }
@@ -556,73 +512,51 @@ function onDragMove(e: MouseEvent) {
   const r = timeRange.value; if (!r) return;
   const dms = pxToMs(e.clientX - d.startX);
   const MIN_WINDOW_MS = 1000;
+  let s = d.startStart;
+  let f = d.startEnd;
   if (d.mode === 'pan') {
     const span = d.startEnd - d.startStart;
-    let s = d.startStart + dms;
-    let f = s + span;
+    s = d.startStart + dms;
+    f = s + span;
     if (s < r.min) { s = r.min; f = s + span; }
     if (f > r.max) { f = r.max; s = f - span; }
-    windowStartMs.value = s;
-    windowEndMs.value = f;
   } else if (d.mode === 'resize-left') {
-    let s = d.startStart + dms;
+    s = d.startStart + dms;
     if (s < r.min) s = r.min;
     if (s > d.startEnd - MIN_WINDOW_MS) s = d.startEnd - MIN_WINDOW_MS;
-    windowStartMs.value = s;
+    f = d.startEnd;
   } else if (d.mode === 'resize-right') {
-    let f = d.startEnd + dms;
+    f = d.startEnd + dms;
     if (f > r.max) f = r.max;
     if (f < d.startStart + MIN_WINDOW_MS) f = d.startStart + MIN_WINDOW_MS;
-    windowEndMs.value = f;
+    s = d.startStart;
   }
+  coord.setRange({ min: s, max: f });
 }
 function onDragEnd() {
+  const ended = brushRange.value;
   dragState.value = null;
   window.removeEventListener('mousemove', onDragMove);
-  const r = timeRange.value;
-  // RIGHT EDGE position determines the pinned-vs-following state.
-  // Drop within 2 s of the right edge → "live" (live mode: follow
-  // streaming edge; archive mode: snap to end-of-session). Works in
-  // BOTH modes — archive's r.max is the end of the playback, which
-  // is the same conceptual "Live" the operator sees.
-  // Drop away from r.max → pinned to the brush window.
-  // No paused guard: dragging right to live edge is itself an explicit
-  // unpause gesture (user is saying "follow the edge from here").
-  const atLiveEdge =
-    !!r
-    && r.max - windowEndMs.value <= 2000;
-  const dropSpan = windowEndMs.value - windowStartMs.value;
-  if (atLiveEdge) {
-    userMovedBrush.value = false;
-    if (coord.state.paused) coord.setPaused(false);
-  }
-
-  // BRUSH WIDTH on release becomes the new liveSpanMs — operator's
+  // BRUSH WIDTH on release becomes the new liveSpan — operator's
   // intent regardless of where the right edge ended up. Pinned drops
   // store the span so it survives the round trip when they later
   // click Live to return; live drops update the span immediately so
-  // every other chart's live-tracker uses the same width. Applies in
-  // BOTH live and archive modes — "live edge" in archive is just the
-  // right edge of the playback; the operator's brush width is the
-  // canonical span either way.
-  if (dropSpan > 0 && coord.state.liveSpanMs !== dropSpan) {
-    coord.setLiveSpanMs(dropSpan);
-  }
-
-  // Reconcile viewport with the new brush window. !userMovedBrush →
-  // clears viewport (charts follow live). userMovedBrush → pins
-  // viewport to the brush range.
-  applyWindowToViewport();
+  // every other chart's live-tracker uses the same width.
+  const dropSpan = ended.max - ended.min;
+  if (dropSpan > 0) coord.setLiveSpan(dropSpan);
+  // RIGHT EDGE within 2 s of the latest sample → snap to live
+  // (charts AND brush follow the right edge as new samples arrive).
+  // Otherwise leave the range pinned to whatever onDragMove last set.
+  if (coord.isAtLiveEdge(ended.max)) coord.setRange(null);
 }
-/** Alt+wheel on the brush rail zooms the focus-window duration.
- *
- *   - AT LIVE (right edge ≈ r.max): left-edge-only — right stays
- *     glued to live, span shrinks/grows from the left.
- *   - OFF LIVE: mouse-anchored — the time under the cursor stays
- *     fixed while both edges move. If the resulting right edge
- *     reaches live, snap the brush back to live tracking
- *     (userMovedBrush=false) so further zooms take the left-only
- *     path.
+
+/** Alt+wheel on the brush rail zooms the focus-window duration. Same
+ *  semantics as Alt+wheel on the chart toolbars:
+ *    - AT LIVE (brush.max ≈ lastSampleMs): grow/shrink span, keep
+ *      right edge glued to live. Updates liveSpan, range stays null.
+ *    - OFF LIVE: mouse-anchored — the time under the cursor stays
+ *      fixed while both edges move. If the new right edge reaches
+ *      live, snap to live tracking.
  *
  *  Plain wheel falls through to native page scroll. */
 function onRailWheel(e: WheelEvent) {
@@ -633,36 +567,34 @@ function onRailWheel(e: WheelEvent) {
   const r = timeRange.value;
   if (!rail || !r) return;
   const fullSpan = Math.max(1, r.max - r.min);
-  const currentSpan = Math.max(1, windowEndMs.value - windowStartMs.value);
+  const current = brushRange.value;
+  const currentSpan = Math.max(1, current.max - current.min);
   const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
   const MIN_SPAN_MS = 1_000;
   const nextSpan = Math.max(MIN_SPAN_MS, Math.min(fullSpan, currentSpan * factor));
   if (nextSpan === currentSpan) return;
-  const atLive = r.max - windowEndMs.value <= 2000;
 
-  let newStart: number;
-  let newEnd: number;
-  if (atLive) {
-    newEnd = r.max;
-    newStart = Math.max(r.min, newEnd - nextSpan);
-  } else {
-    // Mouse-anchored: keep the timestamp under the cursor at the same
-    // x position in the rail after the zoom.
-    const rect = rail.getBoundingClientRect();
-    const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0.5;
-    const anchorTime = r.min + frac * fullSpan;
-    const anchorFracInWindow = (anchorTime - windowStartMs.value) / currentSpan;
-    newStart = anchorTime - anchorFracInWindow * nextSpan;
-    newEnd = newStart + nextSpan;
-    if (newStart < r.min) { newStart = r.min; newEnd = newStart + nextSpan; }
-    if (newEnd > r.max) { newEnd = r.max; newStart = newEnd - nextSpan; }
+  if (coord.isAtLiveEdge(current.max)) {
+    coord.setLiveSpan(nextSpan);
+    coord.setRange(null);
+    return;
   }
-
-  windowStartMs.value = newStart;
-  windowEndMs.value = newEnd;
-  // Snap back to live tracking if the zoom landed at the live edge.
-  const endedAtLive = r.max - newEnd <= 2000;
-  userMovedBrush.value = !endedAtLive;
+  // Mouse-anchored: keep the timestamp under the cursor at the same
+  // x position in the rail after the zoom.
+  const rect = rail.getBoundingClientRect();
+  const frac = rect.width > 0 ? (e.clientX - rect.left) / rect.width : 0.5;
+  const anchorTime = r.min + frac * fullSpan;
+  const anchorFracInWindow = (anchorTime - current.min) / currentSpan;
+  let newStart = anchorTime - anchorFracInWindow * nextSpan;
+  let newEnd = newStart + nextSpan;
+  if (newStart < r.min) { newStart = r.min; newEnd = newStart + nextSpan; }
+  if (newEnd > r.max) { newEnd = r.max; newStart = newEnd - nextSpan; }
+  if (coord.isAtLiveEdge(newEnd)) {
+    coord.setLiveSpan(nextSpan);
+    coord.setRange(null);
+    return;
+  }
+  coord.setRange({ min: newStart, max: newEnd });
 }
 
 function onRailMouseDown(e: MouseEvent) {
@@ -674,15 +606,14 @@ function onRailMouseDown(e: MouseEvent) {
   if (rect.width <= 0) return;
   const frac = (e.clientX - rect.left) / rect.width;
   const target = railFracToMs(frac);
-  const span = windowEndMs.value - windowStartMs.value;
+  const current = brushRange.value;
+  const span = current.max - current.min;
   const r = timeRange.value; if (!r) return;
   let s = target - span / 2;
   let f = s + span;
   if (s < r.min) { s = r.min; f = s + span; }
   if (f > r.max) { f = r.max; s = f - span; }
-  windowStartMs.value = s;
-  windowEndMs.value = f;
-  userMovedBrush.value = true;
+  coord.setRange({ min: s, max: f });
 }
 
 /* ─── Brush-driven panel cursor ─────────────────────────────────── */
@@ -692,99 +623,18 @@ function playerKey(id: string) {
   return ['player', id] as const;
 }
 
-watch([windowStartMs, windowEndMs], () => {
-  // Reconcile chart viewport with the new brush window. `liveSpanMs`
-  // is set explicitly by user gestures (onDragEnd, chart Alt+wheel,
-  // brush-rail Alt+wheel) — NOT auto-fed from this watcher. Earlier
-  // versions did auto-feed, but during the fresh-session auto-grow
-  // phase that wrote the small early-tick width into liveSpanMs,
-  // which then capped subsequent grow ticks at that width. Result:
-  // brush stuck at e.g. 5 s after the second sample, never reaching
-  // the 10-min default.
-  applyWindowToViewport();
-});
-
-function applyWindowToViewport() {
-  // Three states for the chart viewport:
-  //  1. Operator has explicitly moved the brush — pin charts to that
-  //     window (frozen view).
-  //  2. Paused — same: pin charts to the window the operator pinned
-  //     by hitting pause.
-  //  3. Neither — hand the viewport back to coord by clearing it.
-  //     `effectiveViewport` then follows the right edge with the
-  //     coord's liveSpanMs / windowMs span. Works in both modes:
-  //     live = streaming edge advances; archive = right edge stays
-  //     at end-of-session.
-  if (!userMovedBrush.value && !coord.state.paused) {
-    if (coord.state.viewport != null) coord.setViewport(null);
-    return;
-  }
-  if (windowStartMs.value && windowEndMs.value && windowStartMs.value < windowEndMs.value) {
-    coord.setViewport({ min: windowStartMs.value, max: windowEndMs.value });
-  }
-}
-
+// Brush-end-row projection — runs in ALL contexts so SessionDisplay's
+// display panels (PlayerMetrics, SessionDetails, charts) always
+// reflect the state at the brush's right edge. When at the live
+// edge, lastAt(brush.max) returns the latest sample → panels show
+// essentially-current state. When brush moves back, panels show
+// that past moment. The cache key is the prefixed archive id so
+// this never collides with the live cache that outside mutation
+// panels (FaultRules etc.) read.
 watch(
-  () => coord.state.viewport,
-  (v) => {
-    console.log('[BR] coord.viewport watch', v ? `[span=${Math.round((v.max-v.min)/1000)}s]` : 'null', 'userMoved=' + userMovedBrush.value);
-    if (v) {
-      if (windowStartMs.value === v.min && windowEndMs.value === v.max) return;
-      console.log('[BR] coord.viewport set → brush ' + Math.round((v.max-v.min)/1000) + 's, userMovedBrush=true');
-      windowStartMs.value = v.min;
-      windowEndMs.value = v.max;
-      userMovedBrush.value = true;
-      return;
-    }
-    // viewport=null = explicit return to following live (via the Live
-    // toggle's checked → unchecked path or snap-back-to-live on zoom).
-    // Snap brush right edge to r.max and ALWAYS clear userMovedBrush
-    // so charts AND brush move together.
-    //
-    // Works for both modes: live = r.max is the latest streaming
-    // sample (== live edge); archive = r.max is the last archived
-    // sample (== end of the playback). Either way "Live" means
-    // "right edge of the available data".
-    //
-    // Span preference order:
-    //   1. liveSpanMs — set by chart Alt+wheel; the operator picked it
-    //   2. currentSpan — whatever the brush was when pinned (e.g. a
-    //      manual 5-min drag); preserves their inspection width
-    //   3. DEFAULT_FOCUS_MS — last-resort fallback on a fresh session
-    //      where neither has ever been set
-    const r = timeRange.value; if (!r) return;
-    const fullSpan = r.max - r.min;
-    const liveSpan = coord.state.liveSpanMs;
-    const currentSpan = windowEndMs.value - windowStartMs.value;
-    let targetSpan: number;
-    if (liveSpan != null) targetSpan = Math.min(liveSpan, fullSpan);
-    else if (currentSpan > 0) targetSpan = Math.min(currentSpan, fullSpan);
-    else targetSpan = Math.min(DEFAULT_FOCUS_MS, fullSpan);
-    const newStart = Math.max(r.min, r.max - targetSpan);
-    windowStartMs.value = newStart;
-    windowEndMs.value = r.max;
-    userMovedBrush.value = false;
-  },
-);
-
-// Panel-cursor sync: the SessionDetails / PlayerMetrics panels read
-// from the v2-archive store (or live cache in live mode). For archive
-// mode we project the row at the brush's right edge — adapted from
-// CH via chRowToPlayerRecord — into the archive store so panels stay
-// in sync with the focus window.
-// Brush-end-row projection — runs in ALL contexts (live and archive)
-// so SessionDisplay's display panels (PlayerMetrics, SessionDetails,
-// charts) always reflect the state at the brush's right edge.
-// When brush is at the live edge, lastAt(windowEnd) returns the
-// latest sample → panels effectively show live data with at most a
-// 1-sample lag. When brush moves back, panels show that past moment.
-// The cache key is the prefixed archive id so this never collides
-// with the live cache that mutation panels (outside SessionDisplay)
-// read.
-watch(
-  [windowEndMs, () => timeseries.samples.version.value],
-  () => {
-    const row = timeseries.samples.lastAt(windowEndMs.value);
+  [() => brushRange.value.max, () => timeseries.samples.version.value],
+  ([endMs]) => {
+    const row = timeseries.samples.lastAt(endMs);
     if (!row) return;
     const adapted = chRowToPlayerRecord(row);
     setArchivePlayer(archivePlayerId.value, adapted);
@@ -826,17 +676,19 @@ const scrubMax = computed(() => timeRange.value?.max ?? 0);
 
 function skipToStart() {
   const r = timeRange.value; if (!r) return;
-  const span = Math.max(1000, windowEndMs.value - windowStartMs.value);
-  windowStartMs.value = r.min;
-  windowEndMs.value = Math.min(r.max, r.min + span);
-  userMovedBrush.value = true;
+  const current = brushRange.value;
+  const span = Math.max(1000, current.max - current.min);
+  const newStart = r.min;
+  const newEnd = Math.min(r.max, r.min + span);
+  coord.setRange({ min: newStart, max: newEnd });
 }
 function skipToEnd() {
   const r = timeRange.value; if (!r) return;
-  const span = Math.max(1000, windowEndMs.value - windowStartMs.value);
-  windowEndMs.value = r.max;
-  windowStartMs.value = Math.max(r.min, r.max - span);
-  userMovedBrush.value = false;
+  const current = brushRange.value;
+  const span = Math.max(1000, current.max - current.min);
+  // Snap to live — clear range, set liveSpan to current brush width.
+  if (span > 0) coord.setLiveSpan(span);
+  coord.setRange(null);
 }
 
 </script>
@@ -869,7 +721,7 @@ function skipToEnd() {
           type="button"
           class="btn live-toggle brush-live-toggle"
           :class="{ checked: brushLiveChecked }"
-          @click="coord.togglePause()"
+          @click="coord.toggleLive()"
           :title="brushLiveChecked ? 'Pause at current live edge' : 'Resume following live'"
         >
           {{ brushLiveChecked ? '●' : '○' }} Live
@@ -911,8 +763,8 @@ function skipToEnd() {
             class="brush-window"
             :class="{ dragging: dragState }"
             :style="{
-              left: ((windowStartMs - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
-              right: ((scrubMax - windowEndMs) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              left: ((brushRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              right: ((scrubMax - brushRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
             }"
             @mousedown.stop="onBrushMouseDown($event, 'pan')"
           >
@@ -936,8 +788,8 @@ function skipToEnd() {
           v-if="timeRange"
           class="rail-focus-label"
           :style="{
-            left: ((windowStartMs - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
-            right: ((scrubMax - windowEndMs) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            left: ((brushRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            right: ((scrubMax - brushRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
           }"
         >
           <span class="focus-pill">{{ fmtDurShort(windowSpanMs) }} · at end</span>

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -560,12 +560,32 @@ function onDragEnd() {
  *
  *  Plain wheel falls through to native page scroll. */
 function onRailWheel(e: WheelEvent) {
-  if (!e.altKey) return;
-  e.preventDefault();
-  e.stopPropagation();
   const rail = railRef.value;
   const r = timeRange.value;
   if (!rail || !r) return;
+  // Horizontal scroll → pan the brush. deltaX/railWidth maps directly
+  // to fraction-of-full-data-range so a one-rail-width swipe pans by
+  // the entire visible data span. Unlike the line charts, the brush
+  // is CLAMPED to [r.min, r.max] so it never leaves the rail. See
+  // gh#461.
+  if (!e.altKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+    e.preventDefault();
+    e.stopPropagation();
+    const widthPx = rail.clientWidth;
+    if (widthPx <= 0) return;
+    const current = brushRange.value;
+    const span = current.max - current.min;
+    const dms = (e.deltaX / widthPx) * (r.max - r.min);
+    let s = current.min + dms;
+    let f = current.max + dms;
+    if (s < r.min) { s = r.min; f = s + span; }
+    if (f > r.max) { f = r.max; s = f - span; }
+    coord.setRange({ min: s, max: f });
+    return;
+  }
+  if (!e.altKey) return;
+  e.preventDefault();
+  e.stopPropagation();
   const fullSpan = Math.max(1, r.max - r.min);
   const current = brushRange.value;
   const currentSpan = Math.max(1, current.max - current.min);

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1136,7 +1136,12 @@ function skipToEnd() {
   height: 30px;
   background: #d1fae5;
   border-radius: 6px;
-  overflow: visible;
+  /* Clip the brush window so it can't bleed past the rail edges
+   * (and onto the ⏮/⏭ scrub buttons) when the visible focus range
+   * extends past the data — e.g. a 10-min liveSpan on a fresh
+   * session that only has 1 min of samples puts brushRange.min 9
+   * min before scrubMin, which would be a -X% left value. */
+  overflow: hidden;
   cursor: crosshair;
 }
 .brush-rail .brush-tick {

--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -58,6 +58,29 @@ export interface ChartCoordinationState {
    *  operator can see exactly where the prev/next-selected event
    *  sits across all panels. null = no cursor (default). */
   cursorMs: number | null;
+
+  /* ─── Brush-as-source-of-truth refactor (alongside old API) ───────
+   *
+   * `range` collapses what `viewport` + `paused` used to express:
+   *   null         → operator is following live (chart x-axis is
+   *                   `[lastSampleMs - liveSpan, lastSampleMs]`)
+   *   {min, max}   → operator has pinned to this range (chart x-axis
+   *                   is exactly this)
+   *
+   * `liveSpan` collapses `liveSpanMs ?? windowMs`. Defaults to
+   * DEFAULT_FOCUS_MS (10 min) and is updated ONLY by explicit user
+   * gestures: chart Alt+wheel at live edge, brush-rail Alt+wheel at
+   * live edge, drag-end at live edge. Never auto-derived from
+   * incidental brush motion (that was the source of the focus-bar
+   * auto-grow regression we fixed by removing the auto-feedback
+   * watcher).
+   *
+   * Once all consumers have migrated, this pair entirely supersedes
+   * `viewport`, `paused`, `liveSpanMs`, `windowMs`, and `version`.
+   * During the migration the new setters internally also update the
+   * old state so legacy reads stay coherent. */
+  range: ChartViewport | null;
+  liveSpan: number;
 }
 
 const states = new Map<string, ChartCoordinationState>();
@@ -70,17 +93,22 @@ function writeExpandedStored(v: boolean) {
   try { localStorage.setItem(EXPANDED_STORAGE_KEY, v ? 'true' : 'false'); } catch { /* ignore */ }
 }
 
+const DEFAULT_FOCUS_MS = 10 * 60 * 1000;
+const LIVE_EDGE_TOLERANCE_MS = 2_000;
+
 function freshState(): ChartCoordinationState {
   return reactive<ChartCoordinationState>({
     paused: false,
     expanded: readExpandedStored(),
     viewport: null,
     lastSampleMs: 0,
-    windowMs: 10 * 60 * 1000,
+    windowMs: DEFAULT_FOCUS_MS,
     liveSpanMs: null,
     version: 0,
     bandwidthYMax: undefined,
     cursorMs: null,
+    range: null,
+    liveSpan: DEFAULT_FOCUS_MS,
   });
 }
 
@@ -117,6 +145,27 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     const span = s.liveSpanMs != null ? s.liveSpanMs : s.windowMs;
     return { min: end - span, max: end };
   });
+
+  /** New API: the single source of truth for what's currently displayed.
+   *  Derives from `state.range` (when pinned) or `[lastSampleMs - liveSpan,
+   *  lastSampleMs]` (when following live). Replaces `effectiveViewport`
+   *  once all consumers migrate. */
+  const effectiveRange = computed<ChartViewport>(() => {
+    const s = cur();
+    if (s.range) return s.range;
+    const end = s.lastSampleMs || Date.now();
+    return { min: end - s.liveSpan, max: end };
+  });
+
+  /** True when the chart's right edge is within tolerance of the latest
+   *  sample — i.e. the operator's effective view is essentially "live".
+   *  Used by chart pan/zoom-end paths to decide whether to snap back
+   *  into live-tracking mode. */
+  function isAtLiveEdge(rightEdgeMs: number): boolean {
+    const s = cur();
+    if (!s.lastSampleMs) return false;
+    return Math.abs(s.lastSampleMs - rightEdgeMs) <= LIVE_EDGE_TOLERANCE_MS;
+  }
 
   /** Wall-clock anchored tick positions for the visible viewport.
    *  Returns an array of ms-since-epoch timestamps, picked at a "nice"
@@ -155,6 +204,10 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     const trace = new Error().stack?.split('\n').slice(2, 5).join(' | ').slice(0, 200) ?? '';
     console.log('[CC] setViewport span=' + span + 's | ' + trace);
     s.viewport = v;
+    // Mirror into the new `range` so old + new readers stay coherent
+    // during the migration. After Phase E, `viewport` goes away and
+    // only `range` is written.
+    s.range = v;
     s.version++;
   }
 
@@ -181,6 +234,7 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     const end = s.lastSampleMs || Date.now();
     const span = s.liveSpanMs != null ? s.liveSpanMs : s.windowMs;
     s.viewport = { min: end - span, max: end };
+    s.range = s.viewport;
   }
 
   function togglePause() {
@@ -192,6 +246,7 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
       // Returning to live drops any sticky user viewport so the next
       // tick's effectiveViewport snaps back to "now" (the live edge).
       s.viewport = null;
+      s.range = null;
     }
     s.version++;
   }
@@ -200,8 +255,12 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     const s = cur();
     if (s.paused === p) return;
     s.paused = p;
-    if (p) snapshotLiveViewport();
-    else s.viewport = null;
+    if (p) {
+      snapshotLiveViewport();
+    } else {
+      s.viewport = null;
+      s.range = null;
+    }
     s.version++;
   }
 
@@ -211,7 +270,55 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
   function setLiveSpanMs(ms: number | null) {
     const s = cur();
     s.liveSpanMs = ms;
+    // Mirror into the new `liveSpan`. Null clears back to default.
+    s.liveSpan = ms != null ? ms : DEFAULT_FOCUS_MS;
     s.version++;
+  }
+
+  /* ─── New API: setRange / setLiveSpan / toggleLive ─────────────────
+   * These are the brush-as-source-of-truth setters. They mirror into
+   * the OLD state too so consumers that haven't migrated yet keep
+   * seeing coherent reads. After Phase E the old state goes away. */
+
+  /** Set the pinned range (or null = resume following live). The
+   *  single setter that replaces every `setViewport`+`setPaused` pair.
+   *  `range === null` means "follow live"; non-null means "pinned". */
+  function setRange(r: ChartViewport | null) {
+    const s = cur();
+    s.range = r;
+    // Mirror into the deprecated state during migration.
+    s.viewport = r;
+    s.paused = r !== null;
+    s.version++;
+  }
+
+  /** Set the live-edge span (used when range === null). Only updated
+   *  by explicit user gestures: chart Alt+wheel at live edge,
+   *  brush-rail Alt+wheel at live edge, brush drag-end at live edge.
+   *  Defaults to DEFAULT_FOCUS_MS; setting <= 0 reverts to default. */
+  function setLiveSpan(ms: number) {
+    const s = cur();
+    const next = ms > 0 ? ms : DEFAULT_FOCUS_MS;
+    s.liveSpan = next;
+    // Mirror into the deprecated state. `liveSpanMs == null` was the
+    // old "no zoom, use windowMs" signal — by always writing a value
+    // we keep the old effectiveViewport math consistent.
+    s.liveSpanMs = next;
+    s.version++;
+  }
+
+  /** Single-handler Live toggle used by chart toolbars, lane toolbar,
+   *  and the focus-window Live button. Pinned → following = clear
+   *  range. Following → pinned = snapshot current effectiveRange. */
+  function toggleLive() {
+    const s = cur();
+    if (s.range !== null) {
+      setRange(null);
+      return;
+    }
+    // Currently following live; pin to current effectiveRange.
+    const snapshot = effectiveRange.value;
+    setRange({ min: snapshot.min, max: snapshot.max });
   }
 
   function toggleExpanded() {
@@ -247,12 +354,17 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     // re-evaluate when the active player switches.
     get state(): ChartCoordinationState { return cur(); },
     effectiveViewport,
+    effectiveRange,
+    isAtLiveEdge,
     tickPositions,
     noteSample,
     setViewport,
     togglePause,
     setPaused,
     setLiveSpanMs,
+    setRange,
+    setLiveSpan,
+    toggleLive,
     toggleExpanded,
     setWindowMs,
     setBandwidthYMax,

--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -1,27 +1,20 @@
 /**
- * useChartCoordination(playerId) — shared per-session chart state so
- * the bandwidth / RTT / buffer / FPS charts in one card behave as one
- * coordinated unit:
+ * useChartCoordination(playerId) — shared per-session chart state.
  *
- *   - One pause flag: pausing any chart pauses all of them.
- *   - One viewport: zooming/panning any chart syncs the others.
- *   - One window length: changing the rolling window length once
- *     applies everywhere.
+ * The brush IS the source of truth for what's currently displayed.
+ * Charts, the brush rail, the Live toggle's checked state, and the
+ * brush-end-row panel projection all derive from a single computed
+ * `effectiveRange`. There are no separate "viewport" / "paused" /
+ * "userMovedBrush" / "live span" flags scattered across watchers —
+ * every state transition goes through `setRange` / `setLiveSpan` /
+ * `toggleLive` and propagates via Vue's reactive graph in one
+ * direction. No cycles, no defensive `if (a === b) return` guards,
+ * no version counter.
  *
- * Backing store: module-level Map keyed by playerId so the state
- * survives component remount AND is shared across charts on the same
- * session card.
- *
- * Reactivity model: callers may pass either a plain string (legacy) or
- * a `Ref<string>` (TS12 — picker swap without :key remount). When a
- * ref is supplied, the `state` getter + every computed + every mutator
- * re-read `playerIdRef.value` on access, so switching the active
- * player in Testing.vue's picker propagates to every chart in the
- * same SessionDisplay instance without forcing a remount.
- *
- * Matches the legacy session-shell.js semantics: 10-minute default
- * window, viewport in ms relative to the latest sample's wall clock,
- * paused freezes the viewport.
+ * Backing store: module-level Map keyed by playerId so state
+ * survives component remount AND is shared across charts on the
+ * same session card. Pass either a plain string (legacy) or a
+ * `Ref<string>` (picker-swap-aware).
  */
 import { computed, isRef, reactive, ref, type Ref } from 'vue';
 
@@ -32,54 +25,45 @@ export interface ChartViewport {
   max: number;
 }
 
+/** Default "rolling window" span — what the brush sits at on a
+ *  fresh session before any zoom gesture, and the cap for Alt+wheel
+ *  zoom-out. Exported so chart components clamping their own
+ *  zoom-out paths use the same value. */
+export const DEFAULT_FOCUS_MS = 10 * 60 * 1000;
+
+/** Tolerance for "is the right edge at the live sample?" — used by
+ *  isAtLiveEdge to decide whether a drag/zoom should snap back to
+ *  live-tracking mode. */
+const LIVE_EDGE_TOLERANCE_MS = 2_000;
+
 export interface ChartCoordinationState {
-  paused: boolean;
+  /** UI: whether the events-timeline panel is in expanded-height mode. */
   expanded: boolean;
-  /** explicit viewport set by the user (pan, drag-zoom); null = follow live */
-  viewport: ChartViewport | null;
-  /** running "latest sample timestamp" maintained by member charts */
+
+  /** Latest sample timestamp, maintained by chart ingest paths via
+   *  `noteSample`. The right edge of "live tracking" mode. */
   lastSampleMs: number;
-  /** how many ms wide the rolling window is when live-following */
-  windowMs: number;
-  /** When set and the chart is live (not paused) AND no sticky
-   *  viewport, the visible range becomes
-   *  `[lastSampleMs - liveSpanMs, lastSampleMs]`. Lets Alt+wheel zoom
-   *  while keeping the chart anchored at the live edge (matches the
-   *  legacy `installLiveWheelAnchor` behaviour). null = no zoom, use
-   *  full `windowMs`. */
-  liveSpanMs: number | null;
-  /** monotonic version counter so charts react to viewport changes */
-  version: number;
+
   /** Y-axis upper bound for the bandwidth chart (undefined = auto). */
   bandwidthYMax: number | undefined;
-  /** Synchronized "selected event" cursor — ms-since-epoch.
-   *  When non-null every member chart (line charts + events
-   *  timeline) draws a vertical marker at this x position so the
-   *  operator can see exactly where the prev/next-selected event
-   *  sits across all panels. null = no cursor (default). */
+
+  /** Synchronized "selected event" cursor — ms-since-epoch. When
+   *  non-null every member chart draws a vertical marker at this x
+   *  position so the operator can see exactly where the prev/next
+   *  selected event sits across all panels. null = no cursor. */
   cursorMs: number | null;
 
-  /* ─── Brush-as-source-of-truth refactor (alongside old API) ───────
-   *
-   * `range` collapses what `viewport` + `paused` used to express:
-   *   null         → operator is following live (chart x-axis is
-   *                   `[lastSampleMs - liveSpan, lastSampleMs]`)
-   *   {min, max}   → operator has pinned to this range (chart x-axis
-   *                   is exactly this)
-   *
-   * `liveSpan` collapses `liveSpanMs ?? windowMs`. Defaults to
-   * DEFAULT_FOCUS_MS (10 min) and is updated ONLY by explicit user
-   * gestures: chart Alt+wheel at live edge, brush-rail Alt+wheel at
-   * live edge, drag-end at live edge. Never auto-derived from
-   * incidental brush motion (that was the source of the focus-bar
-   * auto-grow regression we fixed by removing the auto-feedback
-   * watcher).
-   *
-   * Once all consumers have migrated, this pair entirely supersedes
-   * `viewport`, `paused`, `liveSpanMs`, `windowMs`, and `version`.
-   * During the migration the new setters internally also update the
-   * old state so legacy reads stay coherent. */
+  /** The single source of truth for "what range is currently
+   *  displayed". null → operator is following live (chart x-axis is
+   *  `[lastSampleMs - liveSpan, lastSampleMs]`). {min, max} →
+   *  operator has pinned to this range. */
   range: ChartViewport | null;
+
+  /** The span the operator wants while range === null. Updated ONLY
+   *  by explicit user gestures: chart Alt+wheel at live edge,
+   *  brush-rail Alt+wheel at live edge, brush drag-end at live edge.
+   *  Never auto-derived from incidental brush motion. Defaults to
+   *  DEFAULT_FOCUS_MS (10 min). */
   liveSpan: number;
 }
 
@@ -93,18 +77,10 @@ function writeExpandedStored(v: boolean) {
   try { localStorage.setItem(EXPANDED_STORAGE_KEY, v ? 'true' : 'false'); } catch { /* ignore */ }
 }
 
-const DEFAULT_FOCUS_MS = 10 * 60 * 1000;
-const LIVE_EDGE_TOLERANCE_MS = 2_000;
-
 function freshState(): ChartCoordinationState {
   return reactive<ChartCoordinationState>({
-    paused: false,
     expanded: readExpandedStored(),
-    viewport: null,
     lastSampleMs: 0,
-    windowMs: DEFAULT_FOCUS_MS,
-    liveSpanMs: null,
-    version: 0,
     bandwidthYMax: undefined,
     cursorMs: null,
     range: null,
@@ -122,11 +98,9 @@ function ensureState(pid: string): ChartCoordinationState {
 }
 
 export function useChartCoordination(playerIdInput: string | Ref<string>) {
-  // Normalise input — accept both a plain string (legacy callers) and
-  // a reactive ref (new picker-swap-aware callers). When a ref is
-  // provided, every getter + computed + mutator below threads through
-  // `playerIdRef.value` so changes propagate to the consumer's
-  // reactive context without a component remount.
+  // Normalise input — accept a plain string or a reactive ref. When
+  // a ref is provided, every getter and mutator threads through
+  // playerIdRef.value so a picker-swap propagates without remount.
   const playerIdRef: Ref<string> = isRef(playerIdInput)
     ? playerIdInput
     : ref(playerIdInput);
@@ -135,21 +109,13 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     return ensureState(playerIdRef.value);
   }
 
-  const effectiveViewport = computed<ChartViewport>(() => {
-    const s = cur();
-    if (s.viewport) return s.viewport;
-    const end = s.lastSampleMs || Date.now();
-    // When live (no sticky viewport) and the user has chosen a tighter
-    // zoom span via Alt+wheel, the visible range follows the live edge
-    // with that span — same as the legacy live-anchored wheel zoom.
-    const span = s.liveSpanMs != null ? s.liveSpanMs : s.windowMs;
-    return { min: end - span, max: end };
-  });
-
-  /** New API: the single source of truth for what's currently displayed.
-   *  Derives from `state.range` (when pinned) or `[lastSampleMs - liveSpan,
-   *  lastSampleMs]` (when following live). Replaces `effectiveViewport`
-   *  once all consumers migrate. */
+  /** The single source of truth for what's currently displayed.
+   *  Derives from `state.range` (pinned) or
+   *  `[lastSampleMs - liveSpan, lastSampleMs]` (following live).
+   *
+   *  Every chart x-axis, the brush window, the Live-toggle's checked
+   *  state, the network-log brush, the brush-end-row projection
+   *  watcher — all bind to this. No further sync needed. */
   const effectiveRange = computed<ChartViewport>(() => {
     const s = cur();
     if (s.range) return s.range;
@@ -157,26 +123,14 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     return { min: end - s.liveSpan, max: end };
   });
 
-  /** True when the chart's right edge is within tolerance of the latest
-   *  sample — i.e. the operator's effective view is essentially "live".
-   *  Used by chart pan/zoom-end paths to decide whether to snap back
-   *  into live-tracking mode. */
-  function isAtLiveEdge(rightEdgeMs: number): boolean {
-    const s = cur();
-    if (!s.lastSampleMs) return false;
-    return Math.abs(s.lastSampleMs - rightEdgeMs) <= LIVE_EDGE_TOLERANCE_MS;
-  }
-
-  /** Wall-clock anchored tick positions for the visible viewport.
-   *  Returns an array of ms-since-epoch timestamps, picked at a "nice"
-   *  interval (1s / 5s / 10s / 30s / 1m / 5m / 10m / 30m) so the chart
-   *  shows ~6 vertical gridlines across the window. Both Chart.js
-   *  (afterBuildTicks) and vis-timeline (addCustomTime) consume this
-   *  same array so the gridlines line up vertically across the
-   *  bandwidth / RTT / buffer / FPS / events-timeline panels in one
+  /** Wall-clock anchored tick positions for the visible range.
+   *  Returns ms-since-epoch timestamps at a "nice" interval so the
+   *  chart shows ~6 vertical gridlines. Both Chart.js
+   *  (afterBuildTicks) and vis-timeline (addCustomTime) consume the
+   *  same array so gridlines line up across all panels in one
    *  session card. */
   const tickPositions = computed<number[]>(() => {
-    const v = effectiveViewport.value;
+    const v = effectiveRange.value;
     const span = Math.max(1, v.max - v.min);
     const target = span / 6;
     const NICE_MS = [1_000, 5_000, 10_000, 30_000, 60_000, 5 * 60_000, 10 * 60_000, 30 * 60_000];
@@ -185,140 +139,53 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
       if (n >= target) { interval = n; break; }
     }
     // Snap each tick to wall-clock boundaries of the chosen interval
-    // so e.g. 60-second ticks land on :00, :01:00, :02:00 — matches
-    // how the user mentally reads clock time across the gridlines.
+    // so e.g. 60-second ticks land on :00, :01:00, :02:00.
     const aligned = Math.floor(v.max / interval) * interval;
     const out: number[] = [];
     for (let t = aligned; t >= v.min; t -= interval) out.push(t);
     return out.reverse();
   });
 
+  /** True when the chart's right edge is within tolerance of the
+   *  latest sample — used by chart pan/zoom-end paths to decide
+   *  whether to snap back into live-tracking mode. */
+  function isAtLiveEdge(rightEdgeMs: number): boolean {
+    const s = cur();
+    if (!s.lastSampleMs) return false;
+    return Math.abs(s.lastSampleMs - rightEdgeMs) <= LIVE_EDGE_TOLERANCE_MS;
+  }
+
   function noteSample(ts: number) {
     const s = cur();
     if (ts > s.lastSampleMs) s.lastSampleMs = ts;
   }
 
-  function setViewport(v: ChartViewport | null) {
-    const s = cur();
-    const span = v ? Math.round((v.max - v.min) / 1000) : 'null';
-    const trace = new Error().stack?.split('\n').slice(2, 5).join(' | ').slice(0, 200) ?? '';
-    console.log('[CC] setViewport span=' + span + 's | ' + trace);
-    s.viewport = v;
-    // Mirror into the new `range` so old + new readers stay coherent
-    // during the migration. After Phase E, `viewport` goes away and
-    // only `range` is written.
-    s.range = v;
-    s.version++;
-  }
-
-  /** Snapshot the current live viewport so the chart freezes here.
-   *  Without this, even though `paused = true`, the effectiveViewport
-   *  keeps sliding with `lastSampleMs` because each new tick advances
-   *  the "live window" end. Capturing once at pause-time is what makes
-   *  the line / state charts visibly stop scrolling.
-   *
-   *  Honours `liveSpanMs` if set, so pausing after an Alt+wheel zoom
-   *  preserves the zoomed range — the user gets a frozen view of
-   *  exactly what they were watching, not a snap-out to the full
-   *  window. */
-  function snapshotLiveViewport() {
-    const s = cur();
-    // If there's already an explicit viewport (set by a brush drag
-    // or an Alt+drag-zoom on a chart), DON'T overwrite it. The whole
-    // point of pausing is to freeze whatever the operator was looking
-    // at; if they had a custom range it IS the visible window. The
-    // legacy "snapshot to [lastSample - liveSpanMs, ...]" path runs
-    // only when no sticky viewport exists — i.e. we're live-tracking
-    // and need to freeze at the live edge.
-    if (s.viewport) return;
-    const end = s.lastSampleMs || Date.now();
-    const span = s.liveSpanMs != null ? s.liveSpanMs : s.windowMs;
-    s.viewport = { min: end - span, max: end };
-    s.range = s.viewport;
-  }
-
-  function togglePause() {
-    const s = cur();
-    s.paused = !s.paused;
-    if (s.paused) {
-      snapshotLiveViewport();
-    } else {
-      // Returning to live drops any sticky user viewport so the next
-      // tick's effectiveViewport snaps back to "now" (the live edge).
-      s.viewport = null;
-      s.range = null;
-    }
-    s.version++;
-  }
-
-  function setPaused(p: boolean) {
-    const s = cur();
-    if (s.paused === p) return;
-    s.paused = p;
-    if (p) {
-      snapshotLiveViewport();
-    } else {
-      s.viewport = null;
-      s.range = null;
-    }
-    s.version++;
-  }
-
-  /** Set the live-edge zoom span. Bumps the version so charts react.
-   *  Pass null to clear (revert to full `windowMs`). Has no effect on
-   *  the paused branch — paused mode uses sticky `viewport`. */
-  function setLiveSpanMs(ms: number | null) {
-    const s = cur();
-    s.liveSpanMs = ms;
-    // Mirror into the new `liveSpan`. Null clears back to default.
-    s.liveSpan = ms != null ? ms : DEFAULT_FOCUS_MS;
-    s.version++;
-  }
-
-  /* ─── New API: setRange / setLiveSpan / toggleLive ─────────────────
-   * These are the brush-as-source-of-truth setters. They mirror into
-   * the OLD state too so consumers that haven't migrated yet keep
-   * seeing coherent reads. After Phase E the old state goes away. */
-
   /** Set the pinned range (or null = resume following live). The
-   *  single setter that replaces every `setViewport`+`setPaused` pair.
-   *  `range === null` means "follow live"; non-null means "pinned". */
+   *  single setter that handles every pan/drag/zoom/Live-toggle
+   *  state transition. */
   function setRange(r: ChartViewport | null) {
-    const s = cur();
-    s.range = r;
-    // Mirror into the deprecated state during migration.
-    s.viewport = r;
-    s.paused = r !== null;
-    s.version++;
+    cur().range = r;
   }
 
   /** Set the live-edge span (used when range === null). Only updated
-   *  by explicit user gestures: chart Alt+wheel at live edge,
-   *  brush-rail Alt+wheel at live edge, brush drag-end at live edge.
-   *  Defaults to DEFAULT_FOCUS_MS; setting <= 0 reverts to default. */
+   *  by explicit user gestures. Pass any positive number; <= 0
+   *  reverts to DEFAULT_FOCUS_MS. */
   function setLiveSpan(ms: number) {
-    const s = cur();
-    const next = ms > 0 ? ms : DEFAULT_FOCUS_MS;
-    s.liveSpan = next;
-    // Mirror into the deprecated state. `liveSpanMs == null` was the
-    // old "no zoom, use windowMs" signal — by always writing a value
-    // we keep the old effectiveViewport math consistent.
-    s.liveSpanMs = next;
-    s.version++;
+    cur().liveSpan = ms > 0 ? ms : DEFAULT_FOCUS_MS;
   }
 
-  /** Single-handler Live toggle used by chart toolbars, lane toolbar,
-   *  and the focus-window Live button. Pinned → following = clear
-   *  range. Following → pinned = snapshot current effectiveRange. */
+  /** Single Live-toggle handler used by chart toolbars, the lane
+   *  toolbar, and the focus-window Live button. Pinned → following =
+   *  clear range. Following → pinned = snapshot current
+   *  effectiveRange. */
   function toggleLive() {
     const s = cur();
     if (s.range !== null) {
-      setRange(null);
+      s.range = null;
       return;
     }
-    // Currently following live; pin to current effectiveRange.
-    const snapshot = effectiveRange.value;
-    setRange({ min: snapshot.min, max: snapshot.max });
+    const snap = effectiveRange.value;
+    s.range = { min: snap.min, max: snap.max };
   }
 
   function toggleExpanded() {
@@ -327,24 +194,14 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     writeExpandedStored(s.expanded);
   }
 
-  function setWindowMs(ms: number) {
-    const s = cur();
-    s.windowMs = Math.max(5_000, ms);
-    s.viewport = null;
-    s.version++;
-  }
-
   function setBandwidthYMax(v: number | undefined) {
     cur().bandwidthYMax = v;
   }
 
   /** Move the synchronized "selected event" cursor. Pass null to
-   *  hide it. Bumps version so chart watchers re-render the marker
-   *  layer in lock-step. */
+   *  hide it. */
   function setCursorMs(ms: number | null) {
-    const s = cur();
-    s.cursorMs = ms;
-    s.version++;
+    cur().cursorMs = ms;
   }
 
   return {
@@ -353,30 +210,23 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     // touch `coord.state.X` therefore depend on playerIdRef and
     // re-evaluate when the active player switches.
     get state(): ChartCoordinationState { return cur(); },
-    effectiveViewport,
     effectiveRange,
-    isAtLiveEdge,
     tickPositions,
+    isAtLiveEdge,
     noteSample,
-    setViewport,
-    togglePause,
-    setPaused,
-    setLiveSpanMs,
     setRange,
     setLiveSpan,
     toggleLive,
     toggleExpanded,
-    setWindowMs,
     setBandwidthYMax,
     setCursorMs,
   };
 }
 
-/** Format a ms-since-epoch timestamp as `HH:MM:SS.mmm` (24h, zero-padded
- *  to 3-digit ms) — used by both Chart.js x-axis labels and vis-timeline
- *  custom-time labels so the gridline labels match across every chart in
- *  a session card. Exported so the components don't drift from this
- *  format. */
+/** Format a ms-since-epoch timestamp as `HH:MM:SS.mmm` (24h,
+ *  zero-padded to 3-digit ms) — used by both Chart.js x-axis labels
+ *  and vis-timeline custom-time labels so the gridline labels match
+ *  across every chart in a session card. */
 export function fmtTickHMSms(ms: number): string {
   const d = new Date(ms);
   const hh = String(d.getHours()).padStart(2, '0');


### PR DESCRIPTION
## Summary

Collapses the v3 chart/brush/Live-toggle state machine to a single source of truth. The brush IS `coord.effectiveRange`; all chart x-axes, the Live toggle's checked state, and the brush-end-row panel projection derive from that single computed.

Before: 5 reactive state sources + 6 watchers wired through `coord.viewport` / `paused` / `liveSpanMs` / `windowMs` / `version` and SessionDisplay-local `windowStartMs` / `windowEndMs` / `userMovedBrush`. The reactive graph had cycles; only defensive `if (a === b) return` early-returns inside individual watchers kept the loops finite. Most recent dashboard bugs (focus bar stuck after one sample, pan snap-back when sample lands mid-drag, snap-to-live resets focus width, drag-to-live doesn't lock when paused, Live toggle doesn't move brush in archive) traced to this tangle.

After: one writer, one derived state, no cycles.

## State machine

```ts
state: {
  range: { min, max } | null,   // null = following live; {} = pinned
  liveSpan: number,             // span used while range==null (default 10 min)
  lastSampleMs: number,
  cursorMs: number | null,
  expanded, bandwidthYMax,
}

effectiveRange = state.range ?? [lastSampleMs - liveSpan, lastSampleMs]
```

Setters: `setRange`, `setLiveSpan`, `toggleLive`, `noteSample`, `setCursorMs`. Helper: `isAtLiveEdge`. Everything else collapses into derived computeds.

Semantic equivalences (no more separate flags):
- Live toggle checked ⇔ `range === null`
- Paused / userMovedBrush ⇔ `range !== null`
- Brush position IS `effectiveRange`

## Phases

A. `useChartCoordination`: add new API alongside old. Old setters mirror into new state so old consumers still work. **Additive — no behaviour change.**

B. Chart components (MetricsLineChart / EventsTimeline / BitrateChartPanelToolbar): swap READS — `effectiveViewport` → `effectiveRange`, `state.viewport` → `state.range`, `state.paused` → `state.range !== null`, `state.liveSpanMs ?? windowMs` → `state.liveSpan`. The triple-watcher `[version, paused, lastSampleMs]` collapses to `watch(coord.effectiveRange)`.

C. Chart components: swap WRITES — `setViewport + setPaused` pairs → single `setRange`. `setLiveSpanMs(null)` → `setLiveSpan(default)`. `togglePause()` → `toggleLive()`. Eight scattered "within 2s of lastSampleMs" hand-rolled checks → `coord.isAtLiveEdge(end)`.

D. `SessionDisplay`: rewrite brush block. Delete `windowStartMs` / `windowEndMs` / `userMovedBrush` local refs, the `timeRange` watcher (auto-grow), the `coord.viewport` watcher, the `coord.liveSpanMs` watcher, the `[windowStart, windowEnd]` watcher, and `applyWindowToViewport`. Brush template binds to `coord.effectiveRange`. Drag handlers call `coord.setRange` directly. Brush-end-row projection watches `coord.effectiveRange.max`. **The actual behaviour-changing phase.**

E. Delete the deprecated coord API surface. `coord.state.windowMs` references in chart components migrate to importing `DEFAULT_FOCUS_MS` from the composable.

## Plus two related fixes folded in

- **gh#461**: horizontal scroll-wheel input (trackpad two-finger swipe / mouse horizontal wheel) pans the brush + every chart via `coord.setRange`. Plain vertical wheel still scrolls the page; Alt+wheel still zooms.
- **brush-rail overflow clip**: `.brush-rail { overflow: hidden }` — prevents the brush window from bleeding onto the ⏮/⏭ scrub buttons when the visible focus range extends past the available data (fresh-session 10-min liveSpan with only 1 min of samples).

## Net file delta

- `useChartCoordination.ts`: 280 → 222 lines (cleanup of mirroring + version counter + snapshot helper)
- `SessionDisplay.vue`: brush block 315 → 150 lines (~165 lines removed)
- `MetricsLineChart.vue` / `EventsTimeline.vue` / `BitrateChartPanelToolbar.vue`: net wash; reads/writes swapped 1:1
- Bundle: `SessionDisplay` chunk -3 KB (105.84 → 103.65 KB)

## Hand-test checklist (17 items)

All passing on test-deploy-dev across `testing.html`, `testing-session.html`, `session-viewer.html` (both in-progress + completed plays):

1. Fresh session: focus bar grows 0 → 10 min ✓
2. Live toggle anywhere checked/unchecked flips together ✓
3. Click Live (pinned) → brush snaps to right edge ✓
4. Click Live (following) → brush stays put, charts pause ✓
5. Drag brush → charts pin, Live unchecked ✓
6. Drag brush right edge to live → snaps to live, brush width = new liveSpan ✓
7. Drag from pinned-paused state to live edge → snaps ✓
8. Alt+wheel line chart at live → left-edge-only zoom ✓
9. Alt+wheel line chart pinned → mouse-anchored zoom ✓
10. Alt+wheel EventsTimeline — same ✓
11. Alt+wheel brush rail — same ✓
12. Pan a chart → brush follows; release snaps-or-pins ✓
13. Pan with sample arriving mid-drag → no snap-back ✓
14. Network log: plain wheel scrolls page, Alt+wheel scrolls rows ✓
15. Cursor sync (clicking event in lane moves chart cursor) ✓
16. Archive replay (session-viewer on completed play) ✓
17. In-progress play via session-viewer (live samples flow through ring overlay) ✓

Plus #461 verification: two-finger horizontal swipe over each surface pans correctly; brush rail clamped to data bounds; charts pan free.

## Commits squashed in

```
1c7e5c5 fix(v3): clip brush rail so focus window can't bleed onto scrub buttons
25eb4f2 feat(v3): horizontal scroll-wheel pans charts + focus brush (#461)
08e1393 refactor(v3): phase E — delete deprecated coord API surface
55d4d3d refactor(v3): phase D — SessionDisplay brush derives from coord.effectiveRange
becb82d refactor(v3): phase C — migrate chart components' WRITES to setRange/setLiveSpan
e316abd refactor(v3): phase B — migrate chart components' READS to range/effectiveRange
af28ed5 refactor(v3): phase A — add brush-as-source-of-truth API to coord
```

Closes #461.

Plan: `/Users/jonathanoliver/.claude/plans/shiny-exploring-jellyfish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
