### PR TITLE
fix(603): Android — play_id pin + restart event + VST preservation + play_start (iOS parity)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -110,6 +110,12 @@ public final class PlaybackMetrics {
     private Double videoStartTimeSeconds;
     private boolean firstFrameReported;
     private boolean playingReported;
+    // #603 — set by a restart (retry / auto-recovery) before it re-issues
+    // loadStream. onPlaybackStarted reads it to PRESERVE the play's startup
+    // measurement (video_start_time / first frame) and fold the re-prepare
+    // wait into residency, instead of the per-play reset it does for a fresh
+    // play. Mirrors iOS resumingFromRestart. Cleared in onPlaybackStarted.
+    private boolean resumingFromRestart;
 
     // Stall tracking.
     private int stallCount;
@@ -424,11 +430,22 @@ public final class PlaybackMetrics {
 
     /** Called when a new stream starts loading. Resets per-playback state. */
     public void onPlaybackStarted() {
-        playbackStartAtMs = System.currentTimeMillis();
-        videoFirstFrameSeconds = null;
-        videoStartTimeSeconds = null;
-        firstFrameReported = false;
-        playingReported = false;
+        if (resumingFromRestart) {
+            // #603 — restart (retry / auto-recovery) within the SAME play:
+            // PRESERVE the startup measurement (playbackStartAtMs /
+            // video_start_time / first-frame; playingReported stays true so
+            // markPlayingStarted no-ops on resume → no second video_start_time),
+            // and fold the re-prepare gap into residency by snapshotting it
+            // into prior before resetResidency() restores it below.
+            resumingFromRestart = false;
+            snapshotForRestart();
+        } else {
+            playbackStartAtMs = System.currentTimeMillis();
+            videoFirstFrameSeconds = null;
+            videoStartTimeSeconds = null;
+            firstFrameReported = false;
+            playingReported = false;
+        }
         lastReportedBitrateMbps = null;
         stallStartAtMs = -1;
         lastHeartbeatPositionMs = -1;
@@ -670,7 +687,16 @@ public final class PlaybackMetrics {
         sendEvent("user_marked", extra);
     }
 
-    /** Called when user triggers a restart (Restart Playback button, etc). */
+    /** #603 — mark that the next onPlaybackStarted is a restart resume, so it
+     *  preserves the startup measurement + folds the gap into residency rather
+     *  than doing the fresh-play reset. Call before re-issuing loadStream. */
+    public void markRestartPending() {
+        resumingFromRestart = true;
+    }
+
+    /** Called when a mid-play recovery restart happens (manual Retry or
+     *  auto-recovery). Emits a `restart` event (reason = user_retry /
+     *  auto_recovery) — play boundaries are play_start/play_end (#603). */
     public void onRestart(String reason) {
         playerRestarts = Math.max(0, playerRestarts) + 1;
         Map<String, Object> extra = new HashMap<>();
@@ -680,6 +706,14 @@ public final class PlaybackMetrics {
         // User-driven restarts should always produce a HAR — bypass the
         // server-side per-player debounce window.
         requestHarSnapshot(reason, 0, /* force= */ true);
+    }
+
+    /** #603 — play-open boundary (symmetric to play_end), emitted when a NEW
+     *  play begins (e.g. Reload). Distinct from `restart`, which is reserved
+     *  for mid-play recovery. */
+    public void onPlayStart() {
+        sendEvent("play_start", Collections.<String, Object>emptyMap());
+        requestHarSnapshot("play_start", 0, /* force= */ true);
     }
 
     /**

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -63,6 +63,15 @@ public final class PlaybackMetrics {
         String currentStreamUrl();
     }
 
+    /** #603 — supplies the play-scoped ids captured at event-fire time so a
+     *  metrics POST carries the SAME play_id on its URL (iOS parity), pinned
+     *  against a play_id rotation that races the async POST (e.g. a play_end
+     *  at a reload boundary that would otherwise bucket onto the next play). */
+    public interface PlayContextProvider {
+        String currentPlayId();
+        String currentStartTime();
+    }
+
     private static final String TAG = "InfiniteStream";
     private static final long HEARTBEAT_INTERVAL_MS = 1000;
     private static final long SESSION_LOOKUP_INTERVAL_MS = 30_000;
@@ -79,6 +88,7 @@ public final class PlaybackMetrics {
     private final BaseUrlProvider baseUrlProvider;
     private final UrlProvider urlProvider;
     private final ContentNameProvider contentNameProvider;
+    private final PlayContextProvider playContextProvider;
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
     private final ExecutorService networkExecutor = Executors.newSingleThreadExecutor();
     private final SimpleDateFormat iso8601;
@@ -373,7 +383,8 @@ public final class PlaybackMetrics {
                     String playerId,
                     BaseUrlProvider baseUrlProvider,
                     UrlProvider urlProvider,
-                    ContentNameProvider contentNameProvider) {
+                    ContentNameProvider contentNameProvider,
+                    PlayContextProvider playContextProvider) {
         this.player = player;
         this.playerView = playerView;
         this.bandwidthMeter = bandwidthMeter;
@@ -381,6 +392,7 @@ public final class PlaybackMetrics {
         this.baseUrlProvider = baseUrlProvider;
         this.urlProvider = urlProvider;
         this.contentNameProvider = contentNameProvider;
+        this.playContextProvider = playContextProvider;
         this.iso8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
         this.iso8601.setTimeZone(TimeZone.getTimeZone("UTC"));
         // Initialise the start clock at construction so first-frame elapsed
@@ -803,6 +815,11 @@ public final class PlaybackMetrics {
         try {
             String timestamp = iso8601.format(new Date());
             p.put("player_metrics_source", "android");
+            // #603 — pin the play-scoped ids at fire time (iOS parity). patchMetrics
+            // puts these on the POST URL so go-proxy buckets the row by THIS play_id,
+            // not whatever it rotated to by the time the async POST runs.
+            p.put("play_id", playContextProvider.currentPlayId());
+            p.put("start_time", playContextProvider.currentStartTime());
             p.put("player_metrics_last_event", event);
             p.put("player_metrics_trigger_type", event);
             p.put("player_metrics_event_time", timestamp);
@@ -1629,12 +1646,31 @@ public final class PlaybackMetrics {
         return null;
     }
 
+    /** URL-encode and append {@code name=value} to the query builder (skips
+     *  empties). Used to pin metrics-URL identity to payload values. #603. */
+    private static void appendQuery(StringBuilder qs, String name, String value) {
+        if (value == null || value.isEmpty()) return;
+        try {
+            if (qs.length() > 0) qs.append('&');
+            qs.append(name).append('=').append(java.net.URLEncoder.encode(value, "UTF-8"));
+        } catch (java.io.UnsupportedEncodingException ignored) {
+            // UTF-8 is always available; ignore.
+        }
+    }
+
     private void patchMetrics(String sid, JSONObject payload) {
         String base = baseUrlProvider.get();
         if (base == null || base.isEmpty()) return;
         HttpURLConnection conn = null;
         try {
-            URL url = new URL(base + "/api/session/" + sid + "/metrics");
+            // #603 — stamp play_id + start_time on the URL (iOS parity) from the
+            // values the payload captured at fire time, so go-proxy buckets this
+            // row by THIS play, not the one it may have rotated to since.
+            StringBuilder qs = new StringBuilder();
+            appendQuery(qs, "play_id", payload.optString("play_id", ""));
+            appendQuery(qs, "start_time", payload.optString("start_time", ""));
+            URL url = new URL(base + "/api/session/" + sid + "/metrics"
+                + (qs.length() > 0 ? "?" + qs : ""));
             conn = (HttpURLConnection) url.openConnection();
             conn.setConnectTimeout(CONNECT_TIMEOUT_MS);
             conn.setReadTimeout(READ_TIMEOUT_MS);

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -681,7 +681,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         if (wasPlaying) buildUrlAndLoad()
     }
 
-    private fun buildUrlAndLoad() {
+    private fun buildUrlAndLoad(rotatePlayId: Boolean = true) {
         val s = _state.value
         val server = s.activeServer ?: return
         if (s.selectedContent.isEmpty()) return
@@ -692,8 +692,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // stream). Same /go-live route in both cases.
         val port = if (s.localProxy) server.port else server.apiPort
         // Fresh play_id at every loadStream boundary (issue #280) so
-        // go-proxy can scope its network log per play.
-        regeneratePlayId()
+        // go-proxy can scope its network log per play. reload() rotates the
+        // id itself (so play_start carries the new id) and passes false here
+        // to avoid minting a second id the play_start row wouldn't match.
+        if (rotatePlayId) regeneratePlayId()
         // Anchor the age clock for the soak-rotation timer. Every
         // fresh loadStream resets the boundary; the Job is rescheduled
         // below once the player has been handed off.
@@ -788,7 +790,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
      * when the player has stalled or surfaced an error and you want the
      * built-in retry kicked off without waiting for it.
      */
-    fun retry() {
+    fun retry(reason: String = "user_retry") {
         val url = _state.value.currentUrl
         if (url.isEmpty()) return
         // #550 retry contract — recovery attempt WITHIN the same play.
@@ -803,8 +805,12 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // the proxy's network log scopes the new round of requests
         // accordingly.
         metrics?.snapshotForRestart()
-        // User-driven Retry deserves its own HAR — bypass per-player debounce.
-        metrics?.requestHarSnapshot("user_retry", 0, /* force= */ true)
+        // #603 — emit a `restart` event (reason=user_retry) so the mid-play
+        // recovery is observable; onRestart also fires the user-driven HAR.
+        // markRestartPending() makes onPlaybackStarted preserve the play's
+        // video_start_time + fold the re-prepare wait into residency.
+        metrics?.onRestart(reason)
+        metrics?.markRestartPending()
         player.stop()
         player.clearMediaItems()
         loadStream(url)
@@ -841,19 +847,25 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         // row + QoE labels instead of dangling `in_progress`. sendEvent
         // snapshots the payload synchronously, so the play_end row carries
         // the OLD play_id + final state even though the POST is async; the
-        // play_id only rotates later in buildUrlAndLoad(). status=
+        // play_id only rotates on the regeneratePlayId() below. status=
         // user_stopped, reason=reloaded (distinct from a back-tap's
-        // user_quit). resetForFreshPlay() then clears the terminal status
-        // so the subsequent restart row reports in_progress (matching iOS).
+        // user_quit).
         metrics?.endSession("user_stopped", "reloaded")
-        // Fresh play boundary: zero the prior accumulators (variant
-        // dwell etc.) BEFORE the restart marker + releasing the old
-        // metrics instance, so a subsequent retry-flow won't inadvertently
-        // inherit values from before the reload. The new PlaybackMetrics
-        // built in bindMetrics() starts with empty priors anyway, but this
-        // guards against a leak if anyone caches a reference.
-        metrics?.resetForFreshPlay()
-        metrics?.onRestart("reload")
+        // #603 — rotate to the NEW play_id BEFORE emitting play_start so the
+        // play-open boundary carries the new play's id (iOS parity). buildUrlAndLoad
+        // below is told NOT to rotate again so the stream URL uses this same id.
+        // regeneratePlayId() also zeroes the per-play accumulators (variant dwell
+        // etc.) on the still-bound metrics instance — the new PlaybackMetrics built
+        // in bindMetrics() starts empty anyway, but this guards a cached reference.
+        regeneratePlayId()
+        playIdMintedAt = System.currentTimeMillis()
+        playIdLastActivityAt = 0L
+        // #603 — a reload opens a NEW play, so emit play_start (the play-open
+        // boundary, symmetric to play_end), NOT restart. `restart` is reserved
+        // for mid-play recovery (retry / auto-recovery). Emitted on the still-live
+        // metrics instance whose payload reads currentPlayId live → carries the
+        // new id just minted above, with zeroed residency.
+        metrics?.onPlayStart()
         metrics?.release()
         metrics = null
         boundPlayerView = null
@@ -865,7 +877,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         attachPlayerListeners()
         applyTrackSelectionParameters()
         _state.update { it.copy(currentUrl = "", playerEpoch = it.playerEpoch + 1) }
-        buildUrlAndLoad()
+        buildUrlAndLoad(rotatePlayId = false)
     }
 
     // -- Metrics binding -----------------------------------------------------
@@ -941,7 +953,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                     }
                     viewModelScope.launch {
                         kotlinx.coroutines.delay(backoff)
-                        retry()
+                        retry("auto_recovery")
                     }
                     return
                 }
@@ -952,7 +964,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                 if (_state.value.autoRecovery && _state.value.currentUrl.isNotEmpty()) {
                     viewModelScope.launch {
                         kotlinx.coroutines.delay(500)
-                        retry()
+                        retry("auto_recovery")
                     }
                     return
                 }

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -895,6 +895,14 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             // instead of staying empty if bindMetrics fired before
             // selectedContent was set.
             { _state.value.selectedContent },
+            // #603 — pin play-scoped ids onto metrics POST URLs (iOS parity).
+            // Read live per emit; PlaybackMetrics captures them synchronously in
+            // buildPayload at fire time, so a play_end at a reload boundary keeps
+            // the OLD play_id even though the POST is async + play_id later rotates.
+            object : PlaybackMetrics.PlayContextProvider {
+                override fun currentPlayId() = currentPlayId
+                override fun currentStartTime() = currentStartTime
+            },
         ).also { it.start() }
     }
 


### PR DESCRIPTION
Brings the Android player to parity with the iOS #605 work under the #603 play-id-lifecycle epic.

## Commits

1. **play_id pin** — metrics POST URLs carry the play_id/start_time captured at payload fire-time (via `PlayContextProvider`), so a `play_end` fired at a reload boundary keeps the OLD play_id even though the POST is async and the id rotates right after. Closes the leading-`play_end` leak on Android (iOS parity).

2. **restart event + VST preservation + play_start**
   - `retry()` / auto-recovery emit a `restart` event with a reason (`user_retry` vs `auto_recovery`) so mid-play recovery is observable; `retry(reason)` is parameterised and both `onPlayerError` recovery paths pass `"auto_recovery"`.
   - `onPlaybackStarted` PRESERVES the play's startup measurement (`playbackStartAtMs` / `video_start_time` / first-frame; `playingReported` stays true so `markPlayingStarted` no-ops → no second `video_start_time`) on a restart resume instead of the per-play reset, and folds the re-prepare wait into residency via a second `snapshotForRestart` flush. Gated on a new `resumingFromRestart` flag set by `markRestartPending()`.
   - `reload()` opens a NEW play with `play_start` (the play-open boundary symmetric to `play_end`), NOT `restart`. The id is rotated up front so `play_start` carries the new play_id (`buildUrlAndLoad(rotatePlayId=false)` avoids minting a second), matching iOS which emits after `regeneratePlayID()`.

Pairs with #605 (iOS), #604 (forwarder leak defense + read-path argMax), and #609 (forwarder restart-reason label split). `restart_reason` (`user_retry` → `warning=restart_user_retry`, `auto_recovery` → `critical=restart_auto_recovery`, `reload`→ n/a since reload now emits `play_start`) is labeled by #609.

Verified: `:app:compileDebugJavaWithJavac` + `:app:compileDebugKotlin` BUILD SUCCESSFUL.

Refs #603
