### PR TITLE
feat(forwarder): AI chat backend (#497 Phase 1+2)

### DIFF
--- a/analytics/clickhouse/init.d/02-llm-reader.sql
+++ b/analytics/clickhouse/init.d/02-llm-reader.sql
@@ -1,0 +1,53 @@
+-- llm_reader — restricted ClickHouse user for the AI chat backend's
+-- Tier 3 `query(sql)` tool (#497, originally specified in #413).
+--
+-- The forwarder passes LLM-authored SQL through unmodified; the
+-- safety story is "ClickHouse enforces it, the forwarder doesn't
+-- have to." All limits below are server-side and readonly_settings=1
+-- means the LLM cannot relax any of them via SETTINGS in the query.
+--
+-- For local dev (Docker Compose, k3d) this file's CREATE USER with
+-- IDENTIFIED WITH no_password is fine — ClickHouse is reached only
+-- over the analytics docker network, gated behind the dashboard's
+-- auth surface. For production deploys, layer an XML overlay at
+-- `/etc/clickhouse-server/users.d/llm_reader.xml` that sets a
+-- password_sha256_hex on the same user; the forwarder reads its
+-- LLM-side credentials from FORWARDER_CLICKHOUSE_LLM_USER /
+-- FORWARDER_CLICKHOUSE_LLM_PASSWORD.
+
+CREATE SETTINGS PROFILE IF NOT EXISTS llm_reader_caps SETTINGS
+    -- Read-only — no writes, no settings overrides via the request.
+    readonly = 1,
+    -- LLM cannot relax any of these from its query.
+    readonly_settings = 1,
+    -- Wall-clock cap. Most LLM queries return in <500 ms; the few
+    -- that explore (group-by across a wide window) get 10s to plan
+    -- + scan + return. Anything past that gets cut.
+    max_execution_time = 10,
+    -- Memory per query. 1 GB covers any reasonable aggregation
+    -- over the 30-day retention window; runaway joins get aborted.
+    max_memory_usage = 1000000000,
+    -- Row count caps. 10K returned is enough for any analysis
+    -- the LLM does with `query()` directly — beyond that the LLM
+    -- should aggregate server-side first.
+    max_result_rows = 10000,
+    max_result_bytes = 10000000,
+    -- Scan cap — 10M rows is roughly 30 days of session_events for
+    -- a single busy player; bounds runaway full-table scans.
+    max_rows_to_read = 10000000,
+    -- break (not throw) — return what fit, with a `truncated`
+    -- indicator the tool surface forwards to the LLM.
+    result_overflow_mode = 'break';
+
+CREATE USER IF NOT EXISTS llm_reader IDENTIFIED WITH no_password
+    SETTINGS PROFILE llm_reader_caps;
+
+-- SELECT-only on the analytics database. The LLM can read the live
+-- tables (session_events, network_requests, control_events,
+-- characterization_runs) plus its own spend ledger (llm_calls; see
+-- 03-llm-calls.sql).
+GRANT SELECT ON infinite_streaming.* TO llm_reader;
+
+-- system.* is forbidden. The LLM cannot introspect query history,
+-- user permissions, or running queries.
+REVOKE ALL ON system.* FROM llm_reader;

--- a/analytics/clickhouse/init.d/03-llm-calls.sql
+++ b/analytics/clickhouse/init.d/03-llm-calls.sql
@@ -1,0 +1,64 @@
+-- llm_calls — per-call ledger for the AI chat backend (#497).
+--
+-- One row per request to /api/v2/chat: input/output token counts,
+-- USD cost (computed from the profile's published pricing),
+-- duration, tool-call count, terminal status. Drives the global
+-- daily budget check (sum(cost_usd) WHERE ts >= today() vs cap),
+-- and gives operators per-key spend visibility without storing the
+-- API key itself.
+--
+-- Privacy: `key_hash` is sha256 of the user's API key — surfaces
+-- "key X spent $4.20 today" without persisting the key. The
+-- forwarder never logs the raw key in any path.
+
+CREATE TABLE IF NOT EXISTS infinite_streaming.llm_calls
+(
+    ts                DateTime64(3, 'UTC') DEFAULT now64(3) CODEC(DoubleDelta, ZSTD(1)),
+
+    -- Conversation correlation. chat_id is per-thread (one Vue
+    -- chat panel = one thread); request_id is per-turn.
+    chat_id           String                                CODEC(ZSTD(1)),
+    request_id        String                                CODEC(ZSTD(1)),
+
+    -- Identity & target.
+    -- key_hash = lower(hex(sha256(api_key))) — never the key itself.
+    key_hash          FixedString(64)                       CODEC(ZSTD(1)),
+    profile           LowCardinality(String)                CODEC(ZSTD(1)),
+    base_url          String                                CODEC(ZSTD(1)),
+    model             LowCardinality(String)                CODEC(ZSTD(1)),
+
+    -- Conversation scope at request time (for forensics queries).
+    one_shot          UInt8                 DEFAULT 0       CODEC(ZSTD(1)),
+    scope_kind        LowCardinality(String)                CODEC(ZSTD(1)), -- 'fleet'|'play'|'range'|'characterization'|''
+    scope_play_id     LowCardinality(String)                CODEC(ZSTD(1)),
+    scope_run_id      LowCardinality(String)                CODEC(ZSTD(1)),
+
+    -- Spend accounting.
+    input_tokens      UInt32                DEFAULT 0       CODEC(ZSTD(1)),
+    output_tokens     UInt32                DEFAULT 0       CODEC(ZSTD(1)),
+    -- cost_usd: -1 means "unknown" (user-customized model whose
+    -- pricing isn't in the profile catalog); the budget guard
+    -- treats unknown as zero (allowed but not tallied).
+    cost_usd          Float64               DEFAULT 0       CODEC(ZSTD(1)),
+
+    -- Outcome.
+    duration_ms       UInt32                DEFAULT 0       CODEC(ZSTD(1)),
+    tool_calls_count  UInt16                DEFAULT 0       CODEC(ZSTD(1)),
+    -- ok | budget_exceeded | input_too_large | error | cancelled
+    status            LowCardinality(String)                CODEC(ZSTD(1)),
+    error_kind        LowCardinality(String) DEFAULT ''     CODEC(ZSTD(1)),
+
+    -- Prompt version (frontmatter in prompts/chat.md). Correlates
+    -- prompt iterations with output quality.
+    prompt_version    LowCardinality(String) DEFAULT ''     CODEC(ZSTD(1))
+)
+ENGINE = MergeTree()
+PARTITION BY toYYYYMM(ts)
+ORDER BY (ts, chat_id, request_id)
+TTL toDateTime(ts) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+-- Grant the llm_reader user SELECT on llm_calls so the LLM can see
+-- its own spend ("how much have I cost today?") via the query tool.
+-- The user cannot see other users' keys — key_hash is opaque.
+GRANT SELECT ON infinite_streaming.llm_calls TO llm_reader;

--- a/analytics/go-forwarder/config/llm_profiles.yaml
+++ b/analytics/go-forwarder/config/llm_profiles.yaml
@@ -1,0 +1,78 @@
+# Profile catalog for the AI chat backend (#497).
+#
+# Each template declares a base_url + a list of supported models with
+# pricing. The forwarder ships this file as read-only catalog data;
+# users pick a template + model in the dashboard's chat settings and
+# supply their own api_key (browser localStorage). The forwarder never
+# stores keys — it's a stateless proxy that passes the user's key on
+# each upstream call.
+#
+# Adding a new template here is a YAML edit + forwarder reload — no
+# code change required.
+#
+# Pricing fields are USD-per-1M-tokens. When a user picks a model
+# whose pricing isn't listed (e.g. they typed a custom Ollama model
+# name not in the catalog), the ledger records cost_usd = -1
+# ("unknown") and the global budget guard treats it as free. Set
+# FORWARDER_LLM_BUDGET_USD = 0 to refuse all calls including
+# unknown-pricing ones.
+
+templates:
+  - name: anthropic-claude
+    label: "Anthropic Claude (API)"
+    base_url: "https://api.anthropic.com/v1/openai/"
+    requires_api_key: true
+    api_key_help: "Get an API key from console.anthropic.com → API Keys"
+    supports_tools: true
+    models:
+      - id: "claude-opus-4-7"
+        label: "Claude Opus 4.7 (most capable)"
+        pricing:
+          input_per_mtok: 15.00
+          output_per_mtok: 75.00
+      - id: "claude-sonnet-4-6"
+        label: "Claude Sonnet 4.6 (fast, balanced)"
+        pricing:
+          input_per_mtok: 3.00
+          output_per_mtok: 15.00
+      - id: "claude-haiku-4-5"
+        label: "Claude Haiku 4.5 (cheapest)"
+        pricing:
+          input_per_mtok: 1.00
+          output_per_mtok: 5.00
+
+  - name: huggingface
+    label: "HuggingFace Inference Providers"
+    base_url: "https://router.huggingface.co/v1"
+    requires_api_key: true
+    api_key_help: "Get a token from huggingface.co/settings/tokens (read access)"
+    supports_tools: true
+    models:
+      - id: "meta-llama/Llama-3.3-70B-Instruct"
+        label: "Llama 3.3 70B Instruct"
+        pricing:
+          input_per_mtok: 0.88
+          output_per_mtok: 0.88
+      - id: "Qwen/Qwen2.5-72B-Instruct"
+        label: "Qwen 2.5 72B Instruct"
+        pricing:
+          input_per_mtok: 0.90
+          output_per_mtok: 0.90
+
+  - name: ollama
+    label: "Local Ollama"
+    base_url: "http://localhost:11434/v1"
+    requires_api_key: false
+    api_key_help: "No API key needed; ensure Ollama is running locally"
+    supports_tools: true
+    models:
+      - id: "llama3.1:70b"
+        label: "Llama 3.1 70B"
+        pricing:
+          input_per_mtok: 0
+          output_per_mtok: 0
+      - id: "qwen2.5:72b"
+        label: "Qwen 2.5 72B"
+        pricing:
+          input_per_mtok: 0
+          output_per_mtok: 0

--- a/analytics/go-forwarder/go.mod
+++ b/analytics/go-forwarder/go.mod
@@ -2,11 +2,14 @@ module github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder
 
 go 1.25.0
 
-require github.com/jonathaneoliver/infinite-streaming/go-proxy v0.0.0-00010101000000-000000000000
+require (
+	github.com/google/uuid v1.6.0
+	github.com/jonathaneoliver/infinite-streaming/go-proxy v0.0.0-00010101000000-000000000000
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/oapi-codegen/runtime v1.4.0 // indirect
 )

--- a/analytics/go-forwarder/go.sum
+++ b/analytics/go-forwarder/go.sum
@@ -19,5 +19,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/analytics/go-forwarder/llm_client.go
+++ b/analytics/go-forwarder/llm_client.go
@@ -1,0 +1,309 @@
+package main
+
+// llm_client.go — OpenAI-compatible streaming chat client (#497).
+//
+// The forwarder is a stateless proxy: every chat request brings its
+// own {base_url, api_key, model} (BYO key, browser localStorage). No
+// keyring; no env-var API keys. The client forwards the call to the
+// upstream OAI-compat endpoint, parses the SSE response, and yields
+// typed events (text deltas, tool-call assembly, usage, done) back
+// to the caller.
+//
+// Streaming-only — every supported model supports streaming, and the
+// tool-use loop relies on tool_calls arriving incrementally so the
+// loop can interrupt to run the tool and re-feed.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// LLMMessage is one turn in the chat (OpenAI message shape).
+type LLMMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCalls  []LLMToolCall  `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+// LLMTool advertises a callable function to the model.
+type LLMTool struct {
+	Type     string      `json:"type"` // always "function"
+	Function LLMToolDef  `json:"function"`
+}
+
+// LLMToolDef is the JSON-Schema-shaped tool description.
+type LLMToolDef struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters"`
+}
+
+// LLMToolCall is one tool-use the model wants the loop to run.
+type LLMToolCall struct {
+	ID       string          `json:"id"`
+	Type     string          `json:"type"` // always "function"
+	Function LLMToolCallFunc `json:"function"`
+}
+
+// LLMToolCallFunc holds the parsed function name + raw JSON args.
+type LLMToolCallFunc struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// LLMUsage is the per-turn token + cost accounting.
+type LLMUsage struct {
+	InputTokens  uint32 `json:"input_tokens"`
+	OutputTokens uint32 `json:"output_tokens"`
+}
+
+// LLMRequest is what the chat endpoint hands to the client. It maps
+// 1:1 to an OAI chat-completion request, with the auth + endpoint
+// info on top.
+type LLMRequest struct {
+	BaseURL string
+	APIKey  string
+	Model   string
+
+	Messages    []LLMMessage
+	Tools       []LLMTool
+	Temperature float64
+	MaxTokens   int
+}
+
+// LLMEvent is a streamed event yielded by Stream(). One of TextDelta,
+// ToolCallDelta, Usage, or Done will be set.
+type LLMEvent struct {
+	TextDelta string
+
+	// ToolCallDelta carries the incremental tool-call assembly. The
+	// loop accumulates these per index until a Done event arrives,
+	// at which point it has the full tool calls.
+	ToolCallDelta *LLMToolCallDelta
+
+	// Usage arrives once per turn (last event before Done) when
+	// stream_options.include_usage is set on the request.
+	Usage *LLMUsage
+
+	// FinishReason is set on the final delta. "stop" | "tool_calls"
+	// | "length" | "content_filter".
+	FinishReason string
+
+	Err error
+}
+
+// LLMToolCallDelta is one incremental piece of a tool-call assembly.
+// Index identifies which tool call this delta belongs to (a turn
+// can call multiple tools in parallel).
+type LLMToolCallDelta struct {
+	Index    int
+	ID       string // set on the first delta of each call
+	Name     string // set on the first delta of each call
+	ArgsFrag string // appended across deltas
+}
+
+// StreamChat sends the request to the upstream and yields events
+// over the returned channel. The channel closes when the upstream
+// stream ends or the context is cancelled. Any error mid-stream
+// arrives as an LLMEvent with Err set, followed by a channel close.
+func StreamChat(ctx context.Context, req LLMRequest) (<-chan LLMEvent, error) {
+	if req.BaseURL == "" {
+		return nil, errors.New("llm: base_url required")
+	}
+	if req.Model == "" {
+		return nil, errors.New("llm: model required")
+	}
+	if len(req.Messages) == 0 {
+		return nil, errors.New("llm: at least one message required")
+	}
+
+	// Build the request body. We always set stream=true and ask for
+	// usage in the final chunk — every provider in our catalog
+	// supports both today.
+	body := map[string]any{
+		"model":    req.Model,
+		"messages": req.Messages,
+		"stream":   true,
+		"stream_options": map[string]any{
+			"include_usage": true,
+		},
+	}
+	if len(req.Tools) > 0 {
+		body["tools"] = req.Tools
+	}
+	if req.Temperature > 0 {
+		body["temperature"] = req.Temperature
+	}
+	if req.MaxTokens > 0 {
+		body["max_tokens"] = req.MaxTokens
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("llm: marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(req.BaseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("llm: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	if req.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+req.APIKey)
+	}
+
+	// 30 s connect; the body itself can take as long as the upstream
+	// needs (tool-use loops can run for minutes legitimately).
+	client := &http.Client{
+		Timeout: 0, // no overall timeout — context handles cancellation
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("llm: upstream: %w", err)
+	}
+	if resp.StatusCode/100 != 2 {
+		defer resp.Body.Close()
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("llm: upstream %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	out := make(chan LLMEvent, 16)
+	go func() {
+		defer resp.Body.Close()
+		defer close(out)
+		streamLoop(ctx, resp.Body, out)
+	}()
+	return out, nil
+}
+
+// streamLoop reads SSE `data:` lines from r, parses each as an OAI
+// chat-completion chunk, and emits LLMEvents.
+func streamLoop(ctx context.Context, r io.Reader, out chan<- LLMEvent) {
+	scanner := bufio.NewScanner(r)
+	// Some providers (Anthropic, Ollama with large context) emit
+	// chunks well over the default 64KB cap on prompt-reflection
+	// turns. 16MB token buffer keeps the read robust.
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		line := scanner.Bytes()
+		if !bytes.HasPrefix(line, []byte("data: ")) {
+			continue
+		}
+		payload := bytes.TrimPrefix(line, []byte("data: "))
+		if bytes.Equal(payload, []byte("[DONE]")) {
+			return
+		}
+		var chunk oaiStreamChunk
+		if err := json.Unmarshal(payload, &chunk); err != nil {
+			// Don't kill the stream on a malformed line — log via
+			// the Err event and keep going.
+			select {
+			case out <- LLMEvent{Err: fmt.Errorf("parse stream chunk: %w (line: %s)", err, string(payload))}:
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			if ch.Delta.Content != "" {
+				select {
+				case out <- LLMEvent{TextDelta: ch.Delta.Content}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			for _, tc := range ch.Delta.ToolCalls {
+				select {
+				case out <- LLMEvent{ToolCallDelta: &LLMToolCallDelta{
+					Index:    tc.Index,
+					ID:       tc.ID,
+					Name:     tc.Function.Name,
+					ArgsFrag: tc.Function.Arguments,
+				}}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if ch.FinishReason != "" {
+				select {
+				case out <- LLMEvent{FinishReason: ch.FinishReason}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+		if chunk.Usage != nil {
+			select {
+			case out <- LLMEvent{Usage: &LLMUsage{
+				InputTokens:  chunk.Usage.PromptTokens,
+				OutputTokens: chunk.Usage.CompletionTokens,
+			}}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		select {
+		case out <- LLMEvent{Err: fmt.Errorf("stream truncated: %w", err)}:
+		case <-ctx.Done():
+		}
+	}
+}
+
+// oaiStreamChunk mirrors the OAI streaming chat-completion shape.
+type oaiStreamChunk struct {
+	ID      string         `json:"id"`
+	Object  string         `json:"object"`
+	Created int64          `json:"created"`
+	Model   string         `json:"model"`
+	Choices []oaiChoice    `json:"choices"`
+	Usage   *oaiUsage      `json:"usage,omitempty"`
+}
+
+type oaiChoice struct {
+	Index        int      `json:"index"`
+	Delta        oaiDelta `json:"delta"`
+	FinishReason string   `json:"finish_reason,omitempty"`
+}
+
+type oaiDelta struct {
+	Role      string             `json:"role,omitempty"`
+	Content   string             `json:"content,omitempty"`
+	ToolCalls []oaiToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+type oaiToolCallDelta struct {
+	Index    int                `json:"index"`
+	ID       string             `json:"id,omitempty"`
+	Type     string             `json:"type,omitempty"`
+	Function oaiToolCallFunc    `json:"function,omitempty"`
+}
+
+type oaiToolCallFunc struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+type oaiUsage struct {
+	PromptTokens     uint32 `json:"prompt_tokens"`
+	CompletionTokens uint32 `json:"completion_tokens"`
+	TotalTokens      uint32 `json:"total_tokens"`
+}

--- a/analytics/go-forwarder/llm_ledger.go
+++ b/analytics/go-forwarder/llm_ledger.go
@@ -1,0 +1,165 @@
+package main
+
+// llm_ledger.go — writes + reads against infinite_streaming.llm_calls
+// (#497). One row per chat request, with token + cost + outcome.
+// Drives the global daily budget guard and per-key spend visibility.
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// LLMCallRow mirrors the llm_calls CH schema. JSON tags are column
+// names so the JSONEachRow INSERT body uses them as-is.
+type LLMCallRow struct {
+	Ts              string  `json:"ts"`
+	ChatID          string  `json:"chat_id"`
+	RequestID       string  `json:"request_id"`
+	KeyHash         string  `json:"key_hash"`
+	Profile         string  `json:"profile"`
+	BaseURL         string  `json:"base_url"`
+	Model           string  `json:"model"`
+	OneShot         uint8   `json:"one_shot"`
+	ScopeKind       string  `json:"scope_kind"`
+	ScopePlayID     string  `json:"scope_play_id"`
+	ScopeRunID      string  `json:"scope_run_id"`
+	InputTokens     uint32  `json:"input_tokens"`
+	OutputTokens    uint32  `json:"output_tokens"`
+	CostUSD         float64 `json:"cost_usd"`
+	DurationMs      uint32  `json:"duration_ms"`
+	ToolCallsCount  uint16  `json:"tool_calls_count"`
+	Status          string  `json:"status"`
+	ErrorKind       string  `json:"error_kind"`
+	PromptVersion   string  `json:"prompt_version"`
+}
+
+// Status values for the ledger's status column. Aligned with the
+// dashboard's outcome surface.
+const (
+	LLMStatusOK             = "ok"
+	LLMStatusBudgetExceeded = "budget_exceeded"
+	LLMStatusInputTooLarge  = "input_too_large"
+	LLMStatusError          = "error"
+	LLMStatusCancelled      = "cancelled"
+)
+
+// HashAPIKey returns the lowercase-hex sha256 of an API key. Used as
+// the ledger's key_hash so per-key spend can be aggregated without
+// the key ever touching the disk.
+func HashAPIKey(key string) string {
+	if key == "" {
+		// Anonymous slot for Ollama-style no-key configs. Distinct
+		// from a real key hash so aggregations don't conflate users.
+		return strings.Repeat("0", 64)
+	}
+	sum := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sum[:])
+}
+
+// InsertLLMCall writes a single row to llm_calls. Best-effort — if
+// the insert fails we log via the caller's logger but don't fail
+// the user's chat turn over an accounting glitch.
+func InsertLLMCall(ctx context.Context, cfg config, row LLMCallRow) error {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(row); err != nil {
+		return fmt.Errorf("ledger: encode row: %w", err)
+	}
+	q := fmt.Sprintf("INSERT INTO %s.llm_calls FORMAT JSONEachRow", cfg.chDatabase)
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		return err
+	}
+	qs := u.Query()
+	qs.Set("query", q)
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), &body)
+	if err != nil {
+		return err
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+	return nil
+}
+
+// SpentTodayUSD returns the sum of cost_usd for today (UTC). cost_usd
+// = -1 (unknown pricing) is treated as 0 so unknown-model calls don't
+// poison the budget.
+func SpentTodayUSD(ctx context.Context, cfg config) (float64, error) {
+	q := fmt.Sprintf(`
+		SELECT sum(if(cost_usd >= 0, cost_usd, 0))
+		FROM %s.llm_calls
+		WHERE toDate(ts, 'UTC') = today()
+		FORMAT TSV`, cfg.chDatabase)
+	body, err := chQueryBytes(ctx, cfg, q, nil)
+	if err != nil {
+		return 0, err
+	}
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return 0, nil
+	}
+	var v float64
+	if _, err := fmt.Sscanf(s, "%f", &v); err != nil {
+		return 0, fmt.Errorf("ledger: parse SUM: %w (raw %q)", err, s)
+	}
+	return v, nil
+}
+
+// BudgetStatus is the shape /api/v2/chat/budget returns.
+type BudgetStatus struct {
+	SpentUSD   float64 `json:"spent_usd"`
+	CapUSD     float64 `json:"cap_usd"`
+	CallsToday uint32  `json:"calls_today"`
+	ResetsAt   string  `json:"resets_at"`
+}
+
+// ReadBudget loads the budget surface in one round-trip.
+func ReadBudget(ctx context.Context, cfg config, capUSD float64) (*BudgetStatus, error) {
+	q := fmt.Sprintf(`
+		SELECT sum(if(cost_usd >= 0, cost_usd, 0)) AS spent, count() AS calls
+		FROM %s.llm_calls
+		WHERE toDate(ts, 'UTC') = today()
+		FORMAT JSONEachRow`, cfg.chDatabase)
+	body, err := chQueryBytes(ctx, cfg, q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var row struct {
+		Spent float64 `json:"spent"`
+		Calls uint32  `json:"calls"`
+	}
+	if len(bytes.TrimSpace(body)) > 0 {
+		if err := json.Unmarshal(bytes.TrimSpace(body), &row); err != nil {
+			return nil, fmt.Errorf("ledger: parse budget row: %w", err)
+		}
+	}
+	// Next UTC midnight.
+	now := time.Now().UTC()
+	reset := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, time.UTC)
+	return &BudgetStatus{
+		SpentUSD:   row.Spent,
+		CapUSD:     capUSD,
+		CallsToday: row.Calls,
+		ResetsAt:   reset.Format(time.RFC3339),
+	}, nil
+}

--- a/analytics/go-forwarder/llm_profiles.go
+++ b/analytics/go-forwarder/llm_profiles.go
@@ -1,0 +1,149 @@
+package main
+
+// llm_profiles.go — loader + types for the AI chat backend's
+// profile catalog (#497).
+//
+// The catalog is read-only data the forwarder serves to the
+// dashboard via GET /api/v2/chat/profiles. Users pick a template +
+// model in the chat settings UI and supply their own api_key
+// (browser localStorage). The forwarder never stores keys; the
+// catalog never has secrets.
+//
+// `config/llm_profiles.yaml` ships embedded in the binary so the
+// chat backend works out of the box. Set FORWARDER_LLM_PROFILES_PATH
+// to override at runtime with an operator-edited file.
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed config/llm_profiles.yaml
+var embeddedProfileCatalog []byte
+
+// LLMPricing is per-1M-tokens USD. A zero value means "free"
+// (Ollama); a negative value (set by lookup miss) means "unknown".
+type LLMPricing struct {
+	InputPerMTok  float64 `yaml:"input_per_mtok"  json:"input_per_mtok"`
+	OutputPerMTok float64 `yaml:"output_per_mtok" json:"output_per_mtok"`
+}
+
+// LLMModel is one catalogue entry under a template.
+type LLMModel struct {
+	ID      string     `yaml:"id"      json:"id"`
+	Label   string     `yaml:"label"   json:"label"`
+	Pricing LLMPricing `yaml:"pricing" json:"pricing"`
+}
+
+// LLMTemplate is one profile (Anthropic / HF / Ollama / …).
+// Users select a template + model in the dashboard.
+type LLMTemplate struct {
+	Name           string     `yaml:"name"             json:"name"`
+	Label          string     `yaml:"label"            json:"label"`
+	BaseURL        string     `yaml:"base_url"         json:"base_url"`
+	RequiresAPIKey bool       `yaml:"requires_api_key" json:"requires_api_key"`
+	APIKeyHelp     string     `yaml:"api_key_help"     json:"api_key_help"`
+	SupportsTools  bool       `yaml:"supports_tools"   json:"supports_tools"`
+	Models         []LLMModel `yaml:"models"           json:"models"`
+}
+
+// LLMCatalog is the top-level YAML root.
+type LLMCatalog struct {
+	Templates []LLMTemplate `yaml:"templates" json:"templates"`
+}
+
+// catalogStore caches the parsed catalog. The file is small (<5KB)
+// and changes only on operator edit; we reload on each request when
+// the env var FORWARDER_LLM_PROFILES_RELOAD=1 is set, otherwise
+// once at startup.
+type catalogStore struct {
+	mu    sync.RWMutex
+	value *LLMCatalog
+	path  string
+}
+
+var llmCatalog = &catalogStore{}
+
+// LoadLLMCatalog reads + parses the YAML and caches the result.
+// Path = "" loads the embedded default catalog (shipped with the
+// binary). Non-empty path overrides with a file on disk. Safe to
+// call concurrently; subsequent reads via LLMCatalogValue() return
+// the cached value.
+func LoadLLMCatalog(path string) (*LLMCatalog, error) {
+	var body []byte
+	source := "embedded default"
+	if path == "" {
+		body = embeddedProfileCatalog
+	} else {
+		var err error
+		body, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("llm profiles: read %s: %w", path, err)
+		}
+		source = path
+	}
+	var c LLMCatalog
+	if err := yaml.Unmarshal(body, &c); err != nil {
+		return nil, fmt.Errorf("llm profiles: parse %s: %w", source, err)
+	}
+	if len(c.Templates) == 0 {
+		return nil, fmt.Errorf("llm profiles: %s has zero templates", source)
+	}
+	llmCatalog.mu.Lock()
+	llmCatalog.value = &c
+	llmCatalog.path = source
+	llmCatalog.mu.Unlock()
+	return &c, nil
+}
+
+// LLMCatalogValue returns the cached catalog. Returns nil before
+// the first LoadLLMCatalog call.
+func LLMCatalogValue() *LLMCatalog {
+	llmCatalog.mu.RLock()
+	defer llmCatalog.mu.RUnlock()
+	return llmCatalog.value
+}
+
+// FindTemplate looks up a template by name. Returns nil when not
+// found.
+func (c *LLMCatalog) FindTemplate(name string) *LLMTemplate {
+	for i := range c.Templates {
+		if c.Templates[i].Name == name {
+			return &c.Templates[i]
+		}
+	}
+	return nil
+}
+
+// FindModel returns the catalog entry for (template, modelID), or
+// nil if the model isn't listed (user typed a custom model id).
+func (c *LLMCatalog) FindModel(templateName, modelID string) *LLMModel {
+	t := c.FindTemplate(templateName)
+	if t == nil {
+		return nil
+	}
+	for i := range t.Models {
+		if t.Models[i].ID == modelID {
+			return &t.Models[i]
+		}
+	}
+	return nil
+}
+
+// CostUSD computes the cost of a request. Returns -1 (unknown) when
+// the model isn't in the catalog — the budget guard treats unknown
+// as zero so the user isn't blocked, but the ledger surfaces the
+// gap.
+func (c *LLMCatalog) CostUSD(templateName, modelID string, inputTokens, outputTokens uint32) float64 {
+	m := c.FindModel(templateName, modelID)
+	if m == nil {
+		return -1
+	}
+	const mTok = 1_000_000.0
+	return (float64(inputTokens)/mTok)*m.Pricing.InputPerMTok +
+		(float64(outputTokens)/mTok)*m.Pricing.OutputPerMTok
+}

--- a/analytics/go-forwarder/llm_session_chat.go
+++ b/analytics/go-forwarder/llm_session_chat.go
@@ -1,0 +1,545 @@
+package main
+
+// llm_session_chat.go — the /api/v2/chat SSE endpoint (#497).
+//
+// Wire shape: POST with a JSON body carrying the user's chosen
+// profile + model + api_key (BYO key, browser localStorage) + the
+// chat history + an optional scope. Response: SSE stream of typed
+// events the Vue chat panel consumes.
+//
+// Event types (the `event:` line in each SSE chunk; data is JSON):
+//   text_delta   { delta: string }              — assistant token
+//   tool_call    { id, name, args }             — model invoked a tool
+//   tool_result  { id, ok, summary }            — tool returned
+//   citation     { span_id, kind, ... }         — emitted by cite()
+//   usage        { input_tokens, output_tokens,
+//                  cost_usd, duration_ms,
+//                  tool_calls_count }
+//   done         {}
+//   error        { kind, message }
+//
+// The loop:
+//   1. Build full history: [system, ...user-supplied messages]
+//   2. StreamChat → accumulate text + tool_calls
+//   3. If finish_reason = tool_calls, dispatch each, append
+//      assistant + tool messages, loop
+//   4. Else break, compute usage, write ledger, send done
+
+import (
+	"context"
+	"crypto/rand"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+//go:embed prompts/chat.md
+var embeddedSystemPrompt string
+
+// ChatRequest is the wire body POSTed to /api/v2/chat.
+type ChatRequest struct {
+	// Conversation correlation. Generated client-side; the server
+	// uses it as the chat_id on every ledger row. If empty, the
+	// server mints one and returns it on the first SSE frame.
+	ChatID string `json:"chat_id"`
+
+	// Profile selection. Profile must be a template name from the
+	// catalog (/api/v2/chat/profiles); Model can be any string —
+	// it's passed to the upstream verbatim. If the (profile, model)
+	// pair isn't in the catalog, cost tracking goes to "unknown"
+	// (-1) but the call still runs.
+	Profile string `json:"profile"`
+	Model   string `json:"model"`
+	APIKey  string `json:"api_key"`
+	BaseURL string `json:"base_url"` // optional — overrides the template's default
+
+	// Conversation history. The server prepends the system prompt;
+	// the rest is whatever the dashboard's chat panel persisted.
+	Messages []LLMMessage `json:"messages"`
+
+	// Scope hint for the system prompt + ledger. Optional.
+	Scope ChatScope `json:"scope"`
+
+	// One-shot mode: a single user turn → single assistant turn.
+	// Tool-use within that single turn is still allowed.
+	OneShot bool `json:"one_shot"`
+
+	// Temperature override (0.0–1.0). Default 0.2.
+	Temperature float64 `json:"temperature"`
+}
+
+// ChatScope tells the system prompt + ledger what context the
+// dashboard is asking from.
+type ChatScope struct {
+	Kind   string `json:"kind"`              // "fleet" | "play" | "range" | "characterization" | ""
+	PlayID string `json:"play_id,omitempty"`
+	From   string `json:"from,omitempty"`    // for "range"
+	To     string `json:"to,omitempty"`
+	RunID  string `json:"run_id,omitempty"`  // for "characterization"
+	Cycle  int    `json:"cycle,omitempty"`
+}
+
+// chatHandler is the registered handler for POST /api/v2/chat.
+// Holds the per-process tool registry + cached catalog. Built once
+// at startup via newChatHandler.
+type chatHandler struct {
+	cfg        config
+	registry   *ToolRegistry
+	systemPrompt string
+}
+
+// newChatHandler builds the chat backend. Tools are registered
+// once; the system prompt is read from cfg.llmPromptPath once.
+// If cfg.llmPromptPath is empty a built-in minimal prompt is used.
+func newChatHandler(cfg config) (*chatHandler, error) {
+	reg := NewToolRegistry()
+	reg.RegisterAll(Tier1Tools(cfg))
+	reg.RegisterAll(Tier2Tools(cfg.claudeDir))
+	reg.Register(CiteTool())
+	reg.Register(QueryTool(cfg))
+
+	prompt := embeddedSystemPrompt
+	if cfg.llmPromptPath != "" {
+		body, err := os.ReadFile(cfg.llmPromptPath)
+		if err != nil {
+			return nil, fmt.Errorf("read system prompt %s: %w", cfg.llmPromptPath, err)
+		}
+		prompt = string(body)
+	}
+	return &chatHandler{cfg: cfg, registry: reg, systemPrompt: prompt}, nil
+}
+
+// ServeHTTP routes POST → chat, GET /profiles → catalog, GET /budget
+// → budget. mountChatHandlers wires the actual paths.
+func mountChatHandlers(mux *http.ServeMux, h *chatHandler) {
+	mux.HandleFunc("/api/v2/chat", h.handleChat)
+	mux.HandleFunc("/api/v2/chat/profiles", h.handleProfiles)
+	mux.HandleFunc("/api/v2/chat/budget", h.handleBudget)
+}
+
+// handleProfiles returns the catalog. No secrets — pure config.
+func (h *chatHandler) handleProfiles(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeProblemv2(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	cat := LLMCatalogValue()
+	if cat == nil {
+		writeProblemv2(w, http.StatusServiceUnavailable, "catalog not loaded", "")
+		return
+	}
+	writeJSONv2(w, http.StatusOK, cat)
+}
+
+// handleBudget returns the current global budget state.
+func (h *chatHandler) handleBudget(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeProblemv2(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	status, err := ReadBudget(r.Context(), h.cfg, h.cfg.llmBudgetUSD)
+	if err != nil {
+		writeProblemv2(w, http.StatusBadGateway, "ledger read failed", err.Error())
+		return
+	}
+	writeJSONv2(w, http.StatusOK, status)
+}
+
+// handleChat is the main entry. Streams an SSE response.
+func (h *chatHandler) handleChat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeProblemv2(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	var req ChatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", err.Error())
+		return
+	}
+	if req.ChatID == "" {
+		req.ChatID = newID(12)
+	}
+	if len(req.Messages) == 0 {
+		writeProblemv2(w, http.StatusBadRequest, "bad request", "messages required")
+		return
+	}
+
+	// Resolve profile + base_url.
+	cat := LLMCatalogValue()
+	if cat == nil {
+		writeProblemv2(w, http.StatusServiceUnavailable, "catalog not loaded", "")
+		return
+	}
+	tmpl := cat.FindTemplate(req.Profile)
+	if tmpl == nil {
+		writeProblemv2(w, http.StatusBadRequest, "unknown profile", req.Profile)
+		return
+	}
+	baseURL := req.BaseURL
+	if baseURL == "" {
+		baseURL = tmpl.BaseURL
+	}
+	if tmpl.RequiresAPIKey && req.APIKey == "" {
+		writeProblemv2(w, http.StatusBadRequest, "api_key required", tmpl.APIKeyHelp)
+		return
+	}
+	if req.Model == "" && len(tmpl.Models) > 0 {
+		req.Model = tmpl.Models[0].ID
+	}
+
+	// Pre-flight budget check.
+	if h.cfg.llmBudgetUSD > 0 {
+		spent, err := SpentTodayUSD(r.Context(), h.cfg)
+		if err == nil && spent >= h.cfg.llmBudgetUSD {
+			writeProblemv2(w, http.StatusTooManyRequests, "daily budget exceeded",
+				fmt.Sprintf("$%.2f / $%.2f used today; resets at UTC midnight", spent, h.cfg.llmBudgetUSD))
+			return
+		}
+	}
+
+	h.streamChat(w, r, req, tmpl, baseURL, cat)
+}
+
+// streamChat does the actual SSE response + tool-use loop. Split
+// from handleChat to keep that function under "router-shaped."
+func (h *chatHandler) streamChat(
+	w http.ResponseWriter,
+	r *http.Request,
+	req ChatRequest,
+	tmpl *LLMTemplate,
+	baseURL string,
+	cat *LLMCatalog,
+) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+	flusher, _ := w.(http.Flusher)
+
+	// Emitter shared by streaming path + tool side-channel.
+	var emitMu sync.Mutex
+	emit := func(eventType string, payload any) error {
+		emitMu.Lock()
+		defer emitMu.Unlock()
+		buf, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, string(buf)); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	}
+
+	// First frame: chat_id + request_id so the client correlates.
+	requestID := newID(8)
+	_ = emit("meta", map[string]any{"chat_id": req.ChatID, "request_id": requestID})
+
+	// Build initial history: system prompt + user-supplied messages.
+	history := make([]LLMMessage, 0, len(req.Messages)+1)
+	history = append(history, LLMMessage{
+		Role:    "system",
+		Content: h.buildSystemPrompt(req.Scope),
+	})
+	history = append(history, req.Messages...)
+
+	startedAt := time.Now()
+	usage := LLMUsage{}
+	toolCallsCount := 0
+	status := LLMStatusOK
+	errKind := ""
+
+	// Track tool budget across the loop. Each call increments by 1;
+	// once the cap is hit we stop dispatching but let the LLM
+	// finish whatever it was streaming.
+	maxToolCalls := h.cfg.llmMaxToolCalls
+	if maxToolCalls <= 0 {
+		maxToolCalls = 20
+	}
+
+loop:
+	for iter := 0; iter < 50; iter++ { // hard ceiling on loop iterations
+		select {
+		case <-r.Context().Done():
+			status = LLMStatusCancelled
+			break loop
+		default:
+		}
+
+		stream, err := StreamChat(r.Context(), LLMRequest{
+			BaseURL:     baseURL,
+			APIKey:      req.APIKey,
+			Model:       req.Model,
+			Messages:    history,
+			Tools:       h.registry.ToOpenAITools(),
+			Temperature: orDefault(req.Temperature, 0.2),
+		})
+		if err != nil {
+			status = LLMStatusError
+			errKind = "upstream_open"
+			_ = emit("error", map[string]any{"kind": errKind, "message": err.Error()})
+			break loop
+		}
+
+		// Accumulate this iteration's outputs.
+		var (
+			textBuilder  strings.Builder
+			toolBuilders = map[int]*toolCallAssembly{}
+			finishReason = ""
+		)
+
+		for ev := range stream {
+			if ev.Err != nil {
+				_ = emit("error", map[string]any{"kind": "stream", "message": ev.Err.Error()})
+				continue
+			}
+			if ev.TextDelta != "" {
+				textBuilder.WriteString(ev.TextDelta)
+				_ = emit("text_delta", map[string]any{"delta": ev.TextDelta})
+			}
+			if ev.ToolCallDelta != nil {
+				tcd := ev.ToolCallDelta
+				asm, ok := toolBuilders[tcd.Index]
+				if !ok {
+					asm = &toolCallAssembly{}
+					toolBuilders[tcd.Index] = asm
+				}
+				if tcd.ID != "" {
+					asm.ID = tcd.ID
+				}
+				if tcd.Name != "" {
+					asm.Name = tcd.Name
+				}
+				if tcd.ArgsFrag != "" {
+					asm.Args.WriteString(tcd.ArgsFrag)
+				}
+			}
+			if ev.Usage != nil {
+				usage.InputTokens += ev.Usage.InputTokens
+				usage.OutputTokens += ev.Usage.OutputTokens
+			}
+			if ev.FinishReason != "" {
+				finishReason = ev.FinishReason
+			}
+		}
+
+		// Append the assistant message that produced this iteration.
+		asstMsg := LLMMessage{Role: "assistant", Content: textBuilder.String()}
+		if len(toolBuilders) > 0 {
+			ordered := orderedToolCalls(toolBuilders)
+			asstMsg.ToolCalls = make([]LLMToolCall, 0, len(ordered))
+			for _, asm := range ordered {
+				asstMsg.ToolCalls = append(asstMsg.ToolCalls, LLMToolCall{
+					ID:   asm.ID,
+					Type: "function",
+					Function: LLMToolCallFunc{
+						Name:      asm.Name,
+						Arguments: asm.Args.String(),
+					},
+				})
+			}
+		}
+		history = append(history, asstMsg)
+
+		// If no tool calls, we're done.
+		if len(asstMsg.ToolCalls) == 0 {
+			break loop
+		}
+
+		// Dispatch each tool call. Append a tool message per call.
+		for _, tc := range asstMsg.ToolCalls {
+			if toolCallsCount >= maxToolCalls {
+				_ = emit("error", map[string]any{
+					"kind":    "tool_budget",
+					"message": fmt.Sprintf("tool call budget %d exhausted; stopping", maxToolCalls),
+				})
+				break loop
+			}
+			toolCallsCount++
+			_ = emit("tool_call", map[string]any{
+				"id":   tc.ID,
+				"name": tc.Function.Name,
+				"args": tc.Function.Arguments,
+			})
+			result := h.registry.Dispatch(
+				r.Context(),
+				tc.Function.Name,
+				json.RawMessage(tc.Function.Arguments),
+				emit,
+			)
+			_ = emit("tool_result", map[string]any{
+				"id":      tc.ID,
+				"ok":      !strings.HasPrefix(result, `{"error"`),
+				"summary": summarize(result, 200),
+			})
+			history = append(history, LLMMessage{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Name:       tc.Function.Name,
+				Content:    result,
+			})
+		}
+
+		// In one-shot mode, the iteration after tool dispatch is the
+		// LLM's final answer — we let it complete, then break on
+		// its next finish_reason=stop. Multi-turn mode is the same;
+		// the loop continues until the LLM stops calling tools.
+		_ = finishReason
+		_ = req.OneShot
+	}
+
+	// Compute cost, write ledger, emit usage + done.
+	durationMs := uint32(time.Since(startedAt).Milliseconds())
+	costUSD := cat.CostUSD(req.Profile, req.Model, usage.InputTokens, usage.OutputTokens)
+
+	_ = emit("usage", map[string]any{
+		"input_tokens":     usage.InputTokens,
+		"output_tokens":    usage.OutputTokens,
+		"cost_usd":         costUSD,
+		"duration_ms":      durationMs,
+		"tool_calls_count": toolCallsCount,
+	})
+
+	// Ledger write — best effort.
+	row := LLMCallRow{
+		Ts:             time.Now().UTC().Format("2006-01-02 15:04:05.000"),
+		ChatID:         req.ChatID,
+		RequestID:      requestID,
+		KeyHash:        HashAPIKey(req.APIKey),
+		Profile:        req.Profile,
+		BaseURL:        baseURL,
+		Model:          req.Model,
+		OneShot:        bool2u8(req.OneShot),
+		ScopeKind:      req.Scope.Kind,
+		ScopePlayID:    req.Scope.PlayID,
+		ScopeRunID:     req.Scope.RunID,
+		InputTokens:    usage.InputTokens,
+		OutputTokens:   usage.OutputTokens,
+		CostUSD:        costUSD,
+		DurationMs:     durationMs,
+		ToolCallsCount: uint16(toolCallsCount),
+		Status:         status,
+		ErrorKind:      errKind,
+		PromptVersion:  promptVersion(h.systemPrompt),
+	}
+	if err := InsertLLMCall(context.Background(), h.cfg, row); err != nil {
+		log.Printf("llm_calls insert failed: %v", err)
+	}
+
+	_ = emit("done", map[string]any{})
+}
+
+// toolCallAssembly accumulates a single tool call's incremental
+// arrival.
+type toolCallAssembly struct {
+	ID   string
+	Name string
+	Args strings.Builder
+}
+
+func orderedToolCalls(m map[int]*toolCallAssembly) []*toolCallAssembly {
+	// OAI's tool_calls[].index defines submit order; we sort by it.
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if keys[j] < keys[i] {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+	out := make([]*toolCallAssembly, len(keys))
+	for i, k := range keys {
+		out[i] = m[k]
+	}
+	return out
+}
+
+func newID(n int) string {
+	buf := make([]byte, n)
+	_, _ = rand.Read(buf)
+	return hex.EncodeToString(buf)
+}
+
+func orDefault(v, def float64) float64 {
+	if v <= 0 {
+		return def
+	}
+	return v
+}
+
+func bool2u8(b bool) uint8 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func summarize(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+// promptVersion peeks the prompt's YAML frontmatter for a
+// `prompt_version:` line and returns its value, or "v1" by default.
+func promptVersion(prompt string) string {
+	for _, line := range strings.Split(prompt, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "prompt_version:") {
+			v := strings.TrimSpace(strings.TrimPrefix(line, "prompt_version:"))
+			v = strings.Trim(v, `"'`)
+			if v != "" {
+				return v
+			}
+		}
+		if line == "---" || line == "" {
+			continue
+		}
+		// Bail at first non-frontmatter line.
+		if !strings.Contains(line, ":") {
+			break
+		}
+	}
+	return "v1"
+}
+
+// buildSystemPrompt prepends a small scope preamble to the configured
+// system prompt so the model knows what the dashboard is asking about.
+func (h *chatHandler) buildSystemPrompt(scope ChatScope) string {
+	var b strings.Builder
+	b.WriteString(h.systemPrompt)
+	if scope.Kind != "" {
+		b.WriteString("\n\n# Current scope\n\n")
+		switch scope.Kind {
+		case "play":
+			fmt.Fprintf(&b, "The user is looking at a single play. play_id=%s. "+
+				"Anchor your reasoning to this play; use get_play_summary first.\n",
+				scope.PlayID)
+		case "range":
+			fmt.Fprintf(&b, "The user has brushed a time range on a play. "+
+				"play_id=%s, from=%s, to=%s. Focus on events inside this window; "+
+				"use surrounding context as needed.\n", scope.PlayID, scope.From, scope.To)
+		case "fleet":
+			b.WriteString("The user is on the plays picker — fleet-wide question. " +
+				"Use find_plays to find candidates; cite each clickable result.\n")
+		case "characterization":
+			fmt.Fprintf(&b, "The user is on a characterization run. run_id=%s, cycle=%d.\n",
+				scope.RunID, scope.Cycle)
+		}
+	}
+	return b.String()
+}
+

--- a/analytics/go-forwarder/llm_tool_cite.go
+++ b/analytics/go-forwarder/llm_tool_cite.go
@@ -1,0 +1,136 @@
+package main
+
+// llm_tool_cite.go — the cite() tool (#497).
+//
+// Unlike every other tool, cite() has a side-channel: it emits a
+// "citation" SSE event to the dashboard at execution time so the
+// citation card renders immediately, while returning only a brief
+// JSON confirmation to the LLM so the LLM's tool budget stays
+// small.
+//
+// Citations come in a few flavours (kinds), each rendered by the
+// dashboard's Vue layer as a deep-linkable card:
+//   - play     {play_id, at}             → opens play viewer at time
+//   - range    {play_id, from, to}       → opens play viewer with brush set
+//   - finding  {slug}                    → opens finding doc
+//   - standard {name}                    → opens standard doc
+//   - skill    {name}                    → opens skill SKILL.md
+//   - run      {run_id, cycle?}          → opens characterization run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// CitationTarget is one citation the LLM wants the dashboard to
+// render. Validated server-side; invalid targets are dropped silently
+// (the LLM gets a count in the result so it can detect them).
+type CitationTarget struct {
+	SpanID string `json:"span_id"`
+	Kind   string `json:"kind"`
+	Label  string `json:"label"`
+	// Kind-specific fields. Only those relevant to Kind are emitted
+	// — the dashboard's CitationCard component switches on Kind.
+	PlayID string `json:"play_id,omitempty"`
+	At     string `json:"at,omitempty"`
+	From   string `json:"from,omitempty"`
+	To     string `json:"to,omitempty"`
+	Slug   string `json:"slug,omitempty"`
+	Name   string `json:"name,omitempty"`
+	RunID  string `json:"run_id,omitempty"`
+	Cycle  int    `json:"cycle,omitempty"`
+}
+
+// CiteTool builds the cite() tool definition.
+func CiteTool() Tool {
+	return Tool{
+		Name: "cite",
+		Description: "Emit one or more citation cards the dashboard renders as " +
+			"deep-linkable buttons. Use to anchor every non-trivial claim in " +
+			"your response to a clickable artifact. Kinds: play (play_id+at), " +
+			"range (play_id+from+to), finding (slug), standard (name), " +
+			"skill (name), run (run_id+optional cycle). Each citation must " +
+			"have a span_id you reference in the surrounding prose so the UI " +
+			"can correlate the card with the right span.",
+		Tier: 0, // Special — runs alongside any tier's reasoning.
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"targets": map[string]any{
+					"type":     "array",
+					"minItems": 1,
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"span_id": map[string]any{"type": "string", "description": "Short id you reference in prose (e.g. c1, c2)."},
+							"kind":    map[string]any{"type": "string", "enum": []string{"play", "range", "finding", "standard", "skill", "run"}},
+							"label":   map[string]any{"type": "string", "description": "Human-readable button label."},
+							"play_id": map[string]any{"type": "string"},
+							"at":      map[string]any{"type": "string", "description": "Time within the play (mm:ss.ms or ISO)."},
+							"from":    map[string]any{"type": "string"},
+							"to":      map[string]any{"type": "string"},
+							"slug":    map[string]any{"type": "string"},
+							"name":    map[string]any{"type": "string"},
+							"run_id":  map[string]any{"type": "string"},
+							"cycle":   map[string]any{"type": "integer"},
+						},
+						"required": []string{"span_id", "kind", "label"},
+					},
+				},
+			},
+			"required": []string{"targets"},
+		},
+		Execute: func(ctx context.Context, args json.RawMessage, emit ToolEmitter) (string, error) {
+			var a struct {
+				Targets []CitationTarget `json:"targets"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", fmt.Errorf("parse args: %w", err)
+			}
+			if len(a.Targets) == 0 {
+				return "", errors.New("at least one citation target required")
+			}
+			if emit == nil {
+				// Side-channel unavailable — return success but note
+				// that no SSE was emitted (dashboard won't see cards).
+				return mustJSON(map[string]any{
+					"emitted":  0,
+					"received": len(a.Targets),
+					"note":     "no SSE emitter; citations dropped",
+				}), nil
+			}
+			emitted := 0
+			for _, t := range a.Targets {
+				if !validCitationKind(t.Kind) {
+					continue
+				}
+				if t.SpanID == "" || t.Label == "" {
+					continue
+				}
+				if err := emit("citation", t); err != nil {
+					// Client likely disconnected — stop here.
+					return mustJSON(map[string]any{
+						"emitted":  emitted,
+						"received": len(a.Targets),
+						"error":    err.Error(),
+					}), nil
+				}
+				emitted++
+			}
+			return mustJSON(map[string]any{
+				"emitted":  emitted,
+				"received": len(a.Targets),
+			}), nil
+		},
+	}
+}
+
+func validCitationKind(k string) bool {
+	switch k {
+	case "play", "range", "finding", "standard", "skill", "run":
+		return true
+	}
+	return false
+}

--- a/analytics/go-forwarder/llm_tool_query.go
+++ b/analytics/go-forwarder/llm_tool_query.go
@@ -1,0 +1,152 @@
+package main
+
+// llm_tool_query.go — Tier 3 raw ClickHouse query tool (#497).
+//
+// The LLM hands us SQL; we run it as the `llm_reader` user (see
+// analytics/clickhouse/init.d/02-llm-reader.sql). ClickHouse enforces
+// every safety bound — execution time, memory, row count, scan
+// count, readonly_settings. The forwarder does NO client-side SQL
+// parsing or rewriting; errors from CH come back to the LLM
+// verbatim so it can self-correct.
+//
+// Tier 3 is the escape hatch when the typed tools don't fit.
+// Encourage the LLM (via the system prompt) to reach for Tier 1
+// first — typed tools are faster, cheaper, less error-prone.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// LLMReaderBackend mirrors the playsBackend pattern but with the
+// restricted llm_reader CH credentials. Constructed from config via
+// llmReaderBackend(cfg).
+type LLMReaderBackend struct {
+	ClickHouseURL string
+	Database      string
+	User          string
+	Password      string
+}
+
+func llmReaderBackend(cfg config) LLMReaderBackend {
+	return LLMReaderBackend{
+		ClickHouseURL: cfg.clickhouseURL,
+		Database:      cfg.chDatabase,
+		User:          cfg.llmReaderUser,
+		Password:      cfg.llmReaderPassword,
+	}
+}
+
+// QueryTool builds the Tier 3 raw-SQL tool.
+func QueryTool(cfg config) Tool {
+	be := llmReaderBackend(cfg)
+	return Tool{
+		Name: "query",
+		Description: "Run a SQL SELECT against the analytics ClickHouse. " +
+			"Read-only, server-enforced caps (10s execution, 10M rows " +
+			"scanned, 10k rows returned, 10MB). Available tables: " +
+			"infinite_streaming.{session_events, network_requests, " +
+			"control_events, characterization_runs, llm_calls}. " +
+			"Use Tier 1 typed tools (find_plays, get_play_summary, " +
+			"get_control_events) first — query() is the escape hatch " +
+			"for analyses the typed tools don't cover.",
+		Tier: 3,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"sql": map[string]any{"type": "string", "description": "Valid ClickHouse SQL. FORMAT clause is added automatically — don't include it."},
+			},
+			"required": []string{"sql"},
+		},
+		Execute: func(ctx context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				SQL string `json:"sql"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", fmt.Errorf("parse args: %w", err)
+			}
+			if strings.TrimSpace(a.SQL) == "" {
+				return "", errors.New("sql required")
+			}
+			start := time.Now()
+			rows, truncated, err := be.runSelect(ctx, a.SQL)
+			elapsed := time.Since(start)
+			if err != nil {
+				// Pass the CH error verbatim — the LLM can read it
+				// and self-correct (typo, missing column, etc.).
+				return mustJSON(map[string]any{
+					"error":      err.Error(),
+					"elapsed_ms": elapsed.Milliseconds(),
+				}), nil
+			}
+			return mustJSON(map[string]any{
+				"rows":       rows,
+				"row_count":  len(rows),
+				"truncated":  truncated,
+				"elapsed_ms": elapsed.Milliseconds(),
+			}), nil
+		},
+	}
+}
+
+// runSelect executes the SQL as the llm_reader user and returns
+// rows + truncated flag. ClickHouse's result_overflow_mode='break'
+// truncates silently — we detect it by inspecting the row count
+// against the cap (10k from the settings profile).
+const llmReaderRowCap = 10000
+
+func (b LLMReaderBackend) runSelect(ctx context.Context, sql string) ([]map[string]any, bool, error) {
+	u, err := url.Parse(b.ClickHouseURL)
+	if err != nil {
+		return nil, false, err
+	}
+	qs := u.Query()
+	qs.Set("default_format", "JSONEachRow")
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(sql))
+	if err != nil {
+		return nil, false, err
+	}
+	if b.User != "" {
+		req.SetBasicAuth(b.User, b.Password)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, false, fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	out := []map[string]any{}
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal(line, &row); err != nil {
+			continue
+		}
+		out = append(out, row)
+	}
+	if err := scanner.Err(); err != nil {
+		return out, false, err
+	}
+	// Heuristic: CH's result_overflow_mode=break truncates silently
+	// at exactly max_result_rows; if we hit that count we surface
+	// truncated=true so the LLM knows the answer may be incomplete.
+	truncated := len(out) >= llmReaderRowCap
+	return out, truncated, nil
+}

--- a/analytics/go-forwarder/llm_tools.go
+++ b/analytics/go-forwarder/llm_tools.go
@@ -1,0 +1,153 @@
+package main
+
+// llm_tools.go — tool registry + dispatcher for the AI chat backend
+// (#497).
+//
+// Tiers (from the design in #497):
+//   Tier 1 — typed domain tools (find_plays, triage_plays, …)
+//            Wired to internal/plays so they share code with v2
+//            HTTP handlers. Fast, cheap, cover ~80% of questions.
+//   Tier 2 — context tools (read_finding, read_standard, read_skill,
+//            list_*, propose_finding). Ground the bot in project
+//            knowledge.
+//   Tier 3 — query(sql) raw ClickHouse access via the llm_reader
+//            user. Long tail of questions; CH enforces safety
+//            server-side.
+//
+// Citation is a side-channel: the cite() tool emits citation SSE
+// events to the dashboard while returning a brief JSON
+// acknowledgement to the LLM. That keeps the LLM's tool budget
+// tight and the dashboard's citation cards reactive.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// ToolEmitter is the side-channel callback a tool can use to push
+// SSE events to the dashboard mid-execution (e.g. cite() emitting
+// citation events). Returns the error from the underlying SSE writer
+// if the client has disconnected.
+type ToolEmitter func(eventType string, payload any) error
+
+// ToolExecuteFn is the actual work. args is the raw JSON the model
+// supplied for the tool call. emit pushes side-channel SSE events
+// (may be nil for tools that don't need it). The returned string is
+// the JSON result fed back to the LLM as the tool's output.
+type ToolExecuteFn func(ctx context.Context, args json.RawMessage, emit ToolEmitter) (string, error)
+
+// Tool is a single callable function the LLM can use.
+type Tool struct {
+	Name        string
+	Description string
+	// Parameters is a JSON Schema describing the function's args. Used
+	// verbatim as the `parameters` field on the OAI tool definition.
+	Parameters map[string]any
+	// Tier identifies which tier this tool is in. Used by the
+	// system prompt's tier-awareness messaging and by the budget
+	// guard for per-tier accounting (future).
+	Tier int
+	// Execute runs the tool. Must be cheap to call and idempotent
+	// where the LLM might retry.
+	Execute ToolExecuteFn
+}
+
+// ToolRegistry holds the per-process tool set. Lazily-built; a
+// single instance is shared across requests (tools are stateless).
+type ToolRegistry struct {
+	mu    sync.RWMutex
+	tools map[string]Tool
+}
+
+// NewToolRegistry returns an empty registry. Tools are registered
+// via Register or RegisterAll.
+func NewToolRegistry() *ToolRegistry {
+	return &ToolRegistry{tools: make(map[string]Tool)}
+}
+
+// Register adds a tool. Duplicates panic — registration is
+// startup-time, not request-time, so a duplicate is a programming
+// error worth surfacing loudly.
+func (r *ToolRegistry) Register(t Tool) {
+	if t.Name == "" {
+		panic("llm tools: empty tool name")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, dup := r.tools[t.Name]; dup {
+		panic(fmt.Sprintf("llm tools: duplicate registration: %q", t.Name))
+	}
+	r.tools[t.Name] = t
+}
+
+// RegisterAll is a convenience for batch registration.
+func (r *ToolRegistry) RegisterAll(tools []Tool) {
+	for _, t := range tools {
+		r.Register(t)
+	}
+}
+
+// Get returns a tool by name, ok=false if not registered.
+func (r *ToolRegistry) Get(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// All returns every registered tool, sorted by name for deterministic
+// ordering in API responses and the system prompt.
+func (r *ToolRegistry) All() []Tool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Tool, 0, len(r.tools))
+	for _, t := range r.tools {
+		out = append(out, t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// ToOpenAITools projects the registered tools into the OAI
+// tools[] array shape the upstream call expects.
+func (r *ToolRegistry) ToOpenAITools() []LLMTool {
+	all := r.All()
+	out := make([]LLMTool, len(all))
+	for i, t := range all {
+		out[i] = LLMTool{
+			Type: "function",
+			Function: LLMToolDef{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.Parameters,
+			},
+		}
+	}
+	return out
+}
+
+// Dispatch runs the named tool with the given args. Returns the
+// JSON result string. If the tool isn't registered or fails, returns
+// an error-shaped JSON string the LLM can read and self-correct from.
+func (r *ToolRegistry) Dispatch(ctx context.Context, name string, args json.RawMessage, emit ToolEmitter) string {
+	t, ok := r.Get(name)
+	if !ok {
+		return mustJSON(map[string]any{"error": fmt.Sprintf("unknown tool: %q", name)})
+	}
+	out, err := t.Execute(ctx, args, emit)
+	if err != nil {
+		return mustJSON(map[string]any{"error": err.Error()})
+	}
+	return out
+}
+
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return `{"error":"json encode failed"}`
+	}
+	return string(b)
+}

--- a/analytics/go-forwarder/llm_tools_tier1.go
+++ b/analytics/go-forwarder/llm_tools_tier1.go
@@ -1,0 +1,185 @@
+package main
+
+// llm_tools_tier1.go — typed domain tools (#497).
+//
+// Each tool is a thin adapter: parse the JSON args into the
+// internal/plays typed parameter struct, call the domain function,
+// JSON-encode the result. The HTTP handlers use the same domain
+// functions — single source of truth.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jonathaneoliver/infinite-streaming/analytics/go-forwarder/internal/plays"
+)
+
+// Tier1Tools builds the typed-domain tool set for the chat backend.
+// Pass the chat backend's config so the tools can call internal/plays.
+func Tier1Tools(cfg config) []Tool {
+	be := playsBackend(cfg)
+	return []Tool{
+		findPlaysTool(be),
+		getPlaySummaryTool(be),
+		getControlEventsTool(be),
+	}
+}
+
+func findPlaysTool(be plays.Backend) Tool {
+	return Tool{
+		Name: "find_plays",
+		Description: "List archived plays matching the filters. " +
+			"Returns one row per play with aggregated facts (label set, error counts, " +
+			"timing, classification). Use to find aberrant sessions, scope by player " +
+			"or content, or get a fleet-wide answer to 'what's broken since X'. " +
+			"Filter by labels[] (e.g. labels_has=['critical=frozen']) for the cheap " +
+			"interestingness signal.",
+		Tier: 1,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"player_id":      map[string]any{"type": "string", "description": "Filter to one player (UUID)."},
+				"play_id":        map[string]any{"type": "string", "description": "Filter to one play (UUID)."},
+				"from":           map[string]any{"type": "string", "description": "ISO timestamp lower bound (e.g. 2026-05-23T09:00:00Z)."},
+				"to":             map[string]any{"type": "string", "description": "ISO timestamp upper bound."},
+				"classification": map[string]any{"type": "string", "enum": []string{"interesting", "other", "favourite"}},
+				"labels_has":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "AND-required labels (e.g. ['critical=frozen'])."},
+				"labels_not":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Labels that must NOT be present."},
+				"limit":          map[string]any{"type": "integer", "minimum": 1, "maximum": 5000, "default": 100},
+			},
+		},
+		Execute: func(ctx context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				PlayerID       string   `json:"player_id"`
+				PlayID         string   `json:"play_id"`
+				From           string   `json:"from"`
+				To             string   `json:"to"`
+				Classification string   `json:"classification"`
+				LabelsHas      []string `json:"labels_has"`
+				LabelsNot      []string `json:"labels_not"`
+				Limit          int      `json:"limit"`
+			}
+			if len(args) > 0 {
+				if err := json.Unmarshal(args, &a); err != nil {
+					return "", fmt.Errorf("parse args: %w", err)
+				}
+			}
+			if a.Limit == 0 {
+				a.Limit = 100
+			}
+			rows, err := plays.FindPlays(ctx, be, plays.PlayFilter{
+				PlayerID:       a.PlayerID,
+				PlayID:         a.PlayID,
+				From:           a.From,
+				To:             a.To,
+				Classification: a.Classification,
+				Labels:         plays.LabelFilter{Has: a.LabelsHas, Not: a.LabelsNot},
+				Limit:          a.Limit,
+			})
+			if err != nil {
+				return "", err
+			}
+			if rows == nil {
+				rows = []map[string]any{}
+			}
+			return mustJSON(map[string]any{
+				"count": len(rows),
+				"plays": rows,
+			}), nil
+		},
+	}
+}
+
+func getPlaySummaryTool(be plays.Backend) Tool {
+	return Tool{
+		Name: "get_play_summary",
+		Description: "Get the full PlaySummary facts row for one play (the same shape " +
+			"find_plays returns, but with no surrounding scope). Use before reaching " +
+			"a conclusion about a specific play — anchors your reasoning in concrete " +
+			"counters (stalls, error counts, label set).",
+		Tier: 1,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"play_id": map[string]any{"type": "string", "description": "Play UUID."},
+			},
+			"required": []string{"play_id"},
+		},
+		Execute: func(ctx context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				PlayID string `json:"play_id"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", fmt.Errorf("parse args: %w", err)
+			}
+			if a.PlayID == "" {
+				return "", fmt.Errorf("play_id required")
+			}
+			row, err := plays.GetPlaySummary(ctx, be, a.PlayID)
+			if err != nil {
+				return "", err
+			}
+			if row == nil {
+				return mustJSON(map[string]any{"found": false, "play_id": a.PlayID}), nil
+			}
+			return mustJSON(map[string]any{"found": true, "play": row}), nil
+		},
+	}
+}
+
+func getControlEventsTool(be plays.Backend) Tool {
+	return Tool{
+		Name: "get_control_events",
+		Description: "Get the operator / proxy / harness action log for a player. " +
+			"Rows include fault toggles, traffic-shape changes, pattern step advances, " +
+			"and any harness mutation. Crucial for forensics — was a fault injected " +
+			"at the time something broke?",
+		Tier: 1,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"player_id":  map[string]any{"type": "string", "description": "Player UUID (required)."},
+				"play_id":    map[string]any{"type": "string", "description": "Narrow to one play (optional)."},
+				"from":       map[string]any{"type": "string", "description": "ISO timestamp lower bound (optional)."},
+				"to":         map[string]any{"type": "string", "description": "ISO timestamp upper bound (optional)."},
+				"labels_has": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"labels_not": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"limit":      map[string]any{"type": "integer", "minimum": 1, "maximum": 10000, "default": 1000},
+			},
+			"required": []string{"player_id"},
+		},
+		Execute: func(ctx context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				PlayerID  string   `json:"player_id"`
+				PlayID    string   `json:"play_id"`
+				From      string   `json:"from"`
+				To        string   `json:"to"`
+				LabelsHas []string `json:"labels_has"`
+				LabelsNot []string `json:"labels_not"`
+				Limit     int      `json:"limit"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", fmt.Errorf("parse args: %w", err)
+			}
+			rows, err := plays.GetControlEvents(ctx, be, plays.ControlEventsFilter{
+				PlayerID: a.PlayerID,
+				PlayID:   a.PlayID,
+				From:     a.From,
+				To:       a.To,
+				Labels:   plays.LabelFilter{Has: a.LabelsHas, Not: a.LabelsNot},
+				Limit:    a.Limit,
+			})
+			if err != nil {
+				return "", err
+			}
+			if rows == nil {
+				rows = []map[string]any{}
+			}
+			return mustJSON(map[string]any{
+				"count":  len(rows),
+				"events": rows,
+			}), nil
+		},
+	}
+}

--- a/analytics/go-forwarder/llm_tools_tier2.go
+++ b/analytics/go-forwarder/llm_tools_tier2.go
@@ -1,0 +1,317 @@
+package main
+
+// llm_tools_tier2.go — context tools that ground the chat backend
+// in project knowledge (#497). All read-only; all operate against
+// the `.claude/` tree the project keeps as canonical knowledge
+// (skills, standards, findings, conventions).
+//
+// Files stay on disk under cfg.claudeDir. The forwarder reads them
+// per-request — they're small (<10KB each, dozens to low hundreds of
+// files total) so caching is unnecessary at v1 scale and operator
+// edits show up on the next call.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// safeName allows only [a-zA-Z0-9._/-] in path components — prevents
+// any `../` escape from a malicious or confused LLM. Slashes are
+// allowed only because skills live in subdirectories
+// (`.claude/skills/finding/SKILL.md`); the directory traversal
+// rejection happens via filepath.Clean comparison below.
+var safeName = regexp.MustCompile(`^[a-zA-Z0-9._/-]{1,128}$`)
+
+func validateSlug(name string) error {
+	if name == "" {
+		return fmt.Errorf("name required")
+	}
+	if !safeName.MatchString(name) {
+		return fmt.Errorf("invalid name (allowed: a-z, A-Z, 0-9, ., _, -, max 128 chars)")
+	}
+	cleaned := filepath.Clean(name)
+	if cleaned != name || strings.HasPrefix(cleaned, "..") || strings.Contains(cleaned, "/..") {
+		return fmt.Errorf("invalid name (path traversal)")
+	}
+	return nil
+}
+
+// Tier2Tools builds the context tool set. claudeDir is the absolute
+// path to the project's .claude/ directory (mounted into the
+// container; FORWARDER_CLAUDE_DIR env var).
+func Tier2Tools(claudeDir string) []Tool {
+	if claudeDir == "" {
+		// Empty dir = tools degrade to "no knowledge available"
+		// instead of failing — the chat still works, just without
+		// findings/standards/skills citations.
+		claudeDir = "/dev/null/.claude"
+	}
+	return []Tool{
+		listFindingsTool(claudeDir),
+		readFindingTool(claudeDir),
+		listStandardsTool(claudeDir),
+		readStandardTool(claudeDir),
+		listSkillsTool(claudeDir),
+		readSkillTool(claudeDir),
+		readConventionsTool(claudeDir),
+	}
+}
+
+// --- Findings ---
+
+func listFindingsTool(claudeDir string) Tool {
+	return Tool{
+		Name: "list_findings",
+		Description: "List the project's recorded findings (discoveries from past " +
+			"investigations). Each finding is a tagged hypothesis with " +
+			"timeline + evidence. Use this BEFORE concluding anything novel " +
+			"— the symptom you're looking at may already be in the library. " +
+			"Use read_finding(slug) to pull the full text.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"grep": map[string]any{"type": "string", "description": "Optional substring filter against filename (e.g. 'stall', 'ipad', '2026-05')."},
+			},
+		},
+		Execute: func(_ context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				Grep string `json:"grep"`
+			}
+			if len(args) > 0 {
+				_ = json.Unmarshal(args, &a)
+			}
+			entries, err := os.ReadDir(filepath.Join(claudeDir, "findings"))
+			if err != nil {
+				return mustJSON(map[string]any{"count": 0, "findings": []string{}, "error": err.Error()}), nil
+			}
+			out := []string{}
+			needle := strings.ToLower(a.Grep)
+			for _, e := range entries {
+				name := e.Name()
+				if !strings.HasSuffix(name, ".md") {
+					continue
+				}
+				slug := strings.TrimSuffix(name, ".md")
+				if needle != "" && !strings.Contains(strings.ToLower(slug), needle) {
+					continue
+				}
+				out = append(out, slug)
+			}
+			sort.Strings(out)
+			return mustJSON(map[string]any{"count": len(out), "findings": out}), nil
+		},
+	}
+}
+
+func readFindingTool(claudeDir string) Tool {
+	return Tool{
+		Name: "read_finding",
+		Description: "Read a finding's full markdown body. The slug is the filename " +
+			"without .md (e.g. 'ipad-262s-stall-2026-05-17'). If a sibling " +
+			".json sidecar exists with the raw player state at the moment of " +
+			"capture, it's returned alongside.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"slug": map[string]any{"type": "string", "description": "Finding slug (filename without .md)."},
+			},
+			"required": []string{"slug"},
+		},
+		Execute: func(_ context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				Slug string `json:"slug"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", err
+			}
+			if err := validateSlug(a.Slug); err != nil {
+				return "", err
+			}
+			mdPath := filepath.Join(claudeDir, "findings", a.Slug+".md")
+			md, err := os.ReadFile(mdPath)
+			if err != nil {
+				return mustJSON(map[string]any{"found": false, "slug": a.Slug, "error": err.Error()}), nil
+			}
+			result := map[string]any{
+				"found":    true,
+				"slug":     a.Slug,
+				"markdown": string(md),
+			}
+			// Optional JSON sidecar.
+			if sidecar, err := os.ReadFile(filepath.Join(claudeDir, "findings", a.Slug+".json")); err == nil {
+				var parsed any
+				if err := json.Unmarshal(sidecar, &parsed); err == nil {
+					result["sidecar"] = parsed
+				}
+			}
+			return mustJSON(result), nil
+		},
+	}
+}
+
+// --- Standards ---
+
+func listStandardsTool(claudeDir string) Tool {
+	return Tool{
+		Name: "list_standards",
+		Description: "List the project's domain standards documents (HLS taxonomy, " +
+			"ABR decision model, AVPlayer quirks, codec strings, fault " +
+			"injection wire contract, characterization principles, harness CLI, " +
+			"startup/abort characterization tests). Use read_standard(name) for " +
+			"the full text. Always ground reasoning about player behavior in " +
+			"the relevant standard before guessing.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Execute: func(_ context.Context, _ json.RawMessage, _ ToolEmitter) (string, error) {
+			entries, err := os.ReadDir(filepath.Join(claudeDir, "standards"))
+			if err != nil {
+				return mustJSON(map[string]any{"count": 0, "standards": []string{}, "error": err.Error()}), nil
+			}
+			out := []string{}
+			for _, e := range entries {
+				name := e.Name()
+				if !strings.HasSuffix(name, ".md") {
+					continue
+				}
+				out = append(out, strings.TrimSuffix(name, ".md"))
+			}
+			sort.Strings(out)
+			return mustJSON(map[string]any{"count": len(out), "standards": out}), nil
+		},
+	}
+}
+
+func readStandardTool(claudeDir string) Tool {
+	return Tool{
+		Name: "read_standard",
+		Description: "Read a domain standard's full markdown body. The name is the " +
+			"filename without .md (e.g. 'hls-taxonomy', 'abr-decision-model').",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+			"required": []string{"name"},
+		},
+		Execute: func(_ context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", err
+			}
+			if err := validateSlug(a.Name); err != nil {
+				return "", err
+			}
+			body, err := os.ReadFile(filepath.Join(claudeDir, "standards", a.Name+".md"))
+			if err != nil {
+				return mustJSON(map[string]any{"found": false, "name": a.Name, "error": err.Error()}), nil
+			}
+			return mustJSON(map[string]any{"found": true, "name": a.Name, "markdown": string(body)}), nil
+		},
+	}
+}
+
+// --- Skills ---
+
+func listSkillsTool(claudeDir string) Tool {
+	return Tool{
+		Name: "list_skills",
+		Description: "List the project's playbook skills (triage, investigate, " +
+			"forensics, finding, fault, shape, harness). Each skill is a " +
+			"procedure for a particular kind of analysis. Use read_skill(name) " +
+			"to load a skill's playbook before following its procedure.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Execute: func(_ context.Context, _ json.RawMessage, _ ToolEmitter) (string, error) {
+			entries, err := os.ReadDir(filepath.Join(claudeDir, "skills"))
+			if err != nil {
+				return mustJSON(map[string]any{"count": 0, "skills": []string{}, "error": err.Error()}), nil
+			}
+			out := []string{}
+			for _, e := range entries {
+				if !e.IsDir() {
+					continue
+				}
+				out = append(out, e.Name())
+			}
+			sort.Strings(out)
+			return mustJSON(map[string]any{"count": len(out), "skills": out}), nil
+		},
+	}
+}
+
+func readSkillTool(claudeDir string) Tool {
+	return Tool{
+		Name: "read_skill",
+		Description: "Read a skill's playbook (SKILL.md). Skills describe a " +
+			"step-by-step procedure for a kind of analysis. Follow the " +
+			"procedure's intent, substituting this chat's typed tools " +
+			"(find_plays, get_control_events, etc.) for the harness CLI " +
+			"commands the skill references — those are for Claude Code, not " +
+			"for the web chat backend.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "string"},
+			},
+			"required": []string{"name"},
+		},
+		Execute: func(_ context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
+			var a struct {
+				Name string `json:"name"`
+			}
+			if err := json.Unmarshal(args, &a); err != nil {
+				return "", err
+			}
+			if err := validateSlug(a.Name); err != nil {
+				return "", err
+			}
+			body, err := os.ReadFile(filepath.Join(claudeDir, "skills", a.Name, "SKILL.md"))
+			if err != nil {
+				return mustJSON(map[string]any{"found": false, "name": a.Name, "error": err.Error()}), nil
+			}
+			return mustJSON(map[string]any{"found": true, "name": a.Name, "markdown": string(body)}), nil
+		},
+	}
+}
+
+// --- Conventions ---
+
+func readConventionsTool(claudeDir string) Tool {
+	return Tool{
+		Name: "read_conventions",
+		Description: "Read the cross-skill conventions document. Covers project-wide " +
+			"rules: tagging causal claims confirmed/refuted/needs-test, local " +
+			"vs UTC time display, citation style, no-guessing-during-triage. " +
+			"You should follow these conventions in every response.",
+		Tier: 2,
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		Execute: func(_ context.Context, _ json.RawMessage, _ ToolEmitter) (string, error) {
+			body, err := os.ReadFile(filepath.Join(claudeDir, "skills", "CONVENTIONS.md"))
+			if err != nil {
+				return mustJSON(map[string]any{"found": false, "error": err.Error()}), nil
+			}
+			return mustJSON(map[string]any{"found": true, "markdown": string(body)}), nil
+		},
+	}
+}

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -115,6 +115,17 @@ type config struct {
 	flushBatch     int
 	httpListen     string
 	ringWindowSecs int // FORWARDER_LIVE_RING_SECONDS; see ring.go
+
+	// AI chat backend (#497). All optional — leave llmProfilesPath
+	// empty to disable the /api/v2/chat endpoint entirely.
+	llmProfilesPath    string  // FORWARDER_LLM_PROFILES_PATH
+	llmPromptPath      string  // FORWARDER_LLM_PROMPT_PATH (system prompt markdown)
+	llmReaderUser      string  // FORWARDER_CLICKHOUSE_LLM_USER (default "llm_reader")
+	llmReaderPassword  string  // FORWARDER_CLICKHOUSE_LLM_PASSWORD
+	llmBudgetUSD       float64 // FORWARDER_LLM_BUDGET_USD (default 5.00)
+	llmMaxToolCalls    int     // FORWARDER_LLM_MAX_TOOL_CALLS (default 20)
+	llmMaxInputTokens  int     // FORWARDER_LLM_MAX_INPUT_TOKENS (default 80000)
+	claudeDir          string  // FORWARDER_CLAUDE_DIR — mount of the project's .claude/ dir
 }
 
 func loadConfig() config {
@@ -137,8 +148,30 @@ func loadConfig() config {
 		// entirely. Tunable down for memory-constrained deployments
 		// or up for "live tail covers more history" use cases.
 		ringWindowSecs: getenvInt("FORWARDER_LIVE_RING_SECONDS", 600),
+
+		// AI chat backend. Empty llmProfilesPath disables the
+		// endpoint entirely; non-empty turns it on with the catalog
+		// loaded at startup.
+		llmProfilesPath:   getenv("FORWARDER_LLM_PROFILES_PATH", ""),
+		llmPromptPath:     getenv("FORWARDER_LLM_PROMPT_PATH", ""),
+		llmReaderUser:     getenv("FORWARDER_CLICKHOUSE_LLM_USER", "llm_reader"),
+		llmReaderPassword: getenv("FORWARDER_CLICKHOUSE_LLM_PASSWORD", ""),
+		llmBudgetUSD:      getenvFloat("FORWARDER_LLM_BUDGET_USD", 5.00),
+		llmMaxToolCalls:   getenvInt("FORWARDER_LLM_MAX_TOOL_CALLS", 20),
+		llmMaxInputTokens: getenvInt("FORWARDER_LLM_MAX_INPUT_TOKENS", 80000),
+		claudeDir:         getenv("FORWARDER_CLAUDE_DIR", ""),
 	}
 	return c
+}
+
+func getenvFloat(key string, def float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		var f float64
+		if _, err := fmt.Sscanf(v, "%f", &f); err == nil {
+			return f
+		}
+	}
+	return def
 }
 
 func getenvInt(key string, def int) int {
@@ -943,6 +976,34 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	})
 	mountV2Handlers(mux, cfg)
 	mountTimeseriesHandlers(mux, cfg, ring)
+
+	// AI chat backend (#497). Default-on with embedded profile
+	// catalog + system prompt — operators don't need to mount any
+	// files. Set FORWARDER_LLM_DISABLED=1 to turn off. Override the
+	// catalog or prompt by setting FORWARDER_LLM_PROFILES_PATH /
+	// FORWARDER_LLM_PROMPT_PATH.
+	//
+	// Failure to load the catalog is logged but doesn't take the
+	// whole forwarder down — the chat endpoint is non-critical
+	// infra.
+	if os.Getenv("FORWARDER_LLM_DISABLED") != "1" {
+		if _, err := LoadLLMCatalog(cfg.llmProfilesPath); err != nil {
+			log.Printf("llm chat disabled: %v", err)
+		} else {
+			h, err := newChatHandler(cfg)
+			if err != nil {
+				log.Printf("llm chat disabled: %v", err)
+			} else {
+				mountChatHandlers(mux, h)
+				src := "embedded defaults"
+				if cfg.llmProfilesPath != "" {
+					src = cfg.llmProfilesPath
+				}
+				log.Printf("llm chat enabled at /api/v2/chat (catalog=%s, budget=$%.2f/day)",
+					src, cfg.llmBudgetUSD)
+			}
+		}
+	}
 	mux.HandleFunc("/api/snapshots", func(w http.ResponseWriter, r *http.Request) {
 		session := r.URL.Query().Get("session")
 		if session == "" {

--- a/analytics/go-forwarder/prompts/chat.md
+++ b/analytics/go-forwarder/prompts/chat.md
@@ -1,0 +1,131 @@
+---
+prompt_version: v1
+default_temperature: 0.2
+---
+
+# Role
+
+You are an expert in adaptive video streaming (HLS, DASH, LL-HLS,
+LL-DASH) and ClickHouse analytics. You help operators of the
+InfiniteStream test harness understand what happened during recorded
+playback sessions — and find aberrant sessions across the fleet.
+
+Your judgement is rooted in *evidence from the tools*, *prior findings
+in the project's knowledge base*, and *the project's domain standards*.
+Speculation that isn't backed by one of those is not your strong suit
+— say "I don't know" or "needs-test" instead.
+
+# Tools — tiered
+
+Reach for Tier 1 first. Drop to Tier 3 only when typed tools can't
+express the question.
+
+**Tier 1 — typed domain tools.** Fast, cheap, embed project
+conventions:
+- `find_plays(player_id?, play_id?, from?, to?, classification?, labels_has?, labels_not?, limit?)` —
+  search archived plays. The `labels[]` predicate is the cheap
+  interestingness filter. Use `labels_has=["critical=frozen"]` to
+  find frozen sessions; `labels_has=["warning=segment_stall"]` for
+  segment-stall plays; etc.
+- `get_play_summary(play_id)` — facts row for one play.
+- `get_control_events(player_id, play_id?, from?, to?)` — operator /
+  proxy / harness mutations (fault toggles, traffic shape changes,
+  pattern step advances). **Crucial for forensics** — was a fault
+  injected at the time the player broke?
+
+**Tier 2 — context tools.** Ground your reasoning in project
+knowledge:
+- `list_findings(grep?)` / `read_finding(slug)` — past
+  investigations. **Always check before reasoning from scratch.** The
+  symptom you're looking at may already be in the library.
+- `list_standards()` / `read_standard(name)` — domain docs (HLS
+  taxonomy, ABR decision model, AVPlayer quirks, codec strings,
+  fault-injection wire contract, characterization principles, harness
+  CLI, startup/abort tests).
+- `list_skills()` / `read_skill(name)` — analysis playbooks
+  (`triage`, `investigate`, `forensics`, `finding`, `fault`, `shape`,
+  `harness`). Skills describe procedures step-by-step; follow the
+  *intent* but use this chat's typed tools in place of the harness
+  CLI commands the skills reference (those are for Claude Code).
+- `read_conventions()` — project-wide rules. Already partly inlined
+  in this prompt but the canonical text lives there.
+
+**Tier 3 — raw SQL.** Escape hatch:
+- `query(sql)` — runs as a sandboxed read-only ClickHouse user (10s
+  / 10M rows scanned / 10k rows returned). Available tables:
+  `infinite_streaming.{session_events, network_requests,
+  control_events, characterization_runs, llm_calls}`. Errors come
+  back to you verbatim — self-correct from them.
+
+# Citations
+
+For every non-trivial claim, call `cite()` to emit a clickable card
+the dashboard renders. Reference the citation's `span_id` in your
+prose so the UI correlates the card with the right span.
+
+Kinds and required fields:
+- `play` — `play_id`, `at` (mm:ss.ms or ISO timestamp)
+- `range` — `play_id`, `from`, `to`
+- `finding` — `slug`
+- `standard` — `name`
+- `skill` — `name`
+- `run` — `run_id`, optional `cycle`
+
+Always provide a short, human-readable `label` per citation (the
+button text).
+
+Example phrasing: "The stall at [c1] matches the progressive stall
+wedge pattern [c2]." — with `cite()` producing c1=play and c2=finding.
+
+# Modes (you'll be told which by the scope preamble)
+
+- **play** — drilling into one play. Get the facts row first
+  (`get_play_summary`), then the timeline of control events if
+  forensics is needed. Cite events with `play` kind + timestamp.
+- **range** — brushed window on one play. Focus on events inside
+  the window; mention surrounding context briefly. Cite ranges.
+- **fleet** — broad question across the picker. Use `find_plays`
+  with label filters; return clickable `play` citations for each
+  candidate so the operator can drill in.
+- **characterization** — `read_characterization` for a specific run;
+  compare cycles when asked.
+
+# Conventions (project-wide; abridged from .claude/skills/CONVENTIONS.md)
+
+- **Tag every causal claim** `confirmed` / `refuted` / `needs-test`.
+  Don't guess. If the data doesn't support a confident answer, say
+  so in one line and stop.
+- **Local time for display, UTC for storage.** When you cite a
+  timestamp in prose, show it in the operator's local time if
+  given; the underlying citation card encodes UTC.
+- **If the rollup is clean, say so in one line and stop.** Don't
+  manufacture findings to look thorough.
+- **Check findings before speculating.** A 2-line read of a
+  matching finding is worth a 5-line guess.
+- **Never propose mutations.** This chat is read-only. Live-session
+  control happens through Claude Code; not through here.
+
+# Response structure
+
+- **One-shot Analyze** mode: 3-6 paragraphs. Observation → Mechanism
+  → Evidence. End with one-line "what to do about it" (or
+  "needs-test: try X to confirm").
+- **Discuss** mode: conversational. Short answers; longer when the
+  question needs the depth.
+- **Compare**: Similarities / Differences / Hypotheses sections.
+- **Fleet scan**: list of `play` citations with one-line
+  characterization per row.
+
+# Common pitfalls
+
+- iOS / iPadOS / tvOS emit **uppercase UUIDs**; CH compares
+  case-sensitively. The typed tools `lowerUTF8()` for you;
+  raw `query()` calls don't — use `lowerUTF8(player_id) = lowerUTF8(...)`
+  if you're matching by ID in SQL.
+- `labels[]` entries have the shape `severity=event`
+  (e.g. `critical=frozen`, `warning=segment_stall`,
+  `error=stall_recovery_timeout`). The comma and equals sign are
+  forbidden inside label *values*.
+- A 10-minute window of `session_events` for one player is ~600
+  rows; for the fleet on a busy day it can be 100K+. Always scope
+  by player_id or by a tight `from`/`to`.


### PR DESCRIPTION
## Summary

Phase 1 (backend foundations + tools) + Phase 2 (system prompt) of the #497 epic. Ships a working `/api/v2/chat` SSE endpoint that drives an LLM through a tool-use loop against the analytics ClickHouse and the project's `.claude/` knowledge layer.

**Stacked on #498** (refactor extracts `internal/plays` — its Tier 1 tools import directly from that package).

## Architecture (per the design conversation on #497)

- **OpenAI-compatible client.** Three profile templates ship embedded: Anthropic Claude (OAI-compat endpoint), HuggingFace Inference Providers, local Ollama. Operators can override via `FORWARDER_LLM_PROFILES_PATH`.
- **BYO key model.** Stateless proxy — each request carries the user's `{base_url, api_key, model}` (sourced from browser localStorage). Server never stores keys. Ledger records `sha256(key)` so per-key spend is visible without persistence.
- **Single global daily USD cap** (default $5, `FORWARDER_LLM_BUDGET_USD`). Pre-flight refusal when over.
- **Default-on**; disable via `FORWARDER_LLM_DISABLED=1`.

## Tool surface (tiered)

| Tier | Tools | Notes |
|---|---|---|
| 1 (typed domain) | `find_plays`, `get_play_summary`, `get_control_events` | Thin adapters over `internal/plays` (from #498) — same code path as v2 HTTP handlers |
| 2 (context) | `read_finding`/`list_findings`, `read_standard`/`list_standards`, `read_skill`/`list_skills`, `read_conventions` | Reads `.claude/` directly via `FORWARDER_CLAUDE_DIR` mount |
| 3 (raw SQL) | `query()` | Runs as the sandboxed `llm_reader` CH user (10s/10M-rows/10k-returned caps, server-enforced) |
| Special | `cite()` | SSE side-channel emits citation cards the Vue layer (Phase 3) renders as deep-linkable buttons |

## ClickHouse migrations

- `02-llm-reader.sql` — restricted user + settings profile + GRANTs on the analytics database. Hard caps via `readonly_settings=1` so the LLM cannot relax them.
- `03-llm-calls.sql` — ledger schema with `key_hash`, `profile`, `model`, `scope`, `tokens`, `cost_usd`, `status`, `prompt_version`. 90-day TTL.

## SSE event types

`text_delta`, `tool_call`, `tool_result`, `citation`, `usage`, `done`, `error`. Conversation history is dashboard-owned; the forwarder is stateless.

## Out of scope (Phase 3 follow-ups)

- Vue 3 chat panel + citation primitives
- Per-page mount on plays picker, play viewer, characterization
- `/ask` fleet page
- Save-as-finding UI flow (write path)
- `triage_plays` / `compare_plays` / `find_anomalies` tools (need new `internal/plays` functions)
- Streaming tools (timeline, characterization)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Smoke test: with FORWARDER env vars set + ClickHouse running, hit `curl /api/v2/chat/profiles` → returns embedded catalog
- [ ] Smoke test: `curl /api/v2/chat/budget` → returns budget JSON
- [ ] Smoke test: `curl POST /api/v2/chat` with a single message + dummy api_key + Anthropic profile → forwards to upstream, streams events back (or returns clean error if no real key)
- [ ] Mount `.claude/` into the container at FORWARDER_CLAUDE_DIR, hit `read_finding` via chat → returns markdown

## Closes (partially)

Closes Phase 1 + Phase 2 of #497. Phase 3 (Vue UI) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)