### PR TITLE
feat(554): rename client play-terminal session_end → play_end

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
@@ -126,7 +126,7 @@ private fun AppRoot() {
         vm.setHudVisible(false)
     }
     BackHandler(enabled = !state.settingsOpen && !state.hudVisible && route == Route.Playback) {
-        // #550 Phase 2 — emit session_end with user_stopped (or
+        // #550 Phase 2 — emit play_end with user_stopped (or
         // abandoned_start if EBVS conditions met) before navigating
         // away. Stamping happens here at the back-press because the
         // route flip + downstream LaunchedEffect tear down the

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -147,7 +147,7 @@ public final class PlaybackMetrics {
     private String lastErrorDetails = "";
 
     // #550 Phase 2 — terminal status/reason. Null while in_progress;
-    // set exactly once at session_end via markTerminal(). Preserved
+    // set exactly once at play_end via markTerminal(). Preserved
     // across retry(); cleared on play-boundary reset (loadStream).
     // Read by buildPayload() to stamp every payload AFTER the terminal
     // event with the terminal values (so a late-arriving heartbeat
@@ -931,7 +931,7 @@ public final class PlaybackMetrics {
             // once endSession() runs the sticky terminal value lands
             // on this and every subsequent payload — covers the case
             // where a heartbeat races the activity teardown after the
-            // session_end event fires.
+            // play_end event fires.
             p.put("player_metrics_playback_status",
                 terminalStatus != null ? terminalStatus : "in_progress");
             p.put("player_metrics_playback_reason",
@@ -945,7 +945,7 @@ public final class PlaybackMetrics {
             }
             // #557 — on a terminal row, surface the fatal error in the
             // dedicated terminal_error_* slot too (was always empty
-            // before, so the failure reason was lost on the session_end
+            // before, so the failure reason was lost on the play_end
             // row). The forwarder's error_classifier + dashboard tiles
             // read terminal_error_* specifically; mirror the error_*
             // capture above, gated on the play having ended.
@@ -1156,19 +1156,21 @@ public final class PlaybackMetrics {
             // No per-event "lastBufferingDurationS" yet on Android —
             // approximate via the running buffering bucket since the
             // most recent state transition. Acceptable: dashboards
-            // only see this on session_end so the value is stable.
+            // only see this on play_end so the value is stable.
             long durMs = bufferingTimeMs;  // accumulated buffering this play
             return durMs >= LONG_STATE_THRESHOLD_MS ? "ended_buffering_long" : "ended_buffering";
         }
         return baseReason;
     }
 
-    /** Mark terminal + emit a single session_end event. Subsequent
-     *  payloads automatically pick up the terminal values from
-     *  buildPayload's terminalStatus fallback. */
+    /** Mark terminal + emit a single play_end event (#554; renamed from
+     *  session_end — the forwarder still classifies both names so
+     *  historical rows keep working). Subsequent payloads automatically
+     *  pick up the terminal values from buildPayload's terminalStatus
+     *  fallback. */
     public void endSession(String status, String reason) {
         markTerminal(status, reason);
-        sendEvent("session_end", Collections.<String, Object>emptyMap());
+        sendEvent("play_end", Collections.<String, Object>emptyMap());
     }
 
     /** Back press / system back. Picks EBVS-or-user_quit by whether

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -149,7 +149,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
      *  route. Picks user_stopped vs abandoned_start based on first-frame
      *  + elapsed-since-play-start (EBVS). Forwards to PlaybackMetrics
      *  which classifies ended_buffering / ended_stalling refinement
-     *  client-side before emitting session_end. */
+     *  client-side before emitting play_end. */
     fun endSessionForUserBack() {
         metrics?.endSessionForUserBack()
     }
@@ -918,7 +918,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                     return
                 }
                 // No auto-recovery → this error is terminal. Phase 2:
-                // metrics emits a session_end with start_failure (no
+                // metrics emits a play_end with start_failure (no
                 // first frame yet) or mid_stream_failure (post-first-
                 // frame), stamping playback_status into CH.
                 metrics?.markFatalTerminal(error.message ?: "")

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -172,7 +172,7 @@ final class PlaybackDiagnostics: ObservableObject {
     // human-readable `lastError` / `itemError` strings whenever
     // describeError() runs. Forwarder error_classifier.go maps the
     // (domain, code) tuple to a controlled playback_reason vocab on
-    // session_end rows; the dashboard surfaces them as Error Code /
+    // play_end rows; the dashboard surfaces them as Error Code /
     // Error Domain tiles. Sticky after first observation so a
     // heartbeat after a transient error still carries the most recent
     // error context — cleared on reset() (play boundary).
@@ -232,8 +232,8 @@ final class PlaybackDiagnostics: ObservableObject {
     @Published var stallStuck: Bool = false
 
     /// Terminal status / reason for the play. Nil while in_progress;
-    /// set exactly once at session_end via markTerminal(). Read by
-    /// PlayerViewModel.buildMetricsPayload to stamp the session_end
+    /// set exactly once at play_end via markTerminal(). Read by
+    /// PlayerViewModel.buildMetricsPayload to stamp the play_end
     /// row's `player_metrics_playback_status` / `_playback_reason`.
     /// Cleared by resetForFreshPlay (Reload button); PRESERVED across
     /// retry() because if the play already hit a terminal state it
@@ -243,7 +243,7 @@ final class PlaybackDiagnostics: ObservableObject {
 
     /// Terminal error captured from the fatal AVFoundation NSError that
     /// ended the play (#557). Stamped once, alongside markTerminal, onto
-    /// the session_end row's `player_metrics_terminal_error_*` so the
+    /// the play_end row's `player_metrics_terminal_error_*` so the
     /// forwarder's error_classifier can derive a specific failure reason.
     /// Code 0 + empty domain = "no error captured" (a clean
     /// completed / user_stopped end). Cleared by resetForFreshPlay.
@@ -275,7 +275,7 @@ final class PlaybackDiagnostics: ObservableObject {
 
     /// Capture the fatal NSError that ended the play (#557). First call
     /// wins, mirroring markTerminal, so the first detected error is the
-    /// one stamped on the session_end row. No-op for a zero code +
+    /// one stamped on the play_end row. No-op for a zero code +
     /// empty domain (nothing to record).
     func markTerminalError(code: Int, domain: String, details: String) {
         guard terminalErrorCode == 0 && terminalErrorDomain.isEmpty else { return }
@@ -285,11 +285,11 @@ final class PlaybackDiagnostics: ObservableObject {
         terminalErrorDetails = details
     }
 
-    /// Returns the playback_reason to stamp on a session_end row,
+    /// Returns the playback_reason to stamp on a play_end row,
     /// given a base reason and the current state + sticky durations.
     /// Refines the generic `"user_quit"` into ended_buffering /
     /// ended_stalling (or their `_long` variants) when the player was
-    /// buffering / stalled at the moment iOS emits session_end.
+    /// buffering / stalled at the moment iOS emits play_end.
     /// Operator-explicit reasons (`app_backgrounded`, `app_terminated`,
     /// `next_content_selected`) pass through untouched. Lives on
     /// PlaybackDiagnostics because every input is already here.

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1120,8 +1120,8 @@ final class PlayerViewModel: ObservableObject {
     }
 
     /// Mark the play as terminated with the given Phase 2 status +
-    /// reason and emit a single session_end event so the dashboard /
-    /// CH see the terminal row. Idempotent — only the FIRST call
+    /// reason and emit a single play_end event (#554; was session_end)
+    /// so the dashboard / CH see the terminal row. Idempotent — only the FIRST call
     /// stamps the terminal state (a user_quit followed by a fatal
     /// error a moment later still reads as user_stopped, which matches
     /// reality from the operator's perspective).
@@ -1141,7 +1141,7 @@ final class PlayerViewModel: ObservableObject {
     /// stays user_stopped / user_quit (user changed their mind quickly).
     /// Mirrors the forwarder's default qoe_thresholds.outcomes.ebvs_threshold_ms
     /// (10s); kept as a Swift constant so the client decision happens
-    /// in one place and the row is stamped right at session_end.
+    /// in one place and the row is stamped right at play_end.
     private static let ebvsThresholdSeconds: TimeInterval = 10
 
     /// Convenience for the playback-back-button tap (and tvOS exit
@@ -1163,15 +1163,18 @@ final class PlayerViewModel: ObservableObject {
     func endSession(status: String, reason: String) {
         // No-op on subsequent calls — diagnostics.markTerminal enforces
         // first-call-wins. Even when terminal is already set we still
-        // emit a session_end (the prior emit may have been swallowed
+        // emit a play_end (the prior emit may have been swallowed
         // by background suspension), but the values stay stable.
         let alreadyTerminal = diagnostics.terminalStatus != nil
         diagnostics.markTerminal(status: status, reason: reason)
         if alreadyTerminal {
-            NSLog("[endSession] terminal already=\(diagnostics.terminalStatus ?? "?") — re-emitting session_end for delivery")
+            NSLog("[endSession] terminal already=\(diagnostics.terminalStatus ?? "?") — re-emitting play_end for delivery")
         }
         Task { [weak self] in
-            await self?.sendPlayerMetrics(event: "session_end")
+            // #554: the play-terminal event is `play_end` (renamed from
+            // `session_end`). The forwarder still classifies both names,
+            // so historical rows keep working.
+            await self?.sendPlayerMetrics(event: "play_end")
         }
     }
 
@@ -1252,10 +1255,10 @@ final class PlayerViewModel: ObservableObject {
         }
         // willTerminate fires on hard-quit (swipe-up from app switcher).
         // Synchronous notification — we get a few hundred ms before iOS
-        // reaps us. Mark terminal + fire-and-forget the session_end.
+        // reaps us. Mark terminal + fire-and-forget the play_end.
         // Best-effort: if iOS reaps us mid-flight the row stays
-        // in_progress and the forwarder treats absent session_end as
-        // "user closed without notifying."
+        // in_progress and the forwarder treats an absent play-terminal
+        // event as "user closed without notifying."
         willTerminateObserver = nc.addObserver(
             forName: UIApplication.willTerminateNotification,
             object: nil, queue: .main
@@ -1401,11 +1404,11 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
-    /// Stamp the play as fatally terminated and emit session_end. The
+    /// Stamp the play as fatally terminated and emit play_end. The
     /// status is `start_failure` when the player never crossed first
     /// frame, `mid_stream_failure` after. When a fatal NSError is in
     /// hand (#557) capture its domain/code/description into the terminal
-    /// error fields so the session_end row carries `terminal_error_*` and
+    /// error fields so the play_end row carries `terminal_error_*` and
     /// the forwarder's error_classifier can derive a specific reason.
     /// The retry-exhaustion path passes error=nil (only a reason string).
     private func markFatalTerminal(error: Error?, message: String) {
@@ -2432,11 +2435,11 @@ extension PlayerViewModel {
             // ── #550 Phase 2: outcome + error ──────────────────────
             // playback_status defaults to 'in_progress' for any
             // non-terminal payload; iOS sets explicit values for
-            // session_end events (completed / user_stopped / failed_*).
+            // play_end events (completed / user_stopped / failed_*).
             // playback_reason mirrors player_state during in_progress;
             // classifier-derived on terminal rows.
             // playback_status / _reason — heartbeats default to
-            // in_progress + the current state. session_end events
+            // in_progress + the current state. play_end events
             // (and any heartbeat after markTerminal fires) pick up
             // the terminal values diagnostics stamped. Once markTerminal
             // has run, EVERY subsequent payload carries the terminal

--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -90,7 +90,8 @@ const fields = computed(() => {
   // #550 Phase 2 + Phase 4 fields — pulled from player_metrics where
   // available. iOS is the canonical source for both buckets; external
   // (UA-parsed) players get partial device coverage and "in_progress"
-  // status by default until they emit a terminal session_end.
+  // status by default until they emit a terminal play_end (issue #554;
+  // legacy rows carry session_end).
   const pm: any = (p as any).player_metrics ?? {};
   const playbackStatus = typeof pm.playback_status === 'string' ? pm.playback_status : '';
   const playbackReason = typeof pm.playback_reason === 'string' ? pm.playback_reason : '';

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1577,7 +1577,7 @@ components:
         loop_count_player:   { type: integer, nullable: true, description: 'How many times the player has reported looping the content. Player-reported, may be 0 on platforms that do not count.' }
         loop_count_delta: { type: integer, nullable: true, description: 'Server-derived increment from the previous report.' }
         profile_shift_count: { type: integer, nullable: true, description: 'Number of ABR rendition shifts the player has reported.' }
-        last_event:          { type: string,  nullable: true, description: 'Most recent player-reported lifecycle event (playing, buffering_start, stall_start, etc.).' }
+        last_event:          { type: string,  nullable: true, description: 'Most recent player-reported lifecycle event (playing, buffering_start, stall_start, etc.). The play-terminal event is `play_end` (issue #554); rows minted before the client rename carry the legacy `session_end` and are still classified. NOTE: distinct from the proxy session-lifecycle `session_end` control_event, which is unchanged.' }
         trigger_type:        { type: string,  nullable: true, description: 'What triggered the most recent metrics tick (timer, event, etc.).' }
         state:               { type: string,  nullable: true, description: 'Player state machine label (idle, playing, paused, buffering, ended, error).' }
         waiting_reason:      { type: string,  nullable: true, description: 'AVFoundation reasonForWaitingToPlay (or platform equivalent) — split labels within `state` like `toMinimizeStalls` vs `evaluatingBufferingRate`.' }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -976,12 +976,12 @@ func (a *App) recordSessionEnd(session SessionData, reason string) {
 	a.emitControlEventForSession(sessionID, source, "session_end", reason)
 
 	// #556 — for a silent death (the player stopped POSTing without a
-	// clean client session_end), synthesize a terminal session_events
-	// frame from the last-known snapshot so the play still gets an
-	// outcome row + QoE outcome labels (vsf/msf/ebvs/tier). Only for
-	// inactive_timeout: operator delete/clear is administrative teardown,
-	// not a play outcome, and a clean client session_end already covers
-	// the happy path (and is deduped below).
+	// clean client play-terminal event), synthesize a terminal
+	// session_events frame from the last-known snapshot so the play still
+	// gets an outcome row + QoE outcome labels (vsf/msf/ebvs/tier). Only
+	// for inactive_timeout: operator delete/clear is administrative
+	// teardown, not a play outcome, and a clean client play_end (or legacy
+	// session_end) already covers the happy path (and is deduped below).
 	if reason == "inactive_timeout" {
 		a.synthesizeTerminalSessionEvent(session, reason)
 	}
@@ -990,7 +990,7 @@ func (a *App) recordSessionEnd(session SessionData, reason string) {
 // synthesizeTerminalSessionEvent publishes one session_events frame
 // stamped as the play's terminal row, derived from the last-known
 // session snapshot. No-op when the client already delivered its own
-// session_end (dedupe on last_event) so we never double-stamp.
+// play-terminal event (dedupe on last_event) so we never double-stamp.
 //
 // playback_status: respect a terminal status the client managed to set
 // before going silent; otherwise classify by whether playback ever
@@ -1010,18 +1010,26 @@ func (a *App) synthesizeTerminalSessionEvent(session SessionData, reason string)
 // terminalFrameForSession derives the synthesized terminal frame from a
 // last-known session snapshot. Pure (no App state) so it's unit-testable.
 // Returns ok=false when no frame should be emitted: a nil session, or
-// the client already delivered its own session_end (dedupe on
+// the client already delivered its own play-terminal event (dedupe on
 // last_event).
+//
+// #554: the play-terminal event is `play_end` (renamed from
+// `session_end`). The dedupe accepts BOTH names so a client that ended
+// cleanly with either is not double-stamped — clients migrate one at a
+// time and historical rows still carry `session_end`. The synthesized
+// frame itself stamps the new canonical `play_end`. (Distinct from the
+// proxy session-lifecycle `session_end` CONTROL event in
+// recordSessionEnd, which is unchanged.)
 func terminalFrameForSession(session SessionData, reason string) (SessionData, bool) {
 	if session == nil {
 		return nil, false
 	}
-	if getString(session, "player_metrics_last_event") == "session_end" {
+	if isPlayTerminalLastEvent(getString(session, "player_metrics_last_event")) {
 		return nil, false // client ended cleanly — don't double-stamp
 	}
 	frame := cloneSession(session)
-	frame["player_metrics_last_event"] = "session_end"
-	frame["player_metrics_trigger_type"] = "session_end"
+	frame["player_metrics_last_event"] = "play_end"
+	frame["player_metrics_trigger_type"] = "play_end"
 	if status := getString(session, "player_metrics_playback_status"); status == "" || status == "in_progress" {
 		if getInt(session, "player_metrics_video_first_frame_time_ms") > 0 {
 			frame["player_metrics_playback_status"] = "user_stopped"
@@ -1031,6 +1039,15 @@ func terminalFrameForSession(session SessionData, reason string) (SessionData, b
 		frame["player_metrics_playback_reason"] = reason
 	}
 	return frame, true
+}
+
+// isPlayTerminalLastEvent reports whether a player_metrics_last_event
+// value marks the play's terminal row. Accepts both the new canonical
+// `play_end` (#554) and the legacy `session_end` so the migration is
+// tolerant in both directions and historical rows keep deduping.
+// Mirrors the forwarder's qoe_labels.go isPlayTerminalEvent.
+func isPlayTerminalLastEvent(lastEvent string) bool {
+	return lastEvent == "play_end" || lastEvent == "session_end"
 }
 
 func (s *NftShapeStep) UnmarshalJSON(data []byte) error {

--- a/go-proxy/cmd/server/synthesize_terminal_test.go
+++ b/go-proxy/cmd/server/synthesize_terminal_test.go
@@ -5,7 +5,8 @@ import "testing"
 // Covers terminalFrameForSession (#556) — the pure frame-builder behind
 // the proxy's synthesized terminal session_events frame on inactive
 // timeout. Verifies the playback_status mapping, reason carry, and the
-// dedupe against a client's own session_end.
+// dedupe against a client's own play-terminal event (play_end / legacy
+// session_end, #554).
 func TestTerminalFrameForSession(t *testing.T) {
 	const reason = "inactive_timeout"
 
@@ -18,8 +19,8 @@ func TestTerminalFrameForSession(t *testing.T) {
 		if !ok {
 			t.Fatal("expected a frame")
 		}
-		if got := getString(frame, "player_metrics_last_event"); got != "session_end" {
-			t.Fatalf("last_event = %q, want session_end", got)
+		if got := getString(frame, "player_metrics_last_event"); got != "play_end" {
+			t.Fatalf("last_event = %q, want play_end", got)
 		}
 		if got := getString(frame, "player_metrics_playback_status"); got != "abandoned_start" {
 			t.Fatalf("playback_status = %q, want abandoned_start", got)
@@ -59,17 +60,26 @@ func TestTerminalFrameForSession(t *testing.T) {
 		if got := getString(frame, "player_metrics_playback_reason"); got != "decoder_init" {
 			t.Fatalf("playback_reason = %q, want decoder_init (not overwritten)", got)
 		}
-		if got := getString(frame, "player_metrics_last_event"); got != "session_end" {
-			t.Fatalf("last_event = %q, want session_end", got)
+		if got := getString(frame, "player_metrics_last_event"); got != "play_end" {
+			t.Fatalf("last_event = %q, want play_end", got)
 		}
 	})
 
-	t.Run("client already sent session_end -> dedupe (no frame)", func(t *testing.T) {
+	t.Run("client already sent play_end -> dedupe (no frame)", func(t *testing.T) {
+		if _, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":      "play_end",
+			"player_metrics_playback_status": "completed",
+		}, reason); ok {
+			t.Fatal("expected no frame when client already ended cleanly with play_end")
+		}
+	})
+
+	t.Run("client already sent legacy session_end -> dedupe (no frame)", func(t *testing.T) {
 		if _, ok := terminalFrameForSession(SessionData{
 			"player_metrics_last_event":      "session_end",
 			"player_metrics_playback_status": "completed",
 		}, reason); ok {
-			t.Fatal("expected no frame when client already ended cleanly")
+			t.Fatal("expected no frame when client already ended cleanly with legacy session_end")
 		}
 	})
 


### PR DESCRIPTION
## What

Renames the **play-scoped terminal** metrics event from `session_end` to `play_end` on iOS and Android, documents it in the API spec, and hardens the proxy's terminal-frame synthesis against the rename.

The proxy **session-lifecycle** `session_end` CONTROL event (`recordSessionEnd` → `emitControlEventForSession`) is a different, session-scoped event and is **left unchanged**.

## Why it's safe to land incrementally

The forwarder already keys the QoE labeler on `last_event ∈ {session_end, play_end}` (`qoe_labels.go isPlayTerminalEvent`, since #553). So clients migrate one at a time with zero forwarder change, and historical `session_end` rows keep classifying for the full TTL window.

## Changes

- **iOS** — `PlayerViewModel.endSession` emits `play_end`; the re-emit log line, doc-comments, and `PlaybackDiagnostics` comments updated. The willTerminate and `markFatalTerminal` paths both route through `endSession()`, so it's the single emit site. **`xcodebuild` BUILD SUCCEEDED.**
- **Android** — `PlaybackMetrics.endSession` emits `play_end`; comments in `PlaybackMetrics` / `MainActivity` / `PlayerViewModel` updated. (Not built in CI-less dev box — no JDK available — change is a string-literal flip.)
- **Dashboard / API spec** — `last_event` renders generically (no equality gates exist); `proxy-v2.yaml` `last_event` now documents `play_end` + legacy `session_end`. `forwarder-v2.yaml` control-event enum left unchanged.
- **Proxy (#556 synthesis)** — the inactive-timeout terminal-frame builder deduped only on `session_end`, so once clients emit `play_end` a clean client end would no longer dedupe and the proxy would **double-stamp** a synthesized terminal row. Added `isPlayTerminalLastEvent` (accepts both names) for the dedupe and switched the synthesized frame to the new canonical `play_end`. Tests cover both names. `go build` / `go vet` / `go test` pass.
- **Forwarder** — no code change; verified it already accepts both names (build/vet/gofmt/test pass).

## Out of scope (deferred)

Roku net-new terminal emit (part of #554's AC) is **deferred** — Roku has no metrics infrastructure today. In the interim, the proxy's inactive-timeout synthesis gives Roku plays a terminal row + QoE labels. Tracking remains under #554.

Refs #554 (not closing — Roku emit still outstanding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
