### PR TITLE
fix(dashboard): unbreak PlayLog.vue build — `*/` inside a block comment

### DIFF
--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -506,7 +506,7 @@ function rowLabels(r: Row): string[] {
  *  (analytics/tools/derive_tokens.py + the read-path merge in
  *  v2_handlers.go / timeseries.go). Network rows carry segment/playlist
  *  tokens (V_SEG/A_SEG/V_PL/…, FAULT); session_events rows carry
- *  lifecycle tokens (STALL_*/RATE_*/BUF_*/FIRST_FRAME). Control and
+ *  lifecycle tokens (STALL_*, RATE_*, BUF_*, FIRST_FRAME). Control and
  *  avmetric rows return '' by design — the token model has no vocabulary
  *  for them (the one control signal that matters, fault injection, is
  *  already a FAULT token on the network request it breaks). */


### PR DESCRIPTION
## Summary

`origin/dev`'s dashboard build is currently broken — `vue-tsc --noEmit` and `vite build` both fail:

```
src/components/PlayLog.vue(509): Unterminated regular expression literal
```

## Cause

The #506 token feature (#583 / #589) added a doc comment listing lifecycle tokens:

```js
/** …
 *  lifecycle tokens (STALL_*/RATE_*/BUF_*/FIRST_FRAME). Control and
 *  … */
```

The `*/` inside `STALL_*/` **closes the block comment early**. Everything after it (through the real `*/` three lines down) is parsed as code, and `/RATE_*/` is read as a regex literal that never terminates — hence the error in both the type-checker and the bundler.

CI didn't catch it because the pipeline has no `vue-tsc` / `vite build` gate (only `update_release_draft`), so #589 merged red.

## Fix

Reword the token list with commas so no `*/` appears inside the comment:

```diff
- *  lifecycle tokens (STALL_*/RATE_*/BUF_*/FIRST_FRAME). Control and
+ *  lifecycle tokens (STALL_*, RATE_*, BUF_*, FIRST_FRAME). Control and
```

One-line, comment-only. `vue-tsc --noEmit` and `vite build` both green again.

## Follow-up (not in this PR)

Worth adding a `vue-tsc --noEmit` (or `npm run build`) gate to CI so a broken dashboard build can't merge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
