### PR TITLE
feat(dashboard): show play Start Time in Session Details

### DIFF
--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -120,6 +120,11 @@ const fields = computed(() => {
     // fall back to server_received_at_ms (the "last snapshot" signal)
     // so the operator sees actual freshness, not a misleading "—".
     { label: 'Last Request', value: fmtDate(effectiveLastSeenAt(p)) },
+    // Play start (current_play.started_at) — the same anchor the Sessions
+    // picker's "Started" column uses. Distinct from "First Request"
+    // (first_seen_at = first HTTP contact). Sits right before the duration
+    // it anchors.
+    { label: 'Start Time', value: fmtDate(cp?.started_at) },
     { label: 'Session Duration', value: fmtDuration(p.first_seen_at, effectiveLastSeenAt(p)) },
     { label: 'Loops (server)', value: String(p.loop_count_server ?? 0) },
     { label: 'Control Rev', value: p.control_revision ?? '—' },


### PR DESCRIPTION
Adds a **Start Time** row to the Session Details panel, right before **Session Duration**, as requested.

## Change

```diff
  { label: 'Last Request', value: fmtDate(effectiveLastSeenAt(p)) },
+ { label: 'Start Time', value: fmtDate(cp?.started_at) },
  { label: 'Session Duration', value: fmtDuration(p.first_seen_at, effectiveLastSeenAt(p)) },
```

Value is `current_play.started_at` — the same field the Sessions picker's **"Started"** column uses, so the two pages agree. It's genuinely distinct from the existing **"First Request"** row (`first_seen_at` = first HTTP contact), so this isn't a duplicate. Falls back to `—` when absent.

`SessionDetails.vue` is the shared panel, so this lands on every page that mounts `SessionDisplay` (session-viewer / testing / testing-session).

Verified: `vue-tsc --noEmit` + `vite build` green; already deployed to test-dev for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
