### PR TITLE
feat(587): pan-back history refetch + client play-scoped start_time + per-play resets

### DIFF
--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -18,6 +18,10 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_events
     revision              UInt64                      CODEC(DoubleDelta, ZSTD(1)),
     session_id            String                      CODEC(ZSTD(1)),
     play_id               LowCardinality(String)      CODEC(ZSTD(1)),
+    -- start_time: client-supplied, play-scoped play start (ISO-8601 UTC
+    -- string), rotated with play_id (#587). Empty for clients that don't
+    -- send it. Stored as String (raw passthrough) — parse client-side.
+    start_time            String                      CODEC(ZSTD(1)),
     -- attempt_id: player-supplied monotonically-incrementing counter
     -- per playback attempt within a play. 1 on the initial play of
     -- any content, +1 on every `restart` event (user-restart OR
@@ -769,6 +773,7 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.control_events
     ts                       DateTime64(3, 'UTC')   CODEC(Delta, ZSTD(1)),
     player_id                LowCardinality(String) CODEC(ZSTD(1)),
     play_id                  LowCardinality(String) CODEC(ZSTD(1)),
+    start_time               String                 CODEC(ZSTD(1)),
     attempt_id               UInt32                 DEFAULT 0 CODEC(ZSTD(1)),
     session_id               String                 CODEC(ZSTD(1)),
     source                   LowCardinality(String) CODEC(ZSTD(1)),
@@ -809,6 +814,7 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.ios_avmetric_events
     ts                DateTime64(3, 'UTC')          CODEC(Delta, ZSTD(1)),
     player_id         LowCardinality(String)        CODEC(ZSTD(1)),
     play_id           LowCardinality(String)        CODEC(ZSTD(1)),
+    start_time        String                        CODEC(ZSTD(1)),
     attempt_id        UInt32                        DEFAULT 0 CODEC(ZSTD(1)),
     session_id        String                        CODEC(ZSTD(1)),
     event_type        LowCardinality(String)        CODEC(ZSTD(1)),

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -198,6 +198,9 @@ type row struct {
 	Revision                 uint64  `json:"revision"`
 	SessionID                string  `json:"session_id"`
 	PlayID                   string  `json:"play_id"`
+	// StartTime — client-supplied, play-scoped play start (ISO-8601 UTC),
+	// rotated with play_id (#587). Empty for clients that don't send it.
+	StartTime                string  `json:"start_time"`
 	AttemptID                uint32  `json:"attempt_id"`
 	PlayerID                 string  `json:"player_id"`
 	GroupID                  string  `json:"group_id"`
@@ -753,6 +756,7 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		Revision:                 revision,
 		SessionID:                sessionID,
 		PlayID:                   playCanonical,
+		StartTime:                getStr(s, "start_time"),
 		// attempt_id is player-supplied and sticky on the session map
 		// at go-proxy:4517-4519 — pull it from the v1 payload (string
 		// form) and parse to uint32 here. 0 (the uint32 zero value)

--- a/analytics/go-forwarder/streambundles.go
+++ b/analytics/go-forwarder/streambundles.go
@@ -82,6 +82,7 @@ var bundleRegistry = map[string]bundleDef{
 		Columns: []string{
 			"ts",
 			"session_id", "play_id", "player_id",
+			"start_time", // client play start (#587) → rail left edge
 			"event_time",
 			// Bandwidth chart series (server + player side)
 			"video_bitrate_mbps",

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -1103,8 +1103,17 @@ public final class PlaybackMetrics {
         // variant dwell snapshot happens inside resetResidency()
     }
 
-    /** Called from PlayerViewModel.reload() — fresh play boundary,
-     *  zero priors so the new play_id starts from scratch. */
+    /** Fresh play boundary (#587) — zero ALL per-play state so the new
+     *  play_id starts from scratch. Called from every play_id rotation
+     *  (PlayerViewModel.regeneratePlayId): the Reload button, content
+     *  switch, segment/filter swap, and soak rotation. reload() also
+     *  recreates the PlaybackMetrics instance, but the other boundaries
+     *  reuse this instance, so this must zero the direct "current"
+     *  counters too — otherwise they carry across plays. (onPlaybackStarted(),
+     *  which runs right after on every load, already clears timing / frozen /
+     *  segment-stall / error / stallStartAtMs state.) retry() does NOT rotate
+     *  play_id and never calls this — it preserves counters via
+     *  snapshotForRestart(). */
     public void resetForFreshPlay() {
         priorPlayingTimeMs = 0;
         priorPausingTimeMs = 0;
@@ -1123,6 +1132,29 @@ public final class PlaybackMetrics {
         terminalReason = null;
         playStartAtMsForEBVS = -1;  // resetResidency() will set new
         observedMaxVariantKbps = 0;
+        // Direct counters that accumulate across the app lifetime and would
+        // otherwise leak into the next play (reload got these for free via
+        // instance recreation).
+        framesRenderedTotal.set(0);
+        droppedFramesTotal = 0;
+        profileShiftCount = 0;
+        playerRestarts = 0;
+        stallCount = 0;
+        totalStallTimeS = 0;
+        lastStallDurationS = 0;
+        loopCountPlayer = 0;
+        lastReportedLoopCount = 0;
+        lastBufferingDurationMs = 0;
+        bufferingStartAtMsForDuration = -1;
+        stallStuck = false;
+        buffering = false;
+        nominalFpsCurrent = 0f;
+        errorCount = 0;
+        lastErrorCode = 0;
+        lastErrorDomain = "";
+        lastErrorDetails = "";
+        variantDwellMs.clear();
+        variantLadder.clear();
         resetResidency();
     }
 

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -63,8 +63,19 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
      */
     private var currentPlayId: String = UUID.randomUUID().toString()
 
+    /**
+     * `start_time` (#587) — client-supplied, play-scoped play start
+     * (ISO-8601 UTC). Minted with `currentPlayId` and rotated at the SAME
+     * boundaries; threaded through every URL as `?start_time=...` so the
+     * play's start is play-scoped end-to-end (the server-derived
+     * `started_at` is session-scoped and goes stale on a play rotation).
+     */
+    private var currentStartTime: String = java.time.Instant.now().toString()
+
     private fun regeneratePlayId() {
         currentPlayId = UUID.randomUUID().toString()
+        // Rotate the play-scoped start with the play_id (#587).
+        currentStartTime = java.time.Instant.now().toString()
     }
 
     /** Rotation Job armed after every successful loadStream and
@@ -83,7 +94,8 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         playIdLastActivityAt = System.currentTimeMillis()
     }
 
-    /** Replace any existing `play_id` query param with `currentPlayId`. */
+    /** Replace any existing `play_id` + `start_time` query params with the
+     *  current play's values (#587 — start_time travels with play_id). */
     private fun withPlayId(url: String): String {
         if (url.isEmpty()) return url
         val (base, query) = url.split("?", limit = 2).let {
@@ -91,7 +103,9 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         }
         val params = if (query.isEmpty()) mutableListOf() else query.split("&").toMutableList()
         params.removeAll { it.startsWith("play_id=") }
+        params.removeAll { it.startsWith("start_time=") }
         params.add("play_id=$currentPlayId")
+        params.add("start_time=$currentStartTime")
         return "$base?${params.joinToString("&")}"
     }
 
@@ -677,7 +691,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // below once the player has been handed off.
         playIdMintedAt = System.currentTimeMillis()
         playIdLastActivityAt = 0L
-        val url = "${server.scheme}://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId&play_id=$currentPlayId"
+        val url = "${server.scheme}://${server.host}:$port/go-live/${s.selectedContent}/$manifest?player_id=$playerId&play_id=$currentPlayId&start_time=$currentStartTime"
         _state.update { it.copy(currentUrl = url, statusText = url) }
         loadStream(url)
         schedulePlayIdRotation()

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -76,6 +76,14 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         currentPlayId = UUID.randomUUID().toString()
         // Rotate the play-scoped start with the play_id (#587).
         currentStartTime = java.time.Instant.now().toString()
+        // Fresh play boundary — reset the per-play counters so the new play's
+        // metrics start from zero. Every play_id rotation (content switch,
+        // segment/filter swap, soak rotation, reload) funnels through here.
+        // reload() additionally recreates the metrics instance; this makes the
+        // reuse-the-instance boundaries consistent. retry() keeps play_id
+        // stable and never calls this, so recovery attempts still preserve
+        // counters via snapshotForRestart().
+        metrics?.resetForFreshPlay()
     }
 
     /** Rotation Job armed after every successful loadStream and

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -919,6 +919,7 @@ components:
         content_id:        { type: string }
         # ---- timing ----
         started_at:        { type: string, format: date-time }
+        start_time:        { type: string, format: date-time, nullable: true, description: "Client-supplied play start (ISO-8601 UTC), play-scoped — minted by the player with play_id and rotated with it. See PlayRecord.start_time in proxy.yaml. Null when the client didn't send it (web/Roku)." }
         last_seen_at:      { type: string, format: date-time }
         labels:
           type: object

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1125,6 +1125,20 @@ components:
             Effective labels = player.labels merged with any play-specific
             additions/overrides. Snapshotted onto archive rows at insert.
         started_at:       { type: string, format: date-time }
+        start_time:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            **Client-supplied** play start (ISO-8601 UTC), minted by the
+            player at the same boundary as `id` (play_id) and re-sent as a
+            `?start_time=` query param on every request. Unlike
+            `started_at` — which the proxy derives from the SESSION's first
+            request and therefore does NOT move when the play_id rotates —
+            this is play-scoped: a content switch yields a new play_id AND
+            a new start_time. Prefer this for "when did THIS play begin";
+            `started_at` is the connection/session start. Null for
+            non-instrumented clients (web, Roku) that don't send it.
         ended_at:         { type: string, format: date-time, nullable: true }
         manifest: { $ref: '#/components/schemas/Manifest' }
         fault_rules:

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -800,6 +800,17 @@ final class PlayerViewModel: ObservableObject {
         currentPlayID = UUID().uuidString
         // Rotate the play-scoped start with the play_id (#587).
         currentStartTime = PlayerViewModel.metricsTimestampFormatter.string(from: Date())
+        // Fresh play boundary — reset the per-play counters so the new play's
+        // metrics start from zero. Previously only reload() did this; the other
+        // boundaries that rotate play_id (content switch, content-filter swap,
+        // soak rotation) all funnel through here, so coupling the reset to the
+        // play_id rotation makes every boundary consistent. retry() does NOT
+        // call this — it keeps play_id stable and preserves counters across the
+        // recovery attempt (snapshotForRestart()).
+        diagnostics.resetForFreshPlay()
+        resetPerVariantForFreshPlay()
+        playerRestarts = 0
+        profileShiftCount = 0
     }
 
     /// Replace any existing `attempt_id` query item with the current
@@ -1229,20 +1240,13 @@ final class PlayerViewModel: ObservableObject {
         // observations and the heartbeat would emit stale data.
         diagnostics.bind(to: newPlayer)
         attachPlayerItemObservers()
-        // Reload = fresh play. Counters start from zero so the new
-        // play's dashboard widgets aren't polluted by the previous
-        // play's totals. Clears both the per-item counters (via
-        // diagnostics.reset()) AND the "prior" accumulators that
-        // snapshotForRestart() populates. retry() does the opposite —
-        // it snapshots so counters carry across recovery attempts.
-        diagnostics.resetForFreshPlay()
-        resetPerVariantForFreshPlay()
-        playerRestarts = 0
-        profileShiftCount = 0
-        // Rotate play_id (new play boundary) AND reset attempt_id
-        // to 1 (fresh play, no recovery attempts yet). retry()
-        // differs — it keeps play_id stable and increments
-        // attempt_id because it's a within-play recovery attempt.
+        // Rotate play_id (new play boundary) AND reset attempt_id to 1 (fresh
+        // play, no recovery attempts yet). regeneratePlayID() now also performs
+        // the full per-play counter reset (resetForFreshPlay etc.) so the new
+        // play's dashboard widgets aren't polluted by the previous play's
+        // totals — every play_id rotation resets, not just reload. retry()
+        // differs — it keeps play_id stable and increments attempt_id because
+        // it's a within-play recovery attempt that must preserve counters.
         regeneratePlayID()
         resetAttemptID()
         let restartPayload = buildMetricsPayload(event: "restart", at: Date(), extra: [

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -145,6 +145,15 @@ final class PlayerViewModel: ObservableObject {
     /// - Soak rotation Task firing
     private var currentPlayID: String = UUID().uuidString
 
+    /// `start_time` (#587) — client-supplied, play-scoped play start
+    /// (ISO-8601 UTC). Minted with `currentPlayID` and rotated at the
+    /// SAME boundaries (`regeneratePlayID`); sent as `?start_time=` on
+    /// every request so the proxy / forwarder / dashboard can anchor
+    /// "when THIS play began" to the play, not the connection (the
+    /// server-derived `started_at` is session-scoped and goes stale on
+    /// a play rotation).
+    private var currentStartTime: String = PlayerViewModel.metricsTimestampFormatter.string(from: Date())
+
     /// `attempt_id` (bug #4) — a **monotonically-incrementing
     /// integer**, 1-based, identifying which playback attempt within
     /// this play the current activity belongs to. First playback of
@@ -710,6 +719,7 @@ final class PlayerViewModel: ObservableObject {
         // go-proxy.)
         final = appendPlayID(to: final)
         final = appendAttemptID(to: final)
+        final = appendStartTime(to: final)
         self.currentURL = final
         self.statusText = final.absoluteString
         loadStream(url: final)
@@ -772,10 +782,24 @@ final class PlayerViewModel: ObservableObject {
         return components.url ?? url
     }
 
+    /// Replace any existing `start_time` query item with the current
+    /// `currentStartTime` (#587). Travels alongside play_id on every
+    /// request so the play's start is play-scoped end-to-end.
+    private func appendStartTime(to url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == "start_time" }
+        items.append(URLQueryItem(name: "start_time", value: currentStartTime))
+        components.queryItems = items
+        return components.url ?? url
+    }
+
     /// Mint a fresh `play_id` UUID. Called only at content-selection
     /// boundaries (see currentPlayID doc). NOT called on restart.
     private func regeneratePlayID() {
         currentPlayID = UUID().uuidString
+        // Rotate the play-scoped start with the play_id (#587).
+        currentStartTime = PlayerViewModel.metricsTimestampFormatter.string(from: Date())
     }
 
     /// Replace any existing `attempt_id` query item with the current
@@ -1088,6 +1112,7 @@ final class PlayerViewModel: ObservableObject {
         incrementAttemptID()
         var refreshed = appendPlayID(to: url)
         refreshed = appendAttemptID(to: refreshed)
+        refreshed = appendStartTime(to: refreshed)
         self.currentURL = refreshed
         Task { [weak self] in
             await self?.requestHARSnapshot(reason: "user_retry", force: true)
@@ -2391,6 +2416,7 @@ extension PlayerViewModel {
             // in the body too is belt-and-braces against a delayed event
             // that races a subsequent id rotation. Bug #4 fix.
             "play_id": currentPlayID,
+            "start_time": currentStartTime,
             "attempt_id": currentAttemptID,
             "player_metrics_source": "ios",
             "player_metrics_last_event": event,
@@ -2659,6 +2685,7 @@ extension PlayerViewModel {
         // land with the OLD attempt_id. Bug #4 fix.
         var url = appendPlayID(to: pathURL)
         url = appendAttemptID(to: url)
+        url = appendStartTime(to: url)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -2766,6 +2793,7 @@ extension PlayerViewModel {
             .appendingPathComponent("avmetrics")
         var url = appendPlayID(to: pathURL)
         url = appendAttemptID(to: url)
+        url = appendStartTime(to: url)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -1227,25 +1227,32 @@ watch(
 // the old session's lanes instead of accumulating both. Watching
 // playerId (a string prop) keeps this simple; SessionDisplay's
 // useSessionTimeSeries already re-subscribes the SSE stream.
+function resetIngest() {
+  statefulEvents.length = 0;
+  pendingLive.length = 0;
+  pendingLiveAV.length = 0;
+  lastIngestedMs = -Infinity;
+  lastAVIngestedMs = -Infinity;
+  prevStalls = prevDropped = null;
+  prevLoopServer = null;
+  prevControlRev = null;
+  prevError = null;
+  prevPlayId = null;
+  prevFirstFrame = prevVideoStart = null;
+  prevVariantMbps = null;
+  if (itemsDS) {
+    try { itemsDS.clear(); } catch { /* ignore */ }
+  }
+}
+
+watch(() => props.playerId, () => { resetIngest(); });
+
+// Cache reset (#587) — the events stream re-subscribed to a new window
+// (refetch-on-pan / return-to-live). The forward-only watermark would
+// miss the freshly-loaded (possibly older) window, so reset and re-drain.
 watch(
-  () => props.playerId,
-  () => {
-    statefulEvents.length = 0;
-    pendingLive.length = 0;
-    pendingLiveAV.length = 0;
-    lastIngestedMs = -Infinity;
-    lastAVIngestedMs = -Infinity;
-    prevStalls = prevDropped = null;
-    prevLoopServer = null;
-    prevControlRev = null;
-    prevError = null;
-    prevPlayId = null;
-    prevFirstFrame = prevVideoStart = null;
-    prevVariantMbps = null;
-    if (itemsDS) {
-      try { itemsDS.clear(); } catch { /* ignore */ }
-    }
-  },
+  () => props.eventsStream.epoch.value,
+  () => { resetIngest(); void drainNewRows(); },
 );
 
 watch(

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -1235,6 +1235,21 @@ watch(
   },
 );
 
+// Cache reset (#587) — the events stream re-subscribed to a different
+// window (refetch-on-pan, or returning to live). Our forward-only
+// watermark would miss the freshly-loaded window (it may be OLDER than
+// what we last drained), so reset and re-drain from scratch.
+watch(
+  () => props.eventsStream.epoch.value,
+  () => {
+    pendingLive.length = 0;
+    lastIngestedMs = -Infinity;
+    ++backfillToken; // abort any in-flight backfill from the prior window
+    for (const arr of dataset) arr.length = 0;
+    void drainNewRows();
+  },
+);
+
 // React to the coordinated visible range. `effectiveRange` collapses
 // the old (version, paused, lastSampleMs) tuple — it changes whenever
 // the range pin shifts (chart pan, brush drag, Live toggle) AND when

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -472,10 +472,13 @@ const timeRange = computed<{ min: number; max: number } | null>(() => {
   // Extend the rail's LEFT edge to THIS play's true start (#587) so the
   // operator can drag the focus bar into windows the recency cap has
   // evicted from the cache — panning there fires the refetch watcher
-  // above. Anchored to the play_id's earliest event (playStartMs), NOT
-  // the stale player-level current_play.started_at. Falls back to the
-  // cache min when the start is unknown.
-  const playStart = playStartMs.value;
+  // above. Prefer the CLIENT-supplied, play-scoped current_play.start_time
+  // (rotates with play_id); fall back to the play_id's earliest archived
+  // event (playStartMs) for non-instrumented clients; then the cache min.
+  // NEVER the stale player-level current_play.started_at.
+  const clientStartStr = (livePlayer.value?.current_play as { start_time?: string | null } | null | undefined)?.start_time;
+  const clientStart = clientStartStr ? Date.parse(clientStartStr) : NaN;
+  const playStart = (Number.isFinite(clientStart) && clientStart > 0) ? clientStart : playStartMs.value;
   const haveStart = playStart != null && Number.isFinite(playStart) && playStart > 0;
   if (!ar && !live && !haveStart) return null;
   let min = ar?.min ?? 0;

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -425,6 +425,40 @@ watch(
   { immediate: true },
 );
 
+/* True start of the CURRENT play (#587). The rail's left edge must
+ * anchor to where THIS play_id began, not `current_play.started_at` —
+ * that's a player-level field that goes stale when the play rotates
+ * (a content switch gives a new play_id but leaves started_at pointing
+ * at the prior play, so the rail stretched back hours to a play that
+ * isn't loaded). Query the earliest archived event for the live play_id
+ * instead; re-query whenever the play_id changes. */
+const playStartMs = ref<number | null>(null);
+watch(
+  () => (livePlayer.value?.current_play as { play_id?: string } | null | undefined)?.play_id
+    ?? playIdRef.value ?? null,
+  async (pid) => {
+    playStartMs.value = null;
+    const player = apiPlayerIdRef.value;
+    if (!pid || !player) return;
+    try {
+      const url = `/analytics/api/v2/events?player_id=${encodeURIComponent(player)}`
+        + `&play_id=${encodeURIComponent(pid)}&order=asc&limit=1`;
+      const r = await fetch(url);
+      if (!r.ok) return;
+      const j = await r.json();
+      const ts = j?.items?.[0]?.ts as string | undefined;
+      if (ts) {
+        const ms = Date.parse(ts);
+        // Guard against a race where the play_id changed mid-fetch.
+        const curPid = (livePlayer.value?.current_play as { play_id?: string } | null | undefined)?.play_id
+          ?? playIdRef.value ?? null;
+        if (Number.isFinite(ms) && curPid === pid) playStartMs.value = ms;
+      }
+    } catch { /* network/parse failure → fall back to cache min */ }
+  },
+  { immediate: true },
+);
+
 /** Effective time range for the brush rail. Reads the cached
  *  rangeBounds of the samples stream as the historical span; always
  *  extends `max` with `coord.lastSampleMs` so the rail's right edge
@@ -435,18 +469,17 @@ watch(
 const timeRange = computed<{ min: number; max: number } | null>(() => {
   const ar = timeseries.events.rangeBounds.value;
   const live = coord.state.lastSampleMs || 0;
-  // Extend the rail's LEFT edge to the play's start (#587) so the
+  // Extend the rail's LEFT edge to THIS play's true start (#587) so the
   // operator can drag the focus bar into windows the recency cap has
   // evicted from the cache — panning there fires the refetch watcher
-  // above. Without this the rail only spans the cached window, leaving
-  // evicted history unreachable. Falls back to the cache min when the
-  // start time is unknown.
-  const startStr = (livePlayer.value?.current_play as { started_at?: string } | null | undefined)?.started_at;
-  const playStart = startStr ? Date.parse(startStr) : NaN;
-  const haveStart = Number.isFinite(playStart) && playStart > 0;
+  // above. Anchored to the play_id's earliest event (playStartMs), NOT
+  // the stale player-level current_play.started_at. Falls back to the
+  // cache min when the start is unknown.
+  const playStart = playStartMs.value;
+  const haveStart = playStart != null && Number.isFinite(playStart) && playStart > 0;
   if (!ar && !live && !haveStart) return null;
   let min = ar?.min ?? 0;
-  if (haveStart && (min === 0 || playStart < min)) min = playStart;
+  if (haveStart && (min === 0 || (playStart as number) < min)) min = playStart as number;
   let max = Math.max(ar?.max ?? 0, live);
   if (!min) min = max;
   if (!max) max = min;
@@ -799,6 +832,11 @@ const draftRange = ref<{ min: number; max: number } | null>(null);
  *  gesturing, else the committed coordinated range. */
 const railRange = computed(() => draftRange.value ?? coord.effectiveRange.value);
 const windowSpanMs = computed(() => Math.max(1, railRange.value.max - railRange.value.min));
+/** Is the focus window parked at the live edge? Drives the rail pill —
+ *  it used to be hardcoded "· at end", which lied once the operator
+ *  pinned to (or panned into) a historical window. Reads railRange so it
+ *  tracks the in-flight draft during a drag too. */
+const atLiveEdge = computed(() => coord.isAtLiveEdge(railRange.value.max));
 
 /** Live toggle checked rule — same across every surface. */
 const brushLiveChecked = computed(() => coord.state.range === null);
@@ -1212,11 +1250,11 @@ function skipToEnd() {
           v-if="timeRange"
           class="rail-focus-label"
           :style="{
-            left: ((brushRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
-            right: ((scrubMax - brushRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            left: Math.max(0, (railRange.min - scrubMin) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
+            right: Math.max(0, (scrubMax - railRange.max) / Math.max(1, scrubMax - scrubMin) * 100) + '%',
           }"
         >
-          <span class="focus-pill">{{ fmtDurShort(windowSpanMs) }} · at end</span>
+          <span class="focus-pill">{{ fmtDurShort(windowSpanMs) }}{{ atLiveEdge ? ' · at end' : ' · ends ' + fmtTime(railRange.max) }}</span>
           <span class="focus-pill subtle">{{ samplesCount.toLocaleString() }} rendered</span>
         </span>
         <span class="rail-edge-label">{{ fmtTime(scrubMax) }}</span>

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -263,6 +263,31 @@ const toMsRef = computed<number | null>(() => {
   return props.showContext ? props.endMs + CONTEXT_PAD_MS : props.endMs;
 });
 
+/* ─── Refetch-on-pan (#587) ─────────────────────────────────────────
+ * When the operator pins the focus bar to a window OLDER than what's in
+ * the rolling cache (evicted by the #582 recency cap), re-point the SSE
+ * at that window so the panels can show the early part of a long session.
+ * Returning to live (range null) drops the override and re-subscribes to
+ * the live tail. Reuses the existing fromMs/toMs Ref re-subscribe path —
+ * the same mechanism SessionViewer's "show context" uses — so reviewing
+ * history pauses live until the operator clicks Live (or drags back to
+ * the right edge). The cache-reset epoch makes the charts/timeline
+ * re-drain the fetched window instead of missing it behind a stale
+ * watermark. The server treats a `to` >5s in the past as a bounded
+ * archive read (no live tail), so the window loads cleanly. */
+const histFromRef = ref<number | null>(null);
+const histToRef = ref<number | null>(null);
+const HISTORY_PAD_MS = 60 * 1000;
+// Live mode backfills only the recent window (cheap), NOT the whole play
+// — a multi-hour play is 10k+ rows and re-streaming it on every
+// return-to-live left the live edge blank for seconds. Deep history is
+// loaded on demand via the pan-back override below. Refreshed whenever
+// we (re)enter live so "return to live" pulls a fresh recent window.
+const LIVE_BACKFILL_MS = 10 * 60 * 1000;
+const liveFromRef = ref<number | null>(props.followLive ? Date.now() - LIVE_BACKFILL_MS : null);
+const tsFromMs = computed<number | null>(() => histFromRef.value ?? liveFromRef.value ?? fromMsRef.value);
+const tsToMs = computed<number | null>(() => histToRef.value ?? toMsRef.value);
+
 /** Resolved [fromMs, toMs] for the CycleBandsRail. When toMsRef is
  *  null (follow-live), use Date.now() as the upper bound so bands
  *  still render. Rail renders nothing when either bound is missing
@@ -285,8 +310,9 @@ const timeseries = useSessionTimeSeries(
     // streams (useSessionTimeSeries). Issue #474 Milestone C.
     streams: ['events', 'network', 'control', 'avmetrics'],
     bundles: ['charts_minimal', 'lanes_v1', 'panel_v1', 'session_details', 'network'],
-    fromMs: fromMsRef,
-    toMs: toMsRef,
+    // History override (#587) takes precedence over the live window.
+    fromMs: tsFromMs,
+    toMs: tsToMs,
   },
 );
 
@@ -300,6 +326,7 @@ watch(
     if (!b) return;
     if (props.startMs != null) return;   // URL gave us the truth
     if (props.showContext) return;        // wider window, don't anchor on it
+    if (props.followLive) return;         // live mode uses liveFromRef (#587)
     if (!playIdRef.value) return;         // live mode
     if (windowBoundsRef.value !== null) return;
     windowBoundsRef.value = b;
@@ -312,6 +339,37 @@ watch(
 // — and so any earlier reactive code (window watcher, brush clamps)
 // sees a coord instance even though it gets consumed mostly later.
 const coord = useChartCoordination(archivePlayerId);
+
+/* Refetch-on-pan driver (#587). Watches the committed focus range (the
+ * #590 brush debounce means this fires once per gesture, not per
+ * mousemove). Pinning before the cached data fetches that window;
+ * returning to live drops the override. Declared after `coord` to avoid
+ * a TDZ on the watch getter. Live mode only — URL-driven archive views
+ * (props.startMs set) already load their bounded window. */
+watch(
+  () => coord.state.range,
+  (range) => {
+    if (props.startMs != null) return; // URL-driven archive; not live
+    if (!range) {
+      // Back to live — re-subscribe to a FRESH recent window (not the
+      // stale one from when the page first loaded).
+      histFromRef.value = null;
+      histToRef.value = null;
+      if (props.followLive) liveFromRef.value = Date.now() - LIVE_BACKFILL_MS;
+      return;
+    }
+    const bounds = timeseries.events.rangeBounds.value;
+    // Only refetch when the pinned window starts MEANINGFULLY before
+    // what's cached; a window already in the cache needs no server
+    // round-trip. The slop keeps the auto-pin fallback (bounds.min − 5s)
+    // and small drag jitter from triggering a needless re-subscribe.
+    const REFETCH_SLOP_MS = 15 * 1000;
+    if (bounds && range.min < bounds.min - REFETCH_SLOP_MS) {
+      histFromRef.value = range.min - HISTORY_PAD_MS;
+      histToRef.value = range.max + HISTORY_PAD_MS;
+    }
+  },
+);
 
 // Pin the focus-window brush as soon as we know the time bounds.
 //   - URL gave us startMs + endMs (sessions.html click): pin
@@ -377,10 +435,23 @@ watch(
 const timeRange = computed<{ min: number; max: number } | null>(() => {
   const ar = timeseries.events.rangeBounds.value;
   const live = coord.state.lastSampleMs || 0;
-  if (!ar && !live) return null;
-  if (!ar) return { min: live, max: live };
-  if (!live) return ar;
-  return { min: ar.min, max: Math.max(ar.max, live) };
+  // Extend the rail's LEFT edge to the play's start (#587) so the
+  // operator can drag the focus bar into windows the recency cap has
+  // evicted from the cache — panning there fires the refetch watcher
+  // above. Without this the rail only spans the cached window, leaving
+  // evicted history unreachable. Falls back to the cache min when the
+  // start time is unknown.
+  const startStr = (livePlayer.value?.current_play as { started_at?: string } | null | undefined)?.started_at;
+  const playStart = startStr ? Date.parse(startStr) : NaN;
+  const haveStart = Number.isFinite(playStart) && playStart > 0;
+  if (!ar && !live && !haveStart) return null;
+  let min = ar?.min ?? 0;
+  if (haveStart && (min === 0 || playStart < min)) min = playStart;
+  let max = Math.max(ar?.max ?? 0, live);
+  if (!min) min = max;
+  if (!max) max = min;
+  if (!min && !max) return null;
+  return { min, max };
 });
 
 const loading = computed(() => timeseries.events.loading.value);

--- a/content/dashboard-v3/src/composables/chRowAdapter.ts
+++ b/content/dashboard-v3/src/composables/chRowAdapter.ts
@@ -299,6 +299,10 @@ export function chRowToPlayerRecord(
       ? {
           id: row.play_id,
           attempt_id: ctx?.maxAttemptId ?? (num(row.attempt_id) ?? undefined),
+          // Client-supplied play-scoped start (#587); empty string when
+          // the client didn't send it.
+          start_time: (typeof row.start_time === 'string' && row.start_time)
+            ? row.start_time : undefined,
           manifest: masterUrl ? { master_url: masterUrl } : undefined,
         }
       : null,

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -57,6 +57,13 @@ export interface Stream<T> {
   rangeBounds: Ref<{ min: number; max: number } | null>;
   loading: Ref<boolean>;
   error: Ref<string | null>;
+  /** Bumped whenever the cache is RESET (a re-subscribe to a new
+   *  player/play/time window cleared all rows). Forward-only consumers
+   *  (chart/timeline watermark drains) watch this to reset their
+   *  watermark + clear their datasets and re-drain from scratch — needed
+   *  for refetch-on-pan (#587), where re-subscribing to an OLDER window
+   *  would otherwise be missed by a watermark sitting at the live edge. */
+  epoch: Ref<number>;
 }
 
 export interface UseSessionTimeSeriesOpts {
@@ -159,6 +166,12 @@ export function useSessionTimeSeries(
   const controlVersion = ref(0);
   const avmetricsVersion = ref(0);
 
+  // Bumped on every cache RESET (re-subscribe). Shared across all four
+  // streams so forward-only consumers can detect "the cache was wiped
+  // and reloaded with a different window" and re-drain from scratch
+  // (#587 refetch-on-pan).
+  const cacheEpoch = ref(0);
+
   const eventsBounds = ref<{ min: number; max: number } | null>(null);
   const networkBounds = ref<{ min: number; max: number } | null>(null);
   const controlBounds = ref<{ min: number; max: number } | null>(null);
@@ -231,6 +244,9 @@ export function useSessionTimeSeries(
     controlError.value = null;
     avmetricsError.value = null;
     lastEventId = '';
+    // Signal consumers that the cache was wiped (#587) so watermark
+    // drains reset rather than missing the freshly-loaded window.
+    cacheEpoch.value++;
   }
 
   /** Build the SSE URL from current opts + identity refs. */
@@ -506,6 +522,7 @@ export function useSessionTimeSeries(
       rangeBounds: boundsRef,
       loading: loadingRef,
       error: errorRef,
+      epoch: cacheEpoch,
     };
   }
 
@@ -526,9 +543,26 @@ export function useSessionTimeSeries(
   const SOFT_CAP_SAMPLES = 20000;
   const SOFT_CAP_NETWORK = 4000;
   const SOFT_CAP_EVENTS = 20000;
-  function trimToCap<T>(arr: T[], cap: number): boolean {
+  // Trim the oldest rows past `cap` AND advance the stream's
+  // rangeBounds.min to the new oldest ts. The bounds update is
+  // essential for refetch-on-pan (#587): the brush rail's left edge and
+  // the "is this window already cached?" check both read rangeBounds.min,
+  // so leaving it at the pre-trim value made the UI think evicted rows
+  // were still in the cache (panning there showed blank, no refetch).
+  function trimToCap(
+    arr: Record<string, unknown>[],
+    cap: number,
+    boundsRef: Ref<{ min: number; max: number } | null>,
+  ): boolean {
     if (arr.length > cap) {
       arr.splice(0, arr.length - cap);
+      const cur = boundsRef.value;
+      if (cur) {
+        const newMin = tsOf(arr[0]);
+        if (Number.isFinite(newMin) && newMin !== cur.min) {
+          boundsRef.value = { min: newMin, max: cur.max };
+        }
+      }
       return true;
     }
     return false;
@@ -536,10 +570,10 @@ export function useSessionTimeSeries(
   watch(
     [eventsVersion, networkVersion, controlVersion, avmetricsVersion],
     () => {
-      if (trimToCap(eventsArr.value, SOFT_CAP_SAMPLES)) triggerRef(eventsArr);
-      if (trimToCap(networkArr.value, SOFT_CAP_NETWORK)) triggerRef(networkArr);
-      if (trimToCap(controlArr.value, SOFT_CAP_EVENTS)) triggerRef(controlArr);
-      if (trimToCap(avmetricsArr.value, SOFT_CAP_EVENTS)) triggerRef(avmetricsArr);
+      if (trimToCap(eventsArr.value, SOFT_CAP_SAMPLES, eventsBounds)) triggerRef(eventsArr);
+      if (trimToCap(networkArr.value, SOFT_CAP_NETWORK, networkBounds)) triggerRef(networkArr);
+      if (trimToCap(controlArr.value, SOFT_CAP_EVENTS, controlBounds)) triggerRef(controlArr);
+      if (trimToCap(avmetricsArr.value, SOFT_CAP_EVENTS, avmetricsBounds)) triggerRef(avmetricsArr);
     },
   );
 

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1569,6 +1569,19 @@ export interface components {
             labels?: components["schemas"]["Labels"];
             /** Format: date-time */
             started_at: string;
+            /**
+             * Format: date-time
+             * @description **Client-supplied** play start (ISO-8601 UTC), minted by the
+             *     player at the same boundary as `id` (play_id) and re-sent as a
+             *     `?start_time=` query param on every request. Unlike
+             *     `started_at` — which the proxy derives from the SESSION's first
+             *     request and therefore does NOT move when the play_id rotates —
+             *     this is play-scoped: a content switch yields a new play_id AND
+             *     a new start_time. Prefer this for "when did THIS play begin";
+             *     `started_at` is the connection/session start. Null for
+             *     non-instrumented clients (web, Roku) that don't send it.
+             */
+            start_time?: string | null;
             /** Format: date-time */
             ended_at?: string | null;
             manifest?: components["schemas"]["Manifest"];
@@ -1918,13 +1931,25 @@ export interface components {
             video_resolution?: string | null;
             /** @description Player-reported window/display resolution (separate from the active video resolution). */
             display_resolution?: string | null;
+            /** @description WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event. */
+            fetching_resolution?: string | null;
             /** Format: float */
             video_bitrate_mbps?: number | null;
             /**
              * Format: float
-             * @description video_bitrate_mbps as a percentage of the top variant in the active manifest
+             * @description video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
              */
             video_quality_pct?: number | null;
+            /**
+             * Format: float
+             * @description Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.
+             */
+            video_quality_60s_pct?: number | null;
+            /**
+             * Format: float
+             * @description Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
+             */
+            video_quality_avg_pct?: number | null;
             /**
              * Format: float
              * @description Player-computed avgNetworkBitrate.
@@ -2006,8 +2031,21 @@ export interface components {
             trigger_type?: string | null;
             /** @description Player state machine label (idle, playing, paused, buffering, ended, error). */
             state?: string | null;
+            /** @description On state_change events: the player_state before the transition. Empty / null on heartbeat rows. */
+            state_from?: string | null;
+            /** @description On state_change events: the player_state after the transition. Empty / null on heartbeat rows. */
+            state_to?: string | null;
             /** @description AVFoundation reasonForWaitingToPlay (or platform equivalent) — split labels within `state` like `toMinimizeStalls` vs `evaluatingBufferingRate`. */
             waiting_reason?: string | null;
+            /** @description Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue. */
+            content_name?: string | null;
+            /** @description On user_marked (911) events: wall-clock ISO-8601 instant the operator pressed the button. Empty on other rows. */
+            user_marked_at?: string | null;
+            /**
+             * Format: float
+             * @description Active variant's nominal frame rate (Hz). Sticky after first observation in the format-change event.
+             */
+            frames_rate?: number | null;
             /** @description Player-encoded PDT (milliseconds since Unix epoch) for the current playhead. Used by the chart engine to compute live offset against the server clock. */
             playhead_wallclock_ms?: number | null;
             /** @description Web-player browser family (e.g. `safari`, `chrome`). Drives native-rendition inference for HLS-on-Safari where bitrate is not directly reported. */
@@ -2049,12 +2087,16 @@ export interface components {
             seeking_count?: number | null;
             /** @description #550 Phase 1: cumulative time at non-1× playback rate (FF / RW). */
             trickplaying_time_ms?: number | null;
+            /** @description JSON-string-encoded map of variant-label → cumulative seconds spent at that variant (e.g. `{"2160p@29857kbps":65.28}`). Preserved across retry()-style restarts. */
+            time_per_variant_s?: string | null;
             /** @description #550 Phase 1: entries into trickplay (rate ∉ {0, ~1}). */
             trickplaying_count?: number | null;
-            /** @description #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats). Replaces legacy last_stall_time_s. */
+            /** @description #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats). */
             stall_duration_ms?: number | null;
-            /** @description #550 Phase 1: duration of the MOST RECENT buffer event (sticky). Replaces legacy last_buffering_time_s. */
+            /** @description #550 Phase 1: duration of the MOST RECENT buffer event (sticky). */
             buffering_duration_ms?: number | null;
+            /** @description #550 Phase 1 ext: orthogonal "this stall won't auto-recover" flag. True from the moment AVPlayer transitions stalled → .paused (give-up) until next .playing transition. State stays "stalled" for residency continuity; dashboards key on this flag to surface operator-actionable stalls. */
+            stall_stuck?: boolean | null;
             /** @description #550 Phase 1: TTFF in ms. Conviva/Mux/Bitmovin canonical units. Replaces legacy video_first_frame_time_s. */
             video_first_frame_time_ms?: number | null;
             /** @description #550 Phase 1: alternate startup-time measurement in ms. */
@@ -2089,15 +2131,8 @@ export interface components {
             device_model?: string | null;
             /** @description #550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`. */
             player_tech?: string | null;
-            /** @description #550 Phase 4: native (physical-pixel) screen width. */
-            screen_width_px?: number | null;
-            /** @description #550 Phase 4: native screen height. */
-            screen_height_px?: number | null;
-            /**
-             * Format: float
-             * @description #550 Phase 4: native scale (points-to-pixels density).
-             */
-            screen_density?: number | null;
+            /** @description Physical-pixel resolution of the device's current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30). */
+            device_resolution?: string | null;
         };
         /**
          * @description Read-only server-observed transport telemetry. Sourced from

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -7397,6 +7397,19 @@ func (a *App) saveSessionByIDReturning(sessionID string, session SessionData) (S
 					merged["player_metrics_event_time"] = nowStr
 				}
 			}
+			// #587 — play_id rotation resets the proxy-accumulated per-play
+			// counters so the new play measures from zero, mirroring the
+			// clients' own per-play reset. Detected at this single merge
+			// chokepoint (every GET/POST that stamps play_id flows through
+			// here). retry()/auto-recovery bumps attempt_id but keeps play_id
+			// stable, so this does NOT fire on recovery. Fault/shaping config,
+			// session identity/timing, and control state are preserved.
+			prevPlay := getString(s, "play_id")
+			newPlay := getString(session, "play_id")
+			if prevPlay != "" && newPlay != "" && prevPlay != newPlay {
+				resetPlayScopedServerCounters(merged)
+				a.resetServerLoopState(sessionID)
+			}
 			updated[i] = merged
 			found = true
 			break
@@ -7407,6 +7420,51 @@ func (a *App) saveSessionByIDReturning(sessionID string, session SessionData) (S
 		return nil, false
 	}
 	return cloneSession(merged), true
+}
+
+// resetPlayScopedServerCounters zeroes the proxy-ACCUMULATED counters that
+// should restart at a fresh play (#587). Called from saveSessionByIDReturning
+// when the player rotates play_id. Deliberately preserves fault/shaping
+// CONFIG, session identity/timing (session_start_time, origination_*), and
+// control state. The server-side loop-detection in-memory state is reset by
+// the caller via resetServerLoopState.
+//
+// IMPORTANT — what is NOT reset, and why:
+//   - The *_requests_count counters (manifest/master/segments/all) are the
+//     fault-pattern CLOCK: FailureHandler.handleFailureCount compares the
+//     running request count against the count-based *_failure_at /
+//     *_failure_recover_at thresholds to decide when to fire. Zeroing the
+//     count without rewinding those thresholds would suppress faults until
+//     the count climbed back, desyncing operator fault patterns. Left
+//     running so injection behaviour is unchanged across a play rotation.
+//   - transport_fault_*_packets can be the "packets"-units cycle counter for
+//     transport faults (and self-reset each on/off cycle), so they're left
+//     alone too.
+// The fault_count_* family below is purely a write-only reporting tally
+// (bumpFaultCounter only writes; every read is reporting/init/projection),
+// so resetting it does NOT affect fault firing.
+func resetPlayScopedServerCounters(m SessionData) {
+	// Server-side loop counter (in-memory seq state reset separately).
+	m["loop_count_server"] = 0
+	delete(m, "loop_count_server_last_at")
+	// Cumulative byte totals + the rolling-window state behind the Mbps
+	// derivations, so the new play measures throughput from zero. These feed
+	// dashboard display only — no control decision reads them.
+	m["bytes_in_total"] = int64(0)
+	m["bytes_out_total"] = int64(0)
+	m["bytes_in_last"] = int64(0)
+	m["bytes_out_last"] = int64(0)
+	delete(m, "bytes_last_ts")
+	delete(m, "io_samples")
+	delete(m, "active_io_samples")
+	// Fault-injection REPORTING tally — one key per category
+	// (fault_count_total, fault_count_socket_*, fault_count_request_*,
+	// fault_count_transfer_*). Write-only; resetting does not change firing.
+	for k := range m {
+		if strings.HasPrefix(k, "fault_count_") {
+			m[k] = 0
+		}
+	}
 }
 
 // hasDeviceFamilyToken reports whether the given User-Agent string

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -2409,6 +2409,12 @@ func (a *App) handlePostSessionMetrics(w http.ResponseWriter, r *http.Request) {
 	if v := strings.TrimSpace(r.URL.Query().Get("attempt_id")); v != "" {
 		metricsOnly["attempt_id"] = v
 	}
+	// Play-scoped client start (#587) — picked up here too so it lands
+	// on long-running iOS sessions between manifest fetches, same as
+	// play_id/attempt_id.
+	if v := strings.TrimSpace(r.URL.Query().Get("start_time")); v != "" {
+		metricsOnly["start_time"] = v
+	}
 	merged, ok := a.saveSessionByIDReturning(id, metricsOnly)
 	// Issue #470: emit one SSE frame per metrics POST. Every POST —
 	// heartbeat or otherwise — flows through so the forwarder writes
@@ -5145,6 +5151,10 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// below.
 	playID := strings.TrimSpace(r.URL.Query().Get("play_id"))
 	attemptIDStr := strings.TrimSpace(r.URL.Query().Get("attempt_id"))
+	// Client-supplied, play-scoped start (#587). Rotates with play_id;
+	// the proxy just carries it through to the session map so it reaches
+	// PlayRecord.start_time (live) and the session_events CH column.
+	startTime := strings.TrimSpace(r.URL.Query().Get("start_time"))
 	var attemptID uint32
 	if attemptIDStr != "" {
 		if n, err := strconv.ParseUint(attemptIDStr, 10, 32); err == nil {
@@ -5472,6 +5482,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// the proxy guessing.
 	if playID != "" {
 		sessionData["play_id"] = playID
+	}
+	// Play-scoped client start (#587). Carried on the session map so
+	// v2translate can project PlayRecord.start_time and the SSE
+	// session_events frame can carry it to ClickHouse. The client
+	// rotates it with play_id, so it always reflects THIS play.
+	if startTime != "" {
+		sessionData["start_time"] = startTime
 	}
 	// Store the raw string so sessionStickyField (a generic
 	// type-asserts-as-string helper) can read it back uniformly

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -1047,8 +1047,19 @@ type PlayRecord struct {
 
 	// Shape Play-scoped shape override. Replaces `player.shape` for this
 	// play if set. Auto-cleared on play end.
-	Shape     *Shape    `json:"shape,omitempty"`
-	StartedAt time.Time `json:"started_at"`
+	Shape *Shape `json:"shape,omitempty"`
+
+	// StartTime **Client-supplied** play start (ISO-8601 UTC), minted by the
+	// player at the same boundary as `id` (play_id) and re-sent as a
+	// `?start_time=` query param on every request. Unlike
+	// `started_at` — which the proxy derives from the SESSION's first
+	// request and therefore does NOT move when the play_id rotates —
+	// this is play-scoped: a content switch yields a new play_id AND
+	// a new start_time. Prefer this for "when did THIS play begin";
+	// `started_at` is the connection/session start. Null for
+	// non-instrumented clients (web, Roku) that don't send it.
+	StartTime *time.Time `json:"start_time,omitempty"`
+	StartedAt time.Time  `json:"started_at"`
 }
 
 // PlayStartedEvent defines model for PlayStartedEvent.
@@ -1214,11 +1225,14 @@ type PlayerMetrics struct {
 	// BufferingCount #550 Phase 1: entries into `buffering` state.
 	BufferingCount *int `json:"buffering_count,omitempty"`
 
-	// BufferingDurationMs #550 Phase 1: duration of the MOST RECENT buffer event (sticky). Replaces legacy last_buffering_time_s.
+	// BufferingDurationMs #550 Phase 1: duration of the MOST RECENT buffer event (sticky).
 	BufferingDurationMs *int `json:"buffering_duration_ms,omitempty"`
 
 	// BufferingTimeMs #550 Phase 1: cumulative buffering time (ms).
 	BufferingTimeMs *int `json:"buffering_time_ms,omitempty"`
+
+	// ContentName Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue.
+	ContentName *string `json:"content_name,omitempty"`
 
 	// DeviceClass #550 Phase 4: form-factor enum: `phone` / `tablet` / `tv` / `desktop` / `unknown`.
 	DeviceClass *string `json:"device_class,omitempty"`
@@ -1226,14 +1240,11 @@ type PlayerMetrics struct {
 	// DeviceModel #550 Phase 4: hardware model identifier (e.g. iPhone15,3) via sysctl hw.machine.
 	DeviceModel *string `json:"device_model,omitempty"`
 
+	// DeviceResolution Physical-pixel resolution of the device's current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30).
+	DeviceResolution *string `json:"device_resolution,omitempty"`
+
 	// DisplayResolution Player-reported window/display resolution (separate from the active video resolution).
 	DisplayResolution *string `json:"display_resolution,omitempty"`
-
-	// FetchingResolution WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder.
-	FetchingResolution *string `json:"fetching_resolution,omitempty"`
-
-	// FramesDropped Player-reported dropped frames count.
-	FramesDropped *int `json:"frames_dropped,omitempty"`
 
 	// Error Most recent player-reported error string.
 	Error *string `json:"error,omitempty"`
@@ -1253,11 +1264,20 @@ type PlayerMetrics struct {
 	// EventTime Player-supplied wallclock for the most recent metrics tick.
 	EventTime *time.Time `json:"event_time,omitempty"`
 
+	// FetchingResolution WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event.
+	FetchingResolution *string `json:"fetching_resolution,omitempty"`
+
 	// FirstFrameTimeS Time-to-first-frame (seconds since play started).
 	FirstFrameTimeS *float32 `json:"first_frame_time_s,omitempty"`
 
 	// FramesDisplayed Player-reported displayed frames count.
 	FramesDisplayed *int `json:"frames_displayed,omitempty"`
+
+	// FramesDropped Player-reported dropped frames count.
+	FramesDropped *int `json:"frames_dropped,omitempty"`
+
+	// FramesRate Active variant's nominal frame rate (Hz). Sticky after first observation in the format-change event.
+	FramesRate *float32 `json:"frames_rate,omitempty"`
 
 	// IdlingCount #550 Phase 1: entries into `idle` state.
 	IdlingCount *int `json:"idling_count,omitempty"`
@@ -1328,10 +1348,6 @@ type PlayerMetrics struct {
 	// ProfileShiftCount Number of ABR rendition shifts the player has reported.
 	ProfileShiftCount *int `json:"profile_shift_count,omitempty"`
 
-	// DeviceResolution Physical-pixel resolution in current orientation, "WxH".
-	// Supersedes screen_width_px / screen_height_px / screen_density.
-	DeviceResolution *string `json:"device_resolution,omitempty"`
-
 	// SeekableEndS Player-reported end of seekable range (seconds).
 	SeekableEndS *float32 `json:"seekable_end_s,omitempty"`
 
@@ -1344,8 +1360,11 @@ type PlayerMetrics struct {
 	// Source Identifier for the metrics source (e.g. avplayer-ios, exoplayer-android).
 	Source *string `json:"source,omitempty"`
 
-	// StallDurationMs #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats). Replaces legacy last_stall_time_s.
+	// StallDurationMs #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats).
 	StallDurationMs *int `json:"stall_duration_ms,omitempty"`
+
+	// StallStuck #550 Phase 1 ext: orthogonal "this stall won't auto-recover" flag. True from the moment AVPlayer transitions stalled → .paused (give-up) until next .playing transition. State stays "stalled" for residency continuity; dashboards key on this flag to surface operator-actionable stalls.
+	StallStuck *bool `json:"stall_stuck,omitempty"`
 
 	// StallTimeS Cumulative stall time (seconds).
 	StallTimeS *float32 `json:"stall_time_s,omitempty"`
@@ -1355,17 +1374,16 @@ type PlayerMetrics struct {
 
 	// StallingTimeMs #550 Phase 1: cumulative stalling time (ms). Single canonical pair replacing legacy stall_count/stall_time_s during soft cutover.
 	StallingTimeMs *int `json:"stalling_time_ms,omitempty"`
-
-	// StallStuck #550 Phase 1 ext: orthogonal "this stall won't auto-recover" flag.
-	// True from the moment AVPlayer transitions stalled → .paused (give-up) until
-	// next .playing transition. State stays "stalled" for residency continuity;
-	// dashboards key on this flag to surface operator-actionable stalls.
-	StallStuck *bool `json:"stall_stuck,omitempty"`
-
-	Stalls *int `json:"stalls,omitempty"`
+	Stalls         *int `json:"stalls,omitempty"`
 
 	// State Player state machine label (idle, playing, paused, buffering, ended, error).
 	State *string `json:"state,omitempty"`
+
+	// StateFrom On state_change events: the player_state before the transition. Empty / null on heartbeat rows.
+	StateFrom *string `json:"state_from,omitempty"`
+
+	// StateTo On state_change events: the player_state after the transition. Empty / null on heartbeat rows.
+	StateTo *string `json:"state_to,omitempty"`
 
 	// TerminalErrorCode #550 Phase 2: error code populated ONLY on terminal failure rows. Querying `WHERE terminal_error_code != 0` is SQL-safe — never returns transient codes.
 	TerminalErrorCode *int `json:"terminal_error_code,omitempty"`
@@ -1376,37 +1394,36 @@ type PlayerMetrics struct {
 	// TerminalErrorDomain #550 Phase 2: error domain on terminal failure rows.
 	TerminalErrorDomain *string `json:"terminal_error_domain,omitempty"`
 
+	// TimePerVariantS JSON-string-encoded map of variant-label → cumulative seconds spent at that variant (e.g. `{"2160p@29857kbps":65.28}`). Preserved across retry()-style restarts.
+	TimePerVariantS *string `json:"time_per_variant_s,omitempty"`
+
 	// TrickplayingCount #550 Phase 1: entries into trickplay (rate ∉ {0, ~1}).
 	TrickplayingCount *int `json:"trickplaying_count,omitempty"`
 
 	// TrickplayingTimeMs #550 Phase 1: cumulative time at non-1× playback rate (FF / RW).
 	TrickplayingTimeMs *int `json:"trickplaying_time_ms,omitempty"`
 
-	// TimePerVariantS JSON-string-encoded map of variant-label →
-	// cumulative seconds spent at that variant. Example: `{"2160p@29857kbps":65.28}`.
-	// Preserved across retry()-style restarts so the dashboard sees
-	// continuous totals through automatic recovery.
-	TimePerVariantS *string `json:"time_per_variant_s,omitempty"`
-
 	// TriggerType What triggered the most recent metrics tick (timer, event, etc.).
 	TriggerType *string `json:"trigger_type,omitempty"`
 
 	// TrueOffsetS Wall-clock offset between player position and real time (seconds).
-	TrueOffsetS      *float32 `json:"true_offset_s,omitempty"`
+	TrueOffsetS *float32 `json:"true_offset_s,omitempty"`
+
+	// UserMarkedAt On user_marked (911) events: wall-clock ISO-8601 instant the operator pressed the button. Empty on other rows.
+	UserMarkedAt     *string  `json:"user_marked_at,omitempty"`
 	VideoBitrateMbps *float32 `json:"video_bitrate_mbps,omitempty"`
 
 	// VideoFirstFrameTimeMs #550 Phase 1: TTFF in ms. Conviva/Mux/Bitmovin canonical units. Replaces legacy video_first_frame_time_s.
 	VideoFirstFrameTimeMs *int `json:"video_first_frame_time_ms,omitempty"`
 
-	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
-	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
-
-	// VideoQuality60sPct Time-weighted (bitrate/maxPeak)×100 over the last 60s of watched playback. Computed by iOS from AVPlayerItem.accessLog().
+	// VideoQuality60sPct Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.
 	VideoQuality60sPct *float32 `json:"video_quality_60s_pct,omitempty"`
 
-	// VideoQualityAvgPct Time-weighted (bitrate/maxPeak)×100 over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
+	// VideoQualityAvgPct Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
 	VideoQualityAvgPct *float32 `json:"video_quality_avg_pct,omitempty"`
 
+	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
+	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
 	VideoResolution *string  `json:"video_resolution,omitempty"`
 
 	// VideoStartTimeMs #550 Phase 1: alternate startup-time measurement in ms.
@@ -1417,21 +1434,6 @@ type PlayerMetrics struct {
 
 	// WaitingReason AVFoundation reasonForWaitingToPlay (or platform equivalent) — split labels within `state` like `toMinimizeStalls` vs `evaluatingBufferingRate`.
 	WaitingReason *string `json:"waiting_reason,omitempty"`
-
-	// StateFrom On state_change events: the player_state before the transition.
-	StateFrom *string `json:"state_from,omitempty"`
-
-	// StateTo On state_change events: the player_state after the transition.
-	StateTo *string `json:"state_to,omitempty"`
-
-	// ContentName Content title bound at metrics-start. Stamped on every payload.
-	ContentName *string `json:"content_name,omitempty"`
-
-	// UserMarkedAt On user_marked (911) events: wall-clock ISO-8601 instant the operator pressed the button.
-	UserMarkedAt *string `json:"user_marked_at,omitempty"`
-
-	// FramesRate Active variant's nominal frame rate (Hz). Sticky after first observation.
-	FramesRate *float32 `json:"frames_rate,omitempty"`
 }
 
 // PlayerPatch Mutable subset of `PlayerRecord`. JSON Merge Patch semantics.

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -564,6 +564,13 @@ func currentPlayFromSession(s map[string]any, playerUUID uuid.UUID) *oapigen.Pla
 	if t, ok := getTime(s, "session_start_time", "first_request_time"); ok {
 		rec.StartedAt = t
 	}
+	// start_time is the CLIENT-supplied, play-scoped start (#587). Unlike
+	// started_at (session_start_time — frozen at the connection's first
+	// request, so stale after a play_id rotation), the player rotates
+	// start_time with play_id, so this reflects when THIS play began.
+	if t, ok := getTime(s, "start_time"); ok {
+		rec.StartTime = &t
+	}
 	// Manifest projection: master_manifest_url is the master playlist
 	// the player loaded; manifest_url is the variant playlist most
 	// recently fetched. Prefer the explicit master, fall back to the

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -893,7 +893,6 @@ type PlayDetail struct {
 	Classification *PlayDetailClassification `json:"classification,omitempty"`
 	ContentId      *string                   `json:"content_id,omitempty"`
 	Downshifts     *int                      `json:"downshifts,omitempty"`
-	FramesDropped  *int                      `json:"frames_dropped,omitempty"`
 
 	// ErrorEventCount Explicit player_error events.
 	ErrorEventCount *int `json:"error_event_count,omitempty"`
@@ -904,6 +903,7 @@ type PlayDetail struct {
 	// FirstFrameS Time-to-first-frame, seconds.
 	FirstFrameS     *float32 `json:"first_frame_s,omitempty"`
 	FramesDisplayed *int     `json:"frames_displayed,omitempty"`
+	FramesDropped   *int     `json:"frames_dropped,omitempty"`
 
 	// FrozenCount Renderer-frozen events (≠ buffer stalls).
 	FrozenCount *int `json:"frozen_count,omitempty"`
@@ -974,11 +974,14 @@ type PlayDetail struct {
 	SegmentStallCount *int `json:"segment_stall_count,omitempty"`
 
 	// SessionId Per-player numeric session counter ('1', '2', …). Empty when archive predates session_id stamping.
-	SessionId         *string   `json:"session_id,omitempty"`
-	Stalls            *int      `json:"stalls,omitempty"`
-	StartedAt         time.Time `json:"started_at"`
-	TransportFailures *int      `json:"transport_failures,omitempty"`
-	Upshifts          *int      `json:"upshifts,omitempty"`
+	SessionId *string `json:"session_id,omitempty"`
+	Stalls    *int    `json:"stalls,omitempty"`
+
+	// StartTime Client-supplied play start (ISO-8601 UTC), play-scoped — minted by the player with play_id and rotated with it. See PlayRecord.start_time in proxy.yaml. Null when the client didn't send it (web/Roku).
+	StartTime         *time.Time `json:"start_time,omitempty"`
+	StartedAt         time.Time  `json:"started_at"`
+	TransportFailures *int       `json:"transport_failures,omitempty"`
+	Upshifts          *int       `json:"upshifts,omitempty"`
 
 	// UserMarkedCount Operator pressed the 911 button N times.
 	UserMarkedCount *int `json:"user_marked_count,omitempty"`
@@ -1045,7 +1048,6 @@ type PlaySummary struct {
 	Classification *PlaySummaryClassification `json:"classification,omitempty"`
 	ContentId      *string                    `json:"content_id,omitempty"`
 	Downshifts     *int                       `json:"downshifts,omitempty"`
-	FramesDropped  *int                       `json:"frames_dropped,omitempty"`
 
 	// ErrorEventCount Explicit player_error events.
 	ErrorEventCount *int `json:"error_event_count,omitempty"`
@@ -1053,6 +1055,7 @@ type PlaySummary struct {
 	// FirstFrameS Time-to-first-frame, seconds.
 	FirstFrameS     *float32 `json:"first_frame_s,omitempty"`
 	FramesDisplayed *int     `json:"frames_displayed,omitempty"`
+	FramesDropped   *int     `json:"frames_dropped,omitempty"`
 
 	// FrozenCount Renderer-frozen events (≠ buffer stalls).
 	FrozenCount *int `json:"frozen_count,omitempty"`
@@ -1118,11 +1121,14 @@ type PlaySummary struct {
 	SegmentStallCount *int `json:"segment_stall_count,omitempty"`
 
 	// SessionId Per-player numeric session counter ('1', '2', …). Empty when archive predates session_id stamping.
-	SessionId         *string   `json:"session_id,omitempty"`
-	Stalls            *int      `json:"stalls,omitempty"`
-	StartedAt         time.Time `json:"started_at"`
-	TransportFailures *int      `json:"transport_failures,omitempty"`
-	Upshifts          *int      `json:"upshifts,omitempty"`
+	SessionId *string `json:"session_id,omitempty"`
+	Stalls    *int    `json:"stalls,omitempty"`
+
+	// StartTime Client-supplied play start (ISO-8601 UTC), play-scoped — minted by the player with play_id and rotated with it. See PlayRecord.start_time in proxy.yaml. Null when the client didn't send it (web/Roku).
+	StartTime         *time.Time `json:"start_time,omitempty"`
+	StartedAt         time.Time  `json:"started_at"`
+	TransportFailures *int       `json:"transport_failures,omitempty"`
+	Upshifts          *int       `json:"upshifts,omitempty"`
 
 	// UserMarkedCount Operator pressed the 911 button N times.
 	UserMarkedCount *int `json:"user_marked_count,omitempty"`

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -1048,8 +1048,19 @@ type PlayRecord struct {
 
 	// Shape Play-scoped shape override. Replaces `player.shape` for this
 	// play if set. Auto-cleared on play end.
-	Shape     *Shape    `json:"shape,omitempty"`
-	StartedAt time.Time `json:"started_at"`
+	Shape *Shape `json:"shape,omitempty"`
+
+	// StartTime **Client-supplied** play start (ISO-8601 UTC), minted by the
+	// player at the same boundary as `id` (play_id) and re-sent as a
+	// `?start_time=` query param on every request. Unlike
+	// `started_at` — which the proxy derives from the SESSION's first
+	// request and therefore does NOT move when the play_id rotates —
+	// this is play-scoped: a content switch yields a new play_id AND
+	// a new start_time. Prefer this for "when did THIS play begin";
+	// `started_at` is the connection/session start. Null for
+	// non-instrumented clients (web, Roku) that don't send it.
+	StartTime *time.Time `json:"start_time,omitempty"`
+	StartedAt time.Time  `json:"started_at"`
 }
 
 // PlayStartedEvent defines model for PlayStartedEvent.
@@ -1215,11 +1226,14 @@ type PlayerMetrics struct {
 	// BufferingCount #550 Phase 1: entries into `buffering` state.
 	BufferingCount *int `json:"buffering_count,omitempty"`
 
-	// BufferingDurationMs #550 Phase 1: duration of the MOST RECENT buffer event (sticky). Replaces legacy last_buffering_time_s.
+	// BufferingDurationMs #550 Phase 1: duration of the MOST RECENT buffer event (sticky).
 	BufferingDurationMs *int `json:"buffering_duration_ms,omitempty"`
 
 	// BufferingTimeMs #550 Phase 1: cumulative buffering time (ms).
 	BufferingTimeMs *int `json:"buffering_time_ms,omitempty"`
+
+	// ContentName Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue.
+	ContentName *string `json:"content_name,omitempty"`
 
 	// DeviceClass #550 Phase 4: form-factor enum: `phone` / `tablet` / `tv` / `desktop` / `unknown`.
 	DeviceClass *string `json:"device_class,omitempty"`
@@ -1227,14 +1241,11 @@ type PlayerMetrics struct {
 	// DeviceModel #550 Phase 4: hardware model identifier (e.g. iPhone15,3) via sysctl hw.machine.
 	DeviceModel *string `json:"device_model,omitempty"`
 
+	// DeviceResolution Physical-pixel resolution of the device's current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30).
+	DeviceResolution *string `json:"device_resolution,omitempty"`
+
 	// DisplayResolution Player-reported window/display resolution (separate from the active video resolution).
 	DisplayResolution *string `json:"display_resolution,omitempty"`
-
-	// FetchingResolution WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder.
-	FetchingResolution *string `json:"fetching_resolution,omitempty"`
-
-	// FramesDropped Player-reported dropped frames count.
-	FramesDropped *int `json:"frames_dropped,omitempty"`
 
 	// Error Most recent player-reported error string.
 	Error *string `json:"error,omitempty"`
@@ -1254,11 +1265,20 @@ type PlayerMetrics struct {
 	// EventTime Player-supplied wallclock for the most recent metrics tick.
 	EventTime *time.Time `json:"event_time,omitempty"`
 
+	// FetchingResolution WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event.
+	FetchingResolution *string `json:"fetching_resolution,omitempty"`
+
 	// FirstFrameTimeS Time-to-first-frame (seconds since play started).
 	FirstFrameTimeS *float32 `json:"first_frame_time_s,omitempty"`
 
 	// FramesDisplayed Player-reported displayed frames count.
 	FramesDisplayed *int `json:"frames_displayed,omitempty"`
+
+	// FramesDropped Player-reported dropped frames count.
+	FramesDropped *int `json:"frames_dropped,omitempty"`
+
+	// FramesRate Active variant's nominal frame rate (Hz). Sticky after first observation in the format-change event.
+	FramesRate *float32 `json:"frames_rate,omitempty"`
 
 	// IdlingCount #550 Phase 1: entries into `idle` state.
 	IdlingCount *int `json:"idling_count,omitempty"`
@@ -1268,7 +1288,6 @@ type PlayerMetrics struct {
 
 	// LastEvent Most recent player-reported lifecycle event (playing, buffering_start, stall_start, etc.).
 	LastEvent *string `json:"last_event,omitempty"`
-
 
 	// LiveEdgeS Player-reported live edge timestamp (seconds).
 	LiveEdgeS *float32 `json:"live_edge_s,omitempty"`
@@ -1330,9 +1349,6 @@ type PlayerMetrics struct {
 	// ProfileShiftCount Number of ABR rendition shifts the player has reported.
 	ProfileShiftCount *int `json:"profile_shift_count,omitempty"`
 
-	// DeviceResolution Physical-pixel resolution in current orientation, "WxH".
-	DeviceResolution *string `json:"device_resolution,omitempty"`
-
 	// SeekableEndS Player-reported end of seekable range (seconds).
 	SeekableEndS *float32 `json:"seekable_end_s,omitempty"`
 
@@ -1345,8 +1361,11 @@ type PlayerMetrics struct {
 	// Source Identifier for the metrics source (e.g. avplayer-ios, exoplayer-android).
 	Source *string `json:"source,omitempty"`
 
-	// StallDurationMs #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats). Replaces legacy last_stall_time_s.
+	// StallDurationMs #550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats).
 	StallDurationMs *int `json:"stall_duration_ms,omitempty"`
+
+	// StallStuck #550 Phase 1 ext: orthogonal "this stall won't auto-recover" flag. True from the moment AVPlayer transitions stalled → .paused (give-up) until next .playing transition. State stays "stalled" for residency continuity; dashboards key on this flag to surface operator-actionable stalls.
+	StallStuck *bool `json:"stall_stuck,omitempty"`
 
 	// StallTimeS Cumulative stall time (seconds).
 	StallTimeS *float32 `json:"stall_time_s,omitempty"`
@@ -1356,14 +1375,16 @@ type PlayerMetrics struct {
 
 	// StallingTimeMs #550 Phase 1: cumulative stalling time (ms). Single canonical pair replacing legacy stall_count/stall_time_s during soft cutover.
 	StallingTimeMs *int `json:"stalling_time_ms,omitempty"`
-
-	// StallStuck #550 Phase 1 ext: orthogonal "this stall won't auto-recover" flag.
-	StallStuck *bool `json:"stall_stuck,omitempty"`
-
-	Stalls *int `json:"stalls,omitempty"`
+	Stalls         *int `json:"stalls,omitempty"`
 
 	// State Player state machine label (idle, playing, paused, buffering, ended, error).
 	State *string `json:"state,omitempty"`
+
+	// StateFrom On state_change events: the player_state before the transition. Empty / null on heartbeat rows.
+	StateFrom *string `json:"state_from,omitempty"`
+
+	// StateTo On state_change events: the player_state after the transition. Empty / null on heartbeat rows.
+	StateTo *string `json:"state_to,omitempty"`
 
 	// TerminalErrorCode #550 Phase 2: error code populated ONLY on terminal failure rows. Querying `WHERE terminal_error_code != 0` is SQL-safe — never returns transient codes.
 	TerminalErrorCode *int `json:"terminal_error_code,omitempty"`
@@ -1374,34 +1395,36 @@ type PlayerMetrics struct {
 	// TerminalErrorDomain #550 Phase 2: error domain on terminal failure rows.
 	TerminalErrorDomain *string `json:"terminal_error_domain,omitempty"`
 
+	// TimePerVariantS JSON-string-encoded map of variant-label → cumulative seconds spent at that variant (e.g. `{"2160p@29857kbps":65.28}`). Preserved across retry()-style restarts.
+	TimePerVariantS *string `json:"time_per_variant_s,omitempty"`
+
 	// TrickplayingCount #550 Phase 1: entries into trickplay (rate ∉ {0, ~1}).
 	TrickplayingCount *int `json:"trickplaying_count,omitempty"`
 
 	// TrickplayingTimeMs #550 Phase 1: cumulative time at non-1× playback rate (FF / RW).
 	TrickplayingTimeMs *int `json:"trickplaying_time_ms,omitempty"`
 
-	// TimePerVariantS JSON-string-encoded variant → cumulative seconds map.
-	TimePerVariantS *string `json:"time_per_variant_s,omitempty"`
-
 	// TriggerType What triggered the most recent metrics tick (timer, event, etc.).
 	TriggerType *string `json:"trigger_type,omitempty"`
 
 	// TrueOffsetS Wall-clock offset between player position and real time (seconds).
-	TrueOffsetS      *float32 `json:"true_offset_s,omitempty"`
+	TrueOffsetS *float32 `json:"true_offset_s,omitempty"`
+
+	// UserMarkedAt On user_marked (911) events: wall-clock ISO-8601 instant the operator pressed the button. Empty on other rows.
+	UserMarkedAt     *string  `json:"user_marked_at,omitempty"`
 	VideoBitrateMbps *float32 `json:"video_bitrate_mbps,omitempty"`
 
 	// VideoFirstFrameTimeMs #550 Phase 1: TTFF in ms. Conviva/Mux/Bitmovin canonical units. Replaces legacy video_first_frame_time_s.
 	VideoFirstFrameTimeMs *int `json:"video_first_frame_time_ms,omitempty"`
 
-	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
-	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
-
-	// VideoQuality60sPct Time-weighted (bitrate/maxPeak)×100 over the last 60s of watched playback.
+	// VideoQuality60sPct Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.
 	VideoQuality60sPct *float32 `json:"video_quality_60s_pct,omitempty"`
 
-	// VideoQualityAvgPct Time-weighted (bitrate/maxPeak)×100 over the lifetime of the play.
+	// VideoQualityAvgPct Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
 	VideoQualityAvgPct *float32 `json:"video_quality_avg_pct,omitempty"`
 
+	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
+	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
 	VideoResolution *string  `json:"video_resolution,omitempty"`
 
 	// VideoStartTimeMs #550 Phase 1: alternate startup-time measurement in ms.
@@ -1412,12 +1435,6 @@ type PlayerMetrics struct {
 
 	// WaitingReason AVFoundation reasonForWaitingToPlay (or platform equivalent) — split labels within `state` like `toMinimizeStalls` vs `evaluatingBufferingRate`.
 	WaitingReason *string `json:"waiting_reason,omitempty"`
-
-	StateFrom         *string  `json:"state_from,omitempty"`
-	StateTo           *string  `json:"state_to,omitempty"`
-	ContentName       *string  `json:"content_name,omitempty"`
-	UserMarkedAt      *string  `json:"user_marked_at,omitempty"`
-	FramesRate *float32 `json:"frames_rate,omitempty"`
 }
 
 // PlayerPatch Mutable subset of `PlayerRecord`. JSON Merge Patch semantics.


### PR DESCRIPTION
## Summary

Deep-history pan-back for the v3 Testing/Session dashboards, plus a client-supplied play-scoped `start_time` plumbed end-to-end and per-play counter resets (issues #587, #592).

**Stacked on `fix/log-brush-sync-586` (PR #597)** — review/merge that first; this PR's diff is only the commits below.

### #587 — refetch evicted history on pan-back
- Dragging the focus bar before the in-memory cache now re-points the SSE at that bounded window (reusing the `fromMs`/`toMs` re-subscribe path); a `cacheEpoch` reset signal makes the charts/timeline re-drain the freshly-loaded window. Returning to live re-subscribes to a recent window (not the whole play). The forwarder already serves a bounded `[from,to]` read for a live play (treats a `to` >5s in the past as a closed archive window), so #592 needs no server change.
- Rail left edge anchors to the play's true start; rail pill reflects real live/paused state (was hardcoded "at end").

### `start_time` — client-supplied, play-scoped play start
- New field minted by iOS + Android with `play_id` and rotated with it, sent as `?start_time=` on every request; projected onto `PlayRecord.start_time`, carried through the SSE to a new `session_events`/`control_events`/`ios_avmetric_events` ClickHouse column, and consumed by the rail. Fixes the rail anchoring to the stale, session-scoped `started_at` (which doesn't rotate on a content switch).

### Per-play resets on `play_id` rotation
- **Clients**: couple the existing comprehensive per-play metric reset to `play_id` rotation, so content-switch / filter-swap / soak-rotation reset counters too (previously only the reload path did). `retry()`/recovery keeps `play_id` stable and preserves counters.
- **Proxy**: reset the decision-free accumulated counters (`loop_count_server`, `bytes_*_total` + Mbps window state, the `fault_count_*` reporting tally) at the play_id-rotation merge chokepoint. Deliberately leaves the `*_requests_count` fault-pattern clock, transport packet-cycle counters, and all fault/shaping config + trigger-timing untouched so injection behaviour is unchanged.

## Test
`vue-tsc` clean; iOS (`xcodebuild`, iPhone 17 sim) + Android (`gradle compileDebug`) build clean; go-proxy + go-forwarder build clean. Verified live on test-dev: pan-back loads/renders evicted history; `current_play.start_time` is play-scoped and distinct from `started_at`; ClickHouse `session_events.start_time` populated.

Closes #587
Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
