### PR TITLE
fix(dashboard): Session Details Start Time uses play-scoped start_time

### DIFF
--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -120,11 +120,14 @@ const fields = computed(() => {
     // fall back to server_received_at_ms (the "last snapshot" signal)
     // so the operator sees actual freshness, not a misleading "—".
     { label: 'Last Request', value: fmtDate(effectiveLastSeenAt(p)) },
-    // Play start (current_play.started_at) — the same anchor the Sessions
-    // picker's "Started" column uses. Distinct from "First Request"
-    // (first_seen_at = first HTTP contact). Sits right before the duration
-    // it anchors.
-    { label: 'Start Time', value: fmtDate(cp?.started_at) },
+    // Play start — the CLIENT-supplied, play-scoped start_time (#587), which
+    // rotates with play_id so it's correct after a content switch. NO fallback
+    // to current_play.started_at: that's server/session-derived and goes stale
+    // on a play rotation, so silently substituting it would make this row
+    // ambiguous (you couldn't tell which value you're seeing). Shows "—" when
+    // the client didn't send one (web/Roku). Distinct from "First Request"
+    // (first_seen_at = first HTTP contact). Sits right before the duration.
+    { label: 'Start Time', value: fmtDate(cp?.start_time) },
     { label: 'Session Duration', value: fmtDuration(p.first_seen_at, effectiveLastSeenAt(p)) },
     { label: 'Loops (server)', value: String(p.loop_count_server ?? 0) },
     { label: 'Control Rev', value: p.control_revision ?? '—' },


### PR DESCRIPTION
## Summary

`#600` added the "Start Time" row in Session Details reading `current_play.started_at` — the server/session-derived field that does **not** rotate with `play_id`, so after a content switch it shows a stale (prior-play) timestamp.

This points the row at the client-supplied, play-scoped `current_play.start_time` (#587), which rotates with `play_id` and is the same anchor the focus rail uses — so Session Details and the rail now agree.

**No fallback to `started_at`**: silently substituting it would make the row ambiguous (you couldn't tell whether you're seeing the real play start or the stale session value). Shows `—` when the client didn't send a `start_time` (web/Roku).

## Test
`vue-tsc` clean. Deployed to test-dev for visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
