### PR TITLE
fix(dashboard): relabel Player Metrics "Video Start" → "Video Start Time"

### DIFF
--- a/content/dashboard-v3/src/components/PlayerMetrics.vue
+++ b/content/dashboard-v3/src/components/PlayerMetrics.vue
@@ -161,7 +161,7 @@ const playerFields = computed(() => {
     { label: 'Display Res', value: fmtStr(m.display_resolution) },
     { label: 'Device Res', value: fmtStr(m.device_resolution) },
     { label: 'First Frame', value: fmtS(m.first_frame_time_s) },
-    { label: 'Video Start', value: fmtS(m.video_start_time_s) },
+    { label: 'Video Start Time', value: fmtS(m.video_start_time_s) },
     { label: 'Video Bitrate', value: fmtMbps(m.video_bitrate_mbps) },
     { label: 'Avg Network', value: fmtMbps(m.avg_network_bitrate_mbps) },
     { label: 'Network Bitrate', value: fmtMbps(m.network_bitrate_mbps) },


### PR DESCRIPTION
Relabels the Player Metrics panel row **"Video Start" → "Video Start Time"** (`PlayerMetrics.vue`).

Disambiguates the VST startup-latency metric (`video_start_time_s`) from the adjacent **"Start Time"** row in Session Details (#601), which is the wall-clock play start (`start_time`). Same value + formatter, clearer label. One line, `vue-tsc` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
