### PR TITLE
chore(api-docs): sync Scalar UI mirror after /api/v2/timeseries addition

### DIFF
--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -34,6 +34,14 @@ tags:
       this playback" questions.
   - name: archive
     description: Raw row queries — snapshots, network, events.
+  - name: timeseries
+    description: |
+      Unified SSE subscription per (player_id, play_id) that
+      multiplexes samples + network + events with ClickHouse
+      backfill + live-ring overlay. One connection drives every
+      chart + lane + panel in a session card; replaces the older
+      pattern of polling /api/v2/snapshots + /session_events +
+      /network_requests separately.
   - name: aggregate
     description: |
       Group-by + metric aggregation pushdowns. Avoids pulling raw rows
@@ -310,6 +318,194 @@ paths:
               schema: { type: string, format: binary }
         '404': { $ref: '#/components/responses/Problem' }
 
+  # ---- Timeseries (SSE) --------------------------------------------------
+
+  /api/v2/timeseries:
+    get:
+      tags: [timeseries]
+      summary: Subscribe to a player's samples / network / events stream
+      operationId: getTimeseries
+      description: |
+        Opens a Server-Sent Events stream. The response is a sequence
+        of SSE frames (`text/event-stream`); the OpenAPI response body
+        below documents the SHAPE of each frame's JSON `data` payload
+        keyed by SSE `event:` name.
+
+        ### Event sequence
+
+        Frames arrive in this order on a successful subscription:
+
+        1. `meta` — exactly once, first frame. Names the requested
+           streams + their resolved column projection + the server's
+           liveness verdict.
+        2. `sample` / `network` / `event` — backfill batch. Rows from
+           ClickHouse for the requested `[from, to]` window, plus any
+           uncommitted rows from the live ring overlay (deduped by
+           `ts` for samples, `entry_fingerprint` for network). Rows
+           are emitted in `ts` ASCending order PER STREAM; streams
+           interleave on the wire.
+        3. (live plays) `sample` / `network` / `event` — live deltas
+           as the ring receives new entries. No further `meta`.
+        4. `heartbeat` — every 15 s (configurable server-side).
+           Keeps proxies from idle-closing the connection. Contains
+           only the server `ts`; consumers may use it as a wallclock
+           sync.
+        5. `complete` (archive-only) — emitted when the play has
+           ended and all backfill is flushed. Connection closes.
+        6. `stream_error` (failure-only) — emitted on transport / CH
+           errors AFTER the initial `meta` (a pre-meta error surfaces
+           as an HTTP 4xx/5xx instead).
+
+        ### Identity resolution
+
+        Exactly one of `player_id` or `session_id` is required:
+
+        - `player_id` is the canonical UUID. Preferred for v2 callers.
+        - `session_id` is the legacy v1 numeric session id. Honoured
+          for callers who haven't migrated; falls back to a
+          `lowerUTF8` match in the CH SELECT.
+        - `player_id` may carry an `archive:<session_id>:<play_id>`
+          shorthand prefix — the server parses it and routes to the
+          archive-only path. Used by `session-viewer.html` for an
+          already-completed play without separate session-id /
+          play-id plumbing.
+
+        `play_id` is optional:
+
+        - Omitted → stream rows across EVERY play of the player
+          (useful for "follow this player as plays rotate").
+        - Specific UUID → filter to that one play. Live deltas for
+          OTHER plays of the same player are dropped on send.
+
+        ### Bundles and field selection
+
+        Renderers request bundles by name to avoid enumerating
+        columns. The resolver unions the column sets of all requested
+        bundles plus any explicit `?fields=…`, dedupes, and includes
+        mandatory identity columns even if the caller forgets them
+        (`ts`, `session_id`, `play_id`, `player_id`, plus
+        `entry_fingerprint` for network).
+
+        See the `BundleCatalogue` schema below for the curated bundle
+        list. Unknown bundle names → 400. Unknown field names are
+        passed through to ClickHouse, which rejects with a clean 400.
+
+        ### Live vs archive
+
+        Liveness is decided server-side from the ring's
+        last-activity timestamp for `(player_id, play_id)` (default
+        30 s window). Surfaced in `meta.live`.
+
+        - `live=true` → backfill, then stay open emitting live deltas
+          until the client disconnects or the bucket is evicted.
+        - `live=false` → backfill, emit `complete`, close.
+
+        The client should not poll for liveness — subscribe and trust
+        the server's verdict.
+
+        ### Resumption
+
+        Reserved for a future revision. Today the server ignores the
+        `Last-Event-ID` request header; clients reconnect with a
+        fresh `from=` query param if they need to resume from a
+        specific point.
+
+        ### Stride and decimation
+
+        `stride_ms` (samples stream only) — server-side downsampling
+        for long backfill windows. Returns one row per `stride_ms`
+        bucket aggregated. Defaults to 0 (no decimation).
+
+        `max_hz` — rate-limit live deltas to at most N per second per
+        stream. Defaults to 0 (no rate-limiting).
+
+        See `analytics/go-forwarder/timeseries.go` for the canonical
+        server implementation and `streambundles.go` for the bundle
+        catalogue.
+      parameters:
+        - $ref: '#/components/parameters/TimeseriesPlayerId'
+        - $ref: '#/components/parameters/TimeseriesSessionId'
+        - $ref: '#/components/parameters/TimeseriesPlayId'
+        - $ref: '#/components/parameters/TimeseriesStreams'
+        - $ref: '#/components/parameters/TimeseriesBundles'
+        - $ref: '#/components/parameters/TimeseriesFields'
+        - $ref: '#/components/parameters/TimeseriesFrom'
+        - $ref: '#/components/parameters/TimeseriesTo'
+        - $ref: '#/components/parameters/TimeseriesLimit'
+        - $ref: '#/components/parameters/TimeseriesStrideMs'
+        - $ref: '#/components/parameters/TimeseriesMaxHz'
+        - $ref: '#/components/parameters/TimeseriesLastEventId'
+      responses:
+        '200':
+          description: |
+            SSE stream opens immediately with `meta`. See `description`
+            on the operation for the full event sequence.
+          headers:
+            Content-Type:
+              schema: { type: string, example: text/event-stream }
+            Cache-Control:
+              schema: { type: string, example: no-cache, no-transform }
+            X-Accel-Buffering:
+              description: Always `no` — disables nginx buffering for the SSE response.
+              schema: { type: string, example: no }
+          content:
+            text/event-stream:
+              schema:
+                $ref: '#/components/schemas/SSEFrameUnion'
+              examples:
+                meta-and-backfill:
+                  $ref: '#/components/examples/MetaAndBackfill'
+                live-delta:
+                  $ref: '#/components/examples/LiveDelta'
+                archive-complete:
+                  $ref: '#/components/examples/ArchiveComplete'
+        '400':
+          description: |
+            Malformed query parameters — missing identity, unknown
+            bundle, unknown stream, out-of-range `stride_ms`/`max_hz`.
+            Emitted BEFORE any SSE headers so the client sees a normal
+            HTTP error (not a stream that immediately closes).
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/ProblemDetails' }
+        '501':
+          description: |
+            `streams=events` requested but the events taxonomy SQL
+            hasn't been lifted into the timeseries backfill path yet.
+            Use the `/api/v2/session_events` endpoint as a workaround.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/ProblemDetails' }
+        '500':
+          description: |
+            Resolver / internal error before the SSE handshake. CH
+            outages encountered AFTER the handshake surface as a
+            `stream_error` event instead.
+          content:
+            application/problem+json:
+              schema: { $ref: '#/components/schemas/ProblemDetails' }
+
+  /api/v2/bundles:
+    get:
+      tags: [diagnostics]
+      summary: List available timeseries bundles + their column projections
+      operationId: getBundles
+      description: |
+        Read-only catalogue — returns the same data hard-coded in
+        `streambundles.go` so a client (or doc generator) can discover
+        what `?bundles=…` values are valid without grepping source.
+
+        **Note:** not yet implemented server-side. Spec'd here so the
+        CLI and dashboard can plan against it. Until the handler
+        lands the catalogue lives in code — copy from
+        `analytics/go-forwarder/streambundles.go::bundleRegistry`.
+      responses:
+        '200':
+          description: Catalogue
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/BundleCatalogue' }
+
 # ---------------------------------------------------------------------------
 
 components:
@@ -385,6 +581,183 @@ components:
         End-of-stream is signalled by `next_cursor: null` in the
         response body; no error / no 404 past the end. See
         `DESIGN.md § Pagination cursor`.
+
+    # Timeseries-specific parameters (used only by /api/v2/timeseries).
+    # Prefixed `Timeseries*` to avoid colliding with the more general
+    # PlayerIdFilter / PlayIdFilter / From / To params above (those are
+    # `?label.X=Y`-aware list-page filters; these are SSE subscription
+    # primitives with different semantics).
+
+    TimeseriesPlayerId:
+      name: player_id
+      in: query
+      required: false
+      description: |
+        Canonical player UUID. Required unless `session_id` is
+        provided. May carry an `archive:<session_id>:<play_id>`
+        shorthand prefix; the server unpacks it.
+      schema:
+        type: string
+        pattern: '^([A-Za-z0-9._\-]+|archive:[A-Za-z0-9._\-]+:[A-Za-z0-9._\-]+)$'
+        example: 97282446-9a14-4193-9fca-857250bc74ae
+
+    TimeseriesSessionId:
+      name: session_id
+      in: query
+      required: false
+      description: |
+        Legacy v1 numeric session id. Honoured for callers who
+        haven't migrated to player_id. Use `player_id` for new
+        consumers — the dashboard does.
+      schema:
+        type: string
+        example: "1"
+
+    TimeseriesPlayId:
+      name: play_id
+      in: query
+      required: false
+      description: |
+        Filter to a single play. Omit to stream rows across every
+        play of the player (live deltas for any play of this player
+        flow through). Pass the literal `—` (em-dash) to filter for
+        rows with NO play_id assigned (rare; useful for diagnostics).
+      schema:
+        type: string
+        example: 8fa22b46-dcce-4955-9970-4df3cda72d92
+
+    TimeseriesStreams:
+      name: streams
+      in: query
+      required: true
+      description: |
+        Comma-separated list of streams to enable. At least one
+        required. Unknown values → 400.
+
+        - `samples` — `session_snapshots` rows (chart feed).
+        - `network` — `network_requests` rows (HAR waterfall).
+        - `events` — derived taxonomy rows (currently 501; lift in
+          progress).
+      schema:
+        type: string
+        pattern: '^(samples|network|events)(,(samples|network|events))*$'
+        example: samples,network
+
+    TimeseriesBundles:
+      name: bundles
+      in: query
+      required: false
+      description: |
+        Comma-separated list of bundle names. Each bundle expands to
+        a fixed column projection for one stream; the resolver unions
+        all bundles' column sets and adds mandatory identity columns.
+
+        - Bundle whose stream isn't in `streams=` → 400.
+        - Unknown bundle name → 400.
+        - The alias `all` expands to `lanes_v1,network,events`.
+
+        See `GET /api/v2/bundles` (or `BundleCatalogue` schema below)
+        for the current registry.
+      schema:
+        type: string
+        example: charts_minimal,network
+
+    TimeseriesFields:
+      name: fields
+      in: query
+      required: false
+      description: |
+        Comma-separated list of additional column names to include
+        beyond what bundles selected. First-cut applies the flat list
+        to EVERY enabled stream; CH rejects unknown columns
+        per-stream with a clean 4xx, which surfaces as
+        `stream_error`. Per-stream syntax (`samples:col1,col2`) is
+        reserved for a future revision.
+      schema:
+        type: string
+        example: headers,query_string
+
+    TimeseriesFrom:
+      name: from
+      in: query
+      required: false
+      description: |
+        ISO-8601 lower bound for the backfill query (inclusive).
+        Parsed server-side by ClickHouse's `parseDateTime64BestEffort`,
+        so most timezone-bearing forms work. Defaults to "open" —
+        the backfill returns everything CH has up to `to` or `limit`.
+      schema:
+        type: string
+        format: date-time
+        example: "2026-05-17T13:00:00Z"
+
+    TimeseriesTo:
+      name: to
+      in: query
+      required: false
+      description: |
+        ISO-8601 upper bound for the backfill (inclusive). Defaults
+        to "now" — the backfill chases the live edge.
+      schema:
+        type: string
+        format: date-time
+        example: "2026-05-17T14:00:00Z"
+
+    TimeseriesLimit:
+      name: limit
+      in: query
+      required: false
+      description: |
+        Server-side row cap per stream during backfill. Defaults to
+        50000 for samples, 5000 for network; the hard ceiling is
+        the same. Set lower for cheap previews. Live deltas are not
+        affected.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200000
+        default: 50000
+
+    TimeseriesStrideMs:
+      name: stride_ms
+      in: query
+      required: false
+      description: |
+        Samples-stream-only. Server-side decimation: returns one row
+        per `stride_ms` bucket aggregated. 0 (default) = no
+        decimation. Use to cap backfill cost on long windows where
+        per-second resolution isn't needed.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 60000
+
+    TimeseriesMaxHz:
+      name: max_hz
+      in: query
+      required: false
+      description: |
+        Rate-limit live deltas to at most N events per second per
+        stream. 0 (default) = no rate-limiting. Useful for a
+        Mosaic-style multi-session dashboard where the cumulative
+        rate would overwhelm rendering.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+
+    TimeseriesLastEventId:
+      name: Last-Event-ID
+      in: header
+      required: false
+      description: |
+        **Reserved for a future revision.** Today the server ignores
+        this header. To resume from a specific point, reconnect with
+        the appropriate `from=` query parameter (the dashboard does
+        this transparently when its cache `version` advances past
+        the last known row).
+      schema:
+        type: string
 
   responses:
     Problem:
@@ -612,3 +985,380 @@ components:
           type: number
           format: float
           description: ClickHouse query wallclock.
+
+    # ---- Timeseries SSE wire shapes (used only by /api/v2/timeseries) ----
+
+    SSEFrameUnion:
+      description: |
+        The polymorphic union of all `/api/v2/timeseries` SSE frame
+        `data` shapes. The frame's `event:` name discriminates.
+        Schemas below are reachable by event name; this `oneOf` is
+        for code-gen consumers.
+      oneOf:
+        - $ref: '#/components/schemas/MetaEvent'
+        - $ref: '#/components/schemas/SampleRow'
+        - $ref: '#/components/schemas/NetworkRow'
+        - $ref: '#/components/schemas/EventRow'
+        - $ref: '#/components/schemas/HeartbeatEvent'
+        - $ref: '#/components/schemas/CompleteEvent'
+        - $ref: '#/components/schemas/StreamErrorEvent'
+      discriminator:
+        propertyName: __event
+        mapping:
+          meta: '#/components/schemas/MetaEvent'
+          sample: '#/components/schemas/SampleRow'
+          network: '#/components/schemas/NetworkRow'
+          event: '#/components/schemas/EventRow'
+          heartbeat: '#/components/schemas/HeartbeatEvent'
+          complete: '#/components/schemas/CompleteEvent'
+          stream_error: '#/components/schemas/StreamErrorEvent'
+
+    MetaEvent:
+      description: |
+        First frame on every successful subscription. Names the
+        resolved per-stream column projection so the client knows
+        what shape `sample` / `network` / `event` rows will have.
+
+        SSE wire shape: `event: meta\ndata: <this object>\n\n`.
+      type: object
+      required: [streams, columns, live, server_caps, ring]
+      additionalProperties: false
+      properties:
+        streams:
+          type: array
+          description: Resolved stream list (in order — samples, network, events).
+          items: { type: string, enum: [samples, network, events] }
+          example: [samples, network]
+        columns:
+          type: object
+          description: |
+            Per-stream column projection that the backfill + live
+            deltas will use. Keys are stream names; values are the
+            column lists (deduped, sorted, with mandatory identity
+            columns prepended).
+          additionalProperties:
+            type: array
+            items: { type: string }
+          example:
+            samples: [buffer_depth_s, manifest_url, network_bitrate_mbps, play_id, player_id, session_id, ts, video_bitrate_mbps]
+            network: [bytes_in, entry_fingerprint, fault_type, faulted, path, play_id, player_id, request_kind, session_id, status, total_ms, ts, ttfb_ms]
+        live:
+          type: boolean
+          description: |
+            Server's verdict on whether the (player, play) is still
+            producing data. true → backfill, then keep streaming;
+            false → backfill, then `complete` and close.
+        server_caps:
+          type: object
+          description: Server-side ceilings the client should respect.
+          additionalProperties: { type: integer }
+          example: { samples: 50000, network: 5000 }
+        ring:
+          type: object
+          description: Live-ring metadata so the client can size caches.
+          properties:
+            window_seconds:
+              type: integer
+              description: How far back the live ring buffer retains entries.
+              example: 600
+          required: [window_seconds]
+        from:
+          type: string
+          description: Echo of the `from=` request parameter (or empty).
+        to:
+          type: string
+          description: Echo of the `to=` request parameter (or empty).
+
+    SampleRow:
+      description: |
+        One row from `session_snapshots` projected by the requested
+        bundles. Concrete column set is reported by
+        `MetaEvent.columns.samples` and varies by selection — this
+        schema documents the type as an open object so codegen
+        consumers don't have to spec every column.
+
+        Required keys are the mandatory identity columns the resolver
+        always includes; everything else is bundle-dependent.
+
+        SSE wire shape: `event: sample\nid: <ts>\ndata: <this object>\n\n`.
+        The `id:` is the row's stringified `ts`, which the client
+        uses as the dedupe key against the live ring overlay.
+
+        Example below is the `charts_minimal` bundle.
+      type: object
+      additionalProperties: true
+      required: [ts, session_id, play_id, player_id]
+      properties:
+        ts: { type: string, format: date-time, description: ms-precision DateTime64, as a string. }
+        session_id: { type: string }
+        play_id: { type: string }
+        player_id: { type: string }
+      example:
+        ts: "2026-05-17 13:50:11.507"
+        session_id: "1"
+        play_id: 8fa22b46-dcce-4955-9970-4df3cda72d92
+        player_id: 97282446-9a14-4193-9fca-857250bc74ae
+        buffer_depth_s: 6.4
+        network_bitrate_mbps: 4.82
+        video_bitrate_mbps: 4.0
+        video_resolution: "1920x1080"
+        player_state: playing
+        manifest_url: "/go-live/SAMPLE/v2160_h264.m3u8"
+        nftables_bandwidth_mbps: 5
+
+    NetworkRow:
+      description: |
+        One row from `network_requests`. Dedupe key is
+        `entry_fingerprint` (server-stable hash of url+ts+bytes).
+        Bundle-projected columns vary by selection — the `network`
+        bundle's columns are documented as required below.
+
+        SSE wire shape: `event: network\nid: <entry_fingerprint>\ndata: <this object>\n\n`.
+      type: object
+      additionalProperties: true
+      required:
+        - ts
+        - session_id
+        - play_id
+        - player_id
+        - entry_fingerprint
+      properties:
+        ts: { type: string, format: date-time }
+        session_id: { type: string }
+        play_id: { type: string }
+        player_id: { type: string }
+        entry_fingerprint: { type: string }
+        method: { type: string, enum: [GET, HEAD, POST] }
+        url: { type: string }
+        path: { type: string }
+        request_kind:
+          type: string
+          enum: [master, manifest, init, segment, partial, image, other]
+        status: { type: integer }
+        bytes_in: { type: integer }
+        bytes_out: { type: integer }
+        ttfb_ms: { type: number, format: float }
+        transfer_ms: { type: number, format: float }
+        total_ms: { type: number, format: float }
+        client_wait_ms: { type: number, format: float }
+        faulted: { type: integer, enum: [0, 1] }
+        fault_type: { type: string }
+        fault_action: { type: string }
+        fault_category:
+          type: string
+          enum: [http, socket, corruption, transport, transfer_timeout, client_disconnect]
+      example:
+        ts: "2026-05-17 13:51:44.921"
+        session_id: "1"
+        play_id: 8fa22b46-dcce-4955-9970-4df3cda72d92
+        player_id: 97282446-9a14-4193-9fca-857250bc74ae
+        entry_fingerprint: "1234567890123456"
+        method: GET
+        path: /go-live/SAMPLE/2160p/segment_00007.m4s
+        request_kind: segment
+        status: 200
+        bytes_in: 15728640
+        ttfb_ms: 41
+        transfer_ms: 18203
+        total_ms: 18244
+        faulted: 1
+        fault_type: client_disconnect
+        fault_action: transfer_abandoned
+        fault_category: client_disconnect
+
+    EventRow:
+      description: |
+        One row from the derived `events` taxonomy. **Not yet
+        implemented** — requesting `streams=events` returns 501. Spec
+        retained so the wire shape is stable across the lift.
+
+        SSE wire shape: `event: event\nid: <ts>:<type>\ndata: <this object>\n\n`.
+
+        `kind` discriminates cause vs effect; `priority` is 1
+        (critical) through 4 (low) on the dashboard's classification
+        ladder.
+      type: object
+      required: [ts, type, kind, priority, play_id, player_id, session_id]
+      additionalProperties: true
+      properties:
+        ts: { type: string, format: date-time }
+        type:
+          description: Event type name (e.g. stall, downshift, manifest_failure, all_failure, fault_on).
+          type: string
+        info:
+          description: Type-specific JSON payload.
+          type: object
+          additionalProperties: true
+        kind:
+          type: string
+          enum: [cause, effect]
+        priority:
+          type: integer
+          enum: [1, 2, 3, 4]
+        play_id: { type: string }
+        player_id: { type: string }
+        session_id: { type: string }
+
+    HeartbeatEvent:
+      description: |
+        Emitted every 15 s on the open SSE channel so proxies and
+        the client don't idle-close. Carries only the server `ts`
+        (a convenient wall-clock sync if the client wants it).
+
+        SSE wire shape: `event: heartbeat\ndata: <this object>\n\n`.
+      type: object
+      required: [ts]
+      additionalProperties: false
+      properties:
+        ts:
+          type: string
+          format: date-time
+          description: RFC3339Nano UTC server timestamp.
+
+    CompleteEvent:
+      description: |
+        Emitted for archive subscriptions after the backfill is
+        flushed. Indicates the server intentionally closed the
+        stream — the client should NOT auto-reconnect; the play is
+        ended.
+
+        SSE wire shape: `event: complete\ndata: <this object>\n\n`.
+      type: object
+      required: [reason]
+      additionalProperties: false
+      properties:
+        reason:
+          type: string
+          description: Free-text reason; today only `archive_or_play_ended`.
+          example: archive_or_play_ended
+
+    StreamErrorEvent:
+      description: |
+        Emitted on transport / CH failures after the initial `meta`
+        frame. The connection closes shortly after; the client may
+        reconnect with a fresh subscription.
+
+        SSE wire shape: `event: stream_error\ndata: <this object>\n\n`.
+      type: object
+      required: [message]
+      additionalProperties: false
+      properties:
+        message:
+          type: string
+          example: "backfill failed: dial tcp 127.0.0.1:8123: connection refused"
+
+    # ---- Bundle catalogue (returned by GET /api/v2/bundles) -------------
+
+    BundleCatalogue:
+      description: |
+        Static description of the bundle registry as defined by
+        `analytics/go-forwarder/streambundles.go::bundleRegistry`.
+        Returned by `GET /api/v2/bundles` (not yet implemented;
+        catalogue currently lives in source — copy from
+        streambundles.go until the handler lands).
+      type: object
+      required: [bundles, aliases, streams]
+      additionalProperties: false
+      properties:
+        bundles:
+          type: array
+          items: { $ref: '#/components/schemas/BundleDef' }
+        aliases:
+          type: object
+          description: Alias name → expanded bundle list.
+          additionalProperties:
+            type: array
+            items: { type: string }
+          example:
+            all: [lanes_v1, network, events]
+        streams:
+          type: array
+          description: |
+            Mandatory identity columns per stream (always included
+            in the projection, even if the caller doesn't request
+            them).
+          items:
+            type: object
+            required: [stream, mandatory_columns]
+            properties:
+              stream:
+                type: string
+                enum: [samples, network, events]
+              mandatory_columns:
+                type: array
+                items: { type: string }
+          example:
+            - stream: samples
+              mandatory_columns: [ts, session_id, play_id, player_id]
+            - stream: network
+              mandatory_columns: [ts, session_id, play_id, player_id, entry_fingerprint]
+            - stream: events
+              mandatory_columns: [ts, play_id, player_id, session_id]
+
+    BundleDef:
+      description: One named bundle's projection of one stream.
+      type: object
+      required: [name, stream, columns]
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          example: charts_minimal
+        stream:
+          type: string
+          enum: [samples, network, events]
+        columns:
+          type: array
+          description: Wire-order list of columns the bundle projects.
+          items: { type: string }
+          example: [ts, session_id, play_id, player_id, video_bitrate_mbps, buffer_depth_s]
+        description:
+          type: string
+          description: |
+            Short human-friendly purpose statement. Optional in the
+            registry; the handler fills in defaults derived from the
+            bundle name when missing.
+
+  examples:
+
+    MetaAndBackfill:
+      summary: Initial meta event + a few backfill rows for a live play
+      description: |
+        Raw SSE bytes the client receives on the first second of a
+        live subscription. Frame separators (`\n\n`) shown as blank
+        lines.
+      value: |
+        event: meta
+        data: {"streams":["samples","network"],"columns":{"samples":["buffer_depth_s","play_id","player_id","session_id","ts","video_bitrate_mbps"],"network":["bytes_in","entry_fingerprint","fault_type","faulted","play_id","player_id","session_id","status","ts"]},"live":true,"server_caps":{"samples":50000,"network":5000},"ring":{"window_seconds":600},"from":"","to":""}
+
+        event: sample
+        id: 2026-05-17 13:50:11.507
+        data: {"ts":"2026-05-17 13:50:11.507","session_id":"1","play_id":"8fa22b46-dcce-4955-9970-4df3cda72d92","player_id":"97282446-9a14-4193-9fca-857250bc74ae","buffer_depth_s":6.4,"video_bitrate_mbps":4.0}
+
+        event: network
+        id: "1234567890123456"
+        data: {"ts":"2026-05-17 13:50:11.520","session_id":"1","play_id":"8fa22b46-dcce-4955-9970-4df3cda72d92","player_id":"97282446-9a14-4193-9fca-857250bc74ae","entry_fingerprint":"1234567890123456","status":200,"bytes_in":2654567,"faulted":0}
+
+    LiveDelta:
+      summary: A live sample arriving after backfill is done
+      value: |
+        event: sample
+        id: 2026-05-17 13:50:12.521
+        data: {"ts":"2026-05-17 13:50:12.521","session_id":"1","play_id":"8fa22b46-dcce-4955-9970-4df3cda72d92","player_id":"97282446-9a14-4193-9fca-857250bc74ae","buffer_depth_s":6.1,"video_bitrate_mbps":4.0}
+
+        event: heartbeat
+        data: {"ts":"2026-05-17T13:50:26.521Z"}
+
+    ArchiveComplete:
+      summary: Final frames of an archive-mode subscription
+      description: |
+        After CH backfill is flushed for a play whose `play.ended`
+        row has been seen, the server emits `complete` and closes.
+        The client should NOT reconnect.
+      value: |
+        event: sample
+        id: 2026-05-17 13:53:05.939
+        data: {"ts":"2026-05-17 13:53:05.939","session_id":"1","play_id":"8fa22b46-dcce-4955-9970-4df3cda72d92","player_id":"97282446-9a14-4193-9fca-857250bc74ae","buffer_depth_s":0,"video_bitrate_mbps":0}
+
+        event: complete
+        data: {"reason":"archive_or_play_ended"}


### PR DESCRIPTION
Follow-up to #463. `content/dashboard/api-docs/forwarder-v2.yaml` is the Scalar-UI-loaded copy and is normally synced by `make openapi`. I forgot to run it after editing the canonical spec, so the dashboard's API browser was still showing the pre-timeseries surface. This commit just runs the cp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)