### PR TITLE
feat(571): add a 'testing' severity tier for operator/test KV labels

### DIFF
--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -1349,10 +1349,11 @@ Labels are `<severity>=<event>` strings attached to **every row** of `session_ev
 The `*` (synthMark) before `<event>` is the only difference between the two flavours.
 
 **Severities** (in escalating order, used for the dashboard's severity filter):
+- `testing`  — operator/test-harness KV metadata, **not playback signal** (e.g. `testing=run_id_20260530T141942Z`, `testing=test_rampup`, `testing=platform_iphone`). Set by the automated test code via `LabelPlay`; emitted by `kvLabelsFromInfo`. **Unranked** — excluded from `worstSeverity`, so it never tints a row or bumps classification. Groups under its own dashboard tier (#571).
 - `info`     — informational; not a failure (e.g. `info=*pattern_step`)
 - `warning`  — concerning; possibly a failure (e.g. `warning=segment_stall`, `warning=*fault_on`)
 - `error`    — failure (e.g. `error=stall_recovery_timeout`)
-- `critical` — severe failure (e.g. `critical=frozen`, `critical=*stall_severe_startup`)
+- `critical` — severe failure (e.g. `critical=frozen`, `critical=*qoe_stall_severe_startup`)
 
 **Find what labels actually exist** by calling `list_labels(from=..., to=..., like='%...%')`. **DO NOT GUESS** label strings when constructing `find_plays(labels_has=[...])` filters — see [[reference_labelplay_value_encoding]] for why guessed labels silently match zero rows.
 
@@ -1480,7 +1481,7 @@ Pattern for synth labels: they fold a `position bucket` (startup / midplay / scr
 
 ### 5.d Severity precedence
 
-When the dashboard rolls up multiple labels on one play, severity precedence is `critical > error > warning > info`. The dashboard's "worst signal" chip shows the highest-severity label present.
+When the dashboard rolls up multiple labels on one play, severity precedence is `critical > error > warning > info`. The dashboard's "worst signal" chip shows the highest-severity label present. (`testing` is **not** in this precedence — it's test-harness metadata, never the worst chip and never tints a row.)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ Shared modules (`content/shared/`):
 
 ### Analytics sidecar (`analytics/`)
 
-Three ClickHouse tables after issue #474, each carrying a `labels Array(LowCardinality(String))` column with the same `<severity>=<event>` vocab (synthesized entries prefixed `*`, severities `error|critical|warning|info`):
+Three ClickHouse tables after issue #474, each carrying a `labels Array(LowCardinality(String))` column with the same `<severity>=<event>` vocab (synthesized entries prefixed `*`, severities `error|critical|warning|info`, plus the unranked `testing` tier for operator/test-harness KV metadata — #571):
 
 - `session_events` — one row per player metrics POST (was `session_snapshots` pre-#472).
 - `network_requests` — one row per HTTP request the proxy handled.

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -37,6 +37,11 @@ const (
 	SevCritical = "critical"
 	SevWarning  = "warning"
 	SevInfo     = "info"
+	// SevTesting tags operator/test-harness KV metadata (run_id, test,
+	// platform, …) so it groups separately from genuine playback signal.
+	// Intentionally NOT ranked by worstSeverity — testing labels must not
+	// tint rows or bump the auto-classification tier. See kvLabelsFromInfo.
+	SevTesting = "testing"
 )
 
 // Synthesized labels carry a `*` prefix on the event portion so the
@@ -649,9 +654,12 @@ func computeControlLabels(r *ctrlRow) []string {
 
 // kvLabelsFromInfo parses a label_changed control_event's `info` JSON
 // (the player's labels map at the moment of change) and renders each
-// pair as one `<sev>=<key>_<value>` label entry. Uses SevInfo because
-// KV labels are operator metadata, not failure signals — they should
-// inherit the existing `info=` chip color in the dashboard.
+// pair as one `<sev>=<key>_<value>` label entry. Uses SevTesting: these
+// KV labels are set by the automated test harness (run_id / test /
+// platform / cycle_id via LabelPlay), so they're test metadata, not
+// playback signal — they group under the dashboard's "Testing" tier
+// rather than drowning real events in Info. testing is unranked in
+// worstSeverity, so these never tint a row or bump classification.
 //
 // Sanitises both key and value to [A-Za-z0-9_-] so the label stays in
 // the strict `<sev>=<event>` grammar.
@@ -670,7 +678,7 @@ func kvLabelsFromInfo(info string) []string {
 		if k == "" || v == "" {
 			continue
 		}
-		out = append(out, SevInfo+"="+k+"_"+v)
+		out = append(out, SevTesting+"="+k+"_"+v)
 	}
 	return out
 }

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -532,3 +532,33 @@ func assertLabelsEqual(t *testing.T, got, want []string) {
 		t.Fatalf("labels mismatch\n got: %v\nwant: %v", got, want)
 	}
 }
+
+// --- Testing tier: operator/test KV labels (#571) --------------------
+
+func TestKVLabelsUseTestingSeverity(t *testing.T) {
+	got := kvLabelsFromInfo(`{"run_id":"20260530T141942Z","test":"rampup"}`)
+	want := map[string]bool{
+		"testing=run_id_20260530T141942Z": true,
+		"testing=test_rampup":             true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want %d testing labels, got %v", len(want), got)
+	}
+	for _, l := range got {
+		if !want[l] {
+			t.Fatalf("operator KV label must be testing= prefixed, got %q in %v", l, got)
+		}
+	}
+}
+
+func TestTestingSeverityUnranked(t *testing.T) {
+	// Testing-only labels register no severity → no row tint, no
+	// classification bump.
+	if sev := worstSeverity([]string{"testing=run_id_x", "testing=test_y"}); sev != "" {
+		t.Fatalf("testing labels must be unranked, got %q", sev)
+	}
+	// A real signal alongside still wins.
+	if sev := worstSeverity([]string{"testing=run_id_x", SevWarning + "=timejump"}); sev != SevWarning {
+		t.Fatalf("real signal must still rank past testing labels, got %q", sev)
+	}
+}

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -1257,6 +1257,7 @@ function onRowsWheel(e: WheelEvent) {
 .label-critical { background: #fecaca; color: #7f1d1d; border-color: #fca5a5; }
 .label-warning  { background: #fde68a; color: #854d0e; border-color: #fcd34d; }
 .label-info     { background: #d1fae5; color: #14532d; border-color: #a7f3d0; }
+.label-testing  { background: #e2e8f0; color: #475569; border-color: #cbd5e1; }
 
 .cell {
   white-space: nowrap;

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -168,7 +168,7 @@ const sessionEvents = computed<SessionEvent[]>(() => {
       // filter UI treats `*manifest_failure` and `manifest_failure`
       // as the same bucket type.
       if (type.startsWith('*')) type = type.slice(1);
-      if (sev !== 'error' && sev !== 'critical' && sev !== 'warning' && sev !== 'info') continue;
+      if (sev !== 'error' && sev !== 'critical' && sev !== 'warning' && sev !== 'info' && sev !== 'testing') continue;
       out.push({ ts, type, severity: sev, kind });
     }
   }
@@ -403,8 +403,8 @@ const enabledKind = ref<Record<'effect' | 'cause', boolean>>({
 // filter UI sweeps both. Critical leads (user-visible playback
 // breakage like qoe_stall_severe_midplay / frozen / restart_auto_recovery); Error
 // sits next for system-detected error states (player_error).
-type Severity = 'error' | 'critical' | 'warning' | 'info';
-const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info'];
+type Severity = 'error' | 'critical' | 'warning' | 'info' | 'testing';
+const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info', 'testing'];
 const SEVERITY_META: Record<Severity, { label: string; color: string; bg: string; border: string }> = {
   // Critical wears the red palette (worst-looking — user-visible
   // playback breakage); Error wears the orange palette. Swapped
@@ -415,17 +415,21 @@ const SEVERITY_META: Record<Severity, { label: string; color: string; bg: string
   critical: { label: 'Critical', color: '#7f1d1d', bg: '#fee2e2', border: '#fca5a5' },
   warning:  { label: 'Warning',  color: '#854d0e', bg: '#fef3c7', border: '#fcd34d' },
   info:     { label: 'Info',     color: '#1f2937', bg: '#f0fdf4', border: '#a7f3d0' },
+  // Testing wears a muted slate palette (visually recessive — it's
+  // test-harness metadata, not playback signal). Lowest in the order
+  // and hidden by default. See the forwarder's SevTesting (#571).
+  testing:  { label: 'Testing',  color: '#475569', bg: '#f1f5f9', border: '#cbd5e1' },
 };
 
 const expandedTiers = ref<Record<Severity, boolean>>({
-  error: true, critical: true, warning: false, info: false,
+  error: true, critical: true, warning: false, info: false, testing: false,
 });
 function toggleTier(p: Severity) {
   expandedTiers.value[p] = !expandedTiers.value[p];
 }
 
 const visiblePriority = ref<Record<Severity, boolean>>({
-  error: true, critical: true, warning: true, info: false,
+  error: true, critical: true, warning: true, info: false, testing: false,
 });
 function togglePriorityVisibility(p: Severity, e: MouseEvent) {
   e.stopPropagation();
@@ -492,7 +496,7 @@ function eventSeverity(ev: SessionEvent): Severity {
   // Fall back to the legacy numeric `priority` for one release while
   // older forwarder builds + historical rows roll out.
   const sev = (ev as { severity?: string }).severity;
-  if (sev === 'error' || sev === 'critical' || sev === 'warning' || sev === 'info') return sev;
+  if (sev === 'error' || sev === 'critical' || sev === 'warning' || sev === 'info' || sev === 'testing') return sev;
   switch (ev.priority) {
     case 1: return 'error';
     case 2: return 'critical';
@@ -528,7 +532,7 @@ const filteredEvents = computed<AnnotatedEvent[]>(
 );
 
 const tierCounts = computed<Record<Severity, number>>(() => {
-  const c: Record<Severity, number> = { error: 0, critical: 0, warning: 0, info: 0 };
+  const c: Record<Severity, number> = { error: 0, critical: 0, warning: 0, info: 0, testing: 0 };
   for (const ev of kindFilteredEvents.value) c[ev._p]++;
   return c;
 });
@@ -541,7 +545,7 @@ function kindCount(k: 'effect' | 'cause'): number {
 
 const tierTypes = computed<Record<Severity, Array<{ type: string; count: number }>>>(() => {
   const buckets: Record<Severity, Map<string, number>> = {
-    error: new Map(), critical: new Map(), warning: new Map(), info: new Map(),
+    error: new Map(), critical: new Map(), warning: new Map(), info: new Map(), testing: new Map(),
   };
   for (const ev of kindFilteredEvents.value) {
     const t = String(ev.type ?? 'event');

--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -622,7 +622,9 @@ components:
         Row-level label inclusion filter. Repeatable; every value
         must be present in the row's `labels[]` (AND-within-includes).
         Format `<severity>=<event>` (with `*` prefix for synthesized
-        labels). Example:
+        labels). Severities: `critical|error|warning|info`, plus the
+        unranked `testing` tier for operator/test-harness KV metadata
+        (e.g. `testing=run_id_...`). Example:
         `?label_has=warning%3Dhttp_4xx&label_has=info%3D%2Apattern_step`.
     LabelNotFilter:
       in: query


### PR DESCRIPTION
Closes #571.

Splits test-harness metadata out of the **Info** severity bucket into a new **`testing`** tier. The Info group had grown to ~14k entries, mostly `run_id_*` and friends — drowning genuine player/control signal.

## Why this is a clean boundary

Every one of those KV labels is created by the **automated test code** — `tests/characterization/modes/*` and `tests/server_behavior/*` set `test` / `platform` / `run_id` / `cycle_id` / `rep` via `LabelPlay`. They flow: test code → `LabelPlay` → proxy `_v2_labels` → a `label_changed` control event → **`kvLabelsFromInfo`**.

`kvLabelsFromInfo` is the single function that turns test-harness KV labels into chips, so the fix needs no string-pattern guessing or maintained allowlist: it now stamps `testing=<key>_<value>` instead of `info=`. Everything it produces — exactly "what the test code made" — moves to the new tier.

Proxy-produced control events (`*pattern_step`, `*request_retry`, `*shaper_config_change`, `*fault_*`, `*session_*`) and player events stay under Info — they're emitted by the proxy, not the test code, and fire during manual fault-injection too.

## Forward-only

Flipping the source affects **new** rows only. Existing `info=test_*` / `run_id_*` rows stay valid and self-clean via the 30-day `'other'` TTL (they're only days old). No allowlist, no re-ingest, no migration.

## Changes

- **Forwarder** (`labels.go`): new `SevTesting = "testing"`; `kvLabelsFromInfo` emits `testing=`. `worstSeverity` intentionally leaves `testing` **unranked** — testing-only rows never tint or bump auto-classification. New tests: `TestKVLabelsUseTestingSeverity`, `TestTestingSeverityUnranked`.
- **Dashboard** (`SessionDisplay.vue`): `testing` added to the `Severity` union, `SEVERITY_ORDER` (last), a muted-slate `SEVERITY_META`, the expand/visibility maps, and the prefix guards — hidden by default. `PlayLog.vue` gets a `.label-testing` chip. `vue-tsc`'s exhaustiveness check confirmed every `Record<Severity>` literal was filled. `NetworkLog.vue` untouched (testing labels never land on network rows).
- **Docs/enum**: `data-fields.md`, `CLAUDE.md`, `forwarder-v2.yaml`.

## Verified

- Forwarder: `go build` / `go vet` / `gofmt -l` (touched) / full `go test ./...` — pass.
- Dashboard: `vue-tsc --noEmit` clean; `vite build` succeeds.

## Caveat

A KV label set by hand in the dashboard would also land in `testing` (same function) — acceptable, it's operator metadata, but noted in case hand-set labels should stay `info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
