### PR TITLE
fix(603): forwarder defense + read-path summary fix (leading play_end leak)

### DIFF
--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -237,10 +237,15 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    countIf(last_event = 'error')         AS error_event_count,
 		    any(classification) AS classification,
 		    maxIf(attempt_id, attempt_id > 0)       AS attempt_id_max,
-		    -- #550 Phase 1: residency totals (max because cumulative)
-		    max(playing_time_ms) AS playing_time_ms,
-		    max(buffering_time_ms) AS buffering_time_ms,
-		    max(stalling_time_ms) AS stalling_time_ms,
+		    -- #550 Phase 1: residency totals. argMax(.., ts) = the value at the
+		    -- play's LAST row (its final cumulative total), NOT max(). A stale
+		    -- leading row — e.g. a mis-bucketed prior-play play_end (#603) — carries
+		    -- a huge value at an EARLY ts; max() would let it win and inflate the
+		    -- per-play total + the derived rate columns. Monotonic within a play, so
+		    -- for a clean play argMax(.., ts) == max() anyway.
+		    argMax(playing_time_ms, ts) AS playing_time_ms,
+		    argMax(buffering_time_ms, ts) AS buffering_time_ms,
+		    argMax(stalling_time_ms, ts) AS stalling_time_ms,
 		    -- #550 Phase 2: outcome (argMax on terminal row; in_progress
 		    -- mid-play rows return last value seen, which is what we
 		    -- want for live sessions).

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -121,6 +121,12 @@ type playLabelState struct {
 	// keeps heart-beating re-stamps the label on every subsequent row
 	// ("endless qoe_msf").
 	terminalEmitted bool
+	// #603 — set true once any non-terminal row is seen for this play
+	// (play_start / restart / state_change / …). A play terminal arriving
+	// while this is still false is the PREVIOUS play's play_end mis-bucketed
+	// onto this play_id (no play_start boundary yet) — its accumulators are
+	// the prior play's, so the QoE labeler ignores it.
+	everOpened bool
 	// #595 — edge-triggering for level/sticky qoe_* labels. qoeActive is
 	// the set of qoe labels that were true on the previous evaluated row.
 	// A label is emitted only on its rising edge (off→on): its first
@@ -273,6 +279,10 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		out = []string{SevInfo + "=first_frame"}
 	case "video_start_time":
 		out = []string{SevInfo + "=playback_start"}
+	case "play_start":
+		// #603 — explicit play-open boundary (symmetric to play_end).
+		// Distinct from `restart`, which is mid-session recovery only.
+		out = []string{SevInfo + "=play_start"}
 
 	// warning — degraded but functioning
 	case "timejump":

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -36,6 +36,7 @@ func TestEventSwitchUnchanged(t *testing.T) {
 		{"rate_shift_down", nil, []string{"info=shift_down"}},
 		{"video_first_frame", nil, []string{"info=first_frame"}},
 		{"video_start_time", nil, []string{"info=playback_start"}},
+		{"play_start", nil, []string{"info=play_start"}}, // #603 play-open boundary
 		// warning — degraded but functioning
 		{"timejump", nil, []string{"warning=timejump"}},
 		{"segment_stall", nil, []string{"warning=stall_segment"}},
@@ -86,6 +87,16 @@ func hasLabel(labels []string, want string) bool {
 // thresholds) and returns the labels.
 func evalQoE(r *row) []string {
 	return computeEventLabelsWithState(newLabelState(), r)
+}
+
+// evalTerminal evaluates a terminal row the way it occurs in reality —
+// after the play has opened. A lone terminal on fresh state is treated as
+// a mis-bucketed leak (#603), so unit-testing terminal labels requires an
+// opening (non-terminal) row first.
+func evalTerminal(r *row) []string {
+	s := newLabelState()
+	computeEventLabelsWithState(s, &row{Ts: "2026-06-01 00:00:00.000", PlayerID: r.PlayerID, PlayID: r.PlayID, PlaybackStatus: "in_progress", LastEvent: "play_start"})
+	return computeEventLabelsWithState(s, r)
 }
 
 const tsBase = "2026-06-01 00:00:00.000"
@@ -485,31 +496,31 @@ func TestQoETerminalGateAndTier(t *testing.T) {
 	}
 
 	// session_end clean → premium.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed"}); !hasLabel(got, tierPremium) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed"}); !hasLabel(got, tierPremium) {
 		t.Fatalf("clean terminal → premium: %v", got)
 	}
 	// session_end with a warning (VST concerning) → acceptable.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed", VideoStartTimeMs: 6000}); !hasLabel(got, tierAcceptable) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "completed", VideoStartTimeMs: 6000}); !hasLabel(got, tierAcceptable) {
 		t.Fatalf("warning terminal → acceptable: %v", got)
 	}
 	// play_end with a critical (VST breach) → unacceptable. Also proves the
 	// {session_end, play_end} terminal-event set both trigger.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "play_end", PlaybackStatus: "completed", VideoStartTimeMs: 20000}); !hasLabel(got, tierUnacceptable) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "play_end", PlaybackStatus: "completed", VideoStartTimeMs: 20000}); !hasLabel(got, tierUnacceptable) {
 		t.Fatalf("critical terminal (play_end) → unacceptable: %v", got)
 	}
 }
 
 func TestQoETerminalFailureLabels(t *testing.T) {
 	// vsf: failed before first frame.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "start_failure", VideoFirstFrameTimeMs: 0}); !hasLabel(got, qoeLabel(SevError, "qoe_vsf")) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "start_failure", VideoFirstFrameTimeMs: 0}); !hasLabel(got, qoeLabel(SevError, "qoe_vsf")) {
 		t.Fatalf("start_failure pre-first-frame → vsf: %v", got)
 	}
 	// msf: failed after first frame.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}); !hasLabel(got, qoeLabel(SevError, "qoe_msf")) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}); !hasLabel(got, qoeLabel(SevError, "qoe_msf")) {
 		t.Fatalf("mid_stream_failure post-first-frame → msf: %v", got)
 	}
 	// ebvs: abandoned start — warning (a user can bail during startup).
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "abandoned_start"}); !hasLabel(got, qoeLabel(SevWarning, "qoe_ebvs")) {
+	if got := evalTerminal(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "abandoned_start"}); !hasLabel(got, qoeLabel(SevWarning, "qoe_ebvs")) {
 		t.Fatalf("abandoned_start → ebvs: %v", got)
 	}
 	// Negative: a failed status WITHOUT the terminal event → no outcome
@@ -530,6 +541,9 @@ func TestQoETerminalEmitOnce(t *testing.T) {
 	mk := func(ts string) *row {
 		return &row{Ts: ts, PlayerID: "p", PlayID: "x", LastEvent: "session_end", PlaybackStatus: "mid_stream_failure", VideoFirstFrameTimeMs: 250}
 	}
+	// Open the play first — a lone terminal on fresh state is treated as a
+	// mis-bucketed leak (#603).
+	computeEventLabelsWithState(s, &row{Ts: "2026-05-31 23:59:59.000", PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LastEvent: "play_start"})
 	first := computeEventLabelsWithState(s, mk("2026-06-01 00:00:00.000"))
 	if !hasLabel(first, msf) || !hasLabel(first, tier) {
 		t.Fatalf("first terminal row should carry msf + tier: %v", first)
@@ -649,5 +663,34 @@ func TestQoETerminalSummaryForcesStillTrue(t *testing.T) {
 	}
 	if !hasLabel(got, qoeLabel(SevWarning, "qoe_tier_acceptable")) {
 		t.Fatalf("tier must reflect the summary (warning → acceptable): %v", got)
+	}
+}
+
+// --- Leading-terminal defense: mis-bucketed play_end (#603) -----------
+
+func TestQoELeadingTerminalIgnored(t *testing.T) {
+	s := newLabelState()
+	// First row of the play is a play_end carrying the PRIOR play's
+	// accumulators (leaked onto this play_id at the boundary). cirr =
+	// 2.5M/(2.5M+57M) = 0.043 ≫ breach — but it must emit nothing and must
+	// NOT consume the emit-once terminal guard. #603.
+	leak := &row{Ts: "2026-06-04 00:00:01.000", PlayerID: "p", PlayID: "x", LastEvent: "play_end",
+		PlaybackStatus: "completed", StallingTimeMs: 2548457, PlayingTimeMs: 57010232, StallingCount: 1}
+	got := computeEventLabelsWithState(s, leak)
+	for _, bad := range []string{
+		qoeLabel(SevCritical, "qoe_cirr_breach"),
+		qoeLabel(SevCritical, "qoe_cirt_breach"),
+		qoeLabel(SevCritical, "qoe_tier_unacceptable"),
+	} {
+		if hasLabel(got, bad) {
+			t.Fatalf("leading play_end must not emit %s: %v", bad, got)
+		}
+	}
+	// Play opens (restart), then a real clean terminal — should still get a
+	// tier, proving the guard wasn't consumed by the leaked frame.
+	computeEventLabelsWithState(s, &row{Ts: "2026-06-04 00:00:01.100", PlayerID: "p", PlayID: "x", LastEvent: "restart", PlaybackStatus: "in_progress"})
+	end := computeEventLabelsWithState(s, &row{Ts: "2026-06-04 00:05:00.000", PlayerID: "p", PlayID: "x", LastEvent: "play_end", PlaybackStatus: "completed", PlayingTimeMs: 290000})
+	if !hasLabel(end, qoeLabel(SevInfo, "qoe_tier_premium")) {
+		t.Fatalf("real terminal after the play opened should still get a tier: %v", end)
 	}
 }

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -61,6 +61,20 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 	if cfg == nil {
 		cfg = fallbackThresholds
 	}
+	// #603 — leading-terminal defense. A play terminal (play_end/session_end)
+	// arriving as a play_id's FIRST row is the previous play's terminal frame
+	// mis-bucketed onto this play (the client emits play_end carrying the next
+	// play's id at the boundary; there's no play_start marker yet). Its
+	// accumulators + status belong to the prior play, so emit nothing and do
+	// NOT consume the emit-once terminal guard — the real terminal arrives
+	// after the play opens. everOpened is set on the first non-terminal row
+	// (play_start / restart / state_change / …).
+	if isPlayTerminalEvent(r) && !ps.everOpened {
+		return nil
+	}
+	if !isPlayTerminalEvent(r) {
+		ps.everOpened = true
+	}
 	// firstTerminal is true only on the FIRST authoritative terminal row
 	// (last_event == session_end|play_end). The client re-emits the
 	// terminal POST for delivery reliability, so the emit-once guard stops


### PR DESCRIPTION
Partial fix for #603 (the deployable forwarder slice — client + read-path remain).

## Problem
At every play boundary the outgoing play's `play_end` frame is mis-bucketed as the **first** row of the incoming play_id, carrying the prior play's cumulative accumulators. Confirmed on player `6cf2ddf5` (3×): `210a2cb9` leading `playing_ms=1,241,839`; `21385cb7` `playing_ms=57M` / `stalling=2.5M` → false `qoe_cirr_breach`/`qoe_cirt_breach`/`qoe_tier_unacceptable`. A `play_end` as a play's *opening* row is definitionally impossible.

## This PR (forwarder, backward-compatible — fixes all current clients)
- **Leading-terminal defense:** a `play_end`/`session_end` arriving while the play hasn't opened (`playLabelState.everOpened == false`) is the leaked prior-play frame → emit nothing, and **don't consume the emit-once terminal guard** so the play's real terminal still classifies after it opens. `everOpened` is set on the first non-terminal row.
- **Recognize `play_start`** → `info=play_start`, the symmetric play-open boundary (companion to #554 `play_end`), distinct from `restart` (mid-session recovery only).

## Known limitation
If the forwarder restarts mid-play and a play's first post-restart row happens to be its real `play_end`, that terminal is also suppressed (loses its tier chip). Narrow window. The exact fix is the **client** emitting `play_start` + pinning `play_end` to the **outgoing** play_id — tracked in #603 — after which this heuristic becomes precise (anchor on `play_start`).

## Still open in #603 (follow-ups)
- Client: emit `play_start`; `play_end` carries outgoing play_id; `restart` = recovery only (iOS/Android/Roku).
- Read-path: summary accumulators use terminal/last value, not `max()`.

## Tests
Leading `play_end` emits nothing + doesn't consume the guard; `play_start` recognized; terminal unit tests now open the play first (`evalTerminal`) to model reality. `go build`/`vet`/`gofmt`/`go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
