### PR TITLE
fix(ci): build forwarder image from repo-root context

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,11 @@ jobs:
       - name: Build and push forwarder
         uses: docker/build-push-action@v7
         with:
-          context: ./analytics/go-forwarder
+          # Repo root context (mirrors docker-compose.yml): the forwarder
+          # Dockerfile COPYs go.work + go-proxy/ so its `replace => ../../go-proxy`
+          # resolves. A narrower context breaks with "/analytics/go-forwarder: not found".
+          context: .
+          file: analytics/go-forwarder/Dockerfile
           push: true
           tags: |
             ${{ steps.meta-forwarder-ghcr.outputs.tags }}


### PR DESCRIPTION
## Summary

The v2.0.0 tag's `docker-publish.yml` run published the **server** image fine but the **forwarder** image build failed:

```
failed to compute cache key: ... "/analytics/go-forwarder": not found
```

**Cause:** the forwarder step used `context: ./analytics/go-forwarder`, but `analytics/go-forwarder/Dockerfile` COPYs repo-root-relative paths (`go.work`, `go-proxy/`, `analytics/go-forwarder/`) to satisfy its `replace => ../../go-proxy` workspace directive. The narrow context made those paths absent.

**Fix:** mirror the working `docker-compose.yml` forwarder build — `context: .` + `file: analytics/go-forwarder/Dockerfile`.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-point the `v2.0.0` tag → confirm both `infinite-streaming:v2.0.0` and `infinite-streaming-forwarder:v2.0.0` publish to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)