### PR TITLE
fix(574): recognize testing= test labels in picker + Automated Testing page

### DIFF
--- a/content/dashboard-v3/src/pages/Characterization.vue
+++ b/content/dashboard-v3/src/pages/Characterization.vue
@@ -98,23 +98,41 @@ function asNumber(v: number | string | null | undefined): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function findLabel(p: PlayRow, prefix: string): string | null {
-  for (const [label] of p.label_histogram || []) {
-    if (label.startsWith(prefix)) return label.slice(prefix.length);
+// findLabel pulls the tail of a harness label by key (e.g. 'run_id_').
+// Matches the testing= tier first (current, #571), then the legacy info=
+// prefix for plays written before #571 (still present within the ≤30-day
+// 'other' TTL).
+function findLabel(p: PlayRow, key: string): string | null {
+  for (const prefix of [`testing=${key}`, `info=${key}`]) {
+    for (const [label] of p.label_histogram || []) {
+      if (label.startsWith(prefix)) return label.slice(prefix.length);
+    }
   }
   return null;
 }
 
 async function fetchOneTest(name: TestName, hours: number): Promise<PlayRow[]> {
   const from = new Date(Date.now() - hours * 3600 * 1000).toISOString();
-  const qs = new URLSearchParams();
-  qs.append('label_has', `info=test_${name}`);
-  qs.append('from', from);
-  qs.append('limit', '200');
-  const resp = await fetch('/analytics/api/v2/plays?' + qs.toString());
-  if (!resp.ok) throw new Error(`/api/v2/plays ${name}: ${resp.status}`);
-  const data: ApiResponse = await resp.json();
-  return data.items ?? [];
+  // Fetch both the testing= tier (current, #571) and the legacy info=
+  // prefix (pre-#571 rows, within the ≤30-day TTL). A single label_has
+  // can't OR two values, so query each and dedupe by play_id.
+  const fetchByLabel = async (label: string): Promise<PlayRow[]> => {
+    const qs = new URLSearchParams();
+    qs.append('label_has', label);
+    qs.append('from', from);
+    qs.append('limit', '200');
+    const resp = await fetch('/analytics/api/v2/plays?' + qs.toString());
+    if (!resp.ok) throw new Error(`/api/v2/plays ${name}: ${resp.status}`);
+    const data: ApiResponse = await resp.json();
+    return data.items ?? [];
+  };
+  const [current, legacy] = await Promise.all([
+    fetchByLabel(`testing=test_${name}`),
+    fetchByLabel(`info=test_${name}`),
+  ]);
+  const byId = new Map<string, PlayRow>();
+  for (const p of [...current, ...legacy]) byId.set(p.play_id, p);
+  return [...byId.values()];
 }
 
 async function fetchCharacterizationRuns(hours: number): Promise<CharRunRow[]> {
@@ -378,8 +396,8 @@ function isoDurationShort(fromISO: string, toISO: string | null): string {
 const grouped = computed<RunGroup[]>(() => {
   const byRun = new Map<string, RunGroup>();
   for (const p of allPlays.value) {
-    const runID = findLabel(p, 'info=run_id_') ?? '(no-run-id)';
-    const platform = findLabel(p, 'info=platform_') ?? 'unknown';
+    const runID = findLabel(p, 'run_id_') ?? '(no-run-id)';
+    const platform = findLabel(p, 'platform_') ?? 'unknown';
     if (platformFilter.value !== 'all' && platform !== platformFilter.value) continue;
 
     let g = byRun.get(`${runID}|${platform}`);

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -126,8 +126,8 @@ const filters = ref<{
   play_id: string;
   classification: 'all' | 'starred' | 'interesting' | 'other';
   // Test-harness origin filter. 'all' = no constraint, 'only' = keep
-  // plays stamped by the characterization framework (have an
-  // info=run_id_… label), 'hide' = exclude them so manual sessions
+  // plays stamped by the characterization framework (have a
+  // testing=run_id_… label, or legacy info=run_id_… pre-#571), 'hide' = exclude them so manual sessions
   // surface without test-noise. See Characterization.vue for how
   // the framework stamps these labels at the start of each run.
   harness: 'all' | 'only' | 'hide';
@@ -146,25 +146,29 @@ const filters = ref<{
 });
 
 // Test-harness label extraction. The characterization framework
-// stamps each play it runs with:
-//   info=run_id_<utc-compact>   e.g. info=run_id_20260524T070148Z
-//   info=platform_<name>        e.g. info=platform_ipad-sim
-//   info=test_<name>            e.g. info=test_rampup
-// These three label PREFIXES (with their value tail) are how
-// Characterization.vue groups plays into runs; this page lifts the
-// same convention to surface "this play came from the harness" on
-// the picker.
-function findLabelTail(r: SessionRow, prefix: string): string | null {
+// stamps each play it runs with these keys (#571 moved them from the
+// info= prefix to the testing= tier):
+//   testing=run_id_<utc-compact>   e.g. testing=run_id_20260524T070148Z
+//   testing=platform_<name>        e.g. testing=platform_ipad-sim
+//   testing=test_<name>            e.g. testing=test_rampup
+// These keys (with their value tail) are how Characterization.vue groups
+// plays into runs; this page lifts the same convention to surface "this
+// play came from the harness" on the picker. We match the testing= tier
+// first, then fall back to the legacy info= prefix for plays written
+// before #571 (still present within the ≤30-day 'other' TTL).
+function findLabelTail(r: SessionRow, key: string): string | null {
   const pairs = Array.isArray(r.labels) ? r.labels : [];
-  for (const [label] of pairs) {
-    const s = String(label);
-    if (s.startsWith(prefix)) return s.slice(prefix.length);
+  for (const prefix of [`testing=${key}`, `info=${key}`]) {
+    for (const [label] of pairs) {
+      const s = String(label);
+      if (s.startsWith(prefix)) return s.slice(prefix.length);
+    }
   }
   return null;
 }
-function harnessRunId(r: SessionRow): string | null { return findLabelTail(r, 'info=run_id_'); }
-function harnessPlatform(r: SessionRow): string | null { return findLabelTail(r, 'info=platform_'); }
-function harnessTest(r: SessionRow): string | null { return findLabelTail(r, 'info=test_'); }
+function harnessRunId(r: SessionRow): string | null { return findLabelTail(r, 'run_id_'); }
+function harnessPlatform(r: SessionRow): string | null { return findLabelTail(r, 'platform_'); }
+function harnessTest(r: SessionRow): string | null { return findLabelTail(r, 'test_'); }
 function isHarnessRow(r: SessionRow): boolean { return harnessRunId(r) !== null; }
 
 // Pretty-print the UTC compact run_id (20260524T070148Z) as local
@@ -417,14 +421,15 @@ function matches(r: SessionRow): boolean {
 
 // Hierarchical label filter — mirrors the SessionDisplay event-filter
 // accordion. One tier per severity (error → critical → warning →
-// info), each containing the distinct labels seen at that tier with
-// occurrence counts. Click a label chip to toggle inclusion;
+// info → testing), each containing the distinct labels seen at that
+// tier with occurrence counts. Click a label chip to toggle inclusion;
 // click the tier header to toggle ALL labels in that tier. Issue
 // #474 follow-up.
-type Severity = 'error' | 'critical' | 'warning' | 'info';
+type Severity = 'error' | 'critical' | 'warning' | 'info' | 'testing';
 // User-facing ordering: Critical leads (the "🚨 something's actually
-// wrong" tier), then Error (player-error transitions), Warning, Info.
-const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info'];
+// wrong" tier), then Error (player-error transitions), Warning, Info,
+// and finally Testing (test-harness KV metadata, #571 — recessive).
+const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info', 'testing'];
 const SEVERITY_META: Record<Severity, { label: string; bg: string; border: string; color: string }> = {
   // Critical wears red (worst-looking — user-visible playback
   // breakage); Error wears orange. Whole palette pair moves
@@ -434,6 +439,9 @@ const SEVERITY_META: Record<Severity, { label: string; bg: string; border: strin
   critical: { label: 'Critical', bg: '#fee2e2', border: '#fca5a5', color: '#7f1d1d' },
   warning:  { label: 'Warning',  bg: '#fef3c7', border: '#fcd34d', color: '#854d0e' },
   info:     { label: 'Info',     bg: '#f0fdf4', border: '#a7f3d0', color: '#1f2937' },
+  // Testing wears muted slate — recessive test-harness metadata, not
+  // playback signal (#571). Mirrors SessionDisplay.vue.
+  testing:  { label: 'Testing',  bg: '#f1f5f9', border: '#cbd5e1', color: '#475569' },
 };
 
 interface LabelEntry {
@@ -449,7 +457,7 @@ interface LabelTier {
 
 const labelTiers = computed<LabelTier[]>(() => {
   const acc: Record<Severity, Map<string, number>> = {
-    error: new Map(), critical: new Map(), warning: new Map(), info: new Map(),
+    error: new Map(), critical: new Map(), warning: new Map(), info: new Map(), testing: new Map(),
   };
   for (const r of rows.value) {
     const pairs = Array.isArray(r.labels) ? r.labels : [];
@@ -484,7 +492,7 @@ const labelTiers = computed<LabelTier[]>(() => {
 // info collapsed (matches SessionDisplay's expandedTiers initial
 // state — the user usually wants to scan the worst tiers first).
 const expandedLabelTiers = ref<Record<Severity, boolean>>({
-  error: true, critical: true, warning: false, info: false,
+  error: true, critical: true, warning: false, info: false, testing: false,
 });
 function toggleLabelTier(sev: Severity) {
   expandedLabelTiers.value[sev] = !expandedLabelTiers.value[sev];
@@ -836,7 +844,7 @@ interface LabelChip {
   label: string;     // raw `<severity>=<event>` string
   name: string;      // event portion (with the `*` synthMark intact)
   count: number;
-  cls: 'info' | 'warning' | 'critical' | 'error';
+  cls: 'info' | 'warning' | 'critical' | 'error' | 'testing';
 }
 function labelChips(r: SessionRow): LabelChip[] {
   const pairs = Array.isArray(r.labels) ? r.labels : [];
@@ -852,6 +860,7 @@ function labelChips(r: SessionRow): LabelChip[] {
       sev === 'error' ? 'error'
       : sev === 'critical' ? 'critical'
       : sev === 'warning' ? 'warning'
+      : sev === 'testing' ? 'testing'
       : 'info';
     out.push({ label, name, count, cls });
   }
@@ -1143,7 +1152,7 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
               >{{ c.label }}</button>
             </div>
 
-            <div class="class-chip-wrap" title="Filter by test-harness origin (plays stamped with info=run_id_… by the characterization framework)">
+            <div class="class-chip-wrap" title="Filter by test-harness origin (plays stamped with testing=run_id_… by the characterization framework)">
               <span class="ctrl-label-text">Harness:</span>
               <button
                 v-for="c in ([
@@ -1645,6 +1654,7 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
 .label-warning  { background: #fef3c7; color: #854d0e; border-color: #fcd34d; }
 .label-critical { background: #fee2e2; color: #7f1d1d; border-color: #fca5a5; }
 .label-error    { background: #ffedd5; color: #7c2d12; border-color: #fdba74; }
+.label-testing  { background: #f1f5f9; color: #475569; border-color: #cbd5e1; }
 
 /* Hierarchical labels filter — mirrors SessionDisplay's Focus Window
  * event-filter accordion. One row per severity tier with a clickable

--- a/tools/harness-cli/README.md
+++ b/tools/harness-cli/README.md
@@ -71,8 +71,8 @@ echo "$out" | jq …
 - **Label filters are `--label-has` / `--label-not`, NOT `--label`.** Used by every `query` subcommand. Repeatable (AND semantics):
     ```sh
     harness --insecure --json query plays \
-        --label-has info=test_rampup \
-        --label-has info=platform_iphone \
+        --label-has testing=test_rampup \
+        --label-has testing=platform_iphone \
         --limit 20
     ```
 - **`harness query control <play_id>`** parses a play_id positionally but the underlying endpoint requires `player_id`. Until that's fixed, use:
@@ -88,10 +88,10 @@ echo "$out" | jq …
 
 1. Lives on the player record (visible via `harness labels show`).
 2. Emits a `label_changed` control event (the proxy fix in #487 made this work on the v2 PATCH path).
-3. The forwarder turns each KV pair into an `info=<key>_<value>` row label on the control_events table.
-4. The Sessions dashboard's Labels column renders them as chips on the current play.
+3. The forwarder turns each KV pair into a `testing=<key>_<value>` row label on the control_events table (the `testing` tier, #571 — was `info=` before that; legacy rows persist for the ≤30-day TTL).
+4. The Sessions dashboard's Labels column renders them as chips on the current play, grouped under the Testing tier.
 
-**Encoding gotcha:** `test=rampup` on the player → `info=test_rampup` on the row. The filter is `query plays --label-has info=test_rampup`, NOT `--label-has test=rampup`.
+**Encoding gotcha:** `test=rampup` on the player → `testing=test_rampup` on the row. The filter is `query plays --label-has testing=test_rampup`, NOT `--label-has test=rampup`. (For rows written before #571, use the legacy `--label-has info=test_rampup`.)
 
 ## Common patterns
 
@@ -108,8 +108,8 @@ harness --insecure ts 3bff77d6 --streams events,network,control
 
 # Find every play tagged by a characterization run
 harness --insecure --json query plays \
-    --label-has info=test_rampup \
-    --label-has info=platform_iphone \
+    --label-has testing=test_rampup \
+    --label-has testing=platform_iphone \
     --limit 20
 
 # Inspect one play's events + label histogram


### PR DESCRIPTION
Closes #574.

Regression follow-up to #571. #571 moved operator/test KV labels from the `info=` prefix to the new `testing=` tier, but several frontend consumers still keyed on `info=`, so newly-tagged characterization runs broke.

## Breakage (all from post-#571 `testing=` labels)

- **Automated Testing page (`Characterization.vue`) — worst:** `fetchOneTest` issued a server-side query `label_has=info=test_${name}`, so new runs returned **zero rows — they didn't appear on the page at all.** Run grouping also keyed on `info=run_id_` / `info=platform_`.
- **Sessions picker (`Sessions.vue`):** the harness pill + "test-harness origin" filter keyed on `info=run_id_`/etc., so new plays got no pill. Its **standalone label-filter sidebar** (separate 4-severity copy from `SessionDisplay.vue`) also dropped `testing=` labels entirely.

## Fix

Match `testing=` first, with an `info=` **legacy fallback** for rows written before #571 (still present within the ≤30-day `'other'` TTL):

- `Characterization.vue` — `findLabel` scans `testing=` then `info=`; `fetchOneTest` queries both `testing=test_${name}` and `info=test_${name}` and dedupes by `play_id` (a single `label_has` can't OR two values).
- `Sessions.vue` — `findLabelTail` dual-prefix (pill/filter), **plus** the `testing` tier added to its label-filter severity machinery (`Severity` union, `SEVERITY_ORDER`, `SEVERITY_META`, accordion bucket, expand-state, chip `cls` + `.label-testing` CSS).
- `harness-cli/README.md` — examples use `testing=`; legacy `info=` noted.

## Verified on test-dev (`:21000`)

The rampup run (`testing=test_rampup`, run `20260602T161717Z`, play `97002242`):
- ✅ appears on the Automated Testing page and groups by run_id/platform
- ✅ Sessions picker shows its harness pill (`rampup` / `ipad-sim`)
- ✅ Sessions picker label filter has a new **Testing** group with the 3 `testing=` labels, split out of Info
- ✅ `vue-tsc --noEmit` clean; `vite build` succeeds

After the 30-day TTL the `info=` fallbacks/queries can be dropped (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
