### PR TITLE
feat(506): event-keyed derived tokens (PlayLog event rows)

### DIFF
--- a/analytics/go-forwarder/timeseries.go
+++ b/analytics/go-forwarder/timeseries.go
@@ -640,10 +640,49 @@ func buildSamplesQuery(cfg config, sel streamSelection, params timeseriesParams)
 	// WHERE clause's `ts >= parseDateTime64BestEffort(...)` is then a
 	// String/DateTime64 comparison that CH rejects with
 	// ILLEGAL_TYPE_OF_ARGUMENT. Same pattern v2_handlers.go uses.
+	// Middle-layer LEFT-JOIN the #506 derived token (event rows are keyed by
+	// event_fingerprint); outer toString projection runs over native `ts`.
 	cols := buildSelectColumns(sel.Columns)
-	q := fmt.Sprintf(`SELECT %s FROM (SELECT * FROM %s.%s WHERE %s ORDER BY ts ASC LIMIT %d) FORMAT JSONEachRow`,
-		cols, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "), limit)
+	dtScope := []string{}
+	if params.playerID != "" {
+		dtScope = append(dtScope, "lowerUTF8(player_id) = lowerUTF8({player:String})")
+	}
+	if params.playID != "" && params.playID != "—" {
+		dtScope = append(dtScope, "lowerUTF8(play_id) = lowerUTF8({play:String})")
+	}
+	if params.from != "" {
+		dtScope = append(dtScope, "ts >= parseDateTime64BestEffort({from:String})")
+	}
+	if params.to != "" {
+		dtScope = append(dtScope, "ts <= parseDateTime64BestEffort({to:String})")
+	}
+	if len(dtScope) == 0 {
+		dtScope = append(dtScope, "ts >= now() - INTERVAL 1 HOUR")
+	}
+	q := fmt.Sprintf(`SELECT %s, token FROM (
+	  SELECT base.*, ifNull(dt.token, '') AS token
+	  FROM (SELECT * FROM %s.%s WHERE %s ORDER BY ts ASC LIMIT %d) base
+	  %s
+	) FORMAT JSONEachRow`,
+		cols, cfg.chDatabase, cfg.chTable, strings.Join(clauses, " AND "), limit,
+		derivedEventTokenJoinSQL(cfg.chDatabase, strings.Join(dtScope, " AND ")))
 	return q, args, nil
+}
+
+// derivedEventTokenJoinSQL is the session_events counterpart to
+// derivedTokenJoinSQL. The live session_events has no per-row fingerprint
+// (sorting key is player_id, ts), so event tokens are keyed by (player_id, ts)
+// — which is also how the SSE layer identities event rows. surface='event'
+// keeps network tokens (which may share a ts) from bleeding in; argMax dedupes
+// the ReplacingMergeTree to the latest score.
+func derivedEventTokenJoinSQL(db, scope string) string {
+	return fmt.Sprintf(`LEFT JOIN (
+	  SELECT player_id, ts, argMax(token, scored_at) AS token
+	  FROM %s.derived_tokens
+	  WHERE surface = 'event' AND %s
+	  GROUP BY player_id, ts
+	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts`,
+		db, scope)
 }
 
 func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams) (string, map[string]string, error) {
@@ -707,7 +746,7 @@ func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams)
 	  %s
 	) FORMAT JSONEachRow`,
 		cols, cfg.chDatabase, strings.Join(clauses, " AND "), limit,
-		derivedTokenJoinSQL(cfg.chDatabase, strings.Join(dtScope, " AND ")))
+		derivedTokenJoinSQL(cfg.chDatabase, "entry_fingerprint", strings.Join(dtScope, " AND ")))
 	return q, args, nil
 }
 
@@ -719,14 +758,18 @@ func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams)
 // duplicates to the latest score. `scope` constrains the build side to the
 // same player/play/time window as the base query (the columns derived_tokens
 // shares) so the join never has to read the whole table.
-func derivedTokenJoinSQL(db, scope string) string {
+// baseFpCol is the fingerprint column on the base table to match against
+// derived_tokens.entry_fingerprint — `entry_fingerprint` for network_requests,
+// `event_fingerprint` for session_events (the batch stores either under
+// entry_fingerprint; surface distinguishes them).
+func derivedTokenJoinSQL(db, baseFpCol, scope string) string {
 	return fmt.Sprintf(`LEFT JOIN (
 	  SELECT player_id, ts, entry_fingerprint, argMax(token, scored_at) AS token
 	  FROM %s.derived_tokens
 	  WHERE %s
 	  GROUP BY player_id, ts, entry_fingerprint
-	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts AND base.entry_fingerprint = dt.entry_fingerprint`,
-		db, scope)
+	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts AND base.%s = dt.entry_fingerprint`,
+		db, scope, baseFpCol)
 }
 
 // buildSelectColumns produces the SELECT projection list. `ts` is

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -422,7 +422,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		)
 		FORMAT JSONEachRow`,
 		cfg.chDatabase, strings.Join(clauses, " AND "), limit,
-		derivedTokenJoinSQL(cfg.chDatabase, strings.Join(dtScope, " AND ")))
+		derivedTokenJoinSQL(cfg.chDatabase, "entry_fingerprint", strings.Join(dtScope, " AND ")))
 
 	rows, err := queryClickHouseRows(r.Context(), cfg, query, params)
 	if err != nil {

--- a/analytics/tools/derive_tokens.py
+++ b/analytics/tools/derive_tokens.py
@@ -30,7 +30,10 @@ import tokenize as tk  # noqa: E402
 
 DB = "infinite_streaming"
 # Columns tokenize_rows needs (classify_row/_is_faulted/_fault_class) + identity + the join key.
-SELECT_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
+NET_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
+# Event-row columns: identity + the lifecycle marker. Event tokens key on (player_id, ts)
+# — the live session_events has no event_fingerprint column (sorting key is player_id, ts).
+EVENT_COLS = "ts, player_id, play_id, last_event"
 
 
 def _auth_header():
@@ -56,16 +59,23 @@ def ch(ch_url, query, body=None, params=None):
         return resp.read().decode()
 
 
-def fetch_rows(ch_url, days, player):
+def fetch_rows(ch_url, days, player, table, cols, order):
     where = ["ts >= now64(3) - INTERVAL {days:UInt32} DAY"]
     params = {"days": str(days)}
     if player:
         where.append("player_id = {pid:String}")
         params["pid"] = player
-    sql = (f"SELECT {SELECT_COLS} FROM {DB}.network_requests "
-           f"WHERE {' AND '.join(where)} ORDER BY player_id, ts, entry_fingerprint")
+    sql = (f"SELECT {cols} FROM {DB}.{table} "
+           f"WHERE {' AND '.join(where)} ORDER BY {order}")
     out = ch(ch_url, sql, params=params)
     return [json.loads(l) for l in out.splitlines() if l.strip()]
+
+
+def group_by_play(rows):
+    by = collections.defaultdict(list)
+    for r in rows:
+        by[r.get("play_id")].append(r)
+    return by
 
 
 def main():
@@ -77,27 +87,40 @@ def main():
     ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
     args = ap.parse_args()
 
-    rows = fetch_rows(args.ch_url, args.days, args.player)
-    by_play = collections.defaultdict(list)
-    for r in rows:
-        by_play[r.get("play_id")].append(r)
+    net_rows = fetch_rows(args.ch_url, args.days, args.player, "network_requests",
+                          NET_COLS, "player_id, ts, entry_fingerprint")
+    event_rows = fetch_rows(args.ch_url, args.days, args.player, "session_events",
+                            EVENT_COLS, "player_id, ts")
+    net_by_play = group_by_play(net_rows)
+    ev_by_play = group_by_play(event_rows)
+    plays = list(net_by_play.keys()) + [p for p in ev_by_play if p not in net_by_play]
     scored_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
     derived = []
-    for play, prows in by_play.items():
+    for play in plays:
+        prows = net_by_play.get(play, [])
+        erows = ev_by_play.get(play, [])
         # A play has exactly one player, but the FIRST network row is often a
         # pre-stamp row (the forwarder hasn't resolved session→player yet) with
         # an empty player_id. Stamping prows[0] would blank the whole play and
         # break the read-path join (which matches on player_id). Take the first
-        # non-empty player_id instead.
-        pid = next((r.get("player_id") for r in prows if r.get("player_id")), "")
+        # non-empty player_id across network + event rows instead.
+        pid = next((r.get("player_id") for r in (prows + erows) if r.get("player_id")), "")
+        # Network rows → entry_fingerprint-keyed tokens; event rows →
+        # event_fingerprint-keyed tokens (both land in entry_fingerprint, surface
+        # distinguishes). The read-path join keys the column appropriately.
         for ts, fp, surface, token in tk.tokenize_rows(prows):
             derived.append({"ts": ts, "player_id": pid, "play_id": play,
                             "entry_fingerprint": fp, "surface": surface, "token": token,
                             "model_version": args.model_version, "scored_at": scored_at})
+        for ts, fp, surface, token in tk.tokenize_event_rows(erows):
+            derived.append({"ts": ts, "player_id": pid, "play_id": play,
+                            "entry_fingerprint": fp, "surface": surface, "token": token,
+                            "model_version": args.model_version, "scored_at": scored_at})
 
-    print(f"#506 derive_tokens — {len(rows)} rows / {len(by_play)} plays / {args.days}d "
-          f"→ {len(derived)} tokens (model={args.model_version})")
+    print(f"#506 derive_tokens — {len(net_rows)} net + {len(event_rows)} event rows / "
+          f"{len(plays)} plays / {args.days}d → {len(derived)} tokens "
+          f"(model={args.model_version})")
     kinds = collections.Counter(t["token"].split("(")[0] for t in derived)
     print("token kinds:", dict(kinds.most_common(10)))
     if args.dry_run:

--- a/analytics/tools/tokenize.py
+++ b/analytics/tools/tokenize.py
@@ -126,14 +126,44 @@ EVENT_TOKEN_MAP = {
 }
 
 
+def _event_last(r):
+    """last_event for a session_events row — flat CH column or nested player_metrics."""
+    le = r.get("last_event")
+    if le:
+        return le
+    pm = r.get("player_metrics") or {}
+    return pm.get("last_event")
+
+
 def event_tokens(event_rows):
     """[(ts, token)] from session_events lifecycle markers. Heartbeats/unknowns dropped."""
     out = []
     for r in event_rows:
         pm = r.get("player_metrics") or {}
-        tok = EVENT_TOKEN_MAP.get(pm.get("last_event"))
+        tok = EVENT_TOKEN_MAP.get(_event_last(r))
         if tok:
             out.append((r.get("ts") or r.get("timestamp") or pm.get("event_time") or "", tok))
+    return out
+
+
+def tokenize_event_rows(event_rows):
+    """Per-row event tokens for the #506 derived-token writer, keyed by (player_id, ts) —
+    the event-row identity the SSE layer already uses (session_events dedupes by ts; the
+    live table has no event_fingerprint column). ONE (ts, fp, surface, token) per row whose
+    last_event maps to a lifecycle marker (STALL_START / RATE_UP / FIRST_FRAME / …);
+    heartbeats and unrecognised events are skipped (no token → the dashboard shows —). fp=0
+    so these land distinctly from network rows (real nonzero entry_fingerprint) in the
+    shared derived_tokens table; the events read-path join keys on (player_id, ts) +
+    surface='event'."""
+    out = []
+    for r in event_rows:
+        tok = EVENT_TOKEN_MAP.get(_event_last(r))
+        if not tok:
+            continue
+        ts = r.get("ts") or r.get("timestamp") or ""
+        if not ts:
+            continue
+        out.append((ts, 0, "event", tok))
     return out
 
 


### PR DESCRIPTION
## What

Follow-up to #583. Extends the #506 per-row derived token from **network rows** to **session_events lifecycle rows**, so PlayLog event rows show a token (`STALL_START`/`STALL_END`, `RATE_UP`/`RATE_DOWN`, `BUF_START`/`BUF_END`, `FIRST_FRAME`, `SEGMENT_STALL`, `TIMEJUMP`) instead of `—`.

**No dashboard change** — PlayLog already renders `r.raw.token`; once the events SSE carries `token`, event rows light up. **No schema migration** — reuses the `derived_tokens` table.

## How

- **`tokenize.py`** — `tokenize_event_rows()`: per-row event tokens keyed by `(player_id, ts)`. The live `session_events` has no `event_fingerprint` column (sorting key is `player_id, ts`), and that's the identity the SSE layer already uses to dedupe event rows. `fp=0` so event tokens land distinctly from network rows (real nonzero `entry_fingerprint`) in the shared table. `_event_last()` reads the flat `last_event` column or nested `player_metrics`.
- **`derive_tokens.py`** — also fetches `session_events` and emits event tokens; `player_id` taken from the first non-empty across network + event rows.
- **`timeseries.go`** — `derivedEventTokenJoinSQL`: joins on `(player_id, ts)` with `surface='event'` (`argMax(token, scored_at)` dedup), wired into `buildSamplesQuery` (events SSE). The network join helper was generalised to take the base fingerprint column.

## Verification (test-dev)

Re-ran the batch over 2 days: 120,816 tokens incl. the event vocab. Events SSE for a rate-shift play surfaces `RATE_UP` ×132, `RATE_DOWN` ×81, `STALL_START/END`, `BUF_START/END`, `SEGMENT_STALL`, `FIRST_FRAME`; heartbeats → empty token. Network path regression-checked (still `V_SEG`/`A_SEG`/`V_PL`/`A_PL`). Forwarder rebuilt + redeployed; `go build` + tests pass.

## Out of scope / follow-ups

- **Control + avmetric rows** show `—` by design — not a follow-up. The token model has no control vocabulary (control_events are operator/server/harness actions; the one playback-affecting one, fault injection, already enters as a `FAULT` token on the network request it breaks). avmetrics is a conceivable future source but would largely duplicate the session_events lifecycle tokens.
- **Batch scheduling** — `derive_tokens.py` still runs manually (a cron/timer is the remaining #506 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

