### PR TITLE
feat(445): HMM latent-regime scorer — CH-direct + #608 train/score split

### DIFF
--- a/analytics/tools/compare_markov_hmm.py
+++ b/analytics/tools/compare_markov_hmm.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""#445 — where do the VOMM and HMM derivers DISAGREE? (the most informative plays).
+
+Both derivers write to the same derived_labels table with distinct model_version
+(vomm-tok-1 vs hmm-tok-1), so this reads CH directly and contrasts the two families PER
+PLAY — no scores.json files, no changes to the VOMM tool:
+
+  * VOMM anomaly score = Σ surprise (nats) over a play's unexpected_<condition> rows.
+  * HMM  anomaly score = Σ surprise over its unexpected_regime_transition rows;
+    its regime ribbon comes from the regime_<STATE> rows (ordered by ts).
+
+Reports Spearman ρ between the two per-play scores and the plays where their ranks diverge
+most — the cases that reveal what each model captures that the other can't. ρ in [0.4, 0.7]
+is the sweet spot (correlated on the obvious anomalies, each adding signal); ρ > 0.9 means
+the HMM is duplicating the VOMM, ρ < 0.2 means one is broken.
+
+Caveat: derived_labels only holds FLAGGED rows — plays both models found clean are absent,
+so ρ measures agreement over the flagged population, not all plays. The disagreement tables
+(one flags, the other is silent) are the payload.
+
+  python3 analytics/tools/compare_markov_hmm.py --days 7 --out /tmp/compare_markov_hmm.md
+"""
+import argparse
+import base64
+import collections
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+DB = "infinite_streaming"
+
+
+def _auth_header():
+    u, p = os.environ.get("FORWARDER_CLICKHOUSE_USER"), os.environ.get("FORWARDER_CLICKHOUSE_PASSWORD")
+    if u:
+        return {"Authorization": "Basic " + base64.b64encode(f"{u}:{p or ''}".encode()).decode()}
+    return {}
+
+
+def ch_rows(ch_url, sql, params):
+    q = {"query": sql, "default_format": "JSONEachRow"}
+    for k, v in params.items():
+        q[f"param_{k}"] = v
+    url = ch_url.rstrip("/") + "/?" + urllib.parse.urlencode(q)
+    req = urllib.request.Request(url, headers=_auth_header())
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return [json.loads(l) for l in resp.read().decode().splitlines() if l.strip()]
+
+
+def _ranks(xs):
+    """Average-rank ranking (ties share the mean rank — what Spearman expects)."""
+    indexed = sorted(enumerate(xs), key=lambda p: p[1])
+    ranks = [0.0] * len(xs)
+    i = 0
+    while i < len(indexed):
+        j = i
+        while j + 1 < len(indexed) and indexed[j + 1][1] == indexed[i][1]:
+            j += 1
+        avg = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            ranks[indexed[k][0]] = avg
+        i = j + 1
+    return ranks
+
+
+def _spearman(xs, ys):
+    n = len(xs)
+    if n < 2:
+        return float("nan")
+    rx, ry = _ranks(xs), _ranks(ys)
+    mx, my = sum(rx) / n, sum(ry) / n
+    num = sum((rx[i] - mx) * (ry[i] - my) for i in range(n))
+    dx = sum((rx[i] - mx) ** 2 for i in range(n)) ** 0.5
+    dy = sum((ry[i] - my) ** 2 for i in range(n)) ** 0.5
+    return num / (dx * dy) if dx and dy else float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--vomm-version", default="vomm-tok-1", help="model_version prefix for VOMM rows")
+    ap.add_argument("--hmm-version", default="hmm-tok-1", help="model_version prefix for HMM rows")
+    ap.add_argument("--top", type=int, default=15)
+    ap.add_argument("--out", default="/tmp/compare_markov_hmm.md")
+    args = ap.parse_args()
+
+    rows = ch_rows(args.ch_url,
+                   f"SELECT play_id, model_version, condition, label, score, ts "
+                   f"FROM {DB}.derived_labels "
+                   f"WHERE ts >= now64(3) - INTERVAL {{days:UInt32}} DAY "
+                   f"ORDER BY play_id, ts",
+                   {"days": str(args.days)})
+    if not rows:
+        print(f"no derived_labels rows in the last {args.days}d.", file=sys.stderr)
+        return 1
+
+    # Per play: sum VOMM surprise, sum HMM transition surprise, collect the regime ribbon.
+    vomm = collections.defaultdict(float)
+    hmm = collections.defaultdict(float)
+    ribbon = collections.defaultdict(list)
+    for r in rows:
+        play, mv, label = r.get("play_id"), r.get("model_version") or "", r.get("label") or ""
+        score = float(r.get("score") or 0.0)
+        if not play:
+            continue
+        if mv.startswith(args.vomm_version):
+            vomm[play] += score
+        elif mv.startswith(args.hmm_version):
+            if label == "unexpected_regime_transition":
+                hmm[play] += score
+            elif label.startswith("regime_"):
+                ribbon[play].append(label[len("regime_"):])
+
+    common = sorted(set(vomm) | set(hmm))
+    vs = [vomm.get(p, 0.0) for p in common]
+    hs = [hmm.get(p, 0.0) for p in common]
+    rho = _spearman(vs, hs)
+    vr, hr = _ranks(vs), _ranks(hs)
+
+    data = [{"play": p, "vomm": vomm.get(p, 0.0), "hmm": hmm.get(p, 0.0),
+             "vrank": vr[i], "hrank": hr[i], "delta": abs(vr[i] - hr[i]),
+             "ribbon": " ".join(ribbon.get(p, [])[:8])}
+            for i, p in enumerate(common)]
+
+    md = ["# VOMM vs HMM deriver comparison\n",
+          f"- Plays flagged by either deriver (last {args.days}d): **{len(common)}** "
+          f"(VOMM {len(vomm)}, HMM {len(hmm)}, both {len(set(vomm) & set(hmm))})",
+          f"- Spearman ρ (per-play VOMM surprise vs HMM regime-transition surprise): **{rho:.3f}**",
+          "",
+          "ρ in [0.4, 0.7] = correlated but complementary. > 0.9 → HMM duplicates VOMM; "
+          "< 0.2 → one is broken (or the flagged populations barely overlap).\n",
+          f"## Top {args.top} plays by rank disagreement\n",
+          "| play | VOMM rank | HMM rank | Δrank | VOMM Σsurprise | HMM Σsurprise | HMM regime ribbon |",
+          "|---|---|---|---|---|---|---|"]
+    for d in sorted(data, key=lambda x: -x["delta"])[:args.top]:
+        md.append(f"| `{d['play'][:8]}` | {int(d['vrank']):>4} | {int(d['hrank']):>4} | "
+                  f"**{d['delta']:.0f}** | {d['vomm']:.1f} | {d['hmm']:.1f} | `{d['ribbon'][:70]}` |")
+
+    md.append("\n## HMM flags, VOMM silent (top 8) — regime anomalies invisible to point-surprise\n")
+    md.append("| play | HMM Σsurprise | HMM regime ribbon |\n|---|---|---|")
+    for d in sorted([x for x in data if x["hmm"] > 0 and x["vomm"] == 0],
+                    key=lambda x: -x["hmm"])[:8]:
+        md.append(f"| `{d['play'][:8]}` | {d['hmm']:.1f} | `{d['ribbon'][:80]}` |")
+
+    md.append("\n## VOMM flags, HMM silent (top 8) — ordering anomalies with no abnormal regime move\n")
+    md.append("| play | VOMM Σsurprise | HMM regime ribbon |\n|---|---|---|")
+    for d in sorted([x for x in data if x["vomm"] > 0 and x["hmm"] == 0],
+                    key=lambda x: -x["vomm"])[:8]:
+        md.append(f"| `{d['play'][:8]}` | {d['vomm']:.1f} | `{d['ribbon'][:80] or '(no regime rows)'}` |")
+
+    Path(args.out).write_text("\n".join(md) + "\n")
+    print(f"wrote {args.out}", file=sys.stderr)
+    print(f"Spearman ρ = {rho:.3f} ({len(common)} flagged plays)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/analytics/tools/hmm-scorer.md
+++ b/analytics/tools/hmm-scorer.md
@@ -1,0 +1,106 @@
+# HMM latent-regime scorer (#445)
+
+A research complement to the VOMM scorer (`scorer.py` / `derive_labels.py`). Same token
+alphabet (`tokenize.py`), different question:
+
+| | question it answers | signal |
+|---|---|---|
+| **VOMM** (`derive_labels.py`) | "is this *ordering* of requests one we see in clean traffic?" | per-transition surprise → `unexpected_<condition>` |
+| **HMM** (`hmm_deriver.py`) | "what *regime* is the player in, and is this regime transition normal?" | latent-state timeline → `regime_<STATE>` + `unexpected_regime_transition` |
+
+The HMM is a **whole-sequence** model: a `CategoricalHMM` (hmmlearn) decodes each play's
+cross-stream token stream into a latent-state timeline — STARTUP / STEADY / RECOVERING /
+STALLED / ENDING. The VOMM scores per-condition episode windows; the HMM scores the whole
+play. They share nothing but the alphabet, so their `derived_labels` rows coexist (distinct
+`model_version` = `hmm-tok-1`).
+
+## Files
+
+- `hmm_model.py` — the model core (CategoricalHMM train/decode, BIC, state auto-labelling
+  from top emissions, RLE intervals, transition surprise, gzipped-JSON artifact I/O).
+  Imported by both tools below.
+- `hmm_deriver.py` — the **production path**: `--mode train` (slow) fits + persists the
+  artifact and a `derived_models` manifest row; `--mode score` (fast) Viterbi-decodes
+  out-of-sample plays and writes `derived_labels`. Mirrors `derive_labels.py`'s #608 split.
+- `hmm_scorer.py` — the **verification harness**: K-sweep / BIC / state-labelability /
+  clean-vs-failed separation. How you decide the deriver is trustworthy before enabling it.
+- `compare_markov_hmm.py` — reads `derived_labels` and reports the plays where the VOMM and
+  HMM derivers disagree most (Spearman ρ + rank-disagreement tables).
+- `requirements.txt` — `hmmlearn` / `numpy` / `scikit-learn` (the only non-stdlib tools here).
+
+## Label family (→ `derived_labels`, `model_version=hmm-tok-1`)
+
+- `regime_<STATE>` — one row at the first token of each Viterbi state interval,
+  `condition='regime'`, `severity='info'`, `score=interval length`. The regime ribbon, on
+  the rows.
+- `unexpected_regime_transition` — a state→state move whose `−log P(transition)` under the
+  learned transition matrix exceeds the train-calibrated p99 threshold. `condition=
+  'regime_transition'`, `severity` from the magnitude, `score=surprise`. The "this regime
+  change is abnormal" signal point-surprise can't see.
+
+Both anchor on the row that emitted the landing token (network rows by `entry_fingerprint`;
+event/sentinel tokens land as `surface='event'`, `entry_fingerprint=0`, joined on
+`(player_id, ts)`) — same read-path join as the VOMM labels and `derived_tokens`.
+
+## Out-of-sample guarantee
+
+Identical to the VOMM deriver: the artifact stamps `trained_at`; the scorer only scores
+plays whose `max_ts` post-dates it. No `now − score_hours` arithmetic — `trained_at` IS the
+cutoff. Training uses **all** plays in the window (bulk-normal), not a hand-split clean
+corpus, so the failure regimes (STALLED/RECOVERING) actually emerge as latent states.
+
+## Running locally (verification)
+
+```bash
+# one-off venv (the sidecars pip-install the same requirements.txt)
+python3 -m venv /tmp/hmm_venv && /tmp/hmm_venv/bin/pip install -r requirements.txt
+
+# pick K via BIC over the last 7 days, then inspect states + clean-vs-failed separation
+/tmp/hmm_venv/bin/python hmm_scorer.py --days 7 --k-sweep 3,5,7,9 --out /tmp/hmm_sweep
+/tmp/hmm_venv/bin/python hmm_scorer.py --days 7 --k 5 --out /tmp/hmm_report
+# (defaults to FORWARDER_CLICKHOUSE_URL=http://localhost:8123; override --ch-url)
+
+# dry-run the production deriver against CH without writing
+/tmp/hmm_venv/bin/python hmm_deriver.py --mode train --train-days 7 --k 5 --model-path /tmp/hmm-model.json.gz
+/tmp/hmm_venv/bin/python hmm_deriver.py --mode score --model-path /tmp/hmm-model.json.gz --dry-run
+
+# where do the two models disagree? (reads derived_labels; pure stdlib, no venv needed)
+python3 compare_markov_hmm.py --days 7 --out /tmp/compare.md
+```
+
+## Running as sidecars (production)
+
+Opt-in behind the `hmm` compose profile (these are P3 research and, unlike the stdlib VOMM
+deriver, pull in hmmlearn/scipy — pip-installed on container start):
+
+```bash
+docker compose --profile hmm up -d hmm-label-trainer hmm-label-scorer
+```
+
+Tunables (env): `HMM_K`, `HMM_TRAIN_DAYS`, `HMM_TRAIN_INTERVAL_SECONDS`,
+`HMM_SCORE_HOURS`, `HMM_SCORE_INTERVAL_SECONDS`, `HMM_MODEL_PATH`, `HMM_MODEL_VERSION`.
+The trainer and scorer share the `hmm-models` volume (artifact handoff).
+
+## Verification checklist (#445)
+
+Run `hmm_scorer.py` and confirm, on real CH data:
+
+- [ ] K-sweep BIC has a clear minimum → set the deriver's `--k` to it.
+- [ ] The K states are labelable from their top emissions (not a wall of `STATE_<i>`).
+- [ ] Failed plays' per-token log-likelihood sits clearly below held-out-clean.
+- [ ] A known-bad play's ribbon shows meaningful RECOVERING/STALLED time.
+- [ ] `compare_markov_hmm.py` Spearman ρ lands in ~[0.4, 0.7], and the top disagreements
+      are intuitively explainable.
+
+## v1 limitations (follow-ups)
+
+- **Single global HMM.** The CH-direct read path doesn't carry `player_kind`/`variant`, so
+  v1 trains one model over all plays. Per-bucket models (the draft's old cascade) need those
+  columns plumbed into the `network_requests`/`session_events` fetch first.
+- **State labels are heuristic** (top-emission keyword match, `STATE_<i>` fallback). They're
+  suggestions for the human reading the report, not ground truth — the report prints the
+  full emission table so you can sanity-check them.
+- **`tokenize.py` shadows stdlib `tokenize`.** Harmless for the pure-stdlib VOMM tools, but
+  the HMM tools pull in scipy (which imports the stdlib `tokenize`), so `hmm_deriver.py` /
+  `hmm_scorer.py` strip their own dir from `sys.path` and load siblings by file path. Any
+  *new* numpy/scipy-using tool in this directory must do the same (or we rename `tokenize.py`).

--- a/analytics/tools/hmm_deriver.py
+++ b/analytics/tools/hmm_deriver.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""#445/#608 HMM latent-regime LABEL deriver (PER ROW) — TRAIN + SCORE split.
+
+Sibling of derive_labels.py (the VOMM deriver). Where the VOMM emits point
+`unexpected_<condition>` surprise on the row whose token transition was improbable, the HMM
+emits a *regime* family decoded from the latent-state timeline:
+
+  * regime_<STATE>             — one row at the FIRST token of each Viterbi state interval
+                                 (STARTUP / STEADY / RECOVERING / STALLED / ENDING …),
+                                 severity=info. The session's regime ribbon, on the rows.
+  * unexpected_regime_transition — a Viterbi state→state move whose −log P(transition) under
+                                 the learned transmat exceeds the train-calibrated p99
+                                 threshold. severity from the magnitude. The "this regime
+                                 change is abnormal" signal the point-surprise model can't see.
+
+Same #608 contract as the VOMM deriver:
+
+  --mode train (SLOW, nightly): fit a CategoricalHMM over the last --train-days of plays
+                (whole cross-stream token sequences — regimes incl. failure modes emerge
+                because the corpus is bulk-normal, not hand-split), auto-label its states,
+                calibrate the transition-surprise p99 threshold, serialize the fitted model
+                to a gzipped-JSON artifact at --model-path, and write a derived_models
+                manifest row. The only place hmmlearn's Baum-Welch runs.
+
+  --mode score (FAST): load the artifact, Viterbi-decode plays whose max_ts POST-DATES the
+                model's trained_at (OUT-OF-SAMPLE by construction — same guarantee as the
+                VOMM deriver), and write derived_labels rows. No training.
+
+Reads ClickHouse directly (reuses derive_tokens.py's ch()/fetch_rows()); reuses tokenize.py's
+cross-stream tokeniser and hmm_model.py's model. v1 trains ONE global HMM (the CH-direct read
+path doesn't carry player_kind/variant; per-bucket models are a follow-up — see hmm-scorer.md).
+
+  python3 analytics/tools/hmm_deriver.py --mode train --train-days 7 --model-path /models/hmm-model.json.gz
+  python3 analytics/tools/hmm_deriver.py --mode score --score-hours 2 --model-path /models/hmm-model.json.gz [--dry-run]
+"""
+import argparse
+import base64
+import collections
+import importlib.util
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# Our sibling module is named tokenize.py, which SHADOWS the stdlib `tokenize`. The VOMM
+# deriver gets away with `import tokenize` because its stack is pure-stdlib and never
+# triggers a stdlib `import tokenize`. The HMM stack pulls in scipy (via hmmlearn), and
+# scipy DOES `import tokenize` internally (inspect.signature over numpy builtins) — if our
+# tokenize.py is found first, scipy explodes. Running this file as a script puts HERE at
+# sys.path[0] automatically, so appending isn't enough: we REMOVE our dir from sys.path and
+# load every sibling explicitly by file path. derive_tokens.py can't be imported for the
+# same reason (it does insert(0, HERE) + `import tokenize`), so its small CH read helpers
+# (ch/fetch_rows/group_by_play) are inlined below.
+sys.path[:] = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != HERE]
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(HERE, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hm = _load("hmm_model", "hmm_model.py")     # CategoricalHMM core + artifact I/O
+tk = _load("iss_tokenize", "tokenize.py")   # cross-stream tokeniser (_token_seq)
+
+DB = "infinite_streaming"
+NET_COLS = "ts, player_id, play_id, entry_fingerprint, url, status, fault_type, fault_category"
+EVENT_COLS = "ts, player_id, play_id, last_event"
+CONDITION = "regime"                       # single global condition for v1
+DEFAULT_MODEL_PATH = os.environ.get("HMM_MODEL_PATH", "/models/hmm-model.json.gz")
+
+
+# ---------- ClickHouse reads (inlined from derive_tokens.py; see import note above) ----------
+def _auth_header():
+    u, p = os.environ.get("FORWARDER_CLICKHOUSE_USER"), os.environ.get("FORWARDER_CLICKHOUSE_PASSWORD")
+    if u:
+        tok = base64.b64encode(f"{u}:{p or ''}".encode()).decode()
+        return {"Authorization": f"Basic {tok}"}
+    return {}
+
+
+def ch(ch_url, query, body=None, params=None):
+    q = {"query": query}
+    if body is None:
+        q["default_format"] = "JSONEachRow"
+    for k, v in (params or {}).items():
+        q[f"param_{k}"] = v
+    url = ch_url.rstrip("/") + "/?" + urllib.parse.urlencode(q)
+    headers = _auth_header()
+    if body is not None:
+        headers["Content-Type"] = "application/x-ndjson"
+    req = urllib.request.Request(url, data=body, method="POST" if body is not None else "GET", headers=headers)
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read().decode()
+
+
+def fetch_rows(ch_url, days, hours, player, table, cols, order):
+    if hours:
+        where, params = ["ts >= now64(3) - INTERVAL {hours:UInt32} HOUR"], {"hours": str(hours)}
+    else:
+        where, params = ["ts >= now64(3) - INTERVAL {days:UInt32} DAY"], {"days": str(days)}
+    if player:
+        where.append("player_id = {pid:String}")
+        params["pid"] = player
+    sql = f"SELECT {cols} FROM {DB}.{table} WHERE {' AND '.join(where)} ORDER BY {order}"
+    return [json.loads(l) for l in ch(ch_url, sql, params=params).splitlines() if l.strip()]
+
+
+def group_by_play(rows):
+    by = collections.defaultdict(list)
+    for r in rows:
+        by[r.get("play_id")].append(r)
+    return by
+
+
+def play_seq_full(net_rows, event_rows):
+    """[(ts, fp, surface, token)] cross-stream + <S>/<E> sentinels (fp=None). The per-token
+    ts/fp/surface let us anchor a decoded regime back onto the row that emitted it."""
+    seq = tk._token_seq(net_rows, event_rows)
+    if not seq:
+        return []
+    return [(seq[0][0], None, "", "<S>")] + list(seq) + [(seq[-1][0], None, "", "<E>")]
+
+
+def build_plays(ch_url, days, hours, player):
+    """{play_id: {pid, full, max_ts}} — whole cross-stream token sequences over a CH window."""
+    net_rows = fetch_rows(ch_url, days, hours, player, "network_requests",
+                          NET_COLS, "player_id, ts, entry_fingerprint")
+    event_rows = fetch_rows(ch_url, days, hours, player, "session_events",
+                            EVENT_COLS, "player_id, ts")
+    net_by_play, ev_by_play = group_by_play(net_rows), group_by_play(event_rows)
+    plays = list(net_by_play.keys()) + [p for p in ev_by_play if p not in net_by_play]
+    builds = {}
+    for play in plays:
+        if not play:
+            continue
+        prows, erows = net_by_play.get(play, []), ev_by_play.get(play, [])
+        full = play_seq_full(prows, erows)
+        if not full:
+            continue
+        pid = next((r.get("player_id") for r in (prows + erows) if r.get("player_id")), "")
+        builds[play] = {"pid": pid, "full": full, "max_ts": full[-1][0]}
+    return builds
+
+
+def severity_for(score, thr):
+    return "critical" if score >= thr * 1.5 else "warning"
+
+
+def _anchor(full, lo, hi):
+    """First non-sentinel token in full[lo:hi] → (ts, entry_fingerprint, surface), or None
+    if the interval is sentinels only. Event/sentinel tokens carry fp=None → land as
+    (0, 'event') so the events read-path joins on (player_id, ts); network rows keep their
+    real fingerprint + surface."""
+    for ts, fp, surface, token in full[lo:hi]:
+        if token in hm.SENTINELS:
+            continue
+        return (ts, 0, "event") if fp is None else (ts, fp, surface or "net")
+    return None
+
+
+# ---------- TRAIN ----------
+def cmd_train(args):
+    builds = build_plays(args.ch_url, args.train_days, 0, args.player)
+    seqs = [[x[3] for x in b["full"]] for b in builds.values()]
+    seqs = [s for s in seqs if len(s) >= 5]
+    trained_at = hm.utc_now()
+    print(f"#445 HMM train — {len(seqs)} plays over {args.train_days}d, K={args.k} "
+          f"→ {args.model_path}")
+    if len(seqs) < args.min_train_plays:
+        print(f"  {len(seqs)} train plays < {args.min_train_plays}; artifact NOT written.")
+        return
+
+    vocab = hm.TokenVocab().fit(seqs)
+    model, train_logL = hm.train_hmm(seqs, vocab, K=args.k, restarts=args.restarts)
+    if model is None:
+        print(f"  training failed (vocab={vocab.n_tokens()}, plays={len(seqs)}); artifact NOT written.")
+        return
+    labels = hm.auto_label_states(model.emissionprob_, vocab)
+
+    # Transition-surprise threshold: p99 of −log P(state→state) across all training Viterbi
+    # paths. The score pass flags moves above this as unexpected_regime_transition.
+    surprises = []
+    for s in seqs:
+        _, states = hm.decode(model, vocab, s)
+        if states:
+            surprises += hm.transition_surprises(model.transmat_, states)
+    trans_thr = hm.p99(surprises)
+    n_obs = sum(len(s) for s in seqs)
+
+    cond = hm.serialize_condition(model, vocab, train_logL, len(seqs), n_obs, trans_thr, labels)
+    artifact = {"model_version": args.model_version, "trained_at": trained_at,
+                "train_window_days": args.train_days, "K": args.k, "restarts": args.restarts,
+                "conditions": {CONDITION: cond}}
+    print(f"  states={labels} vocab={vocab.n_tokens()} logL={train_logL:.1f} "
+          f"trans_thr={trans_thr:.2f} BIC={hm.bic(model, train_logL, n_obs):.1f}")
+    if args.dry_run:
+        print(f"[dry-run] would write artifact (trained_at={trained_at})")
+        return
+
+    size = hm.save_artifact(args.model_path, artifact)
+    manifest = {"trained_at": trained_at, "model_version": args.model_version,
+                "condition": CONDITION, "train_window_days": args.train_days,
+                "n_train_episodes": len(seqs), "threshold": round(trans_thr, 4),
+                "n_contexts": args.k, "vocab": vocab.n_tokens(), "max_order": args.k,
+                "artifact_path": args.model_path, "artifact_bytes": size}
+    body = (json.dumps(manifest) + "\n").encode()
+    ch(args.ch_url, f"INSERT INTO {DB}.derived_models FORMAT JSONEachRow", body=body)
+    print(f"wrote {size} B artifact (K={args.k}, states={labels}) + 1 manifest row.")
+
+
+# ---------- SCORE ----------
+def cmd_score(args):
+    art = hm.load_artifact(args.model_path)
+    if not art:
+        print(f"#445 HMM score — no artifact at {args.model_path} yet "
+              f"(trainer hasn't run?); nothing to score.")
+        return
+    cond = art["conditions"][CONDITION]
+    vocab = hm.TokenVocab(cond["idx2tok"])
+    model = hm.model_from_artifact(cond)
+    labels, thr = cond["state_labels"], cond["trans_thr"]
+    trained_at = art["trained_at"]
+
+    builds = build_plays(args.ch_url, 0, args.score_hours, args.player)
+    # Out-of-sample by construction: only plays that finished AFTER the corpus closed.
+    score_plays = [(p, b) for p, b in builds.items() if b["max_ts"] > trained_at]
+    scored_at = hm.utc_now()
+    print(f"#445 HMM score — model {art['model_version']} trained_at={trained_at}; "
+          f"{len(builds)} plays in last {args.score_hours}h, {len(score_plays)} out-of-sample")
+
+    rows, n_regime, n_trans = [], 0, 0
+    for play, b in score_plays:
+        full, pid = b["full"], b["pid"]
+        toks = [x[3] for x in full]
+        _, states = hm.decode(model, vocab, toks)
+        if not states:
+            continue
+
+        # regime_<STATE> — one row at the first real token of each Viterbi interval.
+        for lbl, _s_pos, _e_pos, count, start_i in hm.rle_intervals(states, labels):
+            a = _anchor(full, start_i, start_i + count)
+            if not a:
+                continue
+            ts, efp, surf = a
+            rows.append({"ts": ts, "player_id": pid, "play_id": play,
+                         "entry_fingerprint": efp, "surface": surf, "condition": CONDITION,
+                         "label": f"regime_{lbl}", "severity": "info", "score": float(count),
+                         "model_version": art["model_version"], "scored_at": scored_at})
+            n_regime += 1
+
+        # unexpected_regime_transition — surprises[j] is the move LANDING on states[j+1].
+        for j, surprise in enumerate(hm.transition_surprises(model.transmat_, states)):
+            if surprise < thr:
+                continue
+            a = _anchor(full, j + 1, j + 2)        # the landing token's own row
+            if not a:
+                continue
+            ts, efp, surf = a
+            rows.append({"ts": ts, "player_id": pid, "play_id": play,
+                         "entry_fingerprint": efp, "surface": surf,
+                         "condition": "regime_transition",
+                         "label": "unexpected_regime_transition",
+                         "severity": severity_for(surprise, thr), "score": round(surprise, 3),
+                         "model_version": art["model_version"], "scored_at": scored_at})
+            n_trans += 1
+
+    # Dedup identical (row, condition) within this run; keep the most salient. Cross-run
+    # dedup is the ReplacingMergeTree(scored_at)'s job.
+    best = {}
+    for r in rows:
+        k = (r["player_id"], r["ts"], r["entry_fingerprint"], r["condition"])
+        if k not in best or r["score"] > best[k]["score"]:
+            best[k] = r
+    rows = list(best.values())
+
+    print(f"emitted {len(rows)} row labels: regime={n_regime} transition={n_trans}")
+    if args.dry_run:
+        for r in sorted(rows, key=lambda x: -x["score"])[:12]:
+            print(f"   {r['severity']:8} {r['label']:28} score={r['score']:6.2f} "
+                  f"surf={r['surface']:9} play={r['play_id'][:8]} @ {r['ts']}")
+        return
+    if not rows:
+        print("nothing to write.")
+        return
+    body = ("\n".join(json.dumps(r) for r in rows) + "\n").encode()
+    ch(args.ch_url, f"INSERT INTO {DB}.derived_labels FORMAT JSONEachRow", body=body)
+    print(f"inserted {len(rows)} rows into {DB}.derived_labels.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--mode", choices=["train", "score"], required=True)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--model-path", default=DEFAULT_MODEL_PATH, help="gzipped-JSON artifact shared by train+score")
+    ap.add_argument("--train-days", type=int, default=7, help="train: corpus window")
+    ap.add_argument("--score-hours", type=int, default=2, help="score: how far back to look for out-of-sample plays")
+    ap.add_argument("--player", default=None, help="limit to one player_id")
+    ap.add_argument("--k", type=int, default=hm.DEFAULT_K, help="number of hidden states")
+    ap.add_argument("--restarts", type=int, default=hm.DEFAULT_RESTARTS, help="random restarts to escape EM local optima")
+    ap.add_argument("--min-train-plays", type=int, default=hm.MIN_TRAIN_SEQUENCES)
+    ap.add_argument("--model-version", default="hmm-tok-1")
+    ap.add_argument("--dry-run", action="store_true", help="compute + summarise, do NOT write")
+    args = ap.parse_args()
+    (cmd_train if args.mode == "train" else cmd_score)(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/analytics/tools/hmm_model.py
+++ b/analytics/tools/hmm_model.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""#445 HMM core — shared model substrate for the latent-regime scorer.
+
+The VOMM (`scorer.py`) answers "is this *ordering* of requests one we see in clean
+traffic" (per-transition surprise). The HMM answers a different question: "what *regime*
+is the player in, and is this regime transition normal" — a latent-state timeline
+(STARTUP / STEADY / RECOVERING / STALLED / ENDING) decoded from the SAME cross-stream
+token alphabet (`tokenize.py`). This module is the model itself; `hmm_deriver.py` wires it
+into the #608 train/score split (→ derived_labels) and `hmm_scorer.py` wraps it for the
+verification report (K-sweep / BIC / emission inspection).
+
+CategoricalHMM (hmmlearn) over the token alphabet, fit with random restarts (Baum-Welch is
+local-optimum prone). The fitted matrices + vocab + auto-assigned state labels + the
+transition-surprise threshold serialize to a gzipped-JSON artifact — the model-agnostic
+seam #608 left generic for exactly this. Scoring reconstructs the model from the artifact
+(no retrain) and Viterbi-decodes each play into a regime timeline.
+
+Dependencies (the deriver sidecar pip-installs these; the stdlib VOMM does not need them):
+    hmmlearn numpy scikit-learn
+"""
+import collections
+import gzip
+import json
+import math
+import os
+import tempfile
+import warnings
+from datetime import datetime, timezone
+
+import numpy as np
+
+# hmmlearn warns on non-convergence per restart; we keep the best restart ourselves.
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.filterwarnings("ignore", message=".*did not converge.*")
+
+DEFAULT_K = 5
+DEFAULT_RESTARTS = 6
+DEFAULT_MAX_ITER = 100
+DEFAULT_TOL = 1e-4
+# Post-fit smoothing floor so a token/transition unseen in training doesn't collapse a
+# scored sequence's log-likelihood to -inf (and so Viterbi never hits a zero-prob wall).
+PROB_FLOOR = 1e-6
+MIN_TRAIN_SEQUENCES = 5      # a bucket with fewer clean plays than this can't train
+SENTINELS = ("<S>", "<E>")
+
+
+# ---------- token vocabulary ----------
+class TokenVocab:
+    """Stable token → contiguous index map. A reserved <UNK> at index 0 lets us score
+    sequences containing tokens absent from training without retraining or reshaping the
+    emission matrix."""
+
+    UNK = "<UNK>"
+
+    def __init__(self, idx2tok=None):
+        if idx2tok:
+            self.idx2tok = list(idx2tok)
+        else:
+            self.idx2tok = [self.UNK]
+        self.tok2idx = {t: i for i, t in enumerate(self.idx2tok)}
+
+    def fit(self, sequences):
+        for seq in sequences:
+            for tok in seq:
+                if tok not in self.tok2idx:
+                    self.tok2idx[tok] = len(self.idx2tok)
+                    self.idx2tok.append(tok)
+        return self
+
+    def transform(self, seq):
+        unk = self.tok2idx[self.UNK]
+        return np.array([self.tok2idx.get(t, unk) for t in seq], dtype=np.int64)
+
+    def n_tokens(self):
+        return len(self.idx2tok)
+
+
+# ---------- training ----------
+def _stack(sequences, vocab):
+    """List of token sequences → (X, lengths) as hmmlearn wants: X is (total_tokens, 1)
+    ints, lengths is per-sequence token counts. Sequences shorter than 2 are dropped (no
+    transition to learn)."""
+    usable = [seq for seq in sequences if len(seq) >= 2]
+    if not usable:
+        return np.zeros((0, 1), dtype=np.int64), np.zeros((0,), dtype=np.int64)
+    flat = np.concatenate([vocab.transform(seq) for seq in usable])
+    lengths = np.array([len(seq) for seq in usable], dtype=np.int64)
+    return flat.reshape(-1, 1), lengths
+
+
+def _floor_and_renormalise(startprob, transmat, emissionprob, floor=PROB_FLOOR):
+    """Clamp each probability array's zeros to `floor` and renormalise rows. Returns the
+    three cleaned arrays. See PROB_FLOOR — protects out-of-sample scoring from -inf."""
+    out = []
+    for arr in (startprob, transmat, emissionprob):
+        a = np.where(np.asarray(arr, dtype=float) < floor, floor, np.asarray(arr, dtype=float))
+        a = a / a.sum() if a.ndim == 1 else a / a.sum(axis=1, keepdims=True)
+        out.append(a)
+    return out
+
+
+def train_hmm(sequences, vocab, K=DEFAULT_K, restarts=DEFAULT_RESTARTS,
+              max_iter=DEFAULT_MAX_ITER, tol=DEFAULT_TOL, seed=0):
+    """Fit a CategoricalHMM with K hidden states; random-restart `restarts` times and keep
+    the highest training log-likelihood (Baum-Welch is initial-condition sensitive).
+
+    Returns (model, train_logL) or (None, -inf) when the bucket is too thin to fit."""
+    from hmmlearn.hmm import CategoricalHMM
+
+    X, lengths = _stack(sequences, vocab)
+    if X.shape[0] < K * 5:                       # too few observations for K states
+        return None, float("-inf")
+
+    best, best_score = None, float("-inf")
+    for r in range(restarts):
+        rng = np.random.default_rng(seed + r)
+        m = CategoricalHMM(
+            n_components=K, n_features=vocab.n_tokens(), n_iter=max_iter, tol=tol,
+            init_params="ste", random_state=int(rng.integers(0, 2**31 - 1)),
+        )
+        try:
+            m.fit(X, lengths)
+            sc = m.score(X, lengths)
+        except (ValueError, RuntimeError):
+            continue
+        if sc > best_score:
+            best, best_score = m, sc
+    if best is not None:
+        best.startprob_, best.transmat_, best.emissionprob_ = _floor_and_renormalise(
+            best.startprob_, best.transmat_, best.emissionprob_)
+    return best, best_score
+
+
+def model_from_artifact(cond):
+    """Rebuild a CategoricalHMM from a serialized condition dict (no retrain) for scoring."""
+    from hmmlearn.hmm import CategoricalHMM
+
+    startprob = np.asarray(cond["startprob"], dtype=float)
+    transmat = np.asarray(cond["transmat"], dtype=float)
+    emissionprob = np.asarray(cond["emissionprob"], dtype=float)
+    m = CategoricalHMM(n_components=len(startprob), n_features=emissionprob.shape[1])
+    m.startprob_, m.transmat_, m.emissionprob_ = startprob, transmat, emissionprob
+    return m
+
+
+def decode(model, vocab, seq):
+    """Viterbi-decode one token sequence → (forward_logL, [state_idx]) or (None, None)."""
+    if model is None or len(seq) < 2:
+        return None, None
+    X = vocab.transform(seq).reshape(-1, 1)
+    try:
+        ll, states = model.decode(X, algorithm="viterbi")
+    except (ValueError, RuntimeError):
+        return None, None
+    return float(ll), states.tolist()
+
+
+def bic(model, log_likelihood, n_observations):
+    """BIC = -2·logL + k·log(N); k = (K-1) start + K(K-1) transition + K(V-1) emission free
+    params. Lower is better — the K-sweep picks the K with the lowest aggregate BIC."""
+    if model is None:
+        return float("inf")
+    K, V = model.n_components, model.n_features
+    k = (K - 1) + K * (K - 1) + K * (V - 1)
+    return -2.0 * log_likelihood + k * math.log(max(n_observations, 1))
+
+
+# ---------- transition surprise (for unexpected_regime_transition) ----------
+def transition_surprises(transmat, states):
+    """[-log P(state_t → state_{t+1})] along a Viterbi path, under the learned transmat.
+    out[j] is the surprise of the move LANDING on states[j+1]."""
+    lt = np.log(np.asarray(transmat, dtype=float))
+    return [float(-lt[states[i - 1], states[i]]) for i in range(1, len(states))]
+
+
+def p99(values):
+    return sorted(values)[min(len(values) - 1, int(0.99 * len(values)))] if values else 0.0
+
+
+# ---------- post-hoc state interpretation (current tokenize.py alphabet) ----------
+# Maps a hidden state to a human regime by inspecting its top emissions. The token families
+# are the CURRENT ones (tokenize.py): V_SEG/A_SEG/V_PROBE, STARTUP_RAMP/LOOP_BOUNDARY,
+# V_PL/A_PL/M_PL, FAULT(surface,class), and event markers STALL_*/BUF_*/RATE_*/FIRST_FRAME/
+# SEGMENT_STALL/TIMEJUMP. Checked most-disruptive-first so a state only falls through to
+# STEADY when nothing more specific dominates.
+_SERVER_FAULT_CLASSES = ("5xx", "404", "auth", "4xx", "injected_reset", "corruption", "server_partial")
+
+
+def label_state(top_tokens):
+    """Return a regime label for a state given its top-emission token strings, or None to
+    fall back to STATE_<i>."""
+    def has(*subs):
+        return any(any(s in t for s in subs) for t in top_tokens)
+
+    server_fault = any(
+        t.startswith("FAULT(") and any(c in t for c in _SERVER_FAULT_CLASSES) for t in top_tokens)
+    if has("STALL_START", "SEGMENT_STALL") or server_fault:
+        return "STALLED"
+    if has("RATE_DOWN", "V_PROBE", "BUF_START", "LOOP_BOUNDARY", "STALL_END",
+           "BUF_END", "TIMEJUMP") or any(t.startswith("FAULT(") for t in top_tokens):
+        return "RECOVERING"
+    if has("STARTUP_RAMP", "FIRST_FRAME", "M_PL", "V_PL", "<S>"):
+        return "STARTUP"
+    if has("<E>"):
+        return "ENDING"
+    if has("V_SEG", "A_SEG", "RATE_UP"):
+        return "STEADY"
+    return None
+
+
+def top_emissions(emissionprob, vocab, state_idx, top_n=8):
+    """[(token, prob)] — the state's highest-probability emissions, descending."""
+    emit = np.asarray(emissionprob[state_idx], dtype=float)
+    return [(vocab.idx2tok[i], float(emit[i])) for i in np.argsort(-emit)[:top_n]]
+
+
+def auto_label_states(emissionprob, vocab, top_n=5):
+    """Label every hidden state from its top emissions; disambiguate collisions with a
+    numeric suffix so the timeline stays distinct (STALLED, STALLED_2, ...)."""
+    raw = [label_state([t for t, _ in top_emissions(emissionprob, vocab, s, top_n)])
+           or f"STATE_{s}" for s in range(len(emissionprob))]
+    counts = collections.Counter(raw)
+    seen, out = collections.Counter(), []
+    for lbl in raw:
+        if counts[lbl] == 1:
+            out.append(lbl)
+        else:
+            seen[lbl] += 1
+            out.append(f"{lbl}_{seen[lbl]}")
+    return out
+
+
+# ---------- run-length encoding of the state timeline ----------
+def rle_intervals(states, state_labels, positions=None):
+    """Collapse consecutive identical states into intervals. positions (optional, same
+    length as states) lets the caller carry per-token anchors (e.g. (ts, fp, surface)) so
+    the FIRST token of each interval can be located. Returns
+    [(label, start_pos, end_pos, count, start_index)]."""
+    if not states:
+        return []
+    pos = positions if positions is not None else list(range(len(states)))
+    out, cur, start, start_i, count = [], states[0], pos[0], 0, 1
+    for i in range(1, len(states)):
+        if states[i] == cur:
+            count += 1
+            continue
+        out.append((state_labels[cur], start, pos[i - 1], count, start_i))
+        cur, start, start_i, count = states[i], pos[i], i, 1
+    out.append((state_labels[cur], start, pos[-1], count, start_i))
+    return out
+
+
+def state_distribution(states, state_labels):
+    c = collections.Counter(state_labels[s] for s in states)
+    total = sum(c.values()) or 1
+    return {lbl: n / total for lbl, n in c.most_common()}
+
+
+# ---------- artifact I/O (gzipped JSON; atomic swap — mirrors derive_labels.py) ----------
+def serialize_condition(model, vocab, train_logL, n_train_seqs, n_obs, trans_thr, labels):
+    """One condition's fitted model + metadata → JSON-safe dict for the artifact."""
+    return {
+        "startprob": np.asarray(model.startprob_).tolist(),
+        "transmat": np.asarray(model.transmat_).tolist(),
+        "emissionprob": np.asarray(model.emissionprob_).tolist(),
+        "idx2tok": vocab.idx2tok,
+        "state_labels": labels,
+        "K": int(model.n_components),
+        "trans_thr": float(trans_thr),
+        "train_logL": float(train_logL),
+        "n_train_seqs": int(n_train_seqs),
+        "n_observations": int(n_obs),
+    }
+
+
+def save_artifact(path, artifact):
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", suffix=".tmp")
+    os.close(fd)
+    with gzip.open(tmp, "wt", encoding="utf-8") as f:
+        json.dump(artifact, f, separators=(",", ":"))
+    os.replace(tmp, path)            # atomic so the scorer never reads a half-written file
+    return os.path.getsize(path)
+
+
+def load_artifact(path):
+    if not os.path.exists(path):
+        return None
+    with gzip.open(path, "rt", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def utc_now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]

--- a/analytics/tools/hmm_scorer.py
+++ b/analytics/tools/hmm_scorer.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""#445 HMM verification harness — the analysis mode behind the production deriver.
+
+`hmm_deriver.py` is the live path (train → artifact → derived_labels). THIS tool is how you
+decide the deriver is trustworthy before turning it on, and re-validate after the alphabet
+or corpus shifts. It reads ClickHouse directly (same substrate as the deriver), trains on a
+clean 80% split, scores the held-out clean 20% vs the failed plays, and writes a report
+covering the issue's verification checklist:
+
+  * K-sweep over {3,5,7,9} with aggregate BIC — pick the K the deriver should default to.
+  * Per-state top-emission tables — are the K states labelable (STARTUP/STEADY/…)?
+  * Per-token log-likelihood, clean-holdout vs failed — does the HMM separate them?
+  * State ribbons for the most anomalous failed plays — does a known-bad play actually
+    show meaningful RECOVERING/STALLED time?
+
+Clean vs failed is read from the token stream itself (no extra columns): a play is FAILED
+if it has any FAULT(...) / STALL_START / SEGMENT_STALL token, CLEAN if it reached
+FIRST_FRAME with none of those. Trains ONE global HMM (per-bucket is a deriver follow-up).
+
+  python3 analytics/tools/hmm_scorer.py --days 7 --k 5 --out /tmp/hmm_report
+  python3 analytics/tools/hmm_scorer.py --days 7 --k-sweep 3,5,7,9 --out /tmp/hmm_sweep
+"""
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# Remove our dir from sys.path and load siblings by file path so our tokenize.py can't
+# shadow the stdlib `tokenize` that scipy (via hmmlearn) needs — see hmm_deriver.py's note.
+sys.path[:] = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != HERE]
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(HERE, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+hm = _load("hmm_model", "hmm_model.py")
+hd = _load("hmm_deriver", "hmm_deriver.py")    # build_plays() + CH reads (whole-play seqs)
+
+
+def classify(toks):
+    """(is_clean, is_failed) from the token stream alone — see module docstring."""
+    failed = any(t.startswith("FAULT(") for t in toks) or any(
+        t in ("STALL_START", "SEGMENT_STALL") for t in toks)
+    clean = ("FIRST_FRAME" in toks) and not failed
+    return clean, failed
+
+
+def fold(play_id):
+    """Deterministic 0..4 bucket from the play UUID — every 5th clean play is held out."""
+    try:
+        return int(play_id[:8], 16) % 5
+    except ValueError:
+        return 0
+
+
+def gather(ch_url, days, player, min_tokens=5):
+    """[(play_id, toks, is_clean, is_failed)] over a CH window."""
+    builds = hd.build_plays(ch_url, days, 0, player)
+    out = []
+    for play, b in builds.items():
+        toks = [x[3] for x in b["full"]]
+        if len(toks) < min_tokens:
+            continue
+        c, f = classify(toks)
+        out.append((play, toks, c, f))
+    return out
+
+
+def _stats(v):
+    if not v:
+        return "n=0"
+    s = sorted(v)
+    p = lambda f: s[min(len(s) - 1, int(f * len(s)))]
+    return f"n={len(s)} p10={p(0.1):.3f} p50={p(0.5):.3f} p90={p(0.9):.3f}"
+
+
+def train_and_score(samples, K, restarts):
+    """Train on the clean 80% split; Viterbi-score every play. Returns
+    (model, vocab, labels, results, meta) or (None, ...) when the clean corpus is too thin."""
+    clean = [(p, t) for p, t, c, _f in samples if c]
+    train = [(p, t) for p, t in clean if fold(p) != 0]
+    if len(train) < hm.MIN_TRAIN_SEQUENCES:
+        return None, None, None, [], {"train_n": len(train)}
+
+    vocab = hm.TokenVocab().fit([t for _p, t, _c, _f in samples])   # all tokens → stable indices
+    model, train_logL = hm.train_hmm([t for _p, t in train], vocab, K=K, restarts=restarts)
+    if model is None:
+        return None, None, None, [], {"train_n": len(train)}
+    labels = hm.auto_label_states(model.emissionprob_, vocab)
+    n_obs = sum(len(t) for _p, t in train)
+
+    results = []
+    for play, toks, is_clean, is_failed in samples:
+        ll, states = hm.decode(model, vocab, toks)
+        if ll is None:
+            continue
+        held_out_clean = is_clean and fold(play) == 0
+        results.append({
+            "play_id": play, "n_tokens": len(toks),
+            "is_clean": is_clean, "is_failed": is_failed, "held_out_clean": held_out_clean,
+            "log_likelihood": ll, "per_token_ll": ll / max(len(toks), 1),
+            "state_distribution": hm.state_distribution(states, labels),
+            "state_intervals": [
+                {"label": lbl, "count": cnt}
+                for lbl, _s, _e, cnt, _i in hm.rle_intervals(states, labels)],
+        })
+    meta = {"train_n": len(train), "train_logL": train_logL, "n_observations": n_obs,
+            "bic": hm.bic(model, train_logL, n_obs), "K": K, "vocab": vocab.n_tokens()}
+    return model, vocab, labels, results, meta
+
+
+def write_report(model, vocab, labels, results, meta, out_dir, K):
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "scores.json").write_text(json.dumps(results, indent=2))
+
+    held = sorted(r["per_token_ll"] for r in results if r["held_out_clean"])
+    bad = sorted(r["per_token_ll"] for r in results if r["is_failed"])
+    md = [f"# HMM verification report (K={K})\n",
+          f"Trained on {meta['train_n']} clean plays (80% split), vocab={meta['vocab']}, "
+          f"train logL={meta['train_logL']:.1f}, BIC={meta['bic']:.1f}.\n",
+          "## Per-token log-likelihood — higher = more model-consistent\n",
+          f"- Held-out clean: {_stats(held)}",
+          f"- Failed: {_stats(bad)}\n",
+          "Separation is healthy when failed p50 sits clearly BELOW held-out-clean p50.\n",
+          "## Hidden states (top emissions) — are they labelable?\n",
+          "| state | label | top emissions (tok, P) |", "|---|---|---|"]
+    for s in range(model.n_components):
+        cells = ", ".join(f"`{t}` {p:.2f}" for t, p in hm.top_emissions(model.emissionprob_, vocab, s)
+                          if p > 0.01)
+        md.append(f"| {s} | `{labels[s]}` | {cells} |")
+    md.append("\n## Most anomalous failed plays (lowest per-token LL)\n")
+    for r in sorted([r for r in results if r["is_failed"]], key=lambda r: r["per_token_ll"])[:15]:
+        dist = ", ".join(f"`{lbl}` {p:.0%}" for lbl, p in r["state_distribution"].items())
+        ribbon = ", ".join(f'{iv["label"]}×{iv["count"]}' for iv in r["state_intervals"][:10])
+        md.append(f"### `{r['play_id'][:8]}` per_token_ll={r['per_token_ll']:.3f} "
+                  f"(n_tokens={r['n_tokens']})")
+        md.append(f"- regimes: {dist}")
+        md.append(f"- ribbon: {ribbon}\n")
+    (out / "report.md").write_text("\n".join(md))
+    return out / "report.md"
+
+
+def cmd_sweep(samples, k_list, restarts, out_dir):
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    md = ["# HMM K-sweep\n", "| K | train_n | train_logL | aggregate_BIC |", "|---|---|---|---|"]
+    for K in k_list:
+        print(f"\n=== K={K} ===", file=sys.stderr)
+        model, vocab, labels, results, meta = train_and_score(samples, K, restarts)
+        if model is None:
+            md.append(f"| {K} | {meta.get('train_n', 0)} | - | - |")
+            continue
+        md.append(f"| {K} | {meta['train_n']} | {meta['train_logL']:.1f} | {meta['bic']:.1f} |")
+        write_report(model, vocab, labels, results, meta, out / f"K_{K}", K)
+    md.append("\nLowest aggregate_BIC wins: it explains the data with the fewest free "
+              "parameters. Set the deriver's --k to that value.\n")
+    (out / "k_sweep.md").write_text("\n".join(md))
+    print(f"\nwrote {out / 'k_sweep.md'}", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ch-url", default=os.environ.get("FORWARDER_CLICKHOUSE_URL", "http://localhost:8123"))
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--player", default=None, help="limit to one player_id")
+    ap.add_argument("--k", type=int, default=hm.DEFAULT_K, help="hidden states (single-run mode)")
+    ap.add_argument("--restarts", type=int, default=hm.DEFAULT_RESTARTS)
+    ap.add_argument("--k-sweep", default=None, help="comma-separated K values for a BIC sweep, e.g. 3,5,7,9")
+    ap.add_argument("--out", default="/tmp/hmm_report")
+    args = ap.parse_args()
+
+    print(f"#445 HMM scorer — fetching {args.days}d from {args.ch_url} ...", file=sys.stderr)
+    samples = gather(args.ch_url, args.days, args.player)
+    nc = sum(1 for _p, _t, c, _f in samples if c)
+    nf = sum(1 for _p, _t, _c, f in samples if f)
+    print(f"  {len(samples)} plays ({nc} clean / {nf} failed)", file=sys.stderr)
+
+    if args.k_sweep:
+        try:
+            k_list = [int(x) for x in args.k_sweep.split(",") if x.strip()]
+        except ValueError:
+            print(f"invalid --k-sweep {args.k_sweep!r}", file=sys.stderr)
+            return 1
+        cmd_sweep(samples, k_list, args.restarts, args.out)
+        return 0
+
+    print(f"\n=== K={args.k} ===", file=sys.stderr)
+    model, vocab, labels, results, meta = train_and_score(samples, args.k, args.restarts)
+    if model is None:
+        print(f"clean corpus too thin to train (train_n={meta['train_n']}, "
+              f"need >= {hm.MIN_TRAIN_SEQUENCES}). Widen --days.", file=sys.stderr)
+        return 1
+    path = write_report(model, vocab, labels, results, meta, args.out, args.k)
+    print(f"\nwrote {path} (and scores.json)", file=sys.stderr)
+    held = sorted(r["per_token_ll"] for r in results if r["held_out_clean"])
+    bad = sorted(r["per_token_ll"] for r in results if r["is_failed"])
+    print(f"\nstates: {labels}")
+    print(f"held-out clean per-token LL: {_stats(held)}")
+    print(f"failed       per-token LL: {_stats(bad)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/analytics/tools/requirements.txt
+++ b/analytics/tools/requirements.txt
@@ -1,0 +1,9 @@
+# #445 HMM latent-regime scorer (hmm_model.py / hmm_deriver.py / hmm_scorer.py).
+#
+# The VOMM scorer (scorer.py / tokenize.py / derive_tokens.py / derive_labels.py) is
+# pure-stdlib by design, so its deriver sidecars run a bare python:3.12-slim with no pip
+# step. The HMM needs Baum-Welch + Viterbi, which we get from hmmlearn — so ONLY the HMM
+# sidecars (hmm-label-trainer / hmm-label-scorer) install these. See docker-compose.yml.
+hmmlearn>=0.3.0
+numpy>=1.26
+scikit-learn>=1.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -347,6 +347,85 @@ services:
       - app_network
     restart: unless-stopped
 
+  # #445 — HMM latent-REGIME label derivation, same TRAIN + SCORE split as the VOMM
+  # deriver above, but a different model + label family. The VOMM emits point
+  # unexpected_<condition> surprise; the HMM emits a regime timeline (regime_<STATE>) +
+  # unexpected_regime_transition decoded from a CategoricalHMM. They share NOTHING but the
+  # token alphabet — separate artifact (hmm-models volume), separate model_version
+  # (hmm-tok-1), so their derived_labels rows never collide.
+  #
+  # OPT-IN (profile: hmm) — research-direction work (P3), and unlike the pure-stdlib VOMM
+  # deriver these need hmmlearn/numpy/scipy. The bare python:3.12-slim pip-installs
+  # requirements.txt on start (keeps the bind-mount-no-rebuild workflow; a purpose-built
+  # image is the obvious optimisation if this graduates off P3). Start with:
+  #   docker compose --profile hmm up -d hmm-label-trainer hmm-label-scorer
+
+  # TRAIN (slow): fit the CategoricalHMM over --train-days of plays, persist the gzipped-JSON
+  # artifact + a derived_models manifest row. Bootstraps once on start, then nightly.
+  hmm-label-trainer:
+    image: python:3.12-slim
+    container_name: infinite-streaming-hmm-label-trainer
+    profiles: ["hmm"]
+    volumes:
+      - ./analytics/tools:/tools:ro
+      - hmm-models:/models
+    environment:
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - HMM_TRAIN_INTERVAL_SECONDS=${HMM_TRAIN_INTERVAL_SECONDS:-86400}
+      - HMM_TRAIN_DAYS=${HMM_TRAIN_DAYS:-7}
+      - HMM_K=${HMM_K:-5}
+      - HMM_MODEL_PATH=${HMM_MODEL_PATH:-/models/hmm-model.json.gz}
+      - HMM_MODEL_VERSION=${HMM_MODEL_VERSION:-hmm-tok-1}
+    command:
+      - sh
+      - -c
+      - |
+        pip install --no-cache-dir -q -r /tools/requirements.txt || { echo "[hmm-label-trainer] pip install failed"; exit 1; }
+        sleep 30
+        while true; do
+          python3 /tools/hmm_deriver.py --mode train --train-days "$$HMM_TRAIN_DAYS" --k "$$HMM_K" --model-path "$$HMM_MODEL_PATH" --model-version "$$HMM_MODEL_VERSION" \
+            || echo "[hmm-label-trainer] run failed (rc=$$?), retrying next tick"
+          sleep "$$HMM_TRAIN_INTERVAL_SECONDS"
+        done
+    depends_on:
+      clickhouse:
+        condition: service_started
+    networks:
+      - app_network
+    restart: unless-stopped
+
+  # SCORE (fast): load the artifact and Viterbi-decode plays that post-date its trained_at
+  # (out-of-sample), writing derived_labels. Skips gracefully until the trainer's first run.
+  hmm-label-scorer:
+    image: python:3.12-slim
+    container_name: infinite-streaming-hmm-label-scorer
+    profiles: ["hmm"]
+    volumes:
+      - ./analytics/tools:/tools:ro
+      - hmm-models:/models
+    environment:
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - HMM_SCORE_INTERVAL_SECONDS=${HMM_SCORE_INTERVAL_SECONDS:-300}
+      - HMM_SCORE_HOURS=${HMM_SCORE_HOURS:-2}
+      - HMM_MODEL_PATH=${HMM_MODEL_PATH:-/models/hmm-model.json.gz}
+    command:
+      - sh
+      - -c
+      - |
+        pip install --no-cache-dir -q -r /tools/requirements.txt || { echo "[hmm-label-scorer] pip install failed"; exit 1; }
+        sleep 40
+        while true; do
+          python3 /tools/hmm_deriver.py --mode score --score-hours "$$HMM_SCORE_HOURS" --model-path "$$HMM_MODEL_PATH" \
+            || echo "[hmm-label-scorer] run failed (rc=$$?), retrying next tick"
+          sleep "$$HMM_SCORE_INTERVAL_SECONDS"
+        done
+    depends_on:
+      clickhouse:
+        condition: service_started
+    networks:
+      - app_network
+    restart: unless-stopped
+
 
 networks:
   app_network:
@@ -356,3 +435,6 @@ volumes:
   # Shared between label-trainer (writes) and label-scorer (reads): the serialized VOMM
   # artifact (#608). Decouples the slow nightly rebuild from the fast scoring loop.
   vomm-models:
+  # Same role for the #445 HMM deriver pair (hmm-label-trainer writes, hmm-label-scorer
+  # reads); kept separate so the two models' artifacts never clobber each other.
+  hmm-models:


### PR DESCRIPTION
Closes #445.

Revives the rescued #445 draft and reconciles it onto the current `dev` substrate (the old draft was bolted to the dead forwarder-API `markov_scorer.py`). The HMM is the home for **regimes** — "what mode is the player in, and is this regime transition normal" — complementing the VOMM's point-surprise "is this ordering one we see in clean traffic."

## What's here
| File | Role |
|---|---|
| `hmm_model.py` *(new)* | CategoricalHMM core — train w/ restarts, Viterbi decode, BIC, state auto-labelling (rewritten for the current `tokenize.py` alphabet), RLE intervals, transition surprise, gzipped-JSON artifact I/O |
| `hmm_deriver.py` *(new)* | Production path — `--mode train`/`--mode score` mirroring `derive_labels.py`'s #608 split; whole-play cross-stream sequences via `tokenize.py` + CH-direct reads |
| `hmm_scorer.py` *(rewritten)* | Verification harness — K-sweep/BIC, state labelability, clean-vs-failed separation |
| `compare_markov_hmm.py` *(rewritten)* | VOMM-vs-HMM disagreement report over `derived_labels` (Spearman ρ + rank tables) |
| `requirements.txt` *(new)* + `docker-compose.yml` | `hmm-label-trainer`/`hmm-label-scorer` sidecars behind an opt-in `hmm` profile + pip layer + shared `hmm-models` volume |

## Label family (→ `derived_labels`, `model_version=hmm-tok-1`)
- `regime_<STATE>` — one row at each Viterbi interval start (STARTUP/STEADY/RECOVERING/STALLED/ENDING), `severity=info`.
- `unexpected_regime_transition` — a state→state move whose `−log P` under the learned transmat exceeds the train-calibrated p99 threshold.

Distinct `model_version` from the VOMM, so the two families coexist in `derived_labels` with no collision. **No schema change** — the `derived_labels`/`derived_models` seam is model-agnostic. Out-of-sample by `trained_at`, same guarantee as the VOMM deriver.

## Design notes
- **Whole-sequence model, not episode windows.** The HMM trains on full plays (so failure regimes emerge as latent states), distinct from the VOMM's per-`EPISODE_CONDITION` models.
- **Single global HMM for v1.** The CH-direct read path doesn't carry `player_kind`/`variant`; per-bucket models are a follow-up (needs those columns plumbed into the fetch).
- **Latent footgun fixed:** `analytics/tools/tokenize.py` shadows the stdlib `tokenize` that scipy (via hmmlearn) imports internally — would crash the HMM sidecar. The pure-stdlib VOMM tools are unaffected; the HMM tools strip their own dir from `sys.path` and importlib-load siblings by file path.

## Verification
- All modules compile + run as scripts; docker compose config validates with HMM sidecars gated to `--profile hmm`.
- Synthetic end-to-end smoke through the real bootstrap (train → serialize → reload → decode → RLE → transition-surprise → anchor) passes; unseen tokens floored (no `-inf`); scipy/tokenize collision resolved.
- The #445 verification *checklist* (K-sweep BIC minimum, state labelability, clean-vs-failed separation, ρ∈[0.4,0.7]) runs against **live ClickHouse post-deploy** — see `analytics/tools/hmm-scorer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
