### PR TITLE
fix(603): iOS — play_id pin, play_start, restart event + VST preservation

### DIFF
--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -49,6 +49,9 @@ Length: one page rendered. If it grows past that, split.
   downshift cascades, what triggers timejump
 - `codec-strings.md` — avc1/hev1/mp4a profile-level-tier, what
   platforms require what, common stripping bugs
+- `qoe-metrics.md` — CIRR/CIRT/VST/EBVS definitions (Conviva
+  provenance, not standards), our label math, the seek-exclusion
+  caveat
 
 ## When to add a new one
 

--- a/.claude/standards/qoe-metrics.md
+++ b/.claude/standards/qoe-metrics.md
@@ -1,0 +1,34 @@
+# QoE metrics — CIRR, CIRT, VST, EBVS
+
+What the `qoe_*` auto-labels actually measure, where the definitions come from, and where our implementation diverges from the industry's.
+
+## Provenance — these are Conviva names, not standards
+
+- **CIRR** (Connection-Induced Rebuffering Ratio) and **CIRT** (Connection-Induced rebuffering Time, mean per interruption) are **Conviva's proprietary metric names**. They feel standardized because Conviva's dashboards made them lingua franca; the only formal standard in this space is **CTA-2066**, which defines plain "rebuffering ratio" with *no* connection-induced/user-induced split. Don't cite CIRR/CIRT as "the standard" in findings — cite them as "Conviva-convention".
+- "Connection-induced" = **excludes user-induced rebuffering**: seek/scrub recovery and quality-change flushes. Conviva counts seek-to-resume time as seek-induced, not connection-induced.
+- Threshold tiers in `qoe_thresholds.go` are calibrated against Conviva's published "best"/"good" tiers (CIRR 0.2%/0.4%, VST 5s/10s, EBVS 8s/10s). Defaults bake in the "good" tier; campaign overrides via `FORWARDER_QOE_THRESHOLDS_PATH`.
+
+## What we compute (forwarder `qoe_labels.go`)
+
+- `CIRR = stalling_time_ms / (stalling_time_ms + playing_time_ms)` → `qoe_cirr_concerning` (≥0.002) / `qoe_cirr_breach` (≥0.004). Denominator is play+stall only — paused/idle/seeking residency doesn't dilute the ratio.
+- `CIRT = stalling_time_ms / stalling_count` → `qoe_cirt_concerning` (≥1000ms) / `qoe_cirt_breach` (≥2000ms). Same CIRR can be 1×4s stall or 8×0.5s stalls — CIRT is what distinguishes them.
+- `VST = video_start_time_ms` → `qoe_vst_concerning` (≥5000) / `qoe_vst_breach` (≥10000). Sticky field — labels are edge-triggered (#595), not re-stamped per heartbeat.
+- **EBVS** — startup still in progress past `ebvs_threshold_ms` (10s) ⇒ terminal outcome `abandoned_start`. Outcome classifier, not a label tier.
+- Stall burst — >3 `stall_start` in 60s ⇒ `qoe_stall_burst` (catches flapping that CIRR averages away).
+
+## ⚠️ Known divergence — seek exclusion (unverified)
+
+The label math uses **raw `stalling_time_ms`**, but #550's seeking semantics put seek-window time into BOTH `buffering_time_ms` AND `seeking_time_ms` (derive connection-induced buffering as `buffering − seeking`). Whether our CIRR is true *connection-induced* RR or plain rebuffer ratio depends on whether the iOS state machine's `stalling` state already excludes seek recovery. **Verify before comparing our numbers to Conviva's tiers in a finding** — if stalling includes seek recovery, our CIRR reads strictly worse than Conviva would report for the same session.
+
+## Common mistakes
+
+- Quoting `qoe_cirr_*` labels as CTA-2066 conformant — CTA-2066 has no connection-induced split; the tiers are Conviva convention.
+- Comparing CIRR across sessions with very different play lengths — a 10s play with one 0.5s stall reads 4.8%, breach-level. Gate on `playing_time_ms` before treating the ratio as meaningful (the ABR labels have `startup_grace_ms` for this reason; CIRR has no equivalent gate).
+- Reading CIRT alone as severity — 1 stall of 2s and 30 stalls of 2s have identical CIRT. It's a *companion* to CIRR/stall-burst, never standalone.
+- Forgetting thresholds are deploy-time config — a finding that says "breached" must note which tier the deployment ran (`[QoE]` startup log line has the resolved values).
+
+## See also
+
+- `analytics/go-forwarder/qoe_labels.go` (computation), `qoe_thresholds.go` (tiers + layered config)
+- `data-fields.md` — the #550 state-residency accumulator columns these derive from
+- Issue #550 (accumulators + seeking semantics), #553 (Phase 3 label conditions), #595 (edge-triggering)

--- a/README.md
+++ b/README.md
@@ -59,12 +59,17 @@ Player bugs are usually environmental — a network blip, a truncated segment, a
 | Tool / approach | Good at | Why InfiniteStream instead |
 |---|---|---|
 | Public test streams (Apple, DASH-IF, Bitmovin demos) | Quick playback sanity checks | Not deterministic; no failure injection; no looping on your schedule |
+| Live-from-VOD fakers ([mock-hls-server](https://github.com/tjenkinson/mock-hls-server), [hls-loop](https://github.com/jbochi/hls-loop)) | Faking a looping live HLS stream from VOD | HLS-only; no faults, no shaping, no shared-clock LL/2s/6s variants, no dashboard |
 | Production origins (Wowza, AWS Elemental, Unified Streaming) | Serving real viewers | Heavy, costly; not built for faults or side-by-side QA |
 | FFmpeg + nginx-rtmp / nginx-vod (DIY) | Full control of the stack | Days of setup; no shared-clock LL-HLS + LL-DASH; no fault UI |
 | Shaka Streamer | Packaging pipelines | Not a live test server; no looping, no faults, no dashboard |
+| [Eyevinn chaos-stream-proxy](https://github.com/Eyevinn/chaos-stream-proxy) | Streaming-aware corruptions over an *existing* HLS/DASH stream | Proxy only — the origin isn't yours or deterministic; per-URL query-param config, no per-session isolation, no shaping/transport faults, no forensics |
 | toxiproxy, `tc`, Chaos Mesh | Generic network faults | Protocol-agnostic — no awareness of segments, partials, playlists |
 | Charles, mitmproxy | Per-request rewriting | Manual, per-operator; not scripted or repeatable across runs |
 | mediamtx, SRS, OvenMediaEngine | Live ingest and serving | Not looping-VOD focused; not QA-focused; no fault injection |
+| [CTA WAVE DPCTF suite](https://github.com/cta-wave/dpctf-deploy) | Device playback *conformance* (camera-observed) | Complementary — conformance on correct media; says nothing about behavior under failure |
+| Locust-based load testing ([unifiedstreaming/streaming-load-testing](https://github.com/unifiedstreaming/streaming-load-testing)) | Stressing an origin with simulated players | The mirror image — it tests servers with fake players; this tests real players with a controlled server |
+| ABR simulators ([Sabre](https://github.com/UMass-LIDS/sabre), ABRSim) | Offline algorithm evaluation on throughput traces | Simulated player model — can't tell you what a *shipped player binary* actually does |
 
 **Why this is as important as live-feed testing for ABR work:**
 

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -794,6 +794,18 @@ final class PlayerViewModel: ObservableObject {
         return components.url ?? url
     }
 
+    /// Set a query item to an explicit value (replacing any existing). Used to
+    /// pin the metrics-URL identity to payload-captured (fire-time) values
+    /// rather than the live current* — see patchSessionMetrics (#603).
+    private func appendQueryItem(_ url: URL, name: String, value: String) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return url }
+        var items = components.queryItems ?? []
+        items.removeAll { $0.name == name }
+        items.append(URLQueryItem(name: name, value: value))
+        components.queryItems = items
+        return components.url ?? url
+    }
+
     /// Mint a fresh `play_id` UUID. Called only at content-selection
     /// boundaries (see currentPlayID doc). NOT called on restart.
     private func regeneratePlayID() {
@@ -1249,11 +1261,12 @@ final class PlayerViewModel: ObservableObject {
         // it's a within-play recovery attempt that must preserve counters.
         regeneratePlayID()
         resetAttemptID()
-        let restartPayload = buildMetricsPayload(event: "restart", at: Date(), extra: [
-            "player_metrics_restart_reason": "reload",
-            "player_restarts": playerRestarts
-        ])
-        Task { [weak self] in await self?.sendPlayerMetrics(payload: restartPayload) }
+        // #603 — a reload opens a NEW play, so emit play_start (the play-open
+        // boundary, symmetric to play_end), NOT restart. `restart` is reserved
+        // for mid-session streaming recovery (see the retry / auto-recovery
+        // path). play_start carries the new play_id just minted above.
+        let startPayload = buildMetricsPayload(event: "play_start", at: Date())
+        Task { [weak self] in await self?.sendPlayerMetrics(payload: startPayload) }
         currentURL = nil
         buildURLAndLoad()
     }
@@ -2687,9 +2700,20 @@ extension PlayerViewModel {
         // GETs — meaning an iPad mid-stream that hasn't re-fetched
         // its manifest after a restart would have its `restart` event
         // land with the OLD attempt_id. Bug #4 fix.
-        var url = appendPlayID(to: pathURL)
-        url = appendAttemptID(to: url)
-        url = appendStartTime(to: url)
+        //
+        // #603 — pin the URL identity (play_id / attempt_id / start_time) to the
+        // values captured in the PAYLOAD when the event fired, not the live
+        // current* which may have rotated before this async send runs. go-proxy
+        // buckets the row by the URL play_id, so a delayed play_end at a play
+        // boundary would otherwise land on the NEXT play's id (the leak that
+        // inflated metrics + tripped false QoE labels). Falls back to live
+        // values when a payload omits them.
+        let pinnedPlayID = (payload["play_id"] as? String) ?? currentPlayID
+        let pinnedStart = (payload["start_time"] as? String) ?? currentStartTime
+        let pinnedAttempt = (payload["attempt_id"] as? Int).map(String.init) ?? String(currentAttemptID)
+        var url = appendQueryItem(pathURL, name: "play_id", value: pinnedPlayID)
+        url = appendQueryItem(url, name: "attempt_id", value: pinnedAttempt)
+        url = appendQueryItem(url, name: "start_time", value: pinnedStart)
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -238,6 +238,12 @@ final class PlayerViewModel: ObservableObject {
     private var videoPlayingTimeSeconds: Double?
     private var firstFrameReported: Bool = false
     private var playingReported: Bool = false
+    // #603 — set by a restart (manual retry / auto-recovery) before it
+    // re-issues loadStream. startPlayback reads it to PRESERVE the play's
+    // startup measurement (video_start_time / first frame) and fold the
+    // re-prepare wait into residency as stalling/buffering, instead of doing
+    // the per-play reset it does for a fresh play. Cleared in startPlayback.
+    private var resumingFromRestart: Bool = false
     private var lastReportedStallCount: Int = 0
     private var lastReportedStallDuration: Double = 0
     private var lastReportedLoopCount: Int = 0
@@ -908,24 +914,34 @@ final class PlayerViewModel: ObservableObject {
             // HOLD-BACK on first ready-to-play. Mirrors testing-session.html.
             scheduleLiveOffsetSeek(reason: "playback started")
         }
-        hasReportedFirstFrame = false
-
-        // Reset per-playback metrics state and emit the `playing` event.
-        // Single `Date()` capture — used as both `playbackStartAt` and
-        // the `playing` event's `at:` stamp so elapsed-since-start in
-        // the `playing` payload is exactly 0 and not skewed by the
-        // few microseconds between two separate `Date()` calls.
-        diagnostics.reset()
         let playingEventAt = Date()
-        playbackStartAt = playingEventAt
-        videoFirstFrameSeconds = nil
-        videoPlayingTimeSeconds = nil
-        firstFrameReported = false
-        playingReported = false
-        lastReportedRenditionMbps = nil
-        lastReportedStallCount = 0
-        lastReportedStallDuration = 0
-        bufferingStartedAt = nil
+        if resumingFromRestart {
+            // #603 — restart (retry / recovery) within the SAME play. Fold the
+            // re-prepare wait (buffering accrued since the retry) into residency
+            // by snapshotting it into `prior` so reset() restores it; leave the
+            // startup measurement (playbackStartAt / video_start_time / first
+            // frame) and the per-emit delta trackers untouched. Because
+            // playingReported / firstFrameReported stay true, markPlayingStarted/
+            // markFirstFrameRendered no-op on resume → no second video_start_time.
+            diagnostics.snapshotForRestart()
+            diagnostics.reset()
+            resumingFromRestart = false
+        } else {
+            hasReportedFirstFrame = false
+            // Reset per-playback metrics state and emit the `playing` event.
+            // playbackStartAt + the `playing` event share one `Date()` so
+            // elapsed-since-start in the payload is exactly 0.
+            diagnostics.reset()
+            playbackStartAt = playingEventAt
+            videoFirstFrameSeconds = nil
+            videoPlayingTimeSeconds = nil
+            firstFrameReported = false
+            playingReported = false
+            lastReportedRenditionMbps = nil
+            lastReportedStallCount = 0
+            lastReportedStallDuration = 0
+            bufferingStartedAt = nil
+        }
         zeroBufferStartedAt = nil
         metricsSessionId = nil
         metricsLastSessionLookup = nil
@@ -1140,6 +1156,15 @@ final class PlayerViewModel: ObservableObject {
         Task { [weak self] in
             await self?.requestHARSnapshot(reason: "user_retry", force: true)
         }
+        // #603 — emit a `restart` event so the mid-play recovery is observable
+        // (it wasn't before; manual retries left no mark on the events lane).
+        // Same play_id, bumped attempt_id; play boundaries are play_start/play_end.
+        let restartPayload = buildMetricsPayload(event: "restart", at: Date(), extra: [
+            "player_metrics_restart_reason": "user_retry",
+            "player_restarts": playerRestarts,
+        ])
+        Task { [weak self] in await self?.sendPlayerMetrics(payload: restartPayload) }
+        resumingFromRestart = true
         loadStream(url: refreshed)
     }
 
@@ -1452,8 +1477,19 @@ final class PlayerViewModel: ObservableObject {
         codecRetries += 1
         let retries = codecRetries
         statusText = "\(reason) — retry \(retries)/\(maxCodecRetries)"
+        // #603 — auto-recovery is also a mid-play restart: emit a `restart`
+        // event (reason=auto_recovery, detail=the trigger) for observability,
+        // same play_id. The re-prepare wait folds into residency via the
+        // resumingFromRestart path in startPlayback.
+        let restartPayload = buildMetricsPayload(event: "restart", at: Date(), extra: [
+            "player_metrics_restart_reason": "auto_recovery",
+            "player_metrics_restart_detail": reason,
+            "player_restarts": playerRestarts,
+        ])
         Task { @MainActor [weak self] in
+            await self?.sendPlayerMetrics(payload: restartPayload)
             try? await Task.sleep(nanoseconds: UInt64(150_000_000 * retries))
+            self?.resumingFromRestart = true
             self?.loadStream(url: url)
         }
     }


### PR DESCRIPTION
Part of #603 (iOS client slice). Companion to #604 (forwarder defense + read-path).

## Root cause (confirmed)
go-proxy buckets a metrics row by the **URL `?play_id=`** (main.go:2406/2495), but `patchSessionMetrics` appended it from the **live `currentPlayID` at send time** (`:2690`). `reload()` builds `play_end` with the old play_id in the payload (`:1227`) but **sends it async** (`:1228`) *after* `regeneratePlayID()` rotates `currentPlayID` (`:1262`) — so the `play_end` POST's URL carried the **next** play's id, and the terminal frame mis-bucketed as the new play's first row (inflated accumulators → false `qoe_cirr_breach`/`qoe_cirt_breach`/`qoe_tier_unacceptable`). Reproduced on player `6cf2ddf5` (`210a2cb9`, `8e82d76f`, `21385cb7`).

## Fix
- **Pin the metrics URL identity to fire-time values.** `patchSessionMetrics` now sets `play_id` / `attempt_id` / `start_time` from the **payload** (the build-time snapshot it already carried as "belt-and-braces against a delayed event that races an id rotation" — the design intent, just never wired to the URL) rather than the live `current*`. New `appendQueryItem(_:name:value:)` helper. Fixes `play_end` and any delayed event.
- **`reload()` emits `play_start`** (the play-open boundary, symmetric to `play_end`) instead of `restart`. **`restart` is now reserved for mid-session streaming recovery** (the retry / auto-recovery path) — per review directive.

The forwarder already recognizes `play_start` and defends against a leading terminal (#604), so these compose.

## Verified
iOS **BUILD SUCCEEDED** (iPad Pro sim). Release-gated — takes effect on the next iOS build.

## #603 remaining
- **Android:** mirror (same send-time play_id pin + `reload`→`play_start` + `restart` = recovery).
- **Roku:** gated on #554 (no terminal event today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
