### PR TITLE
fix(603): forwarder — split restart label on restart_reason

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -290,9 +290,18 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 	// informational; everything else is an involuntary recovery
 	// the operator should see.
 	case "restart":
-		if r.TriggerType == "reload" {
+		// #603 — `restart` is a mid-play recovery (play boundaries are
+		// play_start/play_end). Split on the client's restart_reason:
+		// auto_recovery (player hit a fatal error and recovered itself) is
+		// critical; a manual user_retry is a warning (user perceived a problem
+		// and re-attempted); a legacy reload restart is info. Falls back to
+		// TriggerType=="reload" for older rows that predate restart_reason.
+		switch {
+		case r.RestartReason == "user_retry":
+			out = []string{SevWarning + "=restart_user_retry"}
+		case r.RestartReason == "reload" || r.TriggerType == "reload":
 			out = []string{SevInfo + "=restart_reload"}
-		} else {
+		default: // auto_recovery / unknown
 			out = []string{SevCritical + "=restart_auto_recovery"}
 		}
 

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -42,9 +42,11 @@ func TestEventSwitchUnchanged(t *testing.T) {
 		// critical — user-visible impact
 		{"frozen", nil, []string{"critical=stall_frozen"}},
 		{"user_marked", nil, []string{"critical=user_marked_911"}},
-		// restart splits on trigger_type
+		// restart splits on restart_reason (#603); legacy trigger_type fallback
 		{"restart_reload", func(r *row) { r.LastEvent = "restart"; r.TriggerType = "reload" }, []string{"info=restart_reload"}},
 		{"restart_auto", func(r *row) { r.LastEvent = "restart" }, []string{"critical=restart_auto_recovery"}},
+		{"restart_user_retry", func(r *row) { r.LastEvent = "restart"; r.RestartReason = "user_retry" }, []string{"warning=restart_user_retry"}},
+		{"restart_reason_auto", func(r *row) { r.LastEvent = "restart"; r.RestartReason = "auto_recovery" }, []string{"critical=restart_auto_recovery"}},
 		// error
 		{"error", nil, []string{"error=player_error"}},
 		// pair-open arms emit nothing on the opening row

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -331,6 +331,7 @@ type row struct {
 	EffectiveRateLimitMbps   float32 `json:"effective_rate_limit_mbps"`
 	LastEvent                string  `json:"last_event"`
 	TriggerType              string  `json:"trigger_type"`
+	RestartReason            string  `json:"restart_reason"`
 	EventTime                string  `json:"event_time"`
 	PlayerError              string  `json:"player_error"`
 
@@ -859,6 +860,7 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		EffectiveRateLimitMbps:   getF32(s, "effective_rate_limit_mbps"),
 		LastEvent:                getStr(s, "player_metrics_last_event"),
 		TriggerType:              getStr(s, "player_metrics_trigger_type"),
+		RestartReason:            getStr(s, "player_metrics_restart_reason"),
 		EventTime:                getStr(s, "player_metrics_event_time"),
 		PlayerError:              getStr(s, "player_metrics_error"),
 


### PR DESCRIPTION
Part of #603. Companion to the iOS restart-event work in #605.

## Problem
The restart label arm split on `TriggerType=="reload"`, but clients send `trigger_type=<event>="restart"` — so that branch never matched and **every** restart became `critical=restart_auto_recovery`, including manual retries.

## Fix
Split on the client's **`restart_reason`** (now that play_start/play_end own the boundaries and `restart` = mid-play recovery):
- `user_retry` → `warning=restart_user_retry` (manual Retry button)
- `auto_recovery` / unknown → `critical=restart_auto_recovery`
- `reload`, or legacy `trigger_type=="reload"` → `info=restart_reload`

New `RestartReason` row field read from `player_metrics_restart_reason` at ingest — no schema change (read off the raw session map like `trigger_type`). Tests cover the user_retry / auto_recovery split + the legacy reload fallback. `go test ./...` green.

Note: `main.go` shows gofmt-dirty — pre-existing whole-file struct-alignment drift on `dev` (gofmt re-aligns untouched fields); the new field matches its neighbors, left as-is to avoid a 584-line mass reformat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
