### PR TITLE
feat(607): aberration crawl — invariants catalogue, version-keyed census runner, calibrated assertions

### DIFF
--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -49,6 +49,9 @@ Length: one page rendered. If it grows past that, split.
   downshift cascades, what triggers timejump
 - `codec-strings.md` — avc1/hev1/mp4a profile-level-tier, what
   platforms require what, common stripping bugs
+- `invariants.md` — operating manual for the aberration-crawl rule
+  catalogue (`tests/aberration_crawl/invariants.yaml`): validity
+  windows, census-before-assert, documented NON-rules
 
 ## When to add a new one
 

--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -293,15 +293,21 @@ measured_mbps
 
 video_quality_pct
   type:        Float32
-  units:       percent 0–100
-  populated:   forwarder (derived from variant_idx and the manifest's
-               variant ladder)
+  units:       percent 0–100 (nominal; see gotchas)
+  populated:   player-SDK (player_metrics_video_quality_pct — NOT
+               forwarder-derived; verified against the main.go getF32
+               mapping during #607 Phase 1)
   meaning:     position in the variant ladder. 100% = top variant,
-               smaller values = lower variants. Computed at ingest.
+               smaller values = lower variants.
   gotchas:     "3.35%" doesn't mean playback is 3% of full quality
                visually — it means the player is on the lowest of N
                variants where the bottom is mapped to ~floor pct. Read
                as a relative position, not perceptual quality.
+               Top-variant rows routinely read 100.01 (player-side
+               float overshoot; ~70% of archive rows) — treat <=101 as
+               in-range. Values far above 100 (rare; observed up to
+               457) occur on early-play rows before the ladder is
+               known; video_resolution/content_id are empty on them.
 
 video_first_frame_time_s
   type:        Float32
@@ -315,8 +321,15 @@ video_start_time_s
   type:        Float32
   units:       seconds (since playback intent)
   populated:   player-SDK
-  meaning:     time until the player committed to a variant. Always <=
-               video_first_frame_time_s.
+  meaning:     time until AVPlayer's timeControlStatus first flipped to
+               .playing — "playing smoothly", the Conviva-style VST
+               signal (PlayerViewModel.markPlayingStarted).
+  gotchas:     typically >= video_first_frame_time_s — first frame
+               renders (isReadyForDisplay), THEN playback rate ramps.
+               The two are independent KVO observables, so the order
+               is typical, not guaranteed. (This entry previously
+               claimed the opposite direction; corrected during #607
+               Phase 1 after 45% of archive rows "violated" it.)
 ```
 
 ### 1.c Stalls, errors, lifecycle counters
@@ -710,7 +723,7 @@ Read via:
              routing only)
 ```
 
-**Note on `transfer_ms`:** it's NOT the wire-delivery time to the player; it's proxy→upstream. See §2.d for the full gotcha. This is the most-misread field in this table.
+**Note on `transfer_ms`:** it IS the downstream write+flush time to the player (client-perceived receive) — but `dns/connect/tls/ttfb` are upstream-scoped, and `total_ms` is unreliably maintained. See §2.d; this family is the most-misread in the table (including by an earlier revision of this doc).
 
 ### 2.a Identity
 
@@ -840,24 +853,33 @@ transfer_ms
   type:        Float32
   units:       ms
   populated:   proxy
-  meaning:     UPSTREAM transfer time — time between ttfb and the last
-               byte received from upstream.
-  gotchas:     **this is NOT the wire-delivery time to the player.**
-               If the proxy is shaping egress with tc, transfer_ms can
-               be sub-millisecond (upstream is local) while the actual
-               wire delivery takes tens of seconds. To compute the
-               actual wire-delivery time, derive from consecutive `ts`
-               deltas. This was misinterpreted in a 2026-05-25 chat
-               investigation; carrying the lesson forward as a top-tier
-               gotcha.
+  meaning:     DOWNSTREAM write+flush time to the player — the
+               client-perceived `receive` phase, where traffic-shaping
+               backpressure appears (streamToClientMeasured /
+               NetworkLogEntry doc comment in go-proxy main.go).
+  gotchas:     this entry previously claimed transfer_ms was UPSTREAM
+               transfer time and "NOT wire-delivery to the player" —
+               that described pre-2026-02-13 semantics (the field was
+               re-pointed downstream in 9fb686d) and was corrected
+               during #607 Phase 1 source-verification. Under shaping,
+               transfer_ms DOES grow with the cap (e.g. ~103ms segment
+               writes under a 100 Mbps cap on test-dev). dns/connect/
+               tls/ttfb remain UPSTREAM-scoped — the table mixes the
+               two views; read each field's scope individually.
 
 total_ms
   type:        Float32
   units:       ms
   populated:   proxy
-  meaning:     dns + connect + tls + ttfb + transfer — total upstream
-               request time. Same gotcha as transfer_ms: NOT
-               wire-to-player time.
+  meaning:     nominally max(time-to-upstream-headers, ttfb + transfer)
+               — initially set when upstream headers complete, then
+               lifted by mergeTotalTiming() to ttfb_ms + transfer_ms.
+  gotchas:     the lift is NOT applied on every code path: ~26% of
+               archive rows have total_ms ≈ ttfb_ms while transfer_ms
+               is 100x larger (#607 Phase 1 census). Until that's
+               fixed, prefer ttfb_ms + transfer_ms over total_ms for
+               request duration. The old formula documented here
+               (dns+connect+tls+ttfb+transfer) never matched the code.
 
 client_wait_ms
   type:        Float32
@@ -870,7 +892,7 @@ client_wait_ms
                total_ms stays sub-ms.
 ```
 
-**Rule of thumb for "how long did the player wait":** `client_wait_ms` is closest to truth, but for shaped delivery it can still underestimate because the proxy may have started writing to the socket before all bytes are on the wire. The most accurate wire time = (ts of THIS request - ts of NEXT same-variant segment request) under steady fetch cadence.
+**Rule of thumb for "how long did the player wait":** `client_wait_ms` (time to first response byte) + `transfer_ms` (downstream write+flush) covers the request end-to-end from the player's side; the final kernel-buffer flush can still trail the last write, so for exact wire time under heavy shaping use (ts of THIS request - ts of NEXT same-variant segment request) under steady fetch cadence.
 
 ### 2.e Fault injection
 

--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -324,12 +324,13 @@ video_start_time_s
   meaning:     time until AVPlayer's timeControlStatus first flipped to
                .playing — "playing smoothly", the Conviva-style VST
                signal (PlayerViewModel.markPlayingStarted).
-  gotchas:     typically >= video_first_frame_time_s — first frame
-               renders (isReadyForDisplay), THEN playback rate ramps.
-               The two are independent KVO observables, so the order
-               is typical, not guaranteed. (This entry previously
-               claimed the opposite direction; corrected during #607
-               Phase 1 after 45% of archive rows "violated" it.)
+  gotchas:     NO ordering contract vs video_first_frame_time_s. The
+               two are independent KVO observables; measured per-play
+               over the full archive (#607, 2026-06-04): 44% ttff
+               after vst, 40% before, 6% equal (n=1,326). An earlier
+               revision claimed "always vst <= ttff" and the iOS source
+               comment claims first-frame-typically-first — both are
+               contradicted by data. Use each on its own terms.
 ```
 
 ### 1.c Stalls, errors, lifecycle counters
@@ -766,14 +767,16 @@ query_string
 
 ```
 request_kind
-  type:        LowCardinality(String) — 'manifest' | 'segment' | 'init' | 'other'
+  type:        LowCardinality(String) — 'master_manifest' | 'manifest' |
+               'segment' | 'init' | 'other'
   populated:   proxy (heuristic from URL path)
-  meaning:     what KIND of HTTP request this is, semantically. 'manifest'
-               = .m3u8 / .mpd; 'segment' = .m4s / .ts / .mp4; 'init' =
-               init.mp4 / .init.m4s; 'other' = everything else.
-  gotchas:     'manifest' covers BOTH master and variant playlists — use
-               URL pattern matching to distinguish (master usually has
-               `master_` prefix; variant has `playlist_6s_<variant>`).
+  meaning:     what KIND of HTTP request this is, semantically.
+               'master_manifest' = the master playlist; 'manifest' =
+               variant playlists; 'segment' = .m4s / .ts / .mp4; 'init'
+               = init.mp4 / .init.m4s; 'other' = everything else.
+  gotchas:     an earlier revision said 'manifest' covered both master
+               and variant playlists — stale: master_manifest is its
+               own value (5,163 archive rows; #607 Phase 2 census).
 
 status
   type:        UInt16

--- a/.claude/standards/invariants.md
+++ b/.claude/standards/invariants.md
@@ -1,0 +1,48 @@
+# Invariants — the aberration-crawl rule catalogue
+
+Machine-checkable behaviour rules distilled from the standards library, run
+against the CH archive grouped by version taxonomy (#607). The canonical
+catalogue is **`tests/aberration_crawl/invariants.yaml`** — this page is the
+operating manual, not the rule list.
+
+## The 3 facts
+
+- **Every rule has a validity window, and git dates lie.** The #550 taxonomy
+  hit test-dev on 2026-05-29 — two days *before* its PR merged to dev
+  (hot-deploys). `applicable_since` must be data-calibrated (Phase 3), not
+  copied from `git log`. A rule crawled outside its window "discovers"
+  migrations, not bugs.
+- **Version keys are usable from 2026-05-29 only.** Before that, all rows are
+  version-blind (0% coverage). The crawler still runs version-independent
+  rules (ID case, label grammar, vocabularies) on older rows but reports them
+  in an `unversioned` bucket. External HLS players (unmatched UA) form a
+  separate always-empty group — report it, never merge it.
+- **Census before assert.** Every rule starts `mode: census` (count, never
+  fail). Promotion to `assert` requires one clean calibration pass over the
+  full retained archive. Two rules are structurally census-locked for now:
+  `qoe-cirr-label-recompute` (the seek-exclusion question in
+  [[qoe-metrics]] is unsettled) and `play-start-unique` (#604/#605/#606 not
+  deployed, `pending: true`).
+
+## Common mistakes
+
+- Adding a rule from the **NON-rules list** at the bottom of invariants.yaml
+  (bitrate ≤ cap, resolution stable at play start, error fields empty on sim,
+  …). Each is documented-false; that's why the list exists.
+- Forgetting the **known-noise exclusions** (`-12174` sim noise, first-2-
+  samples carry-forward) — violations vanish or explode depending on whether
+  they're applied. The runner logs dropped-row counts per exclusion; a census
+  with zero logged exclusions on an iOS group is suspect.
+- Treating **QoE thresholds as constants** — they're deploy-time config
+  (`FORWARDER_QOE_THRESHOLDS_PATH`). Resolve the running tier from the
+  `[QoE]` startup log line before comparing recomputed values to labels.
+- Comparing rule output **across the 2026-06-02 rename boundary**
+  (`session_end`→`play_end`, qoe_* namespace consolidation #570) without
+  splitting the window.
+
+## See also
+
+- `tests/aberration_crawl/invariants.yaml` — the catalogue (canonical)
+- [[data-fields]] — the field semantics the rules encode
+- [[qoe-metrics]] — formulas + the open seek-exclusion divergence
+- Issue #607 — phases, census results, validity-window anchors

--- a/go.work
+++ b/go.work
@@ -12,6 +12,7 @@ go 1.25.0
 use (
 	./analytics/go-forwarder
 	./go-proxy
+	./tests/aberration_crawl
 	./tests/characterization
 	./tests/server_behavior
 	./tools/harness-cli

--- a/tests/aberration_crawl/README.md
+++ b/tests/aberration_crawl/README.md
@@ -1,0 +1,68 @@
+# Aberration crawl (#607)
+
+Runs the machine-checkable invariants catalogue (`invariants.yaml`)
+against the analytics ClickHouse archive, grouped by the #550 Phase 4
+version taxonomy (`app_version × os_version_major × device_class ×
+player_tech`). A behaviour regression shows up as "rule R holds
+everywhere except app 2.3.1 on tvOS".
+
+Operating manual (validity windows, census-before-assert, NON-rules):
+[`.claude/standards/invariants.md`](../../.claude/standards/invariants.md).
+
+## Run
+
+ClickHouse on test-dev is loopback-bound — tunnel first:
+
+```bash
+ssh -f -N -L 21123:127.0.0.1:21123 $TEST_SSH   # from .env
+cd tests/aberration_crawl
+go test -run TestAberrationCensus -v -timeout 20m
+```
+
+The test **skips** (not fails) when CH is unreachable, so it's safe in CI.
+`TestCatalogueValid` is the CH-free structural check.
+
+## Env vars
+
+| var | default | meaning |
+|---|---|---|
+| `ABERRATION_CH_URL` | `http://127.0.0.1:21123` | ClickHouse HTTP endpoint |
+| `ABERRATION_DB` | `infinite_streaming` | database |
+| `ABERRATION_CH_USER` / `_PASSWORD` | _(none)_ | basic auth if the CH user needs it |
+| `ABERRATION_MODE` | `census` | `assert` fails on error-severity rules whose catalogue `mode: assert` |
+| `ABERRATION_REPORT` | _(unset)_ | path to write the full JSON report |
+
+## Reading the output
+
+- One line per rule×table: `ok` / `N viol` / `SKIP` / `ERROR`, rows
+  checked, effective `since` window.
+- Per-group detail lines appear only where violations exist — the group
+  string is `app|osMajor|class|tech`, or `unversioned` for pre-taxonomy
+  rows (before 2026-05-29) and UA-unparsed external players.
+- Up to 3 `exemplar` lines per violating rule give `(player_id, play_id,
+  ts)` for drill-down via the `investigate` / `forensics` skills.
+- `[pending]` = the producing change isn't deployed yet (e.g.
+  `play-start-unique` until #604/#605/#606 land); violations expected.
+
+## Adding a rule
+
+Add an entry to `invariants.yaml` (kinds: `row`, `vocab`, `monotonic`,
+`sequence`, `play`, `sql` — see the header comment there for the runner
+contract). Then:
+
+1. `go test -run TestCatalogueValid` — structural check.
+2. Run the census and **look at the violations before believing the
+   rule**. Phase 1/2 falsified five documented claims this way (vst/ttff
+   ordering, quality_pct range, transfer_ms scope, total_ms formula,
+   request_kind vocabulary) — when a predicate fires on >1% of rows,
+   suspect the rule (or the doc it came from) before the data.
+3. Census-only until a clean calibration pass; only then set
+   `mode: assert`.
+4. If the rule encodes a date-bound behaviour change, record the
+   data-calibrated date in `applicable_since` — git merge dates are
+   hints, hot-deploys make them wrong (taxonomy deployed 2 days before
+   its PR merged).
+
+`kind: sql` rules are sketch-only in Phase 2 (`sql_sketch` documents the
+intended query); the runner logs and skips them. They're implemented in
+Phase 3 along with QoE label recomputation.

--- a/tests/aberration_crawl/ch.go
+++ b/tests/aberration_crawl/ch.go
@@ -1,0 +1,111 @@
+package aberration_crawl
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// CHClient is a minimal ClickHouse HTTP client (JSONEachRow), same
+// shape as the forwarder's llm_tool_query.go runSelect.
+type CHClient struct {
+	URL      string
+	Database string
+	User     string
+	Password string
+	HTTP     *http.Client
+}
+
+// NewCHClientFromEnv reads ABERRATION_CH_URL (default
+// http://127.0.0.1:21123 — test-dev's loopback-bound CH; tunnel with
+// `ssh -L 21123:127.0.0.1:21123 $TEST_SSH`), ABERRATION_CH_USER,
+// ABERRATION_CH_PASSWORD, ABERRATION_DB (default infinite_streaming).
+func NewCHClientFromEnv() *CHClient {
+	get := func(k, def string) string {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+		return def
+	}
+	return &CHClient{
+		URL:      get("ABERRATION_CH_URL", "http://127.0.0.1:21123"),
+		Database: get("ABERRATION_DB", "infinite_streaming"),
+		User:     os.Getenv("ABERRATION_CH_USER"),
+		Password: os.Getenv("ABERRATION_CH_PASSWORD"),
+		HTTP:     &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// Query runs sql and returns JSONEachRow-decoded rows. Numbers decode
+// as json.Number so UInt64 counters survive intact.
+func (c *CHClient) Query(ctx context.Context, sql string) ([]map[string]any, error) {
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return nil, err
+	}
+	qs := u.Query()
+	qs.Set("default_format", "JSONEachRow")
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(sql))
+	if err != nil {
+		return nil, err
+	}
+	if c.User != "" {
+		req.SetBasicAuth(c.User, c.Password)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var out []map[string]any
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		dec := json.NewDecoder(strings.NewReader(string(line)))
+		dec.UseNumber()
+		var row map[string]any
+		if err := dec.Decode(&row); err != nil {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out, scanner.Err()
+}
+
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case json.Number:
+		i, _ := n.Int64()
+		return i
+	case float64:
+		return int64(n)
+	case string:
+		var i int64
+		fmt.Sscanf(n, "%d", &i)
+		return i
+	}
+	return 0
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/tests/aberration_crawl/crawl_test.go
+++ b/tests/aberration_crawl/crawl_test.go
@@ -1,0 +1,113 @@
+package aberration_crawl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+	"time"
+)
+
+// TestAberrationCensus runs the full invariants catalogue against the
+// archive. Census mode (default) reports and never fails on violations;
+// ABERRATION_MODE=assert fails on error-severity rules whose mode is
+// 'assert' in the catalogue (none yet — promotion happens in Phase 3).
+//
+// Requires ClickHouse at ABERRATION_CH_URL (default
+// http://127.0.0.1:21123; tunnel: ssh -L 21123:127.0.0.1:21123 $TEST_SSH).
+// Skips when CH is unreachable.
+func TestAberrationCensus(t *testing.T) {
+	ch := NewCHClientFromEnv()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	if _, err := ch.Query(ctx, "SELECT 1"); err != nil {
+		t.Skipf("ClickHouse unreachable at %s (%v) — tunnel with: ssh -L 21123:127.0.0.1:21123 $TEST_SSH", ch.URL, err)
+	}
+
+	cat, err := LoadCatalogue("invariants.yaml")
+	if err != nil {
+		t.Fatalf("load catalogue: %v", err)
+	}
+	t.Logf("catalogue: %d rules", len(cat.Rules))
+
+	results := RunAll(ctx, ch, cat)
+
+	assertMode := os.Getenv("ABERRATION_MODE") == "assert"
+	var lines []string
+	for _, rr := range results {
+		switch {
+		case rr.Err != "":
+			lines = append(lines, fmt.Sprintf("ERROR  %-32s %-18s %s", rr.RuleID, rr.Table, rr.Err))
+			t.Errorf("rule %s/%s: query error: %s", rr.RuleID, rr.Table, rr.Err)
+			continue
+		case rr.Skipped != "":
+			lines = append(lines, fmt.Sprintf("SKIP   %-32s %-18s %s", rr.RuleID, rr.Table, rr.Skipped))
+			continue
+		}
+		total := rr.TotalViolations()
+		var checked int64
+		for _, g := range rr.Groups {
+			checked += g.Checked
+		}
+		status := "ok"
+		if total > 0 {
+			status = fmt.Sprintf("%d viol", total)
+		}
+		pend := ""
+		if rr.Pending {
+			pend = " [pending]"
+		}
+		lines = append(lines, fmt.Sprintf("%-6s %-32s %-18s checked=%-9d since=%s%s",
+			status, rr.RuleID, rr.Table, checked, rr.Since, pend))
+
+		// Per-group detail only where violations exist.
+		for _, g := range rr.Groups {
+			if g.Violations > 0 {
+				lines = append(lines, fmt.Sprintf("         %-40s %d/%d (excl %d)",
+					g.Group, g.Violations, g.Checked, g.Excluded))
+			}
+		}
+		for _, v := range rr.UnknownValues {
+			lines = append(lines, fmt.Sprintf("         unknown %-32s ×%d", v.Value, v.Count))
+		}
+		for _, e := range rr.Exemplars {
+			lines = append(lines, fmt.Sprintf("         exemplar player=%s play=%s ts=%s", e.PlayerID, e.PlayID, e.TS))
+		}
+
+		if assertMode && rr.Mode == "assert" && !rr.Pending && rr.Severity == "error" && total > 0 {
+			t.Errorf("ASSERT rule %s/%s: %d violations", rr.RuleID, rr.Table, total)
+		}
+	}
+
+	sort.SliceStable(lines, func(i, j int) bool { return false }) // keep catalogue order
+	for _, l := range lines {
+		t.Log(l)
+	}
+
+	if path := os.Getenv("ABERRATION_REPORT"); path != "" {
+		blob, err := json.MarshalIndent(results, "", "  ")
+		if err == nil {
+			err = os.WriteFile(path, blob, 0o644)
+		}
+		if err != nil {
+			t.Errorf("write report %s: %v", path, err)
+		} else {
+			t.Logf("report written: %s", path)
+		}
+	}
+}
+
+// TestCatalogueValid is the cheap CI-side check: the YAML parses and
+// every rule passes structural validation, no CH needed.
+func TestCatalogueValid(t *testing.T) {
+	cat, err := LoadCatalogue("invariants.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cat.Rules) < 30 {
+		t.Errorf("catalogue has %d rules; expected >= 30 (issue #607 acceptance)", len(cat.Rules))
+	}
+}

--- a/tests/aberration_crawl/go.mod
+++ b/tests/aberration_crawl/go.mod
@@ -1,0 +1,5 @@
+module github.com/jonathaneoliver/infinite-streaming/tests/aberration_crawl
+
+go 1.25.0
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/tests/aberration_crawl/go.sum
+++ b/tests/aberration_crawl/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/aberration_crawl/invariants.go
+++ b/tests/aberration_crawl/invariants.go
@@ -1,0 +1,155 @@
+// Package aberration_crawl runs the invariants catalogue
+// (invariants.yaml) against the analytics ClickHouse archive, grouped
+// by the #550 Phase 4 version taxonomy. Issue #607.
+package aberration_crawl
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Catalogue mirrors invariants.yaml.
+type Catalogue struct {
+	Version  int      `yaml:"version"`
+	Defaults Defaults `yaml:"defaults"`
+	Groups   Groups   `yaml:"groups"`
+	Rules    []Rule   `yaml:"rules"`
+}
+
+type Defaults struct {
+	Mode      string   `yaml:"mode"`
+	Partition []string `yaml:"partition"`
+	Order     string   `yaml:"order"`
+}
+
+type Groups struct {
+	By                []string `yaml:"by"`
+	UnversionedBucket bool     `yaml:"unversioned_bucket"`
+}
+
+type Rule struct {
+	ID       string   `yaml:"id"`
+	Tables   []string `yaml:"tables"`
+	Kind     string   `yaml:"kind"` // row | vocab | monotonic | sequence | play | sql
+	Severity string   `yaml:"severity"`
+	Mode     string   `yaml:"mode"`    // census (default) | assert
+	Pending  bool     `yaml:"pending"` // producing change not deployed; never assert
+	Where    string   `yaml:"where"`   // optional row pre-filter
+
+	// kind: row | sequence | play
+	Violation string `yaml:"violation"`
+
+	// kind: vocab
+	Field   string   `yaml:"field"`
+	Allowed []string `yaml:"allowed"`
+
+	// kind: monotonic
+	Fields []string `yaml:"fields"`
+
+	// kind: sequence — lag_cols get prev_<col> aliases; columns lists
+	// extra columns the violation references (so the inner SELECT can
+	// stay narrow instead of SELECT *).
+	LagCols []string `yaml:"lag_cols"`
+	Columns []string `yaml:"columns"`
+
+	// kind: play
+	Aggregates map[string]string `yaml:"aggregates"`
+
+	// kind: sql — sketch only; the runner logs and skips.
+	SQLSketch string `yaml:"sql_sketch"`
+
+	ApplicableSince ApplicableSince `yaml:"applicable_since"`
+	Exclusions      []Exclusion     `yaml:"exclusions"`
+	Source          string          `yaml:"source"`
+	Rationale       string          `yaml:"rationale"`
+}
+
+type ApplicableSince struct {
+	Date string `yaml:"date"`
+	Note string `yaml:"note"`
+}
+
+type Exclusion struct {
+	Name  string `yaml:"name"`
+	Where string `yaml:"where"` // empty = documentation-only
+	Note  string `yaml:"note"`
+}
+
+// SinceDate parses applicable_since.date; pending / unparseable dates
+// fall back to the archive floor (census still runs, assert never does).
+func (r Rule) SinceDate(archiveFloor string) string {
+	if _, err := time.Parse("2006-01-02", r.ApplicableSince.Date); err != nil {
+		return archiveFloor
+	}
+	return r.ApplicableSince.Date
+}
+
+func (r Rule) EffectiveMode(def string) string {
+	m := r.Mode
+	if m == "" {
+		m = def
+	}
+	if r.Pending {
+		return "census"
+	}
+	return m
+}
+
+func LoadCatalogue(path string) (*Catalogue, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var c Catalogue
+	if err := yaml.Unmarshal(raw, &c); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := c.validate(); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return &c, nil
+}
+
+func (c *Catalogue) validate() error {
+	seen := map[string]bool{}
+	for _, r := range c.Rules {
+		if r.ID == "" {
+			return fmt.Errorf("rule with empty id")
+		}
+		if seen[r.ID] {
+			return fmt.Errorf("duplicate rule id %q", r.ID)
+		}
+		seen[r.ID] = true
+		if len(r.Tables) == 0 {
+			return fmt.Errorf("rule %s: no tables", r.ID)
+		}
+		switch r.Kind {
+		case "row", "sequence", "play":
+			if r.Violation == "" {
+				return fmt.Errorf("rule %s (kind %s): violation required", r.ID, r.Kind)
+			}
+			if r.Kind == "play" && len(r.Aggregates) == 0 {
+				return fmt.Errorf("rule %s: play kind needs aggregates", r.ID)
+			}
+			if r.Kind == "sequence" && len(r.LagCols) == 0 {
+				return fmt.Errorf("rule %s: sequence kind needs lag_cols", r.ID)
+			}
+		case "vocab":
+			if r.Field == "" || len(r.Allowed) == 0 {
+				return fmt.Errorf("rule %s: vocab kind needs field + allowed", r.ID)
+			}
+		case "monotonic":
+			if len(r.Fields) == 0 {
+				return fmt.Errorf("rule %s: monotonic kind needs fields", r.ID)
+			}
+		case "sql":
+			// sketch-only; nothing to validate yet
+		default:
+			return fmt.Errorf("rule %s: unknown kind %q", r.ID, r.Kind)
+		}
+	}
+	return nil
+}

--- a/tests/aberration_crawl/invariants.go
+++ b/tests/aberration_crawl/invariants.go
@@ -58,8 +58,13 @@ type Rule struct {
 	// kind: play
 	Aggregates map[string]string `yaml:"aggregates"`
 
-	// kind: sql — sketch only; the runner logs and skips.
-	SQLSketch string `yaml:"sql_sketch"`
+	// kind: sql — SQL must return grp, checked, violations; {db} and
+	// {since} placeholders are substituted. ExemplarSQL (optional) must
+	// return player_id, play_id, ts. Rules with only sql_sketch are
+	// logged and skipped.
+	SQL         string `yaml:"sql"`
+	ExemplarSQL string `yaml:"exemplar_sql"`
+	SQLSketch   string `yaml:"sql_sketch"`
 
 	ApplicableSince ApplicableSince `yaml:"applicable_since"`
 	Exclusions      []Exclusion     `yaml:"exclusions"`

--- a/tests/aberration_crawl/invariants.yaml
+++ b/tests/aberration_crawl/invariants.yaml
@@ -1,0 +1,513 @@
+# invariants.yaml — machine-checkable behaviour rules for the aberration crawl (#607)
+#
+# Each rule encodes one documented behaviour from the standards library
+# (.claude/standards/data-fields.md, qoe-metrics.md, the label vocabulary)
+# as a predicate the crawler can run against the ClickHouse archive,
+# grouped by the #550 Phase 4 version taxonomy.
+#
+# Runner contract (tests/aberration_crawl, Phase 2):
+#   - Rules run grouped by `groups.by` (version taxonomy). Rows where all
+#     group keys are empty/0 fall into the `unversioned` bucket — reported
+#     separately, never silently merged.
+#   - `mode: census` (default) counts violations, never fails.
+#     `mode: assert` fails the run on any violation (only set after the
+#     rule survives a Phase 3 calibration pass).
+#   - `applicable_since.date` bounds the crawl window per rule. Dates are
+#     test-dev DATA-calibrated where the census confirmed them; merge-date
+#     hints otherwise (note says which). `pending: true` = the producing
+#     change is not yet deployed; rule stays census regardless of mode.
+#   - `exclusions` are row filters applied BEFORE counting; the runner
+#     logs how many rows each exclusion dropped (no silent caps).
+#
+# Rule kinds:
+#   row        violation = boolean SQL over one row (TRUE = violation)
+#   vocab      field + allowed[]; reports distinct unknown values + counts
+#              (inherently census — vocabulary growth is a finding, not a failure)
+#   monotonic  fields[] must be non-decreasing within partition ordered by ts
+#   sequence   violation may reference prev_<col> for cols in lag_cols[]
+#              (lagInFrame within partition ordered by ts)
+#   play       aggregates{} computed per (player_id, play_id); violation
+#              is a boolean over the aggregate names
+#   sql        full custom SELECT; must return group keys + checked + violations
+#              (escape hatch for cross-table rules)
+
+version: 1
+
+defaults:
+  mode: census
+  partition: [player_id, play_id]
+  order: ts
+
+groups:
+  by: [app_version, os_version_major, device_class, player_tech]
+  unversioned_bucket: true
+
+# ---------------------------------------------------------------------------
+# A. Identity & label grammar (all history — version-independent)
+# ---------------------------------------------------------------------------
+
+rules:
+  - id: ids-lowercase-events
+    tables: [session_events]
+    kind: row
+    severity: error
+    violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
+    applicable_since: { date: "2026-05-15", note: "whole retained archive; canonicalV2ID() predates it" }
+    source: "data-fields.md §1.a player_id gotcha; memory case_sensitivity_ids"
+    rationale: "Any uppercase UUID in CH means an ingest path bypassed canonicalV2ID()."
+
+  - id: ids-lowercase-network
+    tables: [network_requests]
+    kind: row
+    severity: error
+    violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.a; memory case_sensitivity_ids"
+
+  - id: ids-lowercase-control
+    tables: [control_events]
+    kind: row
+    severity: error
+    violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.a; memory case_sensitivity_ids"
+
+  - id: label-grammar
+    tables: [session_events, network_requests, control_events]
+    kind: row
+    severity: error
+    violation: >-
+      arrayExists(l -> NOT match(l, '^(testing|info|warning|error|critical)=\\*?[^,=]+$'), labels)
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §5 label grammar; reference_labelplay_value_encoding"
+    rationale: "Closed severity set; '*' synthMark optional; no ',' or '=' in the value part."
+
+  - id: control-row-has-synth-label
+    tables: [control_events]
+    kind: row
+    severity: warn
+    violation: "length(labels) = 0 OR NOT arrayExists(l -> position(l, '=*') > 0, labels)"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §3.d — every control row gets >=1 label incl. its synth event label"
+    rationale: "label_changed KV expansions are unstarred, but the event's own *-label must be present."
+
+  - id: control-event-vocab
+    tables: [control_events]
+    kind: vocab
+    severity: warn
+    field: event
+    allowed:
+      [fault_on, fault_off, pattern_step, shaper_changed, loop_server,
+       fault_rule_enabled, fault_rule_disabled, fault_rule_config_change,
+       pattern_enabled, pattern_disabled, pattern_config_change,
+       shaper_config_change, timeouts_changed, label_changed,
+       content_changed, session_start, session_end, control_change]
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §3.b (closed set)"
+    rationale: "New values are findings to document, not necessarily bugs — hence vocab/census."
+
+  - id: control-source-vocab
+    tables: [control_events]
+    kind: vocab
+    severity: warn
+    field: source
+    allowed: [harness, proxy, auto]
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §3.a"
+
+# ---------------------------------------------------------------------------
+# B. session_events — row-level field coherence
+# ---------------------------------------------------------------------------
+
+  - id: ttff-le-vst
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: >-
+      video_start_time_s > 0 AND video_first_frame_time_s > 0
+      AND video_first_frame_time_s > video_start_time_s
+    applicable_since: { date: "2026-05-15" }
+    source: >-
+      PlayerViewModel.swift markPlayingStarted/markFirstFrameRendered —
+      vst = timeControlStatus==.playing, ttff = isReadyForDisplay;
+      'typical order: first-frame fires before .playing'
+    rationale: >-
+      Direction VERIFIED against iOS source during Phase 1 smoke-test
+      (2026-06-04): data-fields.md had it backwards ('always vst <= ttff'
+      — 45% of archive rows violated). The two signals are independent
+      KVO observables, so inversion is atypical, not impossible: warn.
+
+  - id: playback-status-vocab
+    tables: [session_events]
+    kind: vocab
+    severity: error
+    field: playback_status
+    allowed: [in_progress, completed, user_stopped, start_failure, abandoned_start, mid_stream_failure]
+    applicable_since: { date: "2026-05-29", note: "#550 Phase 2 on test-dev (data-calibrated)" }
+    source: "data-fields.md §1.c playback_status (closed enum)"
+
+  - id: terminal-error-implies-failure
+    tables: [session_events]
+    kind: row
+    severity: error
+    violation: >-
+      terminal_error_code != 0
+      AND playback_status NOT IN ('start_failure', 'abandoned_start', 'mid_stream_failure')
+    applicable_since: { date: "2026-06-02", note: "#561/#562 terminal_error population (merge-date hint)" }
+    source: "data-fields.md §1.c terminal_error_code — 'ONLY on terminal failure rows'"
+
+  - id: waiting-reason-implies-buffering
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "waiting_reason != '' AND player_state != 'buffering'"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.b waiting_reason — 'empty when not buffering'"
+    rationale: "Census first: the doc says reading it outside buffering is meaningless, not that it's cleared."
+
+  - id: quality-pct-range
+    tables: [session_events]
+    kind: row
+    severity: error
+    violation: "video_quality_pct < 0 OR video_quality_pct > 101"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.b video_quality_pct (percent 0-100)"
+    rationale: >-
+      Tolerance to 101: the player-side ladder math emits 100.01 on ~70%
+      of top-variant rows (975k rows, benign float overshoot — Phase 1
+      smoke-test 2026-06-04). Real violations found: 21 rows up to 457.6,
+      all with empty video_resolution/content_id (early-play, ladder
+      unknown) — kept as violations; they're the exemplar drill-downs.
+
+  - id: version-fields-coherent
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "app_version != '' AND os_version_major = 0"
+    applicable_since: { date: "2026-05-29", note: "#550 Phase 4 on test-dev (data-calibrated, census 2026-06-04)" }
+    source: "Phase 0 census — 23 rows / 5 plays with app_version set but os 0.0"
+    rationale: "DeviceInfo should populate atomically; partial population = plumbing gap."
+
+  - id: nonnegative-gauges
+    tables: [session_events]
+    kind: row
+    severity: error
+    violation: "buffer_depth_s < 0 OR position_s < 0 OR playback_rate < 0"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.b (units: seconds / ratio; negatives undefined)"
+
+  - id: stall-duration-on-stall-end
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "last_event = 'stall_end' AND stall_duration_ms = 0"
+    applicable_since: { date: "2026-05-29", note: "#550 Phase 1 on test-dev" }
+    source: "data-fields.md §1.c stall_duration_ms — set on the stall_end row, sticky after"
+
+  - id: buffering-duration-on-buffering-end
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "last_event = 'buffering_end' AND buffering_duration_ms = 0"
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c buffering_duration_ms"
+
+  - id: legacy-stall-mirror-count
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "stall_count != stalling_count"
+    applicable_since: { date: "2026-05-29", note: "soft-cutover mirror window; retire rule when legacy columns drop" }
+    source: "data-fields.md §1.c legacy stall fields — forwarder mirror-writes from canonical"
+
+  - id: legacy-stall-mirror-time
+    tables: [session_events]
+    kind: row
+    severity: warn
+    violation: "abs(stall_time_s * 1000 - stalling_time_ms) > 1500"
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c — same mirror, time variant (1.5s tolerance for float/rounding)"
+
+# ---------------------------------------------------------------------------
+# C. session_events — sequence / play-level
+# ---------------------------------------------------------------------------
+
+  - id: residency-time-monotonic
+    tables: [session_events]
+    kind: monotonic
+    severity: error
+    fields: [playing_time_ms, pausing_time_ms, buffering_time_ms, stalling_time_ms,
+             idling_time_ms, seeking_time_ms, trickplaying_time_ms]
+    applicable_since: { date: "2026-05-29", note: "#550 Phase 1 on test-dev. STRICT monotonicity only holds post-#605/#606 (play_id fire-time pinning): pre-deploy plays can interleave two clients' accumulator streams under one play_id (#603 family — confirmed live in the 2026-06-03 archive during smoke-testing). Until then violations are mostly known-bug symptoms; stay census." }
+    source: "data-fields.md §1.c — cumulative since play start; resets only at play_id boundary"
+
+  - id: residency-count-monotonic
+    tables: [session_events]
+    kind: monotonic
+    severity: error
+    fields: [playing_count, pausing_count, buffering_count, stalling_count,
+             idling_count, seeking_count, trickplaying_count]
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c — state-entry counters"
+
+  - id: lifecycle-counters-monotonic
+    tables: [session_events]
+    kind: monotonic
+    severity: error
+    fields: [frames_displayed, frames_dropped, error_count, stall_count,
+             player_restarts, profile_shift_count, loop_count_player]
+    applicable_since: { date: "2026-05-15", note: "frames_*/error_count only meaningful post-2026-05-29" }
+    source: "data-fields.md §1.c — documented monotonic per play"
+
+  - id: attempt-id-monotonic
+    tables: [session_events]
+    kind: monotonic
+    severity: error
+    fields: [attempt_id]
+    where: "attempt_id != 0"
+    applicable_since: { date: "2026-05-15" }
+    exclusions:
+      - name: legacy-zero
+        where: "attempt_id = 0"
+        note: "0 = pre-rename rows / non-iOS clients (documented sentinel)"
+    source: "data-fields.md §1.a attempt_id — monotonic, +1 per restart, resets per play"
+
+  - id: delta-reconciles-cumulative
+    tables: [session_events]
+    kind: sequence
+    severity: warn
+    lag_cols: [playing_time_ms, buffering_time_ms, stalling_time_ms]
+    violation: >-
+      (playing_time_ms_delta   != playing_time_ms   - prev_playing_time_ms
+       AND playing_time_ms_delta   != playing_time_ms)
+      OR (buffering_time_ms_delta != buffering_time_ms - prev_buffering_time_ms
+       AND buffering_time_ms_delta != buffering_time_ms)
+      OR (stalling_time_ms_delta  != stalling_time_ms  - prev_stalling_time_ms
+       AND stalling_time_ms_delta  != stalling_time_ms)
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c *_delta — forwarder-computed per-row delta of the paired cumulative"
+    rationale: >-
+      Smoke-tested 2026-06-04 over 396k rows: 89% reconcile via lag; 8%
+      have delta = cumulative — the forwarder's reset/first-row semantics
+      (cache miss, or every row of an interleaved #603-family play looks
+      like a reset) — accepted by the second disjunct. 247 rows matched
+      NEITHER form: those are the aberrations this rule keeps catching.
+
+  - id: no-terminal-resurrection
+    tables: [session_events]
+    kind: sequence
+    severity: error
+    lag_cols: [playback_status]
+    violation: "prev_playback_status NOT IN ('', 'in_progress') AND playback_status = 'in_progress'"
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c playback_status — terminal outcome; a play must not resume after terminal"
+
+  - id: residency-sum-wallclock
+    tables: [session_events]
+    kind: play
+    severity: warn
+    aggregates:
+      residency_ms: >-
+        max(playing_time_ms + pausing_time_ms + buffering_time_ms + stalling_time_ms
+            + idling_time_ms + seeking_time_ms + trickplaying_time_ms)
+      wallclock_ms: "dateDiff('millisecond', min(ts), max(ts))"
+      n_rows: "count()"
+    violation: "n_rows >= 30 AND residency_ms > wallclock_ms * 1.15 + 10000"
+    applicable_since: { date: "2026-05-29" }
+    source: "data-fields.md §1.c — sum across states ~= wall-clock since play start"
+    rationale: >-
+      One-sided: residency exceeding wall-clock is impossible (double-counted state time);
+      residency BELOW wall-clock is legal (gaps before first heartbeat / after last).
+      Short plays (<30 rows) skipped — startup jitter dominates.
+
+  - id: play-end-unique
+    tables: [session_events]
+    kind: play
+    severity: warn
+    aggregates:
+      play_ends: "countIf(last_event = 'play_end')"
+    violation: "play_ends > 1"
+    applicable_since: { date: "2026-06-02", note: "#567 session_end->play_end rename (merge-date hint)" }
+    source: "issue #554/#567 — play_end is the play-terminal event, one per play"
+
+  - id: play-start-unique
+    tables: [session_events]
+    kind: play
+    severity: warn
+    pending: true
+    aggregates:
+      play_starts: "countIf(last_event = 'play_start')"
+    violation: "play_starts != 1"
+    applicable_since: { date: "TBD", note: "#604/#605/#606 not yet merged/deployed; census-only until then" }
+    source: "issue #603 — every play emits exactly one play_start at fire-time"
+
+  - id: ebvs-never-saw-frame
+    tables: [session_events]
+    kind: play
+    severity: error
+    aggregates:
+      status: "argMax(playback_status, ts)"
+      ttff: "max(video_first_frame_time_s)"
+    violation: "status = 'abandoned_start' AND ttff > 0"
+    applicable_since: { date: "2026-05-29" }
+    source: "qoe-metrics.md EBVS — abandoned_start means startup never completed; a TTFF contradicts it"
+
+  - id: loop-count-divergence
+    tables: [session_events]
+    kind: play
+    severity: warn
+    aggregates:
+      lp: "max(loop_count_player)"
+      ls: "max(loop_count_server)"
+    violation: "lp > 0 AND ls > 0 AND abs(toInt64(lp) - toInt64(ls)) > 1"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §1.c loop_count_player/server — 'divergence implies a missed restart event'"
+
+# ---------------------------------------------------------------------------
+# D. network_requests — row-level
+# ---------------------------------------------------------------------------
+
+  - id: request-kind-vocab
+    tables: [network_requests]
+    kind: vocab
+    severity: warn
+    field: request_kind
+    allowed: [manifest, segment, init, other]
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §2.b request_kind (closed set)"
+
+  - id: status-sane
+    tables: [network_requests]
+    kind: row
+    severity: error
+    violation: "status > 599 OR (status < 100 AND status != 0)"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §2.b status — HTTP code, 0 = upstream connect failed"
+
+  - id: faulted-fields-coherent
+    tables: [network_requests]
+    kind: row
+    severity: warn
+    violation: >-
+      (faulted = 1 AND (fault_type = '' OR fault_action = ''))
+      OR (faulted = 0 AND fault_type != '')
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §2.e — fault_type/fault_action populated iff faulted=1"
+
+  - id: get-has-no-body
+    tables: [network_requests]
+    kind: row
+    severity: warn
+    violation: "method = 'GET' AND bytes_in > 0"
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §2.c bytes_in — 'Always 0 for GET (no request body)'"
+
+  - id: timings-nonnegative
+    tables: [network_requests]
+    kind: row
+    severity: error
+    violation: >-
+      dns_ms < 0 OR connect_ms < 0 OR tls_ms < 0 OR ttfb_ms < 0
+      OR transfer_ms < 0 OR total_ms < 0 OR client_wait_ms < 0
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §2.d (all millisecond durations)"
+
+  - id: total-ms-composition
+    tables: [network_requests]
+    kind: row
+    severity: warn
+    violation: "total_ms + 5 < ttfb_ms + transfer_ms"
+    applicable_since: { date: "2026-05-15" }
+    source: "go-proxy main.go mergeTotalTiming() — total_ms should be lifted to >= ttfb + transfer"
+    rationale: >-
+      The doc's original formula (dns+connect+tls+ttfb+transfer) never
+      matched the code. Real contract: mergeTotalTiming() lifts total_ms
+      to ttfb+transfer — but ~26% of archive rows show total_ms ~= ttfb
+      with transfer 100x larger, i.e. code paths that skip the merge
+      (Phase 1 census 2026-06-04). Known proxy gap, not a data aberration;
+      rule stays census to track the rate until the proxy is fixed.
+
+# ---------------------------------------------------------------------------
+# E. Cross-table (kind: sql — full custom queries, built in Phase 2)
+# ---------------------------------------------------------------------------
+
+  - id: play-id-stable-across-mutations
+    tables: [control_events, session_events]
+    kind: sql
+    severity: error
+    applicable_since: { date: "2026-05-15", note: "#474 predates the retained archive" }
+    source: "data-fields.md §1.a play_id gotcha — does NOT rotate on control mutations (post-#474)"
+    sql_sketch: >-
+      For each control_events row with source='harness' and event IN
+      (shaper_config_change, fault_rule_enabled, fault_rule_disabled,
+      pattern_enabled, pattern_disabled) carrying play_id P for player X:
+      the first session_events row for X with ts in (T, T+30s] must still
+      have play_id = P, unless a content_changed/session_end intervenes.
+
+  - id: network-within-play-bounds
+    tables: [network_requests, session_events]
+    kind: sql
+    severity: warn
+    applicable_since: { date: "2026-05-15" }
+    source: "data-fields.md §4.b started_at/last_seen_at"
+    sql_sketch: >-
+      network_requests.ts for play P outside
+      [min(session_events.ts) - 30s, max(session_events.ts) + 30s] is a
+      mis-attributed row (play_id stamped on the wrong play). Grace covers
+      pre-first-heartbeat manifest fetches.
+
+  - id: qoe-cirr-label-recompute
+    tables: [session_events]
+    kind: sql
+    severity: warn
+    applicable_since: { date: "2026-06-01", note: "#559 qoe labels; thresholds are DEPLOY-TIME config — resolve from the [QoE] startup log before asserting" }
+    source: "qoe-metrics.md — CIRR = stalling/(stalling+playing); breach >= 0.004 (default tier)"
+    sql_sketch: >-
+      Per play: recompute CIRR from argMax(stalling_time_ms, ts) and
+      argMax(playing_time_ms, ts); plays with CIRR >= breach threshold and
+      playing_time_ms >= 60s must carry a qoe_cirr_breach label in the play's
+      label histogram, and vice versa. CENSUS ONLY until the Phase 3 seek-
+      exclusion question is settled (stalling may include seek recovery).
+
+  - id: qoe-vst-label-recompute
+    tables: [session_events]
+    kind: sql
+    severity: warn
+    applicable_since: { date: "2026-06-01", note: "edge-triggered since #599 (2026-06-04) — pre-#599 rows have sticky re-stamped labels; expect duplicates before that date" }
+    source: "qoe-metrics.md — VST breach >= 10000ms (default tier)"
+    sql_sketch: >-
+      Per play: max(video_start_time_s) >= 10 implies qoe_vst_breach present;
+      < 5 implies absent (between tiers: concerning band, check qoe_vst_concerning).
+
+# ---------------------------------------------------------------------------
+# F. Documented NON-rules — do not add these as assertions
+# ---------------------------------------------------------------------------
+# Kept here so a future session doesn't "helpfully" add them.
+#
+# - network_bitrate_mbps <= cap: FALSE. iOS avg/network bitrate over-reads
+#   2-3x the cap by design (AVPlayer burst measurement). See
+#   reference_ios_avg_bitrate_overreads + avplayer-quirks.md.
+# - video_resolution constant at play start: FALSE. Carries forward from
+#   the previous play for the first 1-2 heartbeats (36-cycle startup
+#   characterization, #512 / 2026-05-25). Resolution-coherence rules must
+#   exclude the first 2 samples of each play.
+# - player_error empty on healthy plays: FALSE on simulators.
+#   CoreMediaErrorDomain -12174 is documented sim-only noise (#145).
+#   Error-field rules must exclude error_code = -12174.
+# - buffer_depth_s > 0 while playing: FALSE. AVPlayer reports transient 0s
+#   during normal transitions; only SUSTAINED 0 across consecutive rows
+#   matters (data-fields.md §1.b).
+# - playback_rate distinguishing pause vs buffering: FALSE. Documented
+#   ambiguity — must combine with player_state.
+
+exclusions_global:
+  - name: sim-noise-12174
+    applies_to: [session_events]
+    where: "error_code = -12174 OR position(player_error, '-12174') > 0"
+    note: "sim-only CoreMedia noise (#145); excluded from error-bearing rules only"
+  - name: first-samples-of-play
+    applies_to: [session_events]
+    note: >-
+      First 2 rows per play_id excluded from resolution/bitrate coherence
+      rules (carry-forward gotcha). Runner implements as row_number() > 2
+      where a rule opts in via exclusion reference.

--- a/tests/aberration_crawl/invariants.yaml
+++ b/tests/aberration_crawl/invariants.yaml
@@ -51,6 +51,7 @@ rules:
     tables: [session_events]
     kind: row
     severity: error
+    mode: assert
     violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
     applicable_since: { date: "2026-05-15", note: "whole retained archive; canonicalV2ID() predates it" }
     source: "data-fields.md §1.a player_id gotcha; memory case_sensitivity_ids"
@@ -60,6 +61,7 @@ rules:
     tables: [network_requests]
     kind: row
     severity: error
+    mode: assert
     violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
     applicable_since: { date: "2026-05-20", note: "DATA-CALIBRATED (Phase 2 census 2026-06-04): 130,330 uppercase play_ids exist 2026-05-15..2026-05-19 02:41 UTC — the pre-canonicalV2ID()-deploy window (fix deployed mid-day 05-19, so the clean floor is 05-20). Clean since." }
     source: "data-fields.md §1.a; memory case_sensitivity_ids"
@@ -68,6 +70,7 @@ rules:
     tables: [control_events]
     kind: row
     severity: error
+    mode: assert
     violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
     applicable_since: { date: "2026-05-20", note: "DATA-CALIBRATED: 211 uppercase rows confined to 2026-05-18 22:16-23:15 UTC (same pre-fix window as network_requests; floor aligned to 05-20 with the network rule)." }
     source: "data-fields.md §1.a; memory case_sensitivity_ids"
@@ -76,6 +79,7 @@ rules:
     tables: [session_events, network_requests, control_events]
     kind: row
     severity: error
+    mode: assert
     violation: >-
       arrayExists(l -> NOT match(l, '^(testing|info|warning|error|critical)=\\*?[^,=]+$'), labels)
     applicable_since: { date: "2026-05-15" }
@@ -132,6 +136,7 @@ rules:
     tables: [session_events]
     kind: row
     severity: error
+    mode: assert
     violation: >-
       terminal_error_code != 0
       AND playback_status NOT IN ('start_failure', 'abandoned_start', 'mid_stream_failure')
@@ -193,13 +198,18 @@ rules:
     violation: "last_event = 'buffering_end' AND buffering_duration_ms = 0"
     applicable_since: { date: "2026-05-29" }
     source: "data-fields.md §1.c buffering_duration_ms"
+    rationale: >-
+      ONGOING low-grade violation (~670 rows / 385 plays through
+      2026-06-04, every day). Hypotheses (needs-test): sub-ms buffering
+      blips rounding to 0 vs. an unset-field path on iOS. Open triage
+      item from the Phase 2 census.
 
   - id: legacy-stall-mirror-count
     tables: [session_events]
     kind: row
     severity: warn
     violation: "stall_count != stalling_count"
-    applicable_since: { date: "2026-05-29", note: "soft-cutover mirror window; retire rule when legacy columns drop" }
+    applicable_since: { date: "2026-05-30", note: "DATA-CALIBRATED: 1,242 mismatches confined to 2026-05-29 00:00-10:57 (2 plays) — pre-#550 clients posting legacy-only during the deploy morning (legacy>0, canonical=0 on every one). Clean since. Retire rule when legacy columns drop." }
     source: "data-fields.md §1.c legacy stall fields — forwarder mirror-writes from canonical"
 
   - id: legacy-stall-mirror-time
@@ -207,7 +217,7 @@ rules:
     kind: row
     severity: warn
     violation: "abs(stall_time_s * 1000 - stalling_time_ms) > 1500"
-    applicable_since: { date: "2026-05-29" }
+    applicable_since: { date: "2026-05-30", note: "DATA-CALIBRATED: same deploy-morning window as legacy-stall-mirror-count." }
     source: "data-fields.md §1.c — same mirror, time variant (1.5s tolerance for float/rounding)"
 
 # ---------------------------------------------------------------------------
@@ -245,6 +255,7 @@ rules:
     tables: [session_events]
     kind: monotonic
     severity: error
+    mode: assert
     fields: [attempt_id]
     where: "attempt_id != 0"
     applicable_since: { date: "2026-05-15" }
@@ -328,6 +339,7 @@ rules:
     tables: [session_events]
     kind: play
     severity: error
+    mode: assert
     aggregates:
       status: "argMax(playback_status, ts)"
       ttff: "max(video_first_frame_time_s)"
@@ -367,6 +379,7 @@ rules:
     tables: [network_requests]
     kind: row
     severity: error
+    mode: assert
     violation: "status > 599 OR (status < 100 AND status != 0)"
     applicable_since: { date: "2026-05-15" }
     source: "data-fields.md §2.b status — HTTP code, 0 = upstream connect failed"
@@ -393,6 +406,7 @@ rules:
     tables: [network_requests]
     kind: row
     severity: error
+    mode: assert
     violation: >-
       dns_ms < 0 OR connect_ms < 0 OR tls_ms < 0 OR ttfb_ms < 0
       OR transfer_ms < 0 OR total_ms < 0 OR client_wait_ms < 0
@@ -419,29 +433,72 @@ rules:
 # ---------------------------------------------------------------------------
 
   - id: play-id-stable-across-mutations
-    tables: [control_events, session_events]
+    tables: [control_events]
     kind: sql
     severity: error
     applicable_since: { date: "2026-05-15", note: "#474 predates the retained archive" }
     source: "data-fields.md §1.a play_id gotcha — does NOT rotate on control mutations (post-#474)"
-    sql_sketch: >-
-      For each control_events row with source='harness' and event IN
-      (shaper_config_change, fault_rule_enabled, fault_rule_disabled,
-      pattern_enabled, pattern_disabled) carrying play_id P for player X:
-      the first session_events row for X with ts in (T, T+30s] must still
-      have play_id = P, unless a content_changed/session_end intervenes.
+    rationale: >-
+      A content_changed racing inside the 30s window can false-positive;
+      acceptable at census, revisit on promotion.
+    sql: |-
+      SELECT 'all' AS grp, count() AS checked,
+        countIf(e.play_id != '' AND e.play_id != m.play_id
+                AND dateDiff('second', m.ts, e.ts) <= 30) AS violations
+      FROM (
+        SELECT player_id, play_id, ts FROM {db}.control_events
+        WHERE ts >= '{since}' AND source = 'harness' AND play_id != ''
+          AND event IN ('shaper_config_change','fault_rule_enabled','fault_rule_disabled',
+                        'pattern_enabled','pattern_disabled','pattern_config_change',
+                        'fault_rule_config_change')
+      ) AS m
+      ASOF LEFT JOIN (
+        SELECT player_id, play_id, ts FROM {db}.session_events WHERE ts >= '{since}'
+      ) AS e ON m.player_id = e.player_id AND m.ts <= e.ts
+    exemplar_sql: |-
+      SELECT m.player_id AS player_id, m.play_id AS play_id, toString(m.ts) AS ts
+      FROM (
+        SELECT player_id, play_id, ts FROM {db}.control_events
+        WHERE ts >= '{since}' AND source = 'harness' AND play_id != ''
+          AND event IN ('shaper_config_change','fault_rule_enabled','fault_rule_disabled',
+                        'pattern_enabled','pattern_disabled','pattern_config_change',
+                        'fault_rule_config_change')
+      ) AS m
+      ASOF LEFT JOIN (
+        SELECT player_id, play_id, ts FROM {db}.session_events WHERE ts >= '{since}'
+      ) AS e ON m.player_id = e.player_id AND m.ts <= e.ts
+      WHERE e.play_id != '' AND e.play_id != m.play_id
+        AND dateDiff('second', m.ts, e.ts) <= 30
+      LIMIT 3
 
   - id: network-within-play-bounds
-    tables: [network_requests, session_events]
+    tables: [network_requests]
     kind: sql
     severity: warn
     applicable_since: { date: "2026-05-15" }
-    source: "data-fields.md §4.b started_at/last_seen_at"
-    sql_sketch: >-
-      network_requests.ts for play P outside
-      [min(session_events.ts) - 30s, max(session_events.ts) + 30s] is a
-      mis-attributed row (play_id stamped on the wrong play). Grace covers
-      pre-first-heartbeat manifest fetches.
+    source: "data-fields.md §4.b started_at/last_seen_at — 30s grace covers pre-first-heartbeat manifest fetches"
+    sql: |-
+      SELECT 'all' AS grp, count() AS checked,
+        countIf(n_ts < t0 - INTERVAL 30 SECOND OR n_ts > t1 + INTERVAL 30 SECOND) AS violations
+      FROM (
+        SELECT n.ts AS n_ts, b.t0 AS t0, b.t1 AS t1
+        FROM {db}.network_requests AS n
+        INNER JOIN (
+          SELECT play_id, min(ts) AS t0, max(ts) AS t1
+          FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+        ) AS b USING (play_id)
+        WHERE n.ts >= '{since}'
+      )
+    exemplar_sql: |-
+      SELECT n.player_id AS player_id, n.play_id AS play_id, toString(n.ts) AS ts
+      FROM {db}.network_requests AS n
+      INNER JOIN (
+        SELECT play_id, min(ts) AS t0, max(ts) AS t1
+        FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+      ) AS b USING (play_id)
+      WHERE n.ts >= '{since}'
+        AND (n.ts < b.t0 - INTERVAL 30 SECOND OR n.ts > b.t1 + INTERVAL 30 SECOND)
+      LIMIT 3
 
   - id: qoe-cirr-label-recompute
     tables: [session_events]
@@ -449,12 +506,40 @@ rules:
     severity: warn
     applicable_since: { date: "2026-06-01", note: "#559 qoe labels; thresholds are DEPLOY-TIME config — resolve from the [QoE] startup log before asserting" }
     source: "qoe-metrics.md — CIRR = stalling/(stalling+playing); breach >= 0.004 (default tier)"
-    sql_sketch: >-
-      Per play: recompute CIRR from argMax(stalling_time_ms, ts) and
-      argMax(playing_time_ms, ts); plays with CIRR >= breach threshold and
-      playing_time_ms >= 60s must carry a qoe_cirr_breach label in the play's
-      label histogram, and vice versa. CENSUS ONLY until the Phase 3 seek-
-      exclusion question is settled (stalling may include seek recovery).
+    rationale: >-
+      SEEK-EXCLUSION QUESTION SETTLED (Phase 3, 2026-06-04): stalling_time_ms
+      DOES accrue during seek windows — 74% of stalling-delta rows co-occur
+      with seeking deltas, 70% directly follow one (concentrated in the 35
+      seek-plays). Our CIRR is therefore NOT connection-induced RR; it
+      over-reads on seek-heavy plays vs Conviva convention. Forwarder-side
+      fix would be stalling minus the seek-overlapped portion (or an iOS
+      state-machine change). One-directional check (computed-breach without
+      label) — the reverse direction has edge-trigger timing wrinkles (#599).
+    sql: |-
+      SELECT 'all' AS grp, count() AS checked,
+        countIf(playing >= 60000 AND (stalling + playing) > 0
+                AND stalling / (stalling + playing) >= 0.004
+                AND NOT has_breach) AS violations
+      FROM (
+        SELECT play_id,
+          argMax(stalling_time_ms, ts) AS stalling,
+          argMax(playing_time_ms, ts) AS playing,
+          arrayExists(l -> position(l, 'qoe_cirr_breach') > 0,
+                      groupUniqArrayArray(labels)) AS has_breach
+        FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+      )
+    exemplar_sql: |-
+      SELECT player_id, play_id, '' AS ts FROM (
+        SELECT play_id, any(player_id) AS player_id,
+          argMax(stalling_time_ms, ts) AS stalling,
+          argMax(playing_time_ms, ts) AS playing,
+          arrayExists(l -> position(l, 'qoe_cirr_breach') > 0,
+                      groupUniqArrayArray(labels)) AS has_breach
+        FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+      )
+      WHERE playing >= 60000 AND (stalling + playing) > 0
+        AND stalling / (stalling + playing) >= 0.004 AND NOT has_breach
+      LIMIT 3
 
   - id: qoe-vst-label-recompute
     tables: [session_events]
@@ -462,9 +547,26 @@ rules:
     severity: warn
     applicable_since: { date: "2026-06-01", note: "edge-triggered since #599 (2026-06-04) — pre-#599 rows have sticky re-stamped labels; expect duplicates before that date" }
     source: "qoe-metrics.md — VST breach >= 10000ms (default tier)"
-    sql_sketch: >-
-      Per play: max(video_start_time_s) >= 10 implies qoe_vst_breach present;
-      < 5 implies absent (between tiers: concerning band, check qoe_vst_concerning).
+    sql: |-
+      SELECT 'all' AS grp, count() AS checked,
+        countIf(vst_ms >= 10000 AND NOT has_breach) AS violations
+      FROM (
+        SELECT play_id,
+          max(video_start_time_s) * 1000 AS vst_ms,
+          arrayExists(l -> position(l, 'qoe_vst_breach') > 0,
+                      groupUniqArrayArray(labels)) AS has_breach
+        FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+      )
+    exemplar_sql: |-
+      SELECT player_id, play_id, '' AS ts FROM (
+        SELECT play_id, any(player_id) AS player_id,
+          max(video_start_time_s) * 1000 AS vst_ms,
+          arrayExists(l -> position(l, 'qoe_vst_breach') > 0,
+                      groupUniqArrayArray(labels)) AS has_breach
+        FROM {db}.session_events WHERE ts >= '{since}' GROUP BY play_id
+      )
+      WHERE vst_ms >= 10000 AND NOT has_breach
+      LIMIT 3
 
 # ---------------------------------------------------------------------------
 # F. Documented NON-rules — do not add these as assertions

--- a/tests/aberration_crawl/invariants.yaml
+++ b/tests/aberration_crawl/invariants.yaml
@@ -61,7 +61,7 @@ rules:
     kind: row
     severity: error
     violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
-    applicable_since: { date: "2026-05-15" }
+    applicable_since: { date: "2026-05-20", note: "DATA-CALIBRATED (Phase 2 census 2026-06-04): 130,330 uppercase play_ids exist 2026-05-15..2026-05-19 02:41 UTC — the pre-canonicalV2ID()-deploy window (fix deployed mid-day 05-19, so the clean floor is 05-20). Clean since." }
     source: "data-fields.md §1.a; memory case_sensitivity_ids"
 
   - id: ids-lowercase-control
@@ -69,7 +69,7 @@ rules:
     kind: row
     severity: error
     violation: "player_id != lower(player_id) OR play_id != lower(play_id)"
-    applicable_since: { date: "2026-05-15" }
+    applicable_since: { date: "2026-05-20", note: "DATA-CALIBRATED: 211 uppercase rows confined to 2026-05-18 22:16-23:15 UTC (same pre-fix window as network_requests; floor aligned to 05-20 with the network rule)." }
     source: "data-fields.md §1.a; memory case_sensitivity_ids"
 
   - id: label-grammar
@@ -118,24 +118,6 @@ rules:
 # ---------------------------------------------------------------------------
 # B. session_events — row-level field coherence
 # ---------------------------------------------------------------------------
-
-  - id: ttff-le-vst
-    tables: [session_events]
-    kind: row
-    severity: warn
-    violation: >-
-      video_start_time_s > 0 AND video_first_frame_time_s > 0
-      AND video_first_frame_time_s > video_start_time_s
-    applicable_since: { date: "2026-05-15" }
-    source: >-
-      PlayerViewModel.swift markPlayingStarted/markFirstFrameRendered —
-      vst = timeControlStatus==.playing, ttff = isReadyForDisplay;
-      'typical order: first-frame fires before .playing'
-    rationale: >-
-      Direction VERIFIED against iOS source during Phase 1 smoke-test
-      (2026-06-04): data-fields.md had it backwards ('always vst <= ttff'
-      — 45% of archive rows violated). The two signals are independent
-      KVO observables, so inversion is atypical, not impossible: warn.
 
   - id: playback-status-vocab
     tables: [session_events]
@@ -277,6 +259,7 @@ rules:
     kind: sequence
     severity: warn
     lag_cols: [playing_time_ms, buffering_time_ms, stalling_time_ms]
+    columns: [playing_time_ms_delta, buffering_time_ms_delta, stalling_time_ms_delta]
     violation: >-
       (playing_time_ms_delta   != playing_time_ms   - prev_playing_time_ms
        AND playing_time_ms_delta   != playing_time_ms)
@@ -372,9 +355,13 @@ rules:
     kind: vocab
     severity: warn
     field: request_kind
-    allowed: [manifest, segment, init, other]
+    allowed: [master_manifest, manifest, segment, init, other]
     applicable_since: { date: "2026-05-15" }
     source: "data-fields.md §2.b request_kind (closed set)"
+    rationale: >-
+      master_manifest added after the Phase 2 census found 5,163 rows
+      carrying it — the doc's claim that 'manifest' covers both master
+      and variant playlists was stale (master was split out).
 
   - id: status-sane
     tables: [network_requests]
@@ -499,6 +486,14 @@ rules:
 #   matters (data-fields.md §1.b).
 # - playback_rate distinguishing pause vs buffering: FALSE. Documented
 #   ambiguity — must combine with player_state.
+# - video_start_time_s vs video_first_frame_time_s ordering: NO RELIABLE
+#   DIRECTION. Measured per-play over the full archive (2026-06-04):
+#   44% ttff-after-vst / 40% ttff-before-vst / 6% equal (n=1,326 plays
+#   with both > 0). The original doc claim ("always vst <= ttff") AND
+#   the iOS source comment ("typical order: first-frame before .playing")
+#   are BOTH contradicted by data — the two are independent KVO
+#   observables with no ordering contract. Use each on its own terms;
+#   never assert a relationship.
 
 exclusions_global:
   - name: sim-noise-12174

--- a/tests/aberration_crawl/runner.go
+++ b/tests/aberration_crawl/runner.go
@@ -1,0 +1,345 @@
+package aberration_crawl
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ArchiveFloor is the earliest data in the retained archive; rules with
+// unparseable/TBD applicable_since dates census from here.
+const ArchiveFloor = "2026-05-15"
+
+// versionCols is the #550 Phase 4 taxonomy. session_events carries them
+// natively; network_requests / control_events get them via a per-play
+// argMax JOIN (pv CTE).
+var versionCols = []string{"app_version", "os_version_major", "device_class", "player_tech"}
+
+func grpExprNative() string {
+	return "concat(app_version, '|', toString(os_version_major), '|', device_class, '|', player_tech)"
+}
+
+func grpExprPlayAgg() string {
+	return "concat(argMax(app_version, ts), '|', toString(argMax(os_version_major, ts)), '|', argMax(device_class, ts), '|', argMax(player_tech, ts))"
+}
+
+func pvCTE(db, since string) string {
+	return fmt.Sprintf(`WITH pv AS (
+  SELECT play_id,
+    argMax(app_version, ts) AS app_version,
+    argMax(os_version_major, ts) AS os_version_major,
+    argMax(device_class, ts) AS device_class,
+    argMax(player_tech, ts) AS player_tech
+  FROM %s.session_events WHERE ts >= '%s' GROUP BY play_id
+)`, db, since)
+}
+
+// GroupResult is one (rule × table × version-group) census line.
+type GroupResult struct {
+	Group      string `json:"group"` // "app|osMajor|class|tech" or "unversioned"
+	Checked    int64  `json:"checked"`
+	Violations int64  `json:"violations"`
+	Excluded   int64  `json:"excluded,omitempty"`
+}
+
+type Exemplar struct {
+	PlayerID string `json:"player_id"`
+	PlayID   string `json:"play_id"`
+	TS       string `json:"ts,omitempty"`
+}
+
+type ValueCount struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+type RuleResult struct {
+	RuleID        string        `json:"rule_id"`
+	Table         string        `json:"table"`
+	Kind          string        `json:"kind"`
+	Severity      string        `json:"severity"`
+	Mode          string        `json:"mode"`
+	Pending       bool          `json:"pending,omitempty"`
+	Since         string        `json:"since"`
+	Groups        []GroupResult `json:"groups,omitempty"`
+	UnknownValues []ValueCount  `json:"unknown_values,omitempty"`
+	Exemplars     []Exemplar    `json:"exemplars,omitempty"`
+	Skipped       string        `json:"skipped,omitempty"` // reason (kind: sql sketches)
+	Err           string        `json:"error,omitempty"`
+}
+
+func (rr RuleResult) TotalViolations() int64 {
+	var n int64
+	for _, g := range rr.Groups {
+		n += g.Violations
+	}
+	for _, v := range rr.UnknownValues {
+		n += v.Count
+	}
+	return n
+}
+
+// RunAll executes every rule×table in the catalogue. Errors are
+// captured per-result, never aborting the crawl.
+func RunAll(ctx context.Context, ch *CHClient, cat *Catalogue) []RuleResult {
+	var out []RuleResult
+	for _, rule := range cat.Rules {
+		for _, table := range rule.Tables {
+			out = append(out, runOne(ctx, ch, cat, rule, table))
+		}
+	}
+	return out
+}
+
+func runOne(ctx context.Context, ch *CHClient, cat *Catalogue, r Rule, table string) RuleResult {
+	res := RuleResult{
+		RuleID:   r.ID,
+		Table:    table,
+		Kind:     r.Kind,
+		Severity: r.Severity,
+		Mode:     r.EffectiveMode(cat.Defaults.Mode),
+		Pending:  r.Pending,
+		Since:    r.SinceDate(ArchiveFloor),
+	}
+	var err error
+	switch r.Kind {
+	case "row":
+		err = runRow(ctx, ch, r, table, &res)
+	case "vocab":
+		err = runVocab(ctx, ch, r, table, &res)
+	case "monotonic":
+		err = runMonotonic(ctx, ch, r, table, &res)
+	case "sequence":
+		err = runSequence(ctx, ch, r, table, &res)
+	case "play":
+		err = runPlay(ctx, ch, r, table, &res)
+	case "sql":
+		res.Skipped = "kind=sql is sketch-only in Phase 2; implemented in Phase 3"
+	}
+	if err != nil {
+		res.Err = err.Error()
+	}
+	return res
+}
+
+// exclusionExpr ORs together all exclusions that carry a where clause.
+func exclusionExpr(r Rule) string {
+	var parts []string
+	for _, e := range r.Exclusions {
+		if strings.TrimSpace(e.Where) != "" {
+			parts = append(parts, "("+e.Where+")")
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " OR ")
+}
+
+func whereClause(r Rule, since string) string {
+	w := fmt.Sprintf("ts >= '%s'", since)
+	if strings.TrimSpace(r.Where) != "" {
+		w += " AND (" + r.Where + ")"
+	}
+	return w
+}
+
+// fromWithVersions returns the FROM fragment + group expression for a
+// table: session_events natively, others via pv JOIN. The CTE prefix is
+// returned separately (empty for native).
+func fromWithVersions(db, table, since string) (cte, from, grp string) {
+	if table == "session_events" {
+		return "", fmt.Sprintf("%s.%s", db, table), grpExprNative()
+	}
+	return pvCTE(db, since) + "\n",
+		fmt.Sprintf("%s.%s AS t LEFT JOIN pv USING (play_id)", db, table),
+		grpExprNative()
+}
+
+func scanGroups(rows []map[string]any, res *RuleResult) {
+	for _, row := range rows {
+		g := asString(row["grp"])
+		if g == "|0||" || g == "" {
+			g = "unversioned"
+		}
+		res.Groups = append(res.Groups, GroupResult{
+			Group:      g,
+			Checked:    asInt64(row["checked"]),
+			Violations: asInt64(row["violations"]),
+			Excluded:   asInt64(row["excluded"]),
+		})
+	}
+}
+
+func scanExemplars(rows []map[string]any, res *RuleResult) {
+	for _, row := range rows {
+		res.Exemplars = append(res.Exemplars, Exemplar{
+			PlayerID: asString(row["player_id"]),
+			PlayID:   asString(row["play_id"]),
+			TS:       asString(row["ts"]),
+		})
+	}
+}
+
+func runRow(ctx context.Context, ch *CHClient, r Rule, table string, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	cte, from, grp := fromWithVersions(ch.Database, table, since)
+	excl := exclusionExpr(r)
+	violations := fmt.Sprintf("countIf(%s)", r.Violation)
+	excluded := "0"
+	if excl != "" {
+		violations = fmt.Sprintf("countIf((%s) AND NOT (%s))", r.Violation, excl)
+		excluded = fmt.Sprintf("countIf(%s)", excl)
+	}
+	sql := fmt.Sprintf(`%sSELECT %s AS grp, count() AS checked, %s AS violations, %s AS excluded
+FROM %s WHERE %s GROUP BY grp`, cte, grp, violations, excluded, from, whereClause(r, since))
+	rows, err := ch.Query(ctx, sql)
+	if err != nil {
+		return err
+	}
+	scanGroups(rows, res)
+
+	if res.TotalViolations() > 0 {
+		cond := r.Violation
+		if excl != "" {
+			cond = fmt.Sprintf("(%s) AND NOT (%s)", r.Violation, excl)
+		}
+		ex := fmt.Sprintf(`%sSELECT player_id, play_id, toString(ts) AS ts FROM %s
+WHERE %s AND (%s) LIMIT 3`, cte, from, whereClause(r, since), cond)
+		exRows, err := ch.Query(ctx, ex)
+		if err == nil {
+			scanExemplars(exRows, res)
+		}
+	}
+	return nil
+}
+
+func runVocab(ctx context.Context, ch *CHClient, r Rule, table string, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	quoted := make([]string, len(r.Allowed))
+	for i, v := range r.Allowed {
+		quoted[i] = "'" + strings.ReplaceAll(v, "'", "\\'") + "'"
+	}
+	sql := fmt.Sprintf(`SELECT toString(%s) AS value, count() AS c FROM %s.%s
+WHERE %s AND %s NOT IN (%s)
+GROUP BY value ORDER BY c DESC LIMIT 20`,
+		r.Field, ch.Database, table, whereClause(r, since), r.Field, strings.Join(quoted, ", "))
+	rows, err := ch.Query(ctx, sql)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		res.UnknownValues = append(res.UnknownValues, ValueCount{
+			Value: asString(row["value"]),
+			Count: asInt64(row["c"]),
+		})
+	}
+	total, err := ch.Query(ctx, fmt.Sprintf(
+		"SELECT count() AS checked FROM %s.%s WHERE %s", ch.Database, table, whereClause(r, since)))
+	if err == nil && len(total) == 1 {
+		res.Groups = append(res.Groups, GroupResult{Group: "all", Checked: asInt64(total[0]["checked"])})
+	}
+	return nil
+}
+
+func runMonotonic(ctx context.Context, ch *CHClient, r Rule, table string, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	for _, f := range r.Fields {
+		inner := fmt.Sprintf(`SELECT player_id, play_id, ts, %s AS grp, %s AS _cur,
+  lagInFrame(%s) OVER w AS _prev, row_number() OVER w AS _rn
+FROM %s.%s WHERE %s
+WINDOW w AS (PARTITION BY player_id, play_id ORDER BY ts)`,
+			grpExprNative(), f, f, ch.Database, table, whereClause(r, since))
+		sql := fmt.Sprintf(`SELECT grp, count() AS checked,
+  countIf(_rn > 1 AND _cur < _prev) AS violations
+FROM (%s) GROUP BY grp`, inner)
+		rows, err := ch.Query(ctx, sql)
+		if err != nil {
+			return fmt.Errorf("field %s: %w", f, err)
+		}
+		for _, row := range rows {
+			g := asString(row["grp"])
+			if g == "|0||" || g == "" {
+				g = "unversioned"
+			}
+			res.Groups = append(res.Groups, GroupResult{
+				Group:      g + " [" + f + "]",
+				Checked:    asInt64(row["checked"]),
+				Violations: asInt64(row["violations"]),
+			})
+		}
+		// Exemplars per field only when violations exist.
+		var fieldViol int64
+		for _, row := range rows {
+			fieldViol += asInt64(row["violations"])
+		}
+		if fieldViol > 0 && len(res.Exemplars) < 3 {
+			ex := fmt.Sprintf(`SELECT player_id, play_id, toString(ts) AS ts
+FROM (%s) WHERE _rn > 1 AND _cur < _prev LIMIT 3`, inner)
+			exRows, err := ch.Query(ctx, ex)
+			if err == nil {
+				scanExemplars(exRows, res)
+			}
+		}
+	}
+	return nil
+}
+
+func runSequence(ctx context.Context, ch *CHClient, r Rule, table string, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	var sel []string
+	sel = append(sel, "player_id", "play_id", "ts", grpExprNative()+" AS grp")
+	for _, c := range r.LagCols {
+		sel = append(sel, c, fmt.Sprintf("lagInFrame(%s) OVER w AS prev_%s", c, c))
+	}
+	sel = append(sel, r.Columns...)
+	sel = append(sel, "row_number() OVER w AS _rn")
+	inner := fmt.Sprintf(`SELECT %s
+FROM %s.%s WHERE %s
+WINDOW w AS (PARTITION BY player_id, play_id ORDER BY ts)`,
+		strings.Join(sel, ",\n  "), ch.Database, table, whereClause(r, since))
+	sql := fmt.Sprintf(`SELECT grp, count() AS checked,
+  countIf(_rn > 1 AND (%s)) AS violations
+FROM (%s) GROUP BY grp`, r.Violation, inner)
+	rows, err := ch.Query(ctx, sql)
+	if err != nil {
+		return err
+	}
+	scanGroups(rows, res)
+	if res.TotalViolations() > 0 {
+		ex := fmt.Sprintf(`SELECT player_id, play_id, toString(ts) AS ts
+FROM (%s) WHERE _rn > 1 AND (%s) LIMIT 3`, inner, r.Violation)
+		exRows, err := ch.Query(ctx, ex)
+		if err == nil {
+			scanExemplars(exRows, res)
+		}
+	}
+	return nil
+}
+
+func runPlay(ctx context.Context, ch *CHClient, r Rule, table string, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	var aggs []string
+	for name, expr := range r.Aggregates {
+		aggs = append(aggs, fmt.Sprintf("%s AS %s", expr, name))
+	}
+	inner := fmt.Sprintf(`SELECT player_id, play_id, %s AS grp,
+  %s
+FROM %s.%s WHERE %s GROUP BY player_id, play_id`,
+		grpExprPlayAgg(), strings.Join(aggs, ",\n  "), ch.Database, table, whereClause(r, since))
+	sql := fmt.Sprintf(`SELECT grp, count() AS checked, countIf(%s) AS violations
+FROM (%s) GROUP BY grp`, r.Violation, inner)
+	rows, err := ch.Query(ctx, sql)
+	if err != nil {
+		return err
+	}
+	scanGroups(rows, res)
+	if res.TotalViolations() > 0 {
+		ex := fmt.Sprintf(`SELECT player_id, play_id, '' AS ts FROM (%s) WHERE %s LIMIT 3`, inner, r.Violation)
+		exRows, err := ch.Query(ctx, ex)
+		if err == nil {
+			scanExemplars(exRows, res)
+		}
+	}
+	return nil
+}

--- a/tests/aberration_crawl/runner.go
+++ b/tests/aberration_crawl/runner.go
@@ -114,7 +114,11 @@ func runOne(ctx context.Context, ch *CHClient, cat *Catalogue, r Rule, table str
 	case "play":
 		err = runPlay(ctx, ch, r, table, &res)
 	case "sql":
-		res.Skipped = "kind=sql is sketch-only in Phase 2; implemented in Phase 3"
+		if strings.TrimSpace(r.SQL) == "" {
+			res.Skipped = "sql_sketch only — no executable sql yet"
+		} else {
+			err = runSQL(ctx, ch, r, &res)
+		}
 	}
 	if err != nil {
 		res.Err = err.Error()
@@ -310,6 +314,26 @@ FROM (%s) GROUP BY grp`, r.Violation, inner)
 		ex := fmt.Sprintf(`SELECT player_id, play_id, toString(ts) AS ts
 FROM (%s) WHERE _rn > 1 AND (%s) LIMIT 3`, inner, r.Violation)
 		exRows, err := ch.Query(ctx, ex)
+		if err == nil {
+			scanExemplars(exRows, res)
+		}
+	}
+	return nil
+}
+
+func runSQL(ctx context.Context, ch *CHClient, r Rule, res *RuleResult) error {
+	since := r.SinceDate(ArchiveFloor)
+	expand := func(s string) string {
+		s = strings.ReplaceAll(s, "{db}", ch.Database)
+		return strings.ReplaceAll(s, "{since}", since)
+	}
+	rows, err := ch.Query(ctx, expand(r.SQL))
+	if err != nil {
+		return err
+	}
+	scanGroups(rows, res)
+	if res.TotalViolations() > 0 && strings.TrimSpace(r.ExemplarSQL) != "" {
+		exRows, err := ch.Query(ctx, expand(r.ExemplarSQL))
 		if err == nil {
 			scanExemplars(exRows, res)
 		}


### PR DESCRIPTION
## What

Implements all four phases of the historical aberration crawl:

- **`tests/aberration_crawl/invariants.yaml`** — 38 machine-checkable rules extracted from `data-fields.md` / `qoe-metrics.md` / the label vocabulary. Six rule kinds (`row`, `vocab`, `monotonic`, `sequence`, `play`, `sql`), per-rule data-calibrated validity windows, named exclusions, and a documented NON-rules list (claims that look like invariants but are measured false).
- **`tests/aberration_crawl/`** Go runner — crawls the CH archive grouped by the #550 version taxonomy (`app_version × os_version_major × device_class × player_tech`; per-play argMax JOIN for tables without native version columns). Census mode reports per-(rule × group) violation counts + exemplar `(player_id, play_id, ts)`; `ABERRATION_MODE=assert` enforces promoted rules. Full 2.2M-row crawl ≈ 6s. `TestAberrationCensus` skips without CH; `TestCatalogueValid` guards the YAML in CI.
- **`.claude/standards/invariants.md`** — operating manual (validity windows, census-before-assert, NON-rules).
- **`data-fields.md` corrections** — five documented claims were falsified by running the predicates against the archive before trusting them:
  1. `video_start_time_s` "always ≤ ttff" → no ordering exists (44/40/6 per-play split; iOS source comment also wrong)
  2. `video_quality_pct` forwarder-derived / 0–100 → player-supplied, 100.01 overshoot on ~70% of rows
  3. `transfer_ms` "upstream, NOT wire-delivery" → downstream write+flush since 9fb686d (2026-02-13)
  4. `total_ms` = dns+connect+tls+ttfb+transfer → never matched code; `mergeTotalTiming()` contract, skipped on ~26% of rows (live proxy bug, tracked census)
  5. `request_kind` 'manifest' covers masters → `master_manifest` is its own value

## Findings from the first full crawl

- **Historic uppercase-ID ingest gap caught and windowed**: 130,330 uppercase play_ids in `network_requests` (+211 control_events), all pre-canonicalV2ID(), clean since 2026-05-20 — rules now assert.
- **First version-keyed find**: 121 negative-gauge rows are 100% ExoPlayer/tv (Android emits negative buffer/position/rate).
- **CIRR seek-exclusion question settled**: `stalling_time_ms` accrues during seek windows (74% delta co-occurrence) — our CIRR over-reads vs Conviva's connection-induced convention on seek-heavy plays. (`qoe-metrics.md` update deferred: file lands with #605.)
- **#603 interleaving confirmed live in the archive** — monotonic/residency rules stay census until #604/#605/#606 deploy, exactly as the validity-window design intends.
- Nine error-severity rules promoted to `mode: assert` after clean calibration; assert run passes over the full archive.

## Test plan

- [x] `go test -run TestCatalogueValid ./tests/aberration_crawl` (CH-free, CI-safe)
- [x] `go test -run TestAberrationCensus` against test-dev (tunnel) — 38 rules, PASS
- [x] `ABERRATION_MODE=assert` full-archive run — PASS
- [x] `go vet`, `gofmt` clean

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
