### PR TITLE
refactor(forwarder): extract play domain logic into internal/plays (#498)

### DIFF
--- a/analytics/go-forwarder/classification.go
+++ b/analytics/go-forwarder/classification.go
@@ -1,9 +1,9 @@
 // Tiered retention for archived sessions (issue #342).
 //
 // Each row of (session_id, play_id) carries a `classification`
-// LowCardinality(String) in both `session_snapshots` and
-// `network_requests`. ClickHouse TTL evicts rows according to that
-// value:
+// LowCardinality(String) in `session_events`, `network_requests`,
+// and `control_events`. ClickHouse TTL evicts rows according to
+// that value:
 //
 //   'other'        → 30 d  (default; the boring sessions)
 //   'interesting'  → 90 d  (auto-classified at session-end if any of
@@ -14,34 +14,29 @@
 //                              that matches, so rows are never dropped)
 //
 // The forwarder mutates `classification` via ALTER UPDATE on three
-// occasions: session-end (auto-classifier), star, unstar. ClickHouse
-// mutations are async — they complete in seconds at our scale and
-// settle long before the 30-day grace would matter.
-//
-// Per-row TTL evaluates each row's `ts` independently. For long
-// sessions the front of the session may evict before the back over
-// the session's wall-clock duration; #347 tracks the `session_end_ts`
-// polish for strict all-or-nothing eviction once that becomes a real
-// concern.
+// occasions: session-end (auto-classifier), star, unstar. The actual
+// SQL lives in internal/plays/classification.go — this file holds the
+// ingest-time queue + drain loop that batches auto-classification
+// requests so a long session doesn't fire a mutation per row.
 
 package main
 
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder/internal/plays"
 )
 
 // hasInterestingSignal returns true if the snapshot map carries any
 // of the 5 last_event values that drive the picker's "Flags" chips.
-// Matches reclassifySession's SQL predicate exactly so chip + filter
-// + retention tier agree on what "interesting" means.
+// Matches plays.ReclassifySession's SQL predicate exactly so chip +
+// filter + retention tier agree on what "interesting" means.
 func hasInterestingSignal(s map[string]interface{}) bool {
 	switch strings.ToLower(strings.TrimSpace(getStr(s, "player_metrics_last_event"))) {
 	case "user_marked", "frozen", "segment_stall", "restart", "error":
@@ -52,9 +47,9 @@ func hasInterestingSignal(s map[string]interface{}) bool {
 
 // classifyQueue debounces auto-reclassification requests. A session
 // snapshot carrying an interesting signal calls .mark(); a goroutine
-// drains the queue every flushInterval and fires reclassifySession
-// for each (session, play) pair, with `force=false` so existing
-// 'favourite' classifications stay put.
+// drains the queue every flushInterval and fires the domain
+// reclassifier for each (session, play) pair, with `force=false` so
+// existing 'favourite' classifications stay put.
 //
 // The queue is a set, not a list — repeated marks for the same key
 // coalesce into one ALTER UPDATE per flush window.
@@ -93,11 +88,12 @@ func (q *classifyQueue) drain() []classifyKey {
 }
 
 // runClassifyLoop drains the queue periodically and fires the auto-
-// classifier ALTER UPDATEs. Designed to run as a single goroutine
-// for the lifetime of the process.
+// classifier ALTER UPDATEs via internal/plays. Single goroutine for
+// the lifetime of the process.
 func runClassifyLoop(ctx context.Context, cfg config, q *classifyQueue, interval time.Duration) {
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
+	be := playsBackend(cfg)
 	for {
 		select {
 		case <-ctx.Done():
@@ -105,160 +101,12 @@ func runClassifyLoop(ctx context.Context, cfg config, q *classifyQueue, interval
 		case <-tick.C:
 			keys := q.drain()
 			for _, k := range keys {
-				if err := reclassifySession(ctx, cfg, k.sessionID, k.playID, false); err != nil {
+				if err := plays.ReclassifySession(ctx, be, k.sessionID, k.playID, false); err != nil {
 					log.Printf("auto-classify failed sid=%s pid=%s: %v", k.sessionID, k.playID, err)
 				}
 			}
 		}
 	}
-}
-
-// reclassifySession runs the auto-classifier predicate against
-// `session_snapshots` and writes either 'interesting' or 'other' to
-// every row of (session_id, play_id) in both data tables.
-// `force` overrides any existing classification — used by the unstar
-// path to reset a previously-favourited session back to whatever the
-// auto-classifier would have said.
-//
-// `play_id` may be empty (legacy rows ingested before the proxy
-// stamped play_id) — the WHERE clause matches the empty string in
-// that case.
-func reclassifySession(ctx context.Context, cfg config, sessionID, playID string, force bool) error {
-	if sessionID == "" {
-		return errors.New("session id required")
-	}
-	// 1. Determine whether the session is interesting. The signals
-	// match the per-row "Flags" column on the picker exactly — any of
-	// the 5 chip types appearing as a last_event value. Keeping the
-	// predicate narrow (just last_event) means the filter chip on
-	// the picker, the auto-classifier, and the retention tier all
-	// agree on what "interesting" means.
-	probe := fmt.Sprintf(`
-		SELECT count() FROM %s.%s
-		WHERE session_id = {session:String} AND play_id = {play:String}
-		  AND last_event IN ('user_marked', 'frozen', 'segment_stall', 'restart', 'error')
-		FORMAT TSV`, cfg.chDatabase, cfg.chTable)
-	body, err := chQueryBytes(ctx, cfg, probe, map[string]string{
-		"session": sessionID,
-		"play":    playID,
-	})
-	if err != nil {
-		return fmt.Errorf("auto-classifier probe: %w", err)
-	}
-	count := strings.TrimSpace(string(body))
-	target := "other"
-	if count != "" && count != "0" {
-		target = "interesting"
-	}
-	return setClassification(ctx, cfg, sessionID, playID, target, force)
-}
-
-// reclassifyPlay is the play-scoped twin of reclassifySession: same
-// auto-classifier predicate, but the WHERE clause keys on play_id
-// alone (no session_id). Used by PATCH /api/v2/plays/{id}, where the
-// caller has a play_id but no session_id.
-func reclassifyPlay(ctx context.Context, cfg config, playID string, force bool) error {
-	if playID == "" {
-		return errors.New("play id required")
-	}
-	probe := fmt.Sprintf(`
-		SELECT count() FROM %s.%s
-		WHERE play_id = {play:String}
-		  AND last_event IN ('user_marked', 'frozen', 'segment_stall', 'restart', 'error')
-		FORMAT TSV`, cfg.chDatabase, cfg.chTable)
-	body, err := chQueryBytes(ctx, cfg, probe, map[string]string{"play": playID})
-	if err != nil {
-		return fmt.Errorf("auto-classifier probe: %w", err)
-	}
-	target := "other"
-	if c := strings.TrimSpace(string(body)); c != "" && c != "0" {
-		target = "interesting"
-	}
-	return setPlayClassification(ctx, cfg, playID, target, force)
-}
-
-// setPlayClassification is the play-scoped twin of setClassification.
-// Same three-table ALTER UPDATE pattern but keyed on play_id only, so
-// the v2 PATCH endpoint doesn't have to round-trip the session_id.
-//
-// `SETTINGS mutations_sync = 2` makes the ALTER UPDATE wait for the
-// mutation to be applied before returning. Without this CH's default
-// (mutations_sync = 0) returns immediately and the SELECT v2PlayPatchHandler
-// runs right after still reads the pre-mutation classification — the PATCH
-// response then carries a stale value and the dashboard's optimistic flip
-// visibly reverts before the next 5s refetch reconciles. Per-play volumes
-// are tiny so the wait is sub-second in practice.
-func setPlayClassification(ctx context.Context, cfg config, playID, value string, force bool) error {
-	if playID == "" {
-		return errors.New("play id required")
-	}
-	whereSafe := "WHERE play_id = {play:String}"
-	if !force {
-		whereSafe += " AND classification != 'favourite'"
-	}
-	params := map[string]string{"play": playID, "cls": value}
-	const syncSuffix = " SETTINGS mutations_sync = 2"
-	updates := []struct {
-		label string
-		query string
-	}{
-		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, cfg.chTable, whereSafe)},
-		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, whereSafe)},
-		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s"+syncSuffix, cfg.chDatabase, whereSafe)},
-	}
-	for _, u := range updates {
-		if _, err := chQueryBytes(ctx, cfg, u.query, params); err != nil {
-			log.Printf("ALTER UPDATE classification table=%s pid=%s value=%s err=%v",
-				u.label, playID, value, err)
-			return fmt.Errorf("ALTER UPDATE classification on %s: %w", u.label, err)
-		}
-	}
-	return nil
-}
-
-// setClassification writes `value` to every row of (session_id,
-// play_id) in both data tables via parallel ALTER UPDATE statements.
-// When `force=false`, doesn't overwrite an existing 'favourite' (the
-// auto-classifier path shouldn't quietly demote a starred session).
-// When `force=true`, overrides any existing value (used by star and
-// unstar paths).
-func setClassification(ctx context.Context, cfg config, sessionID, playID, value string, force bool) error {
-	whereSafe := "WHERE session_id = {session:String} AND play_id = {play:String}"
-	if !force {
-		// Don't trample 'favourite' — those are user-starred and the
-		// star always wins over the auto-classifier.
-		whereSafe += " AND classification != 'favourite'"
-	}
-	params := map[string]string{
-		"session": sessionID,
-		"play":    playID,
-		"cls":     value,
-	}
-	// Two ALTER UPDATEs run sequentially on different tables. If the
-	// first succeeds but the second fails the tables are momentarily
-	// out of sync (snapshots.classification != network_requests
-	// .classification for the same session+play). At our scale this
-	// is harmless — at most one tier-boundary's worth of premature
-	// or delayed eviction — but log distinguishably so an operator
-	// can see WHICH table failed and re-run by hand if needed.
-	updates := []struct {
-		label string
-		query string
-	}{
-		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s", cfg.chDatabase, cfg.chTable, whereSafe)},
-		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
-		// Mirror onto control_events so the proxy/harness action log
-		// ages out on the same TTL tier as the parent session.
-		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s", cfg.chDatabase, whereSafe)},
-	}
-	for _, u := range updates {
-		if _, err := chQueryBytes(ctx, cfg, u.query, params); err != nil {
-			log.Printf("ALTER UPDATE classification table=%s sid=%s pid=%s value=%s err=%v",
-				u.label, sessionID, playID, value, err)
-			return fmt.Errorf("ALTER UPDATE classification on %s: %w", u.label, err)
-		}
-	}
-	return nil
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/analytics/go-forwarder/internal/plays/backend.go
+++ b/analytics/go-forwarder/internal/plays/backend.go
@@ -1,0 +1,19 @@
+package plays
+
+// Backend is the minimal ClickHouse handle the domain functions need.
+// The forwarder's main package builds one from its `config` struct
+// and passes it on every call.
+//
+// Kept tiny on purpose — anything beyond what's needed to address
+// CH (URL, db, events table, auth) belongs in the call signature, not
+// here.
+type Backend struct {
+	ClickHouseURL string
+	Database      string
+	// EventsTable is the per-snapshot table name. The schema rename in
+	// #472 made the canonical name `session_events`; the field stays
+	// configurable so old deploys / tests can override.
+	EventsTable string
+	User        string
+	Password    string
+}

--- a/analytics/go-forwarder/internal/plays/ch.go
+++ b/analytics/go-forwarder/internal/plays/ch.go
@@ -1,0 +1,93 @@
+package plays
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// queryRows runs a JSONEachRow query and parses the rows. Mirrors
+// the main package's `queryClickHouseRows` — kept private here to
+// avoid coupling the two helper sets.
+func (b Backend) queryRows(ctx context.Context, query string, params map[string]string) ([]map[string]any, error) {
+	u, err := url.Parse(b.ClickHouseURL)
+	if err != nil {
+		return nil, err
+	}
+	qs := u.Query()
+	qs.Set("query", query)
+	qs.Set("default_format", "JSONEachRow")
+	for k, v := range params {
+		qs.Set("param_"+k, v)
+	}
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if b.User != "" {
+		req.SetBasicAuth(b.User, b.Password)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("clickhouse: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var out []map[string]any
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal(line, &row); err != nil {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out, scanner.Err()
+}
+
+// queryBytes is the bytes-back version — used by mutations (ALTER
+// UPDATE) and probes that read a single scalar. Mirrors the main
+// package's `chQueryBytes`.
+func (b Backend) queryBytes(ctx context.Context, query string, params map[string]string) ([]byte, error) {
+	u, err := url.Parse(b.ClickHouseURL)
+	if err != nil {
+		return nil, err
+	}
+	qs := u.Query()
+	qs.Set("default_format", "JSONEachRow")
+	for k, v := range params {
+		qs.Set("param_"+k, v)
+	}
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(query))
+	if err != nil {
+		return nil, err
+	}
+	if b.User != "" {
+		req.SetBasicAuth(b.User, b.Password)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}

--- a/analytics/go-forwarder/internal/plays/classification.go
+++ b/analytics/go-forwarder/internal/plays/classification.go
@@ -1,0 +1,140 @@
+package plays
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+)
+
+// Classification values accepted by the v2 plays PATCH endpoint and
+// the chat tools. `auto` is the request to re-run the auto-classifier
+// (the value finally written is `interesting` or `other`).
+const (
+	ClassificationOther       = "other"
+	ClassificationInteresting = "interesting"
+	ClassificationFavourite   = "favourite"
+)
+
+// SetPlayClassification writes `value` to every row of play_id in
+// session_events + network_requests + control_events. When force is
+// false, existing `favourite` rows are preserved (the auto-classifier
+// must not quietly demote a starred play).
+//
+// `SETTINGS mutations_sync = 2` makes ALTER UPDATE wait for the
+// mutation to apply before returning, so a v2 PATCH response sees the
+// settled value (avoids dashboard optimistic-flip-revert flicker).
+func SetPlayClassification(ctx context.Context, b Backend, playID, value string, force bool) error {
+	if playID == "" {
+		return errors.New("play id required")
+	}
+	whereSafe := "WHERE play_id = {play:String}"
+	if !force {
+		whereSafe += " AND classification != 'favourite'"
+	}
+	params := map[string]string{"play": playID, "cls": value}
+	const syncSuffix = " SETTINGS mutations_sync = 2"
+	updates := []struct {
+		label string
+		query string
+	}{
+		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s"+syncSuffix, b.Database, b.EventsTable, whereSafe)},
+		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s"+syncSuffix, b.Database, whereSafe)},
+		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s"+syncSuffix, b.Database, whereSafe)},
+	}
+	for _, u := range updates {
+		if _, err := b.queryBytes(ctx, u.query, params); err != nil {
+			log.Printf("ALTER UPDATE classification table=%s pid=%s value=%s err=%v",
+				u.label, playID, value, err)
+			return fmt.Errorf("ALTER UPDATE classification on %s: %w", u.label, err)
+		}
+	}
+	return nil
+}
+
+// SetClassification is the session-scoped twin: keyed on (session_id,
+// play_id) so the auto-classifier (which drains by session) doesn't
+// have to round-trip to a play_id-only key.
+//
+// Doesn't use mutations_sync = 2 — the auto-classifier doesn't read
+// back, so the async default is fine (and cheaper at queue-drain
+// rates).
+func SetClassification(ctx context.Context, b Backend, sessionID, playID, value string, force bool) error {
+	whereSafe := "WHERE session_id = {session:String} AND play_id = {play:String}"
+	if !force {
+		whereSafe += " AND classification != 'favourite'"
+	}
+	params := map[string]string{
+		"session": sessionID,
+		"play":    playID,
+		"cls":     value,
+	}
+	updates := []struct {
+		label string
+		query string
+	}{
+		{"session_events", fmt.Sprintf("ALTER TABLE %s.%s UPDATE classification = {cls:String} %s", b.Database, b.EventsTable, whereSafe)},
+		{"network_requests", fmt.Sprintf("ALTER TABLE %s.network_requests UPDATE classification = {cls:String} %s", b.Database, whereSafe)},
+		{"control_events", fmt.Sprintf("ALTER TABLE %s.control_events UPDATE classification = {cls:String} %s", b.Database, whereSafe)},
+	}
+	for _, u := range updates {
+		if _, err := b.queryBytes(ctx, u.query, params); err != nil {
+			log.Printf("ALTER UPDATE classification table=%s sid=%s pid=%s value=%s err=%v",
+				u.label, sessionID, playID, value, err)
+			return fmt.Errorf("ALTER UPDATE classification on %s: %w", u.label, err)
+		}
+	}
+	return nil
+}
+
+// ReclassifyPlay runs the auto-classifier predicate against
+// session_events filtered on play_id alone, then writes the result
+// via SetPlayClassification. Used by PATCH /api/v2/plays/{id} with
+// classification=auto.
+func ReclassifyPlay(ctx context.Context, b Backend, playID string, force bool) error {
+	if playID == "" {
+		return errors.New("play id required")
+	}
+	probe := fmt.Sprintf(`
+		SELECT count() FROM %s.%s
+		WHERE play_id = {play:String}
+		  AND last_event IN ('user_marked', 'frozen', 'segment_stall', 'restart', 'error')
+		FORMAT TSV`, b.Database, b.EventsTable)
+	body, err := b.queryBytes(ctx, probe, map[string]string{"play": playID})
+	if err != nil {
+		return fmt.Errorf("auto-classifier probe: %w", err)
+	}
+	target := ClassificationOther
+	if c := strings.TrimSpace(string(body)); c != "" && c != "0" {
+		target = ClassificationInteresting
+	}
+	return SetPlayClassification(ctx, b, playID, target, force)
+}
+
+// ReclassifySession is the session-scoped twin of ReclassifyPlay,
+// used by the auto-classifier queue drain. play_id may be empty for
+// pre-stamp legacy rows.
+func ReclassifySession(ctx context.Context, b Backend, sessionID, playID string, force bool) error {
+	if sessionID == "" {
+		return errors.New("session id required")
+	}
+	probe := fmt.Sprintf(`
+		SELECT count() FROM %s.%s
+		WHERE session_id = {session:String} AND play_id = {play:String}
+		  AND last_event IN ('user_marked', 'frozen', 'segment_stall', 'restart', 'error')
+		FORMAT TSV`, b.Database, b.EventsTable)
+	body, err := b.queryBytes(ctx, probe, map[string]string{
+		"session": sessionID,
+		"play":    playID,
+	})
+	if err != nil {
+		return fmt.Errorf("auto-classifier probe: %w", err)
+	}
+	count := strings.TrimSpace(string(body))
+	target := ClassificationOther
+	if count != "" && count != "0" {
+		target = ClassificationInteresting
+	}
+	return SetClassification(ctx, b, sessionID, playID, target, force)
+}

--- a/analytics/go-forwarder/internal/plays/control.go
+++ b/analytics/go-forwarder/internal/plays/control.go
@@ -1,0 +1,70 @@
+package plays
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ControlEventsFilter narrows a control_events query. PlayerID is
+// required (the table is indexed on it and every operational view
+// scopes to a player); the other fields are optional narrowings.
+type ControlEventsFilter struct {
+	PlayerID string
+	PlayID   string
+	From     string // CH datetime string
+	To       string
+	Labels   LabelFilter
+	Limit    int // 0 = use default (1000)
+}
+
+const (
+	defaultControlEventsLimit = 1000
+	maxControlEventsLimit     = 10000
+)
+
+// GetControlEvents returns control_events rows for a player, in the
+// same shape /api/v2/control_events serves today. Each row is a
+// map[string]any so the JSON output stays byte-identical.
+//
+// Sort is ascending by ts (matches the dashboard's PlayLog rendering
+// order). Caller is expected to canonicalise PlayerID/PlayID before
+// calling — matches the HTTP handler's contract.
+func GetControlEvents(ctx context.Context, b Backend, f ControlEventsFilter) ([]map[string]any, error) {
+	if f.PlayerID == "" {
+		return nil, errors.New("player_id required")
+	}
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultControlEventsLimit
+	}
+	if limit > maxControlEventsLimit {
+		limit = maxControlEventsLimit
+	}
+
+	params := map[string]string{
+		"player_id": f.PlayerID,
+		"limit":     fmt.Sprintf("%d", limit),
+	}
+	where := []string{"player_id = {player_id:String}"}
+	if f.PlayID != "" {
+		params["play_id"] = f.PlayID
+		where = append(where, "play_id = {play_id:String}")
+	}
+	if f.From != "" {
+		params["from"] = f.From
+		where = append(where, "ts >= parseDateTime64BestEffortOrNull({from:String}, 3)")
+	}
+	if f.To != "" {
+		params["to"] = f.To
+		where = append(where, "ts <= parseDateTime64BestEffortOrNull({to:String}, 3)")
+	}
+	where, params = f.Labels.applyTo(where, params, "labels")
+
+	query := "SELECT ts, player_id, play_id, attempt_id, session_id, source, event, info, labels, event_fingerprint, classification " +
+		"FROM " + b.Database + ".control_events WHERE " +
+		strings.Join(where, " AND ") +
+		" ORDER BY ts ASC LIMIT {limit:UInt32}"
+	return b.queryRows(ctx, query, params)
+}

--- a/analytics/go-forwarder/internal/plays/doc.go
+++ b/analytics/go-forwarder/internal/plays/doc.go
@@ -1,0 +1,19 @@
+// Package plays is the typed domain layer over ClickHouse for play-
+// centric read operations.
+//
+// The HTTP handlers in the forwarder's main package are thin shims:
+// parse the request, call into this package, render the response. The
+// chat backend's typed tools (see #497) call the same functions
+// directly, in-process, with no loopback HTTP / JSON tax.
+//
+// What lives here: anything that has a typed parameter / typed return
+// shape — list/get/filter operations, classification mutations,
+// labels-aware aggregations. Anything that's intrinsically streaming
+// (NDJSON snapshot replay, the v2 timeseries SSE multiplex, ZIP bundle
+// streaming) stays in the main package — those don't fit a "function
+// returns a slice" model.
+//
+// What does NOT live here: SSE event hubs, ring buffers, write-side
+// batchers, label classifiers (those run at ingest time, not query
+// time). They're all in main.
+package plays

--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -1,0 +1,274 @@
+package plays
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FindPlays returns one row per play matching the filter, in the
+// same shape /api/v2/plays renders today. Each row is a
+// map[string]any so the JSON output stays byte-for-byte identical
+// to the v1-era response shape clients depend on.
+//
+// The SQL is the same as the original queryPlaySummaries: snapshot
+// aggregation in `agg`, network counts joined in, label histogram
+// joined in via the labels_unioned/labels_per_play/labels_agg CTEs.
+// Label filters apply AFTER the labels_agg join.
+//
+// The 24h auto-bound fires only when the caller supplied NO scope
+// (no player_id, no play_id, no attempt_id, no from/to) — same
+// behaviour the v1 handler had to keep the snapshots partition scan
+// bounded.
+func FindPlays(ctx context.Context, b Backend, f PlayFilter) ([]map[string]any, error) {
+	clauses, params, err := buildPlaysFilter(f)
+	if err != nil {
+		return nil, err
+	}
+
+	// Post-join label filter — applied against the per-play
+	// labels_distinct array assembled in labels_agg. Same tristate
+	// semantics as the per-row filter on the events/network tables.
+	var post []string
+	post, params = f.Labels.applyTo(post, params, "labels_agg.labels_distinct")
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = defaultPlaysLimit
+	}
+	if limit > maxPlaysLimit {
+		limit = maxPlaysLimit
+	}
+
+	return runPlaysQuery(ctx, b, clauses, params, post, limit)
+}
+
+// GetPlaySummary returns the single PlaySummary for play_id, or nil
+// (no error) when no archived rows exist for that play. Same
+// shape as a single row from FindPlays.
+func GetPlaySummary(ctx context.Context, b Backend, playID string) (map[string]any, error) {
+	if playID == "" {
+		return nil, errors.New("play_id required")
+	}
+	rows, err := FindPlays(ctx, b, PlayFilter{PlayID: playID, Limit: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return rows[0], nil
+}
+
+// buildPlaysFilter shapes the base WHERE clauses + CH parameter map.
+// Same logic as the v1 handler's buildPlaysFilter helper, lifted as-is.
+func buildPlaysFilter(f PlayFilter) ([]string, map[string]string, error) {
+	params := map[string]string{}
+	// play_id != '' drops pre-stamp legacy rows. v1 surfaced them as
+	// the literal "—" but v2 plays are defined to be proper UUIDs.
+	clauses := []string{"play_id != ''"}
+	if f.PlayerID != "" {
+		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+		params["player"] = f.PlayerID
+	}
+	if f.PlayID != "" {
+		clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+		params["play"] = f.PlayID
+	}
+	if f.AttemptID != "" {
+		clauses = append(clauses, "attempt_id = {attempt:UInt32}")
+		params["attempt"] = f.AttemptID
+	}
+	if f.From != "" {
+		clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
+		params["from"] = f.From
+	}
+	if f.To != "" {
+		clauses = append(clauses, "ts < parseDateTime64BestEffort({to:String})")
+		params["to"] = f.To
+	}
+	if f.Classification != "" {
+		switch f.Classification {
+		case "interesting", "other", "favourite":
+			clauses = append(clauses, "classification = {classification:String}")
+			params["classification"] = f.Classification
+		default:
+			return nil, nil, errors.New("classification must be one of: interesting, other, favourite")
+		}
+	}
+	if f.PlayerID == "" && f.PlayID == "" && f.AttemptID == "" && f.From == "" && f.To == "" {
+		// Bound the scan when caller didn't — the events table is
+		// partitioned by toYYYYMMDD(ts).
+		clauses = append(clauses, "ts >= now() - INTERVAL 24 HOUR")
+	}
+	return clauses, params, nil
+}
+
+// runPlaysQuery is the SQL template + execution. Kept private — the
+// shape is awkward (3 clause/param threadings; postClauses for label
+// filter pushdown) and there's no caller outside this file.
+func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[string]string, postClauses []string, limit int) ([]map[string]any, error) {
+	where := "WHERE " + strings.Join(clauses, " AND ")
+	// network_requests has no classification column; rebuild a
+	// classification-free WHERE for the net_counts CTE.
+	netClauses := []string{"play_id != ''"}
+	for _, c := range clauses {
+		if strings.Contains(c, "classification") {
+			continue
+		}
+		if c == "play_id != ''" {
+			continue
+		}
+		netClauses = append(netClauses, c)
+	}
+	netWhere := "WHERE " + strings.Join(netClauses, " AND ")
+
+	query := fmt.Sprintf(`
+		WITH base AS (
+		  SELECT
+		    session_id, play_id, attempt_id, ts,
+		    player_id, group_id, content_id,
+		    player_state, player_error, last_event,
+		    stall_count, dropped_frames, frames_displayed,
+		    video_bitrate_mbps, video_resolution, video_quality_pct,
+		    video_first_frame_time_s,
+		    master_manifest_consecutive_failures,
+		    manifest_consecutive_failures,
+		    segment_consecutive_failures,
+		    all_consecutive_failures,
+		    transport_consecutive_failures,
+		    fault_count_transfer_active_timeout,
+		    fault_count_transfer_idle_timeout,
+		    classification,
+		    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate,
+		    lagInFrame(video_resolution,   1, video_resolution)   OVER w AS prev_resolution
+		  FROM %s.%s
+		  %s
+		  WINDOW w AS (PARTITION BY play_id ORDER BY ts)
+		),
+		net_counts AS (
+		  SELECT play_id,
+		         count() AS net_rows,
+		         countIf(status >= 400) AS net_errors,
+		         countIf(faulted = 1)  AS net_faults
+		  FROM %s.network_requests
+		  %s
+		  GROUP BY play_id
+		),
+		-- Per-play label histogram across all three source tables.
+		-- lowerUTF8 on play_id makes the JOIN survive the case-
+		-- sensitivity gap where some legacy rows landed uppercase.
+		labels_unioned AS (
+		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
+		  FROM %s.%s
+		  %s
+		  UNION ALL
+		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
+		  FROM %s.network_requests
+		  %s
+		  UNION ALL
+		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
+		  FROM %s.control_events
+		  %s
+		),
+		labels_per_play AS (
+		  SELECT play_id, label, count() AS n
+		  FROM labels_unioned
+		  GROUP BY play_id, label
+		),
+		labels_agg AS (
+		  SELECT play_id,
+		         sum(n) AS labels_total,
+		         arrayDistinct(groupArray(label)) AS labels_distinct,
+		         groupArray((label, n)) AS label_pairs
+		  FROM labels_per_play
+		  GROUP BY play_id
+		),
+		agg AS (
+		  SELECT
+		    play_id,
+		    any(session_id) AS session_id,
+		    any(player_id) AS player_id,
+		    any(group_id) AS group_id,
+		    any(content_id) AS content_id,
+		    min(ts) AS started_at,
+		    max(ts) AS last_seen_at,
+		    count() AS metric_events,
+		    max(stall_count) AS stalls,
+		    max(dropped_frames) AS dropped_frames,
+		    argMax(player_state, ts) AS last_state,
+		    argMax(player_error, ts) AS last_player_error,
+		    max(master_manifest_consecutive_failures) AS master_manifest_failures,
+		    max(manifest_consecutive_failures) AS manifest_failures,
+		    max(segment_consecutive_failures) AS segment_failures,
+		    max(all_consecutive_failures) AS all_failures,
+		    max(transport_consecutive_failures) AS transport_failures,
+		    max(fault_count_transfer_active_timeout) AS active_timeouts,
+		    max(fault_count_transfer_idle_timeout) AS idle_timeouts,
+		    countIf(video_bitrate_mbps != prev_bitrate AND video_bitrate_mbps > 0 AND prev_bitrate > 0) AS bitrate_shifts,
+		    countIf(video_bitrate_mbps < prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0) AS downshifts,
+		    countIf(video_bitrate_mbps > prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0) AS upshifts,
+		    countIf(video_resolution != prev_resolution AND video_resolution != '' AND prev_resolution != '') AS resolution_changes,
+		    round(avgIf(video_quality_pct, video_quality_pct > 0), 1) AS avg_quality_pct,
+		    round(minIf(video_quality_pct, video_quality_pct > 0), 1) AS min_quality_pct,
+		    max(frames_displayed) AS frames_displayed,
+		    round(max(video_first_frame_time_s), 2) AS first_frame_s,
+		    countIf(last_event = 'user_marked')   AS user_marked_count,
+		    countIf(last_event = 'frozen')        AS frozen_count,
+		    countIf(last_event = 'segment_stall') AS segment_stall_count,
+		    countIf(last_event = 'restart')       AS restart_count,
+		    countIf(last_event = 'error')         AS error_event_count,
+		    any(classification) AS classification,
+		    maxIf(attempt_id, attempt_id > 0)       AS attempt_id_max
+		  FROM base
+		  GROUP BY play_id
+		)
+		SELECT
+		  agg.play_id   AS play_id,
+		  agg.player_id AS player_id,
+		  agg.attempt_id_max AS attempt_id,
+		  agg.attempt_id_max AS attempt_count,
+		  agg.session_id, agg.group_id, agg.content_id,
+		  toString(agg.started_at)   AS started_at,
+		  toString(agg.last_seen_at) AS last_seen_at,
+		  agg.metric_events, agg.stalls, agg.dropped_frames,
+		  agg.last_state, agg.last_player_error,
+		  agg.master_manifest_failures, agg.manifest_failures, agg.segment_failures,
+		  agg.all_failures, agg.transport_failures, agg.active_timeouts, agg.idle_timeouts,
+		  agg.bitrate_shifts, agg.downshifts, agg.upshifts, agg.resolution_changes,
+		  agg.avg_quality_pct, agg.min_quality_pct,
+		  agg.frames_displayed, agg.first_frame_s,
+		  agg.user_marked_count, agg.frozen_count, agg.segment_stall_count,
+		  agg.restart_count, agg.error_event_count,
+		  agg.classification,
+		  ifNull(net_counts.net_rows,   0) AS net_events,
+		  ifNull(net_counts.net_errors, 0) AS net_errors,
+		  ifNull(net_counts.net_faults, 0) AS net_faults,
+		  ifNull(labels_agg.labels_total,           0)  AS labels_total,
+		  ifNull(length(labels_agg.labels_distinct), 0) AS labels_distinct_count,
+		  ifNull(labels_agg.label_pairs,           []) AS label_histogram
+		FROM agg
+		LEFT JOIN net_counts ON agg.play_id = net_counts.play_id
+		LEFT JOIN labels_agg ON lowerUTF8(agg.play_id) = labels_agg.play_id
+		%s
+		ORDER BY agg.started_at DESC
+		LIMIT %d
+		FORMAT JSONEachRow`,
+		b.Database, b.EventsTable, where,
+		b.Database, netWhere,
+		b.Database, b.EventsTable, where,
+		b.Database, netWhere,
+		b.Database, netWhere,
+		postWhere(postClauses),
+		limit,
+	)
+	return b.queryRows(ctx, query, params)
+}
+
+func postWhere(post []string) string {
+	if len(post) == 0 {
+		return ""
+	}
+	return "WHERE " + strings.Join(post, " AND ")
+}

--- a/analytics/go-forwarder/internal/plays/labels.go
+++ b/analytics/go-forwarder/internal/plays/labels.go
@@ -1,0 +1,51 @@
+package plays
+
+import "strings"
+
+// LabelFilter expresses the tristate label predicate the v2 list
+// endpoints and the chat tools both consume: every Has value must be
+// on the row; none of the Not values may be. Empty fields = no
+// constraint.
+type LabelFilter struct {
+	Has []string
+	Not []string
+}
+
+// applyTo appends the CH WHERE fragments + matching parameters for
+// this filter against `column` (e.g. `labels` or `labels_agg.labels_distinct`).
+// Idempotent on empty input.
+func (f LabelFilter) applyTo(clauses []string, params map[string]string, column string) ([]string, map[string]string) {
+	if len(f.Has) > 0 {
+		names := make([]string, len(f.Has))
+		for i, v := range f.Has {
+			key := "label_has_" + itoa(i)
+			params[key] = v
+			names[i] = "{" + key + ":String}"
+		}
+		clauses = append(clauses, "hasAll("+column+", ["+strings.Join(names, ", ")+"])")
+	}
+	if len(f.Not) > 0 {
+		names := make([]string, len(f.Not))
+		for i, v := range f.Not {
+			key := "label_not_" + itoa(i)
+			params[key] = v
+			names[i] = "{" + key + ":String}"
+		}
+		clauses = append(clauses, "NOT hasAny("+column+", ["+strings.Join(names, ", ")+"])")
+	}
+	return clauses, params
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/analytics/go-forwarder/internal/plays/types.go
+++ b/analytics/go-forwarder/internal/plays/types.go
@@ -1,0 +1,30 @@
+package plays
+
+// PlayFilter is the typed parameter set every list/find operation
+// takes. Empty fields = no constraint.
+//
+// IDs (PlayerID, PlayID) are the caller's responsibility to
+// canonicalise — the handlers do it at the HTTP boundary via the
+// main package's canonicalV2ID; chat tools do it at tool entry. The
+// domain layer just passes them through to lowerUTF8-comparing WHERE
+// clauses, which makes the case-fold idempotent anyway.
+type PlayFilter struct {
+	PlayerID       string
+	PlayID         string
+	AttemptID      string
+	SessionID      string
+	From           string // CH datetime string; parsed via parseDateTime64BestEffort
+	To             string
+	Classification string // "interesting" | "other" | "favourite" — validated
+	Labels         LabelFilter
+
+	// Limit caps the returned rows. Zero means "use the call's default."
+	// FindPlays caps at 5000 regardless to protect CH.
+	Limit int
+}
+
+// defaultLimit returns the per-call default when the caller didn't
+// supply one. Kept tiny so callers see this constant rather than
+// hunting for it inside the function bodies.
+const defaultPlaysLimit = 500
+const maxPlaysLimit = 5000

--- a/analytics/go-forwarder/plays_backend.go
+++ b/analytics/go-forwarder/plays_backend.go
@@ -1,0 +1,17 @@
+package main
+
+import "github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder/internal/plays"
+
+// playsBackend constructs the minimal ClickHouse handle the typed
+// domain layer (internal/plays) needs from this binary's config.
+// Lifted out so every caller — HTTP handlers, the classifier queue
+// drain, the chat backend (#497) — composes the same value.
+func playsBackend(cfg config) plays.Backend {
+	return plays.Backend{
+		ClickHouseURL: cfg.clickhouseURL,
+		Database:      cfg.chDatabase,
+		EventsTable:   cfg.chTable,
+		User:          cfg.chUser,
+		Password:      cfg.chPassword,
+	}
+}

--- a/analytics/go-forwarder/v2_plays.go
+++ b/analytics/go-forwarder/v2_plays.go
@@ -3,10 +3,10 @@ package main
 // v2 plays endpoints — see api/openapi/v2/forwarder.yaml § /api/v2/plays.
 //
 // Replaces v1's /api/sessions for the dashboard's session-picker use
-// case. v1 grouped by (session_id, play_id) and accepted only since/until;
-// v2 groups by play_id, accepts player_id / play_id / classification /
-// from / to / limit filters, and wraps the result in the v2 envelope
-// ({items, next_cursor}).
+// case. v1 grouped by (session_id, play_id) and accepted only
+// since/until; v2 groups by play_id, accepts player_id / play_id /
+// classification / from / to / limit filters, and wraps the result in
+// the v2 envelope ({items, next_cursor}).
 //
 // PATCH /api/v2/plays/{play_id} writes the tiered-retention
 // classification (#342). Live-play mutations (labels / shape /
@@ -14,19 +14,19 @@ package main
 // forwarder handler exists because classification only applies once a
 // play is archived in ClickHouse.
 //
-// Today the query reads session_snapshots + network_requests live, the
-// same way v1 does. The aspirational play_summaries rollup table is
-// blocked on `play.ended` SSE plumbing — when it lands, swap the FROM
-// clause without changing the wire shape.
+// Domain logic — labels-aware aggregation, classification mutation,
+// auto-classifier predicate — lives in internal/plays. The handlers
+// here are thin shims that parse the HTTP request, call the domain
+// function, and serialise the result.
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder/internal/plays"
 )
 
 func mountV2PlaysHandlers(mux *http.ServeMux, cfg config) {
@@ -62,16 +62,71 @@ func playsDispatcher(cfg config) http.HandlerFunc {
 	}
 }
 
+// v2PlaysListHandler answers GET /api/v2/plays.
+func v2PlaysListHandler(w http.ResponseWriter, r *http.Request, cfg config) {
+	q := r.URL.Query()
+	// Canonicalise — see canonicalV2ID()'s doc. Operators who curl
+	// the endpoint with an uppercase UUID would otherwise see an
+	// empty page silently.
+	labelHas, labelNot := readLabelFilters(q)
+	filter := plays.PlayFilter{
+		PlayerID:       canonicalV2ID(q.Get("player_id")),
+		PlayID:         canonicalV2ID(q.Get("play_id")),
+		AttemptID:      q.Get("attempt_id"),
+		From:           q.Get("from"),
+		To:             q.Get("to"),
+		Classification: q.Get("classification"),
+		Labels:         plays.LabelFilter{Has: labelHas, Not: labelNot},
+		Limit:          parseLimit(q.Get("limit"), 500, 5000),
+	}
+	rows, err := plays.FindPlays(r.Context(), playsBackend(cfg), filter)
+	if err != nil {
+		// classification validation rejects with a plain Go error from
+		// the domain layer; map it to a 400 instead of a generic 502 so
+		// curl operators see "bad request" not "clickhouse query failed".
+		if strings.Contains(err.Error(), "classification must be") {
+			writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
+			return
+		}
+		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []map[string]any{}
+	}
+	writeJSONv2(w, http.StatusOK, map[string]any{
+		"items":       rows,
+		"next_cursor": nil,
+	})
+}
+
+// v2PlayDetailHandler answers GET /api/v2/plays/{play_id}. Returns
+// the same PlaySummary shape (no embedded events_summary /
+// network_summary / _links yet — those are spec'd under PlayDetail
+// for a later PR).
+func v2PlayDetailHandler(w http.ResponseWriter, r *http.Request, cfg config, playID string) {
+	if playID == "" {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "play_id required")
+		return
+	}
+	row, err := plays.GetPlaySummary(r.Context(), playsBackend(cfg), playID)
+	if err != nil {
+		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
+		return
+	}
+	if row == nil {
+		writeProblemv2(w, http.StatusNotFound, "not found", fmt.Sprintf("play %q has no archived snapshots", playID))
+		return
+	}
+	writeJSONv2(w, http.StatusOK, row)
+}
+
 // v2PlayPatchHandler answers PATCH /api/v2/plays/{play_id}. Today the
 // only supported field is `classification`, which drives the tiered
-// retention TTL (#342). Star = `favourite`; unstar = `auto` which re-
-// runs the auto-classifier and writes whatever it returns
-// (interesting | other). Explicit values `interesting` / `other` are
-// also accepted for operator-driven reclassification.
-//
-// Live-play mutations live on go-proxy's PATCH /api/v2/plays/{id};
-// this handler exists in the forwarder because classification only
-// makes sense once the play is archived in ClickHouse.
+// retention TTL (#342). Star = `favourite`; unstar = `auto` which
+// re-runs the auto-classifier and writes whatever it returns
+// (`interesting` | `other`). Explicit values `interesting` /
+// `other` are also accepted for operator-driven reclassification.
 func v2PlayPatchHandler(w http.ResponseWriter, r *http.Request, cfg config, playID string) {
 	if playID == "" {
 		writeProblemv2(w, http.StatusBadRequest, "bad request", "play_id required")
@@ -106,14 +161,15 @@ func v2PlayPatchHandler(w http.ResponseWriter, r *http.Request, cfg config, play
 		return
 	}
 	cls := strings.ToLower(strings.TrimSpace(clsRaw))
+	be := playsBackend(cfg)
 	switch cls {
-	case "favourite", "interesting", "other":
-		if err := setPlayClassification(r.Context(), cfg, playID, cls, true); err != nil {
+	case plays.ClassificationFavourite, plays.ClassificationInteresting, plays.ClassificationOther:
+		if err := plays.SetPlayClassification(r.Context(), be, playID, cls, true); err != nil {
 			writeProblemv2(w, http.StatusBadGateway, "clickhouse update failed", err.Error())
 			return
 		}
 	case "auto":
-		if err := reclassifyPlay(r.Context(), cfg, playID, true); err != nil {
+		if err := plays.ReclassifyPlay(r.Context(), be, playID, true); err != nil {
 			writeProblemv2(w, http.StatusBadGateway, "clickhouse update failed", err.Error())
 			return
 		}
@@ -124,17 +180,12 @@ func v2PlayPatchHandler(w http.ResponseWriter, r *http.Request, cfg config, play
 	}
 	// Round-trip the post-patch detail so the caller sees the settled
 	// classification (auto mode runs the predicate before returning).
-	clauses, params, err := buildPlaysFilter("", playID, "", "", "", "")
-	if err != nil {
-		writeProblemv2(w, http.StatusInternalServerError, "internal", err.Error())
-		return
-	}
-	rows, err := queryPlaySummariesFiltered(r.Context(), cfg, clauses, params, nil, nil, 1)
+	row, err := plays.GetPlaySummary(r.Context(), be, playID)
 	if err != nil {
 		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
 		return
 	}
-	if len(rows) == 0 {
+	if row == nil {
 		// Mutation went through but the play has no archived snapshots
 		// yet — surface the requested classification so the UI can flip
 		// optimistically. (Rare: the row would have to have been GC'd
@@ -145,331 +196,5 @@ func v2PlayPatchHandler(w http.ResponseWriter, r *http.Request, cfg config, play
 		})
 		return
 	}
-	writeJSONv2(w, http.StatusOK, rows[0])
-}
-
-// v2PlaysListHandler answers GET /api/v2/plays.
-func v2PlaysListHandler(w http.ResponseWriter, r *http.Request, cfg config) {
-	q := r.URL.Query()
-	// Canonicalise — see canonicalV2ID()'s doc. Operators who curl
-	// the endpoint with an uppercase UUID would otherwise see an
-	// empty page silently.
-	clauses, params, err := buildPlaysFilter(
-		canonicalV2ID(q.Get("player_id")),
-		canonicalV2ID(q.Get("play_id")),
-		q.Get("attempt_id"),
-		q.Get("from"),
-		q.Get("to"),
-		q.Get("classification"),
-	)
-	if err != nil {
-		writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
-		return
-	}
-	// Tristate label filter at the play level — see label_filter.go.
-	// Applied as a post-join predicate against the labels_agg CTE
-	// inside queryPlaySummaries.
-	labelHas, labelNot := readLabelFilters(q)
-	limit := parseLimit(q.Get("limit"), 500, 5000)
-
-	rows, err := queryPlaySummariesFiltered(r.Context(), cfg, clauses, params, labelHas, labelNot, limit)
-	if err != nil {
-		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
-		return
-	}
-	if rows == nil {
-		rows = []map[string]any{}
-	}
-	writeJSONv2(w, http.StatusOK, map[string]any{
-		"items":       rows,
-		"next_cursor": nil,
-	})
-}
-
-// v2PlayDetailHandler answers GET /api/v2/plays/{play_id}. Returns the
-// same PlaySummary shape (no embedded events_summary / network_summary
-// /_links yet — those are spec'd under PlayDetail for a later PR).
-func v2PlayDetailHandler(w http.ResponseWriter, r *http.Request, cfg config, playID string) {
-	if playID == "" {
-		writeProblemv2(w, http.StatusBadRequest, "bad request", "play_id required")
-		return
-	}
-	clauses, params, err := buildPlaysFilter("", playID, "", "", "", "")
-	if err != nil {
-		writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
-		return
-	}
-	rows, err := queryPlaySummariesFiltered(r.Context(), cfg, clauses, params, nil, nil, 1)
-	if err != nil {
-		writeProblemv2(w, http.StatusBadGateway, "clickhouse query failed", err.Error())
-		return
-	}
-	if len(rows) == 0 {
-		writeProblemv2(w, http.StatusNotFound, "not found", fmt.Sprintf("play %q has no archived snapshots", playID))
-		return
-	}
-	writeJSONv2(w, http.StatusOK, rows[0])
-}
-
-// buildPlaysFilter shapes WHERE clauses + ClickHouse parameter values for
-// the plays aggregation. Empty inputs are skipped. Returns an error only
-// when a value is malformed in a way ClickHouse can't recover from
-// (today: nothing — all values are passed through as parameters).
-func buildPlaysFilter(playerID, playID, attemptID, from, to, classification string) ([]string, map[string]string, error) {
-	params := map[string]string{}
-	// play_id != '' filters out pre-stamp legacy rows; the v1 endpoint
-	// surfaces them as the literal "—" but v2 plays are defined to be
-	// proper UUIDs so we drop them here.
-	clauses := []string{"play_id != ''"}
-	if playerID != "" {
-		clauses = append(clauses, "lowerUTF8(player_id) = lowerUTF8({player:String})")
-		params["player"] = playerID
-	}
-	if playID != "" {
-		clauses = append(clauses, "lowerUTF8(play_id) = lowerUTF8({play:String})")
-		params["play"] = playID
-	}
-	if attemptID != "" {
-		// Narrow to plays that contain this specific recovery attempt
-		// — useful when piecing together a multi-attempt debug.
-		clauses = append(clauses, "attempt_id = {attempt:UInt32}")
-		params["attempt"] = attemptID
-	}
-	if from != "" {
-		clauses = append(clauses, "ts >= parseDateTime64BestEffort({from:String})")
-		params["from"] = from
-	}
-	if to != "" {
-		clauses = append(clauses, "ts < parseDateTime64BestEffort({to:String})")
-		params["to"] = to
-	}
-	if classification != "" {
-		switch classification {
-		case "interesting", "other", "favourite":
-			clauses = append(clauses, "classification = {classification:String}")
-			params["classification"] = classification
-		default:
-			return nil, nil, errors.New("classification must be one of: interesting, other, favourite")
-		}
-	}
-	if playerID == "" && playID == "" && attemptID == "" && from == "" && to == "" {
-		// Bound the scan when the caller didn't — the snapshots table
-		// is partitioned by toYYYYMMDD(ts), so without a time bound
-		// ClickHouse would read every partition.
-		clauses = append(clauses, "ts >= now() - INTERVAL 24 HOUR")
-	}
-	return clauses, params, nil
-}
-
-// queryPlaySummariesFiltered is the entry point with the post-join
-// label-presence filter (issue #474 follow-up). labelHas / labelNot
-// are AND-required against the per-play labels_distinct array; pass
-// nil/empty for the no-filter case. Delegates to queryPlaySummaries
-// after appending the appropriate post-join clauses.
-func queryPlaySummariesFiltered(
-	ctx context.Context, cfg config,
-	clauses []string, params map[string]string,
-	labelHas, labelNot []string,
-	limit int,
-) ([]map[string]any, error) {
-	// The base clauses filter the snapshot/network rows. Label
-	// filters are applied AFTER labels_agg builds the per-play
-	// histogram — see the final WHERE in queryPlaySummaries. We
-	// pass them through the params map keyed by `label_has_N` /
-	// `label_not_N` and emit a `postClauses` placeholder the SQL
-	// template substitutes.
-	var post []string
-	post, params = applyLabelFilters(post, params, "labels_agg.labels_distinct", labelHas, labelNot)
-	return queryPlaySummaries(ctx, cfg, clauses, params, post, limit)
-}
-
-// queryPlaySummaries runs the per-play aggregation. Reuses v1's SQL
-// shape (lagInFrame window for ABR-shift counting, left-join against
-// network_requests for the net_* counters) but groups by play_id only —
-// session_id rides along as `any(session_id)` for the dashboard's
-// stable row key.
-//
-// `postClauses` (issue #474 follow-up) are AND'd into the final
-// SELECT's WHERE — they run AFTER the labels_agg JOIN so callers can
-// filter by label presence/absence (e.g. plays that have
-// `warning=http_4xx` but NOT `info=*fault_rule_enabled`). Pass nil
-// when no label filter is in play.
-func queryPlaySummaries(ctx context.Context, cfg config, clauses []string, params map[string]string, postClauses []string, limit int) ([]map[string]any, error) {
-	where := "WHERE " + strings.Join(clauses, " AND ")
-	// network_requests doesn't carry a classification column, so the
-	// net_counts CTE skips the classification clause if present. The
-	// SQL templates handle this by only forwarding ts/player_id/play_id
-	// clauses to net_counts.
-	netClauses := []string{"play_id != ''"}
-	for _, c := range clauses {
-		if strings.Contains(c, "classification") {
-			continue
-		}
-		if c == "play_id != ''" {
-			continue
-		}
-		netClauses = append(netClauses, c)
-	}
-	netWhere := "WHERE " + strings.Join(netClauses, " AND ")
-
-	query := fmt.Sprintf(`
-		WITH base AS (
-		  SELECT
-		    session_id, play_id, attempt_id, ts,
-		    player_id, group_id, content_id,
-		    player_state, player_error, last_event,
-		    stall_count, dropped_frames, frames_displayed,
-		    video_bitrate_mbps, video_resolution, video_quality_pct,
-		    video_first_frame_time_s,
-		    master_manifest_consecutive_failures,
-		    manifest_consecutive_failures,
-		    segment_consecutive_failures,
-		    all_consecutive_failures,
-		    transport_consecutive_failures,
-		    fault_count_transfer_active_timeout,
-		    fault_count_transfer_idle_timeout,
-		    classification,
-		    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate,
-		    lagInFrame(video_resolution,   1, video_resolution)   OVER w AS prev_resolution
-		  FROM %s.%s
-		  %s
-		  WINDOW w AS (PARTITION BY play_id ORDER BY ts)
-		),
-		net_counts AS (
-		  SELECT play_id,
-		         count() AS net_rows,
-		         countIf(status >= 400) AS net_errors,
-		         countIf(faulted = 1)  AS net_faults
-		  FROM %s.network_requests
-		  %s
-		  GROUP BY play_id
-		),
-		-- Per-play label histogram across all three source tables
-		-- (issue #474 follow-up so harness CLI's archive plays
-		-- carries the same per-row labels surface the dashboard's
-		-- Sessions page reads via /analytics/api/v2/plays).
-		-- lowerUTF8 on play_id makes the JOIN survive the case-
-		-- sensitivity gap where some legacy rows landed with
-		-- uppercase play_ids.
-		labels_unioned AS (
-		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
-		  FROM %s.%s
-		  %s
-		  UNION ALL
-		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
-		  FROM %s.network_requests
-		  %s
-		  UNION ALL
-		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
-		  FROM %s.control_events
-		  %s
-		),
-		labels_per_play AS (
-		  SELECT play_id, label, count() AS n
-		  FROM labels_unioned
-		  GROUP BY play_id, label
-		),
-		labels_agg AS (
-		  SELECT play_id,
-		         sum(n) AS labels_total,
-		         arrayDistinct(groupArray(label)) AS labels_distinct,
-		         groupArray((label, n)) AS label_pairs
-		  FROM labels_per_play
-		  GROUP BY play_id
-		),
-		agg AS (
-		  SELECT
-		    play_id,
-		    any(session_id) AS session_id,
-		    any(player_id) AS player_id,
-		    any(group_id) AS group_id,
-		    any(content_id) AS content_id,
-		    min(ts) AS started_at,
-		    max(ts) AS last_seen_at,
-		    count() AS metric_events,
-		    max(stall_count) AS stalls,
-		    max(dropped_frames) AS dropped_frames,
-		    argMax(player_state, ts) AS last_state,
-		    argMax(player_error, ts) AS last_player_error,
-		    max(master_manifest_consecutive_failures) AS master_manifest_failures,
-		    max(manifest_consecutive_failures) AS manifest_failures,
-		    max(segment_consecutive_failures) AS segment_failures,
-		    max(all_consecutive_failures) AS all_failures,
-		    max(transport_consecutive_failures) AS transport_failures,
-		    max(fault_count_transfer_active_timeout) AS active_timeouts,
-		    max(fault_count_transfer_idle_timeout) AS idle_timeouts,
-		    countIf(video_bitrate_mbps != prev_bitrate AND video_bitrate_mbps > 0 AND prev_bitrate > 0) AS bitrate_shifts,
-		    countIf(video_bitrate_mbps < prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0) AS downshifts,
-		    countIf(video_bitrate_mbps > prev_bitrate AND prev_bitrate > 0 AND video_bitrate_mbps > 0) AS upshifts,
-		    countIf(video_resolution != prev_resolution AND video_resolution != '' AND prev_resolution != '') AS resolution_changes,
-		    round(avgIf(video_quality_pct, video_quality_pct > 0), 1) AS avg_quality_pct,
-		    round(minIf(video_quality_pct, video_quality_pct > 0), 1) AS min_quality_pct,
-		    max(frames_displayed) AS frames_displayed,
-		    round(max(video_first_frame_time_s), 2) AS first_frame_s,
-		    countIf(last_event = 'user_marked')   AS user_marked_count,
-		    countIf(last_event = 'frozen')        AS frozen_count,
-		    countIf(last_event = 'segment_stall') AS segment_stall_count,
-		    countIf(last_event = 'restart')       AS restart_count,
-		    countIf(last_event = 'error')         AS error_event_count,
-		    any(classification) AS classification,
-		    -- attempt_id projection: highest attempt observed in this
-		    -- play. Since the player increments attempt_id from 1 by
-		    -- 1, max() doubles as "total attempts": 1 = clean play,
-		    -- N = N-1 recovery attempts after the initial. Aliased to
-		    -- *_max so the alias doesn't shadow the column referenced
-		    -- by another aggregate in the same SELECT.
-		    maxIf(attempt_id, attempt_id > 0)       AS attempt_id_max
-		  FROM base
-		  GROUP BY play_id
-		)
-		SELECT
-		  agg.play_id   AS play_id,
-		  agg.player_id AS player_id,
-		  agg.attempt_id_max AS attempt_id,
-		  agg.attempt_id_max AS attempt_count,
-		  agg.session_id, agg.group_id, agg.content_id,
-		  toString(agg.started_at)   AS started_at,
-		  toString(agg.last_seen_at) AS last_seen_at,
-		  agg.metric_events, agg.stalls, agg.dropped_frames,
-		  agg.last_state, agg.last_player_error,
-		  agg.master_manifest_failures, agg.manifest_failures, agg.segment_failures,
-		  agg.all_failures, agg.transport_failures, agg.active_timeouts, agg.idle_timeouts,
-		  agg.bitrate_shifts, agg.downshifts, agg.upshifts, agg.resolution_changes,
-		  agg.avg_quality_pct, agg.min_quality_pct,
-		  agg.frames_displayed, agg.first_frame_s,
-		  agg.user_marked_count, agg.frozen_count, agg.segment_stall_count,
-		  agg.restart_count, agg.error_event_count,
-		  agg.classification,
-		  ifNull(net_counts.net_rows,   0) AS net_events,
-		  ifNull(net_counts.net_errors, 0) AS net_errors,
-		  ifNull(net_counts.net_faults, 0) AS net_faults,
-		  ifNull(labels_agg.labels_total,           0)  AS labels_total,
-		  ifNull(length(labels_agg.labels_distinct), 0) AS labels_distinct_count,
-		  ifNull(labels_agg.label_pairs,           []) AS label_histogram
-		FROM agg
-		LEFT JOIN net_counts ON agg.play_id = net_counts.play_id
-		LEFT JOIN labels_agg ON lowerUTF8(agg.play_id) = labels_agg.play_id
-		%s
-		ORDER BY agg.started_at DESC
-		LIMIT %d
-		FORMAT JSONEachRow`,
-		cfg.chDatabase, cfg.chTable, where,
-		cfg.chDatabase, netWhere,
-		cfg.chDatabase, cfg.chTable, where,
-		cfg.chDatabase, netWhere,
-		cfg.chDatabase, netWhere,
-		postWhere(postClauses),
-		limit,
-	)
-	return queryClickHouseRows(ctx, cfg, query, params)
-}
-
-// postWhere emits a `WHERE …` fragment (or empty string when no
-// post-join filters were requested) so the outer SELECT's
-// label-filter pushdown only renders when needed.
-func postWhere(post []string) string {
-	if len(post) == 0 {
-		return ""
-	}
-	return "WHERE " + strings.Join(post, " AND ")
+	writeJSONv2(w, http.StatusOK, row)
 }


### PR DESCRIPTION
## Summary

Prep work for #497 (AI chat for session analysis). The chat backend's typed tools will need to call the same code paths the v2 HTTP handlers use, without paying a loopback-HTTP / JSON round-trip tax for each tool invocation. This PR makes that possible by introducing a typed domain package the handlers and the chat tools both consume.

## What moves into `internal/plays`

| Function | Purpose | Backed today by |
|---|---|---|
| `FindPlays` / `GetPlaySummary` | labels-aware play aggregation | `/api/v2/plays` + `/api/v2/plays/{id}` |
| `SetPlayClassification` / `SetClassification` / `ReclassifyPlay` / `ReclassifySession` | tiered-retention mutation (#342) | `PATCH /api/v2/plays/{id}` + classifier queue drain |
| `GetControlEvents` | control_events read | (chat backend; HTTP handler stays NDJSON-passthrough) |
| `Backend` struct + private CH helpers | minimal CH handle | shared across the package |
| `LabelFilter` + tristate predicate composition | label-aware WHERE clauses | shared |

## What stays in `main`

- HTTP handlers (now thin shims: parse → call domain → render)
- `classifyQueue` + `runClassifyLoop` (drain calls `plays.ReclassifySession`)
- `canonicalV2ID` + `applyLabelFilters` helpers (still used by other handlers; can be lifted later if needed)
- Streaming endpoints (timeseries SSE, snapshots NDJSON, bundle ZIP) — these don't fit a typed-return shape

## Wire shape

Byte-identical:
- SQL templates copied verbatim (only `cfg.chDatabase` → `b.Database`, `cfg.chTable` → `b.EventsTable`)
- JSON envelopes (`{items, next_cursor}`) produced by the same `writeJSONv2` helper against the same `map[string]any` rows
- The `control_events` HTTP handler is deliberately **not** refactored to call the new typed function, to avoid introducing column-ordering risk on the NDJSON wire (Go map iteration vs CH `JSONEachRow` SELECT order). The new `GetControlEvents` is for the chat backend.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] No stray references to removed functions (`buildPlaysFilter`, `queryPlaySummaries`, etc.)
- [ ] Live ClickHouse round-trip: curl `/api/v2/plays`, `/api/v2/plays/{id}`, `PATCH /api/v2/plays/{id}` before + after; confirm responses identical
- [ ] Classifier queue drain still fires (look for `auto-classify failed` log absence on a known-good session)

## Closes

#498 — and unblocks #497 Phase 1 (Tier 1 typed tools land as direct imports of this package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)