### PR TITLE
feat(553): threshold-based QoE auto-labels in forwarder

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -3,10 +3,10 @@
 // At ingest, every snapshot / network row gets a small set of label
 // strings stamped onto its `labels` column. Label format:
 //
-//   <severity>=<event>      direct from one column / last_event value
-//   <severity>=*<event>     synthesized — needs cross-row state or
-//                           multi-column logic. The `*` prefix is the
-//                           "introduced by the labeler" signal.
+//	<severity>=<event>      direct from one column / last_event value
+//	<severity>=*<event>     synthesized — needs cross-row state or
+//	                        multi-column logic. The `*` prefix is the
+//	                        "introduced by the labeler" signal.
 //
 // Severities (worst → least): error, critical, warning, info.
 //
@@ -52,6 +52,32 @@ type labelState struct {
 	plays    map[string]*playLabelState // key: player_id|play_id
 	urls     map[string]urlEntry        // key: url; for request_retry
 	lastGCAt time.Time
+	// #553 — QoE label thresholds. Installed once at startup via
+	// SetThresholds; nil falls back to compiled-in defaults so tests
+	// and the no-config boot path stay safe.
+	cfg *QoEThresholds
+}
+
+// fallbackThresholds is the compiled-in default used when no config has
+// been installed (tests, or before SetThresholds runs at startup).
+var fallbackThresholds = qoeDefaults()
+
+// thresholds returns the active QoE thresholds. Caller MUST hold s.mu
+// (the event labeler already does; the network labeler reads under a
+// brief lock).
+func (s *labelState) thresholds() *QoEThresholds {
+	if s.cfg != nil {
+		return s.cfg
+	}
+	return fallbackThresholds
+}
+
+// SetThresholds installs the loaded QoE config. Call once at startup
+// before ingest begins.
+func (s *labelState) SetThresholds(cfg *QoEThresholds) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cfg = cfg
 }
 
 // urlEntry records the most-recent fetch of one URL so the retry
@@ -65,8 +91,8 @@ type urlEntry struct {
 
 type playLabelState struct {
 	// Pair-derivation: open stall/buffering windows.
-	stallStartTs   string
-	stallStartTime time.Time
+	stallStartTs       string
+	stallStartTime     time.Time
 	bufferingStartTs   string
 	bufferingStartTime time.Time
 	// Context detection: ts of the first observed first-frame /
@@ -74,8 +100,66 @@ type playLabelState struct {
 	// classify a stall/buffering as startup / scrub / midplay.
 	firstFrameTime   time.Time
 	lastTimejumpTime time.Time
+	// #553 windowed/dwell state for threshold-based qoe_* labels.
+	// stallBurstTimes / downshiftTimes accumulate event timestamps;
+	// the qoe labeler trims them to the configured window and counts.
+	// minVariantSince marks when the play first pinned the lowest
+	// rung (zero once it climbs off). peakSamples is the recent
+	// server-throughput trail for qoe_throughput_divergence.
+	stallBurstTimes []time.Time
+	downshiftTimes  []time.Time
+	minVariantSince time.Time
+	peakSamples     []tsVal
+	// #553 — terminal aggregate labels (vsf/msf/ebvs + tier) fire once
+	// per play, on the first terminal row. playback_status is sticky
+	// client pass-through, so without this guard a failed session that
+	// keeps heart-beating re-stamps the label on every subsequent row
+	// ("endless qoe_msf").
+	terminalEmitted bool
 	// LRU touch for GC.
 	seen time.Time
+}
+
+// tsVal is a timestamped scalar — recent server-throughput samples for
+// the windowed-peak computation behind qoe_throughput_divergence.
+type tsVal struct {
+	t time.Time
+	v float64
+}
+
+// trimBefore drops entries older than cutoff, in place. Used to bound
+// the per-play windowed slices on every evaluation so they can't grow
+// unbounded between the 5-minute GC sweeps.
+func trimBefore(times []time.Time, cutoff time.Time) []time.Time {
+	kept := times[:0]
+	for _, t := range times {
+		if !t.Before(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
+// recentPeak appends (now, v), drops samples older than window, and
+// returns the trimmed trail plus the max value within it. A zero or
+// negative v is still recorded as a sample timestamp but never lifts
+// the peak.
+func recentPeak(samples []tsVal, now time.Time, v float64, window time.Duration) ([]tsVal, float64) {
+	cutoff := now.Add(-window)
+	kept := samples[:0]
+	for _, s := range samples {
+		if !s.t.Before(cutoff) {
+			kept = append(kept, s)
+		}
+	}
+	kept = append(kept, tsVal{t: now, v: v})
+	var peak float64
+	for _, s := range kept {
+		if s.v > peak {
+			peak = s.v
+		}
+	}
+	return kept, peak
 }
 
 var defaultLabelState = newLabelState()
@@ -158,53 +242,60 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		ps.lastTimejumpTime = now
 	}
 
+	// #550 Phase 3: the LastEvent switch is additive (was early-return).
+	// Each arm appends to `out`; the QoE labeler then layers its
+	// threshold-based labels on top before we return. Keeping the arms
+	// fall-through is what makes the orthogonal qoe_* labels reachable.
+	var out []string
+
 	switch r.LastEvent {
 
 	// info — normal lifecycle worth surfacing
 	case "rate_shift_up":
-		return []string{SevInfo + "=shift_up"}
+		out = []string{SevInfo + "=shift_up"}
 	case "rate_shift_down":
-		return []string{SevInfo + "=shift_down"}
+		out = []string{SevInfo + "=shift_down"}
+		ps.downshiftTimes = append(ps.downshiftTimes, now) // #553 qoe_downshift_storm window
 	case "video_first_frame":
-		labels := []string{SevInfo + "=first_frame"}
+		out = []string{SevInfo + "=first_frame"}
 		if l := videoStartupLabel(r.VideoFirstFrameTimeS); l != "" {
-			labels = append(labels, l)
+			out = append(out, l)
 		}
-		return labels
 	case "video_start_time":
-		return []string{SevInfo + "=playback_start"}
+		out = []string{SevInfo + "=playback_start"}
 
 	// warning — degraded but functioning
 	case "timejump":
-		return []string{SevWarning + "=timejump"}
+		out = []string{SevWarning + "=timejump"}
 	case "segment_stall":
-		return []string{SevWarning + "=stall_segment"}
+		out = []string{SevWarning + "=stall_segment"}
 
 	// critical — user-visible impact
 	case "frozen":
-		return []string{SevCritical + "=stall_frozen"}
+		out = []string{SevCritical + "=stall_frozen"}
 	case "user_marked":
-		return []string{SevCritical + "=user_marked_911"}
+		out = []string{SevCritical + "=user_marked_911"}
 
 	// restart splits on reason — operator-initiated reload is
 	// informational; everything else is an involuntary recovery
 	// the operator should see.
 	case "restart":
 		if r.TriggerType == "reload" {
-			return []string{SevInfo + "=restart_reload"}
+			out = []string{SevInfo + "=restart_reload"}
+		} else {
+			out = []string{SevCritical + "=restart_auto_recovery"}
 		}
-		return []string{SevCritical + "=restart_auto_recovery"}
 
 	// error — system-detected failure
 	case "error":
-		return []string{SevError + "=player_error"}
+		out = []string{SevError + "=player_error"}
 
 	// Pair-derivation: stall_start opens a window; nothing on the
 	// row itself yet (the duration label lands on stall_end).
 	case "stall_start":
 		ps.stallStartTs = r.Ts
 		ps.stallStartTime = now
-		return nil
+		ps.stallBurstTimes = append(ps.stallBurstTimes, now) // #553 qoe_stall_burst window
 	case "stall_end":
 		// stall_duration_ms is the canonical sticky per-event duration.
 		// last_stall_time_s fallback removed; if neither value is set
@@ -215,15 +306,13 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		}
 		ps.stallStartTs = ""
 		ps.stallStartTime = time.Time{}
-		if dur <= 0 {
-			return nil
+		if dur > 0 {
+			out = []string{stallLabel(dur, stallContext(ps, now))}
 		}
-		return []string{stallLabel(dur, stallContext(ps, now))}
 
 	case "buffering_start":
 		ps.bufferingStartTs = r.Ts
 		ps.bufferingStartTime = now
-		return nil
 	case "buffering_end":
 		// Same precedence as stall_end: buffering_duration_ms canonical,
 		// in-process pair cache fills in for clients that don't send it.
@@ -233,12 +322,17 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		}
 		ps.bufferingStartTs = ""
 		ps.bufferingStartTime = time.Time{}
-		if dur <= 0 {
-			return nil
+		if dur > 0 {
+			out = []string{bufferingLabel(dur, bufferingContext(ps, now))}
 		}
-		return []string{bufferingLabel(dur, bufferingContext(ps, now))}
 	}
-	return nil
+
+	// #550 Phase 3 — threshold-based QoE auto-labels. Orthogonal to the
+	// LastEvent switch above; layered on whatever the event arm emitted.
+	// s.thresholds() is read while we still hold s.mu (locked at the top).
+	out = append(out, computeQoEEventLabels(s.thresholds(), ps, r, now)...)
+
+	return out
 }
 
 // bucket categorises a duration in seconds.
@@ -288,9 +382,9 @@ func bufferingContext(ps *playLabelState, now time.Time) string {
 // Sits alongside the existing `info=first_frame` direct emission so a
 // slow cold-start surfaces both signals on the same row.
 //
-//   ttff > 4s  → error=*video_startup_severe
-//   ttff > 2s  → warning=*video_startup_long
-//   else       → "" (fast startup; only the info=first_frame chip lands)
+//	ttff > 4s  → error=*video_startup_severe
+//	ttff > 2s  → warning=*video_startup_long
+//	else       → "" (fast startup; only the info=first_frame chip lands)
 func videoStartupLabel(ttffS float32) string {
 	switch {
 	case ttffS > 4.0:
@@ -402,6 +496,18 @@ func computeNetworkLabelsWithState(s *labelState, r *netRow) []string {
 		}
 		if r.TransferMs > 6000 && isSegmentPath(r.Path) {
 			out = append(out, SevWarning+"=slow_segment")
+		}
+		// #553 — QoE network-tier breaches on clean rows. Thresholds
+		// from config; read under a brief lock (this path doesn't hold
+		// the labelState mutex outside the retry section below).
+		s.mu.Lock()
+		cfg := s.thresholds()
+		s.mu.Unlock()
+		if r.TTFBMs > float32(cfg.Network.TTFBBreachMs) {
+			out = append(out, qoeLabel(SevWarning, "qoe_ttfb_breach"))
+		}
+		if r.TransferMs > float32(cfg.Network.TransferStallMs) {
+			out = append(out, qoeLabel(SevWarning, "qoe_transfer_stall"))
 		}
 	}
 

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -1,0 +1,502 @@
+// labels_test.go — coverage for the write-time labeler (issues #473,
+// #474, #550 Phase 3). TestEventSwitchUnchanged is a characterization
+// guard: it pins every label the LastEvent switch emitted BEFORE the
+// Phase 3 refactor that converted the switch from early-return to an
+// additive `out []string`. If a future change to the switch alters one
+// of these, this test fails loudly rather than silently.
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// minimalRow builds a row that triggers no Phase 3 qoe_* labels: zero
+// residency/error/bitrate inputs, non-terminal status, no manifest
+// ladder. So whatever the LastEvent switch emits is the entire output.
+func minimalRow(lastEvent string) *row {
+	return &row{
+		Ts:             "2026-06-01 00:00:00.000",
+		PlayerID:       "p-char",
+		PlayID:         "play-char",
+		PlaybackStatus: "in_progress",
+		LastEvent:      lastEvent,
+	}
+}
+
+func TestEventSwitchUnchanged(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(r *row)
+		want   []string
+	}{
+		// info — normal lifecycle
+		{"rate_shift_up", nil, []string{"info=shift_up"}},
+		{"rate_shift_down", nil, []string{"info=shift_down"}},
+		{"video_first_frame", nil, []string{"info=first_frame"}},
+		{"video_start_time", nil, []string{"info=playback_start"}},
+		// warning — degraded but functioning
+		{"timejump", nil, []string{"warning=timejump"}},
+		{"segment_stall", nil, []string{"warning=stall_segment"}},
+		// critical — user-visible impact
+		{"frozen", nil, []string{"critical=stall_frozen"}},
+		{"user_marked", nil, []string{"critical=user_marked_911"}},
+		// restart splits on trigger_type
+		{"restart_reload", func(r *row) { r.LastEvent = "restart"; r.TriggerType = "reload" }, []string{"info=restart_reload"}},
+		{"restart_auto", func(r *row) { r.LastEvent = "restart" }, []string{"critical=restart_auto_recovery"}},
+		// error
+		{"error", nil, []string{"error=player_error"}},
+		// pair-open arms emit nothing on the opening row
+		{"stall_start", nil, nil},
+		{"buffering_start", nil, nil},
+		// pair-close arms: sticky per-event duration drives the label.
+		// 1.5s, midplay context (no first-frame witnessed) → long_midplay.
+		{"stall_end", func(r *row) { r.StallDurationMs = 1500 }, []string{"warning=*stall_long_midplay"}},
+		{"buffering_end", func(r *row) { r.BufferingDurationMs = 1500 }, []string{"warning=*stall_long_midplay"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fresh state per case so pair-open/close windows and
+			// first-frame witnesses don't bleed across subtests.
+			s := newLabelState()
+			r := minimalRow(tc.name)
+			if tc.mutate != nil {
+				tc.mutate(r)
+			}
+			got := computeEventLabelsWithState(s, r)
+			assertLabelsEqual(t, got, tc.want)
+		})
+	}
+}
+
+// hasLabel reports whether want is present in labels.
+func hasLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// evalQoE runs one row through the labeler on a fresh state (default
+// thresholds) and returns the labels.
+func evalQoE(r *row) []string {
+	return computeEventLabelsWithState(newLabelState(), r)
+}
+
+const tsBase = "2026-06-01 00:00:00.000"
+
+// --- Startup: VST boundaries -----------------------------------------
+
+func TestQoEVSTBoundaries(t *testing.T) {
+	// Defaults: concerning 5000ms, breach 10000ms. Non-terminal rows so
+	// no tier chip lands.
+	cases := []struct {
+		vst  uint32
+		want string // "" = neither
+	}{
+		{4999, ""},
+		{5000, qoeLabel(SevWarning, "qoe_vst_concerning")},
+		{9999, qoeLabel(SevWarning, "qoe_vst_concerning")},
+		{10000, qoeLabel(SevCritical, "qoe_vst_breach")},
+		{20000, qoeLabel(SevCritical, "qoe_vst_breach")},
+	}
+	for _, tc := range cases {
+		got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoStartTimeMs: tc.vst})
+		if tc.want == "" {
+			if hasLabel(got, qoeLabel(SevWarning, "qoe_vst_concerning")) || hasLabel(got, qoeLabel(SevCritical, "qoe_vst_breach")) {
+				t.Fatalf("vst=%d: expected no VST label, got %v", tc.vst, got)
+			}
+			continue
+		}
+		if !hasLabel(got, tc.want) {
+			t.Fatalf("vst=%d: want %q in %v", tc.vst, tc.want, got)
+		}
+	}
+}
+
+// --- Continuity: CIRR / CIRT boundaries ------------------------------
+
+func TestQoECIRRBoundaries(t *testing.T) {
+	// CIRR = stalling/(stalling+playing). concerning 0.002, breach 0.004.
+	cases := []struct {
+		stalling, playing uint32
+		want              string
+	}{
+		{999, 499001, ""}, // 0.001998 < 0.002
+		{1000, 499000, qoeLabel(SevWarning, "qoe_cirr_concerning")}, // exactly 0.002
+		{2000, 498000, qoeLabel(SevCritical, "qoe_cirr_breach")},    // exactly 0.004
+	}
+	for _, tc := range cases {
+		got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", StallingTimeMs: tc.stalling, PlayingTimeMs: tc.playing})
+		if tc.want == "" {
+			if hasLabel(got, qoeLabel(SevWarning, "qoe_cirr_concerning")) || hasLabel(got, qoeLabel(SevCritical, "qoe_cirr_breach")) {
+				t.Fatalf("cirr(%d,%d): expected none, got %v", tc.stalling, tc.playing, got)
+			}
+			continue
+		}
+		if !hasLabel(got, tc.want) {
+			t.Fatalf("cirr(%d,%d): want %q in %v", tc.stalling, tc.playing, tc.want, got)
+		}
+	}
+}
+
+func TestQoECIRTBoundaries(t *testing.T) {
+	// CIRT = stalling_ms/stalling_count vs 1000/2000. High playing keeps
+	// CIRR silent so we isolate CIRT.
+	const playing = 1_000_000_000
+	cases := []struct {
+		stalling, count uint32
+		want            string
+	}{
+		{9990, 10, ""}, // 999 < 1000
+		{10000, 10, qoeLabel(SevWarning, "qoe_cirt_concerning")}, // 1000
+		{20000, 10, qoeLabel(SevCritical, "qoe_cirt_breach")},    // 2000
+	}
+	for _, tc := range cases {
+		got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", StallingTimeMs: tc.stalling, StallingCount: tc.count, PlayingTimeMs: playing})
+		if tc.want == "" {
+			if hasLabel(got, qoeLabel(SevWarning, "qoe_cirt_concerning")) || hasLabel(got, qoeLabel(SevCritical, "qoe_cirt_breach")) {
+				t.Fatalf("cirt(%d/%d): expected none, got %v", tc.stalling, tc.count, got)
+			}
+			continue
+		}
+		if !hasLabel(got, tc.want) {
+			t.Fatalf("cirt(%d/%d): want %q in %v", tc.stalling, tc.count, tc.want, got)
+		}
+	}
+}
+
+// --- Windowed: stall_burst & downshift_storm -------------------------
+
+func TestQoEStallBurstWindowed(t *testing.T) {
+	// threshold 3, window 60s: the 4th stall_start within the window trips.
+	s := newLabelState()
+	want := qoeLabel(SevCritical, "qoe_stall_burst")
+	for i, ts := range []string{
+		"2026-06-01 00:00:01.000",
+		"2026-06-01 00:00:02.000",
+		"2026-06-01 00:00:03.000",
+		"2026-06-01 00:00:04.000",
+	} {
+		got := computeEventLabelsWithState(s, &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LastEvent: "stall_start"})
+		if i < 3 && hasLabel(got, want) {
+			t.Fatalf("stall #%d should not burst yet: %v", i+1, got)
+		}
+		if i == 3 && !hasLabel(got, want) {
+			t.Fatalf("stall #4 should burst: %v", got)
+		}
+	}
+}
+
+func TestQoEStallBurstWindowExpiry(t *testing.T) {
+	// Stalls spread > window apart never accumulate to a burst.
+	s := newLabelState()
+	want := qoeLabel(SevCritical, "qoe_stall_burst")
+	for _, ts := range []string{
+		"2026-06-01 00:00:00.000",
+		"2026-06-01 00:02:00.000",
+		"2026-06-01 00:04:00.000",
+		"2026-06-01 00:06:00.000",
+	} {
+		got := computeEventLabelsWithState(s, &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LastEvent: "stall_start"})
+		if hasLabel(got, want) {
+			t.Fatalf("ts=%s: stalls 2min apart must not burst: %v", ts, got)
+		}
+	}
+}
+
+func TestQoEDownshiftStormWindowed(t *testing.T) {
+	// threshold 3, window 30s: 4th rate_shift_down within window trips.
+	s := newLabelState()
+	want := qoeLabel(SevWarning, "qoe_downshift_storm")
+	for i, ts := range []string{
+		"2026-06-01 00:00:01.000",
+		"2026-06-01 00:00:05.000",
+		"2026-06-01 00:00:10.000",
+		"2026-06-01 00:00:15.000",
+	} {
+		got := computeEventLabelsWithState(s, &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LastEvent: "rate_shift_down"})
+		if i < 3 && hasLabel(got, want) {
+			t.Fatalf("downshift #%d should not storm yet: %v", i+1, got)
+		}
+		if i == 3 && !hasLabel(got, want) {
+			t.Fatalf("downshift #4 should storm: %v", got)
+		}
+	}
+}
+
+// --- ABR: ladder-aware bitrate cause labels --------------------------
+
+func TestQoEBitrateCauseLabels(t *testing.T) {
+	conservative := qoeLabel(SevWarning, "qoe_abr_conservative")
+	ladderGap := qoeLabel(SevInfo, "qoe_ladder_gap")
+	ladder3 := `[{"bandwidth":1000000},{"bandwidth":5000000},{"bandwidth":8000000}]`
+	ladderGapLadder := `[{"bandwidth":1000000},{"bandwidth":9900000}]`
+
+	cases := []struct {
+		name              string
+		cur, netbw, avgbw float32
+		variants          string
+		wantConservative  bool
+		wantLadderGap     bool
+	}{
+		// cur 1, throughput 10 → 0.1 < 0.5 underutilized; next rung 5 ≤ 8.5 → conservative
+		{"fitting rung", 1, 10, 0, ladder3, true, false},
+		// next rung 9.9 > 8.5 → ladder gap
+		{"no fitting rung", 1, 10, 0, ladderGapLadder, false, true},
+		// at top rung → correctly ceilinged, neither
+		{"top rung", 8, 20, 0, ladder3, false, false},
+		// not underutilized (cur/throughput = 6/10 = 0.6 ≥ 0.5) → neither
+		{"well utilized", 6, 10, 0, ladder3, false, false},
+		// no ladder → can't attribute → neither
+		{"no ladder", 1, 10, 0, "", false, false},
+		// iOS fallback: network_bitrate 0, avg present → uses avg → conservative
+		{"avg fallback", 1, 0, 10, ladder3, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evalQoE(&row{
+				Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+				VideoBitrateMbps: tc.cur, NetworkBitrateMbps: tc.netbw, AvgNetworkBitrateMbps: tc.avgbw,
+				ManifestVariants: tc.variants,
+			})
+			if got1 := hasLabel(got, conservative); got1 != tc.wantConservative {
+				t.Fatalf("conservative=%v want %v (%v)", got1, tc.wantConservative, got)
+			}
+			if got1 := hasLabel(got, ladderGap); got1 != tc.wantLadderGap {
+				t.Fatalf("ladder_gap=%v want %v (%v)", got1, tc.wantLadderGap, got)
+			}
+		})
+	}
+}
+
+func TestQoEBitrateMalformedLadder(t *testing.T) {
+	// Malformed JSON must not panic and must emit no cause label.
+	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+		VideoBitrateMbps: 1, NetworkBitrateMbps: 10, ManifestVariants: "{not json"})
+	if hasLabel(got, qoeLabel(SevWarning, "qoe_abr_conservative")) || hasLabel(got, qoeLabel(SevInfo, "qoe_ladder_gap")) {
+		t.Fatalf("malformed ladder should emit no cause label: %v", got)
+	}
+}
+
+func TestQoEMinVariantStuck(t *testing.T) {
+	// Dwell ≥ 30s at the floor rung trips. Share state across two rows.
+	s := newLabelState()
+	want := qoeLabel(SevWarning, "qoe_min_variant_stuck")
+	ladder := `[{"bandwidth":1000000},{"bandwidth":5000000}]`
+	r1 := &row{Ts: "2026-06-01 00:00:00.000", PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoBitrateMbps: 1, ManifestVariants: ladder}
+	if got := computeEventLabelsWithState(s, r1); hasLabel(got, want) {
+		t.Fatalf("first floor sample should not trip: %v", got)
+	}
+	r2 := &row{Ts: "2026-06-01 00:00:31.000", PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoBitrateMbps: 1, ManifestVariants: ladder}
+	if got := computeEventLabelsWithState(s, r2); !hasLabel(got, want) {
+		t.Fatalf("31s at floor should trip: %v", got)
+	}
+}
+
+func TestQoEFPSDip(t *testing.T) {
+	// dropped/(displayed+dropped) ≥ 0.2.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", FramesDisplayed: 81, FramesDropped: 19}); hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
+		t.Fatalf("19%% drop should not dip: %v", got)
+	}
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", FramesDisplayed: 80, FramesDropped: 20}); !hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
+		t.Fatalf("20%% drop should dip: %v", got)
+	}
+}
+
+// --- Network-tier (event-row inputs) ---------------------------------
+
+func TestQoEThroughputDivergence(t *testing.T) {
+	want := qoeLabel(SevWarning, "qoe_throughput_divergence")
+	// nb matches server peak → no divergence.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 10, MbpsTransferRate: 10}); hasLabel(got, want) {
+		t.Fatalf("matching throughput should not diverge: %v", got)
+	}
+	// nb 5 vs peak 10 → 50% > 15% → diverge.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 5, MbpsTransferRate: 10}); !hasLabel(got, want) {
+		t.Fatalf("nb 5 vs peak 10 should diverge: %v", got)
+	}
+	// nb 5 vs cap 10 (no server peak) → diverge via limit branch.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 5, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("nb 5 vs cap 10 should diverge: %v", got)
+	}
+}
+
+func TestQoERateCapBreach(t *testing.T) {
+	want := qoeLabel(SevWarning, "qoe_rate_cap_breach")
+	// 12 > 10*1.10=11 → breach.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("12 over cap 10 should breach: %v", got)
+	}
+	// 10.5 < 11 → no breach.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 10.5, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
+		t.Fatalf("10.5 within factor should not breach: %v", got)
+	}
+}
+
+func TestQoECMCDMTPDrift(t *testing.T) {
+	want := qoeLabel(SevWarning, "qoe_cmcd_mtp_drift")
+	// measured 10 vs actual 4 → 150% > 50% → drift.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", MeasuredMbps: 10, MbpsTransferRate: 4}); !hasLabel(got, want) {
+		t.Fatalf("measured/actual 10/4 should drift: %v", got)
+	}
+	// measured 5 vs actual 4 → 25% < 50% → no drift.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", MeasuredMbps: 5, MbpsTransferRate: 4}); hasLabel(got, want) {
+		t.Fatalf("measured/actual 5/4 within ratio should not drift: %v", got)
+	}
+}
+
+// --- Network-tier (network-row labels) -------------------------------
+
+func TestQoENetworkRowLabels(t *testing.T) {
+	s := newLabelState()
+	// clean 2xx row, TTFB 600 > 500, transfer 6000 > 5000 stall.
+	got := computeNetworkLabelsWithState(s, &netRow{Ts: tsBase, Status: 200, TTFBMs: 600, TransferMs: 6000})
+	if !hasLabel(got, qoeLabel(SevWarning, "qoe_ttfb_breach")) {
+		t.Fatalf("TTFB 600 should breach: %v", got)
+	}
+	if !hasLabel(got, qoeLabel(SevWarning, "qoe_transfer_stall")) {
+		t.Fatalf("transfer 6000 should stall: %v", got)
+	}
+	// healthy row → neither.
+	got = computeNetworkLabelsWithState(s, &netRow{Ts: tsBase, Status: 200, TTFBMs: 100, TransferMs: 1000})
+	if hasLabel(got, qoeLabel(SevWarning, "qoe_ttfb_breach")) || hasLabel(got, qoeLabel(SevWarning, "qoe_transfer_stall")) {
+		t.Fatalf("healthy row should emit neither: %v", got)
+	}
+}
+
+// --- Live tier -------------------------------------------------------
+
+func TestQoELiveOffset(t *testing.T) {
+	mk := func(off, cfgd float32) []string {
+		return evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+			RecommendedOffsetS: 5, LiveOffsetS: off, ConfiguredOffsetS: cfgd})
+	}
+	concerning := qoeLabel(SevWarning, "qoe_live_offset_concerning")
+	breach := qoeLabel(SevCritical, "qoe_live_offset_breach")
+	holdback := qoeLabel(SevWarning, "qoe_holdback_deviation")
+	// excess 2 < 3 → none; configured == recommended → no holdback.
+	if got := mk(7, 5); hasLabel(got, concerning) || hasLabel(got, breach) || hasLabel(got, holdback) {
+		t.Fatalf("excess 2 / no holdback should be clean: %v", got)
+	}
+	// excess 3 → concerning.
+	if got := mk(8, 5); !hasLabel(got, concerning) {
+		t.Fatalf("excess 3 should be concerning: %v", got)
+	}
+	// excess 10 → breach.
+	if got := mk(15, 5); !hasLabel(got, breach) {
+		t.Fatalf("excess 10 should breach: %v", got)
+	}
+	// configured 8 vs recommended 5 → dev 3 > 2 → holdback.
+	if got := mk(5, 8); !hasLabel(got, holdback) {
+		t.Fatalf("holdback dev 3 should fire: %v", got)
+	}
+}
+
+func TestQoELiveOffsetSilentOnVOD(t *testing.T) {
+	// No recommended offset (VOD) → no live labels.
+	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LiveOffsetS: 60})
+	for _, l := range got {
+		if l == qoeLabel(SevWarning, "qoe_live_offset_concerning") || l == qoeLabel(SevCritical, "qoe_live_offset_breach") {
+			t.Fatalf("VOD row should emit no live-offset label: %v", got)
+		}
+	}
+}
+
+// --- Terminal gate + tier aggregate ----------------------------------
+
+func TestQoETerminalGateAndTier(t *testing.T) {
+	tierPremium := qoeLabel(SevInfo, "qoe_tier_premium")
+	tierAcceptable := qoeLabel(SevWarning, "qoe_tier_acceptable")
+	tierUnacceptable := qoeLabel(SevCritical, "qoe_tier_unacceptable")
+
+	anyTier := func(ls []string) bool {
+		return hasLabel(ls, tierPremium) || hasLabel(ls, tierAcceptable) || hasLabel(ls, tierUnacceptable)
+	}
+
+	// Sticky terminal STATUS without the terminal EVENT → NO tier chip.
+	// This is the fix: post-failure heartbeats carry the status but aren't
+	// the end event, so they must not be classified as the play outcome.
+	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 100})
+	if anyTier(got) {
+		t.Fatalf("sticky terminal status w/o session_end must not get a tier chip: %v", got)
+	}
+
+	// session_end clean → premium.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed"}); !hasLabel(got, tierPremium) {
+		t.Fatalf("clean terminal → premium: %v", got)
+	}
+	// session_end with a warning (VST concerning) → acceptable.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed", VideoStartTimeMs: 6000}); !hasLabel(got, tierAcceptable) {
+		t.Fatalf("warning terminal → acceptable: %v", got)
+	}
+	// play_end with a critical (VST breach) → unacceptable. Also proves the
+	// {session_end, play_end} terminal-event set both trigger.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "play_end", PlaybackStatus: "completed", VideoStartTimeMs: 20000}); !hasLabel(got, tierUnacceptable) {
+		t.Fatalf("critical terminal (play_end) → unacceptable: %v", got)
+	}
+}
+
+func TestQoETerminalFailureLabels(t *testing.T) {
+	// vsf: failed before first frame.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "start_failure", VideoFirstFrameTimeMs: 0}); !hasLabel(got, qoeLabel(SevError, "qoe_vsf")) {
+		t.Fatalf("start_failure pre-first-frame → vsf: %v", got)
+	}
+	// msf: failed after first frame.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}); !hasLabel(got, qoeLabel(SevError, "qoe_msf")) {
+		t.Fatalf("mid_stream_failure post-first-frame → msf: %v", got)
+	}
+	// ebvs: abandoned start — warning (a user can bail during startup).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "abandoned_start"}); !hasLabel(got, qoeLabel(SevWarning, "qoe_ebvs")) {
+		t.Fatalf("abandoned_start → ebvs: %v", got)
+	}
+	// Negative: a failed status WITHOUT the terminal event → no outcome
+	// label (it's a mid-play heartbeat carrying a sticky status).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}); hasLabel(got, qoeLabel(SevError, "qoe_msf")) {
+		t.Fatalf("failed status w/o session_end must not emit msf: %v", got)
+	}
+}
+
+// TestQoETerminalEmitOnce — playback_status is sticky client pass-through,
+// so a failed session re-sends the terminal status on every heartbeat. The
+// terminal aggregates (msf + tier here) must fire only on the FIRST such
+// row, never on the repeats.
+func TestQoETerminalEmitOnce(t *testing.T) {
+	s := newLabelState()
+	msf := qoeLabel(SevError, "qoe_msf")
+	tier := qoeLabel(SevCritical, "qoe_tier_unacceptable")
+	mk := func(ts string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}
+	}
+	first := computeEventLabelsWithState(s, mk("2026-06-01 00:00:00.000"))
+	if !hasLabel(first, msf) || !hasLabel(first, tier) {
+		t.Fatalf("first terminal row should carry msf + tier: %v", first)
+	}
+	for _, ts := range []string{"2026-06-01 00:00:05.000", "2026-06-01 00:00:10.000"} {
+		repeat := computeEventLabelsWithState(s, mk(ts))
+		if hasLabel(repeat, msf) || hasLabel(repeat, tier) {
+			t.Fatalf("sticky-status repeat at %s must NOT re-emit terminal labels: %v", ts, repeat)
+		}
+	}
+}
+
+// assertLabelsEqual compares label slices order-independently — the
+// labeler's ordering is an implementation detail, the set is the
+// contract.
+func assertLabelsEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if len(g) == 0 && len(w) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(g, w) {
+		t.Fatalf("labels mismatch\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -528,6 +528,12 @@ func main() {
 	cfg := loadConfig()
 	log.Printf("forwarder starting: sse=%s ch=%s/%s.%s", cfg.sseURL, cfg.clickhouseURL, cfg.chDatabase, cfg.chTable)
 
+	// #553 — load QoE label thresholds (compiled-in defaults, optionally
+	// overlaid from FORWARDER_QOE_THRESHOLDS_PATH) and install them into
+	// the write-time labeler. loadQoEThresholds logs the resolved tier so
+	// operators can audit which thresholds this deployment is running at.
+	defaultLabelState.SetThresholds(loadQoEThresholds(os.Getenv("FORWARDER_QOE_THRESHOLDS_PATH")))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -1,0 +1,380 @@
+// qoe_labels.go — #553 Phase 3: threshold-based QoE auto-labels.
+//
+// Consumes the #550 Phase 1 (state-residency accumulators) + Phase 2
+// (outcome status / structured error) columns and stamps synthesized
+// `<sev>=*qoe_<event>` labels at ingest. Every numeric threshold is read
+// from the loaded QoEThresholds config (qoe_thresholds.go) — no magic
+// numbers here. These labels flow into row tint, chips, the severity
+// filter, sessions-picker badge counts, and the classification-tier bump
+// with no plumbing beyond this file (they obey the existing label
+// grammar that labels.go documents).
+//
+// All labels are synthesized (cross-column / cross-row), so they carry
+// the `*` synthMark. Severity vocab: `_concerning` → warning; `_breach`
+// → critical; `_vsf`/`_msf` → error; `_ebvs` → warning (a user can bail
+// during startup — not a failure); tier labels map the row's worst qoe
+// severity onto premium/acceptable/unacceptable.
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+// qoeLabel renders a synthesized QoE label in the strict
+// `<sev>=*<event>` grammar.
+func qoeLabel(sev, event string) string {
+	return sev + "=" + synthMark + event
+}
+
+// isPlayTerminalEvent reports whether this row is the play's authoritative
+// terminal row — the client's end-of-play metrics POST carrying the final
+// snapshot + outcome. We key the outcome labels on the discrete END EVENT,
+// NOT on a sticky `playback_status`: the client re-sends the terminal
+// status on every heartbeat after a failure, so gating on status alone
+// stamps the outcome label on every row ("endless qoe_msf").
+//
+// `session_end` is the established cross-client contract today; `play_end`
+// is accepted ahead of the planned cross-platform rename (issue #554) so
+// the labeler is migration-tolerant and historical rows keep classifying.
+// NOTE: the proxy's session-lifecycle `session_end` CONTROL event is a
+// different, correctly session-scoped thing and is unrelated to this.
+func isPlayTerminalEvent(r *row) bool {
+	return r.LastEvent == "session_end" || r.LastEvent == "play_end"
+}
+
+// isFailedStatus reports whether a terminal status represents a failure
+// (vs a clean completion or user stop). Matches any status carrying
+// "fail" so start_failure / mid_stream_failure / failed all qualify.
+// "abandoned_start" is handled separately (qoe_ebvs).
+func isFailedStatus(s string) bool {
+	return strings.Contains(strings.ToLower(s), "fail")
+}
+
+// computeQoEEventLabels stamps the threshold-based QoE labels for one
+// event row. Caller (computeEventLabelsWithState) holds the labelState
+// mutex, so mutating the per-play windowed slices here is safe.
+func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now time.Time) []string {
+	if cfg == nil {
+		cfg = fallbackThresholds
+	}
+	var out []string
+	// firstTerminal is true only on the FIRST authoritative terminal row
+	// (last_event == session_end|play_end). The client re-emits the
+	// terminal POST for delivery reliability, so the emit-once guard stops
+	// vsf/msf/ebvs/tier from being stamped on each re-emit.
+	firstTerminal := isPlayTerminalEvent(r) && !ps.terminalEmitted
+
+	// ── Startup ──────────────────────────────────────────────────────
+	// VST (video start time). Breach takes precedence over concerning.
+	if vst := r.VideoStartTimeMs; vst > 0 {
+		switch {
+		case vst >= cfg.Startup.VSTBreachMs:
+			out = append(out, qoeLabel(SevCritical, "qoe_vst_breach"))
+		case vst >= cfg.Startup.VSTConcerningMs:
+			out = append(out, qoeLabel(SevWarning, "qoe_vst_concerning"))
+		}
+	}
+	if firstTerminal {
+		switch {
+		case r.PlaybackStatus == "abandoned_start":
+			// Exit before video start — a user can simply bail during
+			// startup. Warning, not a system failure.
+			out = append(out, qoeLabel(SevWarning, "qoe_ebvs"))
+		case isFailedStatus(r.PlaybackStatus) && r.VideoFirstFrameTimeMs == 0:
+			out = append(out, qoeLabel(SevError, "qoe_vsf"))
+		case isFailedStatus(r.PlaybackStatus) && r.VideoFirstFrameTimeMs > 0:
+			out = append(out, qoeLabel(SevError, "qoe_msf"))
+		}
+	}
+
+	// ── Continuity ───────────────────────────────────────────────────
+	// CIRR — rebuffer ratio = stalling / (stalling + playing).
+	if denom := r.StallingTimeMs + r.PlayingTimeMs; denom > 0 {
+		cirr := float64(r.StallingTimeMs) / float64(denom)
+		switch {
+		case cirr >= cfg.Continuity.CIRRBreach:
+			out = append(out, qoeLabel(SevCritical, "qoe_cirr_breach"))
+		case cirr >= cfg.Continuity.CIRRConcerning:
+			out = append(out, qoeLabel(SevWarning, "qoe_cirr_concerning"))
+		}
+	}
+	// CIRT — average interruption duration = stalling_ms / stalling_count.
+	if r.StallingCount > 0 {
+		cirt := float64(r.StallingTimeMs) / float64(r.StallingCount)
+		switch {
+		case cirt >= float64(cfg.Continuity.CIRTBreachMs):
+			out = append(out, qoeLabel(SevCritical, "qoe_cirt_breach"))
+		case cirt >= float64(cfg.Continuity.CIRTConcerningMs):
+			out = append(out, qoeLabel(SevWarning, "qoe_cirt_concerning"))
+		}
+	}
+	// Stall burst — > N stall_start within the window (windowed via the
+	// per-play slice the switch records into; trimmed here).
+	{
+		window := time.Duration(cfg.Continuity.StallBurstWindowS) * time.Second
+		ps.stallBurstTimes = trimBefore(ps.stallBurstTimes, now.Add(-window))
+		if uint32(len(ps.stallBurstTimes)) > cfg.Continuity.StallBurstThreshold {
+			out = append(out, qoeLabel(SevCritical, "qoe_stall_burst"))
+		}
+	}
+
+	// ── ABR / quality ────────────────────────────────────────────────
+	out = append(out, abrBitrateLabels(cfg, r)...)
+	// Downshift storm — > N rate_shift_down within the window.
+	{
+		window := time.Duration(cfg.ABR.DownshiftStormWindowS) * time.Second
+		ps.downshiftTimes = trimBefore(ps.downshiftTimes, now.Add(-window))
+		if uint32(len(ps.downshiftTimes)) > cfg.ABR.DownshiftStormThreshold {
+			out = append(out, qoeLabel(SevWarning, "qoe_downshift_storm"))
+		}
+	}
+	if l := minVariantStuckLabel(cfg, ps, r, now); l != "" {
+		out = append(out, l)
+	}
+	if l := fpsDipLabel(cfg, r); l != "" {
+		out = append(out, l)
+	}
+	if l := throughputDivergenceLabel(cfg, ps, r, now); l != "" {
+		out = append(out, l)
+	}
+
+	// ── Live ─────────────────────────────────────────────────────────
+	out = append(out, liveOffsetLabels(cfg, r)...)
+
+	// ── Network (event-row inputs) ───────────────────────────────────
+	if l := rateCapBreachLabel(cfg, r); l != "" {
+		out = append(out, l)
+	}
+	if l := cmcdMTPDriftLabel(cfg, r); l != "" {
+		out = append(out, l)
+	}
+
+	// ── Session-end aggregate tier (first terminal row only) ─────────
+	// Maps the worst severity among this row's qoe_* labels onto a
+	// single tier chip. Emitted once, on the first terminal row (see
+	// firstTerminal above).
+	if firstTerminal {
+		out = append(out, qoeTierLabel(out))
+		ps.terminalEmitted = true
+	}
+
+	return out
+}
+
+// qoeTierLabel collapses the row's worst qoe severity into one tier
+// label. No warning/critical/error ⇒ premium; worst == warning ⇒
+// acceptable; worst >= critical ⇒ unacceptable.
+func qoeTierLabel(labels []string) string {
+	switch worstSeverity(labels) {
+	case SevError, SevCritical:
+		return qoeLabel(SevCritical, "qoe_tier_unacceptable")
+	case SevWarning:
+		return qoeLabel(SevWarning, "qoe_tier_acceptable")
+	default: // info or none
+		return qoeLabel(SevInfo, "qoe_tier_premium")
+	}
+}
+
+// ── ABR helpers ──────────────────────────────────────────────────────
+
+// abrBitrateLabels distinguishes a conservative ABR algorithm from an
+// encoding-ladder gap. Precondition: the chosen variant uses less than
+// BitrateUnderutilizedRatio of available throughput AND isn't already at
+// the top rung. Throughput source is the responsive client measurement
+// (network_bitrate, needs LocalProxy) with the laggy whole-play average
+// as fallback. Then:
+//   - a fitting higher rung exists (next ≤ throughput × headroom) ⇒
+//     qoe_abr_conservative (player should have climbed)
+//   - headroom exists but no rung fits ⇒ qoe_ladder_gap (player correct)
+//
+// With no parseable ladder we can't attribute the cause, so we stay
+// silent rather than guess.
+func abrBitrateLabels(cfg *QoEThresholds, r *row) []string {
+	cur := float64(r.VideoBitrateMbps)
+	if cur <= 0 {
+		return nil
+	}
+	denom := float64(r.NetworkBitrateMbps)
+	if denom <= 0 {
+		denom = float64(r.AvgNetworkBitrateMbps)
+	}
+	if denom <= 0 {
+		return nil
+	}
+	if cur/denom >= cfg.ABR.BitrateUnderutilizedRatio {
+		return nil // using a healthy fraction of the link — not underutilized
+	}
+	ladder := parseVariantLadder(r.ManifestVariants)
+	if len(ladder) == 0 {
+		return nil // no ladder knowledge → can't attribute
+	}
+	if cur >= ladder[len(ladder)-1]*0.999 {
+		return nil // already at the top rung — correctly ceilinged, not underutilized
+	}
+	if next, ok := nextRungAbove(ladder, cur); ok && next <= denom*cfg.ABR.AbrHeadroomMargin {
+		return []string{qoeLabel(SevWarning, "qoe_abr_conservative")}
+	}
+	return []string{qoeLabel(SevInfo, "qoe_ladder_gap")}
+}
+
+// parseVariantLadder parses manifest_variants (JSON array of
+// {bandwidth(bps), average_bandwidth, resolution, url}) into the rung
+// bitrates in Mbps, sorted ascending. Malformed/empty ⇒ nil.
+func parseVariantLadder(raw string) []float64 {
+	if raw == "" || raw == "null" {
+		return nil
+	}
+	var vs []struct {
+		Bandwidth        float64 `json:"bandwidth"`
+		AverageBandwidth float64 `json:"average_bandwidth"`
+	}
+	if err := json.Unmarshal([]byte(raw), &vs); err != nil {
+		return nil
+	}
+	out := make([]float64, 0, len(vs))
+	for _, v := range vs {
+		bw := v.Bandwidth
+		if bw <= 0 {
+			bw = v.AverageBandwidth
+		}
+		if bw > 0 {
+			out = append(out, bw/1e6) // bps → Mbps
+		}
+	}
+	sort.Float64s(out)
+	return out
+}
+
+// nextRungAbove returns the smallest rung strictly above cur (with a
+// small epsilon so the current rung doesn't match itself on float jitter).
+func nextRungAbove(ladder []float64, cur float64) (float64, bool) {
+	for _, m := range ladder { // ascending
+		if m > cur*1.001 {
+			return m, true
+		}
+	}
+	return 0, false
+}
+
+// minVariantStuckLabel fires when the play has dwelt at (within 5% of)
+// the lowest rung for ≥ MinVariantStuckS. Tracks the dwell start on the
+// per-play state; resets the moment it climbs off the floor. Needs ≥2
+// rungs for "at the floor" to mean anything.
+func minVariantStuckLabel(cfg *QoEThresholds, ps *playLabelState, r *row, now time.Time) string {
+	cur := float64(r.VideoBitrateMbps)
+	ladder := parseVariantLadder(r.ManifestVariants)
+	if cur <= 0 || len(ladder) < 2 {
+		ps.minVariantSince = time.Time{}
+		return ""
+	}
+	if cur > ladder[0]*1.05 { // off the floor
+		ps.minVariantSince = time.Time{}
+		return ""
+	}
+	if ps.minVariantSince.IsZero() {
+		ps.minVariantSince = now
+		return ""
+	}
+	if now.Sub(ps.minVariantSince) >= time.Duration(cfg.ABR.MinVariantStuckS)*time.Second {
+		return qoeLabel(SevWarning, "qoe_min_variant_stuck")
+	}
+	return ""
+}
+
+// fpsDipLabel fires when the dropped-frame ratio reaches FPSDipRatio —
+// the proxy for "displayed fps fell below (1 - ratio) of nominal".
+// Uses the cumulative displayed/dropped counters (per-interval rate is
+// Phase 4 work).
+func fpsDipLabel(cfg *QoEThresholds, r *row) string {
+	total := r.FramesDisplayed + uint64(r.FramesDropped)
+	if total == 0 {
+		return ""
+	}
+	if float64(r.FramesDropped)/float64(total) >= cfg.ABR.FPSDipRatio {
+		return qoeLabel(SevWarning, "qoe_fps_dip")
+	}
+	return ""
+}
+
+// throughputDivergenceLabel fires when the client-reported network
+// bitrate diverges by more than ThroughputDivergenceFactor from EITHER
+// the recent-peak server-measured throughput OR the provisioned cap.
+// Always records the current server throughput into the windowed peak
+// trail (even when network_bitrate is absent, so the peak is warm).
+func throughputDivergenceLabel(cfg *QoEThresholds, ps *playLabelState, r *row, now time.Time) string {
+	window := time.Duration(cfg.ABR.ThroughputPeakWindowS) * time.Second
+	var peak float64
+	ps.peakSamples, peak = recentPeak(ps.peakSamples, now, float64(r.MbpsTransferRate), window)
+
+	nb := float64(r.NetworkBitrateMbps)
+	if nb <= 0 {
+		return "" // no responsive client measurement to compare
+	}
+	factor := cfg.ABR.ThroughputDivergenceFactor
+	if peak > 0 && math.Abs(nb-peak)/peak > factor {
+		return qoeLabel(SevWarning, "qoe_throughput_divergence")
+	}
+	if limit := float64(r.EffectiveRateLimitMbps); limit > 0 && math.Abs(nb-limit)/limit > factor {
+		return qoeLabel(SevWarning, "qoe_throughput_divergence")
+	}
+	return ""
+}
+
+// rateCapBreachLabel fires when the observed client network bitrate
+// exceeds the effective cap by more than RateCapBreachFactor. Uses the
+// instantaneous network_bitrate (not the iOS avg, which over-reads).
+func rateCapBreachLabel(cfg *QoEThresholds, r *row) string {
+	limit := float64(r.EffectiveRateLimitMbps)
+	if limit <= 0 {
+		return ""
+	}
+	if float64(r.NetworkBitrateMbps) > limit*cfg.Network.RateCapBreachFactor {
+		return qoeLabel(SevWarning, "qoe_rate_cap_breach")
+	}
+	return ""
+}
+
+// cmcdMTPDriftLabel fires when the client-measured throughput (CMCD mtp,
+// measured_mbps) diverges from the server-observed transfer rate by more
+// than CMCDMTPDriftRatio.
+func cmcdMTPDriftLabel(cfg *QoEThresholds, r *row) string {
+	measured := float64(r.MeasuredMbps)
+	actual := float64(r.MbpsTransferRate)
+	if measured <= 0 || actual <= 0 {
+		return ""
+	}
+	if math.Abs(measured-actual)/actual > cfg.Network.CMCDMTPDriftRatio {
+		return qoeLabel(SevWarning, "qoe_cmcd_mtp_drift")
+	}
+	return ""
+}
+
+// ── Live helpers ─────────────────────────────────────────────────────
+
+// liveOffsetLabels covers live-edge drift. Only meaningful when the
+// manifest advertised a recommended offset (rec > 0) — VOD has none, so
+// these stay silent there.
+func liveOffsetLabels(cfg *QoEThresholds, r *row) []string {
+	rec := float64(r.RecommendedOffsetS)
+	if rec <= 0 {
+		return nil
+	}
+	var out []string
+	if off := float64(r.LiveOffsetS); off > 0 {
+		excess := off - rec
+		switch {
+		case excess >= cfg.Live.OffsetBreachMarginS:
+			out = append(out, qoeLabel(SevCritical, "qoe_live_offset_breach"))
+		case excess >= cfg.Live.OffsetConcerningMarginS:
+			out = append(out, qoeLabel(SevWarning, "qoe_live_offset_concerning"))
+		}
+	}
+	if cfgd := float64(r.ConfiguredOffsetS); cfgd > 0 && math.Abs(cfgd-rec) > cfg.Live.HoldbackDeviationS {
+		out = append(out, qoeLabel(SevWarning, "qoe_holdback_deviation"))
+	}
+	return out
+}

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -43,7 +43,6 @@ type QoEThresholds struct {
 		// watch) vs `user_stopped` (before-substantial-watch, i.e.
 		// bounce).
 		UserStoppedAfterThresholdMs uint32 `json:"user_stopped_after_threshold_ms"`
-
 	} `json:"outcomes"`
 
 	// Phase 3 — auto-labels. Parsed but consumed by a follow-up
@@ -71,19 +70,52 @@ type QoEThresholds struct {
 		RateCapBreachFactor float64 `json:"rate_cap_breach_factor"`
 		CMCDMTPDriftRatio   float64 `json:"cmcd_mtp_drift_ratio"`
 	} `json:"network"`
+
+	// ABR / quality label thresholds (#553). The two bitrate cause
+	// labels (qoe_abr_conservative / qoe_ladder_gap) share the
+	// underutilization ratio + headroom margin; the storm/dwell labels
+	// pair a count/duration with a window.
+	ABR struct {
+		// cur/throughput below this ⇒ underutilized (gate for the two
+		// ladder-aware cause labels).
+		BitrateUnderutilizedRatio float64 `json:"bitrate_underutilized_ratio"`
+		// Next rung "fits" if next_rung_mbps ≤ throughput × this.
+		AbrHeadroomMargin float64 `json:"abr_headroom_margin"`
+		// network_bitrate diverging > this fraction from recent-peak
+		// server throughput OR the cap trips qoe_throughput_divergence.
+		ThroughputDivergenceFactor float64 `json:"throughput_divergence_factor"`
+		// Window (s) over which the recent server-throughput peak is
+		// taken for the divergence comparison.
+		ThroughputPeakWindowS uint32 `json:"throughput_peak_window_s"`
+		// > N rate_shift_down within window ⇒ qoe_downshift_storm.
+		DownshiftStormThreshold uint32 `json:"downshift_storm_threshold"`
+		DownshiftStormWindowS   uint32 `json:"downshift_storm_window_s"`
+		// Dwell (s) pinned at the lowest rung ⇒ qoe_min_variant_stuck.
+		MinVariantStuckS uint32 `json:"min_variant_stuck_s"`
+		// Displayed fps below this fraction of nominal ⇒ qoe_fps_dip.
+		FPSDipRatio float64 `json:"fps_dip_ratio"`
+	} `json:"abr"`
+
+	// Live-edge label thresholds (#553). Margins are seconds BEYOND the
+	// manifest-recommended offset.
+	Live struct {
+		OffsetConcerningMarginS float64 `json:"offset_concerning_margin_s"`
+		OffsetBreachMarginS     float64 `json:"offset_breach_margin_s"`
+		HoldbackDeviationS      float64 `json:"holdback_deviation_s"`
+	} `json:"live"`
 }
 
 // qoeDefaults returns the Conviva "good" tier baked-in defaults.
 // Override values in qoe_thresholds.json or via env var.
 func qoeDefaults() *QoEThresholds {
 	t := &QoEThresholds{Version: "1.0"}
-	t.Outcomes.EBVSThresholdMs = 10000              // Conviva "good"
-	t.Outcomes.UserStoppedAfterThresholdMs = 5000   // 5s = substantial-watch threshold
-	t.Startup.VSTConcerningMs = 5000                // Conviva "best"
-	t.Startup.VSTBreachMs = 10000                   // Conviva "good"
+	t.Outcomes.EBVSThresholdMs = 10000            // Conviva "good"
+	t.Outcomes.UserStoppedAfterThresholdMs = 5000 // 5s = substantial-watch threshold
+	t.Startup.VSTConcerningMs = 5000              // Conviva "best"
+	t.Startup.VSTBreachMs = 10000                 // Conviva "good"
 	t.Startup.DRMDominantRatio = 0.5
-	t.Continuity.CIRRConcerning = 0.002             // Conviva "best"
-	t.Continuity.CIRRBreach = 0.004                 // Conviva "good"
+	t.Continuity.CIRRConcerning = 0.002 // Conviva "best"
+	t.Continuity.CIRRBreach = 0.004     // Conviva "good"
 	t.Continuity.CIRTConcerningMs = 1000
 	t.Continuity.CIRTBreachMs = 2000
 	t.Continuity.StallBurstThreshold = 3
@@ -92,6 +124,17 @@ func qoeDefaults() *QoEThresholds {
 	t.Network.TransferStallMs = 5000
 	t.Network.RateCapBreachFactor = 1.10
 	t.Network.CMCDMTPDriftRatio = 0.5
+	t.ABR.BitrateUnderutilizedRatio = 0.5   // variant using < half the link
+	t.ABR.AbrHeadroomMargin = 0.85          // need ~15% headroom to sustain a rung
+	t.ABR.ThroughputDivergenceFactor = 0.15 // >15% client/server disagreement
+	t.ABR.ThroughputPeakWindowS = 30
+	t.ABR.DownshiftStormThreshold = 3
+	t.ABR.DownshiftStormWindowS = 30
+	t.ABR.MinVariantStuckS = 30
+	t.ABR.FPSDipRatio = 0.2 // displayed fps < 80% of nominal
+	t.Live.OffsetConcerningMarginS = 3
+	t.Live.OffsetBreachMarginS = 10
+	t.Live.HoldbackDeviationS = 2
 	return t
 }
 
@@ -171,6 +214,39 @@ func loadQoEThresholds(path string) *QoEThresholds {
 	if override.Network.CMCDMTPDriftRatio != 0 {
 		cfg.Network.CMCDMTPDriftRatio = override.Network.CMCDMTPDriftRatio
 	}
+	if override.ABR.BitrateUnderutilizedRatio != 0 {
+		cfg.ABR.BitrateUnderutilizedRatio = override.ABR.BitrateUnderutilizedRatio
+	}
+	if override.ABR.AbrHeadroomMargin != 0 {
+		cfg.ABR.AbrHeadroomMargin = override.ABR.AbrHeadroomMargin
+	}
+	if override.ABR.ThroughputDivergenceFactor != 0 {
+		cfg.ABR.ThroughputDivergenceFactor = override.ABR.ThroughputDivergenceFactor
+	}
+	if override.ABR.ThroughputPeakWindowS != 0 {
+		cfg.ABR.ThroughputPeakWindowS = override.ABR.ThroughputPeakWindowS
+	}
+	if override.ABR.DownshiftStormThreshold != 0 {
+		cfg.ABR.DownshiftStormThreshold = override.ABR.DownshiftStormThreshold
+	}
+	if override.ABR.DownshiftStormWindowS != 0 {
+		cfg.ABR.DownshiftStormWindowS = override.ABR.DownshiftStormWindowS
+	}
+	if override.ABR.MinVariantStuckS != 0 {
+		cfg.ABR.MinVariantStuckS = override.ABR.MinVariantStuckS
+	}
+	if override.ABR.FPSDipRatio != 0 {
+		cfg.ABR.FPSDipRatio = override.ABR.FPSDipRatio
+	}
+	if override.Live.OffsetConcerningMarginS != 0 {
+		cfg.Live.OffsetConcerningMarginS = override.Live.OffsetConcerningMarginS
+	}
+	if override.Live.OffsetBreachMarginS != 0 {
+		cfg.Live.OffsetBreachMarginS = override.Live.OffsetBreachMarginS
+	}
+	if override.Live.HoldbackDeviationS != 0 {
+		cfg.Live.HoldbackDeviationS = override.Live.HoldbackDeviationS
+	}
 	log.Printf("[QoE] loaded overrides from %s", path)
 	logQoEResolved(cfg)
 	return cfg
@@ -183,8 +259,14 @@ func logQoEResolved(cfg *QoEThresholds) {
 	log.Printf("[QoE]   continuity.cirr_breach=%.4f cirt_breach_ms=%d stall_burst=%d/%ds",
 		cfg.Continuity.CIRRBreach, cfg.Continuity.CIRTBreachMs,
 		cfg.Continuity.StallBurstThreshold, cfg.Continuity.StallBurstWindowS)
-	log.Printf("[QoE]   network.ttfb_breach_ms=%d transfer_stall_ms=%d",
-		cfg.Network.TTFBBreachMs, cfg.Network.TransferStallMs)
+	log.Printf("[QoE]   network.ttfb_breach_ms=%d transfer_stall_ms=%d rate_cap_breach_factor=%.2f cmcd_mtp_drift_ratio=%.2f",
+		cfg.Network.TTFBBreachMs, cfg.Network.TransferStallMs,
+		cfg.Network.RateCapBreachFactor, cfg.Network.CMCDMTPDriftRatio)
+	log.Printf("[QoE]   abr.bitrate_underutilized_ratio=%.2f abr_headroom_margin=%.2f throughput_divergence_factor=%.2f downshift_storm=%d/%ds min_variant_stuck_s=%d fps_dip_ratio=%.2f",
+		cfg.ABR.BitrateUnderutilizedRatio, cfg.ABR.AbrHeadroomMargin, cfg.ABR.ThroughputDivergenceFactor,
+		cfg.ABR.DownshiftStormThreshold, cfg.ABR.DownshiftStormWindowS, cfg.ABR.MinVariantStuckS, cfg.ABR.FPSDipRatio)
+	log.Printf("[QoE]   live.offset_concerning_margin_s=%.1f offset_breach_margin_s=%.1f holdback_deviation_s=%.1f",
+		cfg.Live.OffsetConcerningMarginS, cfg.Live.OffsetBreachMarginS, cfg.Live.HoldbackDeviationS)
 }
 
 // Suppress the unused-import error in case fmt isn't otherwise


### PR DESCRIPTION
## What

Phase 3 of the #550 observability epic — emits **26 threshold-based QoE auto-labels** at ingest in `analytics/go-forwarder`, all thresholds sourced from the `qoe_thresholds` config (no magic numbers). Fixes #553.

## Labels (26)

- **Startup:** `qoe_vst_concerning/breach`, `qoe_vsf`, `qoe_ebvs`
- **Continuity:** `qoe_cirr_concerning/breach`, `qoe_cirt_concerning/breach`, `qoe_stall_burst`, `qoe_msf`
- **ABR:** `qoe_abr_conservative`, `qoe_ladder_gap` (ladder-aware: poor-ABR vs encoding-gap), `qoe_throughput_divergence`, `qoe_downshift_storm`, `qoe_min_variant_stuck`, `qoe_fps_dip`
- **Live:** `qoe_live_offset_concerning/breach`, `qoe_holdback_deviation`
- **Network:** `qoe_rate_cap_breach` + `qoe_cmcd_mtp_drift` (event rows), `qoe_ttfb_breach` + `qoe_transfer_stall` (network rows)
- **Session-end aggregate:** `qoe_tier_premium/acceptable/unacceptable`

## Notable design points

- **Resurrects the dead `loadQoEThresholds()`** — wired at startup, threaded into the labeler via `labelState.SetThresholds`; logs the resolved tier on boot.
- Adds `ABR` + `Live` threshold groups to `qoe_thresholds.go` (`DRMDominantRatio` left unused per review).
- **Switch refactor:** `computeEventLabelsWithState` went from an early-return `switch` to additive `out[]` so the orthogonal `qoe_*` labels are reachable — guarded by `TestEventSwitchUnchanged` (pins the 14 pre-existing labels).
- **Outcome labels key on the discrete terminal EVENT** (`last_event ∈ {session_end, play_end}`) with an emit-once guard — *not* the sticky `playback_status` (which repeats on every post-failure heartbeat and produced "endless `qoe_msf`"). `play_end` is accepted ahead of the #554 rename, so the labeler is migration-tolerant.
- Severity: `_concerning`=warning, `_breach`=critical, `vsf`/`msf`=error, `ebvs`=warning.
- **No schema change, no new columns.** All logic in `labels.go` + new `qoe_labels.go` (+ tests) and the threshold-config/startup wiring.

## Testing

`go build`/`vet`/`gofmt`/`go test`/`go test -race` all clean. New `labels_test.go`: per-label boundary tables, windowed (`stall_burst`/`downshift_storm`/`min_variant_stuck`), ladder-aware ABR, network-row, terminal-event gate + emit-once, tier composition. Deployed to test-dev and confirmed labels render on a driven faulted session.

## Follow-ups surfaced (filed separately)

- #554 — `session_end` → `play_end` cross-platform rename (+ Roku terminal event)
- #556 — proxy synthesizes a terminal frame on silent session end (crash/timeout)
- #557 — `terminal_error_*` unplumbed on iOS + Android
- #558 — v2 `/network_requests` read API doesn't project `labels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
