### PR TITLE
fix(proxy): unwrap *tls.Conn so RTT sampler sees the socket (#526)

### DIFF
--- a/go-proxy/cmd/server/rtt.go
+++ b/go-proxy/cmd/server/rtt.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net"
 	"sync"
@@ -26,10 +27,19 @@ type tcpInfoSnapshot struct {
 type tcpConnCtxKey struct{}
 
 // withTCPConnContext is the http.Server.ConnContext callback. Down-
-// casts c to *net.TCPConn (true for the stdlib HTTP listener) and
-// stamps it on the per-connection context so handleProxy can pull it
-// off later via tcpConnFromContext.
+// casts c to *net.TCPConn and stamps it on the per-connection context
+// so handleProxy can pull it off later via tcpConnFromContext.
+//
+// Listeners run under ListenAndServeTLS (main.go), so the conn handed
+// in here is *tls.Conn — unwrap it via NetConn() first to reach the
+// underlying *net.TCPConn the TCP_INFO sampler needs. Without this
+// unwrap the downcast silently fails and client_rtt_* is never
+// stamped on the session (regression dating to the TLS-on-go-proxy
+// flip in dcb42c1 / #441).
 func withTCPConnContext(ctx context.Context, c net.Conn) context.Context {
+	if tlsConn, ok := c.(*tls.Conn); ok {
+		c = tlsConn.NetConn()
+	}
 	if tc, ok := c.(*net.TCPConn); ok {
 		return context.WithValue(ctx, tcpConnCtxKey{}, tc)
 	}


### PR DESCRIPTION
## Summary

- Two-line fix: unwrap `*tls.Conn` via `NetConn()` before the existing `*net.TCPConn` downcast in `withTCPConnContext`.
- Restores 5 of 6 series on the dashboard RTT chart that have been silently dark since the v3 TLS flip in `dcb42c1` / #441.
- Full root-cause + history + acceptance criteria in #526.

## Test plan

- [ ] Deploy to test-dev: `make test-deploy-dev` (or whichever target rebuilds go-proxy on the test-dev box).
- [ ] Force-quit and relaunch the iPhone app, start a play (so it hits the per-session HTTPS port, not a cached state). Per [[feedback_iphone_wedge_after_proxy_restart]].
- [ ] Hit testing-session.html for the new `player_id`; confirm the RTT chart now shows the `RTT (ms)`, `RTT min (ms)`, `RTT max (ms)`, `RTO (ms)` series, not just `Path ping (ms)`.
- [ ] `harness --insecure query events <play_id> --limit 5 | jq '.items[0].server_metrics | {rtt_ms, path_ping_rtt_ms}'` shows both populated.
- [ ] Tail proxy logs for `V2_SSE_DBG hasConn=true` on the active session (the existing debug line at `v2_adapter.go:636`).

## Follow-up

A `tcp_rtt_observability_test.go` under `tests/server_behavior/` (sibling to the rate calibration test from #480) would catch this class of silent regression next time a listener flag flips. Noted in #526 — worth filing as a sub-issue of the #518 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)