### PR TITLE
fix(566): emit play_end for the outgoing play on Reload

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -815,14 +815,23 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     fun reload() {
-        metrics?.onRestart("reload")
+        // #566 — terminate the OUTGOING play first so it gets an outcome
+        // row + QoE labels instead of dangling `in_progress`. sendEvent
+        // snapshots the payload synchronously, so the play_end row carries
+        // the OLD play_id + final state even though the POST is async; the
+        // play_id only rotates later in buildUrlAndLoad(). status=
+        // user_stopped, reason=reloaded (distinct from a back-tap's
+        // user_quit). resetForFreshPlay() then clears the terminal status
+        // so the subsequent restart row reports in_progress (matching iOS).
+        metrics?.endSession("user_stopped", "reloaded")
         // Fresh play boundary: zero the prior accumulators (variant
-        // dwell etc.) BEFORE releasing the old metrics instance, so
-        // a subsequent retry-flow won't inadvertently inherit values
-        // from before the reload. The new PlaybackMetrics built in
-        // bindMetrics() starts with empty priors anyway, but this
+        // dwell etc.) BEFORE the restart marker + releasing the old
+        // metrics instance, so a subsequent retry-flow won't inadvertently
+        // inherit values from before the reload. The new PlaybackMetrics
+        // built in bindMetrics() starts with empty priors anyway, but this
         // guards against a leak if anyone caches a reference.
         metrics?.resetForFreshPlay()
+        metrics?.onRestart("reload")
         metrics?.release()
         metrics = null
         boundPlayerView = null

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1179,6 +1179,18 @@ final class PlayerViewModel: ObservableObject {
     }
 
     func reload() {
+        // #566 — terminate the OUTGOING play before we rotate play_id and
+        // reset diagnostics below, so it gets an outcome row + QoE labels
+        // instead of dangling `in_progress` forever. status=user_stopped,
+        // reason=reloaded (distinct from a back-tap's user_quit). Built
+        // SYNCHRONOUSLY here — not via the async endSession() — so the
+        // payload snapshots the OLD play_id + final diagnostics ahead of
+        // regeneratePlayID() / resetForFreshPlay(); the captured dict is
+        // immutable, so the later reset can't retroactively blank it.
+        diagnostics.markTerminal(status: "user_stopped", reason: "reloaded")
+        let endPayload = buildMetricsPayload(event: "play_end", at: Date())
+        Task { [weak self] in await self?.sendPlayerMetrics(payload: endPayload) }
+
         Task { [weak self] in
             await self?.requestHARSnapshot(reason: "user_reload", force: true)
         }


### PR DESCRIPTION
## Problem

Tapping **Reload** left the previous play un-terminated: it stopped heartbeating and `resetForFreshPlay()` nulled `terminalStatus`, so it classified `in_progress` forever — no outcome, no `playback_status`, no `qoe_tier_*` chip. Same silent-death shape #556 patched for `inactive_timeout`, except the client knows the exact boundary here.

The Back button is already correct (routes through `endSessionForUserBack()`); Reload was treated as a *restart*, not an *end*.

## Fix

Emit a terminal `play_end` for the OUTGOING play (status=`user_stopped`, reason=`reloaded` — distinct from a back-tap's `user_quit`) **before** the play_id rotates and diagnostics reset.

- **iOS** `reload()` — mark terminal + build the `play_end` payload **synchronously** at the top, before `regeneratePlayID()` / `resetForFreshPlay()`. The captured dict is immutable, so it carries the OLD play_id + final diagnostics regardless of POST timing; the later reset can't blank it. The FIFO send chain keeps it ahead of the `restart` row. **`xcodebuild` BUILD SUCCEEDED.**
- **Android** `reload()` — `endSession("user_stopped","reloaded")` first (`sendEvent` snapshots the payload synchronously → OLD play_id + final state); then `resetForFreshPlay()` before `onRestart("reload")` so the `restart` row reports `in_progress`, matching iOS. (Not built — no JDK on dev box; mirrors the existing `metrics?.onRestart()` call pattern.)

`reason=reloaded` passes through `refineTerminalReason` unchanged (only `user_quit`/empty get the `ended_buffering`/`ended_stalling` upgrade).

## Acceptance criteria

- [x] Reload produces a terminal row for the outgoing play_id with non-`in_progress` `playback_status` and `playback_reason=reloaded`.
- [x] The terminal fires before play_id rotation (row carries the OLD play_id; the subsequent `restart`/fresh-play rows carry the new one).
- [x] iOS + Android covered.
- [ ] Roku reload path — deferred alongside its net-new terminal (#554).
- [x] Reloaded plays now receive `qoe_tier_*` + outcome labels (via the `play_end` row the forwarder already classifies).

Builds on #554 (uses `play_end`). Refs #566 (Roku reload path still outstanding, so not auto-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
