### PR TITLE
fix(582): bound Testing-page memory + CPU (chart/cache caps, throttle, teardown)

### DIFF
--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -371,6 +371,15 @@ interface StatefulEvent {
 }
 
 const statefulEvents: StatefulEvent[] = [];
+/** Backstop cap on retained stateful events (issue #582). This array was
+ *  appended on every heartbeat and never trimmed within a session, so it
+ *  grew unbounded — and renderStatefulLanes walks + sorts it on each
+ *  render. We normally trim it to the events cache's retained window (so
+ *  the Player State lanes cover the SAME span as the charts on pan-back);
+ *  this count is only a fallback when the cache bounds aren't known yet.
+ *  Set high (well above the cache cap × a few events/heartbeat) so it
+ *  never trims tighter than the cache window. */
+const STATEFUL_EVENTS_CAP = 40000;
 // IDs assigned to coalesced range items so we can replace cleanly on
 // every render. Range items are tagged by the lane key + rendered
 // `range:<key>:<n>` so we can detect & remove them before re-adding.
@@ -976,6 +985,20 @@ async function drainNewRows() {
     }
   }
   lastIngestedMs = highWater;
+  // Bound the stateful-event history (issue #582) WITHOUT trimming
+  // tighter than what the charts show. Trim to the events cache's
+  // retained window (rangeBounds.min) so the Player State lanes fill in
+  // over exactly the same span the charts do when the operator pans the
+  // focus window back. Appended in ascending ts order, so the oldest are
+  // at the front. The fixed cap is only a fallback before bounds exist.
+  const minKeep = props.eventsStream.rangeBounds.value?.min;
+  if (minKeep != null) {
+    let drop = 0;
+    while (drop < statefulEvents.length && statefulEvents[drop].ts < minKeep) drop++;
+    if (drop > 0) statefulEvents.splice(0, drop);
+  } else if (statefulEvents.length > STATEFUL_EVENTS_CAP) {
+    statefulEvents.splice(0, statefulEvents.length - STATEFUL_EVENTS_CAP);
+  }
 }
 
 watch(

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -93,6 +93,31 @@ const coord = useChartCoordination(toRef(props, 'playerId'));
 
 let chart: any = null;
 let dataset: Array<Array<{ x: number; y: number }>> = [];
+
+/** Hard cap on points kept per series (issue #582). A pure memory
+ *  bound: the oldest points are dropped once a series exceeds this, so a
+ *  tab open for hours can't grow the renderer to multiple GB. ~8000
+ *  points is well beyond any visible window (>2 h at 1 Hz) so pan-back
+ *  stays generous; it's the cache's eviction window, not zoom, that
+ *  determines how far back data actually exists. */
+const MAX_POINTS_PER_SERIES = 8000;
+
+/** Listeners attached to `window` outlive this component's canvas (which
+ *  GCs when the chart is destroyed), so they must be removed on unmount
+ *  or they leak the closures — and the chart/dataset they capture —
+ *  every time a chart is torn down (e.g. switching the active session).
+ *  Issue #582. Canvas-bound listeners GC with the canvas, but routing
+ *  them here too is harmless and keeps teardown complete. */
+const teardownFns: Array<() => void> = [];
+function onGlobal(
+  target: EventTarget,
+  type: string,
+  handler: (e: any) => void,
+  opts?: AddEventListenerOptions | boolean,
+) {
+  target.addEventListener(type, handler as EventListener, opts);
+  teardownFns.push(() => target.removeEventListener(type, handler as EventListener, opts as EventListenerOptions));
+}
 // Watermark of the latest CH row already pushed through the chart.
 // Read by the markers-stream watcher to drain only NEW rows on each
 // version bump (the cache holds the full backfill + live tail).
@@ -793,7 +818,7 @@ function installLeftClickLiveToggle() {
     if (x < area.left || x > area.right || y < area.top || y > area.bottom) return;
     coord.toggleLive();
   });
-  window.addEventListener('blur', () => { downAt = null; });
+  onGlobal(window, 'blur', () => { downAt = null; });
 }
 
 function installContextMenuSuppress() {
@@ -817,7 +842,7 @@ function installRightDragPan() {
     // user is dragging (setRange handles both range + paused mirror).
     coord.setRange({ min: sx.min, max: sx.max });
   });
-  window.addEventListener('mousemove', (e) => {
+  onGlobal(window, 'mousemove', (e: MouseEvent) => {
     if (!dragState || !chart) return;
     const area = chart.chartArea;
     if (!area) return;
@@ -827,10 +852,10 @@ function installRightDragPan() {
     const dv = (dx / widthPx) * span;
     coord.setRange({ min: dragState.startMin - dv, max: dragState.startMax - dv });
   });
-  window.addEventListener('mouseup', (e) => {
+  onGlobal(window, 'mouseup', (e: MouseEvent) => {
     if (e.button === 2) dragState = null;
   });
-  window.addEventListener('blur', () => { dragState = null; });
+  onGlobal(window, 'blur', () => { dragState = null; });
 }
 
 /**
@@ -956,14 +981,21 @@ function pushSample(p: PlayerRecord, x: number) {
     insertByX(data, { x, y: Number(y) });
     mutated = true;
   }
-  // Retention is the time-series cache's job (SOFT_CAP_SAMPLES) —
-  // the chart used to trim at `x - windowMs * 2` to bound memory,
-  // but `windowMs` is the *visible* window, not retention. When the
-  // operator zooms in (focusSpan shrinks → setWindowMs shrinks) the
-  // trim was killing older points the PLAYERSTATE lane still had,
-  // producing a chart-vs-lane time-axis mismatch. Chart.js with
-  // `animation: false` handles tens of thousands of points fine.
+  // Bound per-series history (issue #582). The chart used to keep every
+  // point for the life of the tab ("retention is the cache's job"), but
+  // the cache evicts and the chart did not — so the dataset arrays grew
+  // unbounded, ballooning the renderer to multi-GB and pegging CPU as
+  // each redraw re-rasterized hundreds of thousands of points. Cap each
+  // series to MAX_POINTS_PER_SERIES and drop the oldest (front of the
+  // ascending-by-x array). The cap is a memory bound, independent of the
+  // visible window, so it does NOT reintroduce the zoom-in trimming bug
+  // that the old `x - windowMs*2` trim had (that one shrank with zoom).
   if (mutated) {
+    for (const d of dataset) {
+      if (d.length > MAX_POINTS_PER_SERIES) {
+        d.splice(0, d.length - MAX_POINTS_PER_SERIES);
+      }
+    }
     if (coord.state.range === null) {
       applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
@@ -1138,13 +1170,19 @@ watch(
     } catch (err) {
       console.warn('chart viewport apply skipped:', err);
     }
-    // Viewport / pause changes are axis-only updates — render
-    // directly so brush drag feels as smooth as the vis-timeline
-    // events panel. safeChartUpdate's adaptive throttle exists for
-    // data-arrival churn (pushSample / drainNewRows insert many
-    // points per second); applying it here would delay pan response
-    // up to several seconds when a dataset has thousands of points.
-    try { chart.update('none'); } catch (err) { console.warn('chart pan render skipped:', err); }
+    // Interactive viewport changes (brush drag, pan, zoom — i.e. a
+    // pinned range) render directly so they feel as smooth as the
+    // vis-timeline events panel. But in LIVE mode (range === null) this
+    // watcher fires on EVERY sample, because effectiveRange tracks
+    // lastSampleMs — and a direct chart.update() per sample across N
+    // charts is the dominant CPU sink on a long-lived tab (#582). For
+    // the live-edge case, route through the adaptive throttle instead;
+    // the right edge still advances at the metrics emit cadence.
+    if (coord.state.range === null) {
+      safeChartUpdate();
+    } else {
+      try { chart.update('none'); } catch (err) { console.warn('chart pan render skipped:', err); }
+    }
   },
 );
 
@@ -1231,6 +1269,11 @@ function onLiveToggleClick() {
 }
 
 onBeforeUnmount(() => {
+  // Remove window-level listeners so the destroyed chart's closures can
+  // be GC'd (issue #582 — otherwise switching sessions leaks charts).
+  for (const fn of teardownFns) { try { fn(); } catch { /* ignore */ } }
+  teardownFns.length = 0;
+  if (pendingUpdateTimer != null) { clearTimeout(pendingUpdateTimer); pendingUpdateTimer = null; }
   try { chart?.destroy(); } catch { /* ignore */ }
   chart = null;
 });

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -509,41 +509,33 @@ export function useSessionTimeSeries(
     };
   }
 
-  // Periodic eviction guard: if any stream balloons past its soft
-  // cap, drop entries outside the current viewport guardband. The
-  // viewport hint is (samples ∪ network ∪ events) bounds so we
-  // never throw away data the brush is actively showing. Renderers
-  // that pan past the cache trigger a fresh fetch — handled at
-  // the upper layer (TS6).
-  const SOFT_CAP_SAMPLES = 50000;
-  const SOFT_CAP_NETWORK = 5000;
-  const SOFT_CAP_EVENTS = 50000;
+  // Recency cap (issue #582). The previous eviction called
+  // evictOutsideViewport with the streams' OWN merged data bounds —
+  // which keeps `[min − 2·span, max + 2·span]` of the entire cached
+  // range, i.e. it never actually drops anything as the range grows.
+  // So the caches grew unbounded for the life of the tab (a primary
+  // contributor to the 12 GB renderer). Replace with a hard recency
+  // cap: keep only the most recent N rows per stream. Arrays are sorted
+  // ascending by ts (insertSortedDedup), so the oldest are at the front.
+  // Panning past the retained window triggers a fresh range fetch at the
+  // upper layer.
+  const SOFT_CAP_SAMPLES = 10000;
+  const SOFT_CAP_NETWORK = 2000;
+  const SOFT_CAP_EVENTS = 10000;
+  function trimToCap<T>(arr: T[], cap: number): boolean {
+    if (arr.length > cap) {
+      arr.splice(0, arr.length - cap);
+      return true;
+    }
+    return false;
+  }
   watch(
     [eventsVersion, networkVersion, controlVersion, avmetricsVersion],
     () => {
-      const bounds = mergedBounds(
-        eventsBounds.value,
-        networkBounds.value,
-        controlBounds.value,
-        avmetricsBounds.value,
-      );
-      if (!bounds) return;
-      if (eventsArr.value.length > SOFT_CAP_SAMPLES) {
-        evictOutsideViewport(eventsArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(eventsArr);
-      }
-      if (networkArr.value.length > SOFT_CAP_NETWORK) {
-        evictOutsideViewport(networkArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(networkArr);
-      }
-      if (controlArr.value.length > SOFT_CAP_EVENTS) {
-        evictOutsideViewport(controlArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(controlArr);
-      }
-      if (avmetricsArr.value.length > SOFT_CAP_EVENTS) {
-        evictOutsideViewport(avmetricsArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(avmetricsArr);
-      }
+      if (trimToCap(eventsArr.value, SOFT_CAP_SAMPLES)) triggerRef(eventsArr);
+      if (trimToCap(networkArr.value, SOFT_CAP_NETWORK)) triggerRef(networkArr);
+      if (trimToCap(controlArr.value, SOFT_CAP_EVENTS)) triggerRef(controlArr);
+      if (trimToCap(avmetricsArr.value, SOFT_CAP_EVENTS)) triggerRef(avmetricsArr);
     },
   );
 


### PR DESCRIPTION
## What

Bounds the v3 **Testing Monitor** page's memory and CPU. On a long-lived tab with live sessions it grew to **~12 GB renderer memory / ~316% CPU**; this caps every buffer that grew without limit and stops a per-sample full redraw. Pre-existing — confirmed by profiling the baseline with zero compare-charts code (#579) present.

## Changes

- **Chart point cap** (`MetricsLineChart`): each series capped at 8,000 points (oldest dropped). The chart kept every point for the life of the tab while the cache evicted — so dataset arrays grew unbounded. Pure memory bound, independent of zoom (so it doesn't reintroduce the old `x - windowMs*2` trim bug).
- **Real cache cap** (`useSessionTimeSeries`): the previous eviction passed the stream's own merged data bounds to `evictOutsideViewport`, which keeps `[min−2·span, max+2·span]` of the *entire growing range* → a no-op. Replaced with a recency cap (10k samples/events, 2k network).
- **Throttled live redraw** (`MetricsLineChart`): the `effectiveRange` watcher called `chart.update()` directly on **every sample** in live mode (the 316% CPU sink). Live-edge now routes through the existing adaptive throttle; pan/zoom stay direct.
- **Events-lane retention** (`EventsTimeline`): `statefulEvents` was appended every heartbeat, never trimmed, with an O(n) coalesce per render. Trim to the events cache's retained window so the Player State lanes still cover the same span as the charts on pan-back.
- **Listener teardown** (`MetricsLineChart`): `window` listeners (pan `mousemove`/`mouseup`/`blur`, live-toggle `blur`) were never removed on unmount, leaking the chart closures on session switch. Removed in `onBeforeUnmount` + the pending update timer cleared.

## Verification

Profiled the live page (`dev.jeoliver.com:21000`, 2 live sessions):
- JS heap plateaus at **~100 MB over 12+ min** (was unbounded).
- **4 chart instances** (no leaked charts), points capped, **~55 min of history retained**.
- Renderer footprint: **~12 GB → hundreds of MB** after a clean process start.

## Tradeoffs / follow-ups (filed separately)

- Pan-back is now bounded to the retained window (the memory bound). Restoring unlimited pan-back without the leak needs **on-demand refetch on pan** — separate issue.
- Two pre-existing UX gaps surfaced during this work and are ticketed separately: chart ↔ Player-State-timeline **viewport desync** on pan, and Network/Play logs **not syncing to the brushed window**.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
