### PR TITLE
refactor(#478): retire v1 archive API + TanStack plays surface

### DIFF
--- a/analytics/go-forwarder/bundle.go
+++ b/analytics/go-forwarder/bundle.go
@@ -147,7 +147,7 @@ func safeFilenameSegment(s string) string {
 }
 
 // session.json — at-a-glance summary that opens first. Reuses the
-// /api/sessions per-play row plus a couple of derived fields the picker
+// /api/v2/plays per-play row plus a couple of derived fields the picker
 // already computes, so the bundle reads naturally next to a screenshot
 // of the picker row.
 func writeSessionMetadata(ctx context.Context, zw *zip.Writer, cfg config, sessionID, playID string) error {

--- a/analytics/go-forwarder/classification.go
+++ b/analytics/go-forwarder/classification.go
@@ -153,6 +153,60 @@ func reclassifySession(ctx context.Context, cfg config, sessionID, playID string
 	return setClassification(ctx, cfg, sessionID, playID, target, force)
 }
 
+// reclassifyPlay is the play-scoped twin of reclassifySession: same
+// auto-classifier predicate, but the WHERE clause keys on play_id
+// alone (no session_id). Used by PATCH /api/v2/plays/{id}, where the
+// caller has a play_id but no session_id.
+func reclassifyPlay(ctx context.Context, cfg config, playID string, force bool) error {
+	if playID == "" {
+		return errors.New("play id required")
+	}
+	probe := fmt.Sprintf(`
+		SELECT count() FROM %s.%s
+		WHERE play_id = {play:String}
+		  AND last_event IN ('user_marked', 'frozen', 'segment_stall', 'restart', 'error')
+		FORMAT TSV`, cfg.chDatabase, cfg.chTable)
+	body, err := chQueryBytes(ctx, cfg, probe, map[string]string{"play": playID})
+	if err != nil {
+		return fmt.Errorf("auto-classifier probe: %w", err)
+	}
+	target := "other"
+	if c := strings.TrimSpace(string(body)); c != "" && c != "0" {
+		target = "interesting"
+	}
+	return setPlayClassification(ctx, cfg, playID, target, force)
+}
+
+// setPlayClassification is the play-scoped twin of setClassification.
+// Same three-table ALTER UPDATE pattern but keyed on play_id only, so
+// the v2 PATCH endpoint doesn't have to round-trip the session_id.
+func setPlayClassification(ctx context.Context, cfg config, playID, value string, force bool) error {
+	if playID == "" {
+		return errors.New("play id required")
+	}
+	whereSafe := "WHERE play_id = {play:String}"
+	if !force {
+		whereSafe += " AND classification != 'favourite'"
+	}
+	params := map[string]string{"play": playID, "cls": value}
+	updates := []struct {
+		label string
+		query string
+	}{
+		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s", cfg.chDatabase, cfg.chTable, whereSafe)},
+		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
+		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
+	}
+	for _, u := range updates {
+		if _, err := chQueryBytes(ctx, cfg, u.query, params); err != nil {
+			log.Printf("ALTER UPDATE classification table=%s pid=%s value=%s err=%v",
+				u.label, playID, value, err)
+			return fmt.Errorf("ALTER UPDATE classification on %s: %w", u.label, err)
+		}
+	}
+	return nil
+}
+
 // setClassification writes `value` to every row of (session_id,
 // play_id) in both data tables via parallel ALTER UPDATE statements.
 // When `force=false`, doesn't overwrite an existing 'favourite' (the
@@ -196,107 +250,6 @@ func setClassification(ctx context.Context, cfg config, sessionID, playID, value
 		}
 	}
 	return nil
-}
-
-// registerClassificationHandlers wires up the star / unstar / reclassify
-// endpoints. URLs:
-//
-//   POST   /api/sessions/{session_id}/{play_id}/star
-//   DELETE /api/sessions/{session_id}/{play_id}/star
-//   POST   /api/sessions/{session_id}/{play_id}/reclassify
-//
-// `play_id` in the URL accepts the sentinel `—` for rows ingested
-// before the proxy stamped play_id (the picker uses the same
-// sentinel everywhere).
-//
-// We use net/http path parsing rather than gorilla/mux because the
-// rest of the forwarder is mux-free; small enough to roll our own.
-func registerClassificationHandlers(mux *http.ServeMux, cfg config) {
-	mux.HandleFunc("/api/sessions/", func(w http.ResponseWriter, r *http.Request) {
-		// Paths handled here:
-		//   /api/sessions/{sid}/{pid}/star
-		//   /api/sessions/{sid}/{pid}/reclassify
-		// Anything else under /api/sessions/ is delegated to the
-		// existing /api/sessions handler via 404.
-		path := strings.TrimPrefix(r.URL.Path, "/api/sessions/")
-		parts := strings.Split(path, "/")
-		if len(parts) != 3 {
-			http.NotFound(w, r)
-			return
-		}
-		sessionID := parts[0]
-		playID := parts[1]
-		action := parts[2]
-		if playID == "—" {
-			playID = ""
-		}
-		// Canonicalise — ClickHouse stores lowercase UUIDs; an
-		// uppercase URL segment would silently match no rows.
-		// See canonicalV2ID() doc.
-		playID = canonicalV2ID(playID)
-		if sessionID == "" {
-			http.Error(w, "session id required", http.StatusBadRequest)
-			return
-		}
-		switch action {
-		case "star":
-			handleStar(w, r, cfg, sessionID, playID)
-		case "reclassify":
-			handleReclassify(w, r, cfg, sessionID, playID)
-		default:
-			http.NotFound(w, r)
-		}
-	})
-}
-
-func handleStar(w http.ResponseWriter, r *http.Request, cfg config, sessionID, playID string) {
-	switch r.Method {
-	case http.MethodPost:
-		if err := setClassification(r.Context(), cfg, sessionID, playID, "favourite", true); err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-		writeJSON(w, map[string]any{
-			"session_id":     sessionID,
-			"play_id":        playID,
-			"classification": "favourite",
-		})
-	case http.MethodDelete:
-		// Unstar = drop back to whatever the auto-classifier would
-		// say. force=true so we override the current 'favourite'.
-		if err := reclassifySession(r.Context(), cfg, sessionID, playID, true); err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-		writeJSON(w, map[string]any{
-			"session_id": sessionID,
-			"play_id":    playID,
-			"unstarred":  true,
-		})
-	default:
-		w.Header().Set("Allow", "POST, DELETE")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-	}
-}
-
-func handleReclassify(w http.ResponseWriter, r *http.Request, cfg config, sessionID, playID string) {
-	if r.Method != http.MethodPost {
-		w.Header().Set("Allow", "POST")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	// force=false so a session that's currently 'favourite' stays
-	// 'favourite' — explicit user intent always wins over the
-	// auto-classifier.
-	if err := reclassifySession(r.Context(), cfg, sessionID, playID, false); err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
-		return
-	}
-	writeJSON(w, map[string]any{
-		"session_id":   sessionID,
-		"play_id":      playID,
-		"reclassified": true,
-	})
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/analytics/go-forwarder/classification.go
+++ b/analytics/go-forwarder/classification.go
@@ -180,6 +180,14 @@ func reclassifyPlay(ctx context.Context, cfg config, playID string, force bool) 
 // setPlayClassification is the play-scoped twin of setClassification.
 // Same three-table ALTER UPDATE pattern but keyed on play_id only, so
 // the v2 PATCH endpoint doesn't have to round-trip the session_id.
+//
+// `SETTINGS mutations_sync = 2` makes the ALTER UPDATE wait for the
+// mutation to be applied before returning. Without this CH's default
+// (mutations_sync = 0) returns immediately and the SELECT v2PlayPatchHandler
+// runs right after still reads the pre-mutation classification — the PATCH
+// response then carries a stale value and the dashboard's optimistic flip
+// visibly reverts before the next 5s refetch reconciles. Per-play volumes
+// are tiny so the wait is sub-second in practice.
 func setPlayClassification(ctx context.Context, cfg config, playID, value string, force bool) error {
 	if playID == "" {
 		return errors.New("play id required")
@@ -189,13 +197,14 @@ func setPlayClassification(ctx context.Context, cfg config, playID, value string
 		whereSafe += " AND classification != 'favourite'"
 	}
 	params := map[string]string{"play": playID, "cls": value}
+	const syncSuffix = " SETTINGS mutations_sync = 2"
 	updates := []struct {
 		label string
 		query string
 	}{
-		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s", cfg.chDatabase, cfg.chTable, whereSafe)},
-		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
-		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
+		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, cfg.chTable, whereSafe)},
+		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, whereSafe)},
+		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, whereSafe)},
 	}
 	for _, u := range updates {
 		if _, err := chQueryBytes(ctx, cfg, u.query, params); err != nil {

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -1123,40 +1123,6 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 				cfg.chDatabase, where)
 		proxyClickHouseJSON(w, r, cfg, query, params)
 	})
-	mux.HandleFunc("/api/snapshot_count", func(w http.ResponseWriter, r *http.Request) {
-		session := r.URL.Query().Get("session")
-		if session == "" {
-			http.Error(w, "missing session", http.StatusBadRequest)
-			return
-		}
-		params := map[string]string{"session": session}
-		clauses := []string{"session_id = {session:String}"}
-		if v := r.URL.Query().Get("play_id"); v != "" {
-			if v == "—" {
-				clauses = append(clauses, "play_id = ''")
-			} else {
-				clauses = append(clauses, "play_id = {play:String}")
-				params["play"] = canonicalV2ID(v)
-			}
-		}
-		if v := r.URL.Query().Get("from"); v != "" {
-			clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
-			params["from"] = v
-		}
-		if v := r.URL.Query().Get("to"); v != "" {
-			clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
-			params["to"] = v
-		}
-		query := fmt.Sprintf(`
-			SELECT
-			  count() AS count,
-			  toString(min(ts)) AS first_ts,
-			  toString(max(ts)) AS last_ts
-			FROM %s.%s
-			WHERE %s
-			FORMAT JSONEachRow`, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "))
-		proxyClickHouseJSON(w, r, cfg, query, params)
-	})
 	mux.HandleFunc("/api/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		session := r.URL.Query().Get("session")
 		if session == "" {
@@ -1327,88 +1293,6 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	// events now live as `labels[]` on session_events / network_requests
 	// rows and as discrete rows on control_events; consumers iterate
 	// those three tables instead of the derived markers table.
-
-	// Per-request HAR-style log for the session-viewer's network log
-	// fold. Returns rows in the same shape the live go-proxy endpoint
-	// emits ({entries: [...]}) so the existing UI code can consume it
-	// without modification.
-	mux.HandleFunc("/api/network_requests", func(w http.ResponseWriter, r *http.Request) {
-		session := r.URL.Query().Get("session")
-		if session == "" {
-			http.Error(w, "missing session", http.StatusBadRequest)
-			return
-		}
-		params := map[string]string{"session": session}
-		clauses := []string{"session_id = {session:String}"}
-		if v := r.URL.Query().Get("play_id"); v != "" {
-			if v == "—" {
-				clauses = append(clauses, "play_id = ''")
-			} else {
-				clauses = append(clauses, "play_id = {play:String}")
-				params["play"] = canonicalV2ID(v)
-			}
-		}
-		if v := r.URL.Query().Get("from"); v != "" {
-			clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
-			params["from"] = v
-		}
-		if v := r.URL.Query().Get("to"); v != "" {
-			clauses = append(clauses, "ts <= parseDateTime64BestEffort({to:String})")
-			params["to"] = v
-		}
-		limit := 50000
-		if v := r.URL.Query().Get("limit"); v != "" {
-			var n int
-			if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 50000 {
-				limit = n
-			}
-		}
-		// Wrap the rows into the {entries:[...]} envelope go-proxy
-		// returns so the browser code can be source-agnostic. We let
-		// ClickHouse build the JSON via JSONObjectEachRow + manual
-		// envelope rather than a string concat in Go (cheaper, fewer
-		// escapes, and the formatter handles types).
-		query := fmt.Sprintf(`
-			SELECT
-			  toString(ts) AS timestamp,
-			  method, url, upstream_url, path, request_kind AS request_kind,
-			  status, bytes_in, bytes_out, content_type, play_id,
-			  request_range, response_content_range,
-			  dns_ms, connect_ms, tls_ms, ttfb_ms, transfer_ms, total_ms, client_wait_ms,
-			  faulted = 1 AS faulted, fault_type, fault_action, fault_category,
-			  request_headers, response_headers, query_string
-			FROM %s.network_requests
-			WHERE %s
-			ORDER BY ts ASC
-			LIMIT %d
-			FORMAT JSONEachRow`, cfg.chDatabase, strings.Join(clauses, " AND "), limit)
-		// We can't directly stream JSONEachRow as the {entries:[...]}
-		// envelope without rewriting the body. Buffer + assemble.
-		body, err := chQueryBytes(r.Context(), cfg, query, params)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Cache-Control", "no-store")
-		w.Write([]byte(`{"entries":[`))
-		first := true
-		for _, line := range bytes.Split(body, []byte("\n")) {
-			if len(line) == 0 {
-				continue
-			}
-			// Each line is one JSONObject; strings stored as JSON-encoded
-			// header arrays need to be re-parsed so the consumer sees
-			// real arrays rather than escaped strings. Cheap trick: a
-			// post-pass per row.
-			if !first {
-				w.Write([]byte(","))
-			}
-			w.Write(reinflateNetRowJSON(line))
-			first = false
-		}
-		w.Write([]byte("]}"))
-	})
 
 	// /api/session_bundle — ZIP of snapshots + HAR + events for one
 	// (session_id, play_id). Defined in bundle.go.

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -932,9 +932,10 @@ func insert(ctx context.Context, cfg config, rows []row) error {
 // serveHTTP runs the read-only query API. nginx proxies /analytics/api/*
 // here, so the browser never talks to ClickHouse directly. Endpoints:
 //
-//	GET /api/sessions?since=<rfc3339>
-//	GET /api/snapshots?session=<id>&from=<rfc3339>&to=<rfc3339>&limit=<n>
-//	GET /healthz
+//	GET   /api/v2/plays?from=<rfc3339>&to=<rfc3339>&limit=<n>
+//	PATCH /api/v2/plays/{play_id}     {classification: favourite|interesting|other|auto}
+//	GET   /api/snapshots?session=<id>&from=<rfc3339>&to=<rfc3339>&limit=<n>
+//	GET   /healthz
 func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -942,187 +943,6 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	})
 	mountV2Handlers(mux, cfg)
 	mountTimeseriesHandlers(mux, cfg, ring)
-	mux.HandleFunc("/api/sessions", func(w http.ResponseWriter, r *http.Request) {
-		since := r.URL.Query().Get("since")
-		until := r.URL.Query().Get("until")
-		params := map[string]string{}
-		var clauses []string
-		if since != "" {
-			clauses = append(clauses, "ts >= parseDateTime64BestEffort({since:String})")
-			params["since"] = since
-		} else {
-			clauses = append(clauses, "ts >= now() - INTERVAL 24 HOUR")
-		}
-		if until != "" {
-			clauses = append(clauses, "ts <= parseDateTime64BestEffort({until:String})")
-			params["until"] = until
-		}
-		where := "WHERE " + strings.Join(clauses, " AND ")
-		// Per-(session_id, play_id) row so the Session Viewer picker
-		// can offer per-playback granularity. A session that hosted
-		// three loadStream() calls produces three rows here, one per
-		// fresh play_id. Empty play_ids (rows ingested before go-proxy
-		// started stamping the field) are surfaced as "—" so they
-		// remain selectable rather than collapsing into one bucket.
-		// Per-(session_id, play_id) summary. We pre-window the rows so we
-		// can count ABR shifts (bitrate / resolution changes) using
-		// lagInFrame — the *count* of shifts isn't stored directly but
-		// the per-snapshot value is, and a transition between adjacent
-		// snapshots is a shift event.
-		query := fmt.Sprintf(`
-			WITH base AS (
-			  SELECT
-			    session_id, play_id, ts,
-			    player_id, group_id, content_id,
-			    player_state, player_error, last_event,
-			    stall_count, dropped_frames, frames_displayed,
-			    video_bitrate_mbps, video_resolution, video_quality_pct,
-			    video_first_frame_time_s,
-			    master_manifest_consecutive_failures,
-			    manifest_consecutive_failures,
-			    segment_consecutive_failures,
-			    all_consecutive_failures,
-			    transport_consecutive_failures,
-			    fault_count_transfer_active_timeout,
-			    fault_count_transfer_idle_timeout,
-			    classification,
-			    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate,
-			    lagInFrame(video_resolution,   1, video_resolution)   OVER w AS prev_resolution
-			  FROM %s.%s
-			  %s
-			  WINDOW w AS (PARTITION BY session_id, play_id ORDER BY ts)
-			),
-			net_counts AS (
-			  SELECT session_id, play_id, count() AS net_rows,
-			         countIf(status >= 400) AS net_errors,
-			         countIf(faulted = 1)  AS net_faults
-			  FROM %s.network_requests
-			  %s
-			  GROUP BY session_id, play_id
-			),
-			-- Per-(session,play) label histogram across all three source
-			-- tables. Issue #474: every interesting signal is now a label
-			-- on session_events / network_requests / control_events; this
-			-- CTE lets the sessions picker render "N labels" with a
-			-- per-label breakdown without three roundtrips.
-			labels_unioned AS (
-			  SELECT session_id, play_id, arrayJoin(labels) AS label
-			  FROM %s.%s
-			  %s
-			  UNION ALL
-			  SELECT session_id, play_id, arrayJoin(labels) AS label
-			  FROM %s.network_requests
-			  %s
-			  UNION ALL
-			  SELECT session_id, play_id, arrayJoin(labels) AS label
-			  FROM %s.control_events
-			  %s
-			),
-			labels_per_pair AS (
-			  SELECT session_id, play_id, label, count() AS n
-			  FROM labels_unioned
-			  GROUP BY session_id, play_id, label
-			),
-			labels_agg AS (
-			  SELECT session_id, play_id,
-			         sum(n) AS labels_total,
-			         arrayDistinct(groupArray(label)) AS labels_distinct,
-			         groupArray((label, n)) AS label_pairs
-			  FROM labels_per_pair
-			  GROUP BY session_id, play_id
-			),
-			agg AS (
-			  SELECT
-			    session_id,
-			    play_id AS raw_play_id,
-			    any(player_id) AS player_id,
-			    any(group_id) AS group_id,
-			    any(content_id) AS content_id,
-			    min(ts) AS started,
-			    max(ts) AS last_seen,
-			    count() AS metric_events,
-			    max(stall_count) AS stalls,
-			    max(dropped_frames) AS dropped_frames,
-			    argMax(player_state, ts) AS last_state,
-			    argMax(player_error, ts) AS last_player_error,
-			    max(master_manifest_consecutive_failures) AS master_manifest_failures,
-			    max(manifest_consecutive_failures) AS manifest_failures,
-			    max(segment_consecutive_failures) AS segment_failures,
-			    max(all_consecutive_failures) AS all_failures,
-			    max(transport_consecutive_failures) AS transport_failures,
-			    max(fault_count_transfer_active_timeout) AS active_timeouts,
-			    max(fault_count_transfer_idle_timeout) AS idle_timeouts,
-			    countIf(video_bitrate_mbps != prev_bitrate AND video_bitrate_mbps > 0 AND prev_bitrate > 0)                       AS bitrate_shifts,
-			    countIf(video_bitrate_mbps < prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0)                         AS downshifts,
-			    countIf(video_bitrate_mbps > prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0)                         AS upshifts,
-			    countIf(video_resolution != prev_resolution AND video_resolution != '' AND prev_resolution != '')                  AS resolution_changes,
-			    round(avgIf(video_quality_pct, video_quality_pct > 0), 1) AS avg_quality_pct,
-			    round(minIf(video_quality_pct, video_quality_pct > 0), 1) AS min_quality_pct,
-			    max(frames_displayed) AS frames_displayed,
-			    round(max(video_first_frame_time_s), 2) AS first_frame_s,
-			    -- Per-event-type counts of "really bad things" so the
-			    -- session picker can flag rows distinctly.
-			    --   user_marked  → operator-pressed 911 button
-			    --   frozen       → picture frozen (≠ stall: stall is
-			    --                  buffer-empty, frozen is renderer
-			    --                  hung)
-			    --   segment_stall → stall waiting for a segment fetch
-			    --   restart      → mid-session restart (player-side
-			    --                  recovery attempt)
-			    --   error        → explicit player_error event
-			    countIf(last_event = 'user_marked')   AS user_marked_count,
-			    countIf(last_event = 'frozen')         AS frozen_count,
-			    countIf(last_event = 'segment_stall')  AS segment_stall_count,
-			    countIf(last_event = 'restart')        AS restart_count,
-			    countIf(last_event = 'error')          AS error_event_count,
-			    -- Tiered retention class (issue #342). Same value on
-			    -- every row of (session_id, play_id) once the
-			    -- forwarder's session-end / star path stamps it; before
-			    -- that, default 'other'. any() is fine here because
-			    -- once the mutation has settled all rows agree.
-			    any(classification) AS classification
-			  FROM base
-			  GROUP BY session_id, play_id
-			)
-			SELECT
-			  agg.session_id AS session_id,
-			  if(agg.raw_play_id = '', '—', agg.raw_play_id) AS play_id,
-			  agg.player_id, agg.group_id, agg.content_id,
-			  agg.started, agg.last_seen,
-			  agg.metric_events,
-			  agg.metric_events AS rows,
-			  ifNull(net_counts.net_rows,   0) AS net_events,
-			  ifNull(net_counts.net_errors, 0) AS net_errors,
-			  ifNull(net_counts.net_faults, 0) AS net_faults,
-			  agg.stalls, agg.dropped_frames, agg.last_state, agg.last_player_error,
-			  agg.master_manifest_failures, agg.manifest_failures, agg.segment_failures,
-			  agg.all_failures, agg.transport_failures, agg.active_timeouts, agg.idle_timeouts,
-			  agg.bitrate_shifts, agg.downshifts, agg.upshifts, agg.resolution_changes,
-			  agg.avg_quality_pct, agg.min_quality_pct,
-			  agg.frames_displayed, agg.first_frame_s,
-			  agg.user_marked_count, agg.frozen_count, agg.segment_stall_count,
-			  agg.restart_count, agg.error_event_count,
-			  agg.classification,
-			  ifNull(labels_agg.labels_total, 0) AS labels_total,
-			  ifNull(length(labels_agg.labels_distinct), 0) AS labels_distinct_count,
-			  ifNull(labels_agg.label_pairs, []) AS labels
-			FROM agg
-			LEFT JOIN net_counts
-			  ON agg.session_id = net_counts.session_id
-			 AND agg.raw_play_id = net_counts.play_id
-			LEFT JOIN labels_agg
-			  ON agg.session_id = labels_agg.session_id
-			 AND agg.raw_play_id = labels_agg.play_id
-			ORDER BY agg.started DESC
-			LIMIT 1000
-			FORMAT JSONEachRow`,
-				cfg.chDatabase, cfg.chTable, where,
-				cfg.chDatabase, where,
-				cfg.chDatabase, cfg.chTable, where,
-				cfg.chDatabase, where,
-				cfg.chDatabase, where)
-		proxyClickHouseJSON(w, r, cfg, query, params)
-	})
 	mux.HandleFunc("/api/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		session := r.URL.Query().Get("session")
 		if session == "" {
@@ -1297,10 +1117,6 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	// /api/session_bundle — ZIP of snapshots + HAR + events for one
 	// (session_id, play_id). Defined in bundle.go.
 	registerBundleHandler(mux, cfg)
-
-	// /api/sessions/{sid}/{pid}/{star,reclassify} — tiered retention
-	// classification (issue #342). Defined in classification.go.
-	registerClassificationHandlers(mux, cfg)
 
 	// /api/v2/characterization-runs — POST ingest + GET list/detail for
 	// reports the Go test framework uploads at end-of-sweep. Defined

--- a/analytics/go-forwarder/net_log.go
+++ b/analytics/go-forwarder/net_log.go
@@ -2,8 +2,8 @@
 // /api/session/<id>/network endpoint for each live session, dedupes
 // against an in-memory fingerprint set, and batch-inserts new rows into
 // the ClickHouse network_requests table. The session-viewer UI reads
-// from /analytics/api/network_requests so the network log fold replays
-// even after the proxy has released the session.
+// from /api/v2/network_requests so the network log fold replays even
+// after the proxy has released the session.
 package main
 
 import (
@@ -527,41 +527,6 @@ func chQueryBytes(ctx context.Context, cfg config, query string, params map[stri
 		return nil, fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return body, nil
-}
-
-// reinflateNetRowJSON converts the JSONEachRow row from network_requests
-// into the shape the browser network log code expects. The three
-// columns request_headers / response_headers / query_string are stored
-// as JSON-encoded strings (so e.g. "[{\"name\":...}]" arrives as a
-// String), but the consumer wants actual arrays. We re-parse those
-// columns and splice them back in.
-func reinflateNetRowJSON(line []byte) []byte {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(line, &raw); err != nil {
-		return line
-	}
-	for _, key := range [...]string{"request_headers", "response_headers", "query_string"} {
-		val, ok := raw[key]
-		if !ok {
-			continue
-		}
-		// val is a JSON String containing JSON. Decode the outer string
-		// then re-emit the inner JSON as raw.
-		var inner string
-		if err := json.Unmarshal(val, &inner); err != nil {
-			continue
-		}
-		if inner == "" {
-			raw[key] = json.RawMessage("[]")
-			continue
-		}
-		raw[key] = json.RawMessage(inner)
-	}
-	out, err := json.Marshal(raw)
-	if err != nil {
-		return line
-	}
-	return out
 }
 
 func insertNet(ctx context.Context, cfg config, rows []netRow) error {

--- a/analytics/go-forwarder/openapi.go
+++ b/analytics/go-forwarder/openapi.go
@@ -38,17 +38,6 @@ func docsHealthz() {}
 //	@Router   /api/sessions [get]
 func docsArchivedSessions() {}
 
-//	@Summary  Count archived snapshots
-//	@Tags     archive
-//	@Produce  json
-//	@Param    session  query string false "session_id filter"
-//	@Param    play_id  query string false "play_id filter"
-//	@Param    from     query string false "ISO8601 lower bound"
-//	@Param    to       query string false "ISO8601 upper bound"
-//	@Success  200 {object} object "{count: N}"
-//	@Router   /api/snapshot_count [get]
-func docsSnapshotCount() {}
-
 //	@Summary  List session snapshots
 //	@Description Each row is one normalized session-state record; the snapshot stream emits these on every relevant change.
 //	@Tags     archive
@@ -85,19 +74,6 @@ func docsSessionHeatmap() {}
 //	@Success  200 {array} object
 //	@Router   /api/session_events [get]
 func docsSessionEvents() {}
-
-//	@Summary  Historical HAR-shaped network rows
-//	@Description Per-request rows mirrored from go-proxy's `/api/network/stream`, with `fault_category` / `fault_action` columns. ~10s ingestion lag from live.
-//	@Tags     archive
-//	@Produce  json
-//	@Param    session  query string false "session_id filter"
-//	@Param    play_id  query string false "play_id filter"
-//	@Param    from     query string false "ISO8601 lower bound"
-//	@Param    to       query string false "ISO8601 upper bound"
-//	@Param    limit    query int    false "max rows"
-//	@Success  200 {array} object
-//	@Router   /api/network_requests [get]
-func docsNetworkRequests() {}
 
 //	@Summary  Download a session bundle (ZIP)
 //	@Description Streams a ZIP containing snapshots, events, network rows, and a HAR file for the given play_id (or full session_id). Useful for offline forensics.

--- a/analytics/go-forwarder/openapi.go
+++ b/analytics/go-forwarder/openapi.go
@@ -8,7 +8,7 @@
 //
 // All endpoints are exposed externally under the /analytics/api/* prefix
 // (nginx rewrites the leading /analytics off before proxying), so consumer
-// URLs look like http://<host>:21000/analytics/api/sessions.
+// URLs look like http://<host>:21000/analytics/api/v2/plays.
 
 //	@title       Analytics forwarder API
 //	@version     1.0
@@ -27,16 +27,6 @@ package main
 //	@Success  200 {string} string "ok"
 //	@Router   /healthz [get]
 func docsHealthz() {}
-
-//	@Summary  List archived sessions
-//	@Description Returns one row per (session_id, play_id) seen in the archive within the time window.
-//	@Tags     archive
-//	@Produce  json
-//	@Param    since query string false "ISO8601 lower bound (defaults to now-24h)"
-//	@Param    until query string false "ISO8601 upper bound"
-//	@Success  200 {array} object
-//	@Router   /api/sessions [get]
-func docsArchivedSessions() {}
 
 //	@Summary  List session snapshots
 //	@Description Each row is one normalized session-state record; the snapshot stream emits these on every relevant change.
@@ -84,8 +74,3 @@ func docsSessionEvents() {}
 //	@Success  200 {file} binary
 //	@Router   /api/session_bundle [get]
 func docsSessionBundle() {}
-
-// Note: classification.go also registers `/api/sessions/` (with trailing
-// slash) for per-session lookups. That handler is undocumented here
-// pending a clearer canonical URL — the trailing-slash variant is a
-// workaround for ServeMux prefix matching, not a public API.

--- a/analytics/go-forwarder/v2_plays.go
+++ b/analytics/go-forwarder/v2_plays.go
@@ -8,6 +8,12 @@ package main
 // from / to / limit filters, and wraps the result in the v2 envelope
 // ({items, next_cursor}).
 //
+// PATCH /api/v2/plays/{play_id} writes the tiered-retention
+// classification (#342). Live-play mutations (labels / shape /
+// fault_rules) live on go-proxy's PATCH /api/v2/plays/{id} — this
+// forwarder handler exists because classification only applies once a
+// play is archived in ClickHouse.
+//
 // Today the query reads session_snapshots + network_requests live, the
 // same way v1 does. The aspirational play_summaries rollup table is
 // blocked on `play.ended` SSE plumbing — when it lands, swap the FROM
@@ -15,8 +21,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -43,11 +51,101 @@ func playsDispatcher(cfg config) http.HandlerFunc {
 				writeProblemv2(w, http.StatusNotFound, "not found", "no nested resources under /api/v2/plays/{play_id} yet")
 				return
 			}
+			if r.Method == http.MethodPatch {
+				v2PlayPatchHandler(w, r, cfg, canonicalV2ID(playID))
+				return
+			}
 			v2PlayDetailHandler(w, r, cfg, playID)
 		default:
 			writeProblemv2(w, http.StatusNotFound, "not found", "")
 		}
 	}
+}
+
+// v2PlayPatchHandler answers PATCH /api/v2/plays/{play_id}. Today the
+// only supported field is `classification`, which drives the tiered
+// retention TTL (#342). Star = `favourite`; unstar = `auto` which re-
+// runs the auto-classifier and writes whatever it returns
+// (interesting | other). Explicit values `interesting` / `other` are
+// also accepted for operator-driven reclassification.
+//
+// Live-play mutations live on go-proxy's PATCH /api/v2/plays/{id};
+// this handler exists in the forwarder because classification only
+// makes sense once the play is archived in ClickHouse.
+func v2PlayPatchHandler(w http.ResponseWriter, r *http.Request, cfg config, playID string) {
+	if playID == "" {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "play_id required")
+		return
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<16))
+	if err != nil {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "read body failed")
+		return
+	}
+	var patch map[string]any
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &patch); err != nil {
+			writeProblemv2(w, http.StatusBadRequest, "bad request", "invalid json body")
+			return
+		}
+	}
+	if len(patch) == 0 {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "empty patch")
+		return
+	}
+	for k := range patch {
+		if k != "classification" {
+			writeProblemv2(w, http.StatusNotImplemented, "not implemented",
+				fmt.Sprintf("PATCH /api/v2/plays only supports {classification} today; got %q", k))
+			return
+		}
+	}
+	clsRaw, ok := patch["classification"].(string)
+	if !ok {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "classification must be a string")
+		return
+	}
+	cls := strings.ToLower(strings.TrimSpace(clsRaw))
+	switch cls {
+	case "favourite", "interesting", "other":
+		if err := setPlayClassification(r.Context(), cfg, playID, cls, true); err != nil {
+			writeProblemv2(w, http.StatusBadGateway, "clickhouse update failed", err.Error())
+			return
+		}
+	case "auto":
+		if err := reclassifyPlay(r.Context(), cfg, playID, true); err != nil {
+			writeProblemv2(w, http.StatusBadGateway, "clickhouse update failed", err.Error())
+			return
+		}
+	default:
+		writeProblemv2(w, http.StatusBadRequest, "bad request",
+			"classification must be one of: favourite, interesting, other, auto")
+		return
+	}
+	// Round-trip the post-patch detail so the caller sees the settled
+	// classification (auto mode runs the predicate before returning).
+	clauses, params, err := buildPlaysFilter("", playID, "", "", "", "")
+	if err != nil {
+		writeProblemv2(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	rows, err := queryPlaySummariesFiltered(r.Context(), cfg, clauses, params, nil, nil, 1)
+	if err != nil {
+		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
+		return
+	}
+	if len(rows) == 0 {
+		// Mutation went through but the play has no archived snapshots
+		// yet — surface the requested classification so the UI can flip
+		// optimistically. (Rare: the row would have to have been GC'd
+		// between the ALTER UPDATE and the SELECT.)
+		writeJSONv2(w, http.StatusOK, map[string]any{
+			"play_id":        playID,
+			"classification": cls,
+		})
+		return
+	}
+	writeJSONv2(w, http.StatusOK, rows[0])
 }
 
 // v2PlaysListHandler answers GET /api/v2/plays.
@@ -249,7 +347,7 @@ func queryPlaySummaries(ctx context.Context, cfg config, clauses []string, param
 		-- Per-play label histogram across all three source tables
 		-- (issue #474 follow-up so harness CLI's archive plays
 		-- carries the same per-row labels surface the dashboard's
-		-- Sessions page shows via /analytics/api/sessions).
+		-- Sessions page reads via /analytics/api/v2/plays).
 		-- lowerUTF8 on play_id makes the JOIN survive the case-
 		-- sensitivity gap where some legacy rows landed with
 		-- uppercase play_ids.

--- a/api/openapi/forwarder/swagger.json
+++ b/api/openapi/forwarder/swagger.json
@@ -149,48 +149,6 @@
                 ]
             }
         },
-        "/api/sessions": {
-            "get": {
-                "description": "Returns one row per (session_id, play_id) seen in the archive within the time window.",
-                "parameters": [
-                    {
-                        "description": "ISO8601 lower bound (defaults to now-24h)",
-                        "in": "query",
-                        "name": "since",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "until",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "List archived sessions",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
         "/api/snapshots": {
             "get": {
                 "description": "Each row is one normalized session-state record; the snapshot stream emits these on every relevant change.",

--- a/api/openapi/forwarder/swagger.json
+++ b/api/openapi/forwarder/swagger.json
@@ -10,72 +10,6 @@
         "url": ""
     },
     "paths": {
-        "/api/network_requests": {
-            "get": {
-                "description": "Per-request rows mirrored from go-proxy's `/api/network/stream`, with `fault_category` / `fault_action` columns. ~10s ingestion lag from live.",
-                "parameters": [
-                    {
-                        "description": "session_id filter",
-                        "in": "query",
-                        "name": "session",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "play_id filter",
-                        "in": "query",
-                        "name": "play_id",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 lower bound",
-                        "in": "query",
-                        "name": "from",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "to",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "max rows",
-                        "in": "query",
-                        "name": "limit",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "Historical HAR-shaped network rows",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
         "/api/session_bundle": {
             "get": {
                 "description": "Streams a ZIP containing snapshots, events, network rows, and a HAR file for the given play_id (or full session_id). Useful for offline forensics.",
@@ -252,60 +186,6 @@
                     }
                 },
                 "summary": "List archived sessions",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
-        "/api/snapshot_count": {
-            "get": {
-                "parameters": [
-                    {
-                        "description": "session_id filter",
-                        "in": "query",
-                        "name": "session",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "play_id filter",
-                        "in": "query",
-                        "name": "play_id",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 lower bound",
-                        "in": "query",
-                        "name": "from",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "to",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "{count: N}"
-                    }
-                },
-                "summary": "Count archived snapshots",
                 "tags": [
                     "archive"
                 ]

--- a/api/openapi/forwarder/swagger.yaml
+++ b/api/openapi/forwarder/swagger.yaml
@@ -101,33 +101,6 @@ paths:
       summary: Per-second buffer + state heatmap
       tags:
       - archive
-  /api/sessions:
-    get:
-      description: Returns one row per (session_id, play_id) seen in the archive within
-        the time window.
-      parameters:
-      - description: ISO8601 lower bound (defaults to now-24h)
-        in: query
-        name: since
-        schema:
-          type: string
-      - description: ISO8601 upper bound
-        in: query
-        name: until
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  type: object
-                type: array
-          description: OK
-      summary: List archived sessions
-      tags:
-      - archive
   /api/snapshots:
     get:
       description: Each row is one normalized session-state record; the snapshot stream

--- a/api/openapi/forwarder/swagger.yaml
+++ b/api/openapi/forwarder/swagger.yaml
@@ -12,48 +12,6 @@ info:
   version: "1.0"
 openapi: 3.1.0
 paths:
-  /api/network_requests:
-    get:
-      description: Per-request rows mirrored from go-proxy's `/api/network/stream`,
-        with `fault_category` / `fault_action` columns. ~10s ingestion lag from live.
-      parameters:
-      - description: session_id filter
-        in: query
-        name: session
-        schema:
-          type: string
-      - description: play_id filter
-        in: query
-        name: play_id
-        schema:
-          type: string
-      - description: ISO8601 lower bound
-        in: query
-        name: from
-        schema:
-          type: string
-      - description: ISO8601 upper bound
-        in: query
-        name: to
-        schema:
-          type: string
-      - description: max rows
-        in: query
-        name: limit
-        schema:
-          type: integer
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                items:
-                  type: object
-                type: array
-          description: OK
-      summary: Historical HAR-shaped network rows
-      tags:
-      - archive
   /api/session_bundle:
     get:
       description: Streams a ZIP containing snapshots, events, network rows, and a
@@ -168,39 +126,6 @@ paths:
                 type: array
           description: OK
       summary: List archived sessions
-      tags:
-      - archive
-  /api/snapshot_count:
-    get:
-      parameters:
-      - description: session_id filter
-        in: query
-        name: session
-        schema:
-          type: string
-      - description: play_id filter
-        in: query
-        name: play_id
-        schema:
-          type: string
-      - description: ISO8601 lower bound
-        in: query
-        name: from
-        schema:
-          type: string
-      - description: ISO8601 upper bound
-        in: query
-        name: to
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: '{count: N}'
-      summary: Count archived snapshots
       tags:
       - archive
   /api/snapshots:

--- a/api/openapi/proxy/swagger.json
+++ b/api/openapi/proxy/swagger.json
@@ -35,18 +35,6 @@
                 },
                 "type": "object"
             },
-            "main.LinkSessionsRequest": {
-                "properties": {
-                    "session_ids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
             "main.LossRequest": {
                 "properties": {
                     "loss_pct": {
@@ -289,14 +277,6 @@
                     }
                 },
                 "type": "object"
-            },
-            "main.UnlinkSessionRequest": {
-                "properties": {
-                    "session_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
             }
         }
     },
@@ -341,44 +321,6 @@
                 "summary": "External IPs the harness is reachable from",
                 "tags": [
                     "diagnostics"
-                ]
-            }
-        },
-        "/api/failure-settings/{id}": {
-            "post": {
-                "deprecated": true,
-                "description": "Predates the PATCH envelope. Kept for backwards compat with older dashboard code.",
-                "parameters": [
-                    {
-                        "description": "session_id",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "text/plain": {
-                            "schema": {
-                                "title": "body",
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "description": "fault settings",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Legacy fault-settings POST (use PATCH instead)",
-                "tags": [
-                    "internal"
                 ]
             }
         },
@@ -639,89 +581,6 @@
                 ]
             }
         },
-        "/api/session-group/link": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/main.LinkSessionsRequest",
-                                "summary": "body",
-                                "description": "{session_ids: [...]}"
-                            }
-                        }
-                    },
-                    "description": "{session_ids: [...]}",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Link sessions into a fault-propagation group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
-        "/api/session-group/unlink": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/main.UnlinkSessionRequest",
-                                "summary": "body",
-                                "description": "{session_id}"
-                            }
-                        }
-                    },
-                    "description": "{session_id}",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Unlink a session from its group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
-        "/api/session-group/{groupId}": {
-            "get": {
-                "parameters": [
-                    {
-                        "description": "group id",
-                        "in": "path",
-                        "name": "groupId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "Get a session group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
         "/api/session/{id}": {
             "delete": {
                 "description": "Removes the session from the in-memory map and frees its dedicated proxy port.",
@@ -911,43 +770,6 @@
                 "summary": "Get one session's network ring buffer",
                 "tags": [
                     "network"
-                ]
-            }
-        },
-        "/api/session/{id}/update": {
-            "post": {
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "description": "session_id",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "text/plain": {
-                            "schema": {
-                                "title": "body",
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "description": "settings",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Legacy session-update POST (use PATCH instead)",
-                "tags": [
-                    "internal"
                 ]
             }
         },

--- a/api/openapi/proxy/swagger.yaml
+++ b/api/openapi/proxy/swagger.yaml
@@ -22,14 +22,6 @@ components:
         value:
           type: string
       type: object
-    main.LinkSessionsRequest:
-      properties:
-        session_ids:
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-      type: object
     main.LossRequest:
       properties:
         loss_pct:
@@ -236,11 +228,6 @@ components:
         rate_mbps:
           type: number
       type: object
-    main.UnlinkSessionRequest:
-      properties:
-        session_id:
-          type: string
-      type: object
 externalDocs:
   description: ""
   url: ""
@@ -275,32 +262,6 @@ paths:
       summary: External IPs the harness is reachable from
       tags:
       - diagnostics
-  /api/failure-settings/{id}:
-    post:
-      deprecated: true
-      description: Predates the PATCH envelope. Kept for backwards compat with older
-        dashboard code.
-      parameters:
-      - description: session_id
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              title: body
-              type: object
-        description: fault settings
-        required: true
-      responses:
-        "200":
-          description: OK
-      summary: Legacy fault-settings POST (use PATCH instead)
-      tags:
-      - internal
   /api/network/stream:
     get:
       description: |-
@@ -470,59 +431,6 @@ paths:
       summary: Global nftables status
       tags:
       - shaping
-  /api/session-group/{groupId}:
-    get:
-      parameters:
-      - description: group id
-        in: path
-        name: groupId
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                type: object
-          description: OK
-      summary: Get a session group
-      tags:
-      - groups
-  /api/session-group/link:
-    post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/main.LinkSessionsRequest'
-              description: '{session_ids: [...]}'
-              summary: body
-        description: '{session_ids: [...]}'
-        required: true
-      responses:
-        "200":
-          description: OK
-      summary: Link sessions into a fault-propagation group
-      tags:
-      - groups
-  /api/session-group/unlink:
-    post:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/main.UnlinkSessionRequest'
-              description: '{session_id}'
-              summary: body
-        description: '{session_id}'
-        required: true
-      responses:
-        "200":
-          description: OK
-      summary: Unlink a session from its group
-      tags:
-      - groups
   /api/session/{id}:
     delete:
       description: Removes the session from the in-memory map and frees its dedicated
@@ -651,30 +559,6 @@ paths:
       summary: Get one session's network ring buffer
       tags:
       - network
-  /api/session/{id}/update:
-    post:
-      deprecated: true
-      parameters:
-      - description: session_id
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              title: body
-              type: object
-        description: settings
-        required: true
-      responses:
-        "200":
-          description: OK
-      summary: Legacy session-update POST (use PATCH instead)
-      tags:
-      - internal
   /api/sessions:
     get:
       responses:

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -127,6 +127,33 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/PlayDetail' }
         '404': { $ref: '#/components/responses/Problem' }
+    patch:
+      tags: [plays]
+      summary: Update an archived play's classification
+      description: |
+        Today the only supported field is `classification`, which drives
+        the tiered TTL (#342): `favourite` is starred (kept forever),
+        `interesting` / `other` set the auto-classifier tier directly, and
+        `auto` re-runs the auto-classifier and writes whatever it returns.
+        ALTER UPDATEs all three archive tables in one shot.
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              properties:
+                classification:
+                  type: string
+                  enum: [favourite, interesting, other, auto]
+      responses:
+        '200':
+          description: Updated; body is the post-patch play summary.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlaySummary' }
+        '400': { $ref: '#/components/responses/Problem' }
+        '501': { $ref: '#/components/responses/Problem' }
 
   /api/v2/plays/aggregate:
     get:

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -56,8 +56,13 @@ async function toggleStarred() {
   const next = !starred.value;
   starred.value = next; // optimistic
   try {
-    const url = `/analytics/api/sessions/${encodeURIComponent(playerId.value)}/${encodeURIComponent(playId.value)}/star`;
-    const resp = await fetch(url, { method: next ? 'POST' : 'DELETE' });
+    const url = `/analytics/api/v2/plays/${encodeURIComponent(playId.value)}`;
+    const cls = next ? 'favourite' : 'auto';
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      body: JSON.stringify({ classification: cls }),
+    });
     if (!resp.ok) throw new Error(`star ${resp.status}`);
   } catch {
     starred.value = !next; // rollback on failure
@@ -74,15 +79,16 @@ const bundleHref = computed(() => {
 const backHref = '/dashboard/v3/sessions.html';
 
 onMounted(async () => {
-  // Look up the current starred state. The endpoint returns
-  // {"starred": true|false} (or 404 if the play hasn't been touched).
+  // Look up the current starred state via the v2 play summary.
+  // classification === 'favourite' means starred. 404 just means the
+  // play hasn't archived any snapshots yet — treat as unstarred.
   if (playerId.value && playId.value) {
     try {
-      const url = `/analytics/api/sessions/${encodeURIComponent(playerId.value)}/${encodeURIComponent(playId.value)}/star`;
+      const url = `/analytics/api/v2/plays/${encodeURIComponent(playId.value)}`;
       const resp = await fetch(url);
       if (resp.ok) {
         const j = await resp.json();
-        starred.value = !!j.starred;
+        starred.value = String(j?.classification ?? '') === 'favourite';
       }
     } catch {
       // Star lookup is non-essential; the toggle still works.

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -13,10 +13,12 @@
  * routes display panels to the side-channel store in v2-repo instead
  * of the live `/api/v2/players` fetch.
  */
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed } from 'vue';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import SessionDisplay from '@/components/SessionDisplay.vue';
 import { parseTimeAny, canonicalUUID } from '@/composables/urlTimeFormat';
+import { getPlay, patchPlayClassification, type PlaySummary } from '@/repo/v2-repo';
 
 const qs = new URLSearchParams(window.location.search);
 // v3 canonical: identify an archived play by (player_id, play_id).
@@ -48,25 +50,52 @@ const endMs = ref<number | null>(parseTimeAny(qs.get('to') ?? qs.get('end_time')
 const showContext = ref<boolean>(false);
 function toggleShowContext() { showContext.value = !showContext.value; }
 
-// Starred state. Optimistically toggled on click, then synced from
-// the server response. Initial fetch in onMounted below.
-const starred = ref<boolean>(false);
-async function toggleStarred() {
+// Starred state — backed by TanStack so the optimistic flip, the
+// mutation rollback, and any future cache invalidations follow the
+// same contract as Sessions.vue / usePlayer.ts § makeGroupMutation.
+// No auto-refresh on this page, so cancelQueries is mostly defensive.
+const qc = useQueryClient();
+const playQueryKey = computed(() => ['play', playId.value] as const);
+const playQuery = useQuery<PlaySummary | null>({
+  queryKey: playQueryKey,
+  queryFn: () => getPlay(playId.value as string),
+  enabled: computed(() => !!playId.value),
+  // One-shot for the initial starred state; refetch on focus is
+  // enough — no point polling, this is a finished play.
+  refetchInterval: false,
+});
+const starred = computed<boolean>(
+  () => String(playQuery.data.value?.classification ?? '') === 'favourite',
+);
+
+const starMutation = useMutation({
+  mutationFn: (next: boolean) =>
+    patchPlayClassification(playId.value as string, next ? 'favourite' : 'auto'),
+  onMutate: async (next) => {
+    if (!playId.value) return { prev: undefined };
+    await qc.cancelQueries({ queryKey: playQueryKey.value });
+    const prev = qc.getQueryData<PlaySummary | null>(playQueryKey.value);
+    if (prev) {
+      qc.setQueryData<PlaySummary | null>(playQueryKey.value, {
+        ...prev,
+        classification: next ? 'favourite' : '',
+      });
+    }
+    return { prev };
+  },
+  onError: (_err, _vars, ctx) => {
+    if (ctx && 'prev' in ctx) {
+      qc.setQueryData(playQueryKey.value, ctx.prev);
+    }
+  },
+  onSuccess: (settled) => {
+    if (settled) qc.setQueryData(playQueryKey.value, settled);
+  },
+});
+
+function toggleStarred() {
   if (!playerId.value || !playId.value) return;
-  const next = !starred.value;
-  starred.value = next; // optimistic
-  try {
-    const url = `/analytics/api/v2/plays/${encodeURIComponent(playId.value)}`;
-    const cls = next ? 'favourite' : 'auto';
-    const resp = await fetch(url, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/merge-patch+json' },
-      body: JSON.stringify({ classification: cls }),
-    });
-    if (!resp.ok) throw new Error(`star ${resp.status}`);
-  } catch {
-    starred.value = !next; // rollback on failure
-  }
+  starMutation.mutate(!starred.value);
 }
 
 const bundleHref = computed(() => {
@@ -78,23 +107,9 @@ const bundleHref = computed(() => {
 });
 const backHref = '/dashboard/v3/sessions.html';
 
-onMounted(async () => {
-  // Look up the current starred state via the v2 play summary.
-  // classification === 'favourite' means starred. 404 just means the
-  // play hasn't archived any snapshots yet — treat as unstarred.
-  if (playerId.value && playId.value) {
-    try {
-      const url = `/analytics/api/v2/plays/${encodeURIComponent(playId.value)}`;
-      const resp = await fetch(url);
-      if (resp.ok) {
-        const j = await resp.json();
-        starred.value = String(j?.classification ?? '') === 'favourite';
-      }
-    } catch {
-      // Star lookup is non-essential; the toggle still works.
-    }
-  }
-});
+// (Initial starred-state lookup now lives in the playQuery above —
+// useQuery fires automatically when playId is set; the onMounted
+// fetch + try/catch is gone.)
 
 </script>
 

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -212,6 +212,12 @@ async function loadRows(silent = false) {
       // its existing shape without a wider refactor.
       if (!r.started && (r as any).started_at) r.started = (r as any).started_at;
       if (!r.last_seen && (r as any).last_seen_at) r.last_seen = (r as any).last_seen_at;
+      // v2 names the [label, count] tuples `label_histogram`; v1 named
+      // them `labels`. The severity filter + per-row chips both read
+      // from r.labels, so alias to keep that surface intact.
+      if (!r.labels && Array.isArray((r as any).label_histogram)) {
+        r.labels = (r as any).label_histogram;
+      }
       const t0 = Date.parse(r.started ?? '');
       const t1 = Date.parse(r.last_seen ?? '');
       r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -8,8 +8,10 @@
  * looks identical to /dashboard/sessions.html.
  */
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import { sessionViewerURL } from '@/composables/urlTimeFormat';
+import { listPlays, patchPlayClassification, type PlaySummary } from '@/repo/v2-repo';
 
 interface SessionRow {
   session_id: string;
@@ -120,9 +122,8 @@ const filters = ref<{
   labels: [], labelsExclude: [],
 });
 
-const rows = ref<SessionRow[]>([]);
-const loading = ref(false);
-const error = ref<string | null>(null);
+// rows / loading / error are computeds backed by playsQuery; declared
+// further down once the query is constructed.
 const sortKey = ref('started');
 const sortDir = ref<'asc' | 'desc'>('desc');
 // Force-bump on auto-refresh so `fmtRelTime` re-renders even if the
@@ -190,46 +191,63 @@ function deriveHealth(r: SessionRow): void {
   };
 }
 
-let reloadInFlight = false;
-async function loadRows(silent = false) {
-  if (reloadInFlight) return;
-  reloadInFlight = true;
-  if (!silent) loading.value = true;
-  error.value = null;
-  try {
+// Normalise one PlaySummary into a SessionRow: aliases v2 field
+// names (started_at/last_seen_at, label_histogram) to the v1 names the
+// rest of this page reads, derives health metrics, and computes
+// duration. Runs once per fetch inside the queryFn so the cache holds
+// processed rows and the render path stays cheap.
+function normalisePlay(p: PlaySummary): SessionRow {
+  const r: SessionRow = { ...(p as any), session_id: (p as any).session_id ?? '' };
+  if (!r.started && p.started_at) r.started = p.started_at;
+  if (!r.last_seen && p.last_seen_at) r.last_seen = p.last_seen_at;
+  if (!r.labels && Array.isArray(p.label_histogram)) r.labels = p.label_histogram;
+  const t0 = Date.parse(r.started ?? '');
+  const t1 = Date.parse(r.last_seen ?? '');
+  r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;
+  deriveHealth(r);
+  return r;
+}
+
+// Stable query key that refetches when the time range changes. The
+// range tuple is the only server-side filter; player/group/content/
+// classification/labels are post-fetch client-side filters.
+const playsQueryKey = computed(() => {
+  const { since, until } = computeRange();
+  return ['plays', since, until] as const;
+});
+
+const qc = useQueryClient();
+const playsQuery = useQuery<SessionRow[]>({
+  queryKey: playsQueryKey,
+  queryFn: async () => {
     const { since, until } = computeRange();
-    const qs = new URLSearchParams();
-    if (since) qs.set('from', since);
-    if (until) qs.set('to', until);
-    qs.set('limit', '5000');
-    const resp = await fetch('/analytics/api/v2/plays' + (qs.toString() ? '?' + qs : ''));
-    if (!resp.ok) throw new Error(`HTTP ${resp.status} (analytics forwarder reachable?)`);
-    const envelope = await resp.json();
-    const fresh: SessionRow[] = Array.isArray(envelope?.items) ? envelope.items : [];
-    for (const r of fresh) {
-      // v2 surfaces started_at/last_seen_at; alias to started/last_seen
-      // so the rest of the UI (sort keys, badges, fmt helpers) keeps
-      // its existing shape without a wider refactor.
-      if (!r.started && (r as any).started_at) r.started = (r as any).started_at;
-      if (!r.last_seen && (r as any).last_seen_at) r.last_seen = (r as any).last_seen_at;
-      // v2 names the [label, count] tuples `label_histogram`; v1 named
-      // them `labels`. The severity filter + per-row chips both read
-      // from r.labels, so alias to keep that surface intact.
-      if (!r.labels && Array.isArray((r as any).label_histogram)) {
-        r.labels = (r as any).label_histogram;
-      }
-      const t0 = Date.parse(r.started ?? '');
-      const t1 = Date.parse(r.last_seen ?? '');
-      r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;
-      deriveHealth(r);
-    }
-    rows.value = fresh;
-  } catch (e: any) {
-    error.value = String(e?.message ?? e);
-  } finally {
-    if (!silent) loading.value = false;
-    reloadInFlight = false;
-  }
+    const items = await listPlays({ from: since, to: until, limit: 5000 });
+    return items.map(normalisePlay);
+  },
+  // Match the legacy 5s cadence. TanStack pauses the interval while
+  // the tab is backgrounded — same effective behaviour as before.
+  refetchInterval: 5000,
+  // Keep prior rows visible while the refetch runs so the picker
+  // doesn't blank out between ticks.
+  placeholderData: (prev) => prev,
+});
+
+// Surfaces previously held by manual refs. computeds keep the rest of
+// the template trusting `rows`, `loading`, `error` unchanged.
+const rows = computed<SessionRow[]>(() => playsQuery.data.value ?? []);
+const loading = computed<boolean>(() => playsQuery.isLoading.value);
+const error = computed<string | null>(() => {
+  const e = playsQuery.error.value as Error | null;
+  return e ? String(e.message ?? e) : null;
+});
+
+// Stand-in for the old `void loadRows()` calls in user-driven range
+// changes. queryKey reactivity handles the refetch automatically when
+// activeRangeId / customFrom / customTo change; this is the explicit
+// "fetch now" for the rare cases the key didn't shift (eg. clicking
+// the same range button to force a refresh).
+function refreshPlays() {
+  void playsQuery.refetch();
 }
 
 const isInterestingRow = (r: SessionRow): boolean =>
@@ -500,7 +518,10 @@ function clearFilters() {
 
 function onRangeChange() {
   try { localStorage.setItem(RANGE_KEY, activeRangeId.value); } catch { /* ignore */ }
-  if (activeRangeId.value !== 'custom') void loadRows();
+  // Query key is reactive on (since, until); switching range triggers
+  // a refetch automatically. The "custom" branch waits for the user
+  // to fill in both inputs before applyCustomRange() flips since/until.
+  if (activeRangeId.value !== 'custom') refreshPlays();
 }
 function applyCustomRange() {
   customFrom.value = localToIso(customFromInput.value);
@@ -508,7 +529,7 @@ function applyCustomRange() {
   try {
     localStorage.setItem(RANGE_CUSTOM_KEY, JSON.stringify({ from: customFrom.value, to: customTo.value }));
   } catch { /* ignore */ }
-  void loadRows();
+  refreshPlays();
 }
 
 const customFromInput = ref(isoToLocal(customFrom.value));
@@ -737,34 +758,71 @@ function onHeaderClick(col: typeof COLUMNS[number]) {
   }
 }
 
-async function toggleStar(r: SessionRow, ev: MouseEvent) {
+// Star/unstar via the standard TanStack mutation contract used
+// throughout v3 (see composables/usePlayer.ts § makeGroupMutation):
+//   onMutate  — cancel in-flight refetches, snapshot, optimistic write
+//   onError   — restore the snapshot
+//   onSuccess — write the server-settled value back
+// cancelQueries is the key step that fixes the race the homegrown
+// loadRows() had: without it, the 5s refetch could land before the
+// ClickHouse ALTER UPDATE propagated and visibly revert the star.
+type ClassValue = 'favourite' | 'interesting' | 'other' | 'auto';
+type StarVars = { playId: string; target: ClassValue; optimistic: string };
+
+// Predicate matches every ['plays', since, until] cache entry — covers
+// past time-window selections that the user might switch back to.
+const playsQueryPredicate = { predicate: (q: any) => q.queryKey?.[0] === 'plays' };
+
+function applyClassificationToCaches(playId: string, value: string) {
+  qc.setQueriesData<SessionRow[]>(playsQueryPredicate, (old) =>
+    old?.map((r) => (r.play_id === playId ? { ...r, classification: value } : r)),
+  );
+}
+
+const starMutation = useMutation({
+  mutationFn: ({ playId, target }: StarVars) => patchPlayClassification(playId, target),
+  onMutate: async ({ playId, optimistic }) => {
+    // Pause every plays-keyed in-flight refetch so the optimistic
+    // write isn't stomped before the PATCH settles.
+    await qc.cancelQueries(playsQueryPredicate);
+    const prev = qc.getQueriesData<SessionRow[]>(playsQueryPredicate);
+    applyClassificationToCaches(playId, optimistic);
+    return { prev };
+  },
+  onError: (err: any, _vars, ctx) => {
+    if (ctx?.prev) {
+      for (const [key, snapshot] of ctx.prev) {
+        qc.setQueryData(key, snapshot);
+      }
+    }
+    window.alert(`Star toggle failed: ${err?.message ?? err}`);
+  },
+  onSuccess: (settled, { playId }) => {
+    // Server tells us the settled classification ('auto' resolves to
+    // interesting/other server-side). Write it into every cached
+    // plays-list so the chip + filter agree without another refetch.
+    if (typeof settled?.classification === 'string') {
+      applyClassificationToCaches(playId, settled.classification);
+    }
+  },
+});
+
+function toggleStar(r: SessionRow, ev: MouseEvent) {
   ev.stopPropagation();
   ev.preventDefault();
-  const wasStarred = String(r.classification || '') === 'favourite';
   if (!r.play_id || r.play_id === '—') {
     window.alert('Cannot star a row without a play_id (legacy pre-stamp row).');
     return;
   }
-  const url = `/analytics/api/v2/plays/${encodeURIComponent(r.play_id)}`;
-  // 'auto' lets the forwarder rerun the auto-classifier on unstar so
-  // the row drops back to interesting/other based on its content.
-  const next = wasStarred ? 'auto' : 'favourite';
-  r.classification = wasStarred ? '' : 'favourite';
-  try {
-    const resp = await fetch(url, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/merge-patch+json' },
-      body: JSON.stringify({ classification: next }),
-    });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const body = await resp.json().catch(() => null);
-    if (body && typeof body.classification === 'string') {
-      r.classification = body.classification;
-    }
-  } catch (err: any) {
-    r.classification = wasStarred ? 'favourite' : '';
-    window.alert(`Star toggle failed: ${err?.message ?? err}`);
-  }
+  const wasStarred = String(r.classification || '') === 'favourite';
+  // For unstar: empty string optimistically (UI checks === 'favourite');
+  // server's auto-classifier will resolve to 'interesting' or 'other'
+  // and onSuccess writes the real value back.
+  starMutation.mutate({
+    playId: r.play_id,
+    target: wasStarred ? 'auto' : 'favourite',
+    optimistic: wasStarred ? '' : 'favourite',
+  });
 }
 
 function onRowClick(r: SessionRow, ev: MouseEvent) {
@@ -778,17 +836,13 @@ function onRowClick(r: SessionRow, ev: MouseEvent) {
   if (href !== '#') window.location.href = href;
 }
 
-let autoRefreshTimer: number | undefined;
 let clockTimer: number | undefined;
 onMounted(() => {
-  void loadRows();
-  // Auto-refresh every 5s (silent).
-  autoRefreshTimer = window.setInterval(() => void loadRows(true), 5000);
   // 1s clock tick so "1s ago" → "2s ago" updates without a fetch.
+  // The play list itself refetches every 5s via useQuery.refetchInterval.
   clockTimer = window.setInterval(() => { tick.value++; }, 1000);
 });
 onBeforeUnmount(() => {
-  if (autoRefreshTimer) clearInterval(autoRefreshTimer);
   if (clockTimer) clearInterval(clockTimer);
 });
 

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -199,17 +199,19 @@ async function loadRows(silent = false) {
   try {
     const { since, until } = computeRange();
     const qs = new URLSearchParams();
-    if (since) qs.set('since', since);
-    if (until) qs.set('until', until);
-    const resp = await fetch('/analytics/api/sessions' + (qs.toString() ? '?' + qs : ''));
+    if (since) qs.set('from', since);
+    if (until) qs.set('to', until);
+    qs.set('limit', '5000');
+    const resp = await fetch('/analytics/api/v2/plays' + (qs.toString() ? '?' + qs : ''));
     if (!resp.ok) throw new Error(`HTTP ${resp.status} (analytics forwarder reachable?)`);
-    const body = await resp.text();
-    const fresh: SessionRow[] = [];
-    for (const line of body.split('\n')) {
-      if (!line) continue;
-      try { fresh.push(JSON.parse(line)); } catch { /* skip */ }
-    }
+    const envelope = await resp.json();
+    const fresh: SessionRow[] = Array.isArray(envelope?.items) ? envelope.items : [];
     for (const r of fresh) {
+      // v2 surfaces started_at/last_seen_at; alias to started/last_seen
+      // so the rest of the UI (sort keys, badges, fmt helpers) keeps
+      // its existing shape without a wider refactor.
+      if (!r.started && (r as any).started_at) r.started = (r as any).started_at;
+      if (!r.last_seen && (r as any).last_seen_at) r.last_seen = (r as any).last_seen_at;
       const t0 = Date.parse(r.started ?? '');
       const t1 = Date.parse(r.last_seen ?? '');
       r.duration_ms = (Number.isFinite(t0) && Number.isFinite(t1) && t1 >= t0) ? (t1 - t0) : 0;
@@ -733,14 +735,26 @@ async function toggleStar(r: SessionRow, ev: MouseEvent) {
   ev.stopPropagation();
   ev.preventDefault();
   const wasStarred = String(r.classification || '') === 'favourite';
-  const pid = (r.play_id && r.play_id !== '—') ? r.play_id : '—';
-  const url = `/analytics/api/sessions/${encodeURIComponent(r.session_id)}/${encodeURIComponent(pid)}/star`;
-  const method = wasStarred ? 'DELETE' : 'POST';
-  // Optimistic flip.
+  if (!r.play_id || r.play_id === '—') {
+    window.alert('Cannot star a row without a play_id (legacy pre-stamp row).');
+    return;
+  }
+  const url = `/analytics/api/v2/plays/${encodeURIComponent(r.play_id)}`;
+  // 'auto' lets the forwarder rerun the auto-classifier on unstar so
+  // the row drops back to interesting/other based on its content.
+  const next = wasStarred ? 'auto' : 'favourite';
   r.classification = wasStarred ? '' : 'favourite';
   try {
-    const resp = await fetch(url, { method });
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      body: JSON.stringify({ classification: next }),
+    });
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const body = await resp.json().catch(() => null);
+    if (body && typeof body.classification === 'string') {
+      r.classification = body.classification;
+    }
   } catch (err: any) {
     r.classification = wasStarred ? 'favourite' : '';
     window.alert(`Star toggle failed: ${err?.message ?? err}`);

--- a/content/dashboard-v3/src/repo/v2-repo.ts
+++ b/content/dashboard-v3/src/repo/v2-repo.ts
@@ -254,6 +254,118 @@ export async function deleteFaultRule(
   );
 }
 
+// ----- Archived plays (forwarder side) -----
+
+/**
+ * Per-play summary row returned by /api/v2/plays. The full schema lives
+ * in api/openapi/v2/forwarder.yaml § PlaySummary; gen-types only pulls
+ * from proxy.yaml today, so the relevant fields are typed here. Extra
+ * server-side fields surface via index access without breaking the
+ * compile.
+ */
+export interface PlaySummary {
+  play_id: string;
+  player_id?: string;
+  session_id?: string;
+  group_id?: string;
+  content_id?: string;
+  attempt_id?: number;
+  attempt_count?: number;
+  started_at?: string;
+  last_seen_at?: string;
+  classification?: string;
+  last_state?: string;
+  last_player_error?: string;
+  metric_events?: number;
+  net_events?: number;
+  net_errors?: number;
+  net_faults?: number;
+  stalls?: number;
+  dropped_frames?: number;
+  master_manifest_failures?: number;
+  manifest_failures?: number;
+  segment_failures?: number;
+  all_failures?: number;
+  transport_failures?: number;
+  active_timeouts?: number;
+  idle_timeouts?: number;
+  bitrate_shifts?: number;
+  downshifts?: number;
+  upshifts?: number;
+  resolution_changes?: number;
+  avg_quality_pct?: number;
+  min_quality_pct?: number;
+  frames_displayed?: number;
+  first_frame_s?: number;
+  user_marked_count?: number;
+  frozen_count?: number;
+  segment_stall_count?: number;
+  restart_count?: number;
+  error_event_count?: number;
+  label_histogram?: [string, number][];
+  labels_total?: number;
+  labels_distinct_count?: number;
+  [k: string]: unknown;
+}
+
+export interface ListPlaysParams {
+  from?: string;
+  to?: string;
+  player_id?: string;
+  play_id?: string;
+  classification?: string;
+  limit?: number;
+}
+
+export async function listPlays(params: ListPlaysParams = {}): Promise<PlaySummary[]> {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null || v === '') continue;
+    qs.set(k, String(v));
+  }
+  const url = '/analytics/api/v2/plays' + (qs.toString() ? '?' + qs : '');
+  const { data } = await request<{ items: PlaySummary[]; next_cursor: unknown }>(url);
+  return data.items ?? [];
+}
+
+/**
+ * Fetch one archived play's summary. Returns null on 404 (the play
+ * hasn't archived any rows yet — common right after the live session
+ * ends but before the next forwarder flush). Other HTTP errors throw.
+ */
+export async function getPlay(playId: string): Promise<PlaySummary | null> {
+  try {
+    const { data } = await request<PlaySummary>(
+      `/analytics/api/v2/plays/${encodeURIComponent(playId)}`,
+    );
+    return data;
+  } catch (err) {
+    if (err instanceof RepoError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+/**
+ * Update an archived play's tiered-retention classification (#342).
+ * `value` is one of: 'favourite' | 'interesting' | 'other' | 'auto'.
+ * 'auto' re-runs the auto-classifier server-side; the response body
+ * carries the settled value the caller should write back into cache.
+ */
+export async function patchPlayClassification(
+  playId: string,
+  value: 'favourite' | 'interesting' | 'other' | 'auto',
+): Promise<PlaySummary> {
+  const { data } = await request<PlaySummary>(
+    `/analytics/api/v2/plays/${encodeURIComponent(playId)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/merge-patch+json' },
+      body: JSON.stringify({ classification: value }),
+    },
+  );
+  return data;
+}
+
 // ----- Network log -----
 
 export async function getPlayerNetworkLog(

--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -127,6 +127,33 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/PlayDetail' }
         '404': { $ref: '#/components/responses/Problem' }
+    patch:
+      tags: [plays]
+      summary: Update an archived play's classification
+      description: |
+        Today the only supported field is `classification`, which drives
+        the tiered TTL (#342): `favourite` is starred (kept forever),
+        `interesting` / `other` set the auto-classifier tier directly, and
+        `auto` re-runs the auto-classifier and writes whatever it returns.
+        ALTER UPDATEs all three archive tables in one shot.
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              properties:
+                classification:
+                  type: string
+                  enum: [favourite, interesting, other, auto]
+      responses:
+        '200':
+          description: Updated; body is the post-patch play summary.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlaySummary' }
+        '400': { $ref: '#/components/responses/Problem' }
+        '501': { $ref: '#/components/responses/Problem' }
 
   /api/v2/plays/aggregate:
     get:

--- a/content/dashboard/api-docs/forwarder.json
+++ b/content/dashboard/api-docs/forwarder.json
@@ -149,48 +149,6 @@
                 ]
             }
         },
-        "/api/sessions": {
-            "get": {
-                "description": "Returns one row per (session_id, play_id) seen in the archive within the time window.",
-                "parameters": [
-                    {
-                        "description": "ISO8601 lower bound (defaults to now-24h)",
-                        "in": "query",
-                        "name": "since",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "until",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "List archived sessions",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
         "/api/snapshots": {
             "get": {
                 "description": "Each row is one normalized session-state record; the snapshot stream emits these on every relevant change.",

--- a/content/dashboard/api-docs/forwarder.json
+++ b/content/dashboard/api-docs/forwarder.json
@@ -10,72 +10,6 @@
         "url": ""
     },
     "paths": {
-        "/api/network_requests": {
-            "get": {
-                "description": "Per-request rows mirrored from go-proxy's `/api/network/stream`, with `fault_category` / `fault_action` columns. ~10s ingestion lag from live.",
-                "parameters": [
-                    {
-                        "description": "session_id filter",
-                        "in": "query",
-                        "name": "session",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "play_id filter",
-                        "in": "query",
-                        "name": "play_id",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 lower bound",
-                        "in": "query",
-                        "name": "from",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "to",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "max rows",
-                        "in": "query",
-                        "name": "limit",
-                        "schema": {
-                            "type": "integer"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "items": {
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "Historical HAR-shaped network rows",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
         "/api/session_bundle": {
             "get": {
                 "description": "Streams a ZIP containing snapshots, events, network rows, and a HAR file for the given play_id (or full session_id). Useful for offline forensics.",
@@ -252,60 +186,6 @@
                     }
                 },
                 "summary": "List archived sessions",
-                "tags": [
-                    "archive"
-                ]
-            }
-        },
-        "/api/snapshot_count": {
-            "get": {
-                "parameters": [
-                    {
-                        "description": "session_id filter",
-                        "in": "query",
-                        "name": "session",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "play_id filter",
-                        "in": "query",
-                        "name": "play_id",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 lower bound",
-                        "in": "query",
-                        "name": "from",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "description": "ISO8601 upper bound",
-                        "in": "query",
-                        "name": "to",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "{count: N}"
-                    }
-                },
-                "summary": "Count archived snapshots",
                 "tags": [
                     "archive"
                 ]

--- a/content/dashboard/api-docs/proxy.json
+++ b/content/dashboard/api-docs/proxy.json
@@ -35,18 +35,6 @@
                 },
                 "type": "object"
             },
-            "main.LinkSessionsRequest": {
-                "properties": {
-                    "session_ids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
             "main.LossRequest": {
                 "properties": {
                     "loss_pct": {
@@ -289,14 +277,6 @@
                     }
                 },
                 "type": "object"
-            },
-            "main.UnlinkSessionRequest": {
-                "properties": {
-                    "session_id": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
             }
         }
     },
@@ -341,44 +321,6 @@
                 "summary": "External IPs the harness is reachable from",
                 "tags": [
                     "diagnostics"
-                ]
-            }
-        },
-        "/api/failure-settings/{id}": {
-            "post": {
-                "deprecated": true,
-                "description": "Predates the PATCH envelope. Kept for backwards compat with older dashboard code.",
-                "parameters": [
-                    {
-                        "description": "session_id",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "text/plain": {
-                            "schema": {
-                                "title": "body",
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "description": "fault settings",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Legacy fault-settings POST (use PATCH instead)",
-                "tags": [
-                    "internal"
                 ]
             }
         },
@@ -639,89 +581,6 @@
                 ]
             }
         },
-        "/api/session-group/link": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/main.LinkSessionsRequest",
-                                "summary": "body",
-                                "description": "{session_ids: [...]}"
-                            }
-                        }
-                    },
-                    "description": "{session_ids: [...]}",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Link sessions into a fault-propagation group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
-        "/api/session-group/unlink": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/main.UnlinkSessionRequest",
-                                "summary": "body",
-                                "description": "{session_id}"
-                            }
-                        }
-                    },
-                    "description": "{session_id}",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Unlink a session from its group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
-        "/api/session-group/{groupId}": {
-            "get": {
-                "parameters": [
-                    {
-                        "description": "group id",
-                        "in": "path",
-                        "name": "groupId",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    }
-                },
-                "summary": "Get a session group",
-                "tags": [
-                    "groups"
-                ]
-            }
-        },
         "/api/session/{id}": {
             "delete": {
                 "description": "Removes the session from the in-memory map and frees its dedicated proxy port.",
@@ -911,43 +770,6 @@
                 "summary": "Get one session's network ring buffer",
                 "tags": [
                     "network"
-                ]
-            }
-        },
-        "/api/session/{id}/update": {
-            "post": {
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "description": "session_id",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "text/plain": {
-                            "schema": {
-                                "title": "body",
-                                "type": "object"
-                            }
-                        }
-                    },
-                    "description": "settings",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "OK"
-                    }
-                },
-                "summary": "Legacy session-update POST (use PATCH instead)",
-                "tags": [
-                    "internal"
                 ]
             }
         },

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -287,32 +287,6 @@ server {
         add_header Expires "0" always;
     }
 
-    location ~ ^/api/failure-settings/ {
-        proxy_pass https://go_proxy;
-            proxy_ssl_verify off;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Port $server_port;
-        add_header Access-Control-Allow-Origin * always;
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-    }
-
-    location ~ ^/api/session-group/ {
-        proxy_pass https://go_proxy;
-            proxy_ssl_verify off;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Port $server_port;
-        add_header Access-Control-Allow-Origin * always;
-        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
-        add_header Pragma "no-cache" always;
-        add_header Expires "0" always;
-    }
-
     location ~ ^/api/nftables/ {
         proxy_pass https://go_proxy;
             proxy_ssl_verify off;

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1785,8 +1785,6 @@ func main() {
 	router.HandleFunc("/index.html", app.handleIndex).Methods(http.MethodGet)
 	router.HandleFunc("/api/sessions", app.handleGetSessions).Methods(http.MethodGet)
 	router.HandleFunc("/api/sessions/stream", app.handleSessionStream).Methods(http.MethodGet)
-	router.HandleFunc("/api/failure-settings/{id}", app.handleUpdateFailureSettings).Methods(http.MethodPost)
-	router.HandleFunc("/api/session/{id}/update", app.handleUpdateSessionSettings).Methods(http.MethodPost)
 	router.HandleFunc("/api/session/{id}", app.handleSession).Methods(http.MethodGet, http.MethodDelete)
 	router.HandleFunc("/api/session/{id}", app.handlePatchSession).Methods(http.MethodPatch)
 	router.HandleFunc("/api/session/{id}/metrics", app.handlePostSessionMetrics).Methods(http.MethodPost)
@@ -1798,9 +1796,6 @@ func main() {
 	router.HandleFunc("/api/control/stream", app.handleControlStream).Methods(http.MethodGet)
 	router.HandleFunc("/api/external-ips", app.handleGetExternalIPs).Methods(http.MethodGet)
 	router.HandleFunc("/api/clear-sessions", app.handleClearSessions).Methods(http.MethodPost)
-	router.HandleFunc("/api/session-group/link", app.handleLinkSessions).Methods(http.MethodPost)
-	router.HandleFunc("/api/session-group/unlink", app.handleUnlinkSession).Methods(http.MethodPost)
-	router.HandleFunc("/api/session-group/{groupId}", app.handleGetGroup).Methods(http.MethodGet)
 	router.HandleFunc("/myshows", app.handleMyShows).Methods(http.MethodGet)
 	router.HandleFunc("/debug", app.handleDebug).Methods(http.MethodGet)
 	router.HandleFunc("/api/nftables/status", app.handleNftStatus).Methods(http.MethodGet)
@@ -2231,25 +2226,6 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"status": "ok"})
 }
 
-
-func (a *App) handleUpdateFailureSettings(w http.ResponseWriter, r *http.Request) {
-	id := mux.Vars(r)["id"]
-	var payload map[string]interface{}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		writeJSON(w, map[string]string{"error": "invalid json"})
-		return
-	}
-	_, status, errMsg := a.applySessionSettingsUpdate(id, payload, "")
-	if status != http.StatusOK {
-		if errMsg == "" {
-			errMsg = "update failed"
-		}
-		w.WriteHeader(status)
-		writeJSON(w, map[string]string{"error": errMsg})
-		return
-	}
-	writeJSON(w, map[string]string{"message": "Settings updated successfully"})
-}
 
 func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface{}, baseRevision string) (SessionData, int, string) {
 	if payload == nil {
@@ -2787,10 +2763,6 @@ func parseShapeStepsFromSession(session SessionData) []NftShapeStep {
 	return nil
 }
 
-func (a *App) handleUpdateSessionSettings(w http.ResponseWriter, r *http.Request) {
-	a.handleUpdateFailureSettings(w, r)
-}
-
 func (a *App) handleSession(w http.ResponseWriter, r *http.Request) {
 	id := mux.Vars(r)["id"]
 	if r.Method == http.MethodDelete {
@@ -2968,125 +2940,6 @@ func (a *App) handleClearSessions(w http.ResponseWriter, r *http.Request) {
 	}
 	a.saveSessionList([]SessionData{})
 	writeJSON(w, map[string]string{"message": "All sessions cleared successfully"})
-}
-
-func (a *App) handleLinkSessions(w http.ResponseWriter, r *http.Request) {
-	var payload struct {
-		SessionIds []string `json:"session_ids"`
-		GroupId    string   `json:"group_id"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "invalid json"})
-		return
-	}
-	if len(payload.SessionIds) < 2 {
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "at least 2 sessions required"})
-		return
-	}
-	log.Printf("SESSION GROUP LINK request sessions=%v group_id=%s", payload.SessionIds, payload.GroupId)
-	controlRevision := newControlRevision()
-
-	// Generate a group ID if not provided
-	groupID := payload.GroupId
-	if groupID == "" {
-		groupID = fmt.Sprintf("G%d", time.Now().Unix()%10000)
-	}
-
-	linkedCount := 0
-	for _, targetID := range payload.SessionIds {
-		update := SessionData{
-			"session_id":       targetID,
-			"group_id":         groupID,
-			"control_revision": controlRevision,
-		}
-		a.saveSessionByID(targetID, update)
-		linkedCount++
-	}
-	log.Printf("SESSION GROUP LINK result group_id=%s linked=%d", groupID, linkedCount)
-
-	writeJSON(w, map[string]interface{}{
-		"message":      "Sessions linked successfully",
-		"group_id":     groupID,
-		"linked_count": linkedCount,
-	})
-}
-
-func (a *App) handleUnlinkSession(w http.ResponseWriter, r *http.Request) {
-	var payload struct {
-		SessionId   string `json:"session_id"`
-		GroupId     string `json:"group_id"`
-		UnlinkGroup bool   `json:"unlink_group"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "invalid json"})
-		return
-	}
-
-	sessions := a.getSessionList()
-	found := false
-	updated := 0
-	groupID := payload.GroupId
-	if groupID == "" && payload.SessionId != "" {
-		for _, session := range sessions {
-			if getString(session, "session_id") == payload.SessionId {
-				groupID = getString(session, "group_id")
-				break
-			}
-		}
-	}
-	controlRevision := newControlRevision()
-	if payload.UnlinkGroup && groupID != "" {
-		for _, session := range sessions {
-			if getString(session, "group_id") == groupID {
-				sid := getString(session, "session_id")
-				a.saveSessionByID(sid, SessionData{
-					"session_id":       sid,
-					"group_id":         "",
-					"control_revision": controlRevision,
-				})
-				updated++
-				found = true
-			}
-		}
-	} else if payload.SessionId != "" {
-		a.saveSessionByID(payload.SessionId, SessionData{
-			"session_id":       payload.SessionId,
-			"group_id":         "",
-			"control_revision": controlRevision,
-		})
-		updated++
-		found = true
-	}
-
-	if found {
-		writeJSON(w, map[string]interface{}{
-			"message":        "Session group updated successfully",
-			"group_id":       groupID,
-			"unlinked_count": updated,
-		})
-	} else {
-		w.WriteHeader(http.StatusNotFound)
-		writeJSON(w, map[string]string{"error": "Session not found"})
-	}
-}
-
-func (a *App) handleGetGroup(w http.ResponseWriter, r *http.Request) {
-	groupID := mux.Vars(r)["groupId"]
-	if groupID == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		writeJSON(w, map[string]string{"error": "group_id required"})
-		return
-	}
-
-	groupSessions := a.getSessionsByGroupId(groupID)
-	writeJSON(w, map[string]interface{}{
-		"group_id": groupID,
-		"sessions": groupSessions,
-		"count":    len(groupSessions),
-	})
 }
 
 func (a *App) handleMyShows(w http.ResponseWriter, r *http.Request) {
@@ -8835,22 +8688,6 @@ func extractGroupId(playerID string) string {
 		return "G" + matches[1]
 	}
 	return ""
-}
-
-// getSessionsByGroupId returns all sessions that belong to the specified group
-func (a *App) getSessionsByGroupId(groupID string) []SessionData {
-	if groupID == "" {
-		return []SessionData{}
-	}
-	sessions := a.getSessionList()
-	var groupSessions []SessionData
-	for _, session := range sessions {
-		sessionGroupID := getString(session, "group_id")
-		if sessionGroupID == groupID {
-			groupSessions = append(groupSessions, session)
-		}
-	}
-	return groupSessions
 }
 
 // getGroupIdByPort returns the group ID for sessions on the specified port.

--- a/go-proxy/cmd/server/openapi.go
+++ b/go-proxy/cmd/server/openapi.go
@@ -153,28 +153,6 @@ func docsNftStatus() {}
 //	@Router   /api/nftables/capabilities [get]
 func docsNftCapabilities() {}
 
-//	@Summary  Link sessions into a fault-propagation group
-//	@Tags     groups
-//	@Param    body  body  LinkSessionsRequest true "{session_ids: [...]}"
-//	@Success  200
-//	@Router   /api/session-group/link [post]
-func docsLinkSessions() {}
-
-//	@Summary  Unlink a session from its group
-//	@Tags     groups
-//	@Param    body body UnlinkSessionRequest true "{session_id}"
-//	@Success  200
-//	@Router   /api/session-group/unlink [post]
-func docsUnlinkSession() {}
-
-//	@Summary  Get a session group
-//	@Tags     groups
-//	@Param    groupId path string true "group id"
-//	@Produce  json
-//	@Success  200 {object} object
-//	@Router   /api/session-group/{groupId} [get]
-func docsGetGroup() {}
-
 //	@Summary  External IPs the harness is reachable from
 //	@Tags     diagnostics
 //	@Produce  json
@@ -197,25 +175,6 @@ func docsVersion() {}
 //	@Success  200
 //	@Router   /api/session/{id}/metrics [post]
 func docsPostMetrics() {}
-
-//	@Summary  Legacy fault-settings POST (use PATCH instead)
-//	@Description Predates the PATCH envelope. Kept for backwards compat with older dashboard code.
-//	@Tags     internal
-//	@Deprecated
-//	@Param    id   path  string true "session_id"
-//	@Param    body body  object true "fault settings"
-//	@Success  200
-//	@Router   /api/failure-settings/{id} [post]
-func docsFailureSettings() {}
-
-//	@Summary  Legacy session-update POST (use PATCH instead)
-//	@Tags     internal
-//	@Deprecated
-//	@Param    id path string true "session_id"
-//	@Param    body body object true "settings"
-//	@Success  200
-//	@Router   /api/session/{id}/update [post]
-func docsSessionUpdate() {}
 
 // Request/response types referenced from the @Param / @Success blocks above.
 // These are *documentation* types — real handlers may use map[string]any
@@ -272,16 +231,6 @@ type BandwidthRequest struct {
 // LossRequest sets only the packet-loss percentage.
 type LossRequest struct {
 	LossPct float64 `json:"loss_pct"`
-}
-
-// LinkSessionsRequest groups sessions for fault propagation.
-type LinkSessionsRequest struct {
-	SessionIDs []string `json:"session_ids"`
-}
-
-// UnlinkSessionRequest removes one session from its current group.
-type UnlinkSessionRequest struct {
-	SessionID string `json:"session_id"`
 }
 
 // NetworkLogEntry is defined in main.go; swag picks up the real type

--- a/go-proxy/cmd/server/templates/index.html
+++ b/go-proxy/cmd/server/templates/index.html
@@ -335,7 +335,7 @@
 
                             // Fetch failure types from the server
                             $.ajax({
-                                url: `/api/failure-settings/${sessionId}`,
+                                url: `/api/session/${sessionId}`,
                                 method: 'GET',
                                 success: function(failureTypes) {
                                     $(`input[name="segment_failure_type_${sessionId}"][value="${failureTypes.segment_failure_type}"]`).prop('checked', true);
@@ -401,24 +401,25 @@
                 localStorage.setItem(`consecutive_failures_${sessionId}`, consecutiveFailures);
                 localStorage.setItem(`segment_failure_mode_${sessionId}`, segmentFailureMode);
 
+                const settings = {
+                    session_id: sessionId,
+                    segment_failure_type: segmentFailureType,
+                    manifest_failure_type: manifestFailureType,
+                    master_manifest_failure_type: masterManifestFailureType,
+                    segment_failure_frequency: segmentFailureFrequency,
+                    segment_consecutive_units: segmentConsecutiveUnits,
+                    segment_frequency_units: segmentFrequencyUnits,
+                    segment_failure_mode: segmentFailureMode,
+                    manifest_failure_frequency: manifestFailureFrequency,
+                    master_manifest_failure_frequency: masterManifestFailureFrequency,
+                    consecutive_failures: consecutiveFailures
+                };
                 $.ajax({
-                    // URL for the management interface
-                    url: `/api/failure-settings/${sessionId}`,
-                    method: 'POST',
+                    // PATCH /api/session/{id} consolidated v1 surface.
+                    url: `/api/session/${sessionId}`,
+                    method: 'PATCH',
                     contentType: 'application/json',
-                    data: JSON.stringify({
-                        session_id: sessionId,
-                        segment_failure_type: segmentFailureType,
-                            manifest_failure_type: manifestFailureType,
-                            master_manifest_failure_type: masterManifestFailureType,
-                        segment_failure_frequency: segmentFailureFrequency,
-                        segment_consecutive_units: segmentConsecutiveUnits,
-                        segment_frequency_units: segmentFrequencyUnits,
-                        segment_failure_mode: segmentFailureMode,
-                            manifest_failure_frequency: manifestFailureFrequency,
-                            master_manifest_failure_frequency: masterManifestFailureFrequency,
-                        consecutive_failures: consecutiveFailures
-                    }),
+                    data: JSON.stringify({ set: settings, fields: Object.keys(settings) }),
                     success: function(response) {
                         $('#message').text('');
                     },

--- a/tests/hls_failure_probe.py
+++ b/tests/hls_failure_probe.py
@@ -847,8 +847,9 @@ def run_simple_window(kind, url, args, duration_s, verbose_label="MASTER", timeo
 
 
 def apply_failure_settings(api_base, session_id, payload, verbose=False):
-    url = f"{api_base}/api/failure-settings/{session_id}"
-    return api_request_json(url, method="POST", payload=payload, timeout=10, verbose=verbose)
+    url = f"{api_base}/api/session/{session_id}"
+    envelope = {"set": payload, "fields": list(payload.keys())}
+    return api_request_json(url, method="PATCH", payload=envelope, timeout=10, verbose=verbose)
 
 
 def apply_shaping(api_base, port, rate_mbps, delay_ms=0, loss_pct=0.0, verbose=False):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -460,9 +460,10 @@ def wait_for_transport_active(api_base, session_id, timeout=6, verbose=False):
 
 
 def apply_failure_settings(api_base, session_id, payload, verbose=False):
-    """Apply failure settings to session."""
-    url = f"{api_base}/api/failure-settings/{session_id}"
-    return api_request_json(url, method="POST", payload=payload, timeout=10, verbose=verbose)
+    """Apply failure settings to session via PATCH /api/session/{id}."""
+    url = f"{api_base}/api/session/{session_id}"
+    envelope = {"set": payload, "fields": list(payload.keys())}
+    return api_request_json(url, method="PATCH", payload=envelope, timeout=10, verbose=verbose)
 
 
 def apply_shaping(api_base, port, rate_mbps, delay_ms=0, loss_pct=0.0, verbose=False):


### PR DESCRIPTION
## Summary

Closes the #478 milestone: retire the v1 `/api/sessions*` archive surface and move the dashboard plays list + star toggle onto v2 + TanStack Query.

- **Milestone A** (`eba248c`) — drop orphaned v1 routes that had no callers
- **Milestone B** (`93998b6`) — Sessions picker reads `/api/v2/plays`; star toggles via `PATCH /api/v2/plays/{play_id}`; retires `/api/sessions/{sid}/{pid}/{star,reclassify}`
- **Fix** (`5e9a0ee`) — alias v2 `label_histogram` → `labels` so chips + severity filter keep working
- **Fix** (`945df6f`) — wait for ALTER UPDATE to settle on the classification PATCH path (eventual-consistency hazard)
- **Refactor** (`5f022f8`) — route plays list + star toggle through TanStack so cache invalidation is automatic

## Why now

This branch was started before the recent characterization work landed on dev. Rebased onto current dev (resolved 3 conflicts — kept `registerCharacterizationHandlers` and merged additive imports in `Sessions.vue` / `SessionViewer.vue`).

## Test plan

- [x] `go build ./...` on forwarder + go-proxy
- [x] `npm run build` (vue-tsc + vite) on dashboard-v3 — clean
- [ ] Smoke `/dashboard/v3/sessions` against test-dev: load plays, toggle star, severity filter, label chips
- [ ] Smoke `/dashboard/v3/session-viewer` archive view: classification PATCH round-trips
- [ ] `harness archive plays` still works
- [ ] Confirm v1 `/api/sessions*` callers are truly gone (grep dashboard-v3 + any external)

🤖 Generated with [Claude Code](https://claude.com/claude-code)