### PR TITLE
refactor(568): consolidate startup/stall/buffering labels into qoe_* namespace

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -258,9 +258,6 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		ps.downshiftTimes = append(ps.downshiftTimes, now) // #553 qoe_downshift_storm window
 	case "video_first_frame":
 		out = []string{SevInfo + "=first_frame"}
-		if l := videoStartupLabel(r.VideoFirstFrameTimeS); l != "" {
-			out = append(out, l)
-		}
 	case "video_start_time":
 		out = []string{SevInfo + "=playback_start"}
 
@@ -378,22 +375,13 @@ func bufferingContext(ps *playLabelState, now time.Time) string {
 	return "midplay"
 }
 
-// videoStartupLabel classifies player-reported time-to-first-frame.
-// Sits alongside the existing `info=first_frame` direct emission so a
-// slow cold-start surfaces both signals on the same row.
-//
-//	ttff > 4s  → error=*video_startup_severe
-//	ttff > 2s  → warning=*video_startup_long
-//	else       → "" (fast startup; only the info=first_frame chip lands)
-func videoStartupLabel(ttffS float32) string {
-	switch {
-	case ttffS > 4.0:
-		return SevError + "=" + synthMark + "video_startup_severe"
-	case ttffS > 2.0:
-		return SevWarning + "=" + synthMark + "video_startup_long"
-	}
-	return ""
-}
+// Startup latency is now classified solely by qoe_vst_* (qoe_labels.go),
+// keyed on VideoStartTimeMs — the industry-standard Video Start Time
+// (playback actually starting), config-driven thresholds. The legacy
+// video_startup_* labels (keyed on VideoFirstFrameTimeS, hardcoded 2s/4s)
+// were retired in #568; they duplicated qoe_vst_* and disagreed on
+// severity. VideoFirstFrameTimeMs is retained — qoe_vsf/qoe_msf still use
+// it as the "did a frame ever render?" discriminator.
 
 func stallLabel(durS float64, ctx string) string {
 	b := durationBucket(durS)
@@ -401,20 +389,20 @@ func stallLabel(durS float64, ctx string) string {
 	case "startup":
 		switch b {
 		case bucketShort:
-			return SevInfo + "=" + synthMark + "stall_short_startup"
+			return SevInfo + "=" + synthMark + "qoe_stall_short_startup"
 		case bucketLong:
-			return SevWarning + "=" + synthMark + "stall_long_startup"
+			return SevWarning + "=" + synthMark + "qoe_stall_long_startup"
 		default:
-			return SevCritical + "=" + synthMark + "stall_severe_startup"
+			return SevCritical + "=" + synthMark + "qoe_stall_severe_startup"
 		}
 	default: // midplay
 		switch b {
 		case bucketShort:
-			return SevInfo + "=" + synthMark + "stall_short_midplay"
+			return SevInfo + "=" + synthMark + "qoe_stall_short_midplay"
 		case bucketLong:
-			return SevWarning + "=" + synthMark + "stall_long_midplay"
+			return SevWarning + "=" + synthMark + "qoe_stall_long_midplay"
 		default:
-			return SevCritical + "=" + synthMark + "stall_severe_midplay"
+			return SevCritical + "=" + synthMark + "qoe_stall_severe_midplay"
 		}
 	}
 }
@@ -428,20 +416,20 @@ func bufferingLabel(durS float64, ctx string) string {
 	case "scrub":
 		switch b {
 		case bucketShort:
-			return SevInfo + "=" + synthMark + "buffering_short_scrub"
+			return SevInfo + "=" + synthMark + "qoe_buffering_short_scrub"
 		case bucketLong:
-			return SevInfo + "=" + synthMark + "buffering_long_scrub"
+			return SevInfo + "=" + synthMark + "qoe_buffering_long_scrub"
 		default:
-			return SevWarning + "=" + synthMark + "buffering_severe_scrub"
+			return SevWarning + "=" + synthMark + "qoe_buffering_severe_scrub"
 		}
 	default: // startup
 		switch b {
 		case bucketShort:
-			return SevInfo + "=" + synthMark + "buffering_short_startup"
+			return SevInfo + "=" + synthMark + "qoe_buffering_short_startup"
 		case bucketLong:
-			return SevWarning + "=" + synthMark + "buffering_long_startup"
+			return SevWarning + "=" + synthMark + "qoe_buffering_long_startup"
 		default:
-			return SevCritical + "=" + synthMark + "buffering_severe_startup"
+			return SevCritical + "=" + synthMark + "qoe_buffering_severe_startup"
 		}
 	}
 }

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -52,8 +52,9 @@ func TestEventSwitchUnchanged(t *testing.T) {
 		{"buffering_start", nil, nil},
 		// pair-close arms: sticky per-event duration drives the label.
 		// 1.5s, midplay context (no first-frame witnessed) → long_midplay.
-		{"stall_end", func(r *row) { r.StallDurationMs = 1500 }, []string{"warning=*stall_long_midplay"}},
-		{"buffering_end", func(r *row) { r.BufferingDurationMs = 1500 }, []string{"warning=*stall_long_midplay"}},
+		// Prefixed qoe_ in #568 (meaning/severity unchanged).
+		{"stall_end", func(r *row) { r.StallDurationMs = 1500 }, []string{"warning=*qoe_stall_long_midplay"}},
+		{"buffering_end", func(r *row) { r.BufferingDurationMs = 1500 }, []string{"warning=*qoe_stall_long_midplay"}},
 	}
 
 	for _, tc := range cases {
@@ -115,6 +116,37 @@ func TestQoEVSTBoundaries(t *testing.T) {
 		if !hasLabel(got, tc.want) {
 			t.Fatalf("vst=%d: want %q in %v", tc.vst, tc.want, got)
 		}
+	}
+}
+
+// --- Startup: legacy video_startup_* retired (#568) ------------------
+
+func TestStartupLegacyLabelsRetired(t *testing.T) {
+	// A 5s first frame would have tripped the old error=*video_startup_severe
+	// (>4s hardcoded). Post-#568 the video_first_frame arm must emit only its
+	// info=first_frame lifecycle chip — no video_startup_* label.
+	r := minimalRow("video_first_frame")
+	r.VideoFirstFrameTimeS = 5.0
+	got := computeEventLabelsWithState(newLabelState(), r)
+	for _, retired := range []string{
+		SevError + "=" + synthMark + "video_startup_severe",
+		SevWarning + "=" + synthMark + "video_startup_long",
+	} {
+		if hasLabel(got, retired) {
+			t.Fatalf("retired label %q must no longer be produced, got %v", retired, got)
+		}
+	}
+	if !hasLabel(got, "info=first_frame") {
+		t.Fatalf("video_first_frame arm should still emit info=first_frame, got %v", got)
+	}
+
+	// Startup latency is now keyed solely on VideoStartTimeMs (qoe_vst_*),
+	// independent of VideoFirstFrameTimeS: a high first-frame time with no VST
+	// yields no startup-latency label.
+	r2 := &row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoFirstFrameTimeS: 5.0}
+	got2 := evalQoE(r2)
+	if hasLabel(got2, qoeLabel(SevWarning, "qoe_vst_concerning")) || hasLabel(got2, qoeLabel(SevCritical, "qoe_vst_breach")) {
+		t.Fatalf("VideoFirstFrameTimeS must not drive qoe_vst_*, got %v", got2)
 	}
 }
 

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -401,7 +401,7 @@ const enabledKind = ref<Record<'effect' | 'cause', boolean>>({
 // String tiers, worst-first. Same vocabulary the forwarder writes to
 // session_events.labels[] and network_requests.labels[] so a single
 // filter UI sweeps both. Critical leads (user-visible playback
-// breakage like stall_severe / frozen / restart_auto_recovery); Error
+// breakage like qoe_stall_severe_midplay / frozen / restart_auto_recovery); Error
 // sits next for system-detected error states (player_error).
 type Severity = 'error' | 'critical' | 'warning' | 'info';
 const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info'];


### PR DESCRIPTION
Closes #568.

Consolidates the legacy player-experience labels into the standards-aligned `qoe_*` namespace from #553. Forwarder-only (`analytics/go-forwarder/labels.go` + tests) plus one dashboard comment fix. No schema / client / API / Grafana change.

## Tier 1 — retire `video_startup_*` (duplicate + severity conflict)

`video_startup_long` (warning, hardcoded >2s) and `video_startup_severe` (error, hardcoded >4s) keyed on `VideoFirstFrameTimeS` and duplicated `qoe_vst_concerning` (warning, ≥5s) / `qoe_vst_breach` (critical, ≥10s), which key on `VideoStartTimeMs`.

`VideoStartTimeMs` is the correct, industry-standard metric — **VST = time to playback actually starting** (iOS `markPlayingStarted` / `timeControlStatus → .playing`). `VideoFirstFrameTimeS` is the earlier first-frame-rendered signal. A 7s startup previously emitted **both** `error=*video_startup_severe` and `warning=*qoe_vst_concerning` — contradictory severities for one phenomenon.

Dropped the `videoStartupLabel` call + deleted the function. `qoe_vst_*` is now the sole startup-latency label. **`VideoFirstFrameTimeMs` retained** — `qoe_vsf`/`qoe_msf` still use it as the "did a frame ever render?" discriminator.

## Tier 2 — prefix stall/buffering with `qoe_`

Renamed the 12 per-event duration labels (6 `stall_*`, 6 `buffering_*`) under the `qoe_` prefix. Pure rename — meaning and severity unchanged. They remain the per-event drill-down beneath the aggregate `qoe_cirr_*`/`qoe_cirt_*`/`qoe_stall_burst`.

## Left unchanged

Control/network/transport labels (`session_*`, `fault_*`, `pattern_*`, `transport_*`, `segment_failure`, `transfer_*`, etc.) — not QoE. Delivery failures already surface in QoE via `qoe_vsf`/`qoe_msf` (terminal) and `qoe_ttfb_breach`/`qoe_transfer_stall` (network rows).

## Deprecation

Historical `labels[]` rows keep the old strings for their TTL (≤90 days); they just stop being produced — no data migration. Pre-merge grep of `grafana/`, `analytics/grafana/`, and `content/dashboard*` for the old strings found only one stale doc-comment ref (`SessionDisplay.vue`), now fixed.

## Tests

- `TestEventSwitchUnchanged` updated: `stall_end`/`buffering_end` → `qoe_stall_long_midplay`.
- New `TestStartupLegacyLabelsRetired`: a 5s first frame produces no `video_startup_*` label, the `video_first_frame` arm still emits `info=first_frame`, and `VideoFirstFrameTimeS` does not drive `qoe_vst_*`.
- `go build` / `go vet` / `gofmt -l` (touched files) / `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
