### PR TITLE
fix(595): edge-trigger QoE labels + startup grace for abr/throughput

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -121,6 +121,14 @@ type playLabelState struct {
 	// keeps heart-beating re-stamps the label on every subsequent row
 	// ("endless qoe_msf").
 	terminalEmitted bool
+	// #595 — edge-triggering for level/sticky qoe_* labels. qoeActive is
+	// the set of qoe labels that were true on the previous evaluated row.
+	// A label is emitted only on its rising edge (off→on): its first
+	// determination, or a new instance after it cleared. While a condition
+	// stays continuously true it is suppressed (no per-heartbeat repeats).
+	// The terminal row force-emits the still-true set so the summary +
+	// qoe_tier_* reflect end state. nil until first use.
+	qoeActive map[string]struct{}
 	// LRU touch for GC.
 	seen time.Time
 }

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -293,6 +293,7 @@ func TestQoEBitrateCauseLabels(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := evalQoE(&row{
 				Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+				PlayingTimeMs:    10000, // past ABR startup grace (#595)
 				VideoBitrateMbps: tc.cur, NetworkBitrateMbps: tc.netbw, AvgNetworkBitrateMbps: tc.avgbw,
 				ManifestVariants: tc.variants,
 			})
@@ -308,7 +309,7 @@ func TestQoEBitrateCauseLabels(t *testing.T) {
 
 func TestQoEBitrateMalformedLadder(t *testing.T) {
 	// Malformed JSON must not panic and must emit no cause label.
-	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000,
 		VideoBitrateMbps: 1, NetworkBitrateMbps: 10, ManifestVariants: "{not json"})
 	if hasLabel(got, qoeLabel(SevWarning, "qoe_abr_conservative")) || hasLabel(got, qoeLabel(SevInfo, "qoe_ladder_gap")) {
 		t.Fatalf("malformed ladder should emit no cause label: %v", got)
@@ -345,16 +346,41 @@ func TestQoEFPSDip(t *testing.T) {
 func TestQoEThroughputDivergence(t *testing.T) {
 	want := qoeLabel(SevWarning, "qoe_throughput_divergence")
 	// nb matches server peak → no divergence.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 10, MbpsTransferRate: 10}); hasLabel(got, want) {
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 10, MbpsTransferRate: 10}); hasLabel(got, want) {
 		t.Fatalf("matching throughput should not diverge: %v", got)
 	}
 	// nb 5 vs peak 10 → 50% > 15% → diverge.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 5, MbpsTransferRate: 10}); !hasLabel(got, want) {
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 5, MbpsTransferRate: 10}); !hasLabel(got, want) {
 		t.Fatalf("nb 5 vs peak 10 should diverge: %v", got)
 	}
 	// nb 5 vs cap 10 (no server peak) → diverge via limit branch.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 5, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 5, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
 		t.Fatalf("nb 5 vs cap 10 should diverge: %v", got)
+	}
+}
+
+func TestQoEAbrStartupGate(t *testing.T) {
+	// Inputs that trip BOTH qoe_abr_conservative (cur 1 under throughput 10,
+	// next rung 5 fits) and qoe_throughput_divergence (nb 10 vs peak 20). But
+	// during the startup ramp (playing time < grace) both are suppressed (#595).
+	conservative := qoeLabel(SevWarning, "qoe_abr_conservative")
+	divergence := qoeLabel(SevWarning, "qoe_throughput_divergence")
+	ladder := `[{"bandwidth":1000000},{"bandwidth":5000000},{"bandwidth":8000000}]`
+	mk := func(playingMs uint32) *row {
+		return &row{
+			Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+			PlayingTimeMs: playingMs, VideoBitrateMbps: 1, NetworkBitrateMbps: 10,
+			MbpsTransferRate: 20, ManifestVariants: ladder,
+		}
+	}
+	// 5s in — still ramping → suppressed.
+	if got := evalQoE(mk(5000)); hasLabel(got, conservative) || hasLabel(got, divergence) {
+		t.Fatalf("startup ramp (5s playing) must suppress abr/throughput labels: %v", got)
+	}
+	// 10s in — settled → both fire.
+	got := evalQoE(mk(10000))
+	if !hasLabel(got, conservative) || !hasLabel(got, divergence) {
+		t.Fatalf("settled play (10s) should emit both abr_conservative + throughput_divergence: %v", got)
 	}
 }
 
@@ -560,5 +586,68 @@ func TestTestingSeverityUnranked(t *testing.T) {
 	// A real signal alongside still wins.
 	if sev := worstSeverity([]string{"testing=run_id_x", SevWarning + "=timejump"}); sev != SevWarning {
 		t.Fatalf("real signal must still rank past testing labels, got %q", sev)
+	}
+}
+
+// --- Edge-triggering: rising edge + terminal summary (#595) ----------
+
+func TestQoEStickyEmitsOnceNotEveryRow(t *testing.T) {
+	s := newLabelState()
+	concerning := qoeLabel(SevWarning, "qoe_vst_concerning")
+	mk := func(ts string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoStartTimeMs: 6000}
+	}
+	// Row 1: first determination → emit.
+	if got := computeEventLabelsWithState(s, mk("2026-06-03 00:00:01.000")); !hasLabel(got, concerning) {
+		t.Fatalf("first determination should emit %s: %v", concerning, got)
+	}
+	// Rows 2-3: same sticky VST → suppressed, no per-heartbeat repeat.
+	for _, ts := range []string{"2026-06-03 00:00:02.000", "2026-06-03 00:00:03.000"} {
+		if got := computeEventLabelsWithState(s, mk(ts)); hasLabel(got, concerning) {
+			t.Fatalf("sticky VST must not re-stamp %s on %s: %v", concerning, ts, got)
+		}
+	}
+}
+
+func TestQoEReFiresOnNewInstance(t *testing.T) {
+	s := newLabelState()
+	want := qoeLabel(SevWarning, "qoe_cirr_concerning")
+	// CIRR = stalling/(stalling+playing). 0.002 = concerning threshold.
+	hot := func(ts string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", StallingTimeMs: 1000, PlayingTimeMs: 499000}
+	}
+	cold := func(ts string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", StallingTimeMs: 1, PlayingTimeMs: 10_000_000}
+	}
+	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:01.000")); !hasLabel(got, want) {
+		t.Fatalf("rising edge should emit %s: %v", want, got)
+	}
+	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:02.000")); hasLabel(got, want) {
+		t.Fatalf("sustained must suppress %s: %v", want, got)
+	}
+	if got := computeEventLabelsWithState(s, cold("2026-06-03 00:00:03.000")); hasLabel(got, want) {
+		t.Fatalf("cleared row must not emit %s: %v", want, got)
+	}
+	// Cleared then true again = a new instance → re-emit.
+	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:04.000")); !hasLabel(got, want) {
+		t.Fatalf("recurrence after clearing should re-emit %s: %v", want, got)
+	}
+}
+
+func TestQoETerminalSummaryForcesStillTrue(t *testing.T) {
+	s := newLabelState()
+	concerning := qoeLabel(SevWarning, "qoe_vst_concerning")
+	mk := func(ts, ev, status string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", LastEvent: ev, PlaybackStatus: status, VideoStartTimeMs: 6000}
+	}
+	computeEventLabelsWithState(s, mk("2026-06-03 00:00:01.000", "", "in_progress")) // first determination (emits)
+	computeEventLabelsWithState(s, mk("2026-06-03 00:00:02.000", "", "in_progress")) // sustained (suppressed)
+	// Terminal row: summary must force-emit the still-true VST + the tier.
+	got := computeEventLabelsWithState(s, mk("2026-06-03 00:00:03.000", "session_end", "completed"))
+	if !hasLabel(got, concerning) {
+		t.Fatalf("terminal summary must carry still-true %s: %v", concerning, got)
+	}
+	if !hasLabel(got, qoeLabel(SevWarning, "qoe_tier_acceptable")) {
+		t.Fatalf("tier must reflect the summary (warning → acceptable): %v", got)
 	}
 }

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -61,24 +61,128 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 	if cfg == nil {
 		cfg = fallbackThresholds
 	}
-	var out []string
 	// firstTerminal is true only on the FIRST authoritative terminal row
 	// (last_event == session_end|play_end). The client re-emits the
 	// terminal POST for delivery reliability, so the emit-once guard stops
 	// vsf/msf/ebvs/tier from being stamped on each re-emit.
 	firstTerminal := isPlayTerminalEvent(r) && !ps.terminalEmitted
 
-	// ── Startup ──────────────────────────────────────────────────────
-	// VST (video start time). Breach takes precedence over concerning.
+	// ── Collect every level/sticky qoe condition TRUE on this row ──────
+	// These are emitted edge-triggered below — sticky inputs like
+	// VideoStartTimeMs (set once, then repeated on every heartbeat) must
+	// not re-stamp their label every row. #595.
+	var current []string
+
+	// Startup — VST (video start time). Breach takes precedence.
 	if vst := r.VideoStartTimeMs; vst > 0 {
 		switch {
 		case vst >= cfg.Startup.VSTBreachMs:
-			out = append(out, qoeLabel(SevCritical, "qoe_vst_breach"))
+			current = append(current, qoeLabel(SevCritical, "qoe_vst_breach"))
 		case vst >= cfg.Startup.VSTConcerningMs:
-			out = append(out, qoeLabel(SevWarning, "qoe_vst_concerning"))
+			current = append(current, qoeLabel(SevWarning, "qoe_vst_concerning"))
 		}
 	}
+
+	// Continuity — CIRR (rebuffer ratio) and CIRT (mean interruption).
+	if denom := r.StallingTimeMs + r.PlayingTimeMs; denom > 0 {
+		cirr := float64(r.StallingTimeMs) / float64(denom)
+		switch {
+		case cirr >= cfg.Continuity.CIRRBreach:
+			current = append(current, qoeLabel(SevCritical, "qoe_cirr_breach"))
+		case cirr >= cfg.Continuity.CIRRConcerning:
+			current = append(current, qoeLabel(SevWarning, "qoe_cirr_concerning"))
+		}
+	}
+	if r.StallingCount > 0 {
+		cirt := float64(r.StallingTimeMs) / float64(r.StallingCount)
+		switch {
+		case cirt >= float64(cfg.Continuity.CIRTBreachMs):
+			current = append(current, qoeLabel(SevCritical, "qoe_cirt_breach"))
+		case cirt >= float64(cfg.Continuity.CIRTConcerningMs):
+			current = append(current, qoeLabel(SevWarning, "qoe_cirt_concerning"))
+		}
+	}
+	// Stall burst — > N stall_start within the window. The window slice is
+	// fed by the event switch; trim to the window here before counting.
+	{
+		window := time.Duration(cfg.Continuity.StallBurstWindowS) * time.Second
+		ps.stallBurstTimes = trimBefore(ps.stallBurstTimes, now.Add(-window))
+		if uint32(len(ps.stallBurstTimes)) > cfg.Continuity.StallBurstThreshold {
+			current = append(current, qoeLabel(SevCritical, "qoe_stall_burst"))
+		}
+	}
+
+	// ABR / quality. abr_conservative / ladder_gap and throughput_divergence
+	// only make sense once playback has settled past the startup ramp — a low
+	// rung under high throughput is expected during startup, not a defect — so
+	// gate them behind StartupGraceMs of accumulated playing time (#595).
+	settled := r.PlayingTimeMs >= cfg.ABR.StartupGraceMs
+	if settled {
+		current = append(current, abrBitrateLabels(cfg, r)...)
+	}
+	{
+		window := time.Duration(cfg.ABR.DownshiftStormWindowS) * time.Second
+		ps.downshiftTimes = trimBefore(ps.downshiftTimes, now.Add(-window))
+		if uint32(len(ps.downshiftTimes)) > cfg.ABR.DownshiftStormThreshold {
+			current = append(current, qoeLabel(SevWarning, "qoe_downshift_storm"))
+		}
+	}
+	if l := minVariantStuckLabel(cfg, ps, r, now); l != "" {
+		current = append(current, l)
+	}
+	if l := fpsDipLabel(cfg, r); l != "" {
+		current = append(current, l)
+	}
+	if settled {
+		if l := throughputDivergenceLabel(cfg, ps, r, now); l != "" {
+			current = append(current, l)
+		}
+	}
+
+	// Live.
+	current = append(current, liveOffsetLabels(cfg, r)...)
+
+	// Network (event-row inputs).
+	if l := rateCapBreachLabel(cfg, r); l != "" {
+		current = append(current, l)
+	}
+	if l := cmcdMTPDriftLabel(cfg, r); l != "" {
+		current = append(current, l)
+	}
+
+	// ── Edge-trigger: emit rising edges, re-arm the active set ─────────
+	// A label not in qoeActive is a new occurrence (first determination,
+	// or a recurrence after it cleared) → emit. One already active is the
+	// same instance persisting → suppress. Rebuild qoeActive from `current`
+	// so a condition going false re-arms it for next time. #595.
+	if ps.qoeActive == nil {
+		ps.qoeActive = make(map[string]struct{})
+	}
+	prevActive := ps.qoeActive
+	next := make(map[string]struct{}, len(current))
+	var out []string
+	for _, l := range current {
+		if _, dup := next[l]; dup {
+			continue // de-dup within this row
+		}
+		next[l] = struct{}{}
+		if _, on := prevActive[l]; !on {
+			out = append(out, l)
+		}
+	}
+	ps.qoeActive = next
+
+	// ── Terminal row: summary (current-at-end) + outcome + tier ────────
 	if firstTerminal {
+		// Force-emit the still-true conditions that edge-triggering
+		// suppressed above, so the summary row carries the full
+		// current-at-end set and qoe_tier_* below reads a correct set.
+		for _, l := range current {
+			if _, on := prevActive[l]; on {
+				out = append(out, l)
+			}
+		}
+		// Startup outcome (terminal-only).
 		switch {
 		case r.PlaybackStatus == "abandoned_start":
 			// Exit before video start — a user can simply bail during
@@ -89,75 +193,7 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 		case isFailedStatus(r.PlaybackStatus) && r.VideoFirstFrameTimeMs > 0:
 			out = append(out, qoeLabel(SevError, "qoe_msf"))
 		}
-	}
-
-	// ── Continuity ───────────────────────────────────────────────────
-	// CIRR — rebuffer ratio = stalling / (stalling + playing).
-	if denom := r.StallingTimeMs + r.PlayingTimeMs; denom > 0 {
-		cirr := float64(r.StallingTimeMs) / float64(denom)
-		switch {
-		case cirr >= cfg.Continuity.CIRRBreach:
-			out = append(out, qoeLabel(SevCritical, "qoe_cirr_breach"))
-		case cirr >= cfg.Continuity.CIRRConcerning:
-			out = append(out, qoeLabel(SevWarning, "qoe_cirr_concerning"))
-		}
-	}
-	// CIRT — average interruption duration = stalling_ms / stalling_count.
-	if r.StallingCount > 0 {
-		cirt := float64(r.StallingTimeMs) / float64(r.StallingCount)
-		switch {
-		case cirt >= float64(cfg.Continuity.CIRTBreachMs):
-			out = append(out, qoeLabel(SevCritical, "qoe_cirt_breach"))
-		case cirt >= float64(cfg.Continuity.CIRTConcerningMs):
-			out = append(out, qoeLabel(SevWarning, "qoe_cirt_concerning"))
-		}
-	}
-	// Stall burst — > N stall_start within the window (windowed via the
-	// per-play slice the switch records into; trimmed here).
-	{
-		window := time.Duration(cfg.Continuity.StallBurstWindowS) * time.Second
-		ps.stallBurstTimes = trimBefore(ps.stallBurstTimes, now.Add(-window))
-		if uint32(len(ps.stallBurstTimes)) > cfg.Continuity.StallBurstThreshold {
-			out = append(out, qoeLabel(SevCritical, "qoe_stall_burst"))
-		}
-	}
-
-	// ── ABR / quality ────────────────────────────────────────────────
-	out = append(out, abrBitrateLabels(cfg, r)...)
-	// Downshift storm — > N rate_shift_down within the window.
-	{
-		window := time.Duration(cfg.ABR.DownshiftStormWindowS) * time.Second
-		ps.downshiftTimes = trimBefore(ps.downshiftTimes, now.Add(-window))
-		if uint32(len(ps.downshiftTimes)) > cfg.ABR.DownshiftStormThreshold {
-			out = append(out, qoeLabel(SevWarning, "qoe_downshift_storm"))
-		}
-	}
-	if l := minVariantStuckLabel(cfg, ps, r, now); l != "" {
-		out = append(out, l)
-	}
-	if l := fpsDipLabel(cfg, r); l != "" {
-		out = append(out, l)
-	}
-	if l := throughputDivergenceLabel(cfg, ps, r, now); l != "" {
-		out = append(out, l)
-	}
-
-	// ── Live ─────────────────────────────────────────────────────────
-	out = append(out, liveOffsetLabels(cfg, r)...)
-
-	// ── Network (event-row inputs) ───────────────────────────────────
-	if l := rateCapBreachLabel(cfg, r); l != "" {
-		out = append(out, l)
-	}
-	if l := cmcdMTPDriftLabel(cfg, r); l != "" {
-		out = append(out, l)
-	}
-
-	// ── Session-end aggregate tier (first terminal row only) ─────────
-	// Maps the worst severity among this row's qoe_* labels onto a
-	// single tier chip. Emitted once, on the first terminal row (see
-	// firstTerminal above).
-	if firstTerminal {
+		// Tier from the full terminal-row label set (worst severity).
 		out = append(out, qoeTierLabel(out))
 		ps.terminalEmitted = true
 	}

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -94,6 +94,12 @@ type QoEThresholds struct {
 		MinVariantStuckS uint32 `json:"min_variant_stuck_s"`
 		// Displayed fps below this fraction of nominal ⇒ qoe_fps_dip.
 		FPSDipRatio float64 `json:"fps_dip_ratio"`
+		// Playing-time (ms) a play must accumulate before qoe_abr_conservative
+		// / qoe_ladder_gap / qoe_throughput_divergence are evaluated. Below
+		// this the player is still in its startup ramp — sitting at a low
+		// rung under high throughput is expected, not a defect — so those
+		// labels are suppressed to avoid startup false positives. #595.
+		StartupGraceMs uint32 `json:"startup_grace_ms"`
 	} `json:"abr"`
 
 	// Live-edge label thresholds (#553). Margins are seconds BEYOND the
@@ -131,7 +137,8 @@ func qoeDefaults() *QoEThresholds {
 	t.ABR.DownshiftStormThreshold = 3
 	t.ABR.DownshiftStormWindowS = 30
 	t.ABR.MinVariantStuckS = 30
-	t.ABR.FPSDipRatio = 0.2 // displayed fps < 80% of nominal
+	t.ABR.FPSDipRatio = 0.2      // displayed fps < 80% of nominal
+	t.ABR.StartupGraceMs = 10000 // suppress abr/throughput labels for the first 10s of playback
 	t.Live.OffsetConcerningMarginS = 3
 	t.Live.OffsetBreachMarginS = 10
 	t.Live.HoldbackDeviationS = 2
@@ -238,6 +245,9 @@ func loadQoEThresholds(path string) *QoEThresholds {
 	if override.ABR.FPSDipRatio != 0 {
 		cfg.ABR.FPSDipRatio = override.ABR.FPSDipRatio
 	}
+	if override.ABR.StartupGraceMs != 0 {
+		cfg.ABR.StartupGraceMs = override.ABR.StartupGraceMs
+	}
 	if override.Live.OffsetConcerningMarginS != 0 {
 		cfg.Live.OffsetConcerningMarginS = override.Live.OffsetConcerningMarginS
 	}
@@ -262,9 +272,9 @@ func logQoEResolved(cfg *QoEThresholds) {
 	log.Printf("[QoE]   network.ttfb_breach_ms=%d transfer_stall_ms=%d rate_cap_breach_factor=%.2f cmcd_mtp_drift_ratio=%.2f",
 		cfg.Network.TTFBBreachMs, cfg.Network.TransferStallMs,
 		cfg.Network.RateCapBreachFactor, cfg.Network.CMCDMTPDriftRatio)
-	log.Printf("[QoE]   abr.bitrate_underutilized_ratio=%.2f abr_headroom_margin=%.2f throughput_divergence_factor=%.2f downshift_storm=%d/%ds min_variant_stuck_s=%d fps_dip_ratio=%.2f",
+	log.Printf("[QoE]   abr.bitrate_underutilized_ratio=%.2f abr_headroom_margin=%.2f throughput_divergence_factor=%.2f downshift_storm=%d/%ds min_variant_stuck_s=%d fps_dip_ratio=%.2f startup_grace_ms=%d",
 		cfg.ABR.BitrateUnderutilizedRatio, cfg.ABR.AbrHeadroomMargin, cfg.ABR.ThroughputDivergenceFactor,
-		cfg.ABR.DownshiftStormThreshold, cfg.ABR.DownshiftStormWindowS, cfg.ABR.MinVariantStuckS, cfg.ABR.FPSDipRatio)
+		cfg.ABR.DownshiftStormThreshold, cfg.ABR.DownshiftStormWindowS, cfg.ABR.MinVariantStuckS, cfg.ABR.FPSDipRatio, cfg.ABR.StartupGraceMs)
 	log.Printf("[QoE]   live.offset_concerning_margin_s=%.1f offset_breach_margin_s=%.1f holdback_deviation_s=%.1f",
 		cfg.Live.OffsetConcerningMarginS, cfg.Live.OffsetBreachMarginS, cfg.Live.HoldbackDeviationS)
 }


### PR DESCRIPTION
Closes #595.

QoE event labels were stamped on **every heartbeat** a condition held — `qoe_vst_concerning` on every row after startup; one rampup play emitted 43× `qoe_throughput_divergence` and 52× `qoe_live_offset_concerning`. Two changes (forwarder-only):

## 1. Edge-triggering (`qoe_labels.go`)

`computeQoEEventLabels` now collects the conditions true on each row, emits only the **rising edges** (first determination, or a recurrence after the condition cleared), and rebuilds a per-play active set (`playLabelState.qoeActive`) so a condition going false re-arms it. The **first terminal row force-emits the still-true set** so the summary row + `qoe_tier_*` reflect end state (current-at-end semantics — agreed in the issue). Tier behavior is unchanged.

## 2. Startup grace for the utilization labels (`qoe_thresholds.go`)

`qoe_abr_conservative` / `qoe_ladder_gap` / `qoe_throughput_divergence` are suppressed until the play has accumulated `ABR.StartupGraceMs` (default **10000ms**) of playing time. During the startup ramp a low rung under high throughput is expected ABR behavior, not a defect — firing these in the first second (player still climbing from 360p) is a false positive. New config field, defaulted + merged + logged like the rest.

## Effect

A sticky condition stamps **once at first determination + on the summary**, not on all ~N heartbeats; transients re-fire only on a genuinely new occurrence; and the two utilization labels don't fire during startup at all.

## Tests

- Edge-trigger: emit-once-not-every-row, clear-then-recur, terminal summary force-emit + correct tier.
- Startup gate: suppressed at 5s playing, both fire at 10s.
- Existing ABR/throughput tests updated to set `PlayingTimeMs` past the grace window.
- `go build` / `vet` / `gofmt` / full `go test ./...` — green.

Already deployed to test-dev (forwarder rebuild) for the edge-trigger half; the startup-grace half needs one more `make analytics-rebuild-forwarder` to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
