### PR TITLE
feat(556): proxy synthesizes terminal session_events frame on inactive timeout

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -974,6 +974,63 @@ func (a *App) recordSessionEnd(session SessionData, reason string) {
 		source = "harness"
 	}
 	a.emitControlEventForSession(sessionID, source, "session_end", reason)
+
+	// #556 — for a silent death (the player stopped POSTing without a
+	// clean client session_end), synthesize a terminal session_events
+	// frame from the last-known snapshot so the play still gets an
+	// outcome row + QoE outcome labels (vsf/msf/ebvs/tier). Only for
+	// inactive_timeout: operator delete/clear is administrative teardown,
+	// not a play outcome, and a clean client session_end already covers
+	// the happy path (and is deduped below).
+	if reason == "inactive_timeout" {
+		a.synthesizeTerminalSessionEvent(session, reason)
+	}
+}
+
+// synthesizeTerminalSessionEvent publishes one session_events frame
+// stamped as the play's terminal row, derived from the last-known
+// session snapshot. No-op when the client already delivered its own
+// session_end (dedupe on last_event) so we never double-stamp.
+//
+// playback_status: respect a terminal status the client managed to set
+// before going silent; otherwise classify by whether playback ever
+// started — pre-first-frame => abandoned_start (qoe_ebvs), post-first-
+// frame => user_stopped. We deliberately do NOT fabricate a failure
+// (mid_stream_failure): the proxy can't prove one, and a silent
+// disappearance is almost always the user leaving.
+func (a *App) synthesizeTerminalSessionEvent(session SessionData, reason string) {
+	if a == nil {
+		return
+	}
+	if frame, ok := terminalFrameForSession(session, reason); ok {
+		a.emitSessionEvent(frame)
+	}
+}
+
+// terminalFrameForSession derives the synthesized terminal frame from a
+// last-known session snapshot. Pure (no App state) so it's unit-testable.
+// Returns ok=false when no frame should be emitted: a nil session, or
+// the client already delivered its own session_end (dedupe on
+// last_event).
+func terminalFrameForSession(session SessionData, reason string) (SessionData, bool) {
+	if session == nil {
+		return nil, false
+	}
+	if getString(session, "player_metrics_last_event") == "session_end" {
+		return nil, false // client ended cleanly — don't double-stamp
+	}
+	frame := cloneSession(session)
+	frame["player_metrics_last_event"] = "session_end"
+	frame["player_metrics_trigger_type"] = "session_end"
+	if status := getString(session, "player_metrics_playback_status"); status == "" || status == "in_progress" {
+		if getInt(session, "player_metrics_video_first_frame_time_ms") > 0 {
+			frame["player_metrics_playback_status"] = "user_stopped"
+		} else {
+			frame["player_metrics_playback_status"] = "abandoned_start"
+		}
+		frame["player_metrics_playback_reason"] = reason
+	}
+	return frame, true
 }
 
 func (s *NftShapeStep) UnmarshalJSON(data []byte) error {

--- a/go-proxy/cmd/server/synthesize_terminal_test.go
+++ b/go-proxy/cmd/server/synthesize_terminal_test.go
@@ -1,0 +1,94 @@
+package main
+
+import "testing"
+
+// Covers terminalFrameForSession (#556) — the pure frame-builder behind
+// the proxy's synthesized terminal session_events frame on inactive
+// timeout. Verifies the playback_status mapping, reason carry, and the
+// dedupe against a client's own session_end.
+func TestTerminalFrameForSession(t *testing.T) {
+	const reason = "inactive_timeout"
+
+	t.Run("pre-first-frame timeout -> abandoned_start", func(t *testing.T) {
+		frame, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":                "playing",
+			"player_metrics_playback_status":           "in_progress",
+			"player_metrics_video_first_frame_time_ms": 0,
+		}, reason)
+		if !ok {
+			t.Fatal("expected a frame")
+		}
+		if got := getString(frame, "player_metrics_last_event"); got != "session_end" {
+			t.Fatalf("last_event = %q, want session_end", got)
+		}
+		if got := getString(frame, "player_metrics_playback_status"); got != "abandoned_start" {
+			t.Fatalf("playback_status = %q, want abandoned_start", got)
+		}
+		if got := getString(frame, "player_metrics_playback_reason"); got != reason {
+			t.Fatalf("playback_reason = %q, want %q", got, reason)
+		}
+	})
+
+	t.Run("post-first-frame timeout -> user_stopped", func(t *testing.T) {
+		frame, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":                "heartbeat",
+			"player_metrics_playback_status":           "in_progress",
+			"player_metrics_video_first_frame_time_ms": 1200,
+		}, reason)
+		if !ok {
+			t.Fatal("expected a frame")
+		}
+		if got := getString(frame, "player_metrics_playback_status"); got != "user_stopped" {
+			t.Fatalf("playback_status = %q, want user_stopped", got)
+		}
+	})
+
+	t.Run("client already set a terminal status -> respected, no reason override", func(t *testing.T) {
+		frame, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":                "error",
+			"player_metrics_playback_status":           "mid_stream_failure",
+			"player_metrics_playback_reason":           "decoder_init",
+			"player_metrics_video_first_frame_time_ms": 800,
+		}, reason)
+		if !ok {
+			t.Fatal("expected a frame")
+		}
+		if got := getString(frame, "player_metrics_playback_status"); got != "mid_stream_failure" {
+			t.Fatalf("playback_status = %q, want mid_stream_failure (client's own)", got)
+		}
+		if got := getString(frame, "player_metrics_playback_reason"); got != "decoder_init" {
+			t.Fatalf("playback_reason = %q, want decoder_init (not overwritten)", got)
+		}
+		if got := getString(frame, "player_metrics_last_event"); got != "session_end" {
+			t.Fatalf("last_event = %q, want session_end", got)
+		}
+	})
+
+	t.Run("client already sent session_end -> dedupe (no frame)", func(t *testing.T) {
+		if _, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":      "session_end",
+			"player_metrics_playback_status": "completed",
+		}, reason); ok {
+			t.Fatal("expected no frame when client already ended cleanly")
+		}
+	})
+
+	t.Run("nil session -> no frame", func(t *testing.T) {
+		if _, ok := terminalFrameForSession(nil, reason); ok {
+			t.Fatal("expected no frame for nil session")
+		}
+	})
+
+	t.Run("does not mutate the source session", func(t *testing.T) {
+		src := SessionData{
+			"player_metrics_last_event":      "playing",
+			"player_metrics_playback_status": "in_progress",
+		}
+		if _, ok := terminalFrameForSession(src, reason); !ok {
+			t.Fatal("expected a frame")
+		}
+		if got := getString(src, "player_metrics_last_event"); got != "playing" {
+			t.Fatalf("source mutated: last_event = %q, want playing", got)
+		}
+	})
+}


### PR DESCRIPTION
## What

When a player dies **silently** — force-kill, crash, network drop — it never sends its own `session_end` metrics POST, so the play had **no terminal row** on `session_events`, and #553's QoE outcome labels (`vsf`/`msf`/`ebvs`/`tier`) never fired for it. `recordSessionEnd` previously only wrote the internal lifecycle ledger + a `control_events` `session_end`. Fixes #556.

## Change (go-proxy)

On **`inactive_timeout`**, synthesize one terminal `session_events` frame from the last-known snapshot and publish it via the existing `emitSessionEvent` path:

- `last_event = trigger_type = session_end` — the forwarder already keys outcome labels on this (#553), so it gets classified with no forwarder change.
- **`playback_status`:** respect a terminal status the client managed to set before going silent; otherwise **pre-first-frame → `abandoned_start`** (`qoe_ebvs`), **post-first-frame → `user_stopped`**. Deliberately **not** `mid_stream_failure` — the proxy can't prove a failure, and a silent disappearance is almost always the user leaving.
- **End reason** carried in `playback_reason` (`inactive_timeout`) — no schema change / new column.
- **Deduped** against the client's own `session_end` (never double-stamps the happy path).

Only `inactive_timeout` synthesizes a frame — operator `delete`/`clear` is administrative teardown, not a play outcome (already recorded in `control_events`).

## Testing

Frame-builder extracted as the pure `terminalFrameForSession()` and unit-tested: status mapping (pre/post first frame), client-terminal-status respect, reason carry, dedupe, and no source-mutation. `go build`/`vet`/`test` green; diff is +57 in `main.go` (no reformat churn — the file's pre-existing gofmt misalignment is left untouched).

## Live verification (not yet run — needs a go-server redeploy)

Live test requires `make test-deploy-dev` (rebuilds/restarts go-server, which restarts the proxy + drops active player sockets) and a 60s timeout scenario. Logic is covered by unit tests; happy to run the live deploy on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
