### PR TITLE
feat(506): rename surprise chips → unexpected_<condition>

### DIFF
--- a/analytics/clickhouse/init.d/05-derived-labels.sql
+++ b/analytics/clickhouse/init.d/05-derived-labels.sql
@@ -15,7 +15,7 @@
 -- The read API surfaces these two ways: (1) per-row — merged into the network/event row's
 -- labels so it chips in NetworkLog / PlayLog; (2) per-play — rolled up by play_id into
 -- label_histogram so sessions.html can filter. label is the `,`/`=`-free filter key
--- (vomm_<condition>_surprise); `score` is the transition's surprise in nats.
+-- (unexpected_<condition>); `score` is the transition's surprise in nats.
 
 CREATE TABLE IF NOT EXISTS infinite_streaming.derived_labels
 (

--- a/analytics/tools/derive_labels.py
+++ b/analytics/tools/derive_labels.py
@@ -16,7 +16,7 @@ surprising under the fault-condition model — only atypical reactions clear the
 
 Reads ClickHouse directly (reuses derive_tokens.py's ch()/fetch_rows()); reuses scorer.py's
 model + tokenize.py's cross-stream tokeniser/episodes. No hand-built reaction taxonomy: the
-tag is the condition (vomm_<condition>_surprise) + a severity from the surprise magnitude.
+tag is the condition (unexpected_<condition>) + a severity from the surprise magnitude.
 
   python3 analytics/tools/derive_labels.py --train-days 7 --score-hours 12 [--dry-run]
 """
@@ -126,7 +126,7 @@ def main():
                     efp, surf = (0, "event") if fp is None else (fp, surface or "net")
                     rows.append({"ts": ts, "player_id": b["pid"], "play_id": play,
                                  "entry_fingerprint": efp, "surface": surf, "condition": cond,
-                                 "label": f"vomm_{cond}_surprise",
+                                 "label": f"unexpected_{cond}",
                                  "severity": severity_for(surprise, thr), "score": round(surprise, 3),
                                  "model_version": args.model_version, "scored_at": scored_at})
                     n += 1


### PR DESCRIPTION
## What

Renames the #506 anomaly chips from `vomm_<condition>_surprise` → **`unexpected_<condition>`** (`unexpected_fault`, `unexpected_stall`, `unexpected_startup`, `unexpected_end`).

## Why

- **`vomm_` leaked the model name.** VOMM (variable-order Markov) is the *current* detector; #445 may swap in an HMM. A user-facing label should describe the meaning, not the implementation.
- **"surprise" overstated.** We haven't validated that surprise ⟶ bad UX (outcome-correlation is still open). The chip means behaviour around the condition is *unexpected* vs the typical episode the model learned — not "confirmed bad." `unexpected_` is honest.

## Scope

One-line change at the **sole generation point** (`derive_labels.py:129`) + its docstring + the `05-derived-labels.sql` header comment. The read path (`find.go` / `timeseries.go` / `v2_handlers.go`) and the dashboard render labels generically — neither hardcodes `vomm_` — so **no forwarder or dashboard rebuild**.

Deliberately **not** renamed (these correctly name the model itself, not the chip): `model_version=vomm-tok-1`, `scorer.py`, and `report.py`'s `/tmp/vomm_report.md`.

## Apply (test-dev, after merge)

No rebuild. rsync tools → `TRUNCATE derived_labels` + re-derive (so old `vomm_*` are gone, not just superseded in-window) → recreate `label-deriver`.

## Verify

Dry-run confirms the new labels (`critical unexpected_fault`, `unexpected_startup`, …). Post-deploy: `SELECT DISTINCT label FROM derived_labels` → only `unexpected_*`; `--label-has critical=unexpected_fault` filters; chips render `unexpected_*` on rows in session-viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
