### PR TITLE
feat(506): schedule derive_tokens via token-deriver sidecar

### DIFF
--- a/analytics/tools/derive_tokens.py
+++ b/analytics/tools/derive_tokens.py
@@ -59,9 +59,15 @@ def ch(ch_url, query, body=None, params=None):
         return resp.read().decode()
 
 
-def fetch_rows(ch_url, days, player, table, cols, order):
-    where = ["ts >= now64(3) - INTERVAL {days:UInt32} DAY"]
-    params = {"days": str(days)}
+def fetch_rows(ch_url, days, hours, player, table, cols, order):
+    # Trailing window: --hours (bounded re-scan for the scheduled sidecar) wins over
+    # --days (ad-hoc backfill). ReplacingMergeTree(scored_at) dedupes the overlap.
+    if hours:
+        where = ["ts >= now64(3) - INTERVAL {hours:UInt32} HOUR"]
+        params = {"hours": str(hours)}
+    else:
+        where = ["ts >= now64(3) - INTERVAL {days:UInt32} DAY"]
+        params = {"days": str(days)}
     if player:
         where.append("player_id = {pid:String}")
         params["pid"] = player
@@ -82,14 +88,16 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
     ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--hours", type=int, default=0,
+                    help="trailing window in hours (overrides --days; for the scheduled sidecar)")
     ap.add_argument("--player", default=None, help="limit to one player_id")
     ap.add_argument("--model-version", default="vomm-tok-1")
     ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
     args = ap.parse_args()
 
-    net_rows = fetch_rows(args.ch_url, args.days, args.player, "network_requests",
+    net_rows = fetch_rows(args.ch_url, args.days, args.hours, args.player, "network_requests",
                           NET_COLS, "player_id, ts, entry_fingerprint")
-    event_rows = fetch_rows(args.ch_url, args.days, args.player, "session_events",
+    event_rows = fetch_rows(args.ch_url, args.days, args.hours, args.player, "session_events",
                             EVENT_COLS, "player_id, ts")
     net_by_play = group_by_play(net_rows)
     ev_by_play = group_by_play(event_rows)
@@ -118,8 +126,9 @@ def main():
                             "entry_fingerprint": fp, "surface": surface, "token": token,
                             "model_version": args.model_version, "scored_at": scored_at})
 
+    window = f"{args.hours}h" if args.hours else f"{args.days}d"
     print(f"#506 derive_tokens — {len(net_rows)} net + {len(event_rows)} event rows / "
-          f"{len(plays)} plays / {args.days}d → {len(derived)} tokens "
+          f"{len(plays)} plays / {window} → {len(derived)} tokens "
           f"(model={args.model_version})")
     kinds = collections.Counter(t["token"].split("(")[0] for t in derived)
     print("token kinds:", dict(kinds.most_common(10)))

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -502,10 +502,14 @@ function rowLabels(r: Row): string[] {
   return [];
 }
 
-/** #506 batch-derived per-row token, LEFT-JOINed onto network rows by
- *  the forwarder (analytics/tools/derive_tokens.py + the read-path merge
- *  in v2_handlers.go / timeseries.go). Only network rows carry it;
- *  event / control / avmetric rows return '' (no derived tokens yet). */
+/** #506 batch-derived per-row token, LEFT-JOINed by the forwarder
+ *  (analytics/tools/derive_tokens.py + the read-path merge in
+ *  v2_handlers.go / timeseries.go). Network rows carry segment/playlist
+ *  tokens (V_SEG/A_SEG/V_PL/…, FAULT); session_events rows carry
+ *  lifecycle tokens (STALL_*/RATE_*/BUF_*/FIRST_FRAME). Control and
+ *  avmetric rows return '' by design — the token model has no vocabulary
+ *  for them (the one control signal that matters, fault injection, is
+ *  already a FAULT token on the network request it breaks). */
 function rowToken(r: Row): string {
   const t = r.raw?.token;
   return typeof t === 'string' ? t : '';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,45 @@ services:
       - app_network
     restart: unless-stopped
 
+  # #506 — scheduled per-row token derivation. Runs analytics/tools/
+  # derive_tokens.py on a loop against ClickHouse, keeping derived_tokens
+  # populated so the NetworkLog / PlayLog token columns stay fresh without
+  # manual runs. NOT on the forwarder's hot ingest path (the delay is a
+  # feature — resolves the tokenizer's lookahead; see #506).
+  #
+  # Bind-mounts the tools dir (no image rebuild when the still-evolving
+  # tokenizer changes — just restart the service). stdlib-only Python, so a
+  # stock slim image needs no pip install. Trailing-window re-scan +
+  # ReplacingMergeTree(scored_at) dedup handles overlap and lateness.
+  token-deriver:
+    image: python:3.12-slim
+    container_name: infinite-streaming-token-deriver
+    volumes:
+      - ./analytics/tools:/tools:ro
+    environment:
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - DERIVE_INTERVAL_SECONDS=${DERIVE_INTERVAL_SECONDS:-1800}
+      - DERIVE_WINDOW_HOURS=${DERIVE_WINDOW_HOURS:-6}
+      - DERIVE_MODEL_VERSION=${DERIVE_MODEL_VERSION:-vomm-tok-1}
+    # Initial sleep lets ClickHouse finish init.d (incl. 04-derived.sql)
+    # on a cold start; a failed run just logs and retries next tick.
+    command:
+      - sh
+      - -c
+      - |
+        sleep 20
+        while true; do
+          python3 /tools/derive_tokens.py --hours "$$DERIVE_WINDOW_HOURS" --model-version "$$DERIVE_MODEL_VERSION" \
+            || echo "[token-deriver] run failed (rc=$$?), retrying next tick"
+          sleep "$$DERIVE_INTERVAL_SECONDS"
+        done
+    depends_on:
+      clickhouse:
+        condition: service_started
+    networks:
+      - app_network
+    restart: unless-stopped
+
 
 networks:
   app_network:


### PR DESCRIPTION
## What

Schedules the #506 per-row token derivation so the NetworkLog / PlayLog token columns stay fresh without manual `derive_tokens.py` runs — the remaining token-substrate follow-up after #583 (network tokens) and #588 (event tokens).

## How

- **`docker-compose.yml`** — new `token-deriver` sidecar (`python:3.12-slim`, stdlib-only so no pip install). Bind-mounts `analytics/tools` so the still-evolving tokenizer needs no image rebuild — just restart the service. Loops `derive_tokens.py` every `DERIVE_INTERVAL_SECONDS` (default 1800) over a `DERIVE_WINDOW_HOURS` trailing window (default 6); a failed run logs and retries next tick. Explicitly **not** on the forwarder's hot ingest path — the delay resolves the tokenizer's lookahead (the #506 rationale). Trailing-window re-scan + `ReplacingMergeTree(scored_at)` dedup handles overlap and lateness.
- **`derive_tokens.py`** — `--hours` trailing-window flag (overrides `--days`) so the scheduled re-scan stays bounded instead of re-deriving whole days each tick.
- **`PlayLog.vue`** — correct the `rowToken` doc comment: network rows carry segment/playlist tokens, `session_events` rows carry lifecycle tokens, and control + avmetric rows are `''` **by design** (no token vocabulary), not a pending follow-up. The one control signal that matters — fault injection — is already a `FAULT` token on the network request it breaks.

## Verification (test-dev)

`token-deriver` started without disturbing other services (only the new container created; ClickHouse left running). First cycle inserted **16,702 tokens over a 6h window**, including `RATE_UP` / `TIMEJUMP` / `BUF_*` / `FIRST_FRAME` event tokens. Runs every 30 min. `docker compose config` valid; `derive_tokens.py --hours` dry-run confirmed.

## Notes / tuning

- Cadence + window are env-tunable (`DERIVE_INTERVAL_SECONDS`, `DERIVE_WINDOW_HOURS`, `DERIVE_MODEL_VERSION`). 6h window covers long characterization plays; bump it if plays can run longer.
- Parity: added to the base `docker-compose.yml` (covers local + test-dev). The GHCR/k8s deploy paths (`docker-compose.ghcr.yml`, `k8s-analytics.yaml`) don't yet carry it — a k8s `CronJob` is the idiomatic fit there; follow-up if/when those environments need derived tokens.
- This is the token-substrate scheduler only; the full anomaly `derived_labels`/scoring layer (the issue's original goal) remains separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
