### PR TITLE
feat(506): derived_labels — VOMM surprise outliers, tagged + filterable

### DIFF
--- a/analytics/clickhouse/init.d/05-derived-labels.sql
+++ b/analytics/clickhouse/init.d/05-derived-labels.sql
@@ -1,0 +1,37 @@
+-- #506 — derived anomaly LABELS (out-of-band batch; NOT written by the live ingest path).
+-- The sibling of derived_tokens: where derived_tokens carries the per-row #508 token,
+-- derived_labels carries the VOMM scorer's per-(play,condition) SURPRISE verdict. A batch
+-- (analytics/tools/derive_labels.py, reusing scorer.py + tokenize.py) trains per-condition
+-- VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time-split), writing one row
+-- per (play, condition) whose worst episode is notably more surprising than the typical
+-- episode for that condition. The read API unions these into labels[] so sessions.html can
+-- filter on them and session-viewer can mark them.
+--
+-- Granularity (v1): one row per (player_id, play_id, condition) — a play-level rollup keyed
+-- so ReplacingMergeTree(scored_at) supersedes on re-score. `ts` is the play's first ts
+-- (STABLE across re-scores so dedup + partition stay put); `peak_at` is the worst episode's
+-- anchor ts (for a precise session-viewer marker later).
+--
+-- label is the filter key — a clean `,`/`=`-free condition tag (vomm_<condition>_surprise);
+-- the model's peak transition (full of `,`/`(`/spaces the label vocab forbids) rides in the
+-- `peak` String column as detail, NOT as the filter token.
+
+CREATE TABLE IF NOT EXISTS infinite_streaming.derived_labels
+(
+    ts             DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
+    player_id      LowCardinality(String)           CODEC(ZSTD(1)),
+    play_id        LowCardinality(String)           CODEC(ZSTD(1)),
+    condition      LowCardinality(String)           CODEC(ZSTD(1)),
+    label          LowCardinality(String)           CODEC(ZSTD(1)),
+    severity       LowCardinality(String)           CODEC(ZSTD(1)),
+    score          Float32                          CODEC(ZSTD(1)),
+    peak           String                           CODEC(ZSTD(1)),
+    peak_at        DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
+    model_version  LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    scored_at      DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1))
+)
+ENGINE = ReplacingMergeTree(scored_at)
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (player_id, play_id, condition)
+TTL toDateTime(ts) + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;

--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -178,6 +178,15 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		  SELECT lowerUTF8(play_id) AS play_id, arrayJoin(labels) AS label
 		  FROM %s.control_events
 		  %s
+		  UNION ALL
+		  -- #506 derived anomaly labels (analytics/tools/derive_labels.py):
+		  -- one row per (play, condition), surfaced as <severity>=<label> so
+		  -- the existing chip renderer + label filter treat them like any
+		  -- other label. DISTINCT collapses ReplacingMergeTree pre-merge
+		  -- dups; the play_id JOIN below bounds this tiny table to the
+		  -- window's plays, so no time WHERE is needed here.
+		  SELECT DISTINCT lowerUTF8(play_id) AS play_id, concat(severity, '=', label) AS label
+		  FROM %s.derived_labels
 		),
 		labels_per_play AS (
 		  SELECT play_id, label, count() AS n
@@ -297,6 +306,7 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		b.Database, b.EventsTable, where,
 		b.Database, netWhere,
 		b.Database, netWhere,
+		b.Database, // #506 derived_labels branch in labels_unioned
 		postWhere(postClauses),
 		limit,
 	)

--- a/analytics/tools/derive_labels.py
+++ b/analytics/tools/derive_labels.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""#506 batch anomaly-LABEL writer — the sibling of derive_tokens.py.
+
+Trains per-condition VOMMs (PPM-C back-off, from scorer.py) on OLDER plays and scores
+RECENT plays OUT-OF-SAMPLE (a time split: train on plays whose data predates the scoring
+window, score plays inside it — no play is scored by a model trained on itself, which is
+why production needs no k-fold). For each (play, condition) whose worst episode is notably
+more surprising than the typical episode for that condition, writes one row to the
+`derived_labels` table. The read API unions these into labels[] → filterable in
+sessions.html, markable in session-viewer.
+
+Reads ClickHouse directly over HTTP (reuses derive_tokens.py's ch()/fetch_rows()), reusing
+scorer.py's model + tokenize.py's cross-stream tokeniser/episode windows — the SINGLE
+sources of truth. No hand-built reaction taxonomy: the tag is the condition
+(vomm_<condition>_surprise) + a severity from the surprise rate; the model's peak
+transition rides in the `peak` column as detail.
+
+  python3 analytics/tools/derive_labels.py --train-days 7 --score-hours 6 [--dry-run]
+  # CH endpoint via --ch-url or FORWARDER_CLICKHOUSE_URL (default http://localhost:8123)
+"""
+import argparse
+import collections
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import tokenize as tk          # noqa: E402  cross-stream tokeniser + episode windows
+import scorer as sc            # noqa: E402  VOMM model (train / transition_surprises / score / p99)
+import derive_tokens as dt     # noqa: E402  ch() / fetch_rows() / group_by_play() / DB
+
+NET_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
+EVENT_COLS = "ts, player_id, play_id, last_event"
+
+
+def play_tokens_with_ts(net_rows, event_rows):
+    """(tokens, ts_parallel) for one play — cross-stream, ts-sorted, with <S>/<E> sentinels
+    whose ts borrow the first/last real token (so an <E>-anchored episode marks the tail)."""
+    seq = tk._token_seq(net_rows, event_rows)  # [(ts, fp, surface, token)] ts-sorted
+    if not seq:
+        return [], []
+    toks = [s[3] for s in seq]
+    tss = [s[0] for s in seq]
+    return ["<S>"] + toks + ["<E>"], [tss[0]] + tss + [tss[-1]]
+
+
+def ts_episodes(toks, tss, anchor, lead, horizon):
+    """[(anchor_ts, window_tokens)] — tk.episodes() windows + the anchor token's ts."""
+    return [(tss[e["anchor_index"]], e["window"])
+            for e in tk.episodes(toks, anchor=anchor, lead=lead, horizon=horizon)]
+
+
+def severity_for(rate, crit):
+    return "critical" if rate >= crit else "warning"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--train-days", type=int, default=7, help="corpus window for training the per-condition models")
+    ap.add_argument("--score-hours", type=int, default=6, help="recent window whose plays get scored (out-of-sample vs train)")
+    ap.add_argument("--player", default=None, help="limit to one player_id")
+    ap.add_argument("--max-order", type=int, default=4)
+    ap.add_argument("--alpha", type=float, default=0.5)
+    ap.add_argument("--min-train-episodes", type=int, default=20, help="skip a condition with fewer training episodes")
+    ap.add_argument("--emit-rate", type=float, default=0.34, help="episode surprise-rate at/above which a label is emitted")
+    ap.add_argument("--crit-rate", type=float, default=0.60, help="surprise-rate at/above which severity=critical")
+    ap.add_argument("--model-version", default="vomm-tok-1")
+    ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
+    args = ap.parse_args()
+
+    # Fetch the whole train window (which contains the recent score window); split by ts.
+    net_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "network_requests",
+                             NET_COLS, "player_id, ts, entry_fingerprint")
+    event_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "session_events",
+                               EVENT_COLS, "player_id, ts")
+    net_by_play = dt.group_by_play(net_rows)
+    ev_by_play = dt.group_by_play(event_rows)
+    plays = list(net_by_play.keys()) + [p for p in ev_by_play if p not in net_by_play]
+
+    # Build per-play token seqs + recency; ClickHouse ts strings sort lexically.
+    cutoff = (datetime.now(timezone.utc) - timedelta(hours=args.score_hours)).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    builds = {}  # play_id -> {pid, toks, tss, start_ts, max_ts}
+    for play in plays:
+        if not play:
+            continue
+        prows, erows = net_by_play.get(play, []), ev_by_play.get(play, [])
+        toks, tss = play_tokens_with_ts(prows, erows)
+        if not toks:
+            continue
+        pid = next((r.get("player_id") for r in (prows + erows) if r.get("player_id")), "")
+        builds[play] = {"pid": pid, "toks": toks, "tss": tss, "start_ts": tss[0], "max_ts": tss[-1]}
+
+    train_plays = [b for b in builds.values() if b["max_ts"] < cutoff]
+    score_plays = [(p, b) for p, b in builds.items() if b["max_ts"] >= cutoff]
+    scored_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+    print(f"#506 derive_labels — {len(builds)} plays ({len(train_plays)} train / {len(score_plays)} score) "
+          f"train={args.train_days}d score={args.score_hours}h emit>={args.emit_rate:.0%}")
+
+    rows = []
+    per_condition = collections.Counter()
+    for c in sc.EPISODE_CONDITIONS:
+        cond, anchor = c["name"], c["anchor"]
+        train_eps = [w for b in train_plays for _, w in ts_episodes(b["toks"], b["tss"], anchor, c["lead"], c["horizon"])]
+        if len(train_eps) < args.min_train_episodes:
+            print(f"  {cond:8} — {len(train_eps)} train episodes < {args.min_train_episodes}; skipped")
+            continue
+        model = sc.train(train_eps, max_order=args.max_order, alpha=args.alpha)
+        thr = sc.p99([s for w in train_eps for s, _, _ in sc.transition_surprises(model, w)])
+        n_emit = 0
+        for play, b in score_plays:
+            eps = ts_episodes(b["toks"], b["tss"], anchor, c["lead"], c["horizon"])
+            if not eps:
+                continue
+            worst = None  # (rate, peak, anchor_ts)
+            for anchor_ts, w in eps:
+                r = sc.score(model, w, thr)
+                if worst is None or r["rate"] > worst[0]:
+                    worst = (r["rate"], r["argmax"], anchor_ts)
+            if not worst or worst[0] < args.emit_rate:
+                continue
+            rate, peak, peak_at = worst
+            rows.append({"ts": b["start_ts"], "player_id": b["pid"], "play_id": play,
+                         "condition": cond, "label": f"vomm_{cond}_surprise",
+                         "severity": severity_for(rate, args.crit_rate), "score": round(rate, 4),
+                         "peak": peak or "", "peak_at": peak_at,
+                         "model_version": args.model_version, "scored_at": scored_at})
+            n_emit += 1
+        per_condition[cond] = n_emit
+        print(f"  {cond:8} — train_eps={len(train_eps)} thr={thr:.1f} → {n_emit} plays labelled")
+
+    print(f"emitted {len(rows)} labels: {dict(per_condition)}")
+    if args.dry_run:
+        for r in sorted(rows, key=lambda x: -x["score"])[:8]:
+            print(f"   {r['severity']:8} {r['label']:24} score={r['score']:.0%} play={r['play_id'][:8]} peak: {r['peak']}")
+        return
+    if not rows:
+        print("nothing to write.")
+        return
+    import json
+    body = ("\n".join(json.dumps(r) for r in rows) + "\n").encode()
+    dt.ch(args.ch_url, f"INSERT INTO {dt.DB}.derived_labels FORMAT JSONEachRow", body=body)
+    print(f"inserted {len(rows)} rows into {dt.DB}.derived_labels.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,6 +278,42 @@ services:
       - app_network
     restart: unless-stopped
 
+  # #506 — scheduled anomaly LABEL derivation (the VOMM scorer's verdicts).
+  # Runs analytics/tools/derive_labels.py on a loop: trains per-condition
+  # VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time split),
+  # writing derived_labels so the surprise outliers are filterable in
+  # sessions.html + session-viewer. Like token-deriver, NOT on the hot path
+  # and bind-mounts the tools dir (model/tokenizer evolve without a rebuild).
+  # The score window must exceed the interval + a play's length so plays that
+  # finished since the last tick get scored; ReplacingMergeTree supersedes.
+  label-deriver:
+    image: python:3.12-slim
+    container_name: infinite-streaming-label-deriver
+    volumes:
+      - ./analytics/tools:/tools:ro
+    environment:
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - LABEL_INTERVAL_SECONDS=${LABEL_INTERVAL_SECONDS:-3600}
+      - LABEL_TRAIN_DAYS=${LABEL_TRAIN_DAYS:-7}
+      - LABEL_SCORE_HOURS=${LABEL_SCORE_HOURS:-12}
+      - LABEL_MODEL_VERSION=${LABEL_MODEL_VERSION:-vomm-tok-1}
+    command:
+      - sh
+      - -c
+      - |
+        sleep 25
+        while true; do
+          python3 /tools/derive_labels.py --train-days "$$LABEL_TRAIN_DAYS" --score-hours "$$LABEL_SCORE_HOURS" --model-version "$$LABEL_MODEL_VERSION" \
+            || echo "[label-deriver] run failed (rc=$$?), retrying next tick"
+          sleep "$$LABEL_INTERVAL_SECONDS"
+        done
+    depends_on:
+      clickhouse:
+        condition: service_started
+    networks:
+      - app_network
+    restart: unless-stopped
+
 
 networks:
   app_network:


### PR DESCRIPTION
## What

Surfaces the #508 VOMM scorer's **surprise outliers** as **filterable labels** in sessions.html + session-viewer, so plays with abnormal reactions (around faults / stalls / startup / end) are findable instead of buried. This is #506's `derived_labels` endgame — the same batch → derived-table → read-merge pattern as the just-shipped derived_tokens, second table.

## How (mirrors the derived_tokens chain)

- **`05-derived-labels.sql`** — `derived_labels` table (sibling of `derived_tokens`). One row per `(play, condition)`, `ReplacingMergeTree(scored_at)` so a re-score supersedes. `ts` = play start (stable dedup/partition key); `peak_at` = the worst episode's anchor ts (for a precise session-viewer marker later).
- **`derive_labels.py`** — batch writer (CH-direct, reuses `scorer.py`'s PPM-C model + `tokenize.py`'s cross-stream tokeniser/episodes). **Time-split**: trains per-condition VOMMs on *older* plays and scores *recent* plays **out-of-sample** — no play is scored by a model trained on itself, so production needs no k-fold (that was only for offline validation on a fixed corpus). Emits one label per `(play, condition)` whose worst episode exceeds the fold-calibrated threshold.
- **`find.go`** — a 4th `UNION` branch in `labels_unioned` merges `derived_labels` into each play's label set as `<severity>=<label>`. Both **display** (`label_histogram`) and **filter** (the existing post-clause on `labels_distinct`) work — **no dashboard change**: chips render and the label filter handles them like any other `<severity>=<event>` label.
- **`docker-compose.yml`** — `label-deriver` sidecar (mirrors `token-deriver`) runs `derive_labels.py` hourly on a train/score split.

## On naming (deliberate)

**No hand-built reaction taxonomy.** The model detects *improbability*, not semantics. The tag is what we know — the **condition** (`vomm_<condition>_surprise`) + a **severity** from the surprise rate; the model's **peak transition** rides in the `peak` column as detail (it can't *be* the filter key — it's full of `,`/`(`/spaces the label vocab forbids). Names for recurring shapes come **later, data-driven**, once the outliers have actually been browsed.

## Verification (test-dev)

- Writer emitted **83 labels** (fault 65 / end 10 / stall 7 / startup 1; warning/critical split).
- `query plays` `label_histogram` shows `warning=vomm_fault_surprise`, `critical=…`, etc.
- Server-side **`--label-has critical=vomm_fault_surprise`** returns exactly the one matching play — `618de870`, the iPad rampup wedge, **independently flagged** by the scorer.
- **sessions.html** renders the severity-tinted chips on session rows.
- `label-deriver` sidecar live (first cycle ran; hourly).

## Out of scope / follow-ups

- **Peak-transition detail + precise rail marker** in session-viewer (the `peak` / `peak_at` columns are written; surfacing them is a small read-path + Vue follow-up — v1 is the filterable chip).
- **Validation of meaning** — outcome-correlation (do high-surprise plays have worse `playing_time_ms` / stalls / abnormal ends?). The labels make outliers browsable; correlating them with outcomes is the next step.
- Engine filtering (v1 pools all; iOS-focused deploy). GHCR/k8s deploy parity for the sidecar (k8s CronJob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
