### PR TITLE
feat(claude): harness skills + findings + standards (#437)

### DIFF
--- a/.claude/agents/playback-forensics-expert.md
+++ b/.claude/agents/playback-forensics-expert.md
@@ -1,0 +1,93 @@
+---
+name: playback-forensics-expert
+description: Read-only expert that analyses pre-gathered HLS/DASH playback failure data to produce a tagged causal hypothesis. Used by the `forensics` skill — never invoked directly. Reads events / network rows / samples / standards / findings, but does NOT run shell commands or fetch fresh data. Output is a hypothesis tagged confirmed/refuted/needs-test, the minimum evidence to confirm/refute, and a suggested harness command if testing is needed.
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+# You are the playback-forensics-expert
+
+You analyse pre-gathered data from the InfiniteStream test harness and produce *one focused causal hypothesis* about an observed playback failure pattern.
+
+## What you do
+
+Given pre-gathered evidence files (events, network, samples) and pointers to standards / findings, you:
+
+1. Read the standards docs the dispatcher named.
+2. Read the findings library hits the dispatcher named.
+3. Skim the evidence files (`Read` them; `Grep` for patterns; `Glob` if you need to find related files).
+4. Form **one** primary hypothesis (not three — pick the most likely; mention alternates only as briefly-noted runners-up).
+5. Output in the mandatory format below.
+
+## What you don't do
+
+- **No shell.** You have `Read`, `Grep`, `Glob` only. If you need more data, say so in your output — the dispatcher will gather it and re-invoke you. Don't try to work around the lack of Bash.
+- **No code edits.** You don't fix things; you diagnose. The user / dispatcher decides what to do with the hypothesis.
+- **No browsing the web.** Your knowledge is what's in the standards + findings libraries + your training data. If the standards are silent on a topic and you're not sure, say so explicitly rather than confabulating.
+- **No re-querying.** The dispatcher already filtered the evidence to the relevant window. Don't ask for more unless you can name the specific missing data type ("I need network rows for the 30s before the first event" — not "I need more context").
+
+## What you know
+
+You are operating against the InfiniteStream HLS/LL-HLS/DASH testing platform. Players are AVPlayer (iOS/iPadOS/tvOS), ExoPlayer (Android TV / Google TV Streamer), Roku Stream Player, hls.js, Shaka. The server emits live LL-HLS + 6s HLS + LL-DASH from the same source, looping a curated set of segments.
+
+The harness lets operators inject HTTP / socket / transport faults and shape bandwidth/delay/loss. Faults and shape are visible in samples as `nftables_*` and `fault_count_*` columns; faulted requests are visible in network rows as `faulted=1` with a `fault_category` + `fault_type`.
+
+You already know the platform-general HLS/DASH/ABR model. The standards library exists to capture the *non-obvious* product-specific facts. Always cite a standards doc when you use a fact from it; don't claim "the standards say" without naming the file.
+
+## Output format (mandatory)
+
+```markdown
+## Hypothesis
+
+<one paragraph, mid-density, specific to this player + this window. Reference timestamps from the evidence. Tag the paragraph's end with one of:>
+
+**Tag:** confirmed | refuted | needs-test
+
+## Evidence used
+
+- /tmp/forensics-events-X.jsonl:line-range — what it shows
+- /tmp/forensics-net-X.jsonl:line-range — what it shows
+- /tmp/forensics-sam-X.jsonl:line-range — what it shows
+
+## Standards / findings cited
+
+- .claude/standards/<file>.md — which fact
+- .claude/findings/<file>.md — which prior conclusion
+
+## To confirm or refute
+
+<If confirmed: empty — say "no further test required.">
+<If refuted: empty — say "alternate hypotheses worth pursuing: …">
+<If needs-test: one harness command that would reproduce or rule out, with expected vs unexpected outcome.>
+```
+
+## Heuristics
+
+These are the patterns that show up most often. Pattern-match against them first:
+
+1. **Player-abandoned heavy segment → downshift cascade → stall** — see `.claude/findings/ipad-262s-stall-2026-05-17.md` for the canonical case. Look for `fault_type=client_disconnect` + `fault_action=transfer_abandoned` 30-60s before a stall, followed by aggressive rate_shift_down events.
+
+2. **buffer_end_s doesn't advance even though segments are being fetched** — iOS-specific. The player is fetching but not decoding. Usually means an init-segment / variant-boundary issue. See `.claude/standards/avplayer-quirks.md`.
+
+3. **Repeated `loop_server` events without playback issues** — server is looping the source content. Routine, P4. Don't hypothesise about this unless the user asked.
+
+4. **HTTP 4xx burst on segment requests** — usually fault-injected (check sample's `fault_count_*` columns). If not injected, check the manifest — segments may have rotated past what the playlist references.
+
+5. **`all_failure` event** — proxy-side counter incremented when *every* request kind failed in the same tick. Cause is usually transport-level (nftables drop / 100% loss) or the upstream go-live worker died.
+
+When the pattern doesn't match any heuristic, fall back to building causation from the timeline:
+
+- What was the player doing just before the first effect event?
+- What changed (samples → bitrate / state / shaper)?
+- What network activity preceded the change?
+- Is there a known platform behaviour (in standards) that explains the change?
+
+If none of those produce a candidate, your hypothesis is `needs-test` and the test is "capture a wider window and re-dispatch".
+
+## Style
+
+- Concise. No throat-clearing. Operators read this output between fault-injection runs.
+- Specific. "The stall at 18:29:27" not "the recent stall". Reference timestamps.
+- Honest about confidence. `needs-test` is the honest answer most of the time; don't inflate to `confirmed`.
+- One hypothesis primary, alternates briefly. Don't enumerate every possibility — you're the expert, pick the most likely.
+- Cite. Every claim that depends on a standards or findings fact gets the filename.

--- a/.claude/findings/README.md
+++ b/.claude/findings/README.md
@@ -1,0 +1,72 @@
+# Findings library
+
+Per-discovery markdown files capturing what we've learned from real
+investigations. Each file is the operator's narrative explanation of a
+single observed behaviour, paired with a sibling JSON snapshot that
+the `harness finding add` command wrote at the moment of capture.
+
+Skills that read this library:
+
+- `finding` — capture (writes new files) + recall (greps existing)
+- `forensics` — the subagent reads files matching its current query
+  before hypothesising, so we don't re-derive things we've already
+  learned
+
+## When to add a finding
+
+The bar is: *will Future Us thank Past Us for writing this down?*
+
+Add a finding when:
+- A bug or non-obvious behaviour took >20 minutes to understand
+- The cause turned out to be different from the initial hypothesis
+- A workaround exists but the root cause isn't fixed yet
+- A platform (iOS / Roku / Android TV) does something unusual that
+  isn't in our standards docs
+
+Don't add a finding for:
+- Things already obvious from reading the code
+- One-off transient blips with no understood cause
+- Notes you'd put in a commit message instead
+
+## Format
+
+```markdown
+# <Symptom> — <player short id> — <YYYY-MM-DD>
+
+## Summary
+1–3 sentences. What broke; what we now know; what the operator should
+do about it (or "needs more investigation").
+
+## Timeline
+- T+0:00  thing happened
+- T+0:23  next thing
+- T+1:14  …
+
+## Evidence
+Inline `harness` command outputs or jq excerpts that justify the
+timeline. If the JSON snapshot file (`harness finding add`'s output)
+has the raw data, link it: `see ee091d13-1779057782294.json`.
+
+## Hypothesis
+One paragraph. Tag explicitly: **confirmed** | **refuted** |
+**needs-test**.
+
+## Action items
+- [ ] Reproduce with `harness procedure …`
+- [ ] File issue if confirmed bug
+- [ ] Update standards doc if this teaches a new platform fact
+```
+
+## Filename convention
+
+`<player-shortid>-<symptom>-<YYYY-MM-DD>.md` — e.g.
+`ee091d13-buffer-collapse-2026-05-17.md`. The shortid + date is what
+the `finding` skill greps against when surfacing related history.
+
+## Sibling JSON
+
+`harness finding add` writes a JSON file named
+`<shortid>-<unix-ms>.json` containing the full PlayerRecord snapshot,
+recent mutation history, tags, and free-form note at the moment of
+capture. The `.md` file here is the narrative; the `.json` is the data.
+Link the two in the Evidence section.

--- a/.claude/findings/ipad-262s-stall-2026-05-17.md
+++ b/.claude/findings/ipad-262s-stall-2026-05-17.md
@@ -1,0 +1,149 @@
+# 262s stall on 2160p abandon — iPad ee091d13 — 2026-05-17
+
+## Summary
+
+The iPad's 4-minute frozen video at 18:29:27 traces back to a 14 MB 2160p
+segment that took 23.5s to transfer and was abandoned mid-flight
+(`fault_type=client_disconnect`, `fault_action=transfer_abandoned`).
+After the abandon, AVPlayer cascaded down two variant rungs and
+crashed into a stall it took ~262 seconds to recover from — despite
+successfully fetching small audio + 540p segments throughout the
+stall, the player wasn't ingesting them into the play buffer.
+**Tag: needs-test.**
+
+## Timeline
+
+(times are 2026-05-17 UTC)
+
+- **18:28:19** — `rate_shift_up` → 29.86 Mbps (2160p high-bitrate variant)
+- **18:28:33.392** — server starts sending 2160p segment_00004 (~14 MB)
+- **18:28:56** — transfer ends after 23,481 ms; faulted with
+  `fault_type=client_disconnect`, `fault_action=transfer_abandoned`,
+  status=200, `bytes_out=13_889_536`. Player abandoned mid-transfer.
+- **18:28:58.694** — `rate_shift_down` to 1 Mbps (emergency downshift)
+- **18:28:59.571** — `timejump` (state=buffering)
+- **18:28:59.577** — `buffering_start`
+- **18:29:01.881** — `buffering_end` — playing resumed at 1 Mbps
+- **18:29:02–14** — climbing back up the ladder: 1 → 1.84 → 3.46 → 7.06 → 15.36 Mbps over 12s
+- **18:29:26.687** — `rate_shift_down` 15.36 → 7.06 (player backed off)
+- **18:29:27.197** — buffer reading collapsed from 12s to 0s in 0.5s
+- **18:29:27.565** — `stall_start` fires. state=stalled, buffer=0,
+  `buffer_end_s=4074.56`
+- **18:29:30.807** — `rate_shift_down` 7.06 → 1.84 (during stall)
+- **18:29:27 → 18:33:50** — player fetches audio + 540p segments
+  successfully (<10ms transfer each, 200 OK) but `buffer_end_s` stays
+  at 4074.56 throughout. No data flows into the play buffer.
+
+Stall ended at ~18:33:50 (262 seconds after onset).
+
+## Evidence
+
+- See sibling JSON: `harness finding add` was not run for this seed
+  (this is a retrospective finding from a CLI demo session). The
+  evidence below was pulled live via the harness CLI during the
+  investigation.
+
+### Faulted segment
+
+```sh
+harness raw GET "/analytics/api/v2/timeseries?player_id=ee091d13-...&streams=network&bundles=network&from=2026-05-17T18:28:30Z&to=2026-05-17T18:30:00Z"
+```
+
+One faulted row in the window:
+```json
+{"ts":"2026-05-17 18:28:33.392", "bytes_out":13889536,
+ "transfer_ms":23481.547, "faulted":1, "fault_type":"client_disconnect",
+ "fault_action":"transfer_abandoned", "status":200,
+ "path":".../2160p/segment_00004.m4s"}
+```
+
+### Player state across stall onset
+
+```sh
+harness raw GET "/analytics/api/v2/timeseries?player_id=...&streams=samples&bundles=charts_minimal,lanes_v1&stride_ms=1000&from=...&to=..."
+```
+
+```
+18:29:26  state=playing  res=1920x1080  bw=15.36  buf=12s   last=heartbeat
+18:29:27  state=playing  res=2560x1440  bw=7.06   buf=0     last=heartbeat  ← buffer collapsed
+18:29:27  state=stalled  res=2560x1440  bw=7.06   buf=0     last=stall_start
+18:29:30  state=stalled  res=2560x1440  bw=1.84   buf=0     last=rate_shift_down
+... [232 more seconds] ...
+buffer_end_s never advances past 4074.56 during the stall.
+```
+
+### Network during stall (proves segments were succeeding)
+
+```
+18:29:31.027  segment  status=200  540p/segment_00033.m4s  transfer_ms=6.65
+18:29:32.146  segment  status=200  audio/segment_00032.m4s transfer_ms=0.64
+18:29:50–18:33:50  manifest + audio + 540p + 360p all 200 OK in <10ms each
+```
+
+### Shaper was not the cause
+
+```
+nftables_bandwidth_mbps = 0  (no static rate cap)
+nftables_pattern_enabled = 1  (a pattern was running)
+nftables_pattern_rate_runtime_mbps = 3.46 → 7.06 → 15.36  (cycling)
+```
+
+A pattern was active but its lowest rate (3.46 Mbps) was still ~2× the
+player's chosen variant rate (1.84 Mbps). Shaper had ample headroom.
+
+## Hypothesis
+
+The 262s stall was triggered by AVPlayer abandoning a 14MB 2160p
+segment after the transfer took 23.5s. The abandon cascaded into a
+multi-rung downshift, then a stall onset 30s later. During the stall,
+network requests continued to succeed (small variants, fast transfers,
+status 200) but `buffer_end_s` did not advance — strongly suggesting
+the player was fetching segments but failing to ingest them into the
+play buffer, possibly because of an init-segment or variant-boundary
+issue triggered by the rapid 6-step variant rotation during recovery.
+
+Alternative hypothesis: AVPlayer's state machine entered an
+unrecoverable internal state after the abandon and required ~262s for
+its internal watchdog to reset.
+
+**Tag: needs-test.**
+
+## To confirm or refute
+
+Run:
+
+```sh
+harness procedure abr-sweep ipad --rates 30,29.86,15.36,7,3.46,1.84,1 --hold 8s
+```
+
+while observing:
+
+```sh
+harness ts ipad --streams events --bundles events
+```
+
+**Expected if hypothesis is correct:** the rapid forced variant
+rotation reproduces the abandon → stall pattern within 2-3 cycles.
+The stall recovery time should be similar (multi-minute).
+
+**Expected if hypothesis is wrong:** rotations complete cleanly, no
+stall. In that case investigate AVPlayer's internal state-machine
+behaviour after `transfer_abandoned` specifically (set up the
+condition by serving a deliberately-slow 2160p segment via a fault
+rule, e.g. `--type request_body_delayed --kind segment
+--url-substr 2160p`).
+
+## Action items
+
+- [ ] Reproduce with the abr-sweep above
+- [ ] If confirmed: file a finding suggesting AVPlayer-specific
+      "post-abandon recovery delay" as a known platform behaviour
+- [ ] If reproduced: consider whether the proxy should detect heavy
+      segments (>10 MB) and either delay-then-throttle or reject early
+      to prevent player aborts in mid-flight
+
+## See also
+
+- `.claude/standards/avplayer-quirks.md` — transfer abandonment +
+  buffer_end_s reporting
+- `.claude/standards/abr-decision-model.md` — why downshifts cascade

--- a/.claude/skills/fault/SKILL.md
+++ b/.claude/skills/fault/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: fault
+description: Inject HTTP errors, socket faults, or transport-layer drops on a player session via the harness CLI. Invoke when the user says "inject", "drop a 404", "fault on segments", "every N seconds", "kill the connection mid-body", "throttle", "reset faults", or otherwise wants to mutate the proxy's behaviour for one player. This skill owns the English-to-CLI-flag translation including the ambiguous-phrase tables; resolve disambiguation BEFORE running any harness command.
+---
+
+# Inject faults via `harness fault`
+
+Default target: `https://jonathanoliver-ubuntu.local:21000` (test-dev). Every mutation is snapshot-protected by the CLI — `harness undo <target>` rolls back. You never have to manage state.
+
+## Always do this first
+
+Before any `fault add`, show the user what's already there:
+
+```sh
+harness --insecure fault list <target>
+```
+
+If rules are already active, surface them before adding new ones. The CLI's `first-match-wins` rule evaluation means a stale rule at the top of the list can mask a new one entirely.
+
+After every successful add, echo the inverse:
+
+```
+added rule abc12345 — undo with `harness undo <target> --yes` or
+                              `harness fault rm <target> abc12345`
+```
+
+## Phrase disambiguation — read this before parsing the user
+
+English asks routinely map to genuinely different harness behaviours. Resolve these *before* picking flags; ask if you can't.
+
+### "Drop"
+
+| User says | Means | Command |
+|---|---|---|
+| "drop a 404", "drop 500s" | HTTP error | `harness fault add <t> --type 404` (or 500/503) |
+| "drop packets", "blackhole it" | Transport drop (kernel discards) | `harness shape <t> --transport-fault drop` ⚠ |
+| "drop the connection mid-request" | Socket fault | `harness fault add <t> --type request_body_reset` |
+| "drop the session" | Delete the player | `harness players rm <t>` — **confirm first** |
+
+⚠ Transport drop isn't exposed as a top-level shape flag yet — see "Known gaps" below. For now, use `harness raw PATCH` with `{"shape":{"transport_fault":{"type":"drop"}}}`.
+
+### "Every / per / 1-in"
+
+| User phrasing | Flags |
+|---|---|
+| "every 10 seconds", "1 every 10s" | `--frequency 10 --mode seconds` |
+| "every 10 requests", "1 in 10" | `--frequency 10 --mode requests` |
+| "X faults per second on every request" | `--frequency X --mode failures_per_seconds` (rare) |
+| Bare "every 10" | **Ambiguous** — ask requests vs seconds. |
+
+The default `--mode requests` is what most operators mean. `failures_per_seconds` means *X faults per second window*, NOT "once every X seconds" — easy to get wrong; confirm if the user says it.
+
+### "Kill the network" / "break it" / "hose it"
+
+Don't guess. Offer a menu:
+
+- 100% transport drop → `harness raw PATCH /api/v2/players/<id> --body '{"shape":{"transport_fault":{"type":"drop","frequency":1,"mode":"requests","consecutive":1}}}'`
+- Bandwidth = 0 → `harness shape <t> --rate 0` (player will stall on next segment)
+- 100% packet loss → `harness shape <t> --loss 100`
+- All 5xx on every request → `harness fault add <t> --type 503 --frequency 1 --mode requests`
+
+### "All requests" vs "all sessions"
+
+- **"every request kind"** / **"any request"** → omit `--kind` (matches all)
+- **"all sessions"** / **"every player"** → iterate `harness players list`, run the mutation per id. Or create a group with `harness groups create --members A,B,C` and PATCH the group once.
+
+### Reset / clear / undo — three different things
+
+| Verb | Command | Behaviour |
+|---|---|---|
+| **Undo** ("undo that") | `harness undo <t>` | Replays the most-recent snapshot. Restores exactly what was there. |
+| **Clear faults** | `harness fault clear <t>` | Removes all fault rules. Doesn't restore prior state — wipes. |
+| **Wipe everything** | `harness players prune --yes` | Destroys ALL players + state. **Confirm before running.** |
+
+`fault clear` does NOT undo a prior `fault clear`. Once cleared, `undo` will reverse the clear (restore the rules that existed before the clear); `fault clear` again would re-clear them.
+
+### Number/unit normalisation
+
+| User says | Flag value |
+|---|---|
+| "5mb", "5 megabits", "5 Mbps", "5M" | `--rate 5` |
+| "100k", "100 kbps", "100 Kbits" | `--rate 0.1` |
+| "1 gig", "1 Gbps" | `--rate 1000` |
+| "100ms", "0.1s" | `--delay 100` |
+| "5%", "5 percent loss" | `--loss 5` |
+
+For ambiguous units ("100k") pick the streaming-plausible value (kbps for bandwidth) and tell the user what you assumed.
+
+## Fault types
+
+```sh
+harness fault add <target> --type TYPE [--kind KIND] [--frequency N] [--mode MODE] [--consecutive N]
+```
+
+Available `--type`:
+
+| Type | Layer | Notes |
+|---|---|---|
+| `403`, `404`, `500`, `503` | HTTP | Status code returned |
+| `connection_refused` | HTTP | Server rejects the connection |
+| `dns_failure` | HTTP | Synthetic DNS error |
+| `rate_limiting` | HTTP | Returns 429 + Retry-After |
+| `corrupted` | HTTP | Segment payload zero-filled (segment-only) |
+| `request_connect_delayed/hang/reset` | Socket | TCP connect phase |
+| `request_first_byte_delayed/hang/reset` | Socket | First-byte phase |
+| `request_body_delayed/hang/reset` | Socket | Body-transfer phase |
+| `none` | n/a | Disables a rule without removing it |
+
+Available `--kind` (request_kind filter; omit for all):
+`segment`, `partial`, `manifest`, `master_manifest`, `init`, `audio_segment`, `audio_manifest`.
+
+`corrupted` is segment-only — pass `--kind segment` (CLI will reject with 400 otherwise).
+
+## Common recipes
+
+| Ask | Command |
+|---|---|
+| "404 every 10s on every request" | `harness fault add ipad --type 404 --frequency 10 --mode seconds` |
+| "one-shot 404 on the next segment" | `harness fault add ipad --type 404 --kind segment` |
+| "manifest timeout every 5 requests" | `harness fault add ipad --type request_first_byte_hang --kind manifest --frequency 5` |
+| "10 consecutive 503s every minute" | `harness fault add ipad --type 503 --frequency 60 --mode seconds --consecutive 10` |
+| "drop the manifest playlist" | `harness fault add ipad --type 404 --kind manifest` |
+| "kill the connection mid-body" | `harness fault add ipad --type request_body_reset` |
+| "503 only on 2160p segments" | `harness fault add ipad --type 503 --kind segment --url-substr 2160p` |
+| "clear faults on the iPad" | `harness fault clear ipad` |
+| "undo the last thing" | `harness undo ipad --yes` |
+
+## Edit / remove individual rules
+
+```sh
+harness fault list ipad                          # shows short rule_id (8-char prefix ok)
+harness fault edit ipad 20260517 --frequency 5   # change cadence without removing
+harness fault rm ipad 20260517                   # delete one
+harness fault clear ipad                         # delete all
+```
+
+The short rule_id from `fault list` is enough — the CLI expands prefixes.
+
+## Known gaps (CLI follow-ups, not skill bugs)
+
+- `harness shape` doesn't expose `--transport-fault drop|reject` as top-level flags yet. For now use `harness raw PATCH` with the shape body, or wait for the CLI to add typed flags.
+- `harness shape` doesn't expose `--pattern` (square_wave / ramp / pyramid) — for ramp behaviour use `harness procedure abr-sweep --rates X,Y,Z --hold Ns` instead.
+- `harness fault add` for play-scoped (vs player-scoped) rules isn't wrapped yet — use `harness raw POST /api/v2/plays/<play_id>/fault_rules` for play-scope.
+
+## What NOT to do here
+
+- **Don't snapshot first.** The CLI does it automatically on every mutation. Skipping the `harness snapshot` call isn't an oversight — it's redundant.
+- **Don't add a rule without showing the existing list first.** Stale top-of-list rules silently consume requests that the operator thought their new rule would catch.
+- **Don't run `players prune` or `players rm` without explicit user confirmation.** Even with `--yes` the CLI proceeds without asking; require the operator to say yes in the chat first.
+- **Don't echo "rule added" without the undo command.** Every mutation reply ends with the inverse.
+
+## See also
+
+- `shape` — bandwidth / delay / loss / patterns (separate skill)
+- `triage` / `investigate` — find what broke before deciding to inject
+- `finding` — capture what a fault test reproduced
+- `.claude/standards/avplayer-quirks.md` — how iOS reacts to specific faults

--- a/.claude/skills/finding/SKILL.md
+++ b/.claude/skills/finding/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: finding
+description: Capture a discovery into the .claude/findings/ library, or recall existing findings related to the current investigation. Invoke when the user says "save that", "record this finding", "this is worth remembering", "what do we know about X", "have we seen this before", or after a successful `investigate` / `forensics` run that reached a tagged hypothesis. The library is the project's memory across sessions — write to it when a non-obvious cause has been confirmed or strongly suspected.
+---
+
+# Findings library — capture + recall
+
+The library lives at `.claude/findings/` (per-repo, committed). Each finding is a markdown narrative + (usually) a JSON sidecar with the raw player state at the moment of capture. See `.claude/findings/README.md` for the file format and the bar for adding a finding.
+
+## When to invoke
+
+**Capture mode** — triggered on:
+- "save that", "record the finding", "this is worth remembering"
+- After `investigate` reaches a `confirmed` or strongly-suspected `needs-test` hypothesis
+- When the user describes a discovery in chat ("turns out AVPlayer caches the init") and it's not in the library
+
+**Recall mode** — triggered on:
+- "what do we know about X"
+- "have we seen this before"
+- "search findings for stalls / AVPlayer / 2160p / etc"
+- Implicitly: before any `forensics` dispatch (always grep findings first)
+
+## Capture flow
+
+### 1. Get the JSON sidecar via the CLI
+
+If the finding is about a live or recently-active player, call:
+
+```sh
+harness --insecure finding add <target> \
+  --tag <tag1> --tag <tag2> \
+  --note "<one-line operator note>"
+```
+
+The CLI writes `.claude/findings/<shortid>-<unix-ms>.json` containing the full PlayerRecord at this moment + recent mutation snapshots. The note becomes the seed for the markdown narrative.
+
+If the finding has no live target (e.g. "Apple TV `tvOS focus` requires `cinematicFocusFollower` inside Button labels"), skip this step — capture is markdown-only.
+
+### 2. Write the narrative `.md` sibling
+
+Filename: `<player-shortid>-<symptom>-<YYYY-MM-DD>.md` — e.g. `ee091d13-buffer-collapse-2026-05-17.md`. If no player is involved, use `<topic>-<YYYY-MM-DD>.md` — e.g. `avplayer-init-cache-2026-05-17.md`.
+
+Template (also in `.claude/findings/README.md`):
+
+```markdown
+# <Symptom> — <player short id> — <YYYY-MM-DD>
+
+## Summary
+1–3 sentences. What broke; what we now know; what the operator should
+do about it (or "needs more investigation").
+
+## Timeline
+- T+0:00  thing happened
+- T+0:23  next thing
+
+## Evidence
+Inline harness output. Link the JSON sidecar:
+> see `ee091d13-1779057782294.json` for the full PlayerRecord at
+> capture time.
+
+## Hypothesis
+One paragraph. Tag: **confirmed** | **refuted** | **needs-test**.
+
+## Action items
+- [ ] Reproduce with `harness procedure …`
+- [ ] File issue if confirmed bug
+- [ ] Update standards doc if this teaches a new platform fact
+```
+
+Write it dense. The reader 3 months from now wants the headline in the first sentence and the JSON sidecar for full data.
+
+### 3. Suggest related cross-references
+
+After writing, grep for related findings:
+
+```sh
+grep -li <symptom-keyword> .claude/findings/*.md
+```
+
+If matches exist, mention them in the new finding's `## See also` section. The library is more useful as a graph than as a list.
+
+### 4. If this teaches a NEW platform fact, suggest a standards update
+
+If the cause is a platform behaviour we didn't previously know about (e.g. "iOS abandons in-flight transfers after 20s regardless of buffer state"), suggest adding 1–2 lines to the matching `.claude/standards/` doc. The finding records the *incident*; the standards doc records the *general fact*.
+
+## Recall flow
+
+### 1. Grep first, hypothesise later
+
+```sh
+grep -ril <keyword> .claude/findings/
+```
+
+Use multiple keyword passes if you're searching for a concept:
+- For "iPad stall": `grep -ril ipad .claude/findings/` + `grep -ril stall .claude/findings/` then intersect
+- For "AVPlayer cache": `grep -ril avplayer .claude/findings/` + `grep -ril cache .claude/findings/`
+
+### 2. Surface the 1–3 most-relevant
+
+Don't dump the whole grep output. Pick the 1-3 most-relevant by filename + summary. Cite them by filename, quote the Summary section, link to the sidecar JSON if useful.
+
+### 3. State whether the prior finding answers the current question
+
+The recall isn't done when you've found the files — it's done when you've said "yes, [filename] explains this — proceed as it suggests" or "no, this is similar to [filename] but the trigger differs in X way, so we still need to investigate".
+
+## Templates for common capture cases
+
+### Single-event investigation that reached a hypothesis
+
+The `investigate` skill ended with a tagged hypothesis. Capture is mechanical:
+1. `harness finding add <t> --tag stall --note "<the hypothesis 1-liner>"`
+2. Copy the `investigate` output's Timeline + Evidence sections into the new `.md`
+3. Verbatim-copy the Hypothesis paragraph (don't paraphrase — the original wording is the record)
+
+### Platform/protocol fact discovered while debugging
+
+Skip step 1 (no JSON sidecar needed). Just write the `.md`:
+- `# Topic — YYYY-MM-DD`
+- `## Summary` = the fact in one sentence
+- `## How we learned this` = the bug or investigation that led here
+- `## Where this matters` = which player platforms / scenarios
+
+Then propose adding the fact to `.claude/standards/<topic>.md`.
+
+### Reproducibility recipe
+
+When a `forensics` test confirms reproduction:
+- Include the EXACT `harness procedure` / `harness fault add` / `harness shape` command that reproduces, with all flags
+- Note expected vs actual behaviour
+- Tag `confirmed` (since reproduction proves cause)
+
+## What NOT to do here
+
+- **Don't capture findings for transient blips with no understood cause.** The library's value is signal:noise. A finding that says "ipad stalled, dunno why" pollutes future searches.
+- **Don't paraphrase the hypothesis when copying from `investigate`.** Verbatim — the original wording is the record.
+- **Don't capture without checking the library first.** Duplicates make the library worse, not better.
+- **Don't recall by trying to guess the finding's filename.** Grep first.
+
+## See also
+
+- `.claude/findings/README.md` — format spec + when-to-add bar
+- `.claude/standards/README.md` — when a finding teaches a general fact, update the standards
+- `investigate` — the typical upstream that feeds capture
+- `forensics` — recall is always invoked before forensics dispatches to the subagent

--- a/.claude/skills/forensics/SKILL.md
+++ b/.claude/skills/forensics/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: forensics
+description: Multi-event causal analysis — "why does X keep happening", "compare A vs B", "find the pattern across these failures", "is this related to a change". Gathers events/network/samples + relevant past findings + applicable standards, then dispatches to the `playback-forensics-expert` subagent for hypothesis generation. Invoke when one event isn't enough (use `investigate` for single events) and the question is "why" not "what". Returns a tagged hypothesis plus a suggested test to confirm or refute.
+---
+
+# Forensics — dispatch a "why" question to the playback expert
+
+`investigate` answers "what happened at time T". Forensics answers "why does this pattern keep recurring" or "why is A different from B". Different question, different cost: forensics calls out to a Sonnet subagent (`playback-forensics-expert`) primed with HLS/AVPlayer/ABR knowledge. The main session stays cheap; the subagent does the reasoning.
+
+## When to use this over `investigate`
+
+| Question | Skill |
+|---|---|
+| "Why did the player stall at 18:29:27?" | `investigate` |
+| "Why does the iPad keep stalling on 2160p segments?" | `forensics` |
+| "What was happening when the buffer collapsed?" | `investigate` |
+| "Compare the iPad's stall pattern to the Roku's" | `forensics` |
+| "Is this related to the change we made yesterday?" | `forensics` |
+
+Rule of thumb: if the answer requires comparing two or more event clusters, or correlating with a non-obvious cause (a code change, a platform behaviour, a recurring fault pattern), it's forensics. If the answer is "look at what happened in this 90-second window", it's investigate.
+
+## Flow
+
+### 1. Resolve scope
+
+- Which player(s)? Single = "why does X keep stalling". Multi = comparison.
+- Which time window? Default 30 min ending at "now"; expand if the user named a specific range.
+- Which play_id? Optional. Restrict if specified, else span all plays in window.
+
+### 2. Recall first (mandatory)
+
+Before pulling fresh data or dispatching, check the findings library:
+
+```sh
+# pull keywords from the user's question
+grep -ril <keyword-1> .claude/findings/
+grep -ril <keyword-2> .claude/findings/
+```
+
+If the library already answers the question, return that answer instead of dispatching. Cite the finding file. Don't burn subagent tokens on a question we've already answered.
+
+### 3. Gather the data the subagent needs
+
+The subagent is **read-only** — it can't run harness or curl. You have to gather everything upfront.
+
+For each player in scope:
+
+```sh
+# Events for the window
+timeout 6 harness --insecure --json ts <t> --streams events --bundles events 2>/dev/null \
+  | jq -c 'select(.type and .priority and .ts >= "<FROM>" and .ts <= "<TO>")' \
+  > /tmp/forensics-events-<t>.jsonl
+
+# Network for the window
+timeout 8 harness --insecure raw GET \
+  "/analytics/api/v2/timeseries?player_id=$PID&streams=network&bundles=network&from=<FROM_ISO>&to=<TO_ISO>" 2>/dev/null \
+  | grep '^data: ' | sed 's/^data: //' \
+  | jq -c 'select(.ts >= "<FROM>" and .ts <= "<TO>")' \
+  > /tmp/forensics-net-<t>.jsonl
+
+# Samples at 1Hz for the window
+timeout 8 harness --insecure raw GET \
+  "/analytics/api/v2/timeseries?player_id=$PID&streams=samples&bundles=charts_minimal,lanes_v1&from=<FROM_ISO>&to=<TO_ISO>&stride_ms=1000" 2>/dev/null \
+  | grep '^data: ' | sed 's/^data: //' \
+  | jq -c 'select(.ts >= "<FROM>" and .ts <= "<TO>")' \
+  > /tmp/forensics-sam-<t>.jsonl
+```
+
+(Same SSE-bleed-through guard as `investigate` — always filter ts in jq.)
+
+### 4. Identify applicable standards
+
+Based on the user's question, name the standards docs the subagent should read:
+
+- Anything about iOS / iPad / AVPlayer → `.claude/standards/avplayer-quirks.md`
+- ABR / variant choice / downshift / upshift → `.claude/standards/abr-decision-model.md`
+- m3u8 / manifest behaviour → `.claude/standards/hls-taxonomy.md`
+- codec rejection / playback init failure → `.claude/standards/codec-strings.md`
+
+### 5. Dispatch to the subagent
+
+Invoke the `playback-forensics-expert` agent (via the Agent tool, `subagent_type: playback-forensics-expert`). The prompt should be self-contained — the subagent doesn't see your conversation history.
+
+Prompt template:
+
+```
+The user is asking: "<verbatim user question>"
+
+Scope:
+- Player(s): <list with shortids + UA>
+- Window: <FROM> → <TO>
+- play_id(s): <if scoped>
+
+Pre-gathered evidence (already filtered to the window — DON'T re-query):
+- /tmp/forensics-events-<t>.jsonl ({N} events)
+- /tmp/forensics-net-<t>.jsonl ({M} network rows)
+- /tmp/forensics-sam-<t>.jsonl ({K} samples at 1Hz)
+
+Findings library hits (already grepped):
+- <file1.md>: <one-line summary>
+- <file2.md>: <one-line summary>
+(if none: "no prior findings for these keywords")
+
+Standards to read (cite when used):
+- .claude/standards/<applicable>.md
+
+Output format (mandatory):
+- Hypothesis (one paragraph, tagged confirmed | refuted | needs-test)
+- Minimum evidence that would confirm or refute
+- Suggested next harness command if needs-test
+- Citations to standards / findings you used
+```
+
+### 6. Surface the subagent's reply
+
+Don't paraphrase the hypothesis — quote it verbatim. The user is going to take action based on the exact tag (confirmed → ship a fix; refuted → drop the hypothesis; needs-test → run the suggested command).
+
+If the subagent's reply tag is `needs-test`, offer to run the suggested test:
+
+```
+The expert's hypothesis is needs-test. To confirm, run:
+
+  harness procedure abr-sweep ipad --rates 30,29.86 --hold 30s
+
+Run it now? [y/n]
+```
+
+If the user says yes, run it, then re-`investigate` the resulting event(s) to confirm.
+
+## When forensics returns "I need more data"
+
+If the subagent says "the evidence is insufficient, I need X", don't dispatch again immediately. Tell the user what's missing, ask whether to:
+- Pull a wider window of the same streams
+- Pull additional streams (e.g. you only gave events but it needs network)
+- Capture a fresh test (operator runs a reproducible scenario)
+
+Then re-gather and re-dispatch.
+
+## Cost discipline
+
+Forensics is the most-expensive skill — Sonnet reasoning + larger context. Use only when:
+- The question genuinely needs multi-event causal analysis
+- The findings library doesn't already answer it
+- The data is already gathered (don't dispatch on incomplete evidence and hope)
+
+For "what" questions, `triage` + `investigate` are cheaper and usually enough.
+
+## What NOT to do here
+
+- **Don't skip the findings recall.** The library exists to make forensics cheaper over time; bypassing it makes every "why" question pay full price.
+- **Don't let the subagent run shell commands.** It's read-only by design. If it asks for more data, gather it yourself and re-dispatch.
+- **Don't summarise the hypothesis in your own words.** Quote it. The tag matters; paraphrasing weakens the signal.
+- **Don't dispatch without standards pointers.** The subagent reasons better with citable ground truth than without.
+
+## See also
+
+- `triage` / `investigate` — gather data BEFORE dispatching to forensics
+- `finding` — capture the forensics result if it reached a confirmed hypothesis
+- `.claude/agents/playback-forensics-expert.md` — the subagent's system prompt + tool allowlist

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: investigate
+description: Deep-dive ONE specific event on a player — pull network log, samples, and player state from a focused time window around the event, then state an explicit hypothesis about cause. Invoke when the user says "investigate the X at Y", "why did Z happen at T", "what was happening around <timestamp>", or after `triage` has surfaced a specific event worth chasing. Output is timeline + evidence + hypothesis tagged confirmed/refuted/needs-test.
+---
+
+# Investigate one event
+
+`triage` finds *what* broke. `investigate` finds *why* — for one specific event at one specific time.
+
+## Inputs you need
+
+- **target** — same resolver shape as `triage` (UUID, prefix, label, IP, UA substring)
+- **event timestamp** — either an explicit ISO time (`2026-05-17 18:29:27`), a clock time (`18:29:27` — assume today UTC), or a relative anchor (`the 262s stall`, in which case re-run triage and pick the matching event)
+
+If the user said "the worst stall" without a time, re-derive: run a quick triage events query, pick the P1 event with the largest duration in info, use its ts.
+
+## The critical idiom
+
+**The SSE never stops if the play is still live.** A query with `from=` / `to=` will return your historical backfill rows AND then keep emitting current rows. If you just `jq` the full output, you'll see today's 23:xx data mixed in with the 18:xx data you asked for. Always:
+
+1. Cap with `timeout`
+2. Extract `data:` lines with `grep + sed`
+3. **Client-side-filter to the actual window with `jq 'select(.ts >= … and .ts <= …)'`**
+
+Skipping step 3 is the single most-common bug investigating a live player.
+
+## Flow
+
+### 1. Pick the window
+
+Default: **60s before, 90s after** the event timestamp. Override:
+- For stalls: pull from 30s before to (event_ts + stall_duration + 30s)
+- For all_failure / restart events: 120s before, 30s after (causes precede effects)
+- For HAR-derived events (http_5xx, request_*): 30s before, 30s after — narrower because there's more data per second
+
+### 2. Pull network log for the window
+
+```sh
+PID=<player-uuid-from-resolver>
+FROM="2026-05-17T18:28:30Z"   # 60s before the event
+TO="2026-05-17T18:30:30Z"     # 90s after, or longer if event has duration
+
+timeout 8 harness --insecure raw GET \
+  "/analytics/api/v2/timeseries?player_id=$PID&streams=network&bundles=network&from=$FROM&to=$TO" 2>/dev/null \
+  | grep '^data: ' | sed 's/^data: //' \
+  | jq -c 'select(.ts >= "2026-05-17 18:28:30" and .ts <= "2026-05-17 18:30:30")' \
+  > /tmp/net.jsonl
+```
+
+(Note: `harness ts`/`tail` don't accept `from`/`to` flags today — use `raw`. The CLI may add typed flags later; check `harness ts --help` first.)
+
+### 3. Pull samples (1Hz) for the same window
+
+```sh
+timeout 8 harness --insecure raw GET \
+  "/analytics/api/v2/timeseries?player_id=$PID&streams=samples&bundles=charts_minimal,lanes_v1&from=$FROM&to=$TO&stride_ms=1000" 2>/dev/null \
+  | grep '^data: ' | sed 's/^data: //' \
+  | jq -c 'select(.ts >= "2026-05-17 18:28:30" and .ts <= "2026-05-17 18:30:30")' \
+  > /tmp/sam.jsonl
+```
+
+`stride_ms=1000` gives one sample per second — enough to see player_state / buffer / bitrate changes without drowning in data.
+
+### 4. Surface the evidence
+
+Four lenses, in this order. Each is one shell pipeline; show output inline as you go.
+
+**(a) Faulted or slow requests during the window**
+
+```sh
+jq -c 'select(.faulted==1 or (.transfer_ms // 0) > 2000) | {ts, request_kind, status, transfer_ms, faulted, fault_type, path: .path[-50:]}' /tmp/net.jsonl
+```
+
+If `fault_type=client_disconnect`+`fault_action=transfer_abandoned` shows up, the player gave up on an in-flight transfer — that's almost always either bandwidth pain or a too-aggressive variant choice.
+
+**(b) Request volume + variants over the window**
+
+```sh
+echo "by request_kind:" ; jq -r .request_kind /tmp/net.jsonl | sort | uniq -c
+echo "by variant:" ; jq -r 'select(.request_kind=="segment") | .path | split("/")[-2]' /tmp/net.jsonl | sort | uniq -c
+```
+
+A burst of one variant followed by silence on it = the player abandoned that ladder. Rapid rotation through 4+ variants = ABR churn.
+
+**(c) Player state + bitrate timeline at 1Hz**
+
+```sh
+jq -r '[.ts, .player_state, .video_resolution, .video_bitrate_mbps, .buffer_depth_s, .last_event] | @tsv' /tmp/sam.jsonl \
+  | awk -F'\t' '{printf "%s  %-10s  %-9s  bw=%-5s  buf=%-5s  %s\n", $1, $2, $3, $4, $5, $6}'
+```
+
+Look for: `player_state` transitions (playing → stalled → buffering), buffer collapse rate (1s/s = normal drain; 10s/s = something other than playback is consuming buffer), unexplained bitrate jumps.
+
+**(d) Was anything injected?**
+
+```sh
+jq -r '[.ts, .nftables_bandwidth_mbps, .nftables_pattern_enabled, .nftables_pattern_rate_runtime_mbps] | @tsv' /tmp/sam.jsonl | uniq
+```
+
+Rules out "operator hosed it" before chasing "the player did something weird".
+
+### 5. State a hypothesis
+
+End the investigation with one explicit paragraph:
+
+```
+Hypothesis: The 262s stall at 18:29:27 was triggered by the player
+abandoning a 14MB 2160p segment that took 23.5s to transfer (xfer
+finished at 18:28:56, fault_type=client_disconnect). After abandon,
+the player downshifted aggressively (29.86 → 1 Mbps in two steps),
+tried to climb back, then crashed again at 18:29:27. During the
+stall the player WAS successfully fetching small segments (audio/540p
+at <10ms) but buffer_end_s did not advance — suggests the player
+couldn't decode them into the play buffer, possibly because of an
+init-segment / variant boundary issue.
+
+Tag: needs-test
+Next step to confirm: re-run the 30 Mbps upshift with `harness
+procedure abr-sweep ipad --rates 30,29.86 --hold 30s` while watching
+`harness events ipad`. If the same client_disconnect → stall pattern
+reproduces, the cause is variant 2160p being too heavy for the
+shaper's current rate cap.
+```
+
+The hypothesis MUST be tagged one of:
+- **confirmed** — evidence directly demonstrates the cause
+- **refuted** — evidence rules out the cause we initially suspected
+- **needs-test** — plausible but not provable from this data alone
+
+`needs-test` is the most-common honest answer. If you can't test it
+right now, suggest the `fault` / `shape` / `procedure` command that
+would reproduce.
+
+## What NOT to do here
+
+- **Don't pull data outside the window** unless you have a specific
+  reason. Bigger windows = more rows = jq pain + harder to spot
+  patterns.
+- **Don't reason without checking the shaper.** "The shaper was on"
+  vs "the shaper was off" is a different investigation every time.
+  Always include step 4(d).
+- **Don't skip step 5.** A timeline without a hypothesis is a wall
+  of text. If you can't form a hypothesis, say so explicitly and
+  list what additional data you'd need.
+
+## Common gotchas
+
+- **Live SSE bleed-through.** Already covered. The single biggest
+  source of confusion when investigating a live player.
+- **`buffer_depth_s = 0` doesn't always mean empty buffer.** iOS
+  AVPlayer often doesn't report this metric — use `buffer_end_s`
+  (which is the playhead position of the most-distant loaded
+  segment) as the truer signal. If `buffer_end_s` isn't advancing,
+  the player isn't ingesting new segments even if it's "fetching"
+  them.
+- **`fault_counters.*` on the player record is server-side counts.**
+  It tells you proxy-applied faults, not player-experienced ones.
+  For player-perceived faults, use the HAR `faulted` field per row.
+- **CH JSON encoding inconsistency.** `bytes_in` arrives as a JSON
+  string, `faulted` arrives as a JSON number. If a jq filter
+  silently returns nothing, check whether you're treating a number
+  as a string (or vice versa). `tonumber` and `tostring` are your
+  friends.
+
+## See also
+
+- `triage` — the menu that points here
+- `forensics` — when "why does this keep happening" needs multi-event
+  causal analysis, dispatch there instead
+- `finding` — once you've nailed the hypothesis, capture it
+- `.claude/standards/avplayer-quirks.md` — iOS-specific reporting
+  gaps and behaviours
+- `.claude/standards/abr-decision-model.md` — why downshift cascades
+  happen

--- a/.claude/skills/shape/SKILL.md
+++ b/.claude/skills/shape/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: shape
+description: Set bandwidth cap, delay, packet loss, or pattern-based ramp on a player session via the harness CLI. Invoke when the user says "throttle to X Mbps", "add N ms delay", "X percent loss", "ramp up over 30s", "drop-and-recover pattern", "shape the network", or otherwise wants kernel-level traffic shaping. This skill handles unit normalisation and routes ramp-style asks to the `abr-sweep` procedure.
+---
+
+# Network shaping via `harness shape` + `harness procedure abr-sweep`
+
+Defaults: target test-dev; snapshot-protected; `harness undo <target>` rolls back any shape change.
+
+## Single static shape
+
+```sh
+harness --insecure shape <target> [--rate Mbps] [--delay ms] [--loss pct]
+```
+
+All three axes default to "don't change". Pass at least one. The CLI sends a merge-patch — fields you omit stay at their current value.
+
+| User says | Command |
+|---|---|
+| "throttle to 1.5 Mbps" | `harness shape ipad --rate 1.5` |
+| "add 100 ms delay" | `harness shape ipad --delay 100` |
+| "5 percent packet loss" | `harness shape ipad --loss 5` |
+| "1 Mbps with 50 ms delay and 1% loss" | `harness shape ipad --rate 1 --delay 50 --loss 1` |
+| "show me what's shaped" | `harness shape ipad --show` |
+| "clear shaping" | `harness shape ipad --clear` |
+
+## Unit normalisation
+
+Same table as `fault`'s — repeated here so this skill is self-contained:
+
+| User says | `--rate` value |
+|---|---|
+| "5mb", "5 megabits", "5 Mbps", "5M" | `5` |
+| "100k", "100 kbps", "100 Kbits" | `0.1` |
+| "1 gig", "1 Gbps" | `1000` |
+
+| User says | `--delay` value |
+|---|---|
+| "100ms" | `100` |
+| "0.1s", "100 milliseconds" | `100` |
+| "1 second" | `1000` |
+
+| User says | `--loss` value |
+|---|---|
+| "5%", "5 percent" | `5` |
+| "half a percent", "0.5%" | `0.5` |
+
+For ambiguous units ("100k") pick the streaming-plausible value (kbps for bandwidth — 0.1 Mbps) and tell the user what you assumed.
+
+## Ramp / pattern shaping → use `procedure abr-sweep`
+
+The `harness shape` command sets one static value. For time-varying patterns ("ramp from 5 to 1 Mbps over 30 seconds", "square wave between 1 and 5 Mbps every 10 seconds"), use the procedure wrapper:
+
+```sh
+harness procedure abr-sweep <target> --rates 5,2,1,0.5 --hold 60s
+```
+
+Holds 5 Mbps for 60s, then 2 Mbps for 60s, then 1, then 0.5. Clears shape on exit / Ctrl-C.
+
+| User says | Command |
+|---|---|
+| "ramp down from 5 to 1 Mbps over 30s" | `harness procedure abr-sweep ipad --rates 5,3,1 --hold 10s` |
+| "step down through the ladder in 20s intervals" | `harness procedure abr-sweep ipad --rates 30,15,7,3,1 --hold 20s` |
+| "drop to 0 then back up to 5 over 2 minutes" | `harness procedure abr-sweep ipad --rates 5,0,2,5 --hold 30s` |
+
+For tighter timing or non-uniform durations, drop down to `harness raw PATCH` with the Shape's `pattern.steps` array directly — see the OpenAPI schema for the structure. This skill defers to `abr-sweep` for the common cases.
+
+## Confirm before destructive
+
+These bork the player visibly — always confirm before running:
+
+- `--rate 0` (bandwidth = 0 → player stalls within seconds)
+- `--loss 100` (100% loss → player sees connection timeouts)
+- `--clear` while a soak / abr-sweep is mid-run (loses the in-flight pattern)
+
+For one-off "I want to break it briefly", prefer `harness procedure abr-sweep --rates 0,5 --hold 10s` over a manual `--rate 0` + `--clear` — the procedure handles cleanup even on Ctrl-C.
+
+## After every change
+
+Verify with `--show`:
+
+```sh
+harness shape ipad --show
+```
+
+The CLI prints the current Shape including any `pattern_rate_runtime_mbps` (the value the kernel is enforcing *right now* if a pattern is active). If the operator's intent was a static rate but you see a non-zero `pattern_step_runtime`, an old pattern is still running — clear it first.
+
+## Common pitfalls
+
+- **Static `--rate` doesn't kill an existing pattern.** If a pattern is active, you have to either `shape --clear` first or send a PATCH with `{"shape":{"pattern":null,"rate_mbps":X}}`. The CLI's `shape --rate` alone is additive over current state.
+- **`shape --show` doesn't include the player's chosen variant.** A 5 Mbps shape + a 30 Mbps player choice = the kernel chokes down to 5 Mbps and the player downshifts as a result. That's the normal interaction; if the operator's confused about "why is bandwidth low", check `harness players show <t>` for the player's perspective.
+- **Transport faults aren't shape's job.** `harness fault add --type connection_refused` (HTTP layer) vs `transport_fault drop` (kernel layer) — different surfaces, different commands. Transport_fault is currently only reachable via `harness raw PATCH` with the shape body (see `fault` skill).
+
+## What NOT to do here
+
+- **Don't combine `--rate 0` with active fault rules.** Both will mask each other and the operator can't tell which is causing the stall. Either-or.
+- **Don't run `abr-sweep` against a player that's also being used for a real test.** The sweep takes exclusive control of the shape; existing shape gets clobbered.
+- **Don't suggest patterns when the user wants a one-off change.** "Throttle to 1 Mbps" = `shape --rate 1`. "Ramp through" = `procedure abr-sweep`. Don't escalate.
+
+## See also
+
+- `fault` — for HTTP/socket faults (shaping is kernel-level; fault is application-level)
+- `triage` / `investigate` — measure what happened after shaping
+- `.claude/standards/abr-decision-model.md` — how the player reacts to a sudden rate cap

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: triage
+description: Quick health check of a player session — pull the current state, recent events bucketed by priority, and surface the 3-6 most-interesting failures with timestamps. Invoke when the user says "triage X", "what's wrong with X", "diagnose X", "how's X doing", or asks for a summary of recent failures on a player. Output is a short report + suggested next skill to invoke; this skill does NOT drill into individual events (use `investigate` for that).
+---
+
+# Triage a player session
+
+Read first: top of the file at `~/.local/bin/harness` is the `harness` CLI. If `which harness` fails, run `make harness-cli` in the repo root.
+
+Goal: in <10 seconds tell the user what's broken on a player session — at the *menu* level, not the *cause* level.
+
+## Inputs
+
+The user asks "triage ipad", "what's wrong with the apple tv", "how's session ee091d13 doing", or similar. The free-form target is anything the resolver accepts: full UUID, ≥6-char hex prefix, label value (`device=ipad`), player IP, or a substring of the User-Agent. **Don't ask the user for a UUID** unless the resolver returns ambiguous.
+
+## Flow
+
+Always do these four steps in order. Stop at step 4 — drilling deeper is `investigate`'s job.
+
+### 1. Resolve + sanity check
+
+```sh
+harness --insecure players show <target> 2>&1 | head -40
+```
+
+Look at: `id`, `last_seen_at`, `current_play.id`, `user_agent`, `player_metrics.player_state`, `player_metrics.last_event`, `player_metrics.player_error`, `fault_counters.*`.
+
+If `last_seen_at` is more than 60 seconds old, the player has disconnected — say so, suggest checking `harness players list` for a live one, and stop.
+
+### 2. Pull recent events
+
+Live SSE — capture ~5 seconds of backfill then bail. The `timeout` here is what makes this fast; don't use a longer one. The grep+sed extracts the SSE payload; the jq filters to operator-relevant events (drops heartbeats and the meta frame).
+
+```sh
+timeout 5 harness --insecure --json ts <target> --streams events --bundles events 2>/dev/null \
+  | jq -c 'select(.type and .priority)' > /tmp/events.jsonl
+```
+
+If the file is empty, the events stream may have failed — check `harness info` and tell the user (don't silently continue with no data).
+
+### 3. Bucket + surface
+
+Count by priority and type, then surface the most-interesting events:
+
+```sh
+echo "=== count by priority (1=critical … 4=low) ==="
+jq -r .priority /tmp/events.jsonl | sort | uniq -c
+
+echo "=== count by type ==="
+jq -r .type /tmp/events.jsonl | sort | uniq -c | sort -rn | head -10
+
+echo "=== P1 events, chronological ==="
+jq -c 'select(.priority==1) | {ts, type, info}' /tmp/events.jsonl | sort
+
+echo "=== P2 events, most-recent first, top 10 ==="
+jq -c 'select(.priority==2) | {ts, type, info}' /tmp/events.jsonl | sort -r | head -10
+```
+
+### 4. Report
+
+Give the user a tight summary in roughly this shape:
+
+```
+ipad (ee091d13)  player_state=playing  buffer=12.3s  last_event=heartbeat  no errors
+
+Last 5 min: 22 critical, 47 high, 2554 medium/low.
+
+Worst recent events:
+  18:29:27  stall 262s     ← user-visible 4-minute freeze
+  18:52:51  stall 91s
+  18:57:03  stall 84s
+  18:59:26  stall 104s
+
+Recent ABR churn: 1109 upshifts, 297 downshifts in window — heavy
+re-evaluation, suggests the player is hovering near a variant
+boundary or repeatedly probing.
+
+Suggested next:
+  /investigate 18:29:27   — deep-dive the worst single event
+  /forensics              — multi-event "why does this keep happening"
+```
+
+8–15 lines total. State the headline fact first ("player is fine" or
+"frequent stalls"). List 3-6 specific events with timestamps. Suggest
+one next skill — don't list every option.
+
+## What NOT to do here
+
+- **Don't pull network or sample data.** That's investigate's job and
+  it's slow. Triage is the menu, not the meal.
+- **Don't speculate about cause.** Surface the symptom, suggest the
+  next skill. The user (or `investigate`) decides what to chase.
+- **Don't filter out P1 events as noise.** Even if "this player
+  always stalls" is true, the operator wants to see it.
+- **Don't suggest `harness fault add` from triage.** Mutation is a
+  separate skill and a separate decision.
+
+## Common pitfalls
+
+- The events SSE keeps streaming live rows after backfill, so without
+  `timeout` the loop never returns. Always cap with `timeout`.
+- `harness ts --insecure` is required on test-dev (self-signed cert).
+  If the user has `HARNESS_INSECURE=1` exported it works without; if
+  not, the `--insecure` flag is needed every time.
+- The "5 minutes" framing assumes the player's been active that long.
+  If `last_seen_at` is younger, just say "last N minutes since
+  player came online" — don't pretend you have 5 min of data.
+
+## See also
+
+- `investigate` — drill into a single event with windowed context
+- `forensics` — multi-event causal analysis via subagent
+- `finding` — capture what triage + investigate taught you

--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -1,0 +1,58 @@
+# Standards library
+
+One-page operationally-relevant cheat sheets per topic. Read by the
+`forensics` subagent before it hypothesises, and by Claude generally
+when investigating a topic mid-session.
+
+## The bar
+
+If I'm reasoning about this topic mid-investigation, **what 3 facts
+would I want quoted to me?** Those facts go in. Anything else doesn't.
+
+Not specs. Not exhaustive. Not aspirational. These are:
+- Things that are true in the real world *and* relevant to debugging
+  this product
+- Especially things that have already bitten us at least once
+- Stated tersely, with concrete platform names where it matters
+  (AVPlayer, ExoPlayer, Roku Stream Player, hls.js, Shaka)
+
+## Format
+
+```markdown
+# <Topic>
+
+One-sentence framing.
+
+## <Fact category 1>
+- Fact. Why it matters. Where we hit it.
+- Fact. …
+
+## <Fact category 2>
+- …
+
+## Common mistakes
+- …
+
+## See also
+- Other standards / findings to read alongside.
+```
+
+Length: one page rendered. If it grows past that, split.
+
+## Current entries
+
+- `hls-taxonomy.md` — m3u8 tags, what each means, what the proxy
+  emits/strips
+- `avplayer-quirks.md` — iOS-specific behaviours (init cache,
+  transfer_abandoned, buffer metric reporting gaps)
+- `abr-decision-model.md` — how a player chooses variants, why
+  downshift cascades, what triggers timejump
+- `codec-strings.md` — avc1/hev1/mp4a profile-level-tier, what
+  platforms require what, common stripping bugs
+
+## When to add a new one
+
+When an investigation kept getting stuck because we didn't know a
+basic fact about a platform / protocol / behaviour, and that fact
+took >10 min to confirm. Write the 3 facts down so the next session
+doesn't pay the cost.

--- a/.claude/standards/abr-decision-model.md
+++ b/.claude/standards/abr-decision-model.md
@@ -1,0 +1,62 @@
+# ABR (Adaptive Bitrate) decision model
+
+How players choose variants, why downshifts cascade, what triggers timejump. Generic across HLS players unless noted.
+
+## The two signals
+
+A player makes ABR decisions from two primary inputs:
+
+1. **Estimated bandwidth** (`network_bitrate_mbps` in samples). Derived from segment transfer times: bytes / transfer_ms. Smoothed via a moving average over recent segments.
+2. **Buffer health** (`buffer_end_s` distance from playhead). The fuller the buffer, the more risk the player is willing to take on a higher variant.
+
+Decision per segment: pick the *highest variant whose declared bandwidth × safety factor* ≤ *estimated bandwidth*, subject to buffer not being below the panic threshold.
+
+Safety factor: typically 0.7-0.9 (player wants headroom). When the buffer is small, it skews lower.
+
+## Why downshifts cascade
+
+A single slow transfer drops the bandwidth estimate. The player picks the next-lower variant. That variant's segments are smaller → transfer faster → bandwidth estimate stabilises or recovers. The player ramps back up *one variant at a time*, with a short hold between each step (typically 1-2s).
+
+But if the cause of the slow transfer was *the segment*, not *the network* (e.g. a 14MB segment from one specific high-bitrate variant), the next variant down is also slow if the bitrate estimate didn't reflect "this one was an outlier". Result: cascade past where the true network capacity is, then long climb back.
+
+## What triggers `timejump`
+
+- **Live-edge snap.** After a stall, if the playhead is now too far behind the live edge, the player jumps forward (skipping content).
+- **Seek operation.** User-initiated or programmatic. Rare in our test harness (no user controls).
+- **Variant reset.** When the master playlist changes (variant URLs added/removed), some players re-establish from scratch and that can manifest as a timejump.
+
+A `timejump` between `buffering_start` and `buffering_end` is normal stall recovery. A standalone `timejump` (no surrounding buffer events) is unusual — investigate.
+
+## What triggers `restart`
+
+- Player explicitly tore down the AVPlayer instance and built a new one. Usually app-level (user navigated away and back) or recovery-from-fatal-error.
+- After `restart`, `playback_start` fires when the new instance has its first decoded frame.
+- A restart cluster (multiple restarts in <30s) suggests the player is in an unrecoverable state and the app/operator is repeatedly retrying.
+
+## Variant ladder vs effective ladder
+
+The master playlist declares N variants (`#EXT-X-STREAM-INF`). The player's *effective* ladder is the subset it'll actually consider:
+
+- AVPlayer respects declared BANDWIDTH; if it's lying (e.g. proxy stripped AVERAGE-BANDWIDTH and BANDWIDTH is over-declared), the player will probe high variants and burn segments.
+- Some players cap at the highest variant their display can render. Apple TV 4K considers 2160p; iPad considers up to its panel resolution (1366×1024 for non-Pros — they won't pick 2160p on wifi typically).
+- Codec strings matter: a variant declared with `hev1.*` won't be chosen by a player lacking HEVC. See `.claude/standards/codec-strings.md`.
+
+## ABR aggression knobs we control
+
+The harness has two switches that change ABR behaviour:
+
+- **`shape --rate X`** caps the kernel rate. Player's bandwidth estimate falls; player downshifts. Use for forcing a specific variant.
+- **`content --overstate-bandwidth`** inflates BANDWIDTH attribute by 10% in the master. Player picks higher variants for a given network estimate; useful to provoke a stall.
+- **`content --strip-average-bandwidth`** removes AVERAGE-BANDWIDTH; some players fall back to BANDWIDTH which is the per-variant max not average → over-estimation.
+
+## Common mistakes when interpreting ABR data
+
+- Reading `video_bitrate_mbps` as "the player's network choice" — it's the variant's *declared* bandwidth, not what the player measured.
+- Comparing `video_bitrate_mbps` to `nftables_pattern_rate_runtime_mbps` and concluding "shaper isn't throttling". The shaper sets the kernel cap; the variant choice reflects the player's estimate from previous segment transfers, which may lag the shaper change by 5-30 seconds.
+- Treating a downshift as a bug. Downshifts are correct ABR behaviour; cascades into stalls are the bug.
+
+## See also
+
+- `.claude/standards/avplayer-quirks.md` — Apple-specific ABR aggression
+- `.claude/standards/codec-strings.md` — variant-eligibility by codec
+- `.claude/findings/ipad-262s-stall-2026-05-17.md` — abandon → cascade → stall

--- a/.claude/standards/avplayer-quirks.md
+++ b/.claude/standards/avplayer-quirks.md
@@ -1,0 +1,51 @@
+# AVPlayer (iOS / iPadOS / tvOS) quirks
+
+What the Apple HLS stack does differently from the spec — facts we've actually hit while debugging.
+
+## Reporting gaps
+
+- **`buffer_depth_s` is often 0 even during normal playback.** AVPlayer doesn't reliably expose a "seconds of buffer ahead of playhead" metric. Use `buffer_end_s` (most-distant loaded segment position) as the truer signal: if it doesn't advance, the player isn't ingesting new data, regardless of what `buffer_depth_s` says.
+- **`frames_displayed` is always 0 for HLS.** `AVAssetTrack.nominalFrameRate` returns 0 for HLS variants — there's no frame-count surface to report. Tracked in #147 (we read FRAME-RATE from the master playlist to fill this in). Don't use frames_displayed as a liveness signal on iOS.
+- **`stall_count` only counts `stall_start` events the player emitted explicitly.** It does NOT include the implicit stalls from `(frozen)` or `(segment)` taxonomy events — those come from server-side inference, not player notifications.
+
+## Transfer abandonment
+
+- **AVPlayer abandons in-flight segment transfers when it decides the segment is no longer wanted** (e.g. after an ABR rate-shift). The server logs this as `fault_type=client_disconnect`, `fault_action=transfer_abandoned`.
+- The decision threshold is roughly: if a segment is taking longer than the available buffer + 2 seconds, abandon. So a 14MB 2160p segment + a 12s buffer + slow transfer = abandon at ~14s.
+- After abandonment, the player will aggressively downshift (often skipping multiple rungs of the ladder).
+
+## ABR aggression by network type
+
+- On wifi: conservative ramp-up after a stall (1 → 1.84 → 3.46 → 7 → 15 → 30 over ~12s).
+- On 5G cellular: more aggressive ramp-up and more willing to attempt 2160p without sustained probing.
+- On wired (Apple TV ethernet): least aggressive — tends to stick with the chosen variant for ~30s after a transition.
+
+## Init segment caching
+
+- AVPlayer caches init segments in the AVAsset cache. Once fetched for a variant, the init is not re-fetched on subsequent rotations to that variant within the play.
+- Operator implication: when an investigation shows segments being fetched but `buffer_end_s` not advancing, it's NOT usually an init-segment issue (cache has it). More likely: variant-boundary issue or decoder-level rejection.
+- Exception: if the master playlist changes mid-play (e.g. variant URLs rotate), AVPlayer treats it as a new asset and clears the init cache.
+
+## Loop & timejump
+
+- AVPlayer emits `timejump` when the playhead moves non-linearly (seek, live-edge-snap, recovery from stall).
+- A `buffering_start` immediately followed by a `timejump` and then a `buffering_end` is the player skipping forward to the live edge after a stall. This is normal recovery, not a fault.
+- If the player emits `timejump` without a preceding `buffering_start`, it's an unsolicited seek — investigate.
+
+## State-machine peculiarities
+
+- `player_state=playing` is reported even during multi-second underruns; AVPlayer's "stalled" state is only entered after a longer threshold. Use `buffer_end_s` + `last_event` together for ground truth, not `player_state` alone.
+- `player_state=stalled` does NOT immediately stop network requests — AVPlayer keeps fetching segments during stalls (usually at a lower variant). See the iPad 262s-stall finding.
+
+## Common mistakes when reading iPad data
+
+- Trusting `buffer_depth_s` instead of `buffer_end_s`.
+- Assuming `player_state=playing` means playback is healthy.
+- Assuming a `stall` event with `info=(frozen)` came from the player (it's server-inferred).
+- Not accounting for init-cache when seeing "no init segment fetched after variant rotation".
+
+## See also
+
+- `.claude/standards/abr-decision-model.md` — Apple's rate-shift heuristic
+- `.claude/findings/ipad-262s-stall-2026-05-17.md` — canonical abandon-cascade-stall case
+- `.claude/standards/hls-taxonomy.md` — what last_event values mean

--- a/.claude/standards/codec-strings.md
+++ b/.claude/standards/codec-strings.md
@@ -1,0 +1,70 @@
+# Codec strings — `CODECS=` formatting + platform requirements
+
+The `CODECS` attribute on a `#EXT-X-STREAM-INF` line tells the player what decoder it'll need. Get this wrong and a variant is silently skipped on the platform that should support it.
+
+## The format
+
+```
+CODECS="<video>,<audio>"
+```
+
+Most common values:
+
+| String | Meaning | Notes |
+|---|---|---|
+| `avc1.640028` | H.264 High profile, level 4.0 | Universally supported. |
+| `avc1.4d401f` | H.264 Main profile, level 3.1 | Lower-tier compat. |
+| `hev1.1.6.L120.90` | HEVC (H.265) Main profile, level 4.0 | iOS 11+ / tvOS 11+ / Android 5+ |
+| `hvc1.1.6.L120.90` | Same as `hev1.*` but with a different sample-entry-format | Apple platforms prefer `hvc1`; some non-Apple players only accept `hev1`. |
+| `mp4a.40.2` | AAC-LC | Universal. |
+| `mp4a.40.5` | HE-AAC v1 | Lower bitrate. |
+| `mp4a.40.29` | HE-AAC v2 | Lower still. |
+| `ac-3` / `ec-3` | AC-3 / E-AC-3 (Dolby Digital / Digital Plus) | Platform-specific. |
+
+## Decoding the suffix
+
+For `avc1`: `<profile><constraint><level>` in hex. `64=High`, `4D=Main`, `42=Baseline`. Level `28=4.0`, `1F=3.1`.
+
+For `hev1` / `hvc1`: `<profile_space>.<profile_idc>.<compatibility>.L<level>.<constraint>`. Don't try to decode these by eye — copy from a working manifest.
+
+## Platform requirements (the parts we've actually hit)
+
+| Platform | Notes |
+|---|---|
+| AVPlayer (iOS/iPadOS/tvOS) | Prefers `hvc1.*` for HEVC. Will accept `hev1.*` but with some compatibility quirks on older iOS. Requires CODECS to be present — bare BANDWIDTH is silently ignored as "not playable". |
+| ExoPlayer (Android TV / Google TV) | Accepts both `hev1.*` and `hvc1.*`. Tolerant of missing CODECS (probes the segment). |
+| Roku Stream Player | Strict on CODECS strings — case-sensitive, exact-match. Roku-specific compat layer rejects some valid strings. |
+| hls.js (browser) | Probes via MediaSource feature detection; CODECS is informational only. |
+| Shaka Player | Same as hls.js. |
+
+## Common stripping bugs (proxy)
+
+The proxy's `content --strip-codecs` removes the `CODECS=` attribute entirely. After strip:
+
+- **AVPlayer**: variant becomes ineligible. Player picks only variants that still have CODECS.
+- **ExoPlayer / hls.js / Shaka**: variant remains eligible (these tolerate missing CODECS).
+- **Roku**: variant becomes ineligible.
+
+Operator implication: if you `content --strip-codecs` on a master that has all variants with HEVC, AVPlayer will refuse the whole asset. Use selectively (strip on lower variants, leave HEVC ones).
+
+## Variant-eligibility chain
+
+A variant is eligible for selection iff:
+
+1. Its CODECS string is parseable and supported by the player.
+2. Its BANDWIDTH is below the player's current estimate × safety factor.
+3. Its RESOLUTION is below or at the player's display cap (AVPlayer is strict; some Android implementations aren't).
+4. The variant's playlist hasn't 404'd.
+
+Each step filters the set. A common confusion: "why isn't AVPlayer picking the 2160p variant?" Answer is usually #1 (HEVC stripped) or #3 (iPad has 1366×1024 panel, won't pick 2160p typically).
+
+## Common mistakes when reading manifest issues
+
+- Assuming all players accept all codec strings the same way. Apple is strict; Roku is stricter.
+- Stripping CODECS to "test ABR" — it doesn't just hide info, it makes Apple-side variants unplayable.
+- Reading a strange variant choice and concluding "ABR is broken" without checking codec eligibility first.
+
+## See also
+
+- `.claude/standards/hls-taxonomy.md` — manifest tag reference
+- `.claude/standards/abr-decision-model.md` — how the eligibility-filtered set is then ranked

--- a/.claude/standards/hls-taxonomy.md
+++ b/.claude/standards/hls-taxonomy.md
@@ -1,0 +1,77 @@
+# HLS taxonomy — what each tag/event means, what the proxy does
+
+Concise reference for the m3u8 tags that show up in our manifests, plus the event-type taxonomy the forwarder emits at `/api/v2/timeseries?streams=events`.
+
+## Master playlist tags
+
+| Tag | Meaning | Notes / proxy behaviour |
+|---|---|---|
+| `#EXTM3U` | Mandatory first line. Identifies the file as an m3u8 playlist. |
+| `#EXT-X-VERSION:N` | Min playlist version required by features in this file. AVPlayer may refuse playlists with `VERSION > 9`. |
+| `#EXT-X-STREAM-INF:BANDWIDTH=X,RESOLUTION=WxH,CODECS="..."` | Declares one variant. Followed by the variant URL on the next line. |
+| `AVERAGE-BANDWIDTH=X` | Average over the duration; preferred for ABR estimation. Proxy can strip via `content --strip-average-bandwidth`. |
+| `CODECS="avc1.X,mp4a.X"` | Required for a player to pre-filter unsupported variants. Proxy can strip via `content --strip-codecs`. |
+| `FRAME-RATE=N` | We parse this for the iOS `frames_displayed` fix (#147). |
+| `#EXT-X-MEDIA:TYPE=AUDIO,...` | Audio rendition group. Each variant references one. |
+
+## Media (variant) playlist tags
+
+| Tag | Meaning |
+|---|---|
+| `#EXT-X-TARGETDURATION:N` | Max segment duration. Players use this to size their fetch ahead. |
+| `#EXT-X-MEDIA-SEQUENCE:N` | First segment's sequence number in this playlist. Increments as the live edge advances. |
+| `#EXT-X-MAP:URI="init.mp4"` | Init segment for fMP4 variants. Required before any media segment can be decoded. AVPlayer caches the init per variant. |
+| `#EXTINF:duration,` | One segment header, with duration. Followed by segment URL on next line. |
+| `#EXT-X-PART:DURATION=N,URI="..."` | LL-HLS partial segment. Lower latency at the cost of more requests. |
+| `#EXT-X-PRELOAD-HINT:TYPE=PART,URI="..."` | Tells the player to start fetching the next partial before it's announced. |
+| `#EXT-X-DISCONTINUITY` | Boundary between non-contiguous segments (e.g. across a loop boundary). Players reset the decoder. |
+| `#EXT-X-ENDLIST` | This is a VOD playlist; no more segments coming. We never emit this — all our streams are live. |
+
+## Request kinds (proxy classifier)
+
+The proxy classifies each request into one `request_kind`:
+
+| Kind | What it is | Common faults applied |
+|---|---|---|
+| `master_manifest` | The top-level m3u8 (master playlist). | `404` → player can't play anything. `corrupted` not valid (master-only). |
+| `manifest` | A variant media playlist. | `404` → that variant unavailable; player falls back. |
+| `audio_manifest` | Audio rendition playlist. | Same as manifest. |
+| `init` | `init.mp4` for fMP4 variants. | `corrupted` is segment-only; init faults manifest as decoder errors. |
+| `segment` | Regular video media segment. | All fault types valid. |
+| `audio_segment` | Regular audio media segment. | |
+| `partial` | LL-HLS partial. Higher rate than `segment`. | |
+
+## Event taxonomy (forwarder-derived)
+
+These are what `harness ts --streams events` emits. Priority 1=critical → 4=low.
+
+| Type | Priority | Kind | Meaning |
+|---|---|---|---|
+| `error` | 1 | effect | Player emitted an error. `info` has the player_error string. |
+| `master_manifest_failure` | 1 | cause | Counter incremented on a master_manifest fault. Breaks playback. |
+| `all_failure` | 1 | cause | Counter incremented when the catch-all `--kind` filter fired. |
+| `stall` (≥3s) | 1 | effect | Paired stall_start→stall_end with duration. |
+| `stall` (<3s) | 2 | effect | Same but shorter. |
+| `stall` (`info=(frozen)`) | 2 | effect | Inferred from `last_event=frozen` — no explicit end. |
+| `stall` (`info=(segment)`) | 2 | effect | Inferred from `last_event=segment_stall`. |
+| `restart` | 2 | effect | Player tore down + rebuilt. |
+| `transport_failure` | 3 | cause | nftables drop/reject increment. |
+| `manifest_failure` / `segment_failure` | 3 | cause | Per-kind counter increment. |
+| `transfer_active_timeout` / `transfer_idle_timeout` | 3 | cause | Server-side transfer timeout fired. |
+| `fault_on` / `fault_off` | 3 | cause | Transport_fault_active transitioned. |
+| `downshift` / `timejump` / `buffering` | 3 | effect | Player behaviour. |
+| `http_5xx` / `request_timeout` | 2 | cause | HAR-derived. Real failures that often precede stalls. |
+| `http_4xx` / `request_incomplete` / `request_faulted` | 3 | cause | HAR-derived. |
+| `slow_request` (>2s wait) / `slow_segment` (>6s transfer) | 3 | cause | HAR-derived. |
+| `request_retry` (same URL refetched <4s) | 4 | cause | HAR-derived. Often noise. |
+| `upshift` / `playback_start` | 4 | effect | Routine player behaviour. |
+| `loop_server` | 4 | cause | Source content rotated back to start. Routine in our platform. |
+| `user_marked` | 1 | effect | Operator pressed the iOS "911" button (always P1). |
+
+`kind=cause` means proxy/system action; `kind=effect` means user-visible / player-emitted.
+
+## See also
+
+- `.claude/standards/avplayer-quirks.md` — how AVPlayer reacts to specific manifest features
+- `.claude/standards/codec-strings.md` — what codec strings each platform requires
+- forwarder `events_query.go` — the SQL that derives this taxonomy


### PR DESCRIPTION
## Summary

Closes #437.

Skills layer on top of the harness CLI (PR #467) — six SKILL.md files + a Sonnet forensics subagent + two seed libraries. Turns prose ("triage ipad", "drop a 404 every 5s", "why does this keep stalling") into the right `harness` invocations, with disambiguation tables for the ambiguous phrases that bit us in the old curl-based attempt.

When the harness CLI landed, every recipe in this layer collapsed from a 10-line curl + state-file dance to a 1-line typed CLI call. That left the skills with a clearer job: **flow, disambiguation, and cross-references** rather than execution.

## What's in the PR

```
.claude/
├── skills/             (six SKILL.md files, all <180 lines)
│   ├── triage/         entry: health snapshot + event triage
│   ├── investigate/    single-event deep dive (60s before / 90s after)
│   ├── fault/          HTTP/socket fault injection w/ disambiguation tables
│   ├── shape/          bandwidth/delay/loss + procedure abr-sweep ramp
│   ├── finding/        capture (md + JSON sidecar via `harness finding add`) + recall
│   └── forensics/      multi-event "why" → dispatches to subagent
├── agents/
│   └── playback-forensics-expert.md   Sonnet, read-only, primed
├── findings/
│   ├── README.md       format + when-to-add bar
│   └── ipad-262s-stall-2026-05-17.md  canonical seed from today's live investigation
└── standards/
    ├── README.md       one-page-max bar
    ├── avplayer-quirks.md     iOS reporting gaps + transfer_abandoned + init caching
    ├── abr-decision-model.md  how variant choice + downshift cascades work
    ├── hls-taxonomy.md        manifest tags + the full event taxonomy table
    └── codec-strings.md       avc1/hev1/mp4a + platform requirements
```

1,483 lines total. All cross-references between files resolve.

## Why a subagent for forensics

Causal reasoning about HLS/AVPlayer/ABR needs domain knowledge primed in the system prompt. Doing it in the main session means re-explaining the streaming model every "why" question. The `playback-forensics-expert` subagent is Sonnet, read-only (Read/Grep/Glob only — no Bash/Edit), and has a mandatory output format (hypothesis tagged `confirmed`/`refuted`/`needs-test` + minimum evidence + suggested next harness command). Main session stays cheap; the expensive reasoning is one focused call.

## Preserved from the shelved prior attempt

Per the plan, three disambiguation tables from `smashing-claude-skills-437/.claude/skills/session-control/SKILL.md` were preserved verbatim and retargeted from `curl` to `harness` flags:

- **"drop"** — 404 vs transport vs socket vs delete-session
- **"every / per / 1-in"** — `--mode requests` vs `--mode seconds` vs `failures_per_seconds`
- **"kill the network"** — four distinct options, never guess
- **reset / clear / undo** — three different verbs, three different commands
- **number/unit normalisation** — Mbps/Kbits/ms/% canonical forms

These rows encode bugs the operator has lived through. Don't rewrite — port.

## Why the iPad-262s-stall seed finding

To anchor the format of `.claude/findings/*.md`, the canonical example is the live investigation we just did during the CLI demo (the 4-minute frozen video traced to a 14MB 2160p segment abandonment cascading into a multi-rung downshift). It demonstrates:

- The expected Summary/Timeline/Evidence/Hypothesis/Action-items sections
- The `needs-test` tag (most-common honest answer)
- The cross-reference back to `.claude/standards/avplayer-quirks.md`
- The harness command that would confirm or refute

Future findings should mirror its density and explicit tagging.

## Test plan

Skills are loaded at session start, so verification requires a Claude Code restart after merge.

- [ ] After merge: restart Claude Code in this repo, type `/triage ipad`. Expect: resolves target, pulls events, surfaces 3-6 P1/P2 events, suggests next skill. <10s.
- [ ] `/investigate <ts>` against a recent event. Expect: windowed pull, faulted-request surfacing, state timeline, tagged hypothesis. <30s.
- [ ] `/fault ipad "drop a 404 every 5s on segments"`. Expect: parses → `harness fault add ipad --type 404 --kind segment --frequency 5 --mode seconds`; confirms.
- [ ] `/finding "smoke test"`. Expect: sibling .md written + `harness finding add` JSON sidecar.
- [ ] `/forensics "why does the iPad keep stalling on 2160p segments"`. Expect: finds + cites the seed finding; dispatches subagent; returns tagged hypothesis.
- [ ] `grep -li stall .claude/findings/*.md` returns the seed finding.
- [ ] `wc -l .claude/standards/*.md` — each file ≤80 lines (the "one page" bar).

## Dependencies

- The harness CLI (`~/.local/bin/harness`) must be installed. `make harness-cli` after the CLI PR (#467) lands.
- The events stream depends on the forwarder change in PR #466 (without it, `harness ts --streams events` returns 501 and the `triage` skill degrades to a player-state snapshot only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)