### PR TITLE
feat(608): split VOMM label deriver into nightly train + fast score

### DIFF
--- a/analytics/clickhouse/init.d/05-derived-labels.sql
+++ b/analytics/clickhouse/init.d/05-derived-labels.sql
@@ -2,8 +2,10 @@
 -- The VOMM scorer's surprise verdict, anchored on the EXACT row whose token transition was
 -- improbable — so it merges onto that row at read time (like derived_tokens) and shows as a
 -- chip right where the surprise happened, with as many per session as there are surprising
--- rows. A batch (analytics/tools/derive_labels.py, reusing scorer.py + tokenize.py) trains
--- per-condition VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time-split),
+-- rows. analytics/tools/derive_labels.py (reusing scorer.py + tokenize.py) is split (#608):
+-- --mode train (nightly) builds per-condition VOMMs over --train-days and persists them to a
+-- shared artifact (see derived_models); --mode score (fast) loads that artifact and scores
+-- plays whose max_ts post-dates the model's trained_at (OUT-OF-SAMPLE by construction),
 -- emitting one row per above-threshold transition WITHIN a condition episode.
 --
 -- Keyed like derived_tokens so the read-path joins line up:

--- a/analytics/clickhouse/init.d/06-derived-models.sql
+++ b/analytics/clickhouse/init.d/06-derived-models.sql
@@ -1,0 +1,36 @@
+-- #608 — VOMM model manifest (observability only; NOT the model itself).
+--
+-- The #608 split decouples TRAINING the VOMM (slow: nightly full 7-day rebuild) from
+-- SCORING with it (fast: ~1 min). The actual model artifact — per-condition PPM counts +
+-- p99 threshold — is a gzipped-JSON file on a volume shared by the label-trainer and
+-- label-scorer sidecars (LABEL_MODEL_PATH, default /models/labels-model.json.gz); it is too
+-- large and too internal to belong in a queryable column.
+--
+-- This table is the small, queryable MANIFEST the trainer writes alongside that artifact:
+-- one row per (model_version, condition) per train run, so you can see WHEN the reference
+-- model last rebuilt, over how many episodes, and at what threshold — without cracking open
+-- the gzip. `trained_at` is also the out-of-sample cutoff the scorer enforces (it only
+-- scores plays whose max_ts post-dates the model it loaded), so surfacing it here makes the
+-- guarantee auditable.
+--
+-- ReplacingMergeTree(trained_at) keeps the latest row per (model_version, condition).
+
+CREATE TABLE IF NOT EXISTS infinite_streaming.derived_models
+(
+    trained_at        DateTime64(3, 'UTC')             CODEC(Delta, ZSTD(1)),
+    model_version     LowCardinality(String)           CODEC(ZSTD(1)),
+    condition         LowCardinality(String)           CODEC(ZSTD(1)),
+    train_window_days UInt16                            CODEC(ZSTD(1)),
+    n_train_episodes  UInt32                            CODEC(ZSTD(1)),
+    threshold         Float32                          CODEC(ZSTD(1)),
+    n_contexts        UInt32                            CODEC(ZSTD(1)),
+    vocab             UInt32                            CODEC(ZSTD(1)),
+    max_order         UInt8                             CODEC(ZSTD(1)),
+    artifact_path     String                 DEFAULT '' CODEC(ZSTD(1)),
+    artifact_bytes    UInt64                 DEFAULT 0  CODEC(ZSTD(1))
+)
+ENGINE = ReplacingMergeTree(trained_at)
+PARTITION BY toYYYYMMDD(trained_at)
+ORDER BY (model_version, condition)
+TTL toDateTime(trained_at) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;

--- a/analytics/tools/derive_labels.py
+++ b/analytics/tools/derive_labels.py
@@ -1,31 +1,42 @@
 #!/usr/bin/env python3
-"""#506 batch anomaly-LABEL writer (PER ROW) — the sibling of derive_tokens.py.
+"""#506/#608 anomaly-LABEL deriver (PER ROW) — now split into TRAIN and SCORE modes.
 
-Trains per-condition VOMMs (PPM-C back-off, from scorer.py) on OLDER plays and scores
-RECENT plays OUT-OF-SAMPLE (time split: train on plays predating the scoring window, score
-plays inside it — no play is scored by a model trained on itself, so production needs no
-k-fold). For each transition WITHIN a condition episode whose surprise (−log P) exceeds the
-clean-calibrated bar, writes ONE row to `derived_labels`, anchored on the EXACT row whose
-token was improbable. The read API merges these onto that row (→ a chip in NetworkLog /
-PlayLog, as many per session as there are surprising rows) AND rolls them up by play_id (→ a
-filterable play chip in sessions.html).
+#506 introduced per-row VOMM "surprise" labels (unexpected_<condition>). #608 decouples the
+two operations that used to run together every tick:
 
-Condition-anchored + out-of-sample keeps it off the trivial "every FAULT token is rare"
-counter: a typical fault-recovery transition (seen in other plays' fault episodes) is NOT
-surprising under the fault-condition model — only atypical reactions clear the bar.
+  --mode train  (SLOW, nightly): build per-condition VOMMs (PPM-C back-off, from scorer.py)
+                over the last --train-days of plays, calibrate each condition's p99 surprise
+                threshold, and serialize the whole thing to a gzipped-JSON ARTIFACT at
+                --model-path (a volume shared with the scorer). Also writes a small manifest
+                row per condition to derived_models for observability. This is the only place
+                the expensive sc.train runs.
 
-Reads ClickHouse directly (reuses derive_tokens.py's ch()/fetch_rows()); reuses scorer.py's
-model + tokenize.py's cross-stream tokeniser/episodes. No hand-built reaction taxonomy: the
-tag is the condition (unexpected_<condition>) + a severity from the surprise magnitude.
+  --mode score (FAST, ~1 min): load the latest artifact, score recent plays' transitions
+                against it, and write one derived_labels row per above-threshold transition,
+                anchored on the EXACT row whose token was improbable. NO training.
 
-  python3 analytics/tools/derive_labels.py --train-days 7 --score-hours 12 [--dry-run]
+Why the split keeps the out-of-sample guarantee (in fact strengthens it): the artifact stamps
+`trained_at` (= the moment the corpus closed). The scorer only scores plays whose max_ts
+POST-DATES trained_at — those plays did not exist when the model trained, so they are
+out-of-sample by construction. `trained_at` IS the cutoff; no `now − score_hours` arithmetic.
+
+The model that changes slowly (the learned grammar of typical episodes) is rebuilt slowly;
+scoring, which we want fresh, is cheap (dict lookups) and runs often. No hand-built reaction
+taxonomy: the tag is the condition (unexpected_<condition>) + a severity from the surprise
+magnitude. Reads ClickHouse directly (reuses derive_tokens.py's ch()/fetch_rows()); reuses
+scorer.py's model + tokenize.py's cross-stream tokeniser/episodes.
+
+  python3 analytics/tools/derive_labels.py --mode train --train-days 7 --model-path /models/labels-model.json.gz
+  python3 analytics/tools/derive_labels.py --mode score --score-hours 2 --model-path /models/labels-model.json.gz [--dry-run]
 """
 import argparse
 import collections
+import gzip
 import json
 import os
 import sys
-from datetime import datetime, timedelta, timezone
+import tempfile
+from datetime import datetime, timezone
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)
@@ -36,6 +47,7 @@ import derive_tokens as dt     # noqa: E402  ch() / fetch_rows() / group_by_play
 NET_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
 EVENT_COLS = "ts, player_id, play_id, last_event"
 SENTINELS = ("<S>", "<E>")
+DEFAULT_MODEL_PATH = os.environ.get("LABEL_MODEL_PATH", "/models/labels-model.json.gz")
 
 
 def play_seq_full(net_rows, event_rows):
@@ -61,27 +73,14 @@ def severity_for(score, thr):
     return "critical" if score >= thr * 1.5 else "warning"
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
-    ap.add_argument("--train-days", type=int, default=7)
-    ap.add_argument("--score-hours", type=int, default=12)
-    ap.add_argument("--player", default=None, help="limit to one player_id")
-    ap.add_argument("--max-order", type=int, default=4)
-    ap.add_argument("--alpha", type=float, default=0.5)
-    ap.add_argument("--min-train-episodes", type=int, default=20)
-    ap.add_argument("--model-version", default="vomm-tok-1")
-    ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT insert")
-    args = ap.parse_args()
-
-    net_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "network_requests",
+def build_plays(ch_url, days, hours, player):
+    """{play_id: {pid, full, max_ts}} — cross-stream full token sequences over a CH window."""
+    net_rows = dt.fetch_rows(ch_url, days, hours, player, "network_requests",
                              NET_COLS, "player_id, ts, entry_fingerprint")
-    event_rows = dt.fetch_rows(args.ch_url, args.train_days, 0, args.player, "session_events",
+    event_rows = dt.fetch_rows(ch_url, days, hours, player, "session_events",
                                EVENT_COLS, "player_id, ts")
     net_by_play, ev_by_play = dt.group_by_play(net_rows), dt.group_by_play(event_rows)
     plays = list(net_by_play.keys()) + [p for p in ev_by_play if p not in net_by_play]
-
-    cutoff = (datetime.now(timezone.utc) - timedelta(hours=args.score_hours)).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     builds = {}
     for play in plays:
         if not play:
@@ -92,29 +91,123 @@ def main():
             continue
         pid = next((r.get("player_id") for r in (prows + erows) if r.get("player_id")), "")
         builds[play] = {"pid": pid, "full": full, "max_ts": full[-1][0]}
+    return builds
 
-    train_plays = [b for b in builds.values() if b["max_ts"] < cutoff]
-    score_plays = [(p, b) for p, b in builds.items() if b["max_ts"] >= cutoff]
-    scored_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
 
-    print(f"#506 derive_labels (per-row) — {len(builds)} plays "
-          f"({len(train_plays)} train / {len(score_plays)} score) "
-          f"train={args.train_days}d score={args.score_hours}h")
+# ---------- model artifact (gzipped JSON; counts have tuple keys → list form) ----------
+def serialize_model(model):
+    """sc model {counts:[{ctx_tuple: {tok:cnt}}], max_order, V} → JSON-safe nested lists."""
+    return {
+        "max_order": model["max_order"],
+        "V": model["V"],
+        "counts": [[[list(ctx), list(ctr.items())] for ctx, ctr in level.items()]
+                   for level in model["counts"]],
+    }
 
-    rows = []
-    per_condition = collections.Counter()
+
+def deserialize_model(d):
+    """Inverse of serialize_model. Plain dicts are enough for scorer._ppm_prob's reads."""
+    counts = []
+    for level in d["counts"]:
+        counts.append({tuple(ctx): dict(items) for ctx, items in level})
+    return {"counts": counts, "max_order": d["max_order"], "V": d["V"]}
+
+
+def n_contexts(model):
+    return sum(len(level) for level in model["counts"])
+
+
+def save_artifact(path, artifact):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", suffix=".tmp")
+    os.close(fd)
+    with gzip.open(tmp, "wt", encoding="utf-8") as f:
+        json.dump(artifact, f, separators=(",", ":"))
+    os.replace(tmp, path)          # atomic swap so the scorer never reads a half-written file
+    return os.path.getsize(path)
+
+
+def load_artifact(path):
+    if not os.path.exists(path):
+        return None
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+
+# ---------- TRAIN ----------
+def cmd_train(args):
+    builds = build_plays(args.ch_url, args.train_days, 0, args.player)
+    trained_at = utc_now()
+    print(f"#608 train — {len(builds)} plays over {args.train_days}d, K={args.max_order} "
+          f"→ {args.model_path}")
+
+    conditions, manifest = {}, []
     for c in sc.EPISODE_CONDITIONS:
         cond, anchor = c["name"], c["anchor"]
-        train_eps = [[x[3] for x in w] for b in train_plays
+        train_eps = [[x[3] for x in w] for b in builds.values()
                      for w in episode_windows_full(b["full"], anchor, c["lead"], c["horizon"])]
         if len(train_eps) < args.min_train_episodes:
             print(f"  {cond:8} — {len(train_eps)} train episodes < {args.min_train_episodes}; skipped")
             continue
         model = sc.train(train_eps, max_order=args.max_order, alpha=args.alpha)
         thr = sc.p99([s for w in train_eps for s, _, _ in sc.transition_surprises(model, w)])
+        conditions[cond] = {"anchor": anchor, "lead": c["lead"], "horizon": c["horizon"],
+                            "thr": thr, "n_train_episodes": len(train_eps),
+                            "model": serialize_model(model)}
+        manifest.append({"trained_at": trained_at, "model_version": args.model_version,
+                         "condition": cond, "train_window_days": args.train_days,
+                         "n_train_episodes": len(train_eps), "threshold": round(thr, 4),
+                         "n_contexts": n_contexts(model), "vocab": model["V"],
+                         "max_order": args.max_order, "artifact_path": args.model_path})
+        print(f"  {cond:8} — train_eps={len(train_eps)} thr={thr:.1f} "
+              f"contexts={n_contexts(model)} vocab={model['V']}")
+
+    if not conditions:
+        print("no condition had enough episodes to train; artifact NOT written.")
+        return
+    artifact = {"model_version": args.model_version, "trained_at": trained_at,
+                "train_window_days": args.train_days, "max_order": args.max_order,
+                "alpha": args.alpha, "conditions": conditions}
+    if args.dry_run:
+        print(f"[dry-run] would write artifact for {list(conditions)} (trained_at={trained_at})")
+        return
+    size = save_artifact(args.model_path, artifact)
+    for m in manifest:
+        m["artifact_bytes"] = size
+    body = ("\n".join(json.dumps(m) for m in manifest) + "\n").encode()
+    dt.ch(args.ch_url, f"INSERT INTO {dt.DB}.derived_models FORMAT JSONEachRow", body=body)
+    print(f"wrote {size} B artifact ({list(conditions)}) + {len(manifest)} manifest rows.")
+
+
+# ---------- SCORE ----------
+def cmd_score(args):
+    art = load_artifact(args.model_path)
+    if not art:
+        print(f"#608 score — no model artifact at {args.model_path} yet "
+              f"(trainer hasn't run?); nothing to score.")
+        return
+    trained_at = art["trained_at"]
+    builds = build_plays(args.ch_url, 0, args.score_hours, args.player)
+    # Out-of-sample by construction: only plays that finished AFTER the model's training
+    # corpus closed. trained_at IS the cutoff (lexicographic == chronological on UTC strings).
+    score_plays = [(p, b) for p, b in builds.items() if b["max_ts"] > trained_at]
+    scored_at = utc_now()
+    print(f"#608 score — model {art['model_version']} trained_at={trained_at}; "
+          f"{len(builds)} plays in last {args.score_hours}h, {len(score_plays)} out-of-sample")
+
+    rows = []
+    per_condition = collections.Counter()
+    for cond, cdata in art["conditions"].items():
+        model = deserialize_model(cdata["model"])
+        thr, anchor = cdata["thr"], cdata["anchor"]
+        lead, horizon = cdata["lead"], cdata["horizon"]
         n = 0
         for play, b in score_plays:
-            for w in episode_windows_full(b["full"], anchor, c["lead"], c["horizon"]):
+            for w in episode_windows_full(b["full"], anchor, lead, horizon):
                 toks = [x[3] for x in w]
                 # transition_surprises[j] is the surprise of token at window position j+1.
                 for j, (surprise, _prev, _cur) in enumerate(sc.transition_surprises(model, toks)):
@@ -128,10 +221,10 @@ def main():
                                  "entry_fingerprint": efp, "surface": surf, "condition": cond,
                                  "label": f"unexpected_{cond}",
                                  "severity": severity_for(surprise, thr), "score": round(surprise, 3),
-                                 "model_version": args.model_version, "scored_at": scored_at})
+                                 "model_version": art["model_version"], "scored_at": scored_at})
                     n += 1
         per_condition[cond] = n
-        print(f"  {cond:8} — train_eps={len(train_eps)} thr={thr:.1f} → {n} row labels")
+        print(f"  {cond:8} — thr={thr:.1f} → {n} row labels")
 
     # Dedup identical (row, condition) within this run (overlapping episodes can flag a row
     # twice); keep the most surprising. Cross-run dedup is the ReplacingMergeTree's job.
@@ -154,6 +247,23 @@ def main():
     body = ("\n".join(json.dumps(r) for r in rows) + "\n").encode()
     dt.ch(args.ch_url, f"INSERT INTO {dt.DB}.derived_labels FORMAT JSONEachRow", body=body)
     print(f"inserted {len(rows)} rows into {dt.DB}.derived_labels.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--mode", choices=["train", "score"], required=True)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--model-path", default=DEFAULT_MODEL_PATH, help="gzipped-JSON artifact shared by train+score")
+    ap.add_argument("--train-days", type=int, default=7, help="train: corpus window")
+    ap.add_argument("--score-hours", type=int, default=2, help="score: how far back to look for out-of-sample plays")
+    ap.add_argument("--player", default=None, help="limit to one player_id")
+    ap.add_argument("--max-order", type=int, default=4)
+    ap.add_argument("--alpha", type=float, default=0.5)
+    ap.add_argument("--min-train-episodes", type=int, default=20)
+    ap.add_argument("--model-version", default="vomm-tok-1")
+    ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT write")
+    args = ap.parse_args()
+    (cmd_train if args.mode == "train" else cmd_score)(args)
 
 
 if __name__ == "__main__":

--- a/analytics/tools/derive_labels.py
+++ b/analytics/tools/derive_labels.py
@@ -11,7 +11,7 @@ two operations that used to run together every tick:
                 row per condition to derived_models for observability. This is the only place
                 the expensive sc.train runs.
 
-  --mode score (FAST, ~1 min): load the latest artifact, score recent plays' transitions
+  --mode score (FAST, ~5 min): load the latest artifact, score recent plays' transitions
                 against it, and write one derived_labels row per above-threshold transition,
                 anchored on the EXACT row whose token was improbable. NO training.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -278,24 +278,26 @@ services:
       - app_network
     restart: unless-stopped
 
-  # #506 — scheduled anomaly LABEL derivation (the VOMM scorer's verdicts).
-  # Runs analytics/tools/derive_labels.py on a loop: trains per-condition
-  # VOMMs on older plays and scores recent plays OUT-OF-SAMPLE (time split),
-  # writing derived_labels so the surprise outliers are filterable in
-  # sessions.html + session-viewer. Like token-deriver, NOT on the hot path
-  # and bind-mounts the tools dir (model/tokenizer evolve without a rebuild).
-  # The score window must exceed the interval + a play's length so plays that
-  # finished since the last tick get scored; ReplacingMergeTree supersedes.
-  label-deriver:
+  # #506/#608 — anomaly LABEL derivation, SPLIT into train + score (the VOMM scorer's
+  # verdicts). The reference model (typical-episode grammar) changes slowly, so it is
+  # rebuilt slowly (label-trainer, nightly); scoring against it is cheap, so it runs often
+  # (label-scorer, ~1 min) for low-latency unexpected_<condition> chips. They share the
+  # model artifact through the `vomm-models` volume; both bind-mount the tools dir so the
+  # model/tokenizer evolve without a rebuild. Neither is on the hot path.
+
+  # TRAIN (slow): rebuild the full --train-days VOMM and write the gzipped-JSON artifact +
+  # a derived_models manifest row per condition. Bootstraps once on start, then nightly.
+  label-trainer:
     image: python:3.12-slim
-    container_name: infinite-streaming-label-deriver
+    container_name: infinite-streaming-label-trainer
     volumes:
       - ./analytics/tools:/tools:ro
+      - vomm-models:/models
     environment:
       - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
-      - LABEL_INTERVAL_SECONDS=${LABEL_INTERVAL_SECONDS:-3600}
+      - LABEL_TRAIN_INTERVAL_SECONDS=${LABEL_TRAIN_INTERVAL_SECONDS:-86400}
       - LABEL_TRAIN_DAYS=${LABEL_TRAIN_DAYS:-7}
-      - LABEL_SCORE_HOURS=${LABEL_SCORE_HOURS:-12}
+      - LABEL_MODEL_PATH=${LABEL_MODEL_PATH:-/models/labels-model.json.gz}
       - LABEL_MODEL_VERSION=${LABEL_MODEL_VERSION:-vomm-tok-1}
     command:
       - sh
@@ -303,9 +305,40 @@ services:
       - |
         sleep 25
         while true; do
-          python3 /tools/derive_labels.py --train-days "$$LABEL_TRAIN_DAYS" --score-hours "$$LABEL_SCORE_HOURS" --model-version "$$LABEL_MODEL_VERSION" \
-            || echo "[label-deriver] run failed (rc=$$?), retrying next tick"
-          sleep "$$LABEL_INTERVAL_SECONDS"
+          python3 /tools/derive_labels.py --mode train --train-days "$$LABEL_TRAIN_DAYS" --model-path "$$LABEL_MODEL_PATH" --model-version "$$LABEL_MODEL_VERSION" \
+            || echo "[label-trainer] run failed (rc=$$?), retrying next tick"
+          sleep "$$LABEL_TRAIN_INTERVAL_SECONDS"
+        done
+    depends_on:
+      clickhouse:
+        condition: service_started
+    networks:
+      - app_network
+    restart: unless-stopped
+
+  # SCORE (fast): load the latest artifact and score plays that post-date its trained_at
+  # (out-of-sample), writing derived_labels. Skips gracefully until the trainer's first run
+  # produces an artifact. ReplacingMergeTree(scored_at) supersedes re-scores within the window.
+  label-scorer:
+    image: python:3.12-slim
+    container_name: infinite-streaming-label-scorer
+    volumes:
+      - ./analytics/tools:/tools:ro
+      - vomm-models:/models
+    environment:
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - LABEL_SCORE_INTERVAL_SECONDS=${LABEL_SCORE_INTERVAL_SECONDS:-60}
+      - LABEL_SCORE_HOURS=${LABEL_SCORE_HOURS:-2}
+      - LABEL_MODEL_PATH=${LABEL_MODEL_PATH:-/models/labels-model.json.gz}
+    command:
+      - sh
+      - -c
+      - |
+        sleep 35
+        while true; do
+          python3 /tools/derive_labels.py --mode score --score-hours "$$LABEL_SCORE_HOURS" --model-path "$$LABEL_MODEL_PATH" \
+            || echo "[label-scorer] run failed (rc=$$?), retrying next tick"
+          sleep "$$LABEL_SCORE_INTERVAL_SECONDS"
         done
     depends_on:
       clickhouse:
@@ -318,3 +351,8 @@ services:
 networks:
   app_network:
     driver: bridge
+
+volumes:
+  # Shared between label-trainer (writes) and label-scorer (reads): the serialized VOMM
+  # artifact (#608). Decouples the slow nightly rebuild from the fast scoring loop.
+  vomm-models:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -281,7 +281,7 @@ services:
   # #506/#608 — anomaly LABEL derivation, SPLIT into train + score (the VOMM scorer's
   # verdicts). The reference model (typical-episode grammar) changes slowly, so it is
   # rebuilt slowly (label-trainer, nightly); scoring against it is cheap, so it runs often
-  # (label-scorer, ~1 min) for low-latency unexpected_<condition> chips. They share the
+  # (label-scorer, ~5 min) for low-latency unexpected_<condition> chips. They share the
   # model artifact through the `vomm-models` volume; both bind-mount the tools dir so the
   # model/tokenizer evolve without a rebuild. Neither is on the hot path.
 
@@ -327,7 +327,7 @@ services:
       - vomm-models:/models
     environment:
       - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
-      - LABEL_SCORE_INTERVAL_SECONDS=${LABEL_SCORE_INTERVAL_SECONDS:-60}
+      - LABEL_SCORE_INTERVAL_SECONDS=${LABEL_SCORE_INTERVAL_SECONDS:-300}
       - LABEL_SCORE_HOURS=${LABEL_SCORE_HOURS:-2}
       - LABEL_MODEL_PATH=${LABEL_MODEL_PATH:-/models/labels-model.json.gz}
     command:


### PR DESCRIPTION
## What & why

Closes #608. The `label-deriver` sidecar retrained the full 7-day VOMM **every tick** before scoring, flooring `unexpected_<condition>` chip latency at the 1 h retrain interval. But the reference model (the learned grammar of typical episodes) changes *slowly*, while scoring against it is *cheap* and is the only thing we want fresh.

This splits the two onto their natural cadences:

| | cadence | does |
|---|---|---|
| **`label-trainer`** | nightly (`LABEL_TRAIN_INTERVAL_SECONDS`, default 86400) | builds per-condition VOMMs over `--train-days`, calibrates p99 thresholds, serializes a gzipped-JSON artifact + writes a `derived_models` manifest row per condition |
| **`label-scorer`** | ~5 min (`LABEL_SCORE_INTERVAL_SECONDS`, default 300) | loads the artifact, scores out-of-sample plays, writes `derived_labels` — no training |

They share the artifact through a new `vomm-models` volume.

## Out-of-sample is strengthened, not weakened

The artifact stamps `trained_at` (when the corpus closed). The scorer only scores plays whose `max_ts` **post-dates** `trained_at` — those plays didn't exist when the model trained, so they're out-of-sample by construction. `trained_at` *is* the cutoff, replacing the old `now − score_hours` arithmetic.

## Changes

- **`analytics/tools/derive_labels.py`** — `--mode train | score`; gzip-JSON artifact (de)serialization of the PPM model; `build_plays()` shared by both modes. All per-row labeling semantics (anchoring, dedup, severity) unchanged.
- **`analytics/clickhouse/init.d/06-derived-models.sql`** — small observability manifest (`trained_at`, episode counts, thresholds, context/vocab sizes). The model artifact itself is the file, not a CH column.
- **`docker-compose.yml`** — `label-deriver` → `label-trainer` + `label-scorer` + `vomm-models` volume.
- **`05-derived-labels.sql`** — comment reflects the split.

## Verification

- **Round-trip correctness**: scorer surprises are bit-identical before/after `serialize → gzip → deserialize` (unit test).
- **Real-data smoke test** (test-dev CH): train over 7 d → **78 KB** artifact, 4 condition manifest rows (startup/fault/stall/end, thresholds 4.5/3.9/3.8/4.4); score loaded it, correctly filtered to the out-of-sample play, emitted anchored `unexpected_startup`/`unexpected_fault` rows. Temp footprint cleaned; `derived_models` table left in place (deploy needs it).
- `docker compose config` validates; all scripts `py_compile` clean.

## Notes
- Artifact is tiny (~78 KB gzipped — the token alphabet compresses hard), so the file-on-volume approach has no size pressure.
- The artifact seam is model-agnostic, leaving room for the #445 HMM to reuse it.
- **Deploy is not part of this PR.** On merge, the test-dev sidecar swap + new env vars (`LABEL_TRAIN_INTERVAL_SECONDS` / `LABEL_SCORE_INTERVAL_SECONDS`) need applying; the obsolete `LABEL_INTERVAL_SECONDS` override can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
