### PR TITLE
fix(557): populate terminal_error_* on iOS + Android session_end rows

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -943,6 +943,17 @@ public final class PlaybackMetrics {
                 p.put("player_metrics_error_domain", lastErrorDomain);
                 p.put("player_metrics_error_details", lastErrorDetails);
             }
+            // #557 — on a terminal row, surface the fatal error in the
+            // dedicated terminal_error_* slot too (was always empty
+            // before, so the failure reason was lost on the session_end
+            // row). The forwarder's error_classifier + dashboard tiles
+            // read terminal_error_* specifically; mirror the error_*
+            // capture above, gated on the play having ended.
+            if (terminalStatus != null && (lastErrorCode != 0 || !lastErrorDomain.isEmpty())) {
+                p.put("player_metrics_terminal_error_code", lastErrorCode);
+                p.put("player_metrics_terminal_error_domain", lastErrorDomain);
+                p.put("player_metrics_terminal_error_details", lastErrorDetails);
+            }
 
             // #550 Phase 4 — device / platform / version taxonomy.
             // Stamped on every row (Mux / Conviva pattern); the

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -241,6 +241,16 @@ final class PlaybackDiagnostics: ObservableObject {
     @Published var terminalStatus: String? = nil
     @Published var terminalReason: String? = nil
 
+    /// Terminal error captured from the fatal AVFoundation NSError that
+    /// ended the play (#557). Stamped once, alongside markTerminal, onto
+    /// the session_end row's `player_metrics_terminal_error_*` so the
+    /// forwarder's error_classifier can derive a specific failure reason.
+    /// Code 0 + empty domain = "no error captured" (a clean
+    /// completed / user_stopped end). Cleared by resetForFreshPlay.
+    @Published var terminalErrorCode: Int = 0
+    @Published var terminalErrorDomain: String = ""
+    @Published var terminalErrorDetails: String = ""
+
     /// Threshold (seconds) above which a user_stopped row whose state
     /// was buffering / stalled is marked `_long`. Same value across
     /// every client platform — the vocabulary is contract-shaped, not
@@ -261,6 +271,18 @@ final class PlaybackDiagnostics: ObservableObject {
         guard terminalStatus == nil else { return }
         terminalStatus = status
         terminalReason = refineTerminalReason(baseReason: reason, status: status)
+    }
+
+    /// Capture the fatal NSError that ended the play (#557). First call
+    /// wins, mirroring markTerminal, so the first detected error is the
+    /// one stamped on the session_end row. No-op for a zero code +
+    /// empty domain (nothing to record).
+    func markTerminalError(code: Int, domain: String, details: String) {
+        guard terminalErrorCode == 0 && terminalErrorDomain.isEmpty else { return }
+        guard code != 0 || !domain.isEmpty else { return }
+        terminalErrorCode = code
+        terminalErrorDomain = domain
+        terminalErrorDetails = details
     }
 
     /// Returns the playback_reason to stamp on a session_end row,
@@ -519,6 +541,9 @@ final class PlaybackDiagnostics: ObservableObject {
         // terminal state of a play if it already crossed terminal.
         terminalStatus = nil
         terminalReason = nil
+        terminalErrorCode = 0
+        terminalErrorDomain = ""
+        terminalErrorDetails = ""
         // Fresh play → restart the EBVS clock. Nil now so reset()'s
         // nil-coalesce sets it to the new Date() at this fresh play
         // boundary, not the prior play's start.

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1380,14 +1380,16 @@ final class PlayerViewModel: ObservableObject {
         }
         // No auto-recovery → this error is terminal. start_failure if
         // we never reached first frame, otherwise mid_stream_failure.
-        markFatalTerminal(message: message)
+        markFatalTerminal(error: error, message: message)
     }
 
     private func handleErrorRetry(reason: String) {
         guard codecRetries < maxCodecRetries, let url = currentURL else {
             // Retry budget exhausted → the play is dead. Distinguish
-            // pre-vs-post-first-frame for the right Phase 2 status.
-            markFatalTerminal(message: reason)
+            // pre-vs-post-first-frame for the right Phase 2 status. No
+            // NSError on this path (retry exhaustion, not a single fatal
+            // error), so only the reason string is carried.
+            markFatalTerminal(error: nil, message: reason)
             return
         }
         codecRetries += 1
@@ -1401,15 +1403,22 @@ final class PlayerViewModel: ObservableObject {
 
     /// Stamp the play as fatally terminated and emit session_end. The
     /// status is `start_failure` when the player never crossed first
-    /// frame, `mid_stream_failure` after. iOS doesn't yet inspect the
-    /// underlying NSError domain/code to populate a specific
-    /// playback_reason — the forwarder error_classifier (4d8265f) will
-    /// pick that up from terminal_error_* in a follow-up; for now we
-    /// stamp the generic "unknown" so dashboards bucket correctly.
-    private func markFatalTerminal(message: String) {
+    /// frame, `mid_stream_failure` after. When a fatal NSError is in
+    /// hand (#557) capture its domain/code/description into the terminal
+    /// error fields so the session_end row carries `terminal_error_*` and
+    /// the forwarder's error_classifier can derive a specific reason.
+    /// The retry-exhaustion path passes error=nil (only a reason string).
+    private func markFatalTerminal(error: Error?, message: String) {
         let status = diagnostics.hasRenderedFirstFrame ? "mid_stream_failure" : "start_failure"
+        if let nsErr = error as NSError? {
+            diagnostics.markTerminalError(
+                code: nsErr.code,
+                domain: nsErr.domain,
+                details: nsErr.localizedDescription
+            )
+        }
         endSession(status: status, reason: "unknown")
-        NSLog("[endSession] fatal status=\(status) message=\(message)")
+        NSLog("[endSession] fatal status=\(status) message=\(message) err=\((error as NSError?).map { "\($0.domain)#\($0.code)" } ?? "none")")
     }
 
     // MARK: - Persistence (UserDefaults)
@@ -2436,6 +2445,13 @@ extension PlayerViewModel {
             "player_metrics_playback_status": diagnostics.terminalStatus ?? "in_progress",
             "player_metrics_playback_reason": diagnostics.terminalReason ?? diagnostics.state,
             "player_metrics_error_count": diagnostics.errorCount,
+            // #557 — fatal error captured at terminal (0 / "" when none).
+            // Lets the forwarder's error_classifier derive a specific
+            // failure reason; previously these were always empty so the
+            // error was lost on iOS failures.
+            "player_metrics_terminal_error_code": diagnostics.terminalErrorCode,
+            "player_metrics_terminal_error_domain": diagnostics.terminalErrorDomain,
+            "player_metrics_terminal_error_details": diagnostics.terminalErrorDetails,
             // stall_stuck: sticky true when AVPlayer transitioned
             // from .waitingToPlay to .paused mid-stall. The player
             // WILL NOT auto-recover; the dashboard / operator needs


### PR DESCRIPTION
## What

The #550 Phase 2 `terminal_error_code/domain/details` columns were never populated on either client, so the fatal-error reason was lost on failure `session_end` rows. Observed on live test-dev: both empty on iOS **and** Android even on `mid_stream_failure` (iOS captured no error at all; Android only had it in the non-terminal `error_*` fields). Fixes #557.

## iOS

- `PlaybackDiagnostics` gains `terminalErrorCode` / `Domain` / `Details` + a first-call-wins `markTerminalError()`; cleared on fresh play (alongside `terminalStatus`).
- `markFatalTerminal` now **threads the fatal `NSError`** — `handlePlayerError` was already receiving it and discarding it — and captures `domain` / `code` / `localizedDescription`. The retry-exhaustion path passes `error: nil`.
- `buildMetricsPayload` stamps `player_metrics_terminal_error_*` on every payload (`0`/`""` when no fatal error).

## Android (`PlaybackMetrics.java`)

- On a terminal row, stamp `player_metrics_terminal_error_*` from the already-tracked `lastErrorCode` / `Domain` / `Details` (mirrors the `error_*` capture, gated on `terminalStatus != null`).

## Verification

- **iOS:** `xcodebuild -scheme "InfiniteStreamPlayer (iOS)"` → **BUILD SUCCEEDED**.
- **Android:** small addition using existing fields; no Java/Android SDK in this environment to build locally — needs CI / a local gradle build.
- **Release-gated:** both ship with the next app builds; once deployed, failure `session_end` rows will carry `terminal_error_*` for the forwarder's `error_classifier` to derive a specific reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
