### PR TITLE
feat(506): per-row anomaly labels — chip surprises where they happen

### DIFF
--- a/analytics/clickhouse/init.d/05-derived-labels.sql
+++ b/analytics/clickhouse/init.d/05-derived-labels.sql
@@ -1,37 +1,38 @@
--- #506 — derived anomaly LABELS (out-of-band batch; NOT written by the live ingest path).
--- The sibling of derived_tokens: where derived_tokens carries the per-row #508 token,
--- derived_labels carries the VOMM scorer's per-(play,condition) SURPRISE verdict. A batch
--- (analytics/tools/derive_labels.py, reusing scorer.py + tokenize.py) trains per-condition
--- VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time-split), writing one row
--- per (play, condition) whose worst episode is notably more surprising than the typical
--- episode for that condition. The read API unions these into labels[] so sessions.html can
--- filter on them and session-viewer can mark them.
+-- #506 — derived anomaly LABELS, PER ROW (out-of-band batch; NOT the live ingest path).
+-- The VOMM scorer's surprise verdict, anchored on the EXACT row whose token transition was
+-- improbable — so it merges onto that row at read time (like derived_tokens) and shows as a
+-- chip right where the surprise happened, with as many per session as there are surprising
+-- rows. A batch (analytics/tools/derive_labels.py, reusing scorer.py + tokenize.py) trains
+-- per-condition VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time-split),
+-- emitting one row per above-threshold transition WITHIN a condition episode.
 --
--- Granularity (v1): one row per (player_id, play_id, condition) — a play-level rollup keyed
--- so ReplacingMergeTree(scored_at) supersedes on re-score. `ts` is the play's first ts
--- (STABLE across re-scores so dedup + partition stay put); `peak_at` is the worst episode's
--- anchor ts (for a precise session-viewer marker later).
+-- Keyed like derived_tokens so the read-path joins line up:
+--   * network-row labels → entry_fingerprint = the network_requests row's fingerprint.
+--   * event-row labels    → entry_fingerprint = 0, surface = 'event' (join on player_id, ts).
+-- One row per (player_id, ts, entry_fingerprint, condition); ReplacingMergeTree(scored_at)
+-- supersedes on re-score.
 --
--- label is the filter key — a clean `,`/`=`-free condition tag (vomm_<condition>_surprise);
--- the model's peak transition (full of `,`/`(`/spaces the label vocab forbids) rides in the
--- `peak` String column as detail, NOT as the filter token.
+-- The read API surfaces these two ways: (1) per-row — merged into the network/event row's
+-- labels so it chips in NetworkLog / PlayLog; (2) per-play — rolled up by play_id into
+-- label_histogram so sessions.html can filter. label is the `,`/`=`-free filter key
+-- (vomm_<condition>_surprise); `score` is the transition's surprise in nats.
 
 CREATE TABLE IF NOT EXISTS infinite_streaming.derived_labels
 (
-    ts             DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
-    player_id      LowCardinality(String)           CODEC(ZSTD(1)),
-    play_id        LowCardinality(String)           CODEC(ZSTD(1)),
-    condition      LowCardinality(String)           CODEC(ZSTD(1)),
-    label          LowCardinality(String)           CODEC(ZSTD(1)),
-    severity       LowCardinality(String)           CODEC(ZSTD(1)),
-    score          Float32                          CODEC(ZSTD(1)),
-    peak           String                           CODEC(ZSTD(1)),
-    peak_at        DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
-    model_version  LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
-    scored_at      DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1))
+    ts                DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
+    player_id         LowCardinality(String)           CODEC(ZSTD(1)),
+    play_id           LowCardinality(String)           CODEC(ZSTD(1)),
+    entry_fingerprint UInt64                            CODEC(ZSTD(1)),
+    surface           LowCardinality(String)           CODEC(ZSTD(1)),
+    condition         LowCardinality(String)           CODEC(ZSTD(1)),
+    label             LowCardinality(String)           CODEC(ZSTD(1)),
+    severity          LowCardinality(String)           CODEC(ZSTD(1)),
+    score             Float32                          CODEC(ZSTD(1)),
+    model_version     LowCardinality(String) DEFAULT '' CODEC(ZSTD(1)),
+    scored_at         DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1))
 )
 ENGINE = ReplacingMergeTree(scored_at)
 PARTITION BY toYYYYMMDD(ts)
-ORDER BY (player_id, play_id, condition)
+ORDER BY (player_id, ts, entry_fingerprint, condition)
 TTL toDateTime(ts) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192;

--- a/analytics/go-forwarder/timeseries.go
+++ b/analytics/go-forwarder/timeseries.go
@@ -660,7 +660,7 @@ func buildSamplesQuery(cfg config, sel streamSelection, params timeseriesParams)
 		dtScope = append(dtScope, "ts >= now() - INTERVAL 1 HOUR")
 	}
 	q := fmt.Sprintf(`SELECT %s, token FROM (
-	  SELECT base.*, ifNull(dt.token, '') AS token
+	  SELECT base.*, ifNull(dt.token, '') AS token, ifNull(dt.arr, []) AS dl_arr
 	  FROM (SELECT * FROM %s.%s WHERE %s ORDER BY ts ASC LIMIT %d) base
 	  %s
 	) FORMAT JSONEachRow`,
@@ -677,12 +677,25 @@ func buildSamplesQuery(cfg config, sel streamSelection, params timeseriesParams)
 // the ReplacingMergeTree to the latest score.
 func derivedEventTokenJoinSQL(db, scope string) string {
 	return fmt.Sprintf(`LEFT JOIN (
-	  SELECT player_id, ts, argMax(token, scored_at) AS token
-	  FROM %s.derived_tokens
-	  WHERE surface = 'event' AND %s
-	  GROUP BY player_id, ts
+	  SELECT tok.player_id AS player_id, tok.ts AS ts, tok.token AS token, ifNull(lab.arr, []) AS arr
+	  FROM (
+	    SELECT player_id, ts, argMax(token, scored_at) AS token
+	    FROM %s.derived_tokens
+	    WHERE surface = 'event' AND %s
+	    GROUP BY player_id, ts
+	  ) tok
+	  LEFT JOIN (
+	    SELECT player_id, ts, groupArray(sl) AS arr
+	    FROM (
+	      SELECT player_id, ts, condition,
+	             argMax(concat(severity, '=', label), scored_at) AS sl
+	      FROM %s.derived_labels WHERE surface = 'event' AND %s
+	      GROUP BY player_id, ts, condition
+	    )
+	    GROUP BY player_id, ts
+	  ) lab ON tok.player_id = lab.player_id AND tok.ts = lab.ts
 	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts`,
-		db, scope)
+		db, scope, db, scope)
 }
 
 func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams) (string, map[string]string, error) {
@@ -741,7 +754,7 @@ func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams)
 		dtScope = append(dtScope, "ts >= now() - INTERVAL 1 HOUR")
 	}
 	q := fmt.Sprintf(`SELECT %s, token FROM (
-	  SELECT base.*, ifNull(dt.token, '') AS token
+	  SELECT base.*, ifNull(dt.token, '') AS token, ifNull(dt.arr, []) AS dl_arr
 	  FROM (SELECT * FROM %s.network_requests WHERE %s ORDER BY ts ASC LIMIT %d) base
 	  %s
 	) FORMAT JSONEachRow`,
@@ -762,14 +775,35 @@ func buildNetworkQuery(cfg config, sel streamSelection, params timeseriesParams)
 // derived_tokens.entry_fingerprint — `entry_fingerprint` for network_requests,
 // `event_fingerprint` for session_events (the batch stores either under
 // entry_fingerprint; surface distinguishes them).
+// A SINGLE join exposing both `token` (derived_tokens) and `arr` (the #506
+// per-row anomaly labels, derived_labels) — kept to one base join on purpose:
+// CH 24.8's analyzer can't resolve `ts` from `base.*` across two base joins,
+// so the label aggregate is folded in as an inner join in its own scope. The
+// label rows for a given (player_id, ts, entry_fingerprint) always have a token
+// row (a label anchors on a tokenised row), so LEFT JOIN labels onto tokens
+// loses nothing.
 func derivedTokenJoinSQL(db, baseFpCol, scope string) string {
 	return fmt.Sprintf(`LEFT JOIN (
-	  SELECT player_id, ts, entry_fingerprint, argMax(token, scored_at) AS token
-	  FROM %s.derived_tokens
-	  WHERE %s
-	  GROUP BY player_id, ts, entry_fingerprint
+	  SELECT tok.player_id AS player_id, tok.ts AS ts, tok.entry_fingerprint AS entry_fingerprint,
+	         tok.token AS token, ifNull(lab.arr, []) AS arr
+	  FROM (
+	    SELECT player_id, ts, entry_fingerprint, argMax(token, scored_at) AS token
+	    FROM %s.derived_tokens
+	    WHERE %s
+	    GROUP BY player_id, ts, entry_fingerprint
+	  ) tok
+	  LEFT JOIN (
+	    SELECT player_id, ts, entry_fingerprint, groupArray(sl) AS arr
+	    FROM (
+	      SELECT player_id, ts, entry_fingerprint, condition,
+	             argMax(concat(severity, '=', label), scored_at) AS sl
+	      FROM %s.derived_labels WHERE %s
+	      GROUP BY player_id, ts, entry_fingerprint, condition
+	    )
+	    GROUP BY player_id, ts, entry_fingerprint
+	  ) lab ON tok.player_id = lab.player_id AND tok.ts = lab.ts AND tok.entry_fingerprint = lab.entry_fingerprint
 	) dt ON base.player_id = dt.player_id AND base.ts = dt.ts AND base.%s = dt.entry_fingerprint`,
-		db, scope, baseFpCol)
+		db, scope, db, scope, baseFpCol)
 }
 
 // buildSelectColumns produces the SELECT projection list. `ts` is
@@ -782,6 +816,12 @@ func buildSelectColumns(cols []string) string {
 		switch c {
 		case "ts":
 			parts = append(parts, "toString(ts) AS ts")
+		case "labels":
+			// #506 — fold the per-row derived anomaly labels (dl_arr, from
+			// derivedLabelJoinSQL) into the row's labels[] so they render as
+			// chips in NetworkLog / PlayLog with no dashboard change. The
+			// surrounding query always exposes dl_arr (ifNull(...,[])).
+			parts = append(parts, "arrayConcat(labels, dl_arr) AS labels")
 		default:
 			parts = append(parts, c)
 		}

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -390,7 +390,8 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 	// Three layers: innermost `base` keeps native `ts` for WHERE/ORDER BY
 	// (no toString shadowing — same trap the snapshots handler addresses,
 	// commit 9cfca6f); the middle layer LEFT-JOINs the #506 batch-derived
-	// per-row token; the outer applies the toString projection.
+	// per-row token AND per-row anomaly labels (arrayConcat'd into labels[]
+	// so they chip like any ingest label); the outer applies toString.
 	query := fmt.Sprintf(`
 		SELECT
 		  toString(ts) AS timestamp,
@@ -398,9 +399,10 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		  method, url, upstream_url, request_kind, content_type,
 		  status, bytes_in, bytes_out,
 		  ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		  faulted, fault_type, fault_action, fault_category, labels, token
+		  faulted, fault_type, fault_action, fault_category,
+		  arrayConcat(labels, dl_arr) AS labels, token
 		FROM (
-		  SELECT base.*, ifNull(dt.token, '') AS token
+		  SELECT base.*, ifNull(dt.token, '') AS token, ifNull(dt.arr, []) AS dl_arr
 		  FROM (
 		    SELECT
 		      ts, entry_fingerprint,

--- a/analytics/tools/derive_labels.py
+++ b/analytics/tools/derive_labels.py
@@ -1,145 +1,156 @@
 #!/usr/bin/env python3
-"""#506 batch anomaly-LABEL writer — the sibling of derive_tokens.py.
+"""#506 batch anomaly-LABEL writer (PER ROW) — the sibling of derive_tokens.py.
 
 Trains per-condition VOMMs (PPM-C back-off, from scorer.py) on OLDER plays and scores
-RECENT plays OUT-OF-SAMPLE (a time split: train on plays whose data predates the scoring
-window, score plays inside it — no play is scored by a model trained on itself, which is
-why production needs no k-fold). For each (play, condition) whose worst episode is notably
-more surprising than the typical episode for that condition, writes one row to the
-`derived_labels` table. The read API unions these into labels[] → filterable in
-sessions.html, markable in session-viewer.
+RECENT plays OUT-OF-SAMPLE (time split: train on plays predating the scoring window, score
+plays inside it — no play is scored by a model trained on itself, so production needs no
+k-fold). For each transition WITHIN a condition episode whose surprise (−log P) exceeds the
+clean-calibrated bar, writes ONE row to `derived_labels`, anchored on the EXACT row whose
+token was improbable. The read API merges these onto that row (→ a chip in NetworkLog /
+PlayLog, as many per session as there are surprising rows) AND rolls them up by play_id (→ a
+filterable play chip in sessions.html).
 
-Reads ClickHouse directly over HTTP (reuses derive_tokens.py's ch()/fetch_rows()), reusing
-scorer.py's model + tokenize.py's cross-stream tokeniser/episode windows — the SINGLE
-sources of truth. No hand-built reaction taxonomy: the tag is the condition
-(vomm_<condition>_surprise) + a severity from the surprise rate; the model's peak
-transition rides in the `peak` column as detail.
+Condition-anchored + out-of-sample keeps it off the trivial "every FAULT token is rare"
+counter: a typical fault-recovery transition (seen in other plays' fault episodes) is NOT
+surprising under the fault-condition model — only atypical reactions clear the bar.
 
-  python3 analytics/tools/derive_labels.py --train-days 7 --score-hours 6 [--dry-run]
-  # CH endpoint via --ch-url or FORWARDER_CLICKHOUSE_URL (default http://localhost:8123)
+Reads ClickHouse directly (reuses derive_tokens.py's ch()/fetch_rows()); reuses scorer.py's
+model + tokenize.py's cross-stream tokeniser/episodes. No hand-built reaction taxonomy: the
+tag is the condition (vomm_<condition>_surprise) + a severity from the surprise magnitude.
+
+  python3 analytics/tools/derive_labels.py --train-days 7 --score-hours 12 [--dry-run]
 """
 import argparse
 import collections
+import json
 import os
 import sys
 from datetime import datetime, timedelta, timezone
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
-import tokenize as tk          # noqa: E402  cross-stream tokeniser + episode windows
-import scorer as sc            # noqa: E402  VOMM model (train / transition_surprises / score / p99)
+import tokenize as tk          # noqa: E402  cross-stream tokeniser (_token_seq / episodes)
+import scorer as sc            # noqa: E402  VOMM model (train / transition_surprises / p99)
 import derive_tokens as dt     # noqa: E402  ch() / fetch_rows() / group_by_play() / DB
 
 NET_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
 EVENT_COLS = "ts, player_id, play_id, last_event"
+SENTINELS = ("<S>", "<E>")
 
 
-def play_tokens_with_ts(net_rows, event_rows):
-    """(tokens, ts_parallel) for one play — cross-stream, ts-sorted, with <S>/<E> sentinels
-    whose ts borrow the first/last real token (so an <E>-anchored episode marks the tail)."""
-    seq = tk._token_seq(net_rows, event_rows)  # [(ts, fp, surface, token)] ts-sorted
+def play_seq_full(net_rows, event_rows):
+    """[(ts, fp, surface, token)] cross-stream + <S>/<E> sentinels (fp=None). The ts/fp/surface
+    on each entry let us anchor a surprising transition back onto the row that emitted it."""
+    seq = tk._token_seq(net_rows, event_rows)  # network tokens carry fp; event tokens fp=None
     if not seq:
-        return [], []
-    toks = [s[3] for s in seq]
-    tss = [s[0] for s in seq]
-    return ["<S>"] + toks + ["<E>"], [tss[0]] + tss + [tss[-1]]
+        return []
+    return [(seq[0][0], None, "", "<S>")] + list(seq) + [(seq[-1][0], None, "", "<E>")]
 
 
-def ts_episodes(toks, tss, anchor, lead, horizon):
-    """[(anchor_ts, window_tokens)] — tk.episodes() windows + the anchor token's ts."""
-    return [(tss[e["anchor_index"]], e["window"])
-            for e in tk.episodes(toks, anchor=anchor, lead=lead, horizon=horizon)]
+def episode_windows_full(full, anchor, lead, horizon):
+    """[(window_full)] — tk.episodes() windows mapped back to the (ts,fp,surface,token) tuples."""
+    toks = [x[3] for x in full]
+    out = []
+    for e in tk.episodes(toks, anchor=anchor, lead=lead, horizon=horizon):
+        i = e["anchor_index"]
+        out.append(full[max(0, i - lead):min(len(full), i + horizon + 1)])
+    return out
 
 
-def severity_for(rate, crit):
-    return "critical" if rate >= crit else "warning"
+def severity_for(score, thr):
+    return "critical" if score >= thr * 1.5 else "warning"
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
-    ap.add_argument("--train-days", type=int, default=7, help="corpus window for training the per-condition models")
-    ap.add_argument("--score-hours", type=int, default=6, help="recent window whose plays get scored (out-of-sample vs train)")
+    ap.add_argument("--train-days", type=int, default=7)
+    ap.add_argument("--score-hours", type=int, default=12)
     ap.add_argument("--player", default=None, help="limit to one player_id")
     ap.add_argument("--max-order", type=int, default=4)
     ap.add_argument("--alpha", type=float, default=0.5)
-    ap.add_argument("--min-train-episodes", type=int, default=20, help="skip a condition with fewer training episodes")
-    ap.add_argument("--emit-rate", type=float, default=0.34, help="episode surprise-rate at/above which a label is emitted")
-    ap.add_argument("--crit-rate", type=float, default=0.60, help="surprise-rate at/above which severity=critical")
+    ap.add_argument("--min-train-episodes", type=int, default=20)
     ap.add_argument("--model-version", default="vomm-tok-1")
     ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
     args = ap.parse_args()
 
-    # Fetch the whole train window (which contains the recent score window); split by ts.
     net_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "network_requests",
                              NET_COLS, "player_id, ts, entry_fingerprint")
     event_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "session_events",
                                EVENT_COLS, "player_id, ts")
-    net_by_play = dt.group_by_play(net_rows)
-    ev_by_play = dt.group_by_play(event_rows)
+    net_by_play, ev_by_play = dt.group_by_play(net_rows), dt.group_by_play(event_rows)
     plays = list(net_by_play.keys()) + [p for p in ev_by_play if p not in net_by_play]
 
-    # Build per-play token seqs + recency; ClickHouse ts strings sort lexically.
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=args.score_hours)).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
-    builds = {}  # play_id -> {pid, toks, tss, start_ts, max_ts}
+    builds = {}
     for play in plays:
         if not play:
             continue
         prows, erows = net_by_play.get(play, []), ev_by_play.get(play, [])
-        toks, tss = play_tokens_with_ts(prows, erows)
-        if not toks:
+        full = play_seq_full(prows, erows)
+        if not full:
             continue
         pid = next((r.get("player_id") for r in (prows + erows) if r.get("player_id")), "")
-        builds[play] = {"pid": pid, "toks": toks, "tss": tss, "start_ts": tss[0], "max_ts": tss[-1]}
+        builds[play] = {"pid": pid, "full": full, "max_ts": full[-1][0]}
 
     train_plays = [b for b in builds.values() if b["max_ts"] < cutoff]
     score_plays = [(p, b) for p, b in builds.items() if b["max_ts"] >= cutoff]
     scored_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-    print(f"#506 derive_labels — {len(builds)} plays ({len(train_plays)} train / {len(score_plays)} score) "
-          f"train={args.train_days}d score={args.score_hours}h emit>={args.emit_rate:.0%}")
+    print(f"#506 derive_labels (per-row) — {len(builds)} plays "
+          f"({len(train_plays)} train / {len(score_plays)} score) "
+          f"train={args.train_days}d score={args.score_hours}h")
 
     rows = []
     per_condition = collections.Counter()
     for c in sc.EPISODE_CONDITIONS:
         cond, anchor = c["name"], c["anchor"]
-        train_eps = [w for b in train_plays for _, w in ts_episodes(b["toks"], b["tss"], anchor, c["lead"], c["horizon"])]
+        train_eps = [[x[3] for x in w] for b in train_plays
+                     for w in episode_windows_full(b["full"], anchor, c["lead"], c["horizon"])]
         if len(train_eps) < args.min_train_episodes:
             print(f"  {cond:8} — {len(train_eps)} train episodes < {args.min_train_episodes}; skipped")
             continue
         model = sc.train(train_eps, max_order=args.max_order, alpha=args.alpha)
         thr = sc.p99([s for w in train_eps for s, _, _ in sc.transition_surprises(model, w)])
-        n_emit = 0
+        n = 0
         for play, b in score_plays:
-            eps = ts_episodes(b["toks"], b["tss"], anchor, c["lead"], c["horizon"])
-            if not eps:
-                continue
-            worst = None  # (rate, peak, anchor_ts)
-            for anchor_ts, w in eps:
-                r = sc.score(model, w, thr)
-                if worst is None or r["rate"] > worst[0]:
-                    worst = (r["rate"], r["argmax"], anchor_ts)
-            if not worst or worst[0] < args.emit_rate:
-                continue
-            rate, peak, peak_at = worst
-            rows.append({"ts": b["start_ts"], "player_id": b["pid"], "play_id": play,
-                         "condition": cond, "label": f"vomm_{cond}_surprise",
-                         "severity": severity_for(rate, args.crit_rate), "score": round(rate, 4),
-                         "peak": peak or "", "peak_at": peak_at,
-                         "model_version": args.model_version, "scored_at": scored_at})
-            n_emit += 1
-        per_condition[cond] = n_emit
-        print(f"  {cond:8} — train_eps={len(train_eps)} thr={thr:.1f} → {n_emit} plays labelled")
+            for w in episode_windows_full(b["full"], anchor, c["lead"], c["horizon"]):
+                toks = [x[3] for x in w]
+                # transition_surprises[j] is the surprise of token at window position j+1.
+                for j, (surprise, _prev, _cur) in enumerate(sc.transition_surprises(model, toks)):
+                    if surprise < thr:
+                        continue
+                    ts, fp, surface, token = w[j + 1]
+                    if token in SENTINELS:
+                        continue
+                    efp, surf = (0, "event") if fp is None else (fp, surface or "net")
+                    rows.append({"ts": ts, "player_id": b["pid"], "play_id": play,
+                                 "entry_fingerprint": efp, "surface": surf, "condition": cond,
+                                 "label": f"vomm_{cond}_surprise",
+                                 "severity": severity_for(surprise, thr), "score": round(surprise, 3),
+                                 "model_version": args.model_version, "scored_at": scored_at})
+                    n += 1
+        per_condition[cond] = n
+        print(f"  {cond:8} — train_eps={len(train_eps)} thr={thr:.1f} → {n} row labels")
 
-    print(f"emitted {len(rows)} labels: {dict(per_condition)}")
+    # Dedup identical (row, condition) within this run (overlapping episodes can flag a row
+    # twice); keep the most surprising. Cross-run dedup is the ReplacingMergeTree's job.
+    best = {}
+    for r in rows:
+        k = (r["player_id"], r["ts"], r["entry_fingerprint"], r["condition"])
+        if k not in best or r["score"] > best[k]["score"]:
+            best[k] = r
+    rows = list(best.values())
+
+    print(f"emitted {len(rows)} row labels: {dict(per_condition)}")
     if args.dry_run:
-        for r in sorted(rows, key=lambda x: -x["score"])[:8]:
-            print(f"   {r['severity']:8} {r['label']:24} score={r['score']:.0%} play={r['play_id'][:8]} peak: {r['peak']}")
+        for r in sorted(rows, key=lambda x: -x["score"])[:10]:
+            print(f"   {r['severity']:8} {r['label']:24} score={r['score']:5.1f} "
+                  f"surf={r['surface']:5} play={r['play_id'][:8]} @ {r['ts']}")
         return
     if not rows:
         print("nothing to write.")
         return
-    import json
     body = ("\n".join(json.dumps(r) for r in rows) + "\n").encode()
     dt.ch(args.ch_url, f"INSERT INTO {dt.DB}.derived_labels FORMAT JSONEachRow", body=body)
     print(f"inserted {len(rows)} rows into {dt.DB}.derived_labels.")


### PR DESCRIPTION
## What

Supersedes #591's **play-level** `derived_labels` grain with **per-row** labels: a surprising token transition is chipped on the *exact* NetworkLog / PlayLog row it happened on, and a session shows as many chips as it has surprising rows. This answers "can a session have multiple unexpected behaviours?" (yes) and folds in the peak/peak_at surfacing — the labelled row *is* the peak; its `ts` *is* `peak_at`.

We can't write onto the stored `labels[]` of existing rows (that's a MergeTree `ALTER UPDATE` — a #506 hard constraint), so the per-row label is merged onto the row at **read time**, exactly like `derived_tokens`.

## How

- **`05-derived-labels.sql`** — `derived_labels` regrained to per-row: keyed `(player_id, ts, entry_fingerprint, condition)`, mirroring `derived_tokens` (network rows → real `entry_fingerprint`; event rows → `0` + `surface='event'`). Drops `peak`/`peak_at` (the row is the anchor); `score` is the transition surprise in nats. **Schema change** — existing deploys `DROP`+recreate (it's regenerable); `init.d` is authoritative for fresh CH.
- **`derive_labels.py`** — emits one row per above-threshold transition *within a condition episode* (was: one per worst episode), anchored on the row whose token was improbable. Same time-split, out-of-sample, per-condition VOMM.
- **`timeseries.go` / `v2_handlers.go`** — the read-path token join now *also* folds in the per-row label array via an inner join in its own scope, kept to a **single base join** (CH 24.8's analyzer can't resolve `ts` from `base.*` across two base joins). `buildSelectColumns` `arrayConcat`s the labels into `labels[]` → they chip with **no dashboard change**.
- `find.go`'s play-level rollup union (from #591) is **unchanged** — it still works on the per-row table (`DISTINCT play_id, severity=label`), so the filterable play chip stays correct.

## Verification

- **Writer** (against test-dev CH): 2,117 per-row labels; merge keys correct (network surfaces → `entry_fingerprint`, event surfaces → `0`/`surface='event'`).
- **Read query** (validated directly against CH): folds `vomm_*_surprise` into `labels[]` on flagged rows — e.g. play `618de870` `FAULT(video_seg,client_abandon)` row returns its ingest fault labels **plus** `vomm_stall_surprise`; a row can carry multiple derived labels.
- Forwarder `go build` + tests pass.
- **Pending:** live deploy (forwarder recreate) + UI confirmation that chips render on rows — held until an in-progress test-dev session finished; not yet done.

## Notes / follow-ups

- Noise control: per-row threshold is the training p99 (tunable); heavily-faulted plays will chip many rows by design.
- Distinct styling for `vomm_*` chips vs ingest labels (optional; they share the `<severity>=<event>` vocab today).
- Outcome-correlation (does surprise ⟶ worse UX) remains the open validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
