### PR TITLE
fix(582/586/590): bound Testing-page memory, sync logs to focus bar, lock brush to live

### DIFF
--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -371,6 +371,15 @@ interface StatefulEvent {
 }
 
 const statefulEvents: StatefulEvent[] = [];
+/** Backstop cap on retained stateful events (issue #582). This array was
+ *  appended on every heartbeat and never trimmed within a session, so it
+ *  grew unbounded — and renderStatefulLanes walks + sorts it on each
+ *  render. We normally trim it to the events cache's retained window (so
+ *  the Player State lanes cover the SAME span as the charts on pan-back);
+ *  this count is only a fallback when the cache bounds aren't known yet.
+ *  Set high (well above the cache cap × a few events/heartbeat) so it
+ *  never trims tighter than the cache window. */
+const STATEFUL_EVENTS_CAP = 40000;
 // IDs assigned to coalesced range items so we can replace cleanly on
 // every render. Range items are tagged by the lane key + rendered
 // `range:<key>:<n>` so we can detect & remove them before re-adding.
@@ -976,6 +985,20 @@ async function drainNewRows() {
     }
   }
   lastIngestedMs = highWater;
+  // Bound the stateful-event history (issue #582) WITHOUT trimming
+  // tighter than what the charts show. Trim to the events cache's
+  // retained window (rangeBounds.min) so the Player State lanes fill in
+  // over exactly the same span the charts do when the operator pans the
+  // focus window back. Appended in ascending ts order, so the oldest are
+  // at the front. The fixed cap is only a fallback before bounds exist.
+  const minKeep = props.eventsStream.rangeBounds.value?.min;
+  if (minKeep != null) {
+    let drop = 0;
+    while (drop < statefulEvents.length && statefulEvents[drop].ts < minKeep) drop++;
+    if (drop > 0) statefulEvents.splice(0, drop);
+  } else if (statefulEvents.length > STATEFUL_EVENTS_CAP) {
+    statefulEvents.splice(0, statefulEvents.length - STATEFUL_EVENTS_CAP);
+  }
 }
 
 watch(

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -394,6 +394,16 @@ function createChartInstance(Chart: any): any {
       maintainAspectRatio: false,
       animation: false,
       interaction: { mode: 'nearest', intersect: false },
+      // Decimation (issue: chart render cost). Our datasets are already
+      // pre-parsed {x:number,y:number} sorted ascending by x, so we can
+      // turn off Chart.js parsing and mark them normalized — both
+      // required for the decimation plugin. LTTB reduces each series to
+      // ~`samples` representative points within the visible range (peaks
+      // preserved), so a 16k-point series draws ~1k points instead of
+      // 16k. Cuts redraw time dramatically while keeping the deep history
+      // the doubled caps retain.
+      parsing: false,
+      normalized: true,
       layout: {
         padding: {
           // Reserve room on the right edge for the y2 axis. When no y2
@@ -403,6 +413,11 @@ function createChartInstance(Chart: any): any {
         },
       },
       plugins: {
+        decimation: {
+          enabled: true,
+          algorithm: 'lttb',
+          samples: 1000,
+        },
         legend: {
           position: 'bottom',
           labels: {

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -96,11 +96,11 @@ let dataset: Array<Array<{ x: number; y: number }>> = [];
 
 /** Hard cap on points kept per series (issue #582). A pure memory
  *  bound: the oldest points are dropped once a series exceeds this, so a
- *  tab open for hours can't grow the renderer to multiple GB. ~8000
- *  points is well beyond any visible window (>2 h at 1 Hz) so pan-back
- *  stays generous; it's the cache's eviction window, not zoom, that
- *  determines how far back data actually exists. */
-const MAX_POINTS_PER_SERIES = 8000;
+ *  tab open for hours can't grow the renderer to multiple GB. Doubled to
+ *  16000 (~4.4 h at 1 Hz) to match the doubled cache cap so the charts
+ *  cover the same deep history while #587 (refetch) is blocked. It's the
+ *  cache's eviction window, not zoom, that bounds how far back data goes. */
+const MAX_POINTS_PER_SERIES = 16000;
 
 /** Listeners attached to `window` outlive this component's canvas (which
  *  GCs when the chart is destroyed), so they must be removed on unmount

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -996,7 +996,14 @@ function pushSample(p: PlayerRecord, x: number) {
         d.splice(0, d.length - MAX_POINTS_PER_SERIES);
       }
     }
-    if (coord.state.range === null) {
+    // Live-follow: only glue the viewport to a sample at/after the live
+    // edge (the newest known sample). During the initial backfill the
+    // rows arrive oldest→newest; without this guard each older row would
+    // yank the window back and the focus bar would crawl left→right in
+    // hops (#590). drainNewRows seeds lastSampleMs to the latest cached
+    // ts up front, so backfill rows fail this check and only the true
+    // live edge advances the window.
+    if (coord.state.range === null && x >= coord.state.lastSampleMs) {
       applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
     safeChartUpdate();
@@ -1089,6 +1096,15 @@ async function drainNewRows() {
     Number.MAX_SAFE_INTEGER,
   );
   if (!raw.length) return;
+  // Jump the live window to the newest cached sample up front so the
+  // backfill fills in BEHIND the right edge instead of crawling the
+  // window left→right chunk by chunk (#590). Only in live mode; a pinned
+  // (archive/panned) range must stay put. pushSample's live-follow guard
+  // then skips the older backfill rows and only the true edge advances.
+  if (coord.state.range === null) {
+    const latest = props.eventsStream.rangeBounds.value?.max;
+    if (typeof latest === 'number' && Number.isFinite(latest)) coord.noteSample(latest);
+  }
   const myToken = ++drainToken;
   // Chunked iteration with main-thread yields keeps brush + scroll
   // responsive when the initial backfill hits (5–10 k rows).

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -394,16 +394,6 @@ function createChartInstance(Chart: any): any {
       maintainAspectRatio: false,
       animation: false,
       interaction: { mode: 'nearest', intersect: false },
-      // Decimation (issue: chart render cost). Our datasets are already
-      // pre-parsed {x:number,y:number} sorted ascending by x, so we can
-      // turn off Chart.js parsing and mark them normalized — both
-      // required for the decimation plugin. LTTB reduces each series to
-      // ~`samples` representative points within the visible range (peaks
-      // preserved), so a 16k-point series draws ~1k points instead of
-      // 16k. Cuts redraw time dramatically while keeping the deep history
-      // the doubled caps retain.
-      parsing: false,
-      normalized: true,
       layout: {
         padding: {
           // Reserve room on the right edge for the y2 axis. When no y2
@@ -413,11 +403,6 @@ function createChartInstance(Chart: any): any {
         },
       },
       plugins: {
-        decimation: {
-          enabled: true,
-          algorithm: 'lttb',
-          samples: 1000,
-        },
         legend: {
           position: 'bottom',
           labels: {
@@ -1013,14 +998,13 @@ function pushSample(p: PlayerRecord, x: number) {
         d.splice(0, d.length - MAX_POINTS_PER_SERIES);
       }
     }
-    // Live-follow: only glue the viewport to a sample at/after the live
-    // edge (the newest known sample). During the initial backfill the
-    // rows arrive oldest→newest; without this guard each older row would
-    // yank the window back and the focus bar would crawl left→right in
-    // hops (#590). drainNewRows seeds lastSampleMs to the latest cached
-    // ts up front, so backfill rows fail this check and only the true
-    // live edge advances the window.
-    if (coord.state.range === null && x >= coord.state.lastSampleMs) {
+    // Live-follow: keep the viewport glued to the latest drained sample
+    // so the chart always shows data at its right edge. (The previous
+    // "jump to cache edge" optimization left the live edge blank while
+    // the backfill was still draining behind it — #590 regression. With
+    // the per-chunk watermark the drain converges fast, so following the
+    // drained edge no longer crawls noticeably.)
+    if (coord.state.range === null) {
       applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
     safeChartUpdate();
@@ -1113,15 +1097,6 @@ async function drainNewRows() {
     Number.MAX_SAFE_INTEGER,
   );
   if (!raw.length) return;
-  // Jump the live window to the newest cached sample up front so the
-  // backfill fills in BEHIND the right edge instead of crawling the
-  // window left→right chunk by chunk (#590). Only in live mode; a pinned
-  // (archive/panned) range must stay put. pushSample's live-follow guard
-  // then skips the older backfill rows and only the true edge advances.
-  if (coord.state.range === null) {
-    const latest = props.eventsStream.rangeBounds.value?.max;
-    if (typeof latest === 'number' && Number.isFinite(latest)) coord.noteSample(latest);
-  }
   const myToken = ++drainToken;
   // Chunked iteration with main-thread yields keeps brush + scroll
   // responsive when the initial backfill hits (5–10 k rows).
@@ -1151,11 +1126,17 @@ async function drainNewRows() {
       }
       if (x > highWater) highWater = x;
     }
+    // Advance the watermark PER CHUNK so a mid-drain interrupt (a 1 Hz
+    // cache flush bumps drainToken and aborts this loop) doesn't restart
+    // from the beginning. That restart-from-scratch was re-processing the
+    // whole backfill on every flush — ~12 s to catch up on a long
+    // session, during which the live edge stayed blank. Per-chunk
+    // progress makes the drain converge in a couple seconds.
+    lastIngestedMs = highWater;
     if (end < raw.length) {
       await new Promise<void>((r) => setTimeout(r, 0));
     }
   }
-  lastIngestedMs = highWater;
 }
 
 watch(

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -998,13 +998,15 @@ function pushSample(p: PlayerRecord, x: number) {
         d.splice(0, d.length - MAX_POINTS_PER_SERIES);
       }
     }
-    // Live-follow: keep the viewport glued to the latest drained sample
-    // so the chart always shows data at its right edge. (The previous
-    // "jump to cache edge" optimization left the live edge blank while
-    // the backfill was still draining behind it — #590 regression. With
-    // the per-chunk watermark the drain converges fast, so following the
-    // drained edge no longer crawls noticeably.)
-    if (coord.state.range === null) {
+    // Live-follow: advance the viewport ONLY for a genuine live-tail
+    // sample (one at/after the running max). `coord.noteSample(x)` above
+    // already raised `lastSampleMs` to max(prev, x), so a new tail row
+    // has `x === lastSampleMs` and an older backfill row has
+    // `x < lastSampleMs`. Guarding on that stops the recent-first
+    // backfill (older, off-screen rows) from dragging the window
+    // backward — the fix for both the live-edge blank AND the
+    // brush-crawl-across-the-whole-backfill regressions (#590).
+    if (coord.state.range === null && x >= coord.state.lastSampleMs) {
       applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
     safeChartUpdate();
@@ -1085,6 +1087,35 @@ function safeChartUpdate() {
  */
 const pendingLive: { p: PlayerRecord; x: number }[] = [];
 let drainToken = 0;
+let backfillToken = 0;
+
+/**
+ * Background fill of the off-screen history that sits OLDER than the
+ * live window, walked newest→oldest so panning back populates the rows
+ * nearest the window first. These all have `x < lastSampleMs`, so
+ * pushSample's guard leaves the viewport parked at the live edge — no
+ * crawl, no blank. Snapshot is bounded to MAX_POINTS_PER_SERIES rows so
+ * we don't burn the main thread inserting points the per-series cap
+ * would immediately trim off the front anyway.
+ */
+async function backfillOlder(myToken: number, ceilMs: number) {
+  if (!chart) return;
+  const older = props.eventsStream.inRange(0, ceilMs - 1);
+  if (!older.length) return;
+  const from = Math.max(0, older.length - MAX_POINTS_PER_SERIES);
+  const CHUNK = 500;
+  for (let end = older.length; end > from; end -= CHUNK) {
+    if (myToken !== backfillToken) return;
+    const start = Math.max(from, end - CHUNK);
+    for (let i = end - 1; i >= start; i--) {
+      const row = older[i];
+      const x = tsOfRow(row);
+      if (!Number.isFinite(x)) continue;
+      pushSample(chRowToPlayerRecord(row), x);
+    }
+    await new Promise<void>((r) => setTimeout(r, 0));
+  }
+}
 
 async function drainNewRows() {
   if (!chart) {
@@ -1092,6 +1123,40 @@ async function drainNewRows() {
     catch (err) { console.warn('chart ensure failed:', err); return; }
   }
   if (!chart) return;
+
+  // INITIAL live-mode backfill — fill the visible window from the newest
+  // rows FIRST (synchronously, so it lands in one repaint with the
+  // viewport already at the live edge), then backfill the older
+  // off-screen rows behind it. Draining strictly oldest→newest instead
+  // (the generic path below) either left the live edge blank until the
+  // drain reached it, or crawled the brush across the whole backfill —
+  // both #590 regressions. Pinned/archive mode (range !== null) keeps
+  // the generic full-window fill, which never moves the viewport.
+  if (lastIngestedMs === -Infinity && coord.state.range === null) {
+    const all = props.eventsStream.inRange(0, Number.MAX_SAFE_INTEGER);
+    if (!all.length) return;
+    const cacheMax = tsOfRow(all[all.length - 1]);
+    if (Number.isFinite(cacheMax)) {
+      const span = coord.state.liveSpan || DEFAULT_FOCUS_MS;
+      const liveStart = cacheMax - span;
+      // Find the contiguous recent tail (ascending-by-x array).
+      let firstRecent = all.length;
+      for (let i = all.length - 1; i >= 0; i--) {
+        const x = tsOfRow(all[i]);
+        if (Number.isFinite(x) && x >= liveStart) firstRecent = i; else break;
+      }
+      for (let i = firstRecent; i < all.length; i++) {
+        const row = all[i];
+        const x = tsOfRow(row);
+        if (!Number.isFinite(x)) continue;
+        pushSample(chRowToPlayerRecord(row), x);
+      }
+      lastIngestedMs = cacheMax;
+      void backfillOlder(++backfillToken, liveStart);
+      return;
+    }
+  }
+
   const raw = props.eventsStream.inRange(
     lastIngestedMs === -Infinity ? 0 : lastIngestedMs + 1,
     Number.MAX_SAFE_INTEGER,
@@ -1164,6 +1229,7 @@ watch(
   () => {
     pendingLive.length = 0;
     lastIngestedMs = -Infinity;
+    ++backfillToken; // abort any in-flight backfill for the old player
     for (const arr of dataset) arr.length = 0;
     safeChartUpdate();
   },

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -876,12 +876,13 @@ function installLiveWheelAnchor() {
   c.addEventListener(
     'wheel',
     (e: WheelEvent) => {
-      // Horizontal scroll (trackpad two-finger swipe left/right or
-      // mouse horizontal scroll) → pan the chart by deltaX scaled
-      // against the chart's plot-area width. No Alt required; plain
-      // vertical scroll still falls through to page scroll. See
-      // gh#461.
-      if (!e.altKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+      // Horizontal pan: trackpad two-finger swipe (deltaX dominant) OR
+      // Shift+wheel (the mouse way to scroll horizontally). Shift+wheel
+      // reports its magnitude on deltaX in some browsers and deltaY in
+      // others, so take whichever axis is larger. No Alt required; plain
+      // vertical scroll still falls through to page scroll. See gh#461.
+      const horizontalPan = !e.altKey && (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY));
+      if (horizontalPan) {
         e.preventDefault();
         e.stopPropagation();
         const chartArea = chart?.chartArea;
@@ -889,7 +890,8 @@ function installLiveWheelAnchor() {
         const widthPx = chartArea.right - chartArea.left;
         const current = coord.effectiveRange.value;
         const span = current.max - current.min;
-        const dms = (e.deltaX / widthPx) * span;
+        const delta = Math.abs(e.deltaX) >= Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+        const dms = (delta / widthPx) * span;
         coord.setRange({ min: current.min + dms, max: current.max + dms });
         return;
       }
@@ -1319,8 +1321,8 @@ onBeforeUnmount(() => {
         >
           {{ liveChecked ? '●' : '○' }} Live
         </button>
-        <span class="hint" title="Hold Alt (Option on Mac) while scrolling or dragging to zoom; right-click-drag to pan">
-          Alt/⌥+scroll/drag · right-drag pan
+        <span class="hint" title="Alt/Option + scroll or drag = zoom; Shift + scroll (or two-finger horizontal) = pan; right-click-drag = pan">
+          Alt/⌥+scroll/drag zoom · Shift+scroll / right-drag pan
         </span>
       </div>
     </div>

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -93,6 +93,31 @@ const coord = useChartCoordination(toRef(props, 'playerId'));
 
 let chart: any = null;
 let dataset: Array<Array<{ x: number; y: number }>> = [];
+
+/** Hard cap on points kept per series (issue #582). A pure memory
+ *  bound: the oldest points are dropped once a series exceeds this, so a
+ *  tab open for hours can't grow the renderer to multiple GB. ~8000
+ *  points is well beyond any visible window (>2 h at 1 Hz) so pan-back
+ *  stays generous; it's the cache's eviction window, not zoom, that
+ *  determines how far back data actually exists. */
+const MAX_POINTS_PER_SERIES = 8000;
+
+/** Listeners attached to `window` outlive this component's canvas (which
+ *  GCs when the chart is destroyed), so they must be removed on unmount
+ *  or they leak the closures — and the chart/dataset they capture —
+ *  every time a chart is torn down (e.g. switching the active session).
+ *  Issue #582. Canvas-bound listeners GC with the canvas, but routing
+ *  them here too is harmless and keeps teardown complete. */
+const teardownFns: Array<() => void> = [];
+function onGlobal(
+  target: EventTarget,
+  type: string,
+  handler: (e: any) => void,
+  opts?: AddEventListenerOptions | boolean,
+) {
+  target.addEventListener(type, handler as EventListener, opts);
+  teardownFns.push(() => target.removeEventListener(type, handler as EventListener, opts as EventListenerOptions));
+}
 // Watermark of the latest CH row already pushed through the chart.
 // Read by the markers-stream watcher to drain only NEW rows on each
 // version bump (the cache holds the full backfill + live tail).
@@ -793,7 +818,7 @@ function installLeftClickLiveToggle() {
     if (x < area.left || x > area.right || y < area.top || y > area.bottom) return;
     coord.toggleLive();
   });
-  window.addEventListener('blur', () => { downAt = null; });
+  onGlobal(window, 'blur', () => { downAt = null; });
 }
 
 function installContextMenuSuppress() {
@@ -817,7 +842,7 @@ function installRightDragPan() {
     // user is dragging (setRange handles both range + paused mirror).
     coord.setRange({ min: sx.min, max: sx.max });
   });
-  window.addEventListener('mousemove', (e) => {
+  onGlobal(window, 'mousemove', (e: MouseEvent) => {
     if (!dragState || !chart) return;
     const area = chart.chartArea;
     if (!area) return;
@@ -827,10 +852,10 @@ function installRightDragPan() {
     const dv = (dx / widthPx) * span;
     coord.setRange({ min: dragState.startMin - dv, max: dragState.startMax - dv });
   });
-  window.addEventListener('mouseup', (e) => {
+  onGlobal(window, 'mouseup', (e: MouseEvent) => {
     if (e.button === 2) dragState = null;
   });
-  window.addEventListener('blur', () => { dragState = null; });
+  onGlobal(window, 'blur', () => { dragState = null; });
 }
 
 /**
@@ -956,14 +981,21 @@ function pushSample(p: PlayerRecord, x: number) {
     insertByX(data, { x, y: Number(y) });
     mutated = true;
   }
-  // Retention is the time-series cache's job (SOFT_CAP_SAMPLES) —
-  // the chart used to trim at `x - windowMs * 2` to bound memory,
-  // but `windowMs` is the *visible* window, not retention. When the
-  // operator zooms in (focusSpan shrinks → setWindowMs shrinks) the
-  // trim was killing older points the PLAYERSTATE lane still had,
-  // producing a chart-vs-lane time-axis mismatch. Chart.js with
-  // `animation: false` handles tens of thousands of points fine.
+  // Bound per-series history (issue #582). The chart used to keep every
+  // point for the life of the tab ("retention is the cache's job"), but
+  // the cache evicts and the chart did not — so the dataset arrays grew
+  // unbounded, ballooning the renderer to multi-GB and pegging CPU as
+  // each redraw re-rasterized hundreds of thousands of points. Cap each
+  // series to MAX_POINTS_PER_SERIES and drop the oldest (front of the
+  // ascending-by-x array). The cap is a memory bound, independent of the
+  // visible window, so it does NOT reintroduce the zoom-in trimming bug
+  // that the old `x - windowMs*2` trim had (that one shrank with zoom).
   if (mutated) {
+    for (const d of dataset) {
+      if (d.length > MAX_POINTS_PER_SERIES) {
+        d.splice(0, d.length - MAX_POINTS_PER_SERIES);
+      }
+    }
     if (coord.state.range === null) {
       applyViewport({ min: x - DEFAULT_FOCUS_MS, max: x });
     }
@@ -1138,13 +1170,19 @@ watch(
     } catch (err) {
       console.warn('chart viewport apply skipped:', err);
     }
-    // Viewport / pause changes are axis-only updates — render
-    // directly so brush drag feels as smooth as the vis-timeline
-    // events panel. safeChartUpdate's adaptive throttle exists for
-    // data-arrival churn (pushSample / drainNewRows insert many
-    // points per second); applying it here would delay pan response
-    // up to several seconds when a dataset has thousands of points.
-    try { chart.update('none'); } catch (err) { console.warn('chart pan render skipped:', err); }
+    // Interactive viewport changes (brush drag, pan, zoom — i.e. a
+    // pinned range) render directly so they feel as smooth as the
+    // vis-timeline events panel. But in LIVE mode (range === null) this
+    // watcher fires on EVERY sample, because effectiveRange tracks
+    // lastSampleMs — and a direct chart.update() per sample across N
+    // charts is the dominant CPU sink on a long-lived tab (#582). For
+    // the live-edge case, route through the adaptive throttle instead;
+    // the right edge still advances at the metrics emit cadence.
+    if (coord.state.range === null) {
+      safeChartUpdate();
+    } else {
+      try { chart.update('none'); } catch (err) { console.warn('chart pan render skipped:', err); }
+    }
   },
 );
 
@@ -1231,6 +1269,11 @@ function onLiveToggleClick() {
 }
 
 onBeforeUnmount(() => {
+  // Remove window-level listeners so the destroyed chart's closures can
+  // be GC'd (issue #582 — otherwise switching sessions leaks charts).
+  for (const fn of teardownFns) { try { fn(); } catch { /* ignore */ } }
+  teardownFns.length = 0;
+  if (pendingUpdateTimer != null) { clearTimeout(pendingUpdateTimer); pendingUpdateTimer = null; }
   try { chart?.destroy(); } catch { /* ignore */ }
   chart = null;
 });

--- a/content/dashboard-v3/src/components/NetworkLog.vue
+++ b/content/dashboard-v3/src/components/NetworkLog.vue
@@ -243,7 +243,14 @@ const allRows = computed<Row[]>(() => {
 });
 
 const rows = computed<Row[]>(() => {
+  // Follow the focus bar (issue #586): only rows within the coordinated
+  // visible window, so the Network Log lines up with the charts +
+  // timeline. effectiveRange is the live tail when live, or the pinned
+  // window when the operator pans back. (The summary line below stays a
+  // full-log tally on purpose.)
+  const w = coord.effectiveRange.value;
   return allRows.value.filter((r) => {
+    if (w && (r.ts < w.min || r.ts > w.max)) return false;
     if (faultedOnly.value && !r.entry.faulted) return false;
     if (hideSuccessful.value && isSuccessful(r.entry)) return false;
     return true;

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -658,6 +658,18 @@ function sortValue(r: Row, c: SortCol): number | string {
   }
 }
 
+/** Flatten a row's fields to a single `k=v, k=v` string (#586). Rendered
+ *  as one text node instead of one chip element per field — the dominant
+ *  per-row DOM cost. */
+function fieldsToString(fields: DisplayedField[]): string {
+  let s = '';
+  for (let i = 0; i < fields.length; i++) {
+    if (i) s += ', ';
+    s += fields[i].name + '=' + fields[i].value;
+  }
+  return s;
+}
+
 /** Row + the field list to render. Computed in chronological order
  *  so the "Changed fields" diff against the previous same-source row
  *  is well-defined regardless of the display sort. */
@@ -768,13 +780,13 @@ const windowedFull = computed<Row[]>(() => {
   return allRows.value.filter((row) => row.ts >= r.min && row.ts <= r.max);
 });
 
-/** Max rows actually rendered to the DOM. Each row expands to dozens of
- *  kv-chip nodes, so rendering a whole 10-minute window (1000+ rows ⇒
- *  tens of thousands of nodes) made every reactive tick reflow the page
- *  and tanked responsiveness. Render only the most recent N within the
- *  window; narrow the focus bar (or pan) to inspect older rows. A proper
- *  virtualized list is the longer-term fix (see issue). */
-const MAX_RENDER_ROWS = 250;
+/** Max rows actually rendered to the DOM. With fields collapsed to a
+ *  single compact string per row (~8 nodes/row instead of ~100), the
+ *  window can render far more rows cheaply, so this cap is now just a
+ *  safety bound against pathological windows. Narrow the focus bar (or
+ *  pan) to inspect rows beyond it. A virtualized list remains the proper
+ *  long-term fix. */
+const MAX_RENDER_ROWS = 1500;
 const windowedRows = computed<Row[]>(() => {
   const rows = windowedFull.value;
   if (rows.length <= MAX_RENDER_ROWS) return rows;
@@ -1069,12 +1081,13 @@ function onRowsWheel(e: WheelEvent) {
           </div>
           <div class="cell c-fields">
             <span v-if="r.fields.length === 0" class="kv-empty">—</span>
-            <span
-              v-for="f in r.fields"
-              :key="f.name"
-              class="kv"
-              :title="f.name + '=' + f.value"
-            ><span class="kv-name">{{ f.name }}</span>=<span class="kv-value">{{ f.value }}</span></span>
+            <!-- Fields rendered as one compact `k=v, k=v` string instead
+                 of one chip element per field (#586). Each chip was 3 DOM
+                 nodes; a dense row had ~30+ fields → ~100 nodes/row. The
+                 single text node keeps PlayLog light enough to render the
+                 whole window. Full per-field detail stays in the Raw
+                 column. -->
+            <span v-else class="kv-compact" :title="fieldsToString(r.fields)">{{ fieldsToString(r.fields) }}</span>
           </div>
           <div v-if="showRaw" class="cell c-raw" :title="rawValueFor(r)">
             <pre class="raw-pre">{{ rawValueFor(r) }}</pre>
@@ -1353,6 +1366,17 @@ function onRowsWheel(e: WheelEvent) {
 .kv-empty {
   color: #9ca3af;
   font-size: 10px;
+}
+/* Compact single-string field rendering (#586) — one text node instead
+ * of N chip elements. Wraps within the column; full value also in title. */
+.kv-compact {
+  font-size: 10px;
+  line-height: 1.5;
+  color: #374151;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* event_name column — dedicated cell after attempt_id. Lifted out

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -762,11 +762,27 @@ function sortFields(fields: DisplayedField[], source: Source): DisplayedField[] 
  *  the pinned window when the operator pans back — so the Play Log lines
  *  up with the charts and the Player State timeline instead of always
  *  showing the entire cache. */
-const windowedRows = computed<Row[]>(() => {
+const windowedFull = computed<Row[]>(() => {
   const r = coord.effectiveRange.value;
   if (!r) return allRows.value;
   return allRows.value.filter((row) => row.ts >= r.min && row.ts <= r.max);
 });
+
+/** Max rows actually rendered to the DOM. Each row expands to dozens of
+ *  kv-chip nodes, so rendering a whole 10-minute window (1000+ rows ⇒
+ *  tens of thousands of nodes) made every reactive tick reflow the page
+ *  and tanked responsiveness. Render only the most recent N within the
+ *  window; narrow the focus bar (or pan) to inspect older rows. A proper
+ *  virtualized list is the longer-term fix (see issue). */
+const MAX_RENDER_ROWS = 250;
+const windowedRows = computed<Row[]>(() => {
+  const rows = windowedFull.value;
+  if (rows.length <= MAX_RENDER_ROWS) return rows;
+  // Keep the most recent N by ts (the live tail operators watch).
+  return rows.slice().sort((a, b) => a.ts - b.ts).slice(-MAX_RENDER_ROWS);
+});
+/** True when rows were dropped from the rendered set (shown in the bar). */
+const renderCapped = computed(() => windowedFull.value.length > MAX_RENDER_ROWS);
 
 const rowsWithFields = computed<RowWithFields[]>(() => {
   // Build chronological copy so the diff against the previous
@@ -836,16 +852,16 @@ const sortedRows = computed<RowWithFields[]>(() => {
 });
 
 const counts = computed(() => {
-  // Counts reflect the focus window (issue #586) so the toolbar tallies
-  // match what's actually shown.
+  // Counts reflect the full focus window (issue #586), not the capped
+  // render set, so the toolbar tallies match what's in the window.
   let evt = 0, net = 0, ctl = 0, avm = 0;
-  for (const r of windowedRows.value) {
+  for (const r of windowedFull.value) {
     if (r.source === 'event') evt++;
     else if (r.source === 'network') net++;
     else if (r.source === 'avmetrics') avm++;
     else ctl++;
   }
-  return { evt, net, ctl, avm, total: windowedRows.value.length };
+  return { evt, net, ctl, avm, total: windowedFull.value.length };
 });
 
 /** True when the active player has any AVMetrics rows in the cached
@@ -964,6 +980,7 @@ function onRowsWheel(e: WheelEvent) {
       <label v-if="hasAVMetrics" class="opt" title="iOS 18 AVMetrics raw events (issue #486 spike). Parallel observation stream from AVFoundation — compare side-by-side against today's heartbeat-derived Events."><input type="checkbox" v-model="showAVMetrics" /> AVMetrics ({{ counts.avm }})</label>
       <label class="opt"><input type="checkbox" v-model="showRaw" /> Raw</label>
       <span class="count">{{ counts.total }} row{{ counts.total === 1 ? '' : 's' }}</span>
+      <span v-if="renderCapped" class="count" title="Only the most recent rows are rendered for performance; narrow the focus bar to see older rows">(showing last {{ MAX_RENDER_ROWS }})</span>
       <button
         type="button"
         class="btn live-toggle"

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -757,11 +757,22 @@ function sortFields(fields: DisplayedField[], source: Source): DisplayedField[] 
   });
 }
 
+/** Rows within the coordinated focus window (issue #586). The logs now
+ *  "follow the focus bar": effectiveRange is the live tail when live, or
+ *  the pinned window when the operator pans back — so the Play Log lines
+ *  up with the charts and the Player State timeline instead of always
+ *  showing the entire cache. */
+const windowedRows = computed<Row[]>(() => {
+  const r = coord.effectiveRange.value;
+  if (!r) return allRows.value;
+  return allRows.value.filter((row) => row.ts >= r.min && row.ts <= r.max);
+});
+
 const rowsWithFields = computed<RowWithFields[]>(() => {
   // Build chronological copy so the diff against the previous
   // snapshot is well-defined regardless of the display sort
   // direction the operator picks below.
-  const chrono = allRows.value.slice().sort((a, b) => a.ts - b.ts);
+  const chrono = windowedRows.value.slice().sort((a, b) => a.ts - b.ts);
   const mode = displayMode.value;
   // Only snapshots participate in the diff — every network /
   // event row is unique by construction so a per-row diff is
@@ -825,14 +836,16 @@ const sortedRows = computed<RowWithFields[]>(() => {
 });
 
 const counts = computed(() => {
+  // Counts reflect the focus window (issue #586) so the toolbar tallies
+  // match what's actually shown.
   let evt = 0, net = 0, ctl = 0, avm = 0;
-  for (const r of allRows.value) {
+  for (const r of windowedRows.value) {
     if (r.source === 'event') evt++;
     else if (r.source === 'network') net++;
     else if (r.source === 'avmetrics') avm++;
     else ctl++;
   }
-  return { evt, net, ctl, avm, total: allRows.value.length };
+  return { evt, net, ctl, avm, total: windowedRows.value.length };
 });
 
 /** True when the active player has any AVMetrics rows in the cached

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1099,8 +1099,8 @@ function skipToEnd() {
             class="brush-window"
             :class="{ dragging: dragState }"
             :style="{
-              left: ((railRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
-              right: ((scrubMax - railRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              left: Math.max(0, (railRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              right: Math.max(0, (scrubMax - railRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
             }"
             @mousedown.stop="onBrushMouseDown($event, 'pan')"
           >
@@ -1479,12 +1479,12 @@ function skipToEnd() {
   height: 30px;
   background: #d1fae5;
   border-radius: 6px;
-  /* Clip the brush window so it can't bleed past the rail edges
-   * (and onto the ⏮/⏭ scrub buttons) when the visible focus range
-   * extends past the data — e.g. a 10-min liveSpan on a fresh
-   * session that only has 1 min of samples puts brushRange.min 9
-   * min before scrubMin, which would be a -X% left value. */
-  overflow: hidden;
+  /* overflow VISIBLE so the brush window can extend above/below the rail
+   * as a taller grab target (those strips are tick-free, so they're a
+   * clean drag zone). Horizontal bleed past the rail edges onto the
+   * ⏮/⏭ buttons is instead prevented by clamping the window's left/right
+   * to ≥0 in the template binding. */
+  overflow: visible;
   cursor: crosshair;
 }
 .brush-rail .brush-tick {
@@ -1536,8 +1536,12 @@ function skipToEnd() {
 
 .brush-window {
   position: absolute;
-  top: 0;
-  bottom: 0;
+  /* Extend above and below the 30px rail so the grab target is taller
+   * than the rail itself — those strips are tick-free, so you can always
+   * grab the window (or its handles) for dragging without landing on a
+   * marker. */
+  top: -9px;
+  bottom: -9px;
   background: rgba(29, 78, 216, 0.18);
   border: 0;
   border-radius: 6px;
@@ -1551,8 +1555,10 @@ function skipToEnd() {
 .brush-window.dragging { cursor: grabbing; }
 .brush-handle {
   position: absolute;
-  top: -1px;
-  bottom: -1px;
+  /* Match the window's vertical extent so the resize grips are equally
+   * tall and easy to grab above/below the rail. */
+  top: -9px;
+  bottom: -9px;
   width: 8px;
   background: #1d4ed8;
   border-radius: 3px;

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -700,7 +700,19 @@ const railMarkers = computed(() => {
  *  (default 10 min) without any auto-feedback watcher that could get
  *  stuck. */
 const brushRange = computed(() => coord.effectiveRange.value);
-const windowSpanMs = computed(() => Math.max(1, brushRange.value.max - brushRange.value.min));
+
+/** Draft focus window during an active brush gesture (issue #590). While
+ *  the operator drags/resizes the rail (or wheel-zooms it), the rail
+ *  renders from this draft so it tracks the cursor live — but the
+ *  coordinated range the heavy panels read is NOT updated until the
+ *  gesture settles (mouse-release for drag/resize, ~160 ms quiet for
+ *  wheel). So charts/logs/timeline re-render once on commit instead of
+ *  on every mousemove/wheel tick. */
+const draftRange = ref<{ min: number; max: number } | null>(null);
+/** What the rail visual + focus pill render: the in-flight draft while
+ *  gesturing, else the committed coordinated range. */
+const railRange = computed(() => draftRange.value ?? coord.effectiveRange.value);
+const windowSpanMs = computed(() => Math.max(1, railRange.value.max - railRange.value.min));
 
 /** Live toggle checked rule — same across every surface. */
 const brushLiveChecked = computed(() => coord.state.range === null);
@@ -742,7 +754,11 @@ function onBrushMouseDown(e: MouseEvent, mode: 'pan' | 'resize-left' | 'resize-r
     startStart: start.min,
     startEnd: start.max,
   };
+  // Pin coord once so live-follow stops during the drag, and seed the
+  // draft so the rail tracks the cursor live. onDragMove updates only
+  // the draft; coord (and thus the panels) commits on release (#590).
   coord.setRange({ min: start.min, max: start.max });
+  draftRange.value = { min: start.min, max: start.max };
   window.addEventListener('mousemove', onDragMove);
   window.addEventListener('mouseup', onDragEnd, { once: true });
 }
@@ -770,10 +786,14 @@ function onDragMove(e: MouseEvent) {
     if (f < d.startStart + MIN_WINDOW_MS) f = d.startStart + MIN_WINDOW_MS;
     s = d.startStart;
   }
-  coord.setRange({ min: s, max: f });
+  // Update only the draft during the drag (#590) — the rail moves live,
+  // the panels stay parked at the pinned start until release.
+  draftRange.value = { min: s, max: f };
 }
 function onDragEnd() {
-  const ended = brushRange.value;
+  // Commit the draft (the final dragged window) to coord on release.
+  const ended = draftRange.value ?? brushRange.value;
+  draftRange.value = null;
   dragState.value = null;
   window.removeEventListener('mousemove', onDragMove);
   // BRUSH WIDTH on release becomes the new liveSpan — operator's
@@ -783,10 +803,12 @@ function onDragEnd() {
   // every other chart's live-tracker uses the same width.
   const dropSpan = ended.max - ended.min;
   if (dropSpan > 0) coord.setLiveSpan(dropSpan);
-  // RIGHT EDGE within 2 s of the latest sample → snap to live
-  // (charts AND brush follow the right edge as new samples arrive).
-  // Otherwise leave the range pinned to whatever onDragMove last set.
+  // RIGHT EDGE within 2 s of the latest sample → snap to live (charts
+  // AND brush follow the right edge as new samples arrive). Otherwise
+  // commit the dragged window to coord — onDragMove only moved the
+  // draft, so coord is still parked at the drag's start until here (#590).
   if (coord.isAtLiveEdge(ended.max)) coord.setRange(null);
+  else coord.setRange({ min: ended.min, max: ended.max });
 }
 
 /** Alt+wheel on the brush rail zooms the focus-window duration. Same
@@ -798,10 +820,33 @@ function onDragEnd() {
  *      live, snap to live tracking.
  *
  *  Plain wheel falls through to native page scroll. */
+/** Rail-wheel debounce (#590). Wheel events update only the draft (rail
+ *  moves live); the coordinated range commits ~160 ms after the wheel
+ *  goes quiet, so the heavy panels render once per gesture instead of
+ *  per tick. */
+let railWheelTimer: number | null = null;
+function scheduleRailCommit() {
+  if (railWheelTimer != null) clearTimeout(railWheelTimer);
+  railWheelTimer = window.setTimeout(commitRailDraft, 160);
+}
+function commitRailDraft() {
+  if (railWheelTimer != null) { clearTimeout(railWheelTimer); railWheelTimer = null; }
+  const d = draftRange.value;
+  if (!d) return;
+  draftRange.value = null;
+  const span = d.max - d.min;
+  if (span > 0) coord.setLiveSpan(span);
+  // Right edge at live → follow live with the new span; else pin.
+  if (coord.isAtLiveEdge(d.max)) coord.setRange(null);
+  else coord.setRange({ min: d.min, max: d.max });
+}
+
 function onRailWheel(e: WheelEvent) {
   const rail = railRef.value;
   const r = timeRange.value;
   if (!rail || !r) return;
+  // Base the next window on the in-flight draft so successive wheel
+  // ticks compound before the debounced commit (#590).
   // Horizontal scroll → pan the brush. deltaX/railWidth maps directly
   // to fraction-of-full-data-range so a one-rail-width swipe pans by
   // the entire visible data span. Unlike the line charts, the brush
@@ -812,21 +857,22 @@ function onRailWheel(e: WheelEvent) {
     e.stopPropagation();
     const widthPx = rail.clientWidth;
     if (widthPx <= 0) return;
-    const current = brushRange.value;
+    const current = railRange.value;
     const span = current.max - current.min;
     const dms = (e.deltaX / widthPx) * (r.max - r.min);
     let s = current.min + dms;
     let f = current.max + dms;
     if (s < r.min) { s = r.min; f = s + span; }
     if (f > r.max) { f = r.max; s = f - span; }
-    coord.setRange({ min: s, max: f });
+    draftRange.value = { min: s, max: f };
+    scheduleRailCommit();
     return;
   }
   if (!e.altKey) return;
   e.preventDefault();
   e.stopPropagation();
   const fullSpan = Math.max(1, r.max - r.min);
-  const current = brushRange.value;
+  const current = railRange.value;
   const currentSpan = Math.max(1, current.max - current.min);
   const factor = e.deltaY < 0 ? 0.9 : 1 / 0.9;
   const MIN_SPAN_MS = 1_000;
@@ -834,8 +880,9 @@ function onRailWheel(e: WheelEvent) {
   if (nextSpan === currentSpan) return;
 
   if (coord.isAtLiveEdge(current.max)) {
-    coord.setLiveSpan(nextSpan);
-    coord.setRange(null);
+    // At live: keep the right edge glued to live, grow/shrink leftward.
+    draftRange.value = { min: current.max - nextSpan, max: current.max };
+    scheduleRailCommit();
     return;
   }
   // Mouse-anchored: keep the timestamp under the cursor at the same
@@ -848,12 +895,8 @@ function onRailWheel(e: WheelEvent) {
   let newEnd = newStart + nextSpan;
   if (newStart < r.min) { newStart = r.min; newEnd = newStart + nextSpan; }
   if (newEnd > r.max) { newEnd = r.max; newStart = newEnd - nextSpan; }
-  if (coord.isAtLiveEdge(newEnd)) {
-    coord.setLiveSpan(nextSpan);
-    coord.setRange(null);
-    return;
-  }
-  coord.setRange({ min: newStart, max: newEnd });
+  draftRange.value = { min: newStart, max: newEnd };
+  scheduleRailCommit();
 }
 
 function onRailMouseDown(e: MouseEvent) {
@@ -1056,8 +1099,8 @@ function skipToEnd() {
             class="brush-window"
             :class="{ dragging: dragState }"
             :style="{
-              left: ((brushRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
-              right: ((scrubMax - brushRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              left: ((railRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+              right: ((scrubMax - railRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
             }"
             @mousedown.stop="onBrushMouseDown($event, 'pan')"
           >

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -847,19 +847,21 @@ function onRailWheel(e: WheelEvent) {
   if (!rail || !r) return;
   // Base the next window on the in-flight draft so successive wheel
   // ticks compound before the debounced commit (#590).
-  // Horizontal scroll → pan the brush. deltaX/railWidth maps directly
-  // to fraction-of-full-data-range so a one-rail-width swipe pans by
-  // the entire visible data span. Unlike the line charts, the brush
-  // is CLAMPED to [r.min, r.max] so it never leaves the rail. See
-  // gh#461.
-  if (!e.altKey && Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+  // Horizontal pan: trackpad two-finger swipe (deltaX) OR Shift+wheel
+  // (the mouse way to scroll horizontally; magnitude lands on deltaX or
+  // deltaY depending on browser). deltaX/railWidth maps directly to
+  // fraction-of-full-data-range so a one-rail-width swipe pans by the
+  // entire visible data span. The brush is CLAMPED to [r.min, r.max] so
+  // it never leaves the rail. See gh#461.
+  if (!e.altKey && (e.shiftKey || Math.abs(e.deltaX) > Math.abs(e.deltaY))) {
     e.preventDefault();
     e.stopPropagation();
     const widthPx = rail.clientWidth;
     if (widthPx <= 0) return;
     const current = railRange.value;
     const span = current.max - current.min;
-    const dms = (e.deltaX / widthPx) * (r.max - r.min);
+    const delta = Math.abs(e.deltaX) >= Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+    const dms = (delta / widthPx) * (r.max - r.min);
     let s = current.min + dms;
     let f = current.max + dms;
     if (s < r.min) { s = r.min; f = s + span; }

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -352,6 +352,21 @@ watch(
   { immediate: true },
 );
 
+// Live-edge anchor. `coord.lastSampleMs` is the brush's live-follow
+// target (effectiveRange.max) AND the rail's right edge. It used to be
+// advanced ONLY from inside the charts' drain (pushSample → noteSample),
+// so while the charts backfilled asynchronously the brush sat behind the
+// true live edge — "not locked at live" until the drain caught up. The
+// cache's `rangeBounds.max` is the authoritative newest ts the instant
+// the cache has it, so feed the live edge from there directly. The
+// charts' recent-first drain keeps the visible window populated up to
+// this edge, so the chart's right edge stays in sync without a blank.
+watch(
+  () => timeseries.events.rangeBounds.value?.max,
+  (m) => { if (m != null) coord.noteSample(m); },
+  { immediate: true },
+);
+
 /** Effective time range for the brush rail. Reads the cached
  *  rangeBounds of the samples stream as the historical span; always
  *  extends `max` with `coord.lastSampleMs` so the rail's right edge

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -519,9 +519,13 @@ export function useSessionTimeSeries(
   // ascending by ts (insertSortedDedup), so the oldest are at the front.
   // Panning past the retained window triggers a fresh range fetch at the
   // upper layer.
-  const SOFT_CAP_SAMPLES = 10000;
-  const SOFT_CAP_NETWORK = 2000;
-  const SOFT_CAP_EVENTS = 10000;
+  // Doubled from the original #582 values to retain a longer focus-window
+  // history (~5.4h at 1 Hz) for 3h+ sessions while #587 (on-demand
+  // refetch of evicted windows) is blocked on server support. Still a
+  // hard memory bound — ~2× the footprint, far below the old unbounded leak.
+  const SOFT_CAP_SAMPLES = 20000;
+  const SOFT_CAP_NETWORK = 4000;
+  const SOFT_CAP_EVENTS = 20000;
   function trimToCap<T>(arr: T[], cap: number): boolean {
     if (arr.length > cap) {
       arr.splice(0, arr.length - cap);

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -509,41 +509,33 @@ export function useSessionTimeSeries(
     };
   }
 
-  // Periodic eviction guard: if any stream balloons past its soft
-  // cap, drop entries outside the current viewport guardband. The
-  // viewport hint is (samples ∪ network ∪ events) bounds so we
-  // never throw away data the brush is actively showing. Renderers
-  // that pan past the cache trigger a fresh fetch — handled at
-  // the upper layer (TS6).
-  const SOFT_CAP_SAMPLES = 50000;
-  const SOFT_CAP_NETWORK = 5000;
-  const SOFT_CAP_EVENTS = 50000;
+  // Recency cap (issue #582). The previous eviction called
+  // evictOutsideViewport with the streams' OWN merged data bounds —
+  // which keeps `[min − 2·span, max + 2·span]` of the entire cached
+  // range, i.e. it never actually drops anything as the range grows.
+  // So the caches grew unbounded for the life of the tab (a primary
+  // contributor to the 12 GB renderer). Replace with a hard recency
+  // cap: keep only the most recent N rows per stream. Arrays are sorted
+  // ascending by ts (insertSortedDedup), so the oldest are at the front.
+  // Panning past the retained window triggers a fresh range fetch at the
+  // upper layer.
+  const SOFT_CAP_SAMPLES = 10000;
+  const SOFT_CAP_NETWORK = 2000;
+  const SOFT_CAP_EVENTS = 10000;
+  function trimToCap<T>(arr: T[], cap: number): boolean {
+    if (arr.length > cap) {
+      arr.splice(0, arr.length - cap);
+      return true;
+    }
+    return false;
+  }
   watch(
     [eventsVersion, networkVersion, controlVersion, avmetricsVersion],
     () => {
-      const bounds = mergedBounds(
-        eventsBounds.value,
-        networkBounds.value,
-        controlBounds.value,
-        avmetricsBounds.value,
-      );
-      if (!bounds) return;
-      if (eventsArr.value.length > SOFT_CAP_SAMPLES) {
-        evictOutsideViewport(eventsArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(eventsArr);
-      }
-      if (networkArr.value.length > SOFT_CAP_NETWORK) {
-        evictOutsideViewport(networkArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(networkArr);
-      }
-      if (controlArr.value.length > SOFT_CAP_EVENTS) {
-        evictOutsideViewport(controlArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(controlArr);
-      }
-      if (avmetricsArr.value.length > SOFT_CAP_EVENTS) {
-        evictOutsideViewport(avmetricsArr.value, bounds.min, bounds.max, tsOf);
-        triggerRef(avmetricsArr);
-      }
+      if (trimToCap(eventsArr.value, SOFT_CAP_SAMPLES)) triggerRef(eventsArr);
+      if (trimToCap(networkArr.value, SOFT_CAP_NETWORK)) triggerRef(networkArr);
+      if (trimToCap(controlArr.value, SOFT_CAP_EVENTS)) triggerRef(controlArr);
+      if (trimToCap(avmetricsArr.value, SOFT_CAP_EVENTS)) triggerRef(avmetricsArr);
     },
   );
 


### PR DESCRIPTION
## Summary

Testing-page dashboard reliability + focus-bar UX (issues #582, #586, #590). Stacked on `dev`.

### #582 — bound Testing-page memory + CPU
- Hard recency caps on the per-stream caches and per-series chart point caps; adaptive chart-update throttle; listener teardown on unmount. Stops the multi-GB / runaway-CPU growth on long-lived tabs.
- Doubled the retention caps so a long session still keeps a deep focus-window history within the bound.

### #586 — Network Log + Play Log follow the focus bar
- Both panels now window to the focus range. PlayLog rendering bounded (row cap + compact `k=v` field string instead of a chip-per-field) to keep the DOM small.

### #590 — focus-bar gesture polish + brush lock
- Defer heavy panel re-renders until the focus-bar gesture settles (drag/resize/wheel debounce).
- Shift+wheel pans the charts and rail; taller focus-window grab target.
- Brush locked to the live edge with recent-first chart backfill: no blank at the live edge, no crawl during initial fill. (Reverts an LTTB-decimation attempt that was incompatible with live append.)

## Test
`vue-tsc` clean; verified live on test-dev (`:21000`): bounded memory, panels track the focus bar, brush stays at live with data rendered.

Closes #582
Closes #586
Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
