### PR TITLE
v2.0.0 (6/6): TLS toggle + HTTP mirror + OOBE + v3 parity + docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,22 @@ GHCR_ORG=ghcr.io/your-org
 # Remote deployment testing (make test-deploy-all)
 TEST_SSH=user@test-host
 TEST_MEDIA_DIR=/home/user/media
+
+# --- TLS (see docs/TLS.md) ---
+# Dashboard + shaper ports serve HTTPS by default. Set off (or 0/false/no) for
+# plain HTTP — no cert, but loses HTTP/2 (heavy dashboards hit Chrome's SSE cap).
+INFINITE_STREAM_TLS=on
+# SAN list for the auto-generated self-signed cert. List EVERY hostname/IP
+# clients will reach this box by — browsers match on SAN, not CN. Ignored when
+# you mount your own mkcert / Let's Encrypt cert into the certs dir.
+INFINITE_STREAM_TLS_SAN=DNS:localhost,IP:127.0.0.1
+
+# --- What the server publishes to the "Pair a TV" / rendezvous flow ---
+# MUST use a hostname that is in the cert SAN above (or the LE cert's domain),
+# or TLS clients hit a name-mismatch warning. Optional label overrides the
+# hostname shown in the picker.
+INFINITE_STREAM_ANNOUNCE_URL=https://your-host.local:21000
+INFINITE_STREAM_ANNOUNCE_LABEL=
+# Announce URL for the HTTP-only mirror (make test-deploy-dev-http, port 27000).
+# If unset, the target derives http://<TEST_SSH host>:27000.
+INFINITE_STREAM_ANNOUNCE_URL_HTTP=http://your-host.local:27000

--- a/Makefile
+++ b/Makefile
@@ -465,9 +465,41 @@ test-deploy-dev:
 	else \
 		echo "dashboard-v3 not present, skipping Vue build"; \
 	fi
-	ssh -n $(TEST_SSH) 'printf "CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=%s\nINFINITE_STREAM_ANNOUNCE_LABEL=%s\n" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(INFINITE_STREAM_ANNOUNCE_URL)" "$(INFINITE_STREAM_ANNOUNCE_LABEL)" > ~/test-dev/.env'
+	ssh -n $(TEST_SSH) 'printf "CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=%s\nINFINITE_STREAM_ANNOUNCE_LABEL=%s\nINFINITE_STREAM_TLS=%s\nINFINITE_STREAM_TLS_SAN=%s\n" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(INFINITE_STREAM_ANNOUNCE_URL)" "$(INFINITE_STREAM_ANNOUNCE_LABEL)" "$(INFINITE_STREAM_TLS)" "$(INFINITE_STREAM_TLS_SAN)" > ~/test-dev/.env'
 	scp tests/deploy/override-dev.yml $(TEST_SSH):~/test-dev/docker-compose.override.yml
-	ssh $(TEST_SSH) 'cd ~/test-dev && docker compose build && docker compose up -d'
+	ssh $(TEST_SSH) 'cd ~/test-dev && VERSION=$$(cat VERSION) docker compose build && docker compose up -d'
+
+# HTTP-only mirror of test-dev on the 27xxx port range. Same code/working tree,
+# but INFINITE_STREAM_TLS=off (plain HTTP, no cert — handy for the iOS/tvOS
+# LocalHTTPProxy path and any client that can't trust a dev cert). Shares the
+# encoded content library from $(TEST_MEDIA_DIR) via SHARED_CONTENT_DIR (see
+# override-dev-http.yml) while keeping its own state under TEST_HTTP_MEDIA_DIR.
+# Publishes an explicit "http-only" label so it's unmistakable in discovery.
+TEST_HTTP_MEDIA_DIR ?= /home/$(shell echo $(TEST_SSH) | cut -d@ -f1)/test-dev-http-media
+# Announce/base URL for the HTTP mirror. Set INFINITE_STREAM_ANNOUNCE_URL_HTTP in
+# .env to control it explicitly; otherwise derive it from the SSH host.
+INFINITE_STREAM_ANNOUNCE_URL_HTTP ?= http://$(TEST_HOST):27000
+test-deploy-dev-http:
+	@echo "=== Dev (HTTP-only): local working tree (port 27000) ==="
+	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev-http'
+	@echo "Syncing local working tree (excluding .git and .gitignore matches)..."
+	rsync -az --delete \
+		--filter=':- .gitignore' \
+		--exclude='.git/' \
+		--exclude='.env' \
+		--exclude='certs/' \
+		./ $(TEST_SSH):~/test-dev-http/
+	@if [ -f content/dashboard-v3/package.json ]; then \
+		echo "Building & pushing dashboard-v3 (Vue)..."; \
+		(cd content/dashboard-v3 && npm run --silent build) && \
+		ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev-http/content/dashboard/v3' && \
+		rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev-http/content/dashboard/v3/; \
+	else \
+		echo "dashboard-v3 not present, skipping Vue build"; \
+	fi
+	ssh -n $(TEST_SSH) 'printf "COMPOSE_PROJECT_NAME=test-dev-http\nCONTENT_DIR=%s\nSHARED_CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=%s\nINFINITE_STREAM_ANNOUNCE_LABEL=test-dev-http-only\nINFINITE_STREAM_BASE_URL=%s\nINFINITE_STREAM_TLS=off\n" "$(TEST_HTTP_MEDIA_DIR)" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(INFINITE_STREAM_ANNOUNCE_URL_HTTP)" "$(INFINITE_STREAM_ANNOUNCE_URL_HTTP)" > ~/test-dev-http/.env'
+	scp tests/deploy/override-dev-http.yml $(TEST_SSH):~/test-dev-http/docker-compose.override.yml
+	ssh $(TEST_SSH) 'cd ~/test-dev-http && VERSION=$$(cat VERSION) docker compose build && docker compose up -d'
 
 # Iterate on Grafana provisioning (dashboards / datasources) without
 # touching go-server. Sessions keep flowing live; Grafana auto-reloads
@@ -600,10 +632,23 @@ test-deploy-oobe:
 		--exclude='.git/' \
 		--exclude='.env' \
 		./ $(TEST_SSH):~/test-oobe/
-	ssh -n $(TEST_SSH) 'printf "COMPOSE_PROJECT_NAME=test-oobe\nCONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=http://%s:26000\nINFINITE_STREAM_BASE_URL=http://%s:26000\n" \
+	@# The dashboard-v3 Vite build output (content/dashboard/v3/) is gitignored,
+	@# so the --filter ':- .gitignore' rule above hides it from rsync and the
+	@# volume mount would then shadow the image's baked copy with an empty dir
+	@# (dashboard 404). Build + push it as a separate rsync, same as
+	@# test-deploy-dev.
+	@if [ -f content/dashboard-v3/package.json ]; then \
+		echo "Building & pushing dashboard-v3 (Vue)..."; \
+		(cd content/dashboard-v3 && npm run --silent build) && \
+		ssh -n $(TEST_SSH) 'mkdir -p ~/test-oobe/content/dashboard/v3' && \
+		rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-oobe/content/dashboard/v3/; \
+	else \
+		echo "dashboard-v3 not present, skipping Vue build"; \
+	fi
+	ssh -n $(TEST_SSH) 'printf "COMPOSE_PROJECT_NAME=test-oobe\nCONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=https://%s:26000\nINFINITE_STREAM_BASE_URL=https://%s:26000\n" \
 		"$(TEST_OOBE_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(TEST_HOST)" "$(TEST_HOST)" > ~/test-oobe/.env'
 	scp tests/deploy/override-oobe.yml $(TEST_SSH):~/test-oobe/docker-compose.override.yml
-	ssh $(TEST_SSH) 'cd ~/test-oobe && docker compose -p test-oobe build && docker compose -p test-oobe up -d'
+	ssh $(TEST_SSH) 'cd ~/test-oobe && VERSION=$$(cat VERSION) docker compose -p test-oobe build && docker compose -p test-oobe up -d'
 
 test-clean-oobe:
 	@case "$(TEST_OOBE_MEDIA_DIR)" in \
@@ -621,9 +666,9 @@ test-clean-oobe:
 test-deploy-compose:
 	@echo "=== Option 1: Docker Compose from source (port 22000) ==="
 	ssh $(TEST_SSH) 'if [ -d ~/test-compose/.git ]; then cd ~/test-compose && git checkout -- . && git pull; else git clone $(REPO_URL) ~/test-compose; fi'
-	ssh -n $(TEST_SSH) 'printf "CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=http://%s:22000\n" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(TEST_HOST)" > ~/test-compose/.env'
+	ssh -n $(TEST_SSH) 'printf "CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=https://%s:22000\n" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(TEST_HOST)" > ~/test-compose/.env'
 	scp tests/deploy/override-compose.yml $(TEST_SSH):~/test-compose/docker-compose.override.yml
-	ssh $(TEST_SSH) 'cd ~/test-compose && docker compose build && docker compose up -d'
+	ssh $(TEST_SSH) 'cd ~/test-compose && VERSION=$$(cat VERSION) docker compose build && docker compose up -d'
 
 # `test-deploy-run` (the bare `docker run` of a single container)
 # was removed in #394 — the install method it tested can't support
@@ -794,3 +839,17 @@ characterize-androidtv:
 
 characterize-web:
 	./tests/characterization/overnight.sh web
+
+# Server control-surface checks (rate/delay/loss/pattern/fault/transfer/
+# socket/scope/content). Runs against test-dev and posts results to the
+# Automated Testing page as platform=server (the server_* tiles).
+# Override the target with THROUGHPUT_HOST / THROUGHPUT_API_PORT.
+characterize-server:
+	cd tests/server_behavior && THROUGHPUT_HOST=$(TEST_HOST) THROUGHPUT_API_PORT=21000 \
+		go test -run 'TestServer' -timeout 40m -v ./...
+
+# One-shot Automated Testing run: server checks first, then the iPad
+# simulator player characterization — populates the whole Automated Testing
+# page in one command. (Other platforms remain available individually via
+# characterize-{iphone,appletv,androidtv,web}.)
+automated-testing: characterize-server characterize-ipad-sim

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Use live-feed testing to answer "does it work in the wild." Use this to answer "
 
 - **Docker** (and Docker Compose).
 - A **media directory** on the host (`CONTENT_DIR`) for source files and encoded output. It will be mounted into the container as `/media`.
-- **TLS certificates** in `$CONTENT_DIR/certs/`. Self-signed certs are auto-generated on first startup if none exist. To provide your own, drop `localhost.pem` and `localhost-key.pem` into `$CONTENT_DIR/certs/` before starting.
+- **TLS** is on by default (HTTPS + HTTP/2); set `INFINITE_STREAM_TLS=off` for plain HTTP. Certs live in `$CONTENT_DIR/certs/` — a self-signed pair is auto-generated on first start if none exist (its SAN comes from `INFINITE_STREAM_TLS_SAN`). To provide your own, drop `localhost.pem` and `localhost-key.pem` there before starting. See [`docs/TLS.md`](docs/TLS.md) for the HTTP-vs-HTTPS choice and cert options.
 
 ### Start it
 
@@ -105,7 +105,7 @@ cp .env.example .env       # edit CONTENT_DIR
 docker compose up -d       # first run builds the image
 ```
 
-Open **http://localhost:30000/** in a browser. That's the dashboard — everything else happens there.
+Open **https://localhost:30000/** in a browser. That's the dashboard — everything else happens there.
 
 ### First-run setup (out-of-box experience)
 
@@ -173,6 +173,8 @@ That walkthrough exercises the majority of the system. The sections below descri
 - **Go-Monitor** — active workers, request counts, last-request time, idle timeout, tick timings.
 - **Upload Content** — web upload + encoding job tracking.
 - **Source Library** — list of `$CONTENT_DIR/originals/`. Click to kick re-encodes.
+- **Automated Testing** — a read-only viewer over **archived** automated-test runs: server control-surface checks (the `server_*` calibration suite) and player ABR characterization sweeps, grouped by run with per-step drill-down detail. It doesn't run anything itself — the runs execute on the dev host (`make automated-testing` → server checks then iPad-sim players; run commands and per-test detail in [`tests/characterization/README.md`](tests/characterization/README.md) and [`.claude/standards/server-behavior.md`](.claude/standards/server-behavior.md)) and post their results here.
+- **Ask (AI chat)** — a `/ask` fleet page plus an in-page chat panel (Testing / Session Viewer) that answers questions about the rig in prose, scoped to the `player_id` / play you're viewing. See [AI chat and Claude Code skills](#ai-chat-and-claude-code-skills).
 
 Selected content and URL persist across pages in `localStorage` (`ismSelected*`).
 
@@ -185,7 +187,7 @@ Selected content and URL persist across pages in `localStorage` (`ismSelected*`)
 Open directly if you don't want to come from Mosaic:
 
 ```
-http://localhost:30000/dashboard/testing-session.html?player_id=<uuid>&url=<encoded-stream-url>
+https://localhost:30000/dashboard/testing-session.html?player_id=<uuid>&url=<encoded-stream-url>
 ```
 
 The `player_id` is required. go-proxy uses it to allocate a session-specific port (`30181..30881`) so that failure injection and shaping stay scoped to *your* session.
@@ -352,6 +354,15 @@ The two pages downstream of this stack — **Sessions view** (the picker) and **
 
 ---
 
+## AI chat and Claude Code skills
+
+Two ways to drive and interrogate the rig in natural language, both new in v2:
+
+- **In-dashboard AI chat** (#497) — a chat panel mounts on the Testing and Session-Viewer pages (plus a standalone `/ask` fleet page), scoped to the `player_id` / play / brush window you're viewing, so you can ask "why did this session stall at 0:42?" instead of hand-writing ClickHouse queries. The forwarder backend is provider-agnostic: Anthropic-native (with prompt caching) or any OpenAI-compatible endpoint — hosted (OpenAI / litellm / HF) or local (mlx) — with live model discovery and per-user base-URL / per-profile API-key overrides. It's opt-in: with no provider configured the panel is simply inert.
+- **Claude Code skills** under [`.claude/skills/`](.claude/skills/) — `triage`, `investigate`, `forensics`, `fault`, `shape`, and `finding` let an operator drive the rig and run forensic analyses through prose prompts. They're built **on top of the [`harness` CLI](tools/harness-cli/README.md)**: each skill translates the prompt into `harness` commands (`harness fault add`, `harness shape …`, `harness query …`), so the snapshot-before-mutate and `harness undo` discipline comes from the CLI itself rather than the prompt. Backed by the playback-knowledge references in [`.claude/standards/`](.claude/standards/) and a capture-finding library in [`.claude/findings/`](.claude/findings/). Walkthrough: [`.claude/skills/USAGE_WALKTHROUGH.md`](.claude/skills/USAGE_WALKTHROUGH.md).
+
+---
+
 ## Sessions view (the picker)
 
 ![Sessions view](docs/screenshots/sessions.png)
@@ -379,7 +390,7 @@ When something stands out — a row with a 🚨 chip, a stack of ⛔ errors, a s
 
 ![Session Viewer](docs/screenshots/session-viewer.png)
 
-The Session Viewer (`dashboard/session-viewer.html?session=<sid>&play_id=<pid>`) replays one archived play through the same chart stack the live Testing Session page uses. Same widgets, frozen data, with two viewer-only additions across the top.
+The Session Viewer (`dashboard/session-viewer.html?session=<sid>&play_id=<pid>`) replays one archived play through the same chart stack the live Testing Session page uses. Same widgets, frozen data, with viewer-only additions: a scrub bar and event filters across the top, plus **Focus Window** and **Play Log** folds (below).
 
 ### Scrub bar (top)
 
@@ -404,6 +415,13 @@ Below the brush + filters: bandwidth chart (with buffer depth and FPS overlays),
 - **⭐ star and 📥 bundle download** in the banner — same controls as the picker row, applied to the play in view.
 - **🚨 last-event marker** if the play included a `user_marked` event — vertical line on every chart at the exact moment of the 911 press.
 
+### Focus Window and Play Log folds
+
+Two folds backed by the unified events / network / control streams (shared with the live Testing Session via the same display component):
+
+- **Focus Window** (open by default) — a synchronised brush over the play with a severity-filter accordion derived from the `labels[]` across all three streams, so you can narrow to "just the critical window" and have every chart follow. The `start_time` / `end_time` URL params scope it before any SSE backfill lands; a **Show context** toggle widens the window by ±5 min to show what surrounded the incident.
+- **Play Log** — a time-multiplexed scroll interleaving all three sources (event / network / control) in one chronological list, with source-toggle checkboxes, severity tint, label chips, and a Flags column mirroring the Network Log's glyphs for network rows. Uniform columns: time / source / player_id / play_id / attempt_id / name / info.
+
 ---
 
 ## Third-party players
@@ -415,7 +433,7 @@ The Testing Session flow isn't limited to the built-in browser players. Any HTTP
 Inside the dashboard, right-click any tile in **Mosaic (Grid)** → **Open in Testing Window**. That builds the session URL:
 
 ```
-http://<host>:30000/dashboard/testing-session.html?url=<stream-url>&player_id=<uuid>&nav=1
+https://<host>:30000/dashboard/testing-session.html?url=<stream-url>&player_id=<uuid>&nav=1
 ```
 
 For 3rd-party integrations you want the `player_id` and `url` values — those are the only two pieces of state a session needs. Paste the stream URL into your player and use the `player_id` on everything described below.
@@ -431,10 +449,10 @@ A native app integrates in four steps, all plain HTTP:
 3. **Build the stream URL and play it.** Append `?player_id=<id>` to the manifest path:
 
    ```
-   http://<host>:30081/go-live/<content>/master.m3u8?player_id=<id>       # HLS LL
-   http://<host>:30081/go-live/<content>/master_2s.m3u8?player_id=<id>    # HLS 2s
-   http://<host>:30081/go-live/<content>/master_6s.m3u8?player_id=<id>    # HLS 6s
-   http://<host>:30081/go-live/<content>/manifest.mpd?player_id=<id>      # LL-DASH
+   https://<host>:30081/go-live/<content>/master.m3u8?player_id=<id>       # HLS LL
+   https://<host>:30081/go-live/<content>/master_2s.m3u8?player_id=<id>    # HLS 2s
+   https://<host>:30081/go-live/<content>/master_6s.m3u8?player_id=<id>    # HLS 6s
+   https://<host>:30081/go-live/<content>/manifest.mpd?player_id=<id>      # LL-DASH
    ```
 
    The proxy allocates a dedicated session port on first request and responds with `302` to the allocated port (e.g. `30081` → `30281`). **Follow the redirect** — all subsequent segment and playlist requests must stay on that port so faults and shaping apply. Every HLS.js/Shaka/AVPlayer/ExoPlayer/Roku player handles 302 redirects natively; this is zero work for the client.
@@ -525,14 +543,14 @@ To encode outside the dashboard (offline, in CI, or on a build box):
 ### Primary endpoints
 
 **HLS:**
-- `http://localhost:30000/go-live/{content}/master.m3u8` (LL)
-- `http://localhost:30000/go-live/{content}/master_2s.m3u8`
-- `http://localhost:30000/go-live/{content}/master_6s.m3u8`
+- `https://localhost:30000/go-live/{content}/master.m3u8` (LL)
+- `https://localhost:30000/go-live/{content}/master_2s.m3u8`
+- `https://localhost:30000/go-live/{content}/master_6s.m3u8`
 
 **DASH:**
-- `http://localhost:30000/go-live/{content}/manifest.mpd` (LL)
-- `http://localhost:30000/go-live/{content}/manifest_2s.mpd`
-- `http://localhost:30000/go-live/{content}/manifest_6s.mpd`
+- `https://localhost:30000/go-live/{content}/manifest.mpd` (LL)
+- `https://localhost:30000/go-live/{content}/manifest_2s.mpd`
+- `https://localhost:30000/go-live/{content}/manifest_6s.mpd`
 
 Full API (`/api/content`, `/api/jobs`, `/api/sessions/*`, `/api/nftables/*`, etc.) is in [`docs/API.md`](docs/API.md).
 
@@ -715,7 +733,15 @@ That's it — no third-party services beyond a Cloudflare account.
 
 ### HTTP, HTTPS, and iOS App Transport Security
 
-The server defaults to plain HTTP on its dashboard / API / playback ports. That's fine for **LAN use** and **HTTPS-fronted public deployments**, but **plain HTTP to a public hostname** trips the platform-specific cleartext-traffic rules baked into modern OSes:
+The dashboard, API, and per-session shaper ports default to **HTTPS + HTTP/2**, controlled by `INFINITE_STREAM_TLS` (`on` by default; set `off` / `0` / `false` / `no` for plain HTTP). HTTPS is the default because HTTP/2 multiplexes the dashboard's many SSE streams over one connection, dodging Chrome's 6-connections-per-origin cap. Three modes, picked by how clients reach the box:
+
+- **HTTPS with a publicly-trusted cert** (Let's Encrypt for a domain you own) — green padlock, nothing to install on clients; the announced URL must match the cert's hostname.
+- **HTTPS with a self-signed / mkcert cert** — covers any name you put in the SAN (including `.local`), but the cert (self-signed) or CA (mkcert) must be trusted on each client.
+- **Plain HTTP** (`INFINITE_STREAM_TLS=off`) — no cert, but loses HTTP/2 (heavy dashboards hit the SSE cap), and **plain HTTP to a public hostname** trips the platform cleartext-traffic rules below.
+
+Full reference — cert modes, the Cloudflare/Let's-Encrypt DNS-01 runbook, mkcert, the self-signed SAN var (`INFINITE_STREAM_TLS_SAN`), and installing a CA on Apple clients — is in [`docs/TLS.md`](docs/TLS.md).
+
+When run as plain HTTP, the cleartext-traffic rules baked into modern OSes apply:
 
 | Client | Cleartext to LAN (`localhost`, `*.local`, RFC1918) | Cleartext to public hostname |
 |---|---|---|
@@ -726,7 +752,7 @@ The server defaults to plain HTTP on its dashboard / API / playback ports. That'
 
 The iOS/tvOS Info.plist files in this repo include an explicit `NSExceptionDomains` entry for `infinitestreaming.jeoliver.com` (the upstream maintainer's public domain). **If you fork and ship apps that talk to a different public-HTTP hostname** (your own server, a Tailscale MagicDNS name like `*.ts.net`, a Tailscale CGNAT IP in `100.64.0.0/10`, etc.) you must add it to both Info.plists or those clients will silently fail to load anything.
 
-The cleaner long-term answer is to terminate TLS at the server so all clients use HTTPS and no per-domain ATS / cleartext exceptions are needed. The k3d manifests already mount a `certs-vol` for this; flipping the nginx template to `listen … ssl` and pointing it at a Let's Encrypt cert (or whichever cert lives in `K3S_CERTS_DIR`) gets you there.
+The cleaner answer is to keep TLS on (the default) so all clients use HTTPS and no per-domain ATS / cleartext exceptions are needed — terminate at the server with a cert whose hostname matches what clients use (see [`docs/TLS.md`](docs/TLS.md)). For Docker Compose, drop your cert in `$CONTENT_DIR/certs/`; for k3d, the manifests mount a `certs-vol` from `K3S_CERTS_DIR`.
 
 ---
 
@@ -757,7 +783,7 @@ echo "CONTENT_DIR=/path/to/your/media" > .env
 docker compose up -d
 ```
 
-Open `http://localhost:30000/`. The dashboard's Sessions / Session Viewer / Grafana features all work in this mode (analytics tier comes up alongside the main image — see [Analytics tier](#analytics-tier)).
+Open `https://localhost:30000/`. The dashboard's Sessions / Session Viewer / Grafana features all work in this mode (analytics tier comes up alongside the main image — see [Analytics tier](#analytics-tier)).
 
 ### k3d, release tagging, GHCR publishing
 
@@ -801,6 +827,8 @@ Captured from the live dashboard; files live in [`docs/screenshots/`](docs/scree
 - [`analytics/README.md`](analytics/README.md) — analytics sidecar (ClickHouse + Grafana + replay mode)
 - [`tests/server_behavior/`](tests/server_behavior/) + [`.claude/standards/server-behavior.md`](.claude/standards/server-behavior.md) — Go server-behavior tests + calibration baselines
 - [`tests/characterization/README.md`](tests/characterization/README.md) — Go player ABR characterization framework
+- [`tools/harness-cli/README.md`](tools/harness-cli/README.md) — the `harness` CLI (full v2 API surface, snapshot/undo discipline)
+- [`.claude/skills/USAGE_WALKTHROUGH.md`](.claude/skills/USAGE_WALKTHROUGH.md) — prose-driven operation via Claude Code skills
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -322,6 +322,23 @@ dependency left.
 
 ---
 
+### 14. HTTP / HTTPS toggle + cert options
+
+The dashboard, API, and shaper ports now default to **HTTPS + HTTP/2**,
+gated by `INFINITE_STREAM_TLS` (`on` by default; `off`/`0`/`false`/`no` for
+plain HTTP). HTTP/2 is what keeps the dashboard's many SSE streams under
+Chrome's 6-per-origin cap. The toggle flips both the nginx listener **and**
+the nginx→go-proxy `proxy_pass` scheme + go-proxy's own listener, so an
+HTTP-only deploy no longer 502s on `/api/v2/*`. The auto-generated
+self-signed cert takes its SAN list from `INFINITE_STREAM_TLS_SAN` (so it
+can match `.local` / LAN-IP names), and a supplied mkcert / Let's Encrypt
+cert in the certs dir is used untouched. New `make test-deploy-dev-http`
+stands up a plain-HTTP mirror that shares the content library but keeps its
+own state. Full reference — cert modes, the Cloudflare/LE DNS-01 runbook,
+mkcert, and installing a CA on Apple clients — in `docs/TLS.md`.
+
+---
+
 ## Known gaps
 
 These are carried into the next release:

--- a/content/dashboard-v3/src/components/GroupBanner.vue
+++ b/content/dashboard-v3/src/components/GroupBanner.vue
@@ -101,7 +101,7 @@ async function deleteSession() {
   if (!confirm(`Release session ${props.playerId}?`)) return;
   try {
     await repo.deletePlayer(props.playerId);
-    window.location.href = '/dashboard/v3/testing.html';
+    window.location.href = '/dashboard/testing.html';
   } catch (err: any) {
     console.error('release failed', err);
     alert(`Release failed: ${err?.message ?? err}`);

--- a/content/dashboard-v3/src/components/SessionViewerLink.vue
+++ b/content/dashboard-v3/src/components/SessionViewerLink.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 /**
- * SessionViewerLink — single-source link to /dashboard/v3/session-viewer.html
+ * SessionViewerLink — single-source link to /dashboard/session-viewer.html
  * for one time-bounded window. Used by every characterization cycle/step
  * row on the Characterization page so the operator can jump from a
  * per-cycle result straight to the replay scoped to that cycle's window.

--- a/content/dashboard-v3/src/components/ShellLayout.vue
+++ b/content/dashboard-v3/src/components/ShellLayout.vue
@@ -17,7 +17,7 @@
  * the legacy used (`ismSidebarCollapsed`) so the user's collapsed/
  * expanded preference survives the legacy/v3 transition.
  */
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue';
 
 const props = defineProps<{ activePage: string }>();
 
@@ -48,12 +48,117 @@ interface NavSection {
 const DEV_PORT = '5173';
 const DEV_BACKEND = 'https://jonathanoliver-ubuntu.local:21000';
 
+// The v3 pages are served at clean /dashboard/<page>.html in production
+// (nginx rewrites them into /content/dashboard/v3/), but the Vite dev server
+// serves them under its base, /dashboard/v3/. Map the v3 page set back to
+// /v3/ in dev so links stay on the Vite dev server (HMR); legacy/unmigrated
+// pages are served by the real backend.
+const V3_PAGES =
+  /^\/dashboard\/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|ask|hello)\.html/;
 function rewriteHrefForDev(href: string): string {
   if (typeof window === 'undefined') return href;
   if (window.location.port !== DEV_PORT) return href;
-  if (href.startsWith('/dashboard/v3/')) return href; // v3 stays local
+  if (V3_PAGES.test(href)) return href.replace('/dashboard/', '/dashboard/v3/'); // stay on the Vite dev server
   if (href.startsWith('http')) return href;            // already absolute
-  return DEV_BACKEND + href;
+  return DEV_BACKEND + href;                           // legacy pages → backend
+}
+
+// --- "Testing Playback" nav item: build a *playable* URL from the
+// currently-selected content (shared with the legacy nav via the
+// `ismSelectedUrl` localStorage key, written by Grid / play-10ft /
+// playback / segment-duration). Reuse a stable test-playback player_id
+// if one exists, else mint and persist one. Mirrors shared-nav.js. ---
+function mintPlayerId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) crypto.getRandomValues(bytes);
+  else for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function getOrCreateTestPlaybackPlayerId(): string {
+  const KEY = 'ismTestPlaybackPlayerId';
+  try {
+    const existing = localStorage.getItem(KEY);
+    if (existing) return existing;
+    const id = mintPlayerId();
+    localStorage.setItem(KEY, id);
+    return id;
+  } catch {
+    return mintPlayerId();
+  }
+}
+
+// Rewrite a content URL to the per-session shaper port and set player_id
+// (same convention as Grid.vue's buildTestingUrl).
+function buildTestingUrl(url: string, playerId: string): string {
+  let absolute: URL;
+  try {
+    absolute = new URL(url, window.location.href);
+  } catch {
+    return url;
+  }
+  const currentPort =
+    window.location.port || (window.location.protocol === 'https:' ? '443' : '80');
+  if (currentPort !== DEV_PORT && currentPort.length >= 4) {
+    absolute.hostname = window.location.hostname;
+    absolute.port = currentPort.slice(0, -3) + '081';
+    absolute.protocol = window.location.protocol;
+  }
+  absolute.searchParams.set('player_id', playerId);
+  return absolute.toString();
+}
+
+// Navigate to a testing-session built from a content URL: get-or-create a
+// stable player_id, rewrite the content URL to the shaper port + attach the
+// player_id (so it shows in BOTH places, like Grid's right-click), and go.
+function gotoTestingPlayback(contentUrl: string): void {
+  const playerId = getOrCreateTestPlaybackPlayerId();
+  const testingUrl = buildTestingUrl(contentUrl, playerId);
+  const pageUrl =
+    `/dashboard/testing-session.html?player_id=${encodeURIComponent(playerId)}` +
+    `&url=${encodeURIComponent(testingUrl)}`;
+  window.location.href = rewriteHrefForDev(pageUrl);
+}
+
+// "Testing Playback" nav item: always produce a playable URL. Use the
+// selected content (ismSelectedUrl — written on tile focus / content select)
+// if present; otherwise fall back to the first content item from the
+// catalogue. Without this the link landed on the empty ?nav=1 page with no
+// player_id (right-click does NOT set ismSelectedUrl, only left-click focus).
+async function onNavClick(item: NavItem, e: MouseEvent): Promise<void> {
+  if (item.id !== 'test-playback') return;
+  e.preventDefault();
+  let selected = '';
+  try {
+    selected = localStorage.getItem('ismSelectedUrl') || '';
+  } catch {
+    selected = '';
+  }
+  if (selected) {
+    gotoTestingPlayback(selected);
+    return;
+  }
+  // No selection — pick the first available content so the nav item still
+  // generates a working, player_id-bearing URL.
+  try {
+    const r = await fetch('/api/content');
+    const list = (await r.json()) as Array<{ name: string; has_hls?: boolean; has_dash?: boolean }>;
+    const first = Array.isArray(list) ? (list.find((c) => c.has_hls !== false) ?? list[0]) : undefined;
+    if (first?.name) {
+      const path = first.has_hls === false && first.has_dash ? 'manifest_6s.mpd' : 'master_6s.m3u8';
+      gotoTestingPlayback(`/go-live/${first.name}/${path}`);
+      return;
+    }
+  } catch {
+    /* fall through to the empty page */
+  }
+  window.location.href = rewriteHrefForDev('/dashboard/testing-session.html?nav=1');
 }
 
 // Sidebar mirrors shared/shared-nav.js. v3-native pages link to their
@@ -62,7 +167,7 @@ const sections: NavSection[] = [
   {
     title: 'MAIN',
     items: [
-      { id: 'dashboard', icon: '📊', text: 'Dashboard', href: '/dashboard/v3/dashboard.html' },
+      { id: 'dashboard', icon: '📊', text: 'Dashboard', href: '/dashboard/dashboard.html' },
     ],
   },
   {
@@ -76,13 +181,13 @@ const sections: NavSection[] = [
   {
     title: 'PLAYBACK',
     items: [
-      { id: 'grid',          icon: '🎮', text: 'Mosaic',          href: '/dashboard/v3/grid.html', warning: true },
+      { id: 'grid',          icon: '🎮', text: 'Mosaic',          href: '/dashboard/grid.html', warning: true },
       { id: 'mosaic-10ft',   icon: '📺', text: '10ft UI',         href: '/dashboard/mosaic-10ft.html', alpha: true },
       { id: 'playback',      icon: '▶️', text: 'Playback',        href: '/dashboard/playback.html' },
-      { id: 'test-playback', icon: '🧭', text: 'Testing Playback',href: '/dashboard/v3/testing-session.html?nav=1' },
-      { id: 'testing',       icon: '🧪', text: 'Testing Monitor', href: '/dashboard/v3/testing.html' },
-      { id: 'sessions',      icon: '⏪', text: 'Sessions',         href: '/dashboard/v3/sessions.html' },
-      { id: 'characterization', icon: '📈', text: 'Automated Testing', href: '/dashboard/v3/characterization.html' },
+      { id: 'test-playback', icon: '🧭', text: 'Testing Playback',href: '/dashboard/testing-session.html?nav=1' },
+      { id: 'testing',       icon: '🧪', text: 'Testing Monitor', href: '/dashboard/testing.html' },
+      { id: 'sessions',      icon: '⏪', text: 'Sessions',         href: '/dashboard/sessions.html' },
+      { id: 'characterization', icon: '📈', text: 'Automated Testing', href: '/dashboard/characterization.html' },
       { id: 'quartet',       icon: '🎬', text: 'Quartet',          href: '/dashboard/quartet.html', alpha: true },
       { id: 'segment-duration', icon: '⏱️', text: 'Live Offset',   href: '/dashboard/segment-duration-comparison.html', alpha: true },
     ],
@@ -160,6 +265,365 @@ const appClass = computed(() => ({
   'sidebar-collapsed': collapsed.value,
   'mobile-sidebar-open': mobileOpen.value,
 }));
+
+// --- Server Info modal (ported from legacy shared-nav.js showInfo) ---
+// The legacy sidebar footer carried a "Server Info" item that opened a modal
+// with the dashboard URL/host/port/protocol/version, a QR encoding the current
+// origin, and a pair-with-code widget. The v3 shell's footer only showed a
+// version tag, so the modal was missing on every migrated page. This restores
+// it with the same behavior and endpoints (/api/version, /api/rendezvous,
+// /api/announce-now, {rendezvous}/pair) and reuses the shared QR lib.
+const infoOpen = ref(false);
+const serverVersion = ref('unknown');
+const serverLabel = ref('');
+const rendezvousURL = ref('');
+const lanWarnHost = ref(''); // non-empty → dashboard URL is LAN-only; warn
+const pairCode = ref('');
+const pairMsg = ref('');
+const pairMsgColor = ref('#666');
+const pairBusy = ref(false);
+const qrCanvas = ref<HTMLCanvasElement | null>(null);
+
+const infoUrl = computed(() => (typeof window !== 'undefined' ? window.location.origin : ''));
+const infoHost = computed(() => (typeof window !== 'undefined' ? window.location.hostname : ''));
+const infoPort = computed(() => (typeof window !== 'undefined' ? window.location.port || '80' : ''));
+const infoProto = computed(() => (typeof window !== 'undefined' ? window.location.protocol : ''));
+
+let qrLibPromise: Promise<unknown> | null = null;
+function loadQrLib(): Promise<unknown> {
+  const w = window as unknown as { qrcode?: unknown };
+  if (typeof w.qrcode === 'function') return Promise.resolve(w.qrcode);
+  if (qrLibPromise) return qrLibPromise;
+  qrLibPromise = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = rewriteHrefForDev('/shared/qrcode.min.js');
+    s.onload = () => resolve((window as unknown as { qrcode?: unknown }).qrcode);
+    s.onerror = () => reject(new Error('failed to load qrcode.min.js'));
+    document.head.appendChild(s);
+  });
+  return qrLibPromise;
+}
+
+function renderQr(canvas: HTMLCanvasElement, text: string, sizePx: number) {
+  // qrcode-generator: typeNumber=0 = auto, error-correction 'M'.
+  const qrcode = (window as unknown as { qrcode: (t: number, e: string) => any }).qrcode;
+  const qr = qrcode(0, 'M');
+  qr.addData(text);
+  qr.make();
+  const moduleCount: number = qr.getModuleCount();
+  const cell = Math.floor(sizePx / moduleCount);
+  const dim = cell * moduleCount;
+  canvas.width = dim;
+  canvas.height = dim;
+  canvas.style.width = `${dim}px`;
+  canvas.style.height = `${dim}px`;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.fillStyle = '#fff';
+  ctx.fillRect(0, 0, dim, dim);
+  ctx.fillStyle = '#000';
+  for (let r = 0; r < moduleCount; r++) {
+    for (let c = 0; c < moduleCount; c++) {
+      if (qr.isDark(r, c)) ctx.fillRect(c * cell, r * cell, cell, cell);
+    }
+  }
+}
+
+// LAN-only heuristic: .local / loopback / RFC1918 / link-local hosts can't be
+// reached by a TV on another network, so code-pairing would silently fail.
+function computeLanWarn(urlString: string): string {
+  let host = '';
+  try {
+    host = new URL(urlString).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+  const lanOnly =
+    host === 'localhost' ||
+    host.endsWith('.local') ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    host === '::1' ||
+    host.startsWith('fe80:') ||
+    host.startsWith('fc') ||
+    host.startsWith('fd');
+  return lanOnly ? host : '';
+}
+
+async function openServerInfo() {
+  infoOpen.value = true;
+  pairCode.value = '';
+  pairMsg.value = '';
+  pairBusy.value = false;
+  serverLabel.value = '';
+  rendezvousURL.value = '';
+  lanWarnHost.value = '';
+  const url = infoUrl.value;
+  // Fire-and-forget re-announce so opening the panel recovers a missed boot
+  // announce. Server-side coalesces simultaneous triggers, so this is safe.
+  fetch('/api/announce-now', { method: 'POST' }).catch(() => {});
+  try {
+    const r = await fetch('/api/version');
+    serverVersion.value = r.ok
+      ? String((await r.json()).version || '').trim() || 'unknown'
+      : 'unknown';
+  } catch {
+    serverVersion.value = 'unknown';
+  }
+  // Render the QR once the canvas is in the DOM.
+  await nextTick();
+  try {
+    await loadQrLib();
+    if (qrCanvas.value) renderQr(qrCanvas.value, url, 180);
+  } catch {
+    const c = qrCanvas.value;
+    const ctx = c?.getContext('2d');
+    if (c && ctx) {
+      c.width = 180;
+      c.height = 180;
+      ctx.fillStyle = '#f5f5f5';
+      ctx.fillRect(0, 0, 180, 180);
+      ctx.fillStyle = '#999';
+      ctx.font = '12px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.fillText('QR unavailable', 90, 90);
+    }
+  }
+  // Label + pair widget come from the rendezvous config.
+  try {
+    const r = await fetch('/api/rendezvous');
+    const rz = r.ok ? await r.json() : {};
+    serverLabel.value = (rz && rz.label) || '';
+    rendezvousURL.value = (rz && rz.url) || '';
+    if (rendezvousURL.value) lanWarnHost.value = computeLanWarn(url);
+  } catch {
+    rendezvousURL.value = '';
+  }
+}
+
+function closeServerInfo() {
+  infoOpen.value = false;
+}
+
+async function submitPair() {
+  const code = (pairCode.value || '').trim().toUpperCase();
+  if (!/^[A-Z0-9]{4,12}$/.test(code)) {
+    pairMsgColor.value = '#991b1b';
+    pairMsg.value = 'Code must be 4–12 alphanumeric characters.';
+    return;
+  }
+  pairBusy.value = true;
+  pairMsgColor.value = '#666';
+  pairMsg.value = '';
+  try {
+    const endpoint = `${rendezvousURL.value.replace(/\/$/, '')}/pair?code=${encodeURIComponent(code)}`;
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ server_url: infoUrl.value }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (res.ok) {
+      pairMsgColor.value = '#065f46';
+      pairMsg.value = 'Paired. Your TV should pick this up within a couple of seconds.';
+    } else {
+      pairMsgColor.value = '#991b1b';
+      pairMsg.value = body.error || `HTTP ${res.status}`;
+    }
+  } catch (e) {
+    pairMsgColor.value = '#991b1b';
+    pairMsg.value = e instanceof Error ? e.message : 'Network error';
+  } finally {
+    pairBusy.value = false;
+  }
+}
+
+// --- Access restrictions (ported from shared-nav.js) ---
+// Hide content-management (Upload / Sources / Jobs) and the Monitor item when
+// the dashboard is reached over a non-internal (public) host. This is a soft
+// UI hide matching the legacy nav — real auth is the optional htpasswd.
+function isInternalNetworkHost(hostname: string): boolean {
+  const host = (hostname || '').toLowerCase();
+  if (!host) return false;
+  if (host === 'localhost' || host === '::1' || host.startsWith('127.')) return true;
+  if (host.endsWith('.local')) return true;
+  if (!host.includes('.')) return true; // bare single-label hostname
+  if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  if (/^192\.168\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(host)) return true;
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}$/.test(host)) return true; // Tailscale CGNAT
+  return false;
+}
+const restrictContent = computed(
+  () => typeof window !== 'undefined' && !isInternalNetworkHost(window.location.hostname),
+);
+const visibleSections = computed<NavSection[]>(() =>
+  sections
+    .filter((s) => !(restrictContent.value && s.title === 'CONTENT'))
+    .map((s) =>
+      restrictContent.value && s.title === 'LIVE STREAMING'
+        ? { ...s, items: s.items.filter((i) => i.id !== 'monitor') }
+        : s,
+    )
+    .filter((s) => s.items.length > 0),
+);
+
+// --- First-run setup experience (ported from shared-nav.js) ---
+interface SetupStatus {
+  root?: string;
+  root_mounted?: boolean;
+  root_writable?: boolean;
+  content_count?: number;
+  sources_count?: number;
+  outputs_count?: number;
+  content_empty?: boolean;
+  initialized?: boolean;
+  issues?: string[];
+  recommendations?: string[];
+}
+const SETUP_PAGES_REQUIRE_CONTENT = new Set(['playback', 'testing', 'quartet', 'grid', 'segment-duration']);
+const setup = ref<SetupStatus | null>(null);
+const setupModalOpen = ref(false);
+const setupSeedState = ref<'idle' | 'seeding' | 'seeded' | 'failed'>('idle');
+const setupRedirectMsg = ref('');
+let setupRedirectTimer: ReturnType<typeof setTimeout> | null = null;
+
+const setupHasIssues = computed(() => !!setup.value?.issues?.length);
+const setupShowContentActions = computed(
+  () =>
+    !!setup.value?.content_empty &&
+    SETUP_PAGES_REQUIRE_CONTENT.has(props.activePage) &&
+    props.activePage !== 'upload',
+);
+const setupRoot = computed(() => setup.value?.root || '/media');
+const setupDiagnostics = computed(() => {
+  const s = setup.value;
+  if (!s) return 'No diagnostics available.';
+  const lines = [
+    `Root: ${s.root ?? '(unknown)'}`,
+    `Mounted: ${s.root_mounted ? 'yes' : 'no'}`,
+    `Writable: ${s.root_writable ? 'yes' : 'no'}`,
+    `Content items: ${s.content_count ?? 0}`,
+    `Source files: ${s.sources_count ?? 0}`,
+    `Output dirs: ${s.outputs_count ?? 0}`,
+  ];
+  if (s.issues?.length) lines.push(`Issues: ${s.issues.join(', ')}`);
+  return lines.join('\n');
+});
+
+async function loadSetup() {
+  try {
+    const r = await fetch('/api/setup');
+    if (!r.ok) return;
+    setup.value = await r.json();
+    maybeAutoRedirect();
+    maybeShowSetupModal();
+  } catch {
+    /* setup check is best-effort */
+  }
+}
+async function setupSeedSample() {
+  setupSeedState.value = 'seeding';
+  try {
+    await fetch('/api/setup/seed', { method: 'POST' });
+    setupSeedState.value = 'seeded';
+  } catch {
+    setupSeedState.value = 'failed';
+  }
+}
+async function setupMarkInitialized() {
+  try {
+    await fetch('/api/setup/initialize', { method: 'POST' });
+  } catch {
+    /* ignore */
+  }
+  setupModalOpen.value = false;
+  await loadSetup();
+}
+function setupGoUpload() {
+  window.location.href = '/dashboard/upload.html';
+}
+function maybeShowSetupModal() {
+  if (!setup.value || setup.value.initialized) return;
+  if (sessionStorage.getItem('ismSetupModalShown') === '1') return;
+  sessionStorage.setItem('ismSetupModalShown', '1');
+  setupModalOpen.value = true;
+}
+function maybeAutoRedirect() {
+  if (!setup.value?.content_empty) return;
+  if (!SETUP_PAGES_REQUIRE_CONTENT.has(props.activePage) || props.activePage === 'upload') return;
+  if (sessionStorage.getItem('ismSkipUploadRedirect') === '1') return;
+  let secs = 5;
+  const tick = () => {
+    if (secs <= 0) {
+      window.location.href = '/dashboard/upload.html';
+      return;
+    }
+    setupRedirectMsg.value = `No content detected. Redirecting to Upload in ${secs}s…`;
+    secs -= 1;
+    setupRedirectTimer = setTimeout(tick, 1000);
+  };
+  tick();
+}
+function cancelSetupRedirect() {
+  if (setupRedirectTimer) {
+    clearTimeout(setupRedirectTimer);
+    setupRedirectTimer = null;
+  }
+  sessionStorage.setItem('ismSkipUploadRedirect', '1');
+  setupRedirectMsg.value = 'Auto-redirect canceled.';
+}
+
+// --- Global active-job progress badge (ported from shared-nav.js) ---
+// Polls /api/jobs and surfaces the first uploading/encoding job as a floating
+// badge on every v3 page (legacy showed it via shared-nav). The legacy
+// SharedWorker live-upload feed is omitted; 2s polling covers the core.
+interface ActiveJob {
+  job_id: string;
+  status: string;
+  progress?: number;
+  name?: string;
+}
+const activeJob = ref<ActiveJob | null>(null);
+const progressDismissed = ref(false);
+let jobsTimer: ReturnType<typeof setInterval> | null = null;
+
+async function checkActiveJobs() {
+  try {
+    const r = await fetch('/api/jobs');
+    if (!r.ok) return;
+    const data = await r.json();
+    const job = (data.jobs || []).find(
+      (j: ActiveJob) => j.status === 'uploading' || j.status === 'encoding',
+    );
+    if (!job) progressDismissed.value = false; // re-arm for the next job
+    activeJob.value = job || null;
+  } catch {
+    /* polling is best-effort */
+  }
+}
+const progressTitle = computed(() =>
+  activeJob.value?.status === 'uploading' ? 'Uploading…' : 'Encoding…',
+);
+const progressPct = computed(() => Math.round(activeJob.value?.progress ?? 0));
+function viewActiveJob() {
+  if (activeJob.value) {
+    window.location.href = `/dashboard/job-detail.html?id=${activeJob.value.job_id}`;
+  }
+}
+
+onMounted(() => {
+  loadSetup();
+  checkActiveJobs();
+  jobsTimer = setInterval(checkActiveJobs, 2000);
+});
+onBeforeUnmount(() => {
+  if (jobsTimer) clearInterval(jobsTimer);
+  if (setupRedirectTimer) clearTimeout(setupRedirectTimer);
+});
 </script>
 
 <template>
@@ -186,7 +650,7 @@ const appClass = computed(() => ({
       </div>
 
       <nav class="ism-sidebar-content">
-        <div v-for="section in sections" :key="section.title" class="nav-section">
+        <div v-for="section in visibleSections" :key="section.title" class="nav-section">
           <div class="nav-section-title">{{ section.title }}</div>
           <a
             v-for="item in section.items"
@@ -195,6 +659,7 @@ const appClass = computed(() => ({
             class="nav-item"
             :class="{ active: isActive(item.id) }"
             :id="`nav-${item.id}`"
+            @click="onNavClick(item, $event)"
           >
             <span class="nav-item-icon">{{ item.icon }}</span>
             <span class="nav-item-text">{{ item.text }}</span>
@@ -205,6 +670,10 @@ const appClass = computed(() => ({
       </nav>
 
       <div class="ism-sidebar-footer">
+        <a href="#" class="nav-item" id="nav-server-info" @click.prevent="openServerInfo">
+          <span class="nav-item-icon">ℹ️</span>
+          <span class="nav-item-text">Server Info</span>
+        </a>
         <div class="footer-meta">v3 · vue</div>
       </div>
     </aside>
@@ -224,9 +693,167 @@ const appClass = computed(() => ({
       </header>
 
       <main class="ism-content">
+        <div v-if="setupHasIssues" class="ism-setup-banner">
+          <div class="ism-setup-icon">⚠️</div>
+          <div class="ism-setup-body">
+            <div class="ism-setup-title">Setup attention needed</div>
+            <div v-for="issue in setup?.issues || []" :key="issue" class="ism-setup-issue">{{ issue }}</div>
+            <ul v-if="setup?.recommendations?.length" class="ism-setup-recs">
+              <li v-for="rec in setup?.recommendations || []" :key="rec">{{ rec }}</li>
+            </ul>
+            <div class="ism-setup-actions">
+              <button class="ism-btn-sm" type="button" @click="loadSetup">Run Diagnostics</button>
+              <button class="ism-btn-sm" type="button" @click="setupModalOpen = true">Open Setup Guide</button>
+              <button v-if="!setup?.initialized" class="ism-btn-sm" type="button" @click="setupMarkInitialized">Mark Setup Complete</button>
+              <button v-if="setupShowContentActions" class="ism-btn-sm primary" type="button" @click="setupGoUpload">Go to Upload</button>
+              <button
+                v-if="setupShowContentActions"
+                class="ism-btn-sm"
+                type="button"
+                :disabled="setupSeedState === 'seeding'"
+                @click="setupSeedSample"
+              >
+                {{ setupSeedState === 'seeded' ? 'Seeded' : setupSeedState === 'seeding' ? 'Seeding…' : setupSeedState === 'failed' ? 'Seed Failed' : 'Seed Sample Content' }}
+              </button>
+            </div>
+            <div v-if="setupRedirectMsg" class="ism-setup-redirect">
+              {{ setupRedirectMsg }}
+              <button v-if="!setupRedirectMsg.includes('canceled')" class="ism-btn-sm" type="button" @click="cancelSetupRedirect">Cancel</button>
+            </div>
+          </div>
+        </div>
         <slot />
       </main>
     </div>
+
+    <Teleport to="body">
+      <div v-if="infoOpen" class="ism-info-overlay" @click.self="closeServerInfo">
+        <div class="ism-info-panel">
+          <div class="ism-info-head">
+            <h2>{{ serverLabel ? `Server Info — ${serverLabel}` : 'Server Info' }}</h2>
+            <button class="ism-info-close" type="button" @click="closeServerInfo">&times;</button>
+          </div>
+          <div class="ism-info-body">
+            <div class="ism-info-fields">
+              <div v-if="serverLabel"><strong>Name:</strong> {{ serverLabel }}</div>
+              <div><strong>URL:</strong> <code class="ism-info-sel">{{ infoUrl }}</code></div>
+              <div><strong>Host:</strong> {{ infoHost || '(none)' }}</div>
+              <div><strong>Port:</strong> {{ infoPort }}</div>
+              <div><strong>Protocol:</strong> {{ infoProto }}</div>
+              <div><strong>Version:</strong> {{ serverVersion }}</div>
+            </div>
+            <div class="ism-info-qr">
+              <canvas ref="qrCanvas"></canvas>
+              <div class="ism-info-qr-cap">Scan from a phone or TV app<br />to pair with this server</div>
+            </div>
+          </div>
+          <p class="ism-info-note">
+            The QR encodes the URL you used to reach this dashboard. Devices that scan it must be
+            able to reach the same URL (same LAN, Tailscale, public DNS, etc.).
+          </p>
+          <hr class="ism-info-hr" />
+          <div class="ism-info-discovery">
+            <strong>Cloud discovery (no code needed)</strong><br />
+            This server is announcing itself to the pairing rendezvous (Cloudflare Worker). TVs and
+            phones whose <em>public IP matches this server's public IP</em> — i.e. on the same WAN —
+            will see this server in their app's "+ Add server" / "Pair…" screen automatically. Just
+            tap to add. Opening this panel triggers a fresh announce, so the server should be visible
+            within a few seconds.
+          </div>
+          <div class="ism-pair">
+            <h3>Pair with code</h3>
+            <p class="ism-info-note">
+              Enter the 6-character code shown on the TV here; the TV will receive
+              <em>this dashboard's URL</em> via the rendezvous and connect.
+            </p>
+            <div v-if="lanWarnHost" class="ism-pair-warn">
+              <strong>Heads up:</strong> the URL above looks LAN-only (<code>{{ lanWarnHost }}</code>).
+              Pairing will only work if the TV can resolve and reach that URL on its network. For
+              cross-network pairing (cellular, VPN, etc.) you'd need a publicly reachable URL — port
+              forward, Tailscale MagicDNS name, a tunnel, etc.
+            </div>
+            <div v-if="rendezvousURL" class="ism-pair-form">
+              <div class="ism-pair-row">
+                <input
+                  v-model="pairCode"
+                  type="text"
+                  placeholder="ABC123"
+                  maxlength="12"
+                  class="ism-pair-input"
+                  @input="pairCode = pairCode.toUpperCase()"
+                  @keyup.enter="submitPair"
+                />
+                <button class="ism-pair-btn" type="button" :disabled="pairBusy" @click="submitPair">
+                  {{ pairBusy ? 'Pairing…' : 'Pair' }}
+                </button>
+              </div>
+              <div class="ism-pair-msg" :style="{ color: pairMsgColor }">{{ pairMsg }}</div>
+            </div>
+            <div v-else class="ism-pair-unconfigured">
+              Pairing rendezvous URL not configured. Set
+              <code>INFINITE_STREAM_RENDEZVOUS_URL</code> on the server to enable. See
+              <a
+                href="https://github.com/jonathaneoliver/infinite-streaming/tree/main/cloudflare/pair-rendezvous"
+                target="_blank"
+                rel="noopener"
+                >cloudflare/pair-rendezvous/</a
+              >.
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div
+        v-if="activeJob && !progressDismissed"
+        class="ism-progress-badge"
+        :class="{ encoding: activeJob.status === 'encoding' }"
+        @click="viewActiveJob"
+      >
+        <div class="ism-progress-head">
+          <span class="ism-progress-title">{{ progressTitle }}</span>
+          <button class="ism-progress-dismiss" type="button" @click.stop="progressDismissed = true">&times;</button>
+        </div>
+        <div class="ism-progress-name">{{ activeJob.name || 'Processing…' }}</div>
+        <div class="ism-progress-track"><div class="ism-progress-fill" :style="{ width: progressPct + '%' }"></div></div>
+        <div class="ism-progress-pct">{{ progressPct }}%</div>
+      </div>
+    </Teleport>
+
+    <Teleport to="body">
+      <div v-if="setupModalOpen" class="ism-info-overlay" @click.self="setupModalOpen = false">
+        <div class="ism-info-panel">
+          <div class="ism-info-head">
+            <h2>First-Run Setup</h2>
+            <button class="ism-info-close" type="button" @click="setupModalOpen = false">&times;</button>
+          </div>
+          <ol class="ism-setup-steps">
+            <li><strong>Mount a host folder</strong> to <code>{{ setupRoot }}</code>.</li>
+            <li><strong>Upload content</strong> or seed a sample clip.</li>
+            <li><strong>Open Mosaic</strong> to preview streams.</li>
+          </ol>
+          <div class="ism-setup-snippet">
+            <div class="ism-info-note">Docker Compose example</div>
+            <pre>services:
+  infinite-streaming:
+    volumes:
+      - /path/to/InfiniteStream:{{ setupRoot }}</pre>
+          </div>
+          <div class="ism-setup-snippet">
+            <div class="ism-info-note">Diagnostics</div>
+            <pre>{{ setupDiagnostics }}</pre>
+          </div>
+          <div class="ism-setup-modal-footer">
+            <button class="ism-btn-sm" type="button" :disabled="setupSeedState === 'seeding'" @click="setupSeedSample">
+              {{ setupSeedState === 'seeded' ? 'Seeded' : setupSeedState === 'seeding' ? 'Seeding…' : 'Seed Sample Content' }}
+            </button>
+            <button class="ism-btn-sm" type="button" @click="setupGoUpload">Open Upload</button>
+            <button class="ism-btn-sm primary" type="button" @click="setupMarkInitialized">Mark Setup Complete</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -364,6 +991,178 @@ const appClass = computed(() => ({
   color: #9aa0a6;
 }
 .sidebar-collapsed .footer-meta { display: none; }
+
+/* Server Info modal (Teleported to body; scoped styles still apply via the
+   component's data attribute). */
+.ism-info-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ism-info-panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 28px;
+  max-width: 520px;
+  width: 90%;
+  max-height: 90vh;
+  overflow: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  color: #202124;
+  font-size: 14px;
+  line-height: 1.4;
+}
+.ism-info-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.ism-info-head h2 { margin: 0; font-size: 1.4em; }
+.ism-info-close {
+  background: none;
+  border: none;
+  font-size: 1.6em;
+  line-height: 1;
+  cursor: pointer;
+  color: #5f6368;
+}
+.ism-info-body { display: flex; gap: 24px; align-items: flex-start; flex-wrap: wrap; }
+.ism-info-fields { flex: 1; min-width: 200px; }
+.ism-info-fields > div { margin-bottom: 8px; }
+.ism-info-sel { user-select: all; }
+.ism-info-qr { text-align: center; }
+.ism-info-qr canvas {
+  background: #fff;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+.ism-info-qr-cap { font-size: 0.8em; color: #666; margin-top: 6px; }
+.ism-info-note { margin-top: 20px; font-size: 0.85em; color: #666; }
+.ism-info-hr { margin: 20px 0; border: none; border-top: 1px solid #eee; }
+.ism-info-discovery {
+  margin-bottom: 18px;
+  padding: 10px 12px;
+  background: #ecfdf5;
+  border-left: 3px solid #10b981;
+  border-radius: 4px;
+  font-size: 0.85em;
+  color: #065f46;
+}
+.ism-pair h3 { margin: 0 0 8px 0; font-size: 1em; }
+.ism-pair-warn {
+  margin: 0 0 12px 0;
+  padding: 8px 10px;
+  background: #fef3c7;
+  border-left: 3px solid #f59e0b;
+  border-radius: 4px;
+  font-size: 0.8em;
+  color: #78350f;
+}
+.ism-pair-row { display: flex; gap: 8px; align-items: center; }
+.ism-pair-input {
+  flex: 1;
+  padding: 8px 10px;
+  font-family: ui-monospace, monospace;
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1em;
+}
+.ism-pair-btn {
+  padding: 8px 16px;
+  background: #2563eb;
+  color: #fff;
+  border: 0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9em;
+}
+.ism-pair-btn:disabled { opacity: 0.6; cursor: default; }
+.ism-pair-msg { margin-top: 10px; font-size: 0.85em; }
+.ism-pair-unconfigured { font-size: 0.85em; color: #888; font-style: italic; }
+
+/* First-run setup banner */
+.ism-setup-banner {
+  display: flex;
+  gap: 12px;
+  margin: 0 0 16px 0;
+  padding: 14px 16px;
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-left: 3px solid #f59e0b;
+  border-radius: 8px;
+  color: #78350f;
+  font-size: 13px;
+}
+.ism-setup-icon { font-size: 18px; line-height: 1; }
+.ism-setup-body { flex: 1; min-width: 0; }
+.ism-setup-title { font-weight: 600; margin-bottom: 6px; }
+.ism-setup-issue { margin-bottom: 2px; }
+.ism-setup-recs { margin: 6px 0; padding-left: 18px; }
+.ism-setup-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.ism-setup-redirect { margin-top: 10px; font-size: 12px; display: flex; align-items: center; gap: 8px; }
+
+.ism-btn-sm {
+  padding: 5px 12px;
+  font-size: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #fff;
+  color: #374151;
+  cursor: pointer;
+}
+.ism-btn-sm:hover { background: #f3f4f6; }
+.ism-btn-sm:disabled { opacity: 0.6; cursor: default; }
+.ism-btn-sm.primary { background: #2563eb; border-color: #2563eb; color: #fff; }
+.ism-btn-sm.primary:hover { background: #1d4ed8; }
+
+/* First-run setup modal extras (reuses .ism-info-overlay / .ism-info-panel) */
+.ism-setup-steps { margin: 0 0 16px 0; padding-left: 20px; }
+.ism-setup-steps li { margin-bottom: 6px; }
+.ism-setup-snippet { margin-bottom: 14px; }
+.ism-setup-snippet pre {
+  margin: 4px 0 0 0;
+  padding: 10px 12px;
+  background: #f6f8fa;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 12px;
+  overflow: auto;
+  white-space: pre;
+}
+.ism-setup-modal-footer { display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }
+
+/* Global active-job progress badge */
+.ism-progress-badge {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 9999;
+  width: 240px;
+  padding: 12px 14px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  font-size: 13px;
+}
+.ism-progress-badge.encoding { border-left: 3px solid #f59e0b; }
+.ism-progress-head { display: flex; justify-content: space-between; align-items: center; }
+.ism-progress-title { font-weight: 600; }
+.ism-progress-dismiss { background: none; border: none; font-size: 16px; line-height: 1; cursor: pointer; color: #9aa0a6; }
+.ism-progress-name { color: #5f6368; margin: 4px 0 8px 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ism-progress-track { height: 6px; background: #eef0f2; border-radius: 3px; overflow: hidden; }
+.ism-progress-fill { height: 100%; background: #2563eb; transition: width 0.3s ease; }
+.ism-progress-badge.encoding .ism-progress-fill { background: #f59e0b; }
+.ism-progress-pct { text-align: right; font-size: 11px; color: #5f6368; margin-top: 4px; }
 
 .ism-main {
   flex: 1;

--- a/content/dashboard-v3/src/components/chat/CitationCard.vue
+++ b/content/dashboard-v3/src/components/chat/CitationCard.vue
@@ -52,7 +52,7 @@ const href = computed(() => {
       p.set('player_id', c.player_id);
       p.set('play_id', c.play_id);
       if (c.at) p.set('at', c.at);
-      return `/dashboard/v3/session-viewer.html?${p.toString()}`;
+      return `/dashboard/session-viewer.html?${p.toString()}`;
     }
     case 'range': {
       if (!c.player_id || !c.play_id) return null;
@@ -61,11 +61,11 @@ const href = computed(() => {
       p.set('play_id', c.play_id);
       if (c.from) p.set('from', c.from);
       if (c.to) p.set('to', c.to);
-      return `/dashboard/v3/session-viewer.html?${p.toString()}`;
+      return `/dashboard/session-viewer.html?${p.toString()}`;
     }
     case 'run':
       return c.run_id
-        ? `/dashboard/v3/characterization.html?run_id=${encodeURIComponent(c.run_id)}${c.cycle ? `&cycle=${c.cycle}` : ''}`
+        ? `/dashboard/characterization.html?run_id=${encodeURIComponent(c.run_id)}${c.cycle ? `&cycle=${c.cycle}` : ''}`
         : null;
     case 'finding':
     case 'standard':

--- a/content/dashboard-v3/src/composables/urlTimeFormat.ts
+++ b/content/dashboard-v3/src/composables/urlTimeFormat.ts
@@ -1,6 +1,6 @@
 /**
  * urlTimeFormat — shared helpers for the human-visible URL params
- * that link to /dashboard/v3/session-viewer.html (and any other page
+ * that link to /dashboard/session-viewer.html (and any other page
  * that scopes by player_id + play_id + time window).
  *
  * The compact format keeps URLs short and free of percent-encoding:
@@ -76,7 +76,7 @@ export function canonicalUUID(s: string | null | undefined): string {
 
 /**
  * sessionViewerURL — single place to build the canonical link.
- * Returns a complete `/dashboard/v3/session-viewer.html?…` string.
+ * Returns a complete `/dashboard/session-viewer.html?…` string.
  *
  * Inputs: ms-epoch numbers for the window; nulls/NaNs are dropped
  * silently (the viewer falls back to its own bounds detection when
@@ -105,5 +105,5 @@ export function sessionViewerURL(opts: {
   // URLSearchParams encodes the `:` we'd otherwise smuggle through;
   // because the compact form has no `:` at all, the resulting URL is
   // free of `%3A` clutter.
-  return `/dashboard/v3/session-viewer.html?${p.toString()}`;
+  return `/dashboard/session-viewer.html?${p.toString()}`;
 }

--- a/content/dashboard-v3/src/pages/Characterization.vue
+++ b/content/dashboard-v3/src/pages/Characterization.vue
@@ -501,7 +501,7 @@ function playerShort(p: string): string {
 
 function playViewerHref(playID: string, playerID: string): string {
   const qs = new URLSearchParams({ play_id: playID, player_id: playerID });
-  return `/dashboard/v3/session-viewer.html?${qs}`;
+  return `/dashboard/session-viewer.html?${qs}`;
 }
 
 function startedAtLocal(iso: string): string {
@@ -577,11 +577,14 @@ function stepWindow(report: ReportBlob, stepIdx: number): { startMs: number; end
           Click a card to open the play in the Session Viewer.
         </div>
         <div class="page-callout">
-          <strong>How to run:</strong> Characterization tests run from the developer host, not this UI — this page only displays results that have already been archived. Trigger a run with <code>go test</code> on the host:
+          <strong>How to run:</strong> Tests run from the developer host, not this UI — this page only displays results that have already been archived. A single command does the server checks then the iPad-sim players:
+          <pre class="page-callout-code">make automated-testing   <span class="muted"># characterize-server, then characterize-ipad-sim</span></pre>
+          <strong>Server checks</strong> (the <code>server_*</code> tiles) on their own: <code>make characterize-server</code> — runs <code>go test -run TestServer</code> in <code>tests/server_behavior/</code> against test-dev (rate / delay / loss / pattern / fault / transfer / socket / scope / content).
+          <strong>Player characterization</strong> on its own, per platform: <code>make characterize-{ipad-sim,iphone,appletv,androidtv,web}</code>, or directly:
           <pre class="page-callout-code">go test -C tests/characterization ./modes/... -v \
   -run <span class="muted">TestStartupIPadSim</span> \
   -timeout 30m -count=1 -launch-mode=appium</pre>
-          Available <code>-run</code> values: <code>TestStartupIPadSim</code>, <code>TestAbortIPadSim</code>, <code>TestRampupIPadSim</code> (and <code>IPhone</code>, <code>AppleTV</code>, <code>AndroidTV</code>, <code>Web</code> variants per test). The run uploads its report via <code>harness post characterization</code> and lands here within a few seconds.
+          Available <code>-run</code> values: <code>TestStartupIPadSim</code>, <code>TestAbortIPadSim</code>, <code>TestRampupIPadSim</code> (and <code>IPhone</code>, <code>AppleTV</code>, <code>AndroidTV</code>, <code>Web</code> variants per test). Reports upload via <code>harness post characterization</code> and land here within a few seconds.
         </div>
       </div>
 

--- a/content/dashboard-v3/src/pages/Dashboard.vue
+++ b/content/dashboard-v3/src/pages/Dashboard.vue
@@ -186,11 +186,11 @@ function fmtCount(n: number | null): string {
             player behaviour across devices.
           </p>
           <div class="links">
-            <a class="btn primary" href="/dashboard/v3/testing.html">Testing Monitor →</a>
-            <a class="btn secondary" href="/dashboard/v3/testing-session.html?nav=1">Testing Playback →</a>
+            <a class="btn primary" href="/dashboard/testing.html">Testing Monitor →</a>
+            <a class="btn secondary" href="/dashboard/testing-session.html?nav=1">Testing Playback →</a>
             <a class="btn secondary" href="/dashboard/playback.html">Playback</a>
             <a class="btn secondary" href="/dashboard/quartet.html">Quartet Comparison</a>
-            <a class="btn secondary" href="/dashboard/v3/grid.html">Mosaic</a>
+            <a class="btn secondary" href="/dashboard/grid.html">Mosaic</a>
             <a class="btn secondary" href="/dashboard/mosaic-10ft.html">10ft UI</a>
             <a class="btn secondary" href="/dashboard/segment-duration-comparison.html">Live Offset (2s/4s/6s)</a>
           </div>
@@ -207,7 +207,7 @@ function fmtCount(n: number | null): string {
           </p>
           <div class="links">
             <a class="btn primary" href="/dashboard/go-monitor.html">Stream Monitor</a>
-            <a class="btn secondary" href="/dashboard/v3/sessions.html">Archived Sessions</a>
+            <a class="btn secondary" href="/dashboard/sessions.html">Archived Sessions</a>
           </div>
         </article>
       </section>

--- a/content/dashboard-v3/src/pages/Grid.vue
+++ b/content/dashboard-v3/src/pages/Grid.vue
@@ -49,7 +49,7 @@ const developerMode = computed(() => params.developer === '1');
 
 /* ─── Context menu (legacy /dashboard/grid.html parity) ──────────────
  * Right-clicking a tile shows the same 3-option menu as legacy:
- *   - Open in Testing Window  →  /dashboard/v3/testing-session.html
+ *   - Open in Testing Window  →  /dashboard/testing-session.html
  *   - Copy Testing URL        →  clipboard
  *   - Open in HLS.js Demo     →  hlsjs.video-dev.org (developer mode + HLS only)
  *
@@ -128,7 +128,7 @@ function closeMenu() { menu.value.open = false; }
 function menuOpenTesting() {
   const playerId = mintPlayerId();
   const testingUrl = buildTestingUrl(menu.value.url, playerId);
-  const pageUrl = `/dashboard/v3/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
+  const pageUrl = `/dashboard/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
   window.open(pageUrl, '_blank', 'noopener');
   closeMenu();
 }

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -141,7 +141,7 @@ const bundleHref = computed(() => {
   if (playId.value) p.set('play_id', playId.value);
   return '/analytics/api/session_bundle?' + p.toString();
 });
-const backHref = '/dashboard/v3/sessions.html';
+const backHref = '/dashboard/sessions.html';
 
 // (Initial starred-state lookup now lives in the playQuery above —
 // useQuery fires automatically when playId is set; the onMounted
@@ -159,7 +159,7 @@ const backHref = '/dashboard/v3/sessions.html';
       <main class="content">
         <div v-if="!playerId" class="empty">
           <p>No <code>player_id</code> in the URL.</p>
-          <p>Open <code>/dashboard/v3/session-viewer.html?player_id=&lt;uuid&gt;&amp;play_id=&lt;uuid&gt;</code></p>
+          <p>Open <code>/dashboard/session-viewer.html?player_id=&lt;uuid&gt;&amp;play_id=&lt;uuid&gt;</code></p>
         </div>
 
         <template v-else>

--- a/content/dashboard-v3/src/pages/TestingSession.vue
+++ b/content/dashboard-v3/src/pages/TestingSession.vue
@@ -5,7 +5,7 @@
  * the page scaffold + the ShapeSliders proving-ground component.
  *
  * URL contract (matches the legacy v2 page so existing bookmarks work):
- *   /dashboard/v3/testing-session.html?player_id=<uuid>
+ *   /dashboard/testing-session.html?player_id=<uuid>
  */
 import { computed } from 'vue';
 import { useUrlSearchParams } from '@vueuse/core';
@@ -35,33 +35,34 @@ const params = useUrlSearchParams<{ player_id?: string; url?: string }>('history
 const playerId = computed(() => params.player_id ?? '');
 
 /**
- * Defensive rescue for stale grid bundles. Pre-fix grid builds appended
- * the page's fresh player_id to a tile URL that ALREADY carried its own
- * `player_id=<tileId>`, producing `…?player_id=A&player_id=B`. The
- * shaper then registers under the first (`A`) and the page (which
- * queries `B`) 404s forever. If we see duplicates in `url=`, rewrite
- * down to a single `player_id` matching the page's id so the shaper
- * registers under what we'll actually look up.
- *
- * Once every browser is on the post-fix grid bundle this is a no-op,
- * but it costs ~nothing and shields users with cached old code.
+ * Force the stream URL (`url=`) to carry exactly the page's `player_id`.
+ * The shaper registers the per-session redirect (302 :2X081 → :2X181) BY
+ * `player_id`, so a stream URL missing it 404s on the shaper port. Two
+ * sources get this wrong:
+ *   - legacy `shared-nav.js` builds `url=<stream>` WITHOUT an embedded
+ *     player_id (it only sets it as a top-level page param), so we must
+ *     INJECT it here;
+ *   - stale grid bundles appended the page id to a tile URL that already
+ *     carried its own, producing `…?player_id=A&player_id=B`; we collapse
+ *     to a single one matching the page id.
+ * When the page has no player_id there's nothing to enforce → pass through.
  */
 function sanitizeUrlOverride(raw: string, pid: string): string {
   if (!raw) return raw;
+  if (!pid) return raw; // nothing to enforce
   try {
     const u = new URL(raw, window.location.href);
     const all = u.searchParams.getAll('player_id');
-    // No player_id, or already a single matching one → nothing to do.
-    if (all.length === 0) return raw;
+    // Already exactly the page's id → nothing to do.
     if (all.length === 1 && all[0] === pid) return raw;
     u.searchParams.delete('player_id');
-    if (pid) u.searchParams.set('player_id', pid);
+    u.searchParams.set('player_id', pid);
     const fixed = u.toString();
     if (fixed !== raw) {
-      console.warn('[TS] sanitised urlOverride to dedupe player_id', {
+      console.warn('[TS] ensured stream-URL player_id matches the page', {
         before: raw,
         after: fixed,
-        duplicates: all,
+        had: all,
       });
     }
     return fixed;
@@ -132,7 +133,7 @@ const chatScope = computed<ChatScope>(() => ({
       <main class="content">
       <div v-if="!playerId" class="empty">
         <p>No <code>player_id</code> in the URL.</p>
-        <p>Open <code>/dashboard/v3/testing-session.html?player_id=&lt;uuid&gt;</code></p>
+        <p>Open <code>/dashboard/testing-session.html?player_id=&lt;uuid&gt;</code></p>
       </div>
 
       <!-- Loading + error states only kick in when there's NO urlOverride.

--- a/content/dashboard/playback.html
+++ b/content/dashboard/playback.html
@@ -899,7 +899,7 @@
         function openTestingWindow(url) {
             const playerId = createPlayerId();
             const testingUrl = buildTestingUrl(url, playerId);
-            const pageUrl = `/dashboard/v3/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
+            const pageUrl = `/dashboard/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
             const popup = window.open(pageUrl, '_blank');
             if (!popup) {
                 alert('Popup blocked. Allow popups for this site.');

--- a/content/dashboard/quartet.html
+++ b/content/dashboard/quartet.html
@@ -687,8 +687,23 @@
             return encodeURIComponent(name).replace(/%2F/g, '/');
         }
 
+        // Resolve the real content directory name. Legacy content is named
+        // '<base>_<codec>' (e.g. 'fashion' + '_h264' = 'fashion_h264'), but
+        // newer content already carries the codec + timestamp in its name
+        // (e.g. 'INSANE_..._p200_h264_20260423_212139'), so blindly appending
+        // the codec suffix 404s. Prefer the catalogue (QUARTET_CONTENT_META);
+        // fall back to a codec-token check when it isn't loaded yet.
+        function resolveStreamName(content, suffix) {
+            if (!suffix) return content;
+            const withSuffix = `${content}${suffix}`;
+            if (QUARTET_CONTENT_META?.[withSuffix]) return withSuffix;
+            if (QUARTET_CONTENT_META?.[content]) return content;
+            const codec = suffix.replace(/^_/, '');
+            return new RegExp(`(^|_)${codec}(_|$)`, 'i').test(content) ? content : withSuffix;
+        }
+
         function buildMasterUrl(content, encodingConfig, segment = 'll') {
-            const streamName = `${content}${encodingConfig.suffix}`;
+            const streamName = resolveStreamName(content, encodingConfig.suffix);
             const base = window.location.origin;
             let filename;
             if (encodingConfig.protocol === 'dash') {
@@ -1098,7 +1113,7 @@
         function openTestingWindow(url) {
             const playerId = createPlayerId();
             const testingUrl = buildTestingUrl(url, playerId);
-            const pageUrl = `/dashboard/v3/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
+            const pageUrl = `/dashboard/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
             const popup = window.open(pageUrl, '_blank');
             if (!popup) {
                 alert('Popup blocked. Allow popups for this site.');

--- a/content/dashboard/segment-duration-comparison.html
+++ b/content/dashboard/segment-duration-comparison.html
@@ -984,7 +984,7 @@
         function openTestingWindow(url) {
             const playerId = createPlayerId();
             const testingUrl = buildTestingUrl(url, playerId);
-            const pageUrl = `/dashboard/v3/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
+            const pageUrl = `/dashboard/testing-session.html?player_id=${encodeURIComponent(playerId)}&url=${encodeURIComponent(testingUrl)}`;
             const popup = window.open(pageUrl, '_blank');
             if (!popup) {
                 alert('Popup blocked. Allow popups for this site.');

--- a/content/dashboard/upload.html
+++ b/content/dashboard/upload.html
@@ -251,7 +251,7 @@
 
                 <!-- Buttons -->
                 <div style="display: flex; gap: 12px; margin-top: 24px;">
-                    <button type="button" class="btn btn-secondary" onclick="window.location.href='/dashboard/v3/dashboard.html'">Cancel</button>
+                    <button type="button" class="btn btn-secondary" onclick="window.location.href='/dashboard/dashboard.html'">Cancel</button>
                     <button type="submit" class="btn btn-primary" id="submitBtn" style="flex: 1;">Start Encoding</button>
                 </div>
             </form>

--- a/content/index.html
+++ b/content/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/dashboard/v3/dashboard.html">
+    <meta http-equiv="refresh" content="0; url=/dashboard/dashboard.html">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecting - InfiniteStream</title>
     <style>
@@ -24,7 +24,7 @@
 <body>
     <div class="message">
         <h1>Redirecting to dashboard...</h1>
-        <p>If you are not redirected automatically, <a href="/dashboard/v3/dashboard.html">click here</a>.</p>
+        <p>If you are not redirected automatically, <a href="/dashboard/dashboard.html">click here</a>.</p>
     </div>
 </body>
 </html>

--- a/content/shared/shared-nav.js
+++ b/content/shared/shared-nav.js
@@ -9,7 +9,7 @@
     // Configuration
     const NAVIGATION = {
         main: [
-            { id: 'dashboard', icon: '📊', text: 'Dashboard', href: '/dashboard/v3/dashboard.html' }
+            { id: 'dashboard', icon: '📊', text: 'Dashboard', href: '/dashboard/dashboard.html' }
         ],
         content: [
             { id: 'upload', icon: '📤', text: 'Upload Content', href: '/dashboard/upload.html' },
@@ -17,12 +17,12 @@
             { id: 'jobs', icon: '💼', text: 'Encoding Jobs', href: '/dashboard/jobs.html' }
         ],
         testing: [
-            { id: 'grid', icon: '🎮', text: 'Mosaic', href: '/dashboard/v3/grid.html', warning: true },
+            { id: 'grid', icon: '🎮', text: 'Mosaic', href: '/dashboard/grid.html', warning: true },
             { id: 'mosaic-10ft', icon: '📺', text: '10ft UI', href: '/dashboard/mosaic-10ft.html', alpha: true },
             { id: 'playback', icon: '▶️', text: 'Playback', href: '/dashboard/playback.html' },
-            { id: 'test-playback', icon: '🧭', text: 'Testing Playback', href: '/dashboard/v3/testing-session.html?nav=1' },
-            { id: 'testing', icon: '🧪', text: 'Testing Monitor', href: '/dashboard/v3/testing.html' },
-            { id: 'sessions', icon: '⏪', text: 'Sessions', href: '/dashboard/v3/sessions.html' },
+            { id: 'test-playback', icon: '🧭', text: 'Testing Playback', href: '/dashboard/testing-session.html?nav=1' },
+            { id: 'testing', icon: '🧪', text: 'Testing Monitor', href: '/dashboard/testing.html' },
+            { id: 'sessions', icon: '⏪', text: 'Sessions', href: '/dashboard/sessions.html' },
             { id: 'quartet', icon: '🎬', text: 'Quartet', href: '/dashboard/quartet.html', alpha: true },
             { id: 'segment-duration', icon: '⏱️', text: 'Live Offset', href: '/dashboard/segment-duration-comparison.html', alpha: true }
         ],
@@ -489,7 +489,7 @@
                 demoLink.removeAttribute('aria-disabled');
             }
             if (testPlaybackLink) {
-                testPlaybackLink.href = '/dashboard/v3/testing-session.html?nav=1';
+                testPlaybackLink.href = '/dashboard/testing-session.html?nav=1';
                 testPlaybackLink.removeAttribute('aria-disabled');
             }
             return;
@@ -521,7 +521,13 @@
                 }
                 if (testPlaybackLink) {
                     const playerId = getOrCreateTestPlaybackPlayerId();
-                    testPlaybackLink.href = `/dashboard/v3/testing-session.html?url=${encodeURIComponent(absoluteUrl)}&player_id=${encodeURIComponent(playerId)}&nav=1`;
+                    // Embed player_id INSIDE the stream URL too: the shaper
+                    // registers the per-session redirect (:2X081 → :2X181) BY
+                    // player_id, so a stream URL without it 404s. (The v3 nav
+                    // builder embeds it; keep parity so both paths play.)
+                    const sep = absoluteUrl.includes('?') ? '&' : '?';
+                    const streamUrl = `${absoluteUrl}${sep}player_id=${encodeURIComponent(playerId)}`;
+                    testPlaybackLink.href = `/dashboard/testing-session.html?url=${encodeURIComponent(streamUrl)}&player_id=${encodeURIComponent(playerId)}&nav=1`;
                     testPlaybackLink.removeAttribute('aria-disabled');
                     testPlaybackLink.title = 'Open selected stream in Testing Playback';
                 }
@@ -547,7 +553,7 @@
                 shakaLink.removeAttribute('aria-disabled');
             }
             if (testPlaybackLink) {
-                testPlaybackLink.href = '/dashboard/v3/testing-session.html?nav=1';
+                testPlaybackLink.href = '/dashboard/testing-session.html?nav=1';
                 testPlaybackLink.removeAttribute('aria-disabled');
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,10 @@ services:
       - app_network
 
   go-server:
-    build: .
+    build:
+      context: .
+      args:
+        VERSION: ${VERSION:-unknown}
     image: infinite-streaming
     container_name: infinite-streaming
     cap_add:
@@ -62,6 +65,14 @@ services:
       - GO_LIVE_OUTPUT_DIR=/go-live
       - GO_UPLOAD_ADDR=:8003
       - INFINITE_STREAM_LISTEN_PORT=30000
+      # TLS toggle (default on = HTTPS+HTTP/2). Set INFINITE_STREAM_TLS=off
+      # in .env to serve plain HTTP on the dashboard + shaper ports.
+      - INFINITE_STREAM_TLS=${INFINITE_STREAM_TLS:-on}
+      # SAN list for the auto-generated self-signed cert (used only when no
+      # mkcert / Let's Encrypt cert is mounted into the certs dir). Comma-
+      # separated openssl SAN entries — list every hostname/IP clients reach
+      # this box by, since browsers match on SAN not CN. See docs/TLS.md.
+      - INFINITE_STREAM_TLS_SAN=${INFINITE_STREAM_TLS_SAN:-DNS:localhost,IP:127.0.0.1}
       - INFINITE_STREAM_UPSTREAM_HOST=127.0.0.1
       - INFINITE_STREAM_UPSTREAM_PORT=30000
       - INFINITE_STREAM_MAX_SESSIONS=8

--- a/docker/launch.sh
+++ b/docker/launch.sh
@@ -18,22 +18,70 @@ export INFINITE_STREAM_OUTPUT_DIR="${INFINITE_STREAM_OUTPUT_DIR:-${INFINITE_OUTP
 # no-op when the directory already exists.
 mkdir -p /media/logs /media/data "$INFINITE_STREAM_OUTPUT_DIR"
 
-# Auto-generate self-signed TLS certs if missing
-certdir="/media/certs"
-if [ -f "$certdir/localhost.pem" ] && [ -f "$certdir/localhost-key.pem" ]; then
-  echo "Using existing TLS certificates from $certdir"
+# TLS toggle. INFINITE_STREAM_TLS=off (or 0/false/no) serves plain HTTP on
+# the public nginx listener AND go-proxy's shaper ports; default on (HTTPS).
+# Plain HTTP loses HTTP/2, so the dashboard's SSE streams fall back under
+# Chrome's per-origin connection cap — fine for quick / cert-free use.
+case "$(printf '%s' "${INFINITE_STREAM_TLS:-on}" | tr 'A-Z' 'a-z')" in
+  off|0|false|no) INFINITE_STREAM_TLS=off ;;
+  *)              INFINITE_STREAM_TLS=on ;;
+esac
+export INFINITE_STREAM_TLS
+
+if [ "$INFINITE_STREAM_TLS" = on ]; then
+  # Substituted into the nginx template's listen lines + cert block.
+  export INFINITE_STREAM_TLS_LISTEN_OPTS=" ssl http2"
+  # nginx → go-proxy upstream scheme. go-proxy serves TLS on 30081 when
+  # TLS is on, plain HTTP when off, so nginx's proxy_pass scheme must
+  # track it or the handshake fails with 502 (see nginx template).
+  export INFINITE_STREAM_PROXY_SCHEME="https"
+  export INFINITE_STREAM_TLS_DIRECTIVES="ssl_certificate /etc/nginx/certs/localhost.pem;
+    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+    ssl_session_timeout 10m;
+    ssl_protocols TLSv1.2 TLSv1.3;"
+
+  # Auto-generate a self-signed cert when none is supplied. The SAN list comes
+  # from INFINITE_STREAM_TLS_SAN so each deployment can cover its own hostnames
+  # — browsers match on SAN, not CN, so every name/IP clients reach this box by
+  # must be listed. A manually-supplied cert (mkcert / Let's Encrypt) carries no
+  # .self-signed-san marker and is left untouched. A self-signed cert is
+  # regenerated when the requested SAN changes, so editing the var in .env takes
+  # effect on the next start. See docs/TLS.md.
+  certdir="/media/certs"
+  san_marker="$certdir/.self-signed-san"
+  want_san="${INFINITE_STREAM_TLS_SAN:-DNS:localhost,IP:127.0.0.1}"
+  have_cert=false
+  [ -f "$certdir/localhost.pem" ] && [ -f "$certdir/localhost-key.pem" ] && have_cert=true
+
+  if [ "$have_cert" = true ] && [ ! -f "$san_marker" ]; then
+    echo "Using supplied TLS certificate in $certdir (not self-signed; left untouched)."
+  elif [ "$have_cert" = true ] && [ "$(cat "$san_marker" 2>/dev/null)" = "$want_san" ]; then
+    echo "Using existing self-signed TLS certificate in $certdir (SAN=$want_san)."
+  else
+    mkdir -p "$certdir"
+    # CN is legacy and ignored by modern browsers, but keep it readable: the
+    # first DNS: entry in the SAN, falling back to localhost.
+    cn="$(printf '%s' "$want_san" | tr ',' '\n' | sed -n 's/^DNS://p' | head -n1)"
+    cn="${cn:-localhost}"
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+      -keyout "$certdir/localhost-key.pem" \
+      -out "$certdir/localhost.pem" \
+      -subj "/CN=$cn" \
+      -addext "subjectAltName=$want_san" 2>/dev/null
+    printf '%s' "$want_san" > "$san_marker"
+    echo "Auto-generated self-signed TLS certificate in $certdir (CN=$cn SAN=$want_san)."
+  fi
+  # Ensure nginx can find the certs
+  mkdir -p /etc/nginx/certs
+  ln -sf "$certdir/localhost.pem" /etc/nginx/certs/localhost.pem
+  ln -sf "$certdir/localhost-key.pem" /etc/nginx/certs/localhost-key.pem
+  echo "TLS ENABLED — HTTPS + HTTP/2 on :$INFINITE_STREAM_LISTEN_PORT and the shaper ports."
 else
-  mkdir -p "$certdir"
-  openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-    -keyout "$certdir/localhost-key.pem" \
-    -out "$certdir/localhost.pem" \
-    -subj "/CN=localhost" 2>/dev/null
-  echo "Auto-generated self-signed TLS certificates in $certdir"
+  export INFINITE_STREAM_TLS_LISTEN_OPTS=""
+  export INFINITE_STREAM_TLS_DIRECTIVES=""
+  export INFINITE_STREAM_PROXY_SCHEME="http"
+  echo "TLS DISABLED — plain HTTP (HTTP/2 off; dashboard SSE limited by Chrome's per-origin cap)."
 fi
-# Ensure nginx can find the certs
-mkdir -p /etc/nginx/certs
-ln -sf "$certdir/localhost.pem" /etc/nginx/certs/localhost.pem
-ln -sf "$certdir/localhost-key.pem" /etc/nginx/certs/localhost-key.pem
 export INFINITE_STREAM_PROXY_HOST="${INFINITE_STREAM_PROXY_HOST:-127.0.0.1}"
 
 # Analytics sidecar (forwarder + Grafana) is OPT-IN. Compose sets
@@ -73,7 +121,7 @@ else
   export INFINITE_STREAM_AUTH_DIRECTIVES="auth_basic off;"
   echo "Basic auth disabled (set INFINITE_STREAM_AUTH_HTPASSWD to a htpasswd file path to enable)."
 fi
-envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_LISTEN_PORT} ${INFINITE_STREAM_AUTH_DIRECTIVES}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
+envsubst '${INFINITE_STREAM_OUTPUT_DIR} ${INFINITE_STREAM_PROXY_HOST} ${INFINITE_STREAM_LISTEN_PORT} ${INFINITE_STREAM_AUTH_DIRECTIVES} ${INFINITE_STREAM_TLS_LISTEN_OPTS} ${INFINITE_STREAM_TLS_DIRECTIVES} ${INFINITE_STREAM_PROXY_SCHEME}' < /etc/nginx/http.d/nginx-content.conf.template > /etc/nginx/http.d/nginx-content.conf
 
 # Analytics fragment: emitted only when the sidecar is enabled.
 # /etc/nginx/snippets/ is glob-included from inside the main config's

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -45,22 +45,22 @@ upstream go_proxy {
 # Normal server
 server {
 
-    # TLS + HTTP/2 for browsers (external traffic). Browsers refuse
-    # cleartext h2 so the port must be HTTPS for multiplexing to
-    # apply — eliminates Chrome's 6-per-origin HTTP/1.1 cap so SSE
-    # streams + REST polls share one TCP connection per tab.
-    listen ${INFINITE_STREAM_LISTEN_PORT} ssl http2 default_server;
-    listen [::]:${INFINITE_STREAM_LISTEN_PORT} ssl http2 default_server;
+    # External listener. INFINITE_STREAM_TLS (in launch.sh) decides the
+    # scheme: when on, the listen opts become "ssl http2" (browsers refuse
+    # cleartext h2, so the port must be HTTPS for the multiplexing that
+    # dodges Chrome's 6-per-origin HTTP/1.1 cap on SSE streams); when off
+    # they're empty and the cert block below is blank → plain HTTP/1.1.
+    listen ${INFINITE_STREAM_LISTEN_PORT}${INFINITE_STREAM_TLS_LISTEN_OPTS} default_server;
+    listen [::]:${INFINITE_STREAM_LISTEN_PORT}${INFINITE_STREAM_TLS_LISTEN_OPTS} default_server;
     # Cleartext loopback listener for in-container internal calls
     # (go-proxy → nginx → go-live). go-proxy's UPSTREAM_PORT env
     # points here so it can speak plain HTTP without negotiating
     # TLS against the same nginx instance.
     listen 127.0.0.1:30005;
 
-    ssl_certificate /etc/nginx/certs/localhost.pem;
-    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
-    ssl_session_timeout 10m;
-    ssl_protocols TLSv1.2 TLSv1.3;
+    # ssl_certificate / ssl_protocols etc. — rendered by launch.sh only
+    # when INFINITE_STREAM_TLS is on; empty in plain-HTTP mode.
+    ${INFINITE_STREAM_TLS_DIRECTIVES}
 
     add_header Access-Control-Allow-Origin *;
     # Log to stderr for proper time-interleaving in Docker logs, AND to
@@ -147,10 +147,19 @@ server {
         add_header Expires "0" always;
     }
 
-    # Legacy /dashboard/*.html pages (testing, testing-session,
-    # session-viewer, sessions, grid, dashboard) have been removed —
-    # their Vue 3 replacements live under /dashboard/v3/. Unmatched
-    # /dashboard/* requests fall back to the v3 landing.
+    # The Vue 3 dashboard pages are served at clean /dashboard/<page>.html
+    # URLs (no /v3/ in the address bar). Their built files physically live
+    # in /content/dashboard/v3/; this regex location aliases the page set
+    # into that dir. A matching regex location takes precedence over the
+    # /dashboard/ prefix location below. Page assets are still referenced
+    # under /dashboard/v3/assets/ and served by the prefix location, and
+    # /dashboard/v3/<page>.html keeps working for old bookmarks. Surviving
+    # legacy static pages (upload, jobs, sources, playback, …) also serve
+    # from the prefix location.
+    location ~ ^/dashboard/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|ask|hello)\.html$ {
+        ${INFINITE_STREAM_AUTH_DIRECTIVES}
+        alias /content/dashboard/v3/$1.html;
+    }
 
     location /dashboard/ {
         ${INFINITE_STREAM_AUTH_DIRECTIVES}
@@ -164,7 +173,7 @@ server {
     }
 
     location = /dashboard.html {
-        return 302 /dashboard/v3/dashboard.html;
+        return 302 /dashboard/dashboard.html;
     }
 
     location / {
@@ -206,7 +215,7 @@ server {
     include /etc/nginx/snippets/analytics-*.conf;
 
     location = /api/sessions {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -219,7 +228,7 @@ server {
     }
 
     location = /api/version {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -232,7 +241,7 @@ server {
     }
 
     location = /api/sessions/stream {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -249,7 +258,7 @@ server {
     }
 
     location = /api/clear-sessions {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -262,7 +271,7 @@ server {
     }
 
     location = /api/external-ips {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -275,7 +284,7 @@ server {
     }
 
     location ~ ^/api/session/ {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -288,7 +297,7 @@ server {
     }
 
     location ~ ^/api/nftables/ {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -304,7 +313,7 @@ server {
     # is SSE — needs the same buffering/timeout overrides as /api/sessions/stream
     # but the location regex below covers the non-stream paths first.
     location = /api/v2/events {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -319,7 +328,7 @@ server {
     }
 
     location ~ ^/api/v2/ {
-        proxy_pass https://go_proxy;
+        proxy_pass ${INFINITE_STREAM_PROXY_SCHEME}://go_proxy;
             proxy_ssl_verify off;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -1,0 +1,302 @@
+# TLS & Certificates
+
+The dashboard and the per-session shaper ports serve over HTTPS by default. This
+page explains the three ways to get a cert the clients accept, why the choice
+hinges on **hostname**, and how to turn TLS off entirely. If you just hit a
+browser cert warning, jump to [Why am I getting a warning?](#why-am-i-getting-a-warning).
+
+## Why HTTPS at all
+
+Plain HTTP works, but loses HTTP/2. Without HTTP/2 the dashboard's many
+Server-Sent-Events streams fall under Chrome's **6-connections-per-origin** cap,
+so live charts stall once enough players are open. HTTPS → HTTP/2 multiplexes
+them over one connection. That's the only hard reason TLS is the default; if you
+don't care about the SSE cap, plain HTTP is fine (see [Turning TLS off](#turning-tls-off)).
+
+## The two checks every cert must pass
+
+A cert can fail for two completely independent reasons. Keep them separate or
+the modes below won't make sense:
+
+1. **Trust** — is the cert's *issuer* in the client's trust store? Public CAs
+   (Let's Encrypt) are pre-trusted everywhere. A self-signed cert or a private
+   CA is trusted only on machines where you installed it.
+2. **Name** — does the cert's **SAN** (Subject Alternative Name) list cover the
+   exact hostname the client connected to? `dev.jeoliver.com` ≠
+   `jonathanoliver-ubuntu.local` ≠ `localhost` ≠ a bare IP. Modern browsers
+   ignore the legacy `CN` field entirely and require a matching SAN.
+
+A green padlock needs **both**. Most confusing warnings are a *name* failure on
+an otherwise-valid cert (see below).
+
+## The three modes
+
+| Mode | Hostname you use | Trusted? | Install on clients? | Covers `.local`? |
+|---|---|---|---|---|
+| **Plain HTTP** (TLS off) | any | n/a | nothing | n/a |
+| **Self-signed / mkcert** | `.local`, IP, anything you choose | only where you installed it | the cert (self-signed) or the CA once (mkcert) | **yes** — you control the SAN |
+| **Public Let's Encrypt** | a real DNS name you own (`dev.jeoliver.com`) | yes, everywhere | nothing | **no** — public CAs refuse `.local` |
+
+The split that trips people up: a **public** CA limits you on *name* (must be a
+real domain you own; never `.local`), while a **self-signed/mkcert** cert limits
+you on *trust* (must be installed per-client) but lets you list **any** names —
+including `.local`, the LAN IP, and a real domain all in one cert.
+
+## The TLS toggle
+
+`INFINITE_STREAM_TLS` (env var, default `on`) flips the whole stack between HTTPS
+and plain HTTP — both the public nginx listener and go-proxy's shaper ports:
+
+```
+INFINITE_STREAM_TLS=on    # HTTPS + HTTP/2 (default)
+INFINITE_STREAM_TLS=off   # plain HTTP, no cert, no HTTP/2
+```
+
+`off` is accepted as any of `off` / `0` / `false` / `no` (case-insensitive);
+anything else is `on`. Implemented in `docker/launch.sh` (nginx listen opts +
+cert block + the `${INFINITE_STREAM_PROXY_SCHEME}` used for nginx's
+`proxy_pass` to go-proxy) and `go-proxy/cmd/server/main.go` (`ListenAndServe` vs
+`ListenAndServeTLS`). The proxy-scheme piece matters: go-proxy serves TLS on
+30081 when on and plain HTTP when off, so nginx's upstream scheme must track it
+or every `/api/v2/*` and `/api/sessions*` route 502s. For test-dev the value is
+threaded into the remote `.env` by the `make test-deploy-dev` target.
+
+### Turning TLS off
+
+Set `INFINITE_STREAM_TLS=off` in `.env` and redeploy. No cert is generated, no
+warning ever appears, and you reach everything over `http://…`. The only cost is
+HTTP/2 — heavy multi-player dashboards may hit Chrome's SSE cap. Good for quick,
+cert-free local use.
+
+## Mode 1 — self-signed (built-in default)
+
+When `INFINITE_STREAM_TLS=on` and no cert is present, `launch.sh` auto-generates
+a self-signed pair into `/media/certs/{localhost.pem,localhost-key.pem}` and
+symlinks them into `/etc/nginx/certs/`. If those files already exist it uses them
+untouched — that's the hook the mkcert and LE paths below rely on.
+
+**Trust:** nothing trusts a self-signed cert until you install *that exact cert*
+on each client. Regenerate it (new key/host/SAN) and you re-install everywhere —
+there's no chain, the cert is its own issuer.
+
+**Name:** the SAN comes from the **`INFINITE_STREAM_TLS_SAN`** env var, so each
+deployment covers its own hostnames. It's a comma-separated openssl SAN list —
+default `DNS:localhost,IP:127.0.0.1`. Set it in `.env` to every name/IP clients
+reach the box by, for example:
+
+```
+INFINITE_STREAM_TLS_SAN=DNS:dev.jeoliver.com,DNS:jonathanoliver-ubuntu.local,DNS:localhost,IP:192.168.1.50
+```
+
+A self-signed cert can list **all** of those at once — you're your own CA, so no
+one checks domain ownership. (Trust is still per-client; SAN only fixes the
+name half.) The cert's `CN` is set to the first `DNS:` entry for readability,
+but browsers ignore it.
+
+**Regeneration:** `launch.sh` records the SAN it generated in
+`/media/certs/.self-signed-san`. Change `INFINITE_STREAM_TLS_SAN` in `.env` and
+redeploy — because the recorded SAN no longer matches, the cert is regenerated
+with the new names. A **manually supplied** cert (mkcert / LE) has no marker
+file, so it is never regenerated over.
+
+## Mode 2 — mkcert (self-signed, but with a trusted local CA)
+
+mkcert is the ergonomic upgrade over plain self-signed. It splits the job in two:
+
+1. Creates a **local root CA** once (`rootCA.pem` / `rootCA-key.pem`) and installs
+   that CA into your OS + browser trust stores via `mkcert -install`.
+2. Issues **leaf** server certs *signed by that CA*.
+
+Because clients trust the **CA**, they trust any leaf it signs — so you can
+regenerate server certs forever and never touch the clients again, as long as the
+CA stays installed.
+
+| | Plain self-signed | mkcert |
+|---|---|---|
+| Trust chain | leaf signs itself | local root CA → leaf |
+| Install on clients | the cert, every time it changes | the CA, once |
+| SAN handling | manual `-addext subjectAltName` | pass names; builds proper SAN + `serverAuth` EKU |
+| Blast radius if key leaks | vouches only for itself | CA key can mint a cert for **any** domain → guard `rootCA-key.pem` |
+
+### Using mkcert with this server
+
+On a Mac that has mkcert installed:
+
+```bash
+mkcert -install                                            # trust the local CA on this machine
+mkcert jonathanoliver-ubuntu.local localhost 127.0.0.1     # multi-SAN leaf
+```
+
+Copy the resulting `*.pem` (cert) and `*-key.pem` (key) to the host's cert dir as
+`localhost.pem` / `localhost-key.pem`. The test-dev compose override already wires
+this up — `tests/deploy/override-dev.yml` bind-mounts `./certs → /media/certs:ro`,
+and `launch.sh` skips its self-signed fallback when those files exist, so the
+mounted mkcert pair wins. For k3d, drop them in `$K3S_CERTS_DIR`.
+
+Every client that should get a green padlock needs mkcert's **CA** installed —
+that's the catch, and it's why AppleTV is painful (see [AppleTV](#appletv-and-tvos)).
+
+## Mode 3 — public Let's Encrypt via Cloudflare DNS-01
+
+This is the cert currently on test-dev: a real Let's Encrypt cert for
+`dev.jeoliver.com`. "Issued By: R12 / Let's Encrypt" in a browser confirms it —
+**Cloudflare did not sign it**; Cloudflare is only the DNS provider used to solve
+the ACME challenge.
+
+### How it was issued (recoverable runbook)
+
+The cert was obtained with the **DNS-01** challenge, which proves domain control
+by publishing a TXT record — no inbound port 80/443 needed, so it works for a box
+that isn't WAN-reachable.
+
+1. **Own the domain on Cloudflare.** `jeoliver.com` is hosted on Cloudflare DNS.
+
+2. **Publish an A record** for the subdomain pointing at the box's LAN IP, DNS-only
+   (grey cloud, no proxy):
+
+   ```
+   dev.jeoliver.com  A  192.168.1.50
+   ```
+
+   This is a *public* DNS record holding a *private* IP — see
+   [No WAN exposure](#no-wan-exposure) for why that's safe.
+
+3. **Issue the cert with `lego`** (Go ACME client) using the Cloudflare DNS plugin.
+   Create a scoped Cloudflare API token (Zone → DNS → Edit on `jeoliver.com`) and:
+
+   ```bash
+   export CLOUDFLARE_DNS_API_TOKEN='<scoped-token>'
+   lego --email you@example.com \
+        --dns cloudflare \
+        --domains dev.jeoliver.com \
+        --path /tmp/lego \
+        run --accept-tos
+   ```
+
+   `lego` writes the TXT record via the Cloudflare API, waits for propagation,
+   completes the challenge, and drops `dev.jeoliver.com.crt` (fullchain) +
+   `dev.jeoliver.com.key` under `/tmp/lego/certificates/`.
+
+   > **Security:** the token can edit `jeoliver.com` DNS. Export it for the run
+   > and clear it after; never commit it. If a token ends up in shell history or
+   > a transcript, **revoke it** in the Cloudflare dashboard.
+
+4. **Install the cert** on the host as the server's `localhost.pem` (fullchain) and
+   `localhost-key.pem` (key) — same slots the self-signed/mkcert paths use.
+
+5. **Point the announce URL at the matching name** (see [Announce URL](#the-announce-url-must-match-the-cert)):
+
+   ```
+   INFINITE_STREAM_ANNOUNCE_URL=https://dev.jeoliver.com:21000
+   ```
+
+6. **Renew** — LE certs last 90 days. Cron `lego renew` (weekly) and reinstall.
+   `acme.sh` or `certbot --dns-cloudflare` are equivalent alternatives; `lego` was
+   chosen as a single static binary.
+
+### No WAN exposure
+
+`dev.jeoliver.com` resolves to `192.168.1.50` — an RFC1918 LAN address — in
+**public** DNS. That sounds alarming but isn't:
+
+- **On the LAN:** your machine resolves the name to `192.168.1.50` and connects
+  directly over the local network. The cert name matches → green padlock. The WAN
+  is never involved.
+- **From the internet:** the same lookup returns `192.168.1.50`, which is
+  non-routable on the public internet. There's no port-forward and no firewall
+  hole — the box is invisible from outside.
+
+The only "public" thing is the DNS *record*; the IP it hands out goes nowhere off
+your LAN. Side effect: it publishes your internal IP (harmless), and the name only
+*works* for clients sitting on the `192.168.0.x` network.
+
+## The announce URL must match the cert
+
+`INFINITE_STREAM_ANNOUNCE_URL` is what the rendezvous / "Pair a TV" flow hands to
+clients. **It must use a hostname that's in the cert's SAN**, or every TLS client
+hits the name-mismatch warning:
+
+| Serving this cert | Announce as | Why |
+|---|---|---|
+| LE `dev.jeoliver.com` | `https://dev.jeoliver.com:21000` | only SAN in the cert; LAN clients resolve it via public DNS |
+| mkcert/self-signed with `.local` SAN | `https://jonathanoliver-ubuntu.local:21000` | matches SAN; mDNS resolves it on the LAN with zero DNS setup |
+| TLS off | either name over `http://` | no cert, no name check |
+
+You can't have one **public** cert that's clean for both `dev.jeoliver.com` *and*
+`jonathanoliver-ubuntu.local` — a public CA won't sign `.local`. If you need both
+names clean, that's a self-signed/mkcert multi-SAN cert (and the CA installed on
+clients). Note the Server-Info QR derives its URL from `window.location`, so it
+mismatches if you *manually* browse by a name not in the cert; the announce URL
+only governs the pairing broadcast.
+
+## Why am I getting a warning?
+
+The common case: **a valid cert, wrong name.** Example — the browser shows "not
+secure" for `https://jonathanoliver-ubuntu.local:21000`, but the Certificate
+Viewer says the cert is a real Let's Encrypt cert for `dev.jeoliver.com`. That's
+purely a name mismatch: the cert is trusted and fine, you just reached it by a
+name the cert doesn't list. Browsers let you click through; strict clients don't —
+Go/curl fail hard with:
+
+```
+x509: certificate is valid for dev.jeoliver.com, not jonathanoliver-ubuntu.local
+```
+
+Fixes, in order of cleanliness:
+
+- **Reach it by the name in the cert** — `https://dev.jeoliver.com:21000`. Zero
+  install, instant green padlock (works for LAN clients; see [No WAN exposure](#no-wan-exposure)).
+- **Reissue the cert with the name you want in the SAN** — mkcert if you want
+  `.local`; only a public CA can give a warning-free *real* domain.
+- **Turn TLS off** for cert-free local use.
+
+If the warning is about the *issuer* (not the name) — "self-signed", "unknown
+authority" — that's a **trust** failure: install the cert (self-signed) or the CA
+(mkcert) on that client.
+
+## AppleTV and tvOS
+
+tvOS has no Settings UI to install a profile from a file, and no browser — and an
+AppleTV 4K (2nd gen) has no USB port. A custom cert or CA must be delivered as a
+**configuration profile** (`.mobileconfig`) over the network. Two tools, both
+confusingly named "Configurator":
+
+- **Apple Configurator (iPhone app):** tap **Add → Apple TV**, **hold the phone
+  near the AppleTV**, enter the pairing code shown on the TV, then push the
+  `.mobileconfig` containing your CA. The cleanest wireless path for a portless TV.
+- **Apple Configurator 2 (Mac app):** pairs with the AppleTV over Wi-Fi/Bonjour
+  (Paired Devices → 6-digit code on the TV; needs an Apple ID signed into the app,
+  both devices on the same SSID/VLAN), then drag the `.mobileconfig` onto its tile.
+- **MDM** enrollment pushing the CA profile (overkill for home/dev).
+
+Either way the AppleTV is the highest-friction client — discovery/pairing is
+flaky across VLANs and tvOS versions. That friction is what pushed test-dev toward
+the public LE cert: a publicly-trusted cert needs **nothing** installed on the TV.
+The tradeoff is the LE cert only covers the real domain, so the TV must reach the
+box by `dev.jeoliver.com` (and therefore be on the LAN where that name resolves).
+
+To build the `.mobileconfig` wrapping an mkcert CA:
+
+```bash
+CA_PEM="$HOME/Library/Application Support/mkcert/rootCA.pem"
+B64=$(base64 -i "$CA_PEM" | tr -d '\n')
+# Wrap $B64 in a Configuration Profile plist with a com.apple.security.root
+# payload, then validate with: plutil -lint out.mobileconfig
+```
+
+iOS/web players are more forgiving: ATS exceptions
+(`NSAllowsLocalNetworking` / `NSExceptionAllowsInsecureHTTPLoads`) relax *cleartext*
+and some TLS strictness, which is why streaming sometimes "works" over a
+mismatched `.local` name — but ATS exceptions do **not** disable cert hostname
+validation in general, so don't rely on it.
+
+## Choosing a mode
+
+- **Just developing locally, don't care about the SSE cap** → `INFINITE_STREAM_TLS=off`.
+- **Want HTTP/2 + green padlock on your own machines, reachable by `.local`** →
+  mkcert, install the CA on each client.
+- **Need AppleTV / many clients with zero per-client install** → public LE cert,
+  reach the box by its real domain on the LAN.
+
+See issue #484 for the proposal to wire these into first-class `make` targets
+(`make ssl-mkcert` / `make ssl-letsencrypt`).

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1850,11 +1850,18 @@ func main() {
 	// machine. h2 turns on automatically once TLS is in play.
 	const tlsCertFile = "/etc/nginx/certs/localhost.pem"
 	const tlsKeyFile = "/etc/nginx/certs/localhost-key.pem"
+	// INFINITE_STREAM_TLS=off (or 0/false/no) serves plain HTTP on the
+	// shaper ports instead of TLS, matching nginx's listener so an HTTP
+	// dashboard embeds HTTP playback (no mixed content). Default: on.
+	tlsEnabled := true
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("INFINITE_STREAM_TLS"))) {
+	case "off", "0", "false", "no":
+		tlsEnabled = false
+	}
 	errorCh := make(chan error, len(ports))
 	for _, port := range ports {
 		addr := fmt.Sprintf(":%d", port)
 		go func(bind string) {
-			log.Printf("go-proxy listening on %s (TLS)", bind)
 			srv := &http.Server{
 				Addr:    bind,
 				Handler: router,
@@ -1864,7 +1871,13 @@ func main() {
 				// read. Issue #401.
 				ConnContext: withTCPConnContext,
 			}
-			errorCh <- srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
+			if tlsEnabled {
+				log.Printf("go-proxy listening on %s (TLS)", bind)
+				errorCh <- srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
+			} else {
+				log.Printf("go-proxy listening on %s (plain HTTP)", bind)
+				errorCh <- srv.ListenAndServe()
+			}
 		}(addr)
 	}
 

--- a/tests/characterization/README.md
+++ b/tests/characterization/README.md
@@ -34,8 +34,8 @@ PREFLIGHT — what your environment supports
   ✗ Appium server        not reachable              (fix: only needed for Apple TV automation)
 
 DEVICES (currently discoverable)
-  iphone     Jonathans iPhone        EBB41BDC-...
-  appletv    appletv                 7312834B-...
+  iphone     My iPhone               <udid>
+  appletv    Apple TV                <udid>
 
 RECOMMENDED LAUNCH_MODE=cli
   why: Xcode and/or adb available; CLI handles sim + real iOS + Android TV
@@ -79,6 +79,12 @@ tests/characterization/
 # From the repo root:
 make harness-cli                                                # installs `harness` to ~/.local/bin
 
+# Convenience make targets (wrap overnight.sh per platform; results post to
+# the dashboard's Automated Testing page):
+make characterize-ipad-sim      # or -iphone / -appletv / -androidtv / -web
+make characterize-server        # server_* control-surface checks (tests/server_behavior) vs test-dev
+make automated-testing          # one-shot: server checks, then iPad-sim players
+
 # Smooth sweep on first iPad sim found — no env vars needed.
 # Artifacts land in tests/characterization/artifacts/.
 go test -C tests/characterization ./modes/... \
@@ -88,7 +94,7 @@ go test -C tests/characterization ./modes/... \
 go test -C tests/characterization ./runner/... -v
 
 # Target a specific device (e.g. for parallel runs across two sims)
-CHARACTERIZATION_DEVICE_UDID=8C792303-...                       \
+CHARACTERIZATION_DEVICE_UDID=<device-udid>                      \
   go test -C tests/characterization ./modes/... \
       -v -run TestSmoothIPadSim -timeout 90m -count=1
 

--- a/tests/deploy/override-dev-http.yml
+++ b/tests/deploy/override-dev-http.yml
@@ -1,0 +1,58 @@
+services:
+  go-server:
+    container_name: test-dev-http-server
+    # HTTP-only mirror of test-dev (no TLS — INFINITE_STREAM_TLS=off in .env),
+    # on the 27xxx port range (21-26 are taken on the box by the other test
+    # stacks and an ad-hoc test-docker-run). Shares the encoded content +
+    # sources from the primary test-dev media library so it plays the same
+    # catalogue without a re-upload/re-encode, while keeping its OWN state
+    # (data / logs / clickhouse / grafana) under this stack's CONTENT_DIR.
+    # Content discovery is filesystem-based (go-upload scans
+    # /media/dynamic_content), so overlaying just these dirs is enough for the
+    # catalogue to appear.
+    #
+    # No certs mount and no INFINITE_STREAM_UPSTREAM_PORT override: with TLS off,
+    # nginx's external listener on 30000 is already cleartext, so in-container
+    # go-proxy → nginx calls use it directly (the 30005 loopback split is a
+    # TLS-only concern).
+    volumes:
+      - ${SHARED_CONTENT_DIR}/dynamic_content:/media/dynamic_content
+      - ${SHARED_CONTENT_DIR}/originals:/media/originals
+      - ${SHARED_CONTENT_DIR}/uploads:/media/uploads
+    environment:
+      # Match test-dev's baseline rate cap (#480) for parity.
+      - INFINITE_STREAM_DEFAULT_RATE_MBPS=100
+    ports:
+      !override
+      - "27000:30000"
+      - "27081:30081"
+      - "27181:30181"
+      - "27281:30281"
+      - "27381:30381"
+      - "27481:30481"
+      - "27581:30581"
+      - "27681:30681"
+      - "27781:30781"
+      - "27881:30881"
+  clickhouse:
+    container_name: test-dev-http-clickhouse
+    # Loopback-only, distinct host port from the other stacks.
+    ports:
+      !override
+      - "127.0.0.1:27123:8123"
+  grafana:
+    container_name: test-dev-http-grafana
+    # Reached via the nginx /grafana/ prefix on this stack's port. The root URL
+    # is left to docker-compose.yml's default, which reads INFINITE_STREAM_BASE_URL
+    # — written into the generated .env from $(TEST_HOST) by the make target — so
+    # no hostname is hardcoded here.
+    ports: !override []
+  forwarder:
+    container_name: test-dev-http-forwarder
+    environment:
+      # Plain HTTP to the proxy SSE — with TLS off the shaper/SSE ports are
+      # cleartext (https here would fail the handshake).
+      - FORWARDER_SSE_URL=http://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_events


### PR DESCRIPTION
Part **6 of 6** of the staged v2.0.0 merge. Base: `rel/5-server-tests` (merge after PR 5).

- clean `/dashboard/*.html` URLs + testing-playback/quartet fixes (#531)
- `INFINITE_STREAM_TLS` on/off toggle + nginx→go-proxy proxy-scheme fix; `make test-deploy-dev-http` HTTP-only mirror; `docs/TLS.md`
- `test-deploy-oobe` fix (build+push v3 bundle, pass VERSION)
- port Server Info, first-run setup, access restrictions, and active-job progress badge into the v3 shell
- README + release-notes HTTP/HTTPS coverage; PII scrub ahead of main

Final PR. After this merges, `main` == `dev`.