### PR TITLE
feat(506): per-row derived TOKEN — batch → derived CH table → read-merge → dashboard

### DIFF
--- a/analytics/clickhouse/init.d/04-derived.sql
+++ b/analytics/clickhouse/init.d/04-derived.sql
@@ -1,0 +1,29 @@
+-- #506 — derived per-row tokens (out-of-band batch; NOT written by the live ingest path).
+-- A batch process (analytics/tools/derive_tokens.py, reusing tokenize.py) computes the
+-- #508 token for each network_requests row and writes it here; the read API LEFT-JOINs
+-- this onto rows by (player_id, ts, entry_fingerprint) so the token is available
+-- everywhere (network log, play log, API, offline) from one computation.
+--
+-- ReplacingMergeTree(scored_at): a re-score (same player_id/ts/entry_fingerprint, newer
+-- scored_at) supersedes the prior token. The read-path JOIN must dedupe to the latest
+-- (argMax(token, scored_at) or FINAL) since pre-merge duplicates are possible.
+--
+-- IDs are written verbatim from network_requests (already canonical-lowercase per the
+-- forwarder's canonicalV2ID on ingest) — the batch must NOT re-canonicalise.
+
+CREATE TABLE IF NOT EXISTS infinite_streaming.derived_tokens
+(
+    ts                DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
+    player_id         LowCardinality(String)           CODEC(ZSTD(1)),
+    play_id           LowCardinality(String)           CODEC(ZSTD(1)),
+    entry_fingerprint UInt64                            CODEC(ZSTD(1)),
+    surface           LowCardinality(String)           CODEC(ZSTD(1)),
+    token             LowCardinality(String)           CODEC(ZSTD(1)),
+    model_version     LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    scored_at         DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1))
+)
+ENGINE = ReplacingMergeTree(scored_at)
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (player_id, ts, entry_fingerprint)
+TTL toDateTime(ts) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;

--- a/analytics/go-forwarder/timeseries.go
+++ b/analytics/go-forwarder/timeseries.go
@@ -681,11 +681,52 @@ func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams)
 		limit = backfillCapNetwork
 	}
 	// Subquery wrap — same DateTime64-vs-String aliasing reason as
-	// buildSamplesQuery above.
+	// buildSamplesQuery above. The middle layer LEFT-JOINs the #506
+	// batch-derived per-row token (analytics/tools/derive_tokens.py); the
+	// outer toString projection then operates on the native `ts`.
 	cols := buildSelectColumns(sel.Columns)
-	q := fmt.Sprintf(`SELECT %s FROM (SELECT * FROM %s.network_requests WHERE %s ORDER BY ts ASC LIMIT %d) FORMAT JSONEachRow`,
-		cols, cfg.chDatabase, strings.Join(clauses, " AND "), limit)
+	dtScope := []string{}
+	if params.playerID != "" {
+		dtScope = append(dtScope, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+	}
+	if params.playID != "" && params.playID != "—" {
+		dtScope = append(dtScope, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+	}
+	if params.from != "" {
+		dtScope = append(dtScope, "ts >= parseDateTime64BestEffort({from:String})")
+	}
+	if params.to != "" {
+		dtScope = append(dtScope, "ts <= parseDateTime64BestEffort({to:String})")
+	}
+	if len(dtScope) == 0 {
+		dtScope = append(dtScope, "ts >= now() - INTERVAL 1 HOUR")
+	}
+	q := fmt.Sprintf(`SELECT %s, token FROM (
+	  SELECT base.*, ifNull(dt.token, '') AS token
+	  FROM (SELECT * FROM %s.network_requests WHERE %s ORDER BY ts ASC LIMIT %d) base
+	  %s
+	) FORMAT JSONEachRow`,
+		cols, cfg.chDatabase, strings.Join(clauses, " AND "), limit,
+		derivedTokenJoinSQL(cfg.chDatabase, strings.Join(dtScope, " AND ")))
 	return q, args, nil
+}
+
+// derivedTokenJoinSQL returns a LEFT JOIN fragment that attaches the #506
+// batch-derived per-row token (analytics/tools/derive_tokens.py, reusing the
+// single tokenizer in analytics/tools/tokenize.py) to a base query aliased
+// `base`, matched by (player_id, ts, entry_fingerprint). derived_tokens is a
+// ReplacingMergeTree, so argMax(token, scored_at) collapses pre-merge
+// duplicates to the latest score. `scope` constrains the build side to the
+// same player/play/time window as the base query (the columns derived_tokens
+// shares) so the join never has to read the whole table.
+func derivedTokenJoinSQL(db, scope string) string {
+	return fmt.Sprintf(`LEFT JOIN (
+	  SELECT player_id, ts, entry_fingerprint, argMax(token, scored_at) AS token
+	  FROM %s.derived_tokens
+	  WHERE %s
+	  GROUP BY player_id, ts, entry_fingerprint
+	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts AND base.entry_fingerprint = dt.entry_fingerprint`,
+		db, scope)
 }
 
 // buildSelectColumns produces the SELECT projection list. `ts` is

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -366,36 +366,63 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		clauses = append(clauses, "ts >= now() - INTERVAL 1 HOUR")
 	}
 
-	// Wrap in a sub-select so the outer toString aliases don't shadow
-	// the typed `ts` column referenced by WHERE / ORDER BY (same trap
-	// the snapshots handler addresses; see commit 9cfca6f).
+	// derived_tokens join scope — the player/play/time columns
+	// derived_tokens shares, reusing the same params as the base WHERE so
+	// the join's build side is bounded to this query's window (see
+	// derivedTokenJoinSQL in timeseries.go).
+	dtScope := []string{}
+	if playerID != "" {
+		dtScope = append(dtScope, "lowerUTF8(player_id) = lowerUTF8({pid:String})")
+	}
+	if playID != "" && playID != "—" {
+		dtScope = append(dtScope, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+	}
+	if from != "" {
+		dtScope = append(dtScope, "ts >= parseDateTime64BestEffort({from:String})")
+	}
+	if to != "" {
+		dtScope = append(dtScope, "ts < parseDateTime64BestEffort({to:String})")
+	}
+	if len(dtScope) == 0 {
+		dtScope = append(dtScope, "ts >= now() - INTERVAL 1 HOUR")
+	}
+
+	// Three layers: innermost `base` keeps native `ts` for WHERE/ORDER BY
+	// (no toString shadowing — same trap the snapshots handler addresses,
+	// commit 9cfca6f); the middle layer LEFT-JOINs the #506 batch-derived
+	// per-row token; the outer applies the toString projection.
 	query := fmt.Sprintf(`
 		SELECT
-		  toString(ts_raw) AS timestamp,
+		  toString(ts) AS timestamp,
 		  session_id, player_id, play_id, attempt_id,
 		  method, url, upstream_url, request_kind, content_type,
 		  status, bytes_in, bytes_out,
 		  ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		  faulted, fault_type, fault_action, fault_category, labels
+		  faulted, fault_type, fault_action, fault_category, labels, token
 		FROM (
-		  SELECT
-		    ts AS ts_raw,
-		    session_id, player_id, play_id, attempt_id,
-		    method, url, upstream_url, request_kind, content_type,
-		    status, bytes_in, bytes_out,
-		    ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		    faulted, fault_type, fault_action, fault_category, labels
-		  FROM %s.network_requests
-		  WHERE %s
-		  -- DESC so the LIMIT keeps the most recent N rows. ASC
-		  -- caused rare 4xx / faulted rows to be squeezed out by
-		  -- bulk 200s on long sessions; the NetworkLog table sorts
-		  -- client-side so display order is unaffected.
-		  ORDER BY ts DESC
-		  LIMIT %d
+		  SELECT base.*, ifNull(dt.token, '') AS token
+		  FROM (
+		    SELECT
+		      ts, entry_fingerprint,
+		      session_id, player_id, play_id, attempt_id,
+		      method, url, upstream_url, request_kind, content_type,
+		      status, bytes_in, bytes_out,
+		      ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
+		      faulted, fault_type, fault_action, fault_category, labels
+		    FROM %s.network_requests
+		    WHERE %s
+		    -- DESC so the LIMIT keeps the most recent N rows. ASC
+		    -- caused rare 4xx / faulted rows to be squeezed out by
+		    -- bulk 200s on long sessions; the NetworkLog table sorts
+		    -- client-side so display order is unaffected.
+		    ORDER BY ts DESC
+		    LIMIT %d
+		  ) base
+		  %s
 		)
 		FORMAT JSONEachRow`,
-		cfg.chDatabase, strings.Join(clauses, " AND "), limit)
+		cfg.chDatabase, strings.Join(clauses, " AND "), limit,
+		derivedTokenJoinSQL(cfg.chDatabase, strings.Join(dtScope, " AND ")))
 
 	rows, err := queryClickHouseRows(r.Context(), cfg, query, params)
 	if err != nil {
@@ -444,6 +471,12 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		// mirroring how ts/session_id/player_id are added above.
 		if labels, ok := row["labels"]; ok && labels != nil {
 			item["labels"] = labels
+		}
+		// #506 — the batch-derived per-row token (V_SEG(ΔP,ΔS), V_PROBE,
+		// STARTUP_RAMP, LOOP_BOUNDARY, …), LEFT-JOINed from derived_tokens.
+		// Empty for rows not yet scored by derive_tokens.py.
+		if tok, ok := row["token"].(string); ok && tok != "" {
+			item["token"] = tok
 		}
 		out = append(out, item)
 	}

--- a/analytics/tools/derive_tokens.py
+++ b/analytics/tools/derive_tokens.py
@@ -85,7 +85,12 @@ def main():
 
     derived = []
     for play, prows in by_play.items():
-        pid = prows[0].get("player_id")
+        # A play has exactly one player, but the FIRST network row is often a
+        # pre-stamp row (the forwarder hasn't resolved session→player yet) with
+        # an empty player_id. Stamping prows[0] would blank the whole play and
+        # break the read-path join (which matches on player_id). Take the first
+        # non-empty player_id instead.
+        pid = next((r.get("player_id") for r in prows if r.get("player_id")), "")
         for ts, fp, surface, token in tk.tokenize_rows(prows):
             derived.append({"ts": ts, "player_id": pid, "play_id": play,
                             "entry_fingerprint": fp, "surface": surface, "token": token,

--- a/analytics/tools/derive_tokens.py
+++ b/analytics/tools/derive_tokens.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""#506 batch derived-token writer — reads network_requests from ClickHouse, computes the
+#508 per-row token (reusing tokenize.py — the single source of truth), and writes them to
+the `derived_tokens` table. The read API LEFT-JOINs this onto rows so the token is
+available everywhere.
+
+Out-of-band / delayed by design (NOT the forwarder ingest path): batch sees the whole play
+so the lookahead-dependent tokens (V_PROBE, STARTUP_RAMP) resolve correctly. Idempotent —
+re-runs supersede via ReplacingMergeTree(scored_at).
+
+Reads CH directly over HTTP (the read API doesn't project entry_fingerprint, which is the
+join key). IDs are written verbatim (already canonical-lowercase in the archive).
+
+  python3 analytics/tools/derive_tokens.py --days 7 [--player <id>] [--dry-run]
+  # CH endpoint: --ch-url, or env FORWARDER_CLICKHOUSE_URL (default http://localhost:8123);
+  # optional FORWARDER_CLICKHOUSE_USER / _PASSWORD.
+"""
+import argparse
+import base64
+import collections
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tokenize as tk  # noqa: E402
+
+DB = "infinite_streaming"
+# Columns tokenize_rows needs (classify_row/_is_faulted/_fault_class) + identity + the join key.
+SELECT_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
+
+
+def _auth_header():
+    u, p = os.environ.get("FORWARDER_CLICKHOUSE_USER"), os.environ.get("FORWARDER_CLICKHOUSE_PASSWORD")
+    if u:
+        tok = base64.b64encode(f"{u}:{p or ''}".encode()).decode()
+        return {"Authorization": f"Basic {tok}"}
+    return {}
+
+
+def ch(ch_url, query, body=None, params=None):
+    q = {"query": query}
+    if body is None:
+        q["default_format"] = "JSONEachRow"
+    for k, v in (params or {}).items():
+        q[f"param_{k}"] = v
+    url = ch_url.rstrip("/") + "/?" + urllib.parse.urlencode(q)
+    headers = _auth_header()
+    if body is not None:
+        headers["Content-Type"] = "application/x-ndjson"
+    req = urllib.request.Request(url, data=body, method="POST" if body is not None else "GET", headers=headers)
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read().decode()
+
+
+def fetch_rows(ch_url, days, player):
+    where = ["ts >= now64(3) - INTERVAL {days:UInt32} DAY"]
+    params = {"days": str(days)}
+    if player:
+        where.append("player_id = {pid:String}")
+        params["pid"] = player
+    sql = (f"SELECT {SELECT_COLS} FROM {DB}.network_requests "
+           f"WHERE {' AND '.join(where)} ORDER BY player_id, ts, entry_fingerprint")
+    out = ch(ch_url, sql, params=params)
+    return [json.loads(l) for l in out.splitlines() if l.strip()]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--player", default=None, help="limit to one player_id")
+    ap.add_argument("--model-version", default="vomm-tok-1")
+    ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
+    args = ap.parse_args()
+
+    rows = fetch_rows(args.ch_url, args.days, args.player)
+    by_play = collections.defaultdict(list)
+    for r in rows:
+        by_play[r.get("play_id")].append(r)
+    scored_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    derived = []
+    for play, prows in by_play.items():
+        pid = prows[0].get("player_id")
+        for ts, fp, surface, token in tk.tokenize_rows(prows):
+            derived.append({"ts": ts, "player_id": pid, "play_id": play,
+                            "entry_fingerprint": fp, "surface": surface, "token": token,
+                            "model_version": args.model_version, "scored_at": scored_at})
+
+    print(f"#506 derive_tokens — {len(rows)} rows / {len(by_play)} plays / {args.days}d "
+          f"→ {len(derived)} tokens (model={args.model_version})")
+    kinds = collections.Counter(t["token"].split("(")[0] for t in derived)
+    print("token kinds:", dict(kinds.most_common(10)))
+    if args.dry_run:
+        print("dry-run — not inserting. sample:")
+        for d in derived[:5]:
+            print("  ", d)
+        return
+    if not derived:
+        print("nothing to write.")
+        return
+    body = ("\n".join(json.dumps(d) for d in derived) + "\n").encode()
+    ch(args.ch_url, f"INSERT INTO {DB}.derived_tokens FORMAT JSONEachRow", body=body)
+    print(f"inserted {len(derived)} rows into {DB}.derived_tokens.")
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/tools/tokenize.py
+++ b/analytics/tools/tokenize.py
@@ -56,6 +56,7 @@ Usage:
                                             #  not an artifact of the play boundary)
 """
 import argparse
+import collections
 import json
 import re
 import subprocess
@@ -239,12 +240,22 @@ def tokenize(rows, event_rows=None):
 
 
 def tokenize_rows(rows):
-    """Per-row tokens for the #506 derived-token writer: [(ts, entry_fingerprint, surface,
-    token)] for the network-derived tokens (those with a source-row fingerprint). Markers
-    (STARTUP_RAMP/LOOP_BOUNDARY) carry their triggering row's fingerprint; sentinels and
-    event-derived tokens (fp=None) are excluded. Lookahead (V_PROBE/STARTUP_RAMP) is
-    resolved because batch sees the whole play."""
-    return [(ts, fp, surf, tok) for ts, fp, surf, tok in _token_seq(rows) if fp is not None]
+    """Per-row tokens for the #506 derived-token writer: ONE (ts, entry_fingerprint,
+    surface, token) per source network row, keyed uniquely by its fingerprint. A row can
+    emit multiple sequence tokens (e.g. STARTUP_RAMP/LOOP_BOUNDARY *then* the V_SEG — all
+    sharing the row's fingerprint); those are joined into one combined token string
+    ("STARTUP_RAMP V_SEG(+2,+0)") so the derived row stays unique on
+    (player_id, ts, entry_fingerprint) and the read-path join is 1:1. (tokenize() keeps
+    them as separate sequence tokens for the model — different purpose.) Sentinels and
+    event-derived tokens (fp=None) are excluded; lookahead resolves because batch sees the
+    whole play."""
+    by_row = collections.OrderedDict()  # (ts, fp) -> [surface, [tokens]]
+    for ts, fp, surf, tok in _token_seq(rows):
+        if fp is None:
+            continue
+        slot = by_row.setdefault((ts, fp), [surf, []])
+        slot[1].append(tok)
+    return [(ts, fp, surf, " ".join(toks)) for (ts, fp), (surf, toks) in by_row.items()]
 
 
 def episodes(tokens, anchor="FAULT", lead=4, horizon=8):

--- a/analytics/tools/tokenize.py
+++ b/analytics/tools/tokenize.py
@@ -136,9 +136,10 @@ def event_tokens(event_rows):
     return out
 
 
-def tokenize(rows, event_rows=None):
-    """rows: network_requests dicts. event_rows (optional): session_events dicts to
-    interleave by timestamp (cross-stream). Returns a list of token strings."""
+def _token_seq(rows, event_rows=None):
+    """Internal: build the ts-sorted token sequence as (ts, entry_fingerprint, surface,
+    token) tuples — fingerprint/surface carried for the #506 per-row derived-token writer;
+    fp is None for event-derived tokens. tokenize()/tokenize_rows() wrap this."""
     rows = [r for r in rows if r.get("url")]
     rows.sort(key=lambda r: r.get("ts") or r.get("timestamp") or "")
 
@@ -175,11 +176,12 @@ def tokenize(rows, event_rows=None):
         if rend != prev_rend and reverts and backward:
             probe_rows.add(ridx)  # single-segment excursion at a backward segnum
 
-    # ts-tagged emission so session_events can be interleaved by timestamp.
-    seq = []          # (ts, token)
-    state = {"ts": ""}
+    # ts-tagged emission (+ source-row entry_fingerprint/surface for the derived-token
+    # writer) so session_events can be interleaved by timestamp.
+    seq = []          # (ts, entry_fingerprint, surface, token)
+    state = {"ts": "", "fp": None, "surface": ""}
     def emit(tok):
-        seq.append((state["ts"], tok))
+        seq.append((state["ts"], state["fp"], state["surface"], tok))
 
     last_vrend = None
     last_vseg = None
@@ -188,7 +190,9 @@ def tokenize(rows, event_rows=None):
 
     for i, r in enumerate(rows):
         state["ts"] = r.get("ts") or r.get("timestamp") or ""
+        state["fp"] = r.get("entry_fingerprint")
         kind, rend, seg = classify_row(r["url"])
+        state["surface"] = _surface(kind)
         if _is_faulted(r):
             emit(f"FAULT({_surface(kind)},{_fault_class(r)})")
             continue
@@ -223,9 +227,24 @@ def tokenize(rows, event_rows=None):
     # Cross-stream: interleave session_events lifecycle tokens by timestamp. Stable sort
     # keeps request-token order within equal timestamps.
     if event_rows:
-        seq.extend(event_tokens(event_rows))
+        seq.extend((ts, None, "", tok) for ts, tok in event_tokens(event_rows))
     seq.sort(key=lambda x: x[0] or "")
-    return ["<S>"] + [t for _, t in seq] + ["<E>"]
+    return seq
+
+
+def tokenize(rows, event_rows=None):
+    """rows: network_requests dicts. event_rows (optional): session_events dicts to
+    interleave by timestamp (cross-stream). Returns a list of token strings."""
+    return ["<S>"] + [tok for _, _, _, tok in _token_seq(rows, event_rows)] + ["<E>"]
+
+
+def tokenize_rows(rows):
+    """Per-row tokens for the #506 derived-token writer: [(ts, entry_fingerprint, surface,
+    token)] for the network-derived tokens (those with a source-row fingerprint). Markers
+    (STARTUP_RAMP/LOOP_BOUNDARY) carry their triggering row's fingerprint; sentinels and
+    event-derived tokens (fp=None) are excluded. Lookahead (V_PROBE/STARTUP_RAMP) is
+    resolved because batch sees the whole play."""
+    return [(ts, fp, surf, tok) for ts, fp, surf, tok in _token_seq(rows) if fp is not None]
 
 
 def episodes(tokens, anchor="FAULT", lead=4, horizon=8):

--- a/content/dashboard-v3/src/components/NetworkLog.vue
+++ b/content/dashboard-v3/src/components/NetworkLog.vue
@@ -168,6 +168,9 @@ interface Row {
   // entry instead of on NetworkLogEntry itself because the OpenAPI-
   // generated type doesn't know about labels yet.
   labels: string[];
+  // #506 — batch-derived per-row token (V_SEG(ΔP,ΔS), V_PROBE, …)
+  // LEFT-JOINed onto the row by the forwarder. Empty for un-scored rows.
+  token: string;
 }
 
 function num(v: unknown): number {
@@ -175,7 +178,7 @@ function num(v: unknown): number {
   return Number.isFinite(n) ? n : 0;
 }
 
-function buildRow(e: NetworkLogEntry, labels: string[]): Row | null {
+function buildRow(e: NetworkLogEntry, labels: string[], token: string): Row | null {
   const ts = e.timestamp ? Date.parse(e.timestamp) : NaN;
   if (!Number.isFinite(ts)) return null;
   const dns = Math.max(0, num(e.dns_ms));
@@ -189,7 +192,7 @@ function buildRow(e: NetworkLogEntry, labels: string[]): Row | null {
   const transfer = Math.max(0, num(e.transfer_ms));
   let duration = num(e.total_ms);
   if (duration <= 0) duration = dns + connect + tls + wait + transfer;
-  return { entry: e, ts, duration, dns, connect, tls, wait, transfer, labels };
+  return { entry: e, ts, duration, dns, connect, tls, wait, transfer, labels, token };
 }
 
 // Per-label rendering helpers — mirror PlayLog so chips look the
@@ -235,7 +238,10 @@ const allRows = computed<Row[]>(() => {
     const labels = Array.isArray((obj as { labels?: unknown }).labels)
       ? ((obj as { labels: unknown[] }).labels).filter((x): x is string => typeof x === 'string')
       : [];
-    const r = buildRow(entry, labels);
+    const token = typeof (obj as { token?: unknown }).token === 'string'
+      ? ((obj as { token: string }).token)
+      : '';
+    const r = buildRow(entry, labels, token);
     if (!r) continue;
     built.push(r);
   }
@@ -623,6 +629,7 @@ function onRowsWheel(e: WheelEvent) {
         <div class="cell c-time sortable" @click="clickSort('time')">Time<span class="arr">{{ arrow('time') }}</span></div>
         <div class="cell c-flags">⚑</div>
         <div class="cell c-labels">Labels</div>
+        <div class="cell c-token">Token</div>
         <div class="cell c-method sortable" @click="clickSort('method')">M<span class="arr">{{ arrow('method') }}</span></div>
         <div class="cell c-path sortable" @click="clickSort('path')">Path<span class="arr">{{ arrow('path') }}</span></div>
         <div class="cell c-bytes sortable" @click="clickSort('bytes')">KB<span class="arr">{{ arrow('bytes') }}</span></div>
@@ -651,6 +658,10 @@ function onRowsWheel(e: WheelEvent) {
               :title="l"
             >{{ labelName(l) }}</span>
             <span v-if="!r.labels.length" class="dash">—</span>
+          </div>
+          <div class="cell c-token" :title="r.token">
+            <span v-if="r.token" class="nl-token">{{ r.token }}</span>
+            <span v-else class="dash">—</span>
           </div>
           <div class="cell c-method">{{ r.entry.method ?? '?' }}</div>
           <div class="cell c-path" :title="r.entry.url ?? r.entry.path ?? ''">
@@ -797,6 +808,7 @@ function onRowsWheel(e: WheelEvent) {
     var(--c-time, 96px)
     var(--c-flags, 28px)
     var(--c-labels, minmax(120px, 1fr))
+    var(--c-token, minmax(110px, 0.8fr))
     var(--c-method, 44px)
     var(--c-path, minmax(140px, 1fr))
     var(--c-bytes, 64px)
@@ -863,6 +875,16 @@ function onRowsWheel(e: WheelEvent) {
 }
 .c-time { color: #6b7280; }
 .c-flags { text-align: center; font-weight: 700; }
+.c-token { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.nl-token {
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 10px;
+  color: #3730a3;
+  background: #eef2ff;
+  border: 1px solid #e0e7ff;
+  border-radius: 3px;
+  padding: 0 4px;
+}
 .c-labels {
   display: flex; flex-wrap: wrap; gap: 3px;
   align-items: center; min-width: 0;

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -502,6 +502,15 @@ function rowLabels(r: Row): string[] {
   return [];
 }
 
+/** #506 batch-derived per-row token, LEFT-JOINed onto network rows by
+ *  the forwarder (analytics/tools/derive_tokens.py + the read-path merge
+ *  in v2_handlers.go / timeseries.go). Only network rows carry it;
+ *  event / control / avmetric rows return '' (no derived tokens yet). */
+function rowToken(r: Row): string {
+  const t = r.raw?.token;
+  return typeof t === 'string' ? t : '';
+}
+
 /** Pull the severity prefix from a label like 'critical=stall_frozen'.
  *  Returns '' for labels that don't follow the schema. */
 function labelSeverity(label: string): string {
@@ -999,6 +1008,7 @@ function onRowsWheel(e: WheelEvent) {
         <div class="cell c-play">play_id</div>
         <div class="cell c-attempt">attempt_id</div>
         <div class="cell c-eventname">event_name</div>
+        <div class="cell c-token" title="#506 batch-derived per-row token (V_SEG(ΔP,ΔS), V_PROBE, …). Network rows only; LEFT-JOINed from derived_tokens by the forwarder.">token</div>
         <div class="cell c-fields">fields</div>
         <div v-if="showRaw" class="cell c-raw">raw</div>
       </div>
@@ -1035,6 +1045,10 @@ function onRowsWheel(e: WheelEvent) {
               :class="`event-name-${r.source}`"
               :title="r.eventName"
             >{{ r.eventName }}</span>
+            <span v-else class="event-name-empty">—</span>
+          </div>
+          <div class="cell c-token" :title="rowToken(r)">
+            <span v-if="rowToken(r)" class="pl-token">{{ rowToken(r) }}</span>
             <span v-else class="event-name-empty">—</span>
           </div>
           <div class="cell c-fields">
@@ -1151,6 +1165,7 @@ function onRowsWheel(e: WheelEvent) {
     var(--c-play, 90px)
     var(--c-attempt, 90px)
     var(--c-eventname, minmax(140px, 280px))
+    var(--c-token, minmax(120px, 0.9fr))
     var(--c-fields, minmax(280px, 4fr));
   gap: 8px;
   padding: 4px 8px;
@@ -1160,6 +1175,22 @@ function onRowsWheel(e: WheelEvent) {
   border-top: 1px solid #f3f4f6;
 }
 .c-flags { text-align: center; font-weight: 700; }
+.c-token { overflow: hidden; }
+.pl-token {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 10px;
+  color: #3730a3;
+  background: #eef2ff;
+  border: 1px solid #e0e7ff;
+  border-radius: 3px;
+  padding: 0 4px;
+}
 
 /* When the Raw column is toggled on, the row grid grows by one slot
  * and the fields column tightens so the raw cell has room. */
@@ -1173,6 +1204,7 @@ function onRowsWheel(e: WheelEvent) {
     var(--c-play, 90px)
     var(--c-attempt, 90px)
     var(--c-eventname, minmax(140px, 280px))
+    var(--c-token, minmax(120px, 0.9fr))
     var(--c-fields, minmax(200px, 2fr))
     var(--c-raw, minmax(280px, 3fr));
 }


### PR DESCRIPTION
## What

Surfaces the #508 tokenizer's **per-row token** (the context-dependent delta tokens — `V_SEG(ΔP,ΔS)`, `V_PROBE`, `STARTUP_RAMP`, embedded `LOOP_BOUNDARY`) **everywhere** — testing network log, play log, read API, and offline — from **one** computation.

Implements #506. The token is **not** computed in the forwarder at ingest: (a) the delta tokens need lookahead the online path doesn't have, and (b) the tokenizer is still evolving. Instead a delayed batch reuses the single tokenizer (`analytics/tools/tokenize.py` — no Go/TS re-port, no drift), writes a derived ClickHouse table, and the read API LEFT-JOINs it onto rows.

## How (3 phases)

**Phase 1 — batch → `derived_tokens` table**
- New CH table `infinite_streaming.derived_tokens` (per-row: `ts`, `player_id`, `play_id`, `entry_fingerprint`, `surface`, `token`, `model_version`, `scored_at`), `ReplacingMergeTree(scored_at)`, `ORDER BY (player_id, ts, entry_fingerprint)`, 90-day TTL.
- `tokenize.tokenize_rows()` — one combined token per source row, fingerprint-tagged (markers embedded, e.g. `LOOP_BOUNDARY V_SEG(+0,-2)`); the sequence tokenizer still emits separate tokens for the model.
- `analytics/tools/derive_tokens.py` — reads `network_requests` from CH HTTP, tokenizes per play (batch sees the whole play, so lookahead resolves), writes derived rows. Idempotent via `scored_at`.

**Phase 2 — read-path merge (forwarder)**
- LEFT-JOIN `derived_tokens` onto the network read paths: `v2NetworkRequestsHandler` (REST) and `buildNetworkQuery` (timeseries SSE — the dashboard path).
- New `derivedTokenJoinSQL` helper: `argMax(token, scored_at)` collapses ReplacingMergeTree pre-merge dups to the latest; the join is scoped by the same player/play/time window so the build side never reads the whole table. `ifNull(...,'')` for un-scored rows.

**Phase 3 — dashboard columns**
- `NetworkLog.vue`: Token column after Labels (sibling semantic annotations).
- `PlayLog.vue`: token column after `event_name`.
- No client-side tokenizer — displays the server field.

## Fix included
The Phase-2 merge exposed a Phase-1 bug: `derive_tokens.py` stamped every row of a play with `prows[0].player_id`, but row 0 is usually the pre-stamp row (empty `player_id`), which blanked whole plays and made the join match only ~11 rows. Now takes the first non-empty `player_id`.

## Verification
- CH join coverage **99.8%** (7106/7121 on play `f556a705`); the ~15-row gap is pre-stamp empty-`player_id` network rows that legitimately can't match a real-player token.
- REST + SSE read APIs return a correct `token` per row (`harness raw GET`, SSE probe).
- Live dashboard (session-viewer): **4,997 token cells** rendered, values match API/CH — `V_SEG(+0,+1)`, `A_SEG`, `V_PL(2160p)`, `A_PL`, embedded `LOOP_BOUNDARY V_SEG`; un-scored rows show `—`.
- Forwarder `go build` + tests pass; dashboard `make build-dashboard-v3` clean.

## Out of scope / follow-ups
- Only **network rows** carry tokens. Event/control/avmetric rows in PlayLog show `—` (only `network_requests` is tokenized, keyed by `entry_fingerprint`). Cross-stream event tokens (`STALL_START`, `RATE_UP`, …) need an event-keyed derivation — clean follow-up.
- Full anomaly `derived_labels` / scoring verdicts (same table + merge extends later).
- Batch scheduling/cron (run manually for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
