### PR TITLE
fix(558): project labels[] in v2 /network_requests read API

### DIFF
--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -376,7 +376,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		  method, url, upstream_url, request_kind, content_type,
 		  status, bytes_in, bytes_out,
 		  ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		  faulted, fault_type, fault_action, fault_category
+		  faulted, fault_type, fault_action, fault_category, labels
 		FROM (
 		  SELECT
 		    ts AS ts_raw,
@@ -384,7 +384,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		    method, url, upstream_url, request_kind, content_type,
 		    status, bytes_in, bytes_out,
 		    ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		    faulted, fault_type, fault_action, fault_category
+		    faulted, fault_type, fault_action, fault_category, labels
 		  FROM %s.network_requests
 		  WHERE %s
 		  -- DESC so the LIMIT keeps the most recent N rows. ASC
@@ -436,6 +436,14 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		}
 		if pid, _ := row["play_id"].(string); pid != "" {
 			item["play_id"] = pid
+		}
+		// #558 — surface the ingest-time labels[] so the dashboard can
+		// render network-row chips (http_5xx / slow_segment / fault_* and
+		// the #553 qoe_ttfb_breach / qoe_transfer_stall). NetworkLogEntry
+		// has no labels field, so patch it onto the row map directly,
+		// mirroring how ts/session_id/player_id are added above.
+		if labels, ok := row["labels"]; ok && labels != nil {
+			item["labels"] = labels
 		}
 		out = append(out, item)
 	}


### PR DESCRIPTION
## What

The v2 `/network_requests` read API wasn't projecting the `labels` column, so network-row chips never rendered on the dashboard — a silent regression that affected the **pre-existing** network labels (`http_5xx`, `slow_segment`, `fault_*`, `*segment_failure`, `*transport_*`, `*request_retry`) as well as #553's `qoe_ttfb_breach` / `qoe_transfer_stall`. Fixes #558.

## Change

- Add `labels` to both the inner and outer SELECT in `v2NetworkRequestsHandler` (`analytics/go-forwarder/v2_handlers.go`).
- Patch `labels` onto the output row map — same pattern as `ts`/`session_id`/`player_id`, which also aren't part of the `NetworkLogEntry` schema. So no OpenAPI change for consistency.
- **No frontend change:** `NetworkLog.vue` already has a `labels: string[]` row field, a "Labels" column, and severity-colored chip rendering (`labelSeverity`/`labelName`) — it was just never fed.

## Verification

Deployed to test-dev. `/api/v2/network_requests` now returns labels on faulted/error rows (e.g. `error=http_5xx`, `warning=slow_segment`, `warning=*segment_failure`, `warning=*transport_disconnect`) — **was 0 rows-with-labels before, 5 after** on the same archived play. `go build`/`vet`/`gofmt`/`test` clean.

## Note

`qoe_ttfb_breach` (from #553) keys on `netRow.TTFBMs`, which is the **proxy→origin** hop (sub-ms) rather than client-perceived TTFB — so that particular label won't fire meaningfully until its input is revisited. Captured in #558's body; out of scope for this projection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
