### PR TITLE
feat(551): dual-rung (avg+peak) filled limit ladder, shared across characterization + shape patterns

### DIFF
--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -47,6 +47,8 @@ Length: one page rendered. If it grows past that, split.
   transfer_abandoned, buffer metric reporting gaps)
 - `abr-decision-model.md` — how a player chooses variants, why
   downshift cascades, what triggers timejump
+- `abr-ladder.md` — peak vs average per player/phase, the dual-rung
+  filled limit ladder, manifest ladder hazards
 - `codec-strings.md` — avc1/hev1/mp4a profile-level-tier, what
   platforms require what, common stripping bugs
 - `qoe-metrics.md` — CIRR/CIRT/VST/EBVS definitions (Conviva

--- a/.claude/standards/abr-ladder.md
+++ b/.claude/standards/abr-ladder.md
@@ -1,0 +1,79 @@
+# ABR ladder: peak vs average, and the limit ladder we shape with
+
+Which bitrate scalar a player keys on per phase, and how the test rig's
+limit ladder is built so a sweep characterizes that behaviour. Issue #551.
+
+## Which scalar each player uses (read from source)
+
+`BANDWIDTH` (peak per HLS spec) and `AVERAGE-BANDWIDTH` are two scalars
+per variant. Rendition selection keys almost entirely on **peak**:
+
+- **hls.js** (v1.6.16) — peak for startup / down-switch / abandon;
+  average only in one narrow steady-state case (buffer ≥ 2 segments AND a
+  zero-rebuffer-tolerance pass). `src/controller/abr-controller.ts:944`.
+- **ExoPlayer / Media3** (1.10.1) — peak only. `Format.bitrate` resolves
+  to `peakBitrate`; `averageBitrate` is parsed but never reaches the
+  selector. `AdaptiveTrackSelection.java:563`, `Format.java:1205`.
+- **Shaka** (`main`) — peak only. `variant.bandwidth` is `BANDWIDTH ||
+  AVERAGE-BANDWIDTH`; the `||` fallback never fires when BANDWIDTH is
+  present. `simple_abr_manager.js:309`.
+- **AVPlayer** (our ship target) — **unknown**, closed-source. 3-of-3 OSS
+  players key on peak, so peak-correctness is the safe assumption, but the
+  only way to *know* is to instrument it with a discriminating ladder
+  (the #551 stretch / follow-up).
+
+Mental model for tests: **startup pick = peak. Switch-down = peak.
+Switch-up-with-full-buffer = *may* be average, but only hls.js.** Down-
+switching on average is something no audited player does.
+
+## The limit ladder (go-proxy/pkg/ladder)
+
+One shared builder feeds the characterization harness, the harness CLI
+(`shape --pattern`), and the dashboard's pattern panel (JS mirror):
+
+- **Both rungs per variant.** Each variant contributes a peak anchor and
+  an average anchor (avg skipped when AVERAGE-BANDWIDTH is absent). We
+  carry both because AVPlayer is unknown — a sweep then probes both
+  regimes regardless of which scalar the player uses.
+- **Flat +5% bump** (`--margin`, default 5) on each anchor — covers
+  TCP/IP + TLS + HTTP framing. Replaced the old `margin × 1.07-TCP`
+  two-factor. `0%` is a deliberate-stall footgun.
+- **Geometric fills to ≤1.15×** (`--max-step` / `CHAR_LADDER_MAX_STEP`)
+  between anchors, so a downward sweep can't skip the rung where a player
+  switches. For the 6-variant tears-of-steel h264 ladder this is 12
+  anchors + 22 fills = 34 rungs.
+- **Discriminating band.** A variant's avg→peak gap is where peak- and
+  avg-keyed players diverge: a cap parked inside it (e.g. 6.3 Mbps,
+  between 1080p avg 5.4 and peak 7.2) makes a peak-keyed player drop to
+  720p while an avg-keyed player holds 1080p. This is what makes the
+  AVPlayer probe (throttle-into-the-gap) decisive.
+
+## Manifest ladder hazards (ValidateLadder)
+
+Real hazards to lint a published ladder for — overlap is NOT one:
+
+- **Inversion** — the average column disagrees with the peak ordering
+  (peak rises while avg falls across rungs).
+- **Duplicate BANDWIDTH** — two variants share a peak value.
+- **Tight spacing** — adjacent peak ratio < 1.5× (players can't tell the
+  rungs apart and oscillate).
+- **NOT a hazard: avg→peak band overlap across rungs.** Normal capped-VBR;
+  RFC 8216 imposes no non-overlap rule; players reason over one scalar per
+  variant, not the interval. Never flag it.
+
+## Common mistakes
+
+- Anchoring startup / down-switch test expectations to AVERAGE-BANDWIDTH.
+  All three OSS players use peak; expectations must too.
+- Treating an avg-based up-switch assertion as cross-player — it's
+  hls.js-specific.
+- Flagging avg→peak overlap as a ladder defect. It isn't.
+- Assuming AVPlayer keys on peak. It probably does, but it's unverified —
+  say "unknown" until the probe ladder settles it.
+
+## See also
+
+- `.claude/standards/abr-decision-model.md` — ABR decision mechanics, the `content` aggression knobs
+- `.claude/standards/avplayer-quirks.md` — Apple-specific ABR behaviour
+- `.claude/standards/characterization-principles.md` — how the sweeps are run
+- `go-proxy/pkg/ladder/` — the shared builder + `ladder_test.go` golden vectors

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -62,6 +62,11 @@ const MAX_STEP_CHOICES = [1.1, 1.15, 1.2, 1.5, 2.0] as const;
 const DEFAULT_MAX_STEP = 1.15;
 const maxStep = ref<number>(DEFAULT_MAX_STEP);
 
+// #551 — start the ladder this % over the top variant's peak (a headroom
+// start rung above the +bump top anchor) so playback settles at the top
+// variant before the pattern constrains it. Mirrors the Go default.
+const DEFAULT_TOP_HEADROOM = 25;
+
 interface LadderVariant {
   avgBps: number;
   peakBps: number;
@@ -70,14 +75,19 @@ interface LadderVariant {
 const round3 = (v: number): number => Math.round(v * 1000) / 1000;
 
 /** Dual-rung (avg+peak) + geometrically-filled limit ladder, descending
- *  by Mbps. Mirrors go-proxy/pkg/ladder.StandardLadder — keep in sync
- *  with that package's golden vectors (ladder_test.go). */
-function standardLadder(variants: LadderVariant[], bumpPct: number, step: number): number[] {
+ *  by Mbps, with an optional top-headroom start rung. Mirrors
+ *  go-proxy/pkg/ladder.StandardLadder — keep in sync with that package's
+ *  golden vectors (ladder_test.go). */
+function standardLadder(variants: LadderVariant[], bumpPct: number, step: number, topHeadroomPct: number): number[] {
   const f = 1 + bumpPct / 100;
   const anchors: number[] = [];
   for (const v of variants) {
     if (v.peakBps > 0) anchors.push(round3((v.peakBps * f) / 1e6));
     if (v.avgBps > 0) anchors.push(round3((v.avgBps * f) / 1e6));
+  }
+  if (topHeadroomPct > 0) {
+    const maxPeak = variants.reduce((m, v) => Math.max(m, v.peakBps), 0);
+    if (maxPeak > 0) anchors.push(round3((maxPeak * (1 + topHeadroomPct / 100)) / 1e6));
   }
   anchors.sort((a, b) => b - a); // descending
   if (step <= 1 || anchors.length < 2) return anchors;
@@ -188,7 +198,7 @@ function ladderVariants(): LadderVariant[] {
  *  dual-rung + geometrically-filled limit ladder (#551), then orders it
  *  per template — mirrors ladder.BuildPattern in go-proxy/pkg/ladder. */
 function buildSteps(t: Template, marginPct: number, stepSecs: number): Pattern['steps'] {
-  const desc = standardLadder(ladderVariants(), marginPct, maxStep.value); // descending
+  const desc = standardLadder(ladderVariants(), marginPct, maxStep.value, DEFAULT_TOP_HEADROOM); // descending
   if (!desc.length) return [];
   const asc = desc.slice().reverse(); // ascending
 

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -52,6 +52,50 @@ const DEFAULT_MARGIN_PCT: Margin = 5;
 const STEP_SECONDS_CHOICES = [6, 12, 18, 24] as const;
 type StepSeconds = (typeof STEP_SECONDS_CHOICES)[number];
 
+// #551 — fill density. The limit ladder carries BOTH a peak (BANDWIDTH)
+// and an average (AVERAGE-BANDWIDTH) rung per variant, each ×(1+margin),
+// then inserts geometric fills so no two consecutive caps differ by more
+// than this ratio. Mirrors go-proxy/pkg/ladder + the harness CLI's
+// --max-step. Higher = coarser + shorter pattern (a pyramid over a dense
+// ladder can run ~13 min/cycle).
+const MAX_STEP_CHOICES = [1.1, 1.15, 1.2, 1.5, 2.0] as const;
+const DEFAULT_MAX_STEP = 1.15;
+const maxStep = ref<number>(DEFAULT_MAX_STEP);
+
+interface LadderVariant {
+  avgBps: number;
+  peakBps: number;
+}
+
+const round3 = (v: number): number => Math.round(v * 1000) / 1000;
+
+/** Dual-rung (avg+peak) + geometrically-filled limit ladder, descending
+ *  by Mbps. Mirrors go-proxy/pkg/ladder.StandardLadder — keep in sync
+ *  with that package's golden vectors (ladder_test.go). */
+function standardLadder(variants: LadderVariant[], bumpPct: number, step: number): number[] {
+  const f = 1 + bumpPct / 100;
+  const anchors: number[] = [];
+  for (const v of variants) {
+    if (v.peakBps > 0) anchors.push(round3((v.peakBps * f) / 1e6));
+    if (v.avgBps > 0) anchors.push(round3((v.avgBps * f) / 1e6));
+  }
+  anchors.sort((a, b) => b - a); // descending
+  if (step <= 1 || anchors.length < 2) return anchors;
+  const out: number[] = [];
+  for (let i = 0; i < anchors.length; i++) {
+    out.push(anchors[i]);
+    if (i + 1 >= anchors.length) continue;
+    const hi = anchors[i];
+    const lo = anchors[i + 1];
+    if (lo <= 0 || hi <= lo) continue;
+    const n = Math.ceil(Math.log(hi / lo) / Math.log(step)) - 1;
+    for (let k = 1; k <= n; k++) {
+      out.push(round3(hi * Math.pow(lo / hi, k / (n + 1))));
+    }
+  }
+  return out;
+}
+
 const props = defineProps<{ playerId: string }>();
 const { player, setPattern } = usePlayer(toRef(props, 'playerId'));
 
@@ -95,17 +139,23 @@ const sortedVariants = computed(() => {
 const stepPresets = computed<{ value: number; label: string }[]>(() => {
   const items: { value: number; label: string }[] = [];
   items.push({ value: 0, label: '0 Mbps (stall)' });
-  const m = margin.value;
+  const f = 1 + margin.value / 100;
+  // #551 — offer BOTH rungs per variant: the average (AVERAGE-BANDWIDTH,
+  // long-term sustainable) and the peak (BANDWIDTH, per-segment peak,
+  // typically 30-40% higher). Carrying both lets an operator park a cap
+  // inside a variant's avg→peak band to probe which scalar the player
+  // keys on.
   for (const v of sortedVariants.value) {
-    // Prefer AVERAGE-BANDWIDTH when present — the variant's long-term
-    // sustainable rate. BANDWIDTH (the HLS spec attribute) is the peak
-    // segment rate, typically 30-40% above AVERAGE for CBR encoders;
-    // using the peak gives every step ~35% of unwarranted headroom.
-    const baseBps = (v as any).average_bandwidth || v.bandwidth || 0;
-    const mbps = Math.round((baseBps * (1 + m / 100)) / 1000) / 1000;
-    if (!Number.isFinite(mbps) || mbps <= 0) continue;
-    const tag = (v as any).average_bandwidth ? '' : ' (peak)';
-    items.push({ value: mbps, label: `${v.resolution} · ${mbps.toFixed(2)} Mbps${tag}` });
+    const avg = ((v as any).average_bandwidth as number) || 0;
+    const peak = (v.bandwidth as number) || 0;
+    if (avg > 0) {
+      const mbps = round3((avg * f) / 1e6);
+      if (mbps > 0) items.push({ value: mbps, label: `${v.resolution} avg · ${mbps.toFixed(2)} Mbps` });
+    }
+    if (peak > 0) {
+      const mbps = round3((peak * f) / 1e6);
+      if (mbps > 0) items.push({ value: mbps, label: `${v.resolution} peak · ${mbps.toFixed(2)} Mbps` });
+    }
   }
   const top = items[items.length - 1];
   if (top && top.value > 0) {
@@ -126,28 +176,31 @@ function onPresetChange(idx: number, e: Event) {
   setStepField(idx, 'rate_mbps', Number(v));
 }
 
-/** Generate step rates from template + margin + variants. */
+/** Adapt the manifest variants to the ladder's neutral shape. */
+function ladderVariants(): LadderVariant[] {
+  return sortedVariants.value.map((v) => ({
+    avgBps: ((v as any).average_bandwidth as number) || 0,
+    peakBps: (v.bandwidth as number) || 0,
+  }));
+}
+
+/** Generate step rates from template + margin + variants. Uses the shared
+ *  dual-rung + geometrically-filled limit ladder (#551), then orders it
+ *  per template — mirrors ladder.BuildPattern in go-proxy/pkg/ladder. */
 function buildSteps(t: Template, marginPct: number, stepSecs: number): Pattern['steps'] {
-  const rates = sortedVariants.value
-    .map((v) => {
-      // See stepPresets: prefer AVERAGE-BANDWIDTH, fall back to BANDWIDTH.
-      const baseBps = (v as any).average_bandwidth || v.bandwidth || 0;
-      return Math.round((baseBps * (1 + marginPct / 100)) / 1000) / 1000; // bps → Mbps
-    })
-    .filter((r) => Number.isFinite(r) && r > 0);
-  if (!rates.length) return [];
+  const desc = standardLadder(ladderVariants(), marginPct, maxStep.value); // descending
+  if (!desc.length) return [];
+  const asc = desc.slice().reverse(); // ascending
 
   let seq: number[] = [];
   if (t === 'square_wave') {
-    // Lowest + highest, alternating.
-    seq = [rates[0], rates[rates.length - 1]];
+    seq = [asc[0], asc[asc.length - 1]]; // lowest + highest
   } else if (t === 'ramp_up') {
-    seq = rates.slice();
+    seq = asc.slice();
   } else if (t === 'ramp_down') {
-    seq = rates.slice().reverse();
+    seq = asc.slice().reverse();
   } else if (t === 'pyramid') {
-    const asc = rates.slice();
-    seq = asc.concat(asc.slice(0, -1).reverse());
+    seq = asc.concat(asc.slice(0, -1).reverse()); // up then down, no apex dupe
   } else {
     seq = [];
   }
@@ -283,6 +336,25 @@ function onStepSecondsChange(d: StepSeconds) {
   } as Pattern;
 }
 
+// #551 — fill density. Not part of the server Pattern payload (it only
+// shapes how many client-side steps buildSteps emits), so we keep it in a
+// local ref and regenerate the draft steps when it changes.
+function onMaxStepChange(s: number) {
+  maxStep.value = s;
+  if (!editMode.value) startEdit();
+  const draft = ensureDraft();
+  const t = (draft.template as Template) ?? 'ramp_up';
+  if (t === 'sliders' as Template) return;
+  const m = (draft.margin_pct ?? 0) as number;
+  const d = (draft.default_step_seconds ?? 6) as number;
+  draftPattern.value = {
+    template: t as any,
+    margin_pct: m as any,
+    default_step_seconds: d as any,
+    steps: buildSteps(t, m, d),
+  } as Pattern;
+}
+
 /* ─── Per-step row editing ─────────────────────────────────────── */
 //
 // Per-row edits write to `draftPattern.steps` in edit mode, or commit
@@ -402,6 +474,27 @@ const runtimeStep = computed(() => player.value?.shape?.pattern_step_runtime ?? 
             />
             {{ d }}s
           </label>
+        </div>
+      </div>
+
+      <!-- #551 — fill density: both an avg + a peak rung per variant, then
+           geometric fills to this ratio. Lower = finer + longer pattern. -->
+      <div class="row">
+        <span class="lbl">Fill density</span>
+        <div class="radio-group">
+          <label v-for="s in MAX_STEP_CHOICES" :key="s">
+            <input
+              type="radio"
+              :name="`fill-${playerId}`"
+              :value="s"
+              :checked="maxStep === s"
+              @change="onMaxStepChange(s)"
+            />
+            {{ s.toFixed(2) }}×
+          </label>
+          <span class="fill-count" v-if="displaySteps.length">
+            → {{ displaySteps.length }} rung{{ displaySteps.length === 1 ? '' : 's' }}
+          </span>
         </div>
       </div>
 

--- a/content/dashboard-v3/src/pages/Characterization.vue
+++ b/content/dashboard-v3/src/pages/Characterization.vue
@@ -209,7 +209,7 @@ interface RunCard {
 interface StepRow {
   rate_mbps: number;
   hold_s?: number;
-  variant?: { resolution: string; margin_pct?: number };
+  variant?: { resolution: string; margin_pct?: number; source?: string };
   exit_reason?: string;
   hold_actual_s?: number;
   min_buffer_s?: number;
@@ -361,10 +361,6 @@ async function toggleSteps(runID: string, testName: TestName) {
 function fmtMbps(v: number | undefined): string {
   if (v == null || !Number.isFinite(v)) return '—';
   return v.toFixed(3) + ' Mbps';
-}
-function fmtPct(v: number | undefined): string {
-  if (v == null || !Number.isFinite(v)) return '';
-  return (v >= 0 ? '+' : '') + v + '%';
 }
 function fmtSeconds(v: number | undefined): string {
   if (v == null || !Number.isFinite(v)) return '—';
@@ -912,7 +908,7 @@ function stepWindow(report: ReportBlob, stepIdx: number): { startMs: number; end
                             <tr v-for="(s, i) in expandedSteps.get(charRunKey(g.run_id, t))!.report!.steps!" :key="i">
                               <td>{{ i + 1 }}</td>
                               <td class="mono">{{ s.rate_mbps?.toFixed(3) }}</td>
-                              <td class="mono">{{ s.variant?.resolution ?? '—' }} <span v-if="s.variant?.margin_pct != null" class="muted">{{ fmtPct(s.variant!.margin_pct) }}</span></td>
+                              <td class="mono">{{ s.variant?.resolution ?? '—' }} <span v-if="s.variant?.source" class="muted">{{ s.variant!.source }}</span></td>
                               <td>{{ s.exit_reason ?? '—' }}</td>
                               <td>{{ fmtSeconds(s.hold_actual_s ?? s.hold_s) }}</td>
                               <td>{{ s.min_buffer_s?.toFixed(1) ?? '—' }} / {{ s.max_buffer_s?.toFixed(1) ?? '—' }}</td>
@@ -1099,7 +1095,7 @@ function stepWindow(report: ReportBlob, stepIdx: number): { startMs: number; end
                         <tr v-for="(s, i) in expandedSteps.get(charRunKey(g.run_id, t))!.report!.steps!" :key="i">
                           <td>{{ i + 1 }}</td>
                           <td class="mono">{{ s.rate_mbps?.toFixed(3) }}</td>
-                          <td class="mono">{{ s.variant?.resolution ?? '—' }} <span v-if="s.variant?.margin_pct != null" class="muted">{{ fmtPct(s.variant!.margin_pct) }}</span></td>
+                          <td class="mono">{{ s.variant?.resolution ?? '—' }} <span v-if="s.variant?.source" class="muted">{{ s.variant!.source }}</span></td>
                           <td>{{ s.exit_reason ?? '—' }}</td>
                           <td>{{ fmtSeconds(s.hold_actual_s ?? s.hold_s) }}</td>
                           <td class="mono">

--- a/go-proxy/pkg/ladder/ladder.go
+++ b/go-proxy/pkg/ladder/ladder.go
@@ -37,6 +37,11 @@ import (
 const (
 	DefaultBumpPct = 5.0
 	DefaultMaxStep = 1.15
+	// DefaultTopHeadroomPct prepends a starting rung at the top variant's
+	// peak × (1 + this/100), above the +bump top anchor, so a sweep settles
+	// the player comfortably at the top variant before constraining it.
+	// Over the RAW top peak, not compounded with the bump.
+	DefaultTopHeadroomPct = 25.0
 )
 
 // Variant is one rung of a player's published manifest ladder, reduced to
@@ -50,8 +55,9 @@ type Variant struct {
 }
 
 // Rung is one cap in the limit ladder, in Mbps. Kind is "peak", "avg"
-// (an anchor derived from a variant's BANDWIDTH / AVERAGE-BANDWIDTH) or
-// "fill" (a geometric interpolation inserted between two anchors).
+// (an anchor derived from a variant's BANDWIDTH / AVERAGE-BANDWIDTH),
+// "fill" (a geometric interpolation inserted between two anchors), or
+// "headroom" (the optional top start rung above the top variant's peak).
 // Anchors carry their source variant in Variant; fills carry the two
 // anchors they sit between in HiVar/LoVar (a fill between a variant's own
 // avg and peak is that variant's discriminating band).
@@ -125,9 +131,31 @@ func FillLadder(anchors []Rung, maxStep float64) []Rung {
 }
 
 // StandardLadder is the one entry point callers use: dual-rung anchors at
-// the given flat bump, geometrically filled to maxStep, sorted descending.
-func StandardLadder(vs []Variant, bumpPct, maxStep float64) []Rung {
-	return FillLadder(AnchorCaps(vs, bumpPct), maxStep)
+// the given flat bump, optionally a top-headroom start rung at the top
+// variant's peak × (1 + topHeadroomPct/100), geometrically filled to
+// maxStep, sorted descending. topHeadroomPct <= 0 disables the start rung.
+func StandardLadder(vs []Variant, bumpPct, maxStep, topHeadroomPct float64) []Rung {
+	anchors := AnchorCaps(vs, bumpPct)
+	if topHeadroomPct > 0 {
+		maxPeak := 0
+		topRes := ""
+		for _, v := range vs {
+			if v.PeakBps > maxPeak {
+				maxPeak = v.PeakBps
+				topRes = v.Resolution
+			}
+		}
+		if maxPeak > 0 {
+			hr := Rung{
+				Mbps:    round3(float64(maxPeak) * (1 + topHeadroomPct/100) / 1e6),
+				Variant: topRes,
+				Kind:    "headroom",
+			}
+			anchors = append([]Rung{hr}, anchors...)
+			sort.SliceStable(anchors, func(i, j int) bool { return anchors[i].Mbps > anchors[j].Mbps })
+		}
+	}
+	return FillLadder(anchors, maxStep)
 }
 
 func round3(v float64) float64 { return math.Round(v*1000) / 1000 }

--- a/go-proxy/pkg/ladder/ladder.go
+++ b/go-proxy/pkg/ladder/ladder.go
@@ -1,0 +1,133 @@
+// Package ladder builds the network "limit ladder" the test rig shapes
+// throughput down to characterize a player's ABR behaviour, and the
+// step lists the built-in shape patterns (ramp_up / ramp_down / pyramid
+// / square_wave) walk. It lives outside go-proxy/internal/ so the three
+// runtimes that used to each carry their own copy share one source of
+// truth: the characterization Go harness (tests/characterization), the
+// harness CLI (tools/harness-cli), and — mirrored in JS, kept in sync
+// against ladder_test.go's golden vectors — the dashboard's
+// NetworkShapingPattern.vue.
+//
+// Issue #551 — the ladder carries BOTH scalars per variant: the peak
+// (HLS BANDWIDTH) and the average (AVERAGE-BANDWIDTH). A source audit of
+// hls.js / ExoPlayer / Shaka showed rendition selection keys on peak for
+// startup + down-switch, and average only in hls.js's full-buffer
+// up-switch; AVPlayer is closed-source and unknown. Carrying both means
+// a sweep probes both regimes regardless of which scalar a player keys
+// on, and each variant's avg->peak band becomes a discriminating zone
+// (a cap parked inside it makes a peak-keyed player drop while an
+// avg-keyed player holds).
+//
+// All functions are pure — they never mutate their inputs.
+package ladder
+
+import (
+	"math"
+	"sort"
+)
+
+// Default headroom + fill density. DefaultBumpPct is the flat percentage
+// added on top of a variant's published bitrate so a cap at that rung is
+// just sustainable on a clean network — 5% covers TCP/IP + TLS + HTTP
+// framing overhead (#551 replaced the old margin × 1.07-TCP two-factor
+// with this single flat bump across all three runtimes). DefaultMaxStep
+// is the largest ratio allowed between two consecutive caps before a
+// geometric fill is inserted, so a downward sweep can't skip the rung at
+// which a player actually switches.
+const (
+	DefaultBumpPct = 5.0
+	DefaultMaxStep = 1.15
+)
+
+// Variant is one rung of a player's published manifest ladder, reduced to
+// the two scalars the limit ladder cares about. Callers adapt their own
+// variant structs (the harness PlayerRecord, the CLI's generated proxy
+// client, etc.) into this neutral shape.
+type Variant struct {
+	AvgBps     int    // AVERAGE-BANDWIDTH, 0 when the playlist omits it
+	PeakBps    int    // BANDWIDTH (per HLS spec — the peak segment rate)
+	Resolution string // e.g. "1920x1080" — label only, not used in math
+}
+
+// Rung is one cap in the limit ladder, in Mbps. Kind is "peak", "avg"
+// (an anchor derived from a variant's BANDWIDTH / AVERAGE-BANDWIDTH) or
+// "fill" (a geometric interpolation inserted between two anchors).
+// Anchors carry their source variant in Variant; fills carry the two
+// anchors they sit between in HiVar/LoVar (a fill between a variant's own
+// avg and peak is that variant's discriminating band).
+type Rung struct {
+	Mbps    float64 `json:"mbps"`
+	Variant string  `json:"variant,omitempty"`
+	Kind    string  `json:"kind"`
+	HiVar   string  `json:"hi_var,omitempty"`
+	LoVar   string  `json:"lo_var,omitempty"`
+}
+
+// Label renders a short descriptor for a rung, e.g. "1920x1080 peak" for
+// an anchor or "fill" for an interpolated step.
+func (r Rung) Label() string {
+	if r.Kind == "fill" || r.Variant == "" {
+		return r.Kind
+	}
+	return r.Variant + " " + r.Kind
+}
+
+// AnchorCaps emits up to two anchor rungs per variant — peak×(1+bump) and
+// avg×(1+bump) — skipping the avg rung when AVERAGE-BANDWIDTH is absent
+// and any rung whose source bitrate is non-positive. The result is sorted
+// descending by Mbps. bumpPct is a percentage (5 => ×1.05).
+func AnchorCaps(vs []Variant, bumpPct float64) []Rung {
+	f := 1 + bumpPct/100
+	out := make([]Rung, 0, len(vs)*2)
+	for _, v := range vs {
+		if v.PeakBps > 0 {
+			out = append(out, Rung{Mbps: round3(float64(v.PeakBps) * f / 1e6), Variant: v.Resolution, Kind: "peak"})
+		}
+		if v.AvgBps > 0 {
+			out = append(out, Rung{Mbps: round3(float64(v.AvgBps) * f / 1e6), Variant: v.Resolution, Kind: "avg"})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Mbps > out[j].Mbps })
+	return out
+}
+
+// FillLadder inserts geometric fills between adjacent (descending) anchors
+// so no consecutive pair exceeds maxStep. Between hi and lo it adds
+// ceil(log(hi/lo)/log(maxStep)) - 1 evenly-ratioed steps. Insertion
+// preserves the descending order; the anchors themselves are kept. maxStep
+// <= 1 (or fewer than two anchors) is a no-op.
+func FillLadder(anchors []Rung, maxStep float64) []Rung {
+	if maxStep <= 1 || len(anchors) < 2 {
+		return anchors
+	}
+	out := make([]Rung, 0, len(anchors)*3)
+	for i, a := range anchors {
+		out = append(out, a)
+		if i+1 >= len(anchors) {
+			break
+		}
+		hi, lo := a.Mbps, anchors[i+1].Mbps
+		if lo <= 0 || hi <= lo {
+			continue
+		}
+		n := int(math.Ceil(math.Log(hi/lo)/math.Log(maxStep))) - 1
+		for k := 1; k <= n; k++ {
+			v := hi * math.Pow(lo/hi, float64(k)/float64(n+1))
+			out = append(out, Rung{
+				Mbps:  round3(v),
+				Kind:  "fill",
+				HiVar: a.Label(),
+				LoVar: anchors[i+1].Label(),
+			})
+		}
+	}
+	return out
+}
+
+// StandardLadder is the one entry point callers use: dual-rung anchors at
+// the given flat bump, geometrically filled to maxStep, sorted descending.
+func StandardLadder(vs []Variant, bumpPct, maxStep float64) []Rung {
+	return FillLadder(AnchorCaps(vs, bumpPct), maxStep)
+}
+
+func round3(v float64) float64 { return math.Round(v*1000) / 1000 }

--- a/go-proxy/pkg/ladder/ladder_test.go
+++ b/go-proxy/pkg/ladder/ladder_test.go
@@ -45,7 +45,7 @@ func TestAnchorCapsNoAverage(t *testing.T) {
 }
 
 func TestStandardLadderFilled(t *testing.T) {
-	got := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep)
+	got := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, 0)
 	if len(got) != 34 {
 		t.Fatalf("filled ladder: got %d rungs want 34 (12 anchors + 22 fills)", len(got))
 	}
@@ -114,8 +114,37 @@ func TestValidateOverlapNotFlagged(t *testing.T) {
 	}
 }
 
+func TestStandardLadderTopHeadroom(t *testing.T) {
+	base := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, 0)
+	got := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, DefaultTopHeadroomPct)
+	// Headroom adds a start rung above the +bump top anchor, plus the
+	// geometric fill(s) bridging the 1.25×→1.05× gap.
+	if len(got) <= len(base) {
+		t.Fatalf("headroom ladder len %d should exceed base %d", len(got), len(base))
+	}
+	// Top rung = top peak (29.584915 Mbps) × 1.25 = 36.981.
+	if got[0].Kind != "headroom" {
+		t.Errorf("top rung kind = %q, want headroom", got[0].Kind)
+	}
+	if got[0].Mbps < 36.97 || got[0].Mbps > 36.99 {
+		t.Errorf("headroom cap = %.3f, want ~36.981 (top peak × 1.25)", got[0].Mbps)
+	}
+	if got[0].Variant != "3840x2160" {
+		t.Errorf("headroom rung variant = %q, want 3840x2160", got[0].Variant)
+	}
+	// Still strictly descending within the step ratio.
+	for i := 1; i < len(got); i++ {
+		if got[i].Mbps >= got[i-1].Mbps {
+			t.Errorf("not descending at %d", i)
+		}
+		if r := got[i-1].Mbps / got[i].Mbps; r > DefaultMaxStep+0.002 {
+			t.Errorf("step %d ratio %.4fx exceeds %.2fx", i, r, DefaultMaxStep)
+		}
+	}
+}
+
 func TestBuildPattern(t *testing.T) {
-	rungs := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep)
+	rungs := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, 0)
 	n := len(rungs)
 
 	up := BuildPattern(RampUp, rungs, 12)

--- a/go-proxy/pkg/ladder/ladder_test.go
+++ b/go-proxy/pkg/ladder/ladder_test.go
@@ -1,0 +1,158 @@
+package ladder
+
+import (
+	"math"
+	"testing"
+)
+
+// tearsH264 is the real published ladder of tears-of-steel-4k_p200_h264
+// as served by test-dev (dev.jeoliver.com:21000/go-live/.../master.m3u8).
+// It is the golden fixture all three runtimes' ladders must reproduce.
+var tearsH264 = []Variant{
+	{AvgBps: 793601, PeakBps: 1033456, Resolution: "640x360"},
+	{AvgBps: 1387608, PeakBps: 1852154, Resolution: "960x540"},
+	{AvgBps: 2579294, PeakBps: 3523216, Resolution: "1280x720"},
+	{AvgBps: 5147499, PeakBps: 6841582, Resolution: "1920x1080"},
+	{AvgBps: 11125902, PeakBps: 14972084, Resolution: "2560x1440"},
+	{AvgBps: 21741872, PeakBps: 29584915, Resolution: "3840x2160"},
+}
+
+func TestAnchorCaps(t *testing.T) {
+	got := AnchorCaps(tearsH264, DefaultBumpPct)
+	if len(got) != 12 {
+		t.Fatalf("anchors: got %d want 12 (2 per variant)", len(got))
+	}
+	// Descending, top = 2160p peak, bottom = 360p avg, both ×1.05.
+	if got[0].Mbps != 31.064 || got[0].Kind != "peak" {
+		t.Errorf("top anchor = %.3f %s, want 31.064 peak", got[0].Mbps, got[0].Kind)
+	}
+	if last := got[len(got)-1]; last.Mbps != 0.833 || last.Kind != "avg" {
+		t.Errorf("bottom anchor = %.3f %s, want 0.833 avg", last.Mbps, last.Kind)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Mbps > got[i-1].Mbps {
+			t.Errorf("anchors not descending at %d: %.3f > %.3f", i, got[i].Mbps, got[i-1].Mbps)
+		}
+	}
+}
+
+func TestAnchorCapsNoAverage(t *testing.T) {
+	// AVERAGE-BANDWIDTH absent ⇒ one (peak) anchor per variant.
+	vs := []Variant{{PeakBps: 2_000_000, Resolution: "a"}, {PeakBps: 6_000_000, Resolution: "b"}}
+	if got := AnchorCaps(vs, DefaultBumpPct); len(got) != 2 {
+		t.Fatalf("got %d anchors, want 2", len(got))
+	}
+}
+
+func TestStandardLadderFilled(t *testing.T) {
+	got := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep)
+	if len(got) != 34 {
+		t.Fatalf("filled ladder: got %d rungs want 34 (12 anchors + 22 fills)", len(got))
+	}
+	if got[0].Mbps != 31.064 || got[len(got)-1].Mbps != 0.833 {
+		t.Errorf("ladder bounds = %.3f..%.3f, want 31.064..0.833", got[0].Mbps, got[len(got)-1].Mbps)
+	}
+	// Every consecutive step within the target ratio (tiny slack for the
+	// 3-dp rounding of each cap).
+	for i := 1; i < len(got); i++ {
+		ratio := got[i-1].Mbps / got[i].Mbps
+		if ratio > DefaultMaxStep+0.002 {
+			t.Errorf("step %d→%d ratio %.4fx exceeds %.2fx", i-1, i, ratio, DefaultMaxStep)
+		}
+		if got[i].Mbps > got[i-1].Mbps {
+			t.Errorf("ladder not descending at %d", i)
+		}
+	}
+	// No fill escapes the anchor envelope.
+	for _, r := range got {
+		if r.Mbps > 31.064 || r.Mbps < 0.833 {
+			t.Errorf("rung %.3f outside [0.833, 31.064]", r.Mbps)
+		}
+	}
+}
+
+func TestValidateLadderClean(t *testing.T) {
+	if hz := ValidateLadder(tearsH264); len(hz) != 0 {
+		t.Errorf("deployed ladder should be clean, got %v", hz)
+	}
+}
+
+func TestValidateLadderHazards(t *testing.T) {
+	cases := []struct {
+		name string
+		vs   []Variant
+		kind string
+	}{
+		{"duplicate", []Variant{{PeakBps: 2_000_000, Resolution: "a"}, {PeakBps: 2_000_000, Resolution: "b"}}, "duplicate_bandwidth"},
+		{"tight", []Variant{{PeakBps: 2_000_000, Resolution: "a"}, {PeakBps: 2_400_000, Resolution: "b"}}, "tight_spacing"},
+		{"inversion", []Variant{
+			{AvgBps: 4_500_000, PeakBps: 6_000_000, Resolution: "A"},
+			{AvgBps: 4_000_000, PeakBps: 6_500_000, Resolution: "B"}, // peak↑ but avg↓
+		}, "inversion"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			hz := ValidateLadder(c.vs)
+			if !hasHazard(hz, c.kind) {
+				t.Errorf("expected %s hazard, got %v", c.kind, hz)
+			}
+		})
+	}
+}
+
+func TestValidateOverlapNotFlagged(t *testing.T) {
+	// Deliberate avg→peak band overlap with healthy peak spacing: rung A
+	// avg 4 / peak 9, rung B avg 8 / peak 16. B's avg (8) sits inside A's
+	// band (4–9) so the bands overlap, but peak spacing is 1.78× and the
+	// avg order matches the peak order ⇒ must NOT be flagged.
+	vs := []Variant{
+		{AvgBps: 4_000_000, PeakBps: 9_000_000, Resolution: "A"},
+		{AvgBps: 8_000_000, PeakBps: 16_000_000, Resolution: "B"},
+	}
+	if hz := ValidateLadder(vs); len(hz) != 0 {
+		t.Errorf("overlap must not be flagged, got %v", hz)
+	}
+}
+
+func TestBuildPattern(t *testing.T) {
+	rungs := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep)
+	n := len(rungs)
+
+	up := BuildPattern(RampUp, rungs, 12)
+	if len(up) != n || up[0].RateMbps >= up[len(up)-1].RateMbps {
+		t.Errorf("ramp_up: len %d (want %d), first %.3f should be < last %.3f", len(up), n, up[0].RateMbps, up[len(up)-1].RateMbps)
+	}
+	down := BuildPattern(RampDown, rungs, 12)
+	if len(down) != n || down[0].RateMbps <= down[len(down)-1].RateMbps {
+		t.Errorf("ramp_down should descend, got %.3f..%.3f", down[0].RateMbps, down[len(down)-1].RateMbps)
+	}
+	pyr := BuildPattern(Pyramid, rungs, 12)
+	if len(pyr) != 2*n-1 {
+		t.Errorf("pyramid len %d, want %d (asc + desc without apex)", len(pyr), 2*n-1)
+	}
+	sq := BuildPattern(SquareWave, rungs, 12)
+	if len(sq) != 2 || sq[0].RateMbps != 0.833 || sq[1].RateMbps != 31.064 {
+		t.Errorf("square_wave = %v, want [0.833, 31.064]", sq)
+	}
+	if BuildPattern("sliders", rungs, 12) != nil {
+		t.Errorf("unknown template should return nil")
+	}
+}
+
+func hasHazard(hz []Hazard, kind string) bool {
+	for _, h := range hz {
+		if h.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRound3(t *testing.T) {
+	if got := round3(1.0851288); got != 1.085 {
+		t.Errorf("round3 = %v want 1.085", got)
+	}
+	if math.Abs(round3(0.83328105)-0.833) > 1e-9 {
+		t.Errorf("round3 avg mismatch")
+	}
+}

--- a/go-proxy/pkg/ladder/pattern.go
+++ b/go-proxy/pkg/ladder/pattern.go
@@ -1,0 +1,69 @@
+package ladder
+
+import "sort"
+
+// Pattern template names accepted by BuildPattern. These mirror the
+// PatternTemplate enum in go-proxy's v2 OpenAPI surface and the
+// dashboard's NetworkShapingPattern.vue.
+const (
+	RampUp     = "ramp_up"
+	RampDown   = "ramp_down"
+	Pyramid    = "pyramid"
+	SquareWave = "square_wave"
+)
+
+// Step is one entry of a shape pattern: hold RateMbps for DurationSeconds.
+type Step struct {
+	RateMbps        float64 `json:"rate_mbps"`
+	DurationSeconds int     `json:"duration_seconds"`
+}
+
+// BuildPattern orders a limit ladder into a shape-pattern step list:
+//
+//   - ramp_up     ascending caps (lowest → highest)
+//   - ramp_down   descending caps (highest → lowest)
+//   - pyramid     ascending then descending, without duplicating the apex
+//   - square_wave just the lowest and highest cap, alternating
+//
+// rungs may arrive in any order (StandardLadder returns them descending);
+// the ascending sequence is derived here. Every step holds for stepSecs.
+// An unknown template or empty ladder returns nil (the slider-only path).
+func BuildPattern(template string, rungs []Rung, stepSecs int) []Step {
+	if len(rungs) == 0 {
+		return nil
+	}
+	asc := make([]float64, len(rungs))
+	for i, r := range rungs {
+		asc[i] = r.Mbps
+	}
+	sort.Float64s(asc)
+
+	var seq []float64
+	switch template {
+	case RampUp:
+		seq = asc
+	case RampDown:
+		seq = reversedFloat(asc)
+	case Pyramid:
+		down := reversedFloat(asc[:len(asc)-1]) // drop the apex so it isn't held twice
+		seq = append(append([]float64{}, asc...), down...)
+	case SquareWave:
+		seq = []float64{asc[0], asc[len(asc)-1]}
+	default:
+		return nil
+	}
+
+	out := make([]Step, 0, len(seq))
+	for _, r := range seq {
+		out = append(out, Step{RateMbps: r, DurationSeconds: stepSecs})
+	}
+	return out
+}
+
+func reversedFloat(in []float64) []float64 {
+	out := make([]float64, len(in))
+	for i, v := range in {
+		out[len(in)-1-i] = v
+	}
+	return out
+}

--- a/go-proxy/pkg/ladder/validate.go
+++ b/go-proxy/pkg/ladder/validate.go
@@ -1,0 +1,76 @@
+package ladder
+
+import (
+	"fmt"
+	"sort"
+)
+
+// MinPeakSpacing is the smallest ratio allowed between two adjacent
+// rungs' peak (BANDWIDTH) values before ValidateLadder flags them as too
+// tightly spaced. Below ~1.5× a player can't tell the rungs apart and
+// oscillates between them. Per #551 the real hazards are inversion,
+// duplicate BANDWIDTH, and tight peak spacing — NOT avg→peak band
+// overlap, which is normal capped-VBR and is never flagged.
+const MinPeakSpacing = 1.5
+
+// Hazard is one structural problem found in a published manifest ladder.
+type Hazard struct {
+	Kind   string // "inversion" | "duplicate_bandwidth" | "tight_spacing"
+	Detail string
+}
+
+// ValidateLadder audits the published manifest ladder (not the shaped
+// limit ladder) for the three #551 hazards. It considers only variants
+// with a positive peak, sorts them ascending by peak, and reports:
+//
+//   - duplicate_bandwidth — two variants share a BANDWIDTH value
+//   - tight_spacing       — adjacent peak ratio < MinPeakSpacing
+//   - inversion           — average decreases while peak increases
+//     (the avg column disagrees with the peak ordering)
+//
+// avg→peak band overlap across rungs is intentionally NOT reported.
+// Returns nil when the ladder is clean.
+func ValidateLadder(vs []Variant) []Hazard {
+	list := make([]Variant, 0, len(vs))
+	for _, v := range vs {
+		if v.PeakBps > 0 {
+			list = append(list, v)
+		}
+	}
+	if len(list) < 2 {
+		return nil
+	}
+	sort.SliceStable(list, func(i, j int) bool { return list[i].PeakBps < list[j].PeakBps })
+
+	var hz []Hazard
+	for i := 1; i < len(list); i++ {
+		prev, cur := list[i-1], list[i]
+		if cur.PeakBps == prev.PeakBps {
+			hz = append(hz, Hazard{
+				Kind:   "duplicate_bandwidth",
+				Detail: fmt.Sprintf("%s and %s share BANDWIDTH=%d", label(prev), label(cur), cur.PeakBps),
+			})
+			continue // ratio is 1.0; the duplicate finding already covers it
+		}
+		if ratio := float64(cur.PeakBps) / float64(prev.PeakBps); ratio < MinPeakSpacing {
+			hz = append(hz, Hazard{
+				Kind:   "tight_spacing",
+				Detail: fmt.Sprintf("%s→%s peak ratio %.2fx < %.2fx", label(prev), label(cur), ratio, MinPeakSpacing),
+			})
+		}
+		if prev.AvgBps > 0 && cur.AvgBps > 0 && cur.AvgBps < prev.AvgBps {
+			hz = append(hz, Hazard{
+				Kind:   "inversion",
+				Detail: fmt.Sprintf("%s avg %d < %s avg %d while peak rises", label(cur), cur.AvgBps, label(prev), prev.AvgBps),
+			})
+		}
+	}
+	return hz
+}
+
+func label(v Variant) string {
+	if v.Resolution == "" {
+		return fmt.Sprintf("bw=%d", v.PeakBps)
+	}
+	return v.Resolution
+}

--- a/tests/characterization/go.mod
+++ b/tests/characterization/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
+	github.com/jonathaneoliver/infinite-streaming/go-proxy v0.0.0-00010101000000-000000000000
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
@@ -29,3 +30,5 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/jonathaneoliver/infinite-streaming/go-proxy => ../../go-proxy

--- a/tests/characterization/modes/abort_test.go
+++ b/tests/characterization/modes/abort_test.go
@@ -151,9 +151,9 @@ func runAbort(t *testing.T, p runner.Platform) {
 	if err != nil {
 		t.Fatalf("PlayerState (post-warmup): %v", err)
 	}
-	variants, err := runner.VariantRatesDesc(rec, 0)
+	variants, err := runner.StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantRatesDesc: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
 	topResolutions := []string{variants[0].Resolution}
 	t.Logf("top variant: %s (%.3f Mbps avg)", topResolutions[0], float64(variants[0].AvgBps)/1_000_000)

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -75,13 +75,12 @@ func runPyramid(t *testing.T, p runner.Platform) {
 	if err != nil {
 		t.Fatalf("PlayerState: %v", err)
 	}
-	desc, err := runner.VariantSweep(rec, rampupMargins)
+	desc, err := runner.StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantSweep: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
-	desc = dropOverlapsWithLowerVariant(desc)
 	if len(desc) == 0 {
-		t.Fatal("VariantSweep returned no entries")
+		t.Fatal("StandardLadderRates returned no entries")
 	}
 
 	// Filter by variant identity, not numeric floor — see the long
@@ -116,9 +115,9 @@ func runPyramid(t *testing.T, p runner.Platform) {
 		if i >= len(asc) {
 			phase = "↓"
 		}
-		t.Logf("  [%2d] %s %-10s  %+3d%%  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps",
-			i, phase, v.Resolution, v.MarginPct, v.CapMbps,
-			float64(v.AvgBps)/1_000_000, float64(v.PeakBps)/1_000_000)
+		t.Logf("  [%2d] %s %-10s  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps  (source=%s)",
+			i, phase, v.Resolution, v.CapMbps,
+			float64(v.AvgBps)/1_000_000, float64(v.PeakBps)/1_000_000, v.Source)
 	}
 
 	steps := make([]runner.Step, len(pyramid))

--- a/tests/characterization/modes/rampdown_test.go
+++ b/tests/characterization/modes/rampdown_test.go
@@ -3,22 +3,20 @@ package modes
 import (
 	"context"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
 )
 
-// Rampdown — variant-aware ramp_down at multiple margins.
+// Rampdown — variant-aware descending sweep over the shared limit ladder.
 //
-// For each variant in the current play's manifest we apply 6 caps in
-// descending order (×1.50, ×1.25, ×1.10, ×1.05, ×1.00, ×0.95), merged
-// across all variants into one strictly-descending series. Any candidate
-// that would have caused the cap to *increase* vs. the previous step gets
-// dropped (happens on tight ladders where var_low×1.50 > var_high×0.95).
+// The ladder (go-proxy/pkg/ladder via runner.StandardLadderRates) carries
+// both a peak (BANDWIDTH) and an average (AVERAGE-BANDWIDTH) anchor per
+// variant — each ×1.05 — plus geometric fills so no two consecutive caps
+// differ by more than CHAR_LADDER_MAX_STEP (1.15×). We apply them in
+// descending order. Each rung is attributed to the variant a peak-keyed
+// player should sustain at that cap (#551).
 //
 // Each step is held for up to rampdownMaxHold (60 s) but exits early as
 // soon as the buffer has been stable across the last rampdownEarlyExitWindow
@@ -32,44 +30,8 @@ import (
 // above SustainableBufferS (1 s) with zero stalls. Anything below that is
 // where the player starts depleting / stalling.
 
-// Symmetric 9-margin grid around each variant's AVG-bandwidth (TCP
-// overhead is layered separately in runner.TCPOverheadPct, applied
-// inside the CapMbps formula). Negative margins are required for the
-// rampdown tail where we deliberately stall the bottom variant.
-// dropOverlapsWithLowerVariant in sweep.go removes entries whose cap
-// falls inside the next-lower variant's [avg×0.5, avg×1.5] range so we
-// don't test the same operational territory twice.
-//
-// Override with CHAR_RAMPDOWN_MARGINS=50,25,10,5,0 (csv) to run a
-// shorter sweep for fast iteration — e.g. dropping the negative
-// margins cuts the run roughly in half and avoids the deliberate
-// stall-floor exploration on the bottom variant.
-var rampdownMargins = parseRampdownMargins([]int{50, 25, 10, 5, 0, -5, -10, -25, -50})
-
-func parseRampdownMargins(defaults []int) []int {
-	raw := strings.TrimSpace(os.Getenv("CHAR_RAMPDOWN_MARGINS"))
-	if raw == "" {
-		return defaults
-	}
-	var out []int
-	for _, p := range strings.Split(raw, ",") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		n, err := strconv.Atoi(p)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "CHAR_RAMPDOWN_MARGINS: invalid integer %q — ignoring override, using defaults\n", p)
-			return defaults
-		}
-		out = append(out, n)
-	}
-	if len(out) == 0 {
-		return defaults
-	}
-	fmt.Fprintf(os.Stderr, "CHAR_RAMPDOWN_MARGINS override active: %v\n", out)
-	return out
-}
+// Fill density + headroom are controlled by CHAR_LADDER_MAX_STEP (default
+// 1.15×) and CHAR_LADDER_BUMP_PCT (default 5%) — see runner.StandardLadderRates.
 
 const (
 	rampdownMaxHold         = 60 * time.Second
@@ -137,19 +99,18 @@ func runRampdown(t *testing.T, p runner.Platform) {
 	if err != nil {
 		t.Fatalf("PlayerState: %v", err)
 	}
-	sweep, err := runner.VariantSweep(rec, rampdownMargins)
+	sweep, err := runner.StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantSweep: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
-	sweep = dropOverlapsWithLowerVariant(sweep)
 
 	// Pre-sweep dump — every limit gets logged so the operator can sanity
 	// check before the sweep runs.
-	t.Logf("sweep plan: %d steps (margins %v, max-hold %s, early-exit when buffer stable %s)",
-		len(sweep), rampdownMargins, rampdownMaxHold, rampdownEarlyExitWindow)
+	t.Logf("sweep plan: %d rungs (bump %.0f%%, max-step %.2fx, max-hold %s, early-exit when buffer stable %s)",
+		len(sweep), runner.LadderBumpPct(), runner.LadderMaxStep(), rampdownMaxHold, rampdownEarlyExitWindow)
 	for i, v := range sweep {
-		t.Logf("  [%2d] %-10s  %+3d%%  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps  (source=%s)",
-			i, v.Resolution, v.MarginPct, v.CapMbps,
+		t.Logf("  [%2d] %-10s  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps  (source=%s)",
+			i, v.Resolution, v.CapMbps,
 			float64(v.AvgBps)/1_000_000, float64(v.PeakBps)/1_000_000, v.Source)
 	}
 
@@ -256,8 +217,8 @@ func runRampdown(t *testing.T, p runner.Platform) {
 			continue
 		}
 		upperFailures = append(upperFailures, fmt.Sprintf(
-			"step %d cap=%.3f Mbps %s/%+d%%: stalls=%d min_buf=%.1fs",
-			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.MarginPct,
+			"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
+			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
 			st.StallsDelta, st.MinBufferS))
 	}
 	if len(upperFailures) > 0 {
@@ -277,9 +238,9 @@ func joinLines(ss []string) string {
 	return out
 }
 
-// unionRungs collapses the per-step VariantSweep slice (one entry per
-// (variant, margin) pair) down to one entry per unique variant — what
-// Finalize's per-rung sample classification needs.
+// unionRungs collapses the limit-ladder slice (multiple rungs per
+// variant: peak/avg anchors + fills) down to one entry per unique
+// variant — what Finalize's per-rung sample classification needs.
 func unionRungs(sweep []runner.VariantRate) []runner.VariantRate {
 	seen := map[string]int{} // resolution → index in out
 	out := []runner.VariantRate{}

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -21,19 +21,15 @@ import (
 // to "constrained sweep". For non-Appium launchers we fall back to
 // the legacy warmup-then-sweep path which has a brief cliff at step 1.
 //
-// Why floor + 0% on bottom variant (was +10%): with TCP overhead
-// baked separately into the cap formula (runner.TCPOverheadPct=7),
-// margin=0 already produces "variant_avg × 1.07" — the
-// just-barely-sustainable rate. Lower margins (−5, −10, …, −50) are
-// rampdown territory; higher (+5, +10, +25, +50) are the climb.
-
-var rampupMargins = rampdownMargins
-
+// The ladder is the shared dual-rung (avg+peak) + geometrically-filled
+// limit ladder (runner.StandardLadderRates); rampup walks it ascending
+// from the floor.
+//
 // rampup deliberately skips the bottom variant — testing caps at
 // the bottom variant's range is rampdown's territory ("how low can we
 // go"). Rampup tests "given a constrained start, when does the player
 // climb?" — the floor for that is the second-from-bottom variant's
-// lowest surviving cap (after the dropOverlapsWithLowerVariant prune).
+// lowest surviving cap in the filled ladder.
 //
 // conservativeWarmupCap is the rate cap we apply when bootstrap can't
 // find a previous heartbeating player (typically right after a wedge
@@ -92,11 +88,10 @@ func runRampup(t *testing.T, p runner.Platform) {
 	} else if preRec.CurrentPlay == nil || len(preRec.CurrentPlay.Manifest.Variants) == 0 {
 		t.Logf("pre-launch: no current play / no variants yet (cold-start unavailable)")
 	} else {
-		preDesc, err = runner.VariantSweep(preRec, rampupMargins)
+		preDesc, err = runner.StandardLadderRates(preRec)
 		if err != nil {
-			t.Logf("pre-launch VariantSweep: %v (cold-start unavailable)", err)
+			t.Logf("pre-launch StandardLadderRates: %v (cold-start unavailable)", err)
 		} else {
-			preDesc = dropOverlapsWithLowerVariant(preDesc)
 			preFloor = rampupFloorFrom(preDesc)
 			t.Logf("bootstrap: pre-launch floor = %.3f Mbps (from current player's manifest)", preFloor)
 		}
@@ -259,13 +254,12 @@ func runRampup(t *testing.T, p runner.Platform) {
 	if err != nil {
 		t.Fatalf("PlayerState: %v", err)
 	}
-	desc, err := runner.VariantSweep(rec, rampupMargins)
+	desc, err := runner.StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantSweep: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
-	desc = dropOverlapsWithLowerVariant(desc)
 	if len(desc) == 0 {
-		t.Fatal("VariantSweep returned no entries")
+		t.Fatal("StandardLadderRates returned no entries")
 	}
 
 	// --- ascending step list ------------------------------------
@@ -289,11 +283,11 @@ func runRampup(t *testing.T, p runner.Platform) {
 		asc[i], asc[j] = asc[j], asc[i]
 	}
 
-	t.Logf("sweep plan: %d steps ascending from %.3f Mbps (skipping bottom variant — rampdown's territory)",
+	t.Logf("sweep plan: %d rungs ascending from %.3f Mbps (skipping bottom variant — rampdown's territory)",
 		len(asc), floor)
 	for i, v := range asc {
-		t.Logf("  [%2d] %-10s  %+3d%%  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps  (source=%s)",
-			i, v.Resolution, v.MarginPct, v.CapMbps,
+		t.Logf("  [%2d] %-10s  cap=%6.3f Mbps   avg=%.3f peak=%.3f Mbps  (source=%s)",
+			i, v.Resolution, v.CapMbps,
 			float64(v.AvgBps)/1_000_000, float64(v.PeakBps)/1_000_000, v.Source)
 	}
 
@@ -378,8 +372,8 @@ func runRampup(t *testing.T, p runner.Platform) {
 			continue
 		}
 		upperFailures = append(upperFailures, fmt.Sprintf(
-			"step %d cap=%.3f Mbps %s/%+d%%: stalls=%d min_buf=%.1fs",
-			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.MarginPct,
+			"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
+			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
 			st.StallsDelta, st.MinBufferS))
 	}
 	if len(upperFailures) > 0 {
@@ -392,10 +386,9 @@ func runRampup(t *testing.T, p runner.Platform) {
 	_ = preDesc
 }
 
-// rampupFloorFrom returns the lowest cap from a desc-order
-// VariantSweep, skipping the bottom variant entirely (its cap range is
-// rampdown's territory). Floor = the second-from-bottom variant's
-// lowest surviving cap.
+// rampupFloorFrom returns the lowest cap from a desc-order limit ladder,
+// skipping the bottom variant entirely (its cap range is rampdown's
+// territory). Floor = the second-from-bottom variant's lowest cap.
 func rampupFloorFrom(desc []runner.VariantRate) float64 {
 	if len(desc) == 0 {
 		return 0

--- a/tests/characterization/modes/startup_test.go
+++ b/tests/characterization/modes/startup_test.go
@@ -53,36 +53,35 @@ const (
 	startupSamplerPeriod      = 500 * time.Millisecond
 )
 
-// startupCapMarginFraction is the headroom multiplied onto each
-// variant's AVERAGE-BANDWIDTH to derive its "just-pick-this-variant"
-// cap. avg × (1 + headroom) × (1 + TCPOverhead) sits below the next
-// variant's avg, so the player's variant-selection algorithm should
-// land on this rung. Tuned to match what AVPlayer settles on in
-// practice — too low and the player won't pick the intended variant;
-// too high and it overshoots.
-const startupCapMarginFraction = 0.20
-
 // computeStartupCaps derives one cap per video variant from the
-// manifest. Each cap is variant.avg × 1.20 × 1.07 (TCP overhead) —
-// enough headroom that the player picks that variant comfortably,
-// but below the next variant's avg.
+// manifest, anchored on the variant's PEAK (BANDWIDTH) rate (#551 — the
+// audited OSS players all key startup selection on peak). Each cap is
+// variant.peak × (1 + LadderBumpPct) so it sits just above THIS variant's
+// peak and below the next variant's peak (the ladder's ≥1.5× spacing
+// guards that), which is what makes a peak-keyed player land on this rung
+// at cold start.
+//
+// NOTE (#551): re-anchored from AVERAGE-BANDWIDTH × 1.20 × 1.07-TCP to
+// peak × 1.05. The exact bump may need empirical re-tuning on the sim —
+// if a player overshoots/undershoots the intended variant, adjust via
+// CHAR_LADDER_BUMP_PCT.
 //
 // Returns the caps in DESCENDING order (top variant first) so the
 // most interesting case (no-constraint) runs first.
 //
 // Override CHAR_STARTUP_CAPS=30,8,3 to bypass and use a literal list.
 func computeStartupCaps(bws map[string]runner.VariantBandwidth) []float64 {
-	avgs := make([]float64, 0, len(bws))
+	peaks := make([]float64, 0, len(bws))
 	for _, bw := range bws {
-		if bw.AvgMbps > 0 {
-			avgs = append(avgs, bw.AvgMbps)
+		if bw.PeakMbps > 0 {
+			peaks = append(peaks, bw.PeakMbps)
 		}
 	}
-	sort.Sort(sort.Reverse(sort.Float64Slice(avgs)))
-	out := make([]float64, 0, len(avgs))
-	for _, avg := range avgs {
-		cap := avg * (1 + startupCapMarginFraction) * (1 + float64(runner.TCPOverheadPct)/100)
-		out = append(out, math.Round(cap*1000)/1000)
+	sort.Sort(sort.Reverse(sort.Float64Slice(peaks)))
+	f := 1 + runner.LadderBumpPct()/100
+	out := make([]float64, 0, len(peaks))
+	for _, pk := range peaks {
+		out = append(out, math.Round(pk*f*1000)/1000)
 	}
 	return out
 }

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -92,55 +92,6 @@ func OpenSession(t *testing.T, platform runner.Platform) *runner.Session {
 	return sess
 }
 
-// dropOverlapsWithLowerVariant filters a desc-sorted VariantSweep list:
-// for each variant V (other than the lowest), drop entries whose cap
-// falls inside the next-lower variant V₋₁'s range
-// [V₋₁.avg×0.5, V₋₁.avg×1.5]. The experiment at that cap is more
-// naturally attributed to V₋₁ (the player would settle there) — keeping
-// both adds redundant steps that test the same operational point.
-//
-// On a ladder where adjacent variant avgs are ≥ 2× apart (typical),
-// this drops a variant's −50% and −25% margin entries when their caps
-// fall within the lower rung's range. On tighter ladders more drops
-// happen automatically.
-func dropOverlapsWithLowerVariant(rates []runner.VariantRate) []runner.VariantRate {
-	if len(rates) < 2 {
-		return rates
-	}
-	// Per-resolution avg lookup (an entry's AvgBps is the same for every
-	// margin of that variant, so any entry works).
-	avgByRes := map[string]int{}
-	descRes := []string{}
-	seen := map[string]bool{}
-	for _, r := range rates {
-		if r.AvgBps > 0 {
-			avgByRes[r.Resolution] = r.AvgBps
-		}
-		if !seen[r.Resolution] {
-			seen[r.Resolution] = true
-			descRes = append(descRes, r.Resolution)
-		}
-	}
-	// For each variant (except the lowest), record V₋₁'s range.
-	lowerRange := map[string][2]float64{}
-	for i := 0; i+1 < len(descRes); i++ {
-		v := descRes[i]
-		lower := descRes[i+1]
-		lowerAvg := float64(avgByRes[lower]) / 1_000_000
-		lowerRange[v] = [2]float64{lowerAvg * 0.5, lowerAvg * 1.5}
-	}
-	out := make([]runner.VariantRate, 0, len(rates))
-	for _, r := range rates {
-		if rng, ok := lowerRange[r.Resolution]; ok {
-			if r.CapMbps >= rng[0] && r.CapMbps <= rng[1] {
-				continue // cap is in next-lower variant's range — drop
-			}
-		}
-		out = append(out, r)
-	}
-	return out
-}
-
 // LinearSteps generates a descending series of evenly-spaced rate steps.
 // "smooth" callers use a small step (~10) over a wide range; "shock"
 // callers use 2 steps. count must be ≥ 2 — the slice is undefined otherwise.

--- a/tests/characterization/runner/variants.go
+++ b/tests/characterization/runner/variants.go
@@ -40,10 +40,14 @@ type VariantRate struct {
 	CapMbps    float64 `json:"cap_mbps"`   // the rate to shape to for this rung
 }
 
-// LadderBumpPct / LadderMaxStep read the optional operator overrides,
-// falling back to the shared package defaults (5% flat bump, 1.15× steps).
+// LadderBumpPct / LadderMaxStep / LadderTopHeadroomPct read the optional
+// operator overrides, falling back to the shared package defaults (5% flat
+// bump, 1.15× steps, 25% top-headroom start rung).
 func LadderBumpPct() float64 { return envFloat("CHAR_LADDER_BUMP_PCT", ladder.DefaultBumpPct) }
 func LadderMaxStep() float64 { return envFloat("CHAR_LADDER_MAX_STEP", ladder.DefaultMaxStep) }
+func LadderTopHeadroomPct() float64 {
+	return envFloat("CHAR_LADDER_TOP_HEADROOM_PCT", ladder.DefaultTopHeadroomPct)
+}
 
 func envFloat(key string, def float64) float64 {
 	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
@@ -73,7 +77,7 @@ func StandardLadderRates(rec *PlayerRecord) ([]VariantRate, error) {
 		lv = append(lv, ladder.Variant{AvgBps: v.AverageBandwidth, PeakBps: v.Bandwidth, Resolution: v.Resolution})
 	}
 	bump := LadderBumpPct()
-	rungs := ladder.StandardLadder(lv, bump, LadderMaxStep())
+	rungs := ladder.StandardLadder(lv, bump, LadderMaxStep(), LadderTopHeadroomPct())
 	if len(rungs) == 0 {
 		return nil, errors.New("ladder: all variants had zero bandwidth")
 	}

--- a/tests/characterization/runner/variants.go
+++ b/tests/characterization/runner/variants.go
@@ -4,104 +4,123 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/ladder"
 )
 
-// TCPOverheadPct is the framework's per-cap allowance for TCP+IP+TLS+
-// HTTP framing overhead. Applied multiplicatively on top of any test
-// margin so that "margin 0" means "cap = variant_avg × 1.07" — the
-// just-barely-sustainable real-world cap. Empirically the on-wire
-// overhead is 5-8% across the throughput range we test (per-packet TCP
-// headers ≈ 2.7%, TLS framing ≈ 3-5%, HTTP/2 frames ≈ 1-2%); 7% is the
-// midpoint and covers low-rate connection-setup amortization concerns
-// without being wasteful at the top of the ladder.
-const TCPOverheadPct = 7
-
-// VariantRate is one rung of the current play's ladder, with the cap rate
-// the characterization sweep should apply for it: the variant's
-// AVERAGE-BANDWIDTH (preferred — long-term sustainable) or BANDWIDTH (peak
-// per HLS spec) × (1 + marginPct/100) × (1 + TCPOverheadPct/100).
+// VariantRate is one rung of the current play's limit ladder, with the
+// cap rate the characterization sweep applies for it. Since #551 the
+// ladder is built by the shared go-proxy/pkg/ladder package: it carries
+// BOTH a peak (BANDWIDTH) and an average (AVERAGE-BANDWIDTH) anchor per
+// variant, each ×(1+bump) at a flat bump (default 5%), plus geometric
+// fills so no two consecutive caps differ by more than CHAR_LADDER_MAX_STEP.
 //
-// Both AvgBps + PeakBps are recorded for diagnostics — Source tells you
-// which one fed the cap calc. RawBps is kept as an alias of "the one we
-// used" for backward compat with existing report JSON.
-//
-// Why both matter: a cap at avg×1.05 is enough for *sustained* playback
-// at that variant, but the player's per-segment fetch peak can be 30-40%
-// higher than avg for typical CBR. If the cap is below peak, the player
-// can't keep up during peak segments and downshifts — which is exactly
-// the "+5% isn't enough" finding the smooth sweep surfaces on AVPlayer.
+// Each rung is attributed to the manifest variant a PEAK-keyed player
+// should sustain at that cap (the confirmed model: hls.js/ExoPlayer/Shaka
+// all key down-switch on peak; AVPlayer is unknown so we carry both
+// scalars). Resolution/AvgBps/PeakBps therefore describe that expected
+// variant; Source records the rung's provenance ("peak", "avg" or
+// "fill"). RawBps mirrors PeakBps for backward-compat with report JSON
+// and stepOnTarget's expected-bitrate check. MarginPct is retained for
+// the report schema but is 0 under the flat-bump model.
 type VariantRate struct {
 	Resolution string  `json:"resolution"`
 	URL        string  `json:"url"`
-	AvgBps     int     `json:"avg_bps"`     // AVERAGE-BANDWIDTH from the master playlist, 0 if absent
-	PeakBps    int     `json:"peak_bps"`    // BANDWIDTH (per HLS spec — peak segment rate)
-	RawBps     int     `json:"raw_bps"`     // value used for cap calc (avg if present, else peak)
-	Source     string  `json:"source"`      // "average" or "peak" — which one fed RawBps
-	MarginPct  int     `json:"margin_pct"`  // headroom we applied
-	CapMbps    float64 `json:"cap_mbps"`    // RawBps × (1+margin/100) / 1e6
+	AvgBps     int     `json:"avg_bps"`    // expected variant's AVERAGE-BANDWIDTH, 0 if absent
+	PeakBps    int     `json:"peak_bps"`   // expected variant's BANDWIDTH (peak per HLS spec)
+	RawBps     int     `json:"raw_bps"`    // == PeakBps (peak-anchored matching)
+	Source     string  `json:"source"`     // "peak" | "avg" | "fill" — rung provenance
+	MarginPct  int     `json:"margin_pct"` // 0 under the flat-bump ladder
+	CapMbps    float64 `json:"cap_mbps"`   // the rate to shape to for this rung
 }
 
-// VariantRatesDesc reads the bound player's current manifest variants and
-// returns one VariantRate per rung, sorted descending by cap rate. Margin
-// is in percent (5 = 5% headroom). The descending order mirrors the
-// server's `ramp_down` pattern and the dashboard's buildSteps shape.
-//
-// Errors when the player has no manifest variants yet (master playlist
-// hasn't been fetched, or the v2 projection is missing them).
-func VariantRatesDesc(rec *PlayerRecord, marginPct int) ([]VariantRate, error) {
+// LadderBumpPct / LadderMaxStep read the optional operator overrides,
+// falling back to the shared package defaults (5% flat bump, 1.15× steps).
+func LadderBumpPct() float64 { return envFloat("CHAR_LADDER_BUMP_PCT", ladder.DefaultBumpPct) }
+func LadderMaxStep() float64 { return envFloat("CHAR_LADDER_MAX_STEP", ladder.DefaultMaxStep) }
+
+func envFloat(key string, def float64) float64 {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+			return f
+		}
+	}
+	return def
+}
+
+// StandardLadderRates builds the dual-rung + geometrically-filled limit
+// ladder for the bound player's current manifest, sorted descending by
+// cap. Every rung (peak/avg anchor or interpolated fill) is attributed to
+// the manifest variant a peak-keyed player should sustain at that cap, so
+// the variant-aware sweep (stepOnTarget / per-variant pass-fail / Finalize)
+// works unchanged. Errors when the master playlist hasn't been fetched.
+func StandardLadderRates(rec *PlayerRecord) ([]VariantRate, error) {
 	if rec == nil || rec.CurrentPlay == nil {
-		return nil, errors.New("variant rates: player has no current play")
+		return nil, errors.New("ladder: player has no current play")
 	}
 	variants := rec.CurrentPlay.Manifest.Variants
 	if len(variants) == 0 {
-		return nil, errors.New("variant rates: manifest has no variants (master playlist not fetched yet?)")
+		return nil, errors.New("ladder: manifest has no variants (master playlist not fetched yet?)")
 	}
-	if marginPct <= -100 {
-		return nil, fmt.Errorf("variant rates: margin %d would zero or invert the cap", marginPct)
-	}
-	rates := make([]VariantRate, 0, len(variants))
+	lv := make([]ladder.Variant, 0, len(variants))
 	for _, v := range variants {
-		bps := v.Bandwidth
-		source := "peak"
-		if v.AverageBandwidth > 0 {
-			bps = v.AverageBandwidth
-			source = "average"
-		}
-		if bps <= 0 {
+		lv = append(lv, ladder.Variant{AvgBps: v.AverageBandwidth, PeakBps: v.Bandwidth, Resolution: v.Resolution})
+	}
+	bump := LadderBumpPct()
+	rungs := ladder.StandardLadder(lv, bump, LadderMaxStep())
+	if len(rungs) == 0 {
+		return nil, errors.New("ladder: all variants had zero bandwidth")
+	}
+	// Manifest variants sorted descending by peak, for cap→variant attribution.
+	manifest := make([]struct {
+		res        string
+		url        string
+		avg, peak  int
+		peakCapMbp float64
+	}, 0, len(variants))
+	f := 1 + bump/100
+	for _, v := range variants {
+		if v.Bandwidth <= 0 {
 			continue
 		}
-		// cap = raw × (1 + margin/100) × (1 + TCP_overhead/100) / 1e6
-		// The TCP overhead factor is a framework constant — operators
-		// only pick margin; the framework adds 7% on top so margin=0
-		// produces a just-barely-sustainable cap (i.e. variant_avg
-		// PLUS the on-wire framing tax).
-		cap := float64(bps) *
-			(1 + float64(marginPct)/100) *
-			(1 + float64(TCPOverheadPct)/100) /
-			1_000_000
-		// Round to 3 decimal places — same precision the harness CLI uses
-		// so the dashboard and the framework apply identical numbers.
-		cap = math.Round(cap*1000) / 1000
-		rates = append(rates, VariantRate{
-			Resolution: v.Resolution,
-			URL:        v.URL,
-			AvgBps:     v.AverageBandwidth,
-			PeakBps:    v.Bandwidth,
-			RawBps:     bps,
-			Source:     source,
-			MarginPct:  marginPct,
-			CapMbps:    cap,
+		manifest = append(manifest, struct {
+			res        string
+			url        string
+			avg, peak  int
+			peakCapMbp float64
+		}{v.Resolution, v.URL, v.AverageBandwidth, v.Bandwidth, math.Round(float64(v.Bandwidth)*f/1e6*1000) / 1000})
+	}
+	sort.Slice(manifest, func(i, j int) bool { return manifest[i].peak > manifest[j].peak })
+
+	out := make([]VariantRate, 0, len(rungs))
+	for _, r := range rungs {
+		// Highest variant whose peak cap is still affordable at this rung's
+		// rate is the one a peak-keyed player should sustain; below them all
+		// it's the bottom variant.
+		ev := manifest[len(manifest)-1]
+		for _, m := range manifest {
+			if m.peakCapMbp <= r.Mbps {
+				ev = m
+				break
+			}
+		}
+		out = append(out, VariantRate{
+			Resolution: ev.res,
+			URL:        ev.url,
+			AvgBps:     ev.avg,
+			PeakBps:    ev.peak,
+			RawBps:     ev.peak,
+			Source:     r.Kind,
+			CapMbps:    r.Mbps,
 		})
 	}
-	if len(rates) == 0 {
-		return nil, errors.New("variant rates: all variants had zero bandwidth")
-	}
-	sort.Slice(rates, func(i, j int) bool { return rates[i].CapMbps > rates[j].CapMbps })
-	return rates, nil
+	return out, nil
 }
 
 // StepsFromVariants converts a descending variant-rate list into a Step
@@ -114,50 +133,6 @@ func StepsFromVariants(rates []VariantRate, hold time.Duration) []Step {
 		out = append(out, Step{RateMbps: r.CapMbps, Hold: hold})
 	}
 	return out
-}
-
-// VariantSweep produces a fine-grained descending sweep over every
-// (variant, margin) pair, then prunes any cap that doesn't strictly
-// decrease against the previous emitted cap. Used by the smooth mode to
-// characterize each rung at several headroom levels:
-//
-//	margins := []int{50, 25, 10, 5, 0, -5}
-//	→ +50% (comfortable) … +5% (operational default) … -5% (forced downshift)
-//
-// The "strictly decrease" prune is the safety net the operator asked for:
-// on tight ladders where a high margin on a low rung would overshoot a
-// low margin on the next-higher rung (e.g. var_high×0.95 < var_low×1.50),
-// we drop the offending step so the cap series remains monotonically
-// non-increasing. On the test-dev ladder this never fires because
-// adjacent rungs are ≥2× apart — every candidate survives.
-//
-// Returned slice is the cap series to apply, in order; each VariantRate
-// carries the variant identity + the specific margin used at that step.
-func VariantSweep(rec *PlayerRecord, margins []int) ([]VariantRate, error) {
-	if len(margins) == 0 {
-		return nil, errors.New("variant sweep: no margins supplied")
-	}
-	// Build per-variant candidates at every margin.
-	all := []VariantRate{}
-	for _, m := range margins {
-		rates, err := VariantRatesDesc(rec, m)
-		if err != nil {
-			return nil, err
-		}
-		all = append(all, rates...)
-	}
-	// Sort all candidates descending by cap.
-	sort.Slice(all, func(i, j int) bool { return all[i].CapMbps > all[j].CapMbps })
-	// Walk through, emitting only strict-decreases vs. the last emitted.
-	out := make([]VariantRate, 0, len(all))
-	last := math.Inf(1)
-	for _, c := range all {
-		if c.CapMbps < last {
-			out = append(out, c)
-			last = c.CapMbps
-		}
-	}
-	return out, nil
 }
 
 // VariantBandwidth captures the per-rung bandwidth from the manifest

--- a/tests/characterization/runner/variants_test.go
+++ b/tests/characterization/runner/variants_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestVariantRatesDescPrefersAverage(t *testing.T) {
+func TestStandardLadderRatesDualRungFilled(t *testing.T) {
 	// Fixture matching the current test-dev master playlist: 5 variants,
 	// all carrying AVERAGE-BANDWIDTH alongside BANDWIDTH.
 	rec := mkPlayerWithVariants(t, []variantSeed{
@@ -16,126 +16,88 @@ func TestVariantRatesDescPrefersAverage(t *testing.T) {
 		{res: "3840x2160", avg: 10845181, peak: 15363854, url: "playlist_6s_2160p.m3u8"},
 	})
 
-	rates, err := VariantRatesDesc(rec, 5)
+	rates, err := StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantRatesDesc: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
-	if len(rates) != 5 {
-		t.Fatalf("len=%d want 5", len(rates))
+	// 10 anchors (5 variants × {peak,avg}) + geometric fills.
+	if len(rates) <= 10 {
+		t.Fatalf("len=%d, want >10 (10 anchors + fills)", len(rates))
 	}
-	// Descending order check.
+	// Descending, within the target step ratio (slack for 3-dp rounding).
+	maxStep := LadderMaxStep()
 	for i := 1; i < len(rates); i++ {
 		if rates[i-1].CapMbps <= rates[i].CapMbps {
-			t.Errorf("rates not descending at %d: %.3f vs %.3f", i, rates[i-1].CapMbps, rates[i].CapMbps)
+			t.Errorf("not descending at %d: %.3f vs %.3f", i, rates[i-1].CapMbps, rates[i].CapMbps)
+		}
+		if r := rates[i-1].CapMbps / rates[i].CapMbps; r > maxStep+0.005 {
+			t.Errorf("step %d ratio %.3fx exceeds %.2fx", i, r, maxStep)
 		}
 	}
-	// Top rung (10.845 Mbps avg) × 1.05 (margin) × 1.07 (TCP) ≈ 12.184.
-	if got := rates[0].CapMbps; got < 12.17 || got > 12.20 {
-		t.Errorf("top cap %.3f Mbps, want ~12.184 (top avg × 1.05 × 1.07 TCP)", got)
+	// Top rung is the top variant's PEAK anchor ×1.05.
+	if rates[0].Source != "peak" || rates[0].Resolution != "3840x2160" {
+		t.Errorf("top rung = %s/%s, want 3840x2160/peak", rates[0].Resolution, rates[0].Source)
 	}
-	// Bottom rung (0.725 Mbps avg) × 1.05 × 1.07 ≈ 0.815.
-	if got := rates[len(rates)-1].CapMbps; got < 0.81 || got > 0.82 {
-		t.Errorf("bottom cap %.3f Mbps, want ~0.815 (bottom avg × 1.05 × 1.07 TCP)", got)
+	if got := rates[0].CapMbps; got < 16.12 || got > 16.14 {
+		t.Errorf("top cap %.3f Mbps, want ~16.132 (top peak × 1.05)", got)
 	}
-	// All five should report source=average since avg was populated.
+	// Bottom rung is attributed to the bottom variant; cap = bottom avg ×1.05.
+	last := rates[len(rates)-1]
+	if last.Resolution != "640x360" {
+		t.Errorf("bottom rung attributed to %s, want 640x360", last.Resolution)
+	}
+	if got := last.CapMbps; got < 0.755 || got > 0.766 {
+		t.Errorf("bottom cap %.3f Mbps, want ~0.761 (bottom avg × 1.05)", got)
+	}
+	// Every rung is attributed to a real variant + carries its peak.
 	for _, r := range rates {
-		if r.Source != "average" {
-			t.Errorf("%s reported source=%q want average", r.Resolution, r.Source)
+		if r.Resolution == "" || r.PeakBps <= 0 {
+			t.Errorf("rung cap=%.3f not attributed to a variant (res=%q peak=%d)", r.CapMbps, r.Resolution, r.PeakBps)
+		}
+		if r.Source != "peak" && r.Source != "avg" && r.Source != "fill" {
+			t.Errorf("rung cap=%.3f bad source %q", r.CapMbps, r.Source)
 		}
 	}
 }
 
-func TestVariantRatesDescFallsBackToPeak(t *testing.T) {
+func TestStandardLadderRatesPeakOnly(t *testing.T) {
+	// AVERAGE-BANDWIDTH absent ⇒ a single (peak) anchor per variant.
+	rec := mkPlayerWithVariants(t, []variantSeed{
+		{res: "640x360", avg: 0, peak: 1000000, url: "p.m3u8"},
+		{res: "1920x1080", avg: 0, peak: 6000000, url: "q.m3u8"},
+	})
+	rates, err := StandardLadderRates(rec)
+	if err != nil {
+		t.Fatalf("StandardLadderRates: %v", err)
+	}
+	if rates[0].Source != "peak" {
+		t.Errorf("top source=%q want peak", rates[0].Source)
+	}
+	// Top cap = 6.0 Mbps peak × 1.05 = 6.300.
+	if got := rates[0].CapMbps; got < 6.29 || got > 6.31 {
+		t.Errorf("top cap=%.3f want ~6.300 (peak 6.0 × 1.05)", got)
+	}
+}
+
+func TestStandardLadderRatesEnvBump(t *testing.T) {
+	t.Setenv("CHAR_LADDER_BUMP_PCT", "0")
 	rec := mkPlayerWithVariants(t, []variantSeed{
 		{res: "640x360", avg: 0, peak: 1000000, url: "p.m3u8"},
 	})
-	rates, err := VariantRatesDesc(rec, 0)
+	rates, err := StandardLadderRates(rec)
 	if err != nil {
-		t.Fatalf("VariantRatesDesc: %v", err)
+		t.Fatalf("StandardLadderRates: %v", err)
 	}
-	if rates[0].Source != "peak" {
-		t.Errorf("source=%q want peak (avg=0 forces fallback)", rates[0].Source)
-	}
-	// 1.0 Mbps × 1.0 (0% margin) × 1.07 (TCP) = 1.07
-	if got := rates[0].CapMbps; got < 1.06 || got > 1.08 {
-		t.Errorf("CapMbps=%.3f want ~1.070 (peak 1.0 × 0%% margin × 1.07 TCP)", got)
+	// bump 0 ⇒ cap = peak exactly (1.000 Mbps).
+	if got := rates[0].CapMbps; got < 0.999 || got > 1.001 {
+		t.Errorf("cap=%.3f want 1.000 (peak × bump 0%%)", got)
 	}
 }
 
-func TestVariantRatesDescEmptyManifest(t *testing.T) {
+func TestStandardLadderRatesEmptyManifest(t *testing.T) {
 	rec := mkPlayerWithVariants(t, nil)
-	if _, err := VariantRatesDesc(rec, 5); err == nil {
+	if _, err := StandardLadderRates(rec); err == nil {
 		t.Error("expected error for empty variants")
-	}
-}
-
-func TestVariantRatesDescNegativeMarginAccepted(t *testing.T) {
-	rec := mkPlayerWithVariants(t, []variantSeed{
-		{res: "640x360", avg: 1000000, peak: 1500000, url: "p.m3u8"},
-	})
-	rates, err := VariantRatesDesc(rec, -5)
-	if err != nil {
-		t.Fatalf("VariantRatesDesc(-5): %v (negative margins must be allowed)", err)
-	}
-	// 1.0 Mbps × 0.95 × 1.07 (TCP) ≈ 1.017
-	if got := rates[0].CapMbps; got < 1.01 || got > 1.02 {
-		t.Errorf("CapMbps=%.3f want ~1.017 (peak 1.0 × −5%% × 1.07 TCP)", got)
-	}
-}
-
-func TestVariantSweepProducesStrictDescent(t *testing.T) {
-	rec := mkPlayerWithVariants(t, []variantSeed{
-		{res: "640x360", avg: 725000, peak: 1000000, url: "p.m3u8"},
-		{res: "960x540", avg: 1307000, peak: 1800000, url: "p.m3u8"},
-		{res: "1920x1080", avg: 4989000, peak: 7000000, url: "p.m3u8"},
-	})
-	margins := []int{50, 25, 10, 5, 0, -5}
-	sweep, err := VariantSweep(rec, margins)
-	if err != nil {
-		t.Fatalf("VariantSweep: %v", err)
-	}
-	// 3 variants × 6 margins = 18 candidates; with this widely-spaced
-	// ladder all should survive the strict-descent prune.
-	if len(sweep) != 18 {
-		t.Errorf("len=%d want 18 (no candidates should be dropped)", len(sweep))
-	}
-	for i := 1; i < len(sweep); i++ {
-		if sweep[i].CapMbps >= sweep[i-1].CapMbps {
-			t.Errorf("strict descent violated at %d: %.3f → %.3f",
-				i, sweep[i-1].CapMbps, sweep[i].CapMbps)
-		}
-	}
-	// First cap = 1080p × 1.50 × 1.07 (TCP) ≈ 8.007 Mbps;
-	// last = 360p × 0.95 × 1.07 ≈ 0.737 Mbps.
-	if got := sweep[0].CapMbps; got < 8.00 || got > 8.02 {
-		t.Errorf("first cap %.3f Mbps, want ~8.007", got)
-	}
-	if got := sweep[len(sweep)-1].CapMbps; got < 0.736 || got > 0.738 {
-		t.Errorf("last cap %.3f Mbps, want ~0.737", got)
-	}
-}
-
-func TestVariantSweepDropsAscendingOnTightLadder(t *testing.T) {
-	// Adjacent variants very close: 540p avg 1.0 Mbps, 720p avg 1.1 Mbps.
-	// 720p × 0.95 = 1.045; 540p × 1.50 = 1.500 — the lower variant's high
-	// margin would *increase* the cap vs. the higher variant's low margin,
-	// so the prune must drop it.
-	rec := mkPlayerWithVariants(t, []variantSeed{
-		{res: "960x540", avg: 1000000, peak: 1200000, url: "p.m3u8"},
-		{res: "1280x720", avg: 1100000, peak: 1300000, url: "p.m3u8"},
-	})
-	sweep, err := VariantSweep(rec, []int{50, 25, 10, 5, 0, -5})
-	if err != nil {
-		t.Fatalf("VariantSweep: %v", err)
-	}
-	// Some candidates must have been dropped; check strict descent.
-	for i := 1; i < len(sweep); i++ {
-		if sweep[i].CapMbps >= sweep[i-1].CapMbps {
-			t.Errorf("strict descent violated at %d: %s/%+d%% %.3f → %s/%+d%% %.3f",
-				i,
-				sweep[i-1].Resolution, sweep[i-1].MarginPct, sweep[i-1].CapMbps,
-				sweep[i].Resolution, sweep[i].MarginPct, sweep[i].CapMbps)
-		}
 	}
 }
 

--- a/tests/characterization/runner/variants_test.go
+++ b/tests/characterization/runner/variants_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestStandardLadderRatesDualRungFilled(t *testing.T) {
+	t.Setenv("CHAR_LADDER_TOP_HEADROOM_PCT", "0") // isolate the dual-rung core
 	// Fixture matching the current test-dev master playlist: 5 variants,
 	// all carrying AVERAGE-BANDWIDTH alongside BANDWIDTH.
 	rec := mkPlayerWithVariants(t, []variantSeed{
@@ -61,6 +62,7 @@ func TestStandardLadderRatesDualRungFilled(t *testing.T) {
 }
 
 func TestStandardLadderRatesPeakOnly(t *testing.T) {
+	t.Setenv("CHAR_LADDER_TOP_HEADROOM_PCT", "0")
 	// AVERAGE-BANDWIDTH absent ⇒ a single (peak) anchor per variant.
 	rec := mkPlayerWithVariants(t, []variantSeed{
 		{res: "640x360", avg: 0, peak: 1000000, url: "p.m3u8"},
@@ -81,6 +83,7 @@ func TestStandardLadderRatesPeakOnly(t *testing.T) {
 
 func TestStandardLadderRatesEnvBump(t *testing.T) {
 	t.Setenv("CHAR_LADDER_BUMP_PCT", "0")
+	t.Setenv("CHAR_LADDER_TOP_HEADROOM_PCT", "0")
 	rec := mkPlayerWithVariants(t, []variantSeed{
 		{res: "640x360", avg: 0, peak: 1000000, url: "p.m3u8"},
 	})
@@ -91,6 +94,30 @@ func TestStandardLadderRatesEnvBump(t *testing.T) {
 	// bump 0 ⇒ cap = peak exactly (1.000 Mbps).
 	if got := rates[0].CapMbps; got < 0.999 || got > 1.001 {
 		t.Errorf("cap=%.3f want 1.000 (peak × bump 0%%)", got)
+	}
+}
+
+func TestStandardLadderRatesTopHeadroom(t *testing.T) {
+	// Default 25% top-headroom: the top rung is the top variant's peak
+	// × 1.25, tagged source=headroom, above the +5% top anchor.
+	rec := mkPlayerWithVariants(t, []variantSeed{
+		{res: "640x360", avg: 724620, peak: 998009, url: "p.m3u8"},
+		{res: "3840x2160", avg: 10845181, peak: 15363854, url: "q.m3u8"},
+	})
+	rates, err := StandardLadderRates(rec)
+	if err != nil {
+		t.Fatalf("StandardLadderRates: %v", err)
+	}
+	top := rates[0]
+	if top.Source != "headroom" {
+		t.Errorf("top rung source=%q want headroom", top.Source)
+	}
+	// 15363854 × 1.25 / 1e6 = 19.205.
+	if top.CapMbps < 19.19 || top.CapMbps > 19.22 {
+		t.Errorf("headroom cap=%.3f want ~19.205 (top peak × 1.25)", top.CapMbps)
+	}
+	if top.Resolution != "3840x2160" {
+		t.Errorf("headroom rung attributed to %q, want 3840x2160", top.Resolution)
 	}
 }
 

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/ladder"
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/format"
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/v2gen/proxy"
@@ -22,9 +23,15 @@ Slider mode (any subset; omitted fields are not modified):
 Pattern mode (generates a step list from the player's current variants):
   --pattern NAME     pyramid | ramp_up | ramp_down | square_wave | sliders
   --step-seconds N   per-step duration: 6 | 12 | 18 | 24 (default 12)
-  --margin PCT       headroom above variant rate: 0 | 5 | 10 | 25 | 50 (default 5)
-                     5% covers TCP/IP+TLS+HTTP framing; 0% is a
-                     deliberate-stall footgun
+  --margin PCT       flat headroom above each variant rate: 0|5|10|25|50
+                     (default 5; covers TCP/IP+TLS+HTTP framing; 0 is a
+                     deliberate-stall footgun)
+  --max-step RATIO   fill density: max ratio between consecutive caps before
+                     a geometric fill is inserted (default 1.15). The ladder
+                     carries BOTH a peak (BANDWIDTH) and an average
+                     (AVERAGE-BANDWIDTH) rung per variant, then fills the
+                     gaps — raise --max-step to coarsen + shorten the pattern
+                     (a pyramid over a dense ladder can run ~13 min/cycle)
   --clear-pattern    stop any running pattern (back to slider rate)
   --show-pattern     print current pattern + active step
 
@@ -61,6 +68,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	pattern := fs.String("pattern", "", "pattern template (pyramid|ramp_up|ramp_down|square_wave|sliders)")
 	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
+	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
 	clearPattern := fs.Bool("clear-pattern", false, "stop any running pattern")
 	showPattern := fs.Bool("show-pattern", false, "print current pattern, don't modify")
 	clear := fs.Bool("clear", false, "send {shape:null}")
@@ -85,7 +93,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	case *clearPattern:
 		return doClearPattern(client, ctx, pid, asJSON)
 	case *pattern != "":
-		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin)
+		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin, *maxStep)
 	}
 
 	if *rate < 0 && *delay < 0 && *loss < 0 {
@@ -306,11 +314,13 @@ func doClearPattern(client *api.Client, ctx context.Context, pid string, asJSON 
 }
 
 // doPattern generates step rates from the player's current manifest
-// variants using the same algorithm the dashboard's NetworkShapingPattern
-// panel runs (see buildSteps in that .vue). Snapshots pre-state for
-// `harness undo` and PATCHes.
+// variants via the shared go-proxy/pkg/ladder builder — the same one the
+// characterization harness uses and the dashboard's NetworkShapingPattern
+// panel mirrors in JS. The ladder carries both a peak and an average
+// anchor per variant, +marginPct flat, with geometric fills to maxStep
+// (#551). Snapshots pre-state for `harness undo` and PATCHes.
 func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
-	tplStr string, stepSecs, marginPct int) error {
+	tplStr string, stepSecs, marginPct int, maxStep float64) error {
 
 	tpl, err := parseTemplate(tplStr)
 	if err != nil {
@@ -335,12 +345,12 @@ func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
 	if err != nil {
 		return err
 	}
-	rates, err := variantRatesMbps(rec, marginPct)
+	rungs, err := variantLadder(rec, float64(marginPct), maxStep)
 	if err != nil {
 		return err
 	}
 
-	steps := buildPatternSteps(tpl, rates, stepSecs)
+	steps := buildPatternSteps(tpl, rungs, stepSecs)
 	if len(steps) == 0 && tpl != proxy.Sliders {
 		return fmt.Errorf("template %q produced an empty step list — does the player have a manifest yet?", tplStr)
 	}
@@ -401,11 +411,12 @@ func parseMarginPct(n int) (proxy.PatternMarginPct, error) {
 	return 0, fmt.Errorf("invalid --margin %d: must be 0|5|10|25|50", n)
 }
 
-// variantRatesMbps pulls the player's manifest variants, applies the
-// margin %, and returns the sorted-ascending Mbps list the buildSteps
-// algorithm consumes. Returns an error when the player has no variants
-// yet (master playlist not fetched).
-func variantRatesMbps(rec *proxy.PlayerRecord, marginPct int) ([]float32, error) {
+// variantLadder pulls the player's manifest variants and builds the
+// shared dual-rung (avg+peak) + geometrically-filled limit ladder via
+// go-proxy/pkg/ladder, descending by cap. bumpPct is the flat headroom
+// (the operator --margin); maxStep is the fill density. Returns an error
+// when the player has no variants yet (master playlist not fetched).
+func variantLadder(rec *proxy.PlayerRecord, bumpPct, maxStep float64) ([]ladder.Rung, error) {
 	if rec == nil || rec.CurrentPlay == nil || rec.CurrentPlay.Manifest == nil || rec.CurrentPlay.Manifest.Variants == nil {
 		return nil, errors.New("player has no manifest variants yet — has it fetched the master playlist?")
 	}
@@ -413,84 +424,36 @@ func variantRatesMbps(rec *proxy.PlayerRecord, marginPct int) ([]float32, error)
 	if len(variants) == 0 {
 		return nil, errors.New("player has no manifest variants yet — has it fetched the master playlist?")
 	}
-	rates := make([]float32, 0, len(variants))
+	lv := make([]ladder.Variant, 0, len(variants))
 	for _, v := range variants {
-		// Prefer AVERAGE-BANDWIDTH when the source playlist provided
-		// it — the variant's long-term sustainable rate, which is the
-		// honest minimum for "this variant should play smoothly."
-		// BANDWIDTH (per HLS spec) is the peak segment rate, which is
-		// 30–40% higher than AVERAGE for typical CBR encoders. Using
-		// the peak gives every step ~35% of unwarranted headroom.
-		bps := float32(v.Bandwidth)
-		if v.AverageBandwidth != nil && *v.AverageBandwidth > 0 {
-			bps = float32(*v.AverageBandwidth)
+		avg := 0
+		if v.AverageBandwidth != nil {
+			avg = *v.AverageBandwidth
 		}
-		// Same shape as dashboard's buildSteps: bps × (1 + margin) / 1000
-		// rounded to 3 dp.
-		mbps := bps * (1 + float32(marginPct)/100) / 1_000_000
-		if mbps > 0 {
-			rates = append(rates, roundFloat32(mbps, 3))
-		}
+		lv = append(lv, ladder.Variant{AvgBps: avg, PeakBps: v.Bandwidth, Resolution: v.Resolution})
 	}
-	if len(rates) == 0 {
+	rungs := ladder.StandardLadder(lv, bumpPct, maxStep)
+	if len(rungs) == 0 {
 		return nil, errors.New("manifest_variants present but all bandwidths zero")
 	}
-	// Sort ascending for the build algorithm.
-	for i := 1; i < len(rates); i++ {
-		for j := i; j > 0 && rates[j-1] > rates[j]; j-- {
-			rates[j-1], rates[j] = rates[j], rates[j-1]
-		}
-	}
-	return rates, nil
+	return rungs, nil
 }
 
-// buildPatternSteps mirrors the dashboard's NetworkShapingPattern.vue
-// `buildSteps` function. Keep in sync — operator workflows expect a
-// CLI-applied pattern to look identical to a UI-applied one.
-func buildPatternSteps(t proxy.PatternTemplate, rates []float32, stepSecs int) []proxy.PatternStep {
-	var seq []float32
-	switch t {
-	case proxy.SquareWave:
-		seq = []float32{rates[0], rates[len(rates)-1]}
-	case proxy.RampUp:
-		seq = append([]float32(nil), rates...)
-	case proxy.RampDown:
-		seq = append([]float32(nil), rates...)
-		reverseFloat32(seq)
-	case proxy.Pyramid:
-		asc := append([]float32(nil), rates...)
-		desc := append([]float32(nil), rates[:len(rates)-1]...)
-		reverseFloat32(desc)
-		seq = append(asc, desc...)
-	default:
-		// sliders / square / unknown — empty step list
-		return nil
-	}
-
+// buildPatternSteps orders the limit ladder into a pattern step list via
+// the shared ladder.BuildPattern (the same logic the dashboard's
+// NetworkShapingPattern.vue mirrors in JS, parity-checked against
+// go-proxy/pkg/ladder's golden vectors).
+func buildPatternSteps(t proxy.PatternTemplate, rungs []ladder.Rung, stepSecs int) []proxy.PatternStep {
+	lsteps := ladder.BuildPattern(string(t), rungs, stepSecs)
 	enabled := true
-	out := make([]proxy.PatternStep, 0, len(seq))
-	for _, r := range seq {
+	out := make([]proxy.PatternStep, 0, len(lsteps))
+	for _, s := range lsteps {
 		e := enabled
 		out = append(out, proxy.PatternStep{
-			RateMbps:        r,
-			DurationSeconds: stepSecs,
+			RateMbps:        float32(s.RateMbps),
+			DurationSeconds: s.DurationSeconds,
 			Enabled:         &e,
 		})
 	}
 	return out
 }
-
-func reverseFloat32(a []float32) {
-	for i, j := 0, len(a)-1; i < j; i, j = i+1, j-1 {
-		a[i], a[j] = a[j], a[i]
-	}
-}
-
-func roundFloat32(v float32, dp int) float32 {
-	m := float32(1)
-	for i := 0; i < dp; i++ {
-		m *= 10
-	}
-	return float32(int(v*m+0.5)) / m
-}
-

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -32,6 +32,10 @@ Pattern mode (generates a step list from the player's current variants):
                      (AVERAGE-BANDWIDTH) rung per variant, then fills the
                      gaps — raise --max-step to coarsen + shorten the pattern
                      (a pyramid over a dense ladder can run ~13 min/cycle)
+  --top-headroom PCT start the ladder this %% over the top variant's peak
+                     (default 25; adds a headroom start rung above the
+                     top anchor so playback settles before constraining;
+                     0 disables it)
   --clear-pattern    stop any running pattern (back to slider rate)
   --show-pattern     print current pattern + active step
 
@@ -69,6 +73,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
+	topHeadroom := fs.Float64("top-headroom", ladder.DefaultTopHeadroomPct, "start the ladder this %% over the top variant's peak (default 25; 0 disables the headroom start rung)")
 	clearPattern := fs.Bool("clear-pattern", false, "stop any running pattern")
 	showPattern := fs.Bool("show-pattern", false, "print current pattern, don't modify")
 	clear := fs.Bool("clear", false, "send {shape:null}")
@@ -93,7 +98,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	case *clearPattern:
 		return doClearPattern(client, ctx, pid, asJSON)
 	case *pattern != "":
-		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin, *maxStep)
+		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin, *maxStep, *topHeadroom)
 	}
 
 	if *rate < 0 && *delay < 0 && *loss < 0 {
@@ -320,7 +325,7 @@ func doClearPattern(client *api.Client, ctx context.Context, pid string, asJSON 
 // anchor per variant, +marginPct flat, with geometric fills to maxStep
 // (#551). Snapshots pre-state for `harness undo` and PATCHes.
 func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
-	tplStr string, stepSecs, marginPct int, maxStep float64) error {
+	tplStr string, stepSecs, marginPct int, maxStep, topHeadroomPct float64) error {
 
 	tpl, err := parseTemplate(tplStr)
 	if err != nil {
@@ -345,7 +350,7 @@ func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
 	if err != nil {
 		return err
 	}
-	rungs, err := variantLadder(rec, float64(marginPct), maxStep)
+	rungs, err := variantLadder(rec, float64(marginPct), maxStep, topHeadroomPct)
 	if err != nil {
 		return err
 	}
@@ -416,7 +421,7 @@ func parseMarginPct(n int) (proxy.PatternMarginPct, error) {
 // go-proxy/pkg/ladder, descending by cap. bumpPct is the flat headroom
 // (the operator --margin); maxStep is the fill density. Returns an error
 // when the player has no variants yet (master playlist not fetched).
-func variantLadder(rec *proxy.PlayerRecord, bumpPct, maxStep float64) ([]ladder.Rung, error) {
+func variantLadder(rec *proxy.PlayerRecord, bumpPct, maxStep, topHeadroomPct float64) ([]ladder.Rung, error) {
 	if rec == nil || rec.CurrentPlay == nil || rec.CurrentPlay.Manifest == nil || rec.CurrentPlay.Manifest.Variants == nil {
 		return nil, errors.New("player has no manifest variants yet — has it fetched the master playlist?")
 	}
@@ -432,7 +437,7 @@ func variantLadder(rec *proxy.PlayerRecord, bumpPct, maxStep float64) ([]ladder.
 		}
 		lv = append(lv, ladder.Variant{AvgBps: avg, PeakBps: v.Bandwidth, Resolution: v.Resolution})
 	}
-	rungs := ladder.StandardLadder(lv, bumpPct, maxStep)
+	rungs := ladder.StandardLadder(lv, bumpPct, maxStep, topHeadroomPct)
 	if len(rungs) == 0 {
 		return nil, errors.New("manifest_variants present but all bandwidths zero")
 	}

--- a/tools/harness-cli/go.mod
+++ b/tools/harness-cli/go.mod
@@ -7,4 +7,9 @@ require (
 	github.com/oapi-codegen/runtime v1.4.0
 )
 
-require github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+require (
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/jonathaneoliver/infinite-streaming/go-proxy v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/jonathaneoliver/infinite-streaming/go-proxy => ../../go-proxy


### PR DESCRIPTION
## What

The test rig shapes throughput down a "limit ladder" to characterize where a player switches renditions. Today that ladder is **single-rung and avg-anchored**, and the logic is **triplicated** (Go harness, harness CLI, dashboard JS). A #551 source audit of hls.js / ExoPlayer / Shaka shows selection keys on **peak** (`BANDWIDTH`) for startup + down-switch; **average** only ever appears in hls.js's full-buffer up-switch. **AVPlayer (our ship target) is closed-source and unknown** — so the ladder now carries **both** scalars per variant, and a sweep probes both regimes regardless of which one a player keys on. Each variant's avg→peak band is a discriminating zone (a cap parked inside it makes a peak-keyed player drop while an avg-keyed player holds).

## The ladder

- **Both rungs per variant** — a peak (BANDWIDTH) and an average (AVERAGE-BANDWIDTH) anchor, each **+5% flat** (replaces the old `margin × 1.07-TCP` two-factor).
- **Geometric fills to ≤1.15×** so a downward sweep can't skip the switch rung. For the deployed 6-variant tears-of-steel h264 ladder: 12 anchors + 22 fills = 34 rungs.

## New shared package — `go-proxy/pkg/ladder/`

One source of truth for the two Go runtimes (forwarder→go-proxy precedent; `go.work` joins all modules); the dashboard mirrors it in JS, parity-checked against the package's golden vectors.

- `AnchorCaps` / `FillLadder` / `StandardLadder` — the dual-rung filled ladder.
- `BuildPattern` — `ramp_up` / `ramp_down` / `pyramid` / `square_wave` ordering.
- `ValidateLadder` — lints the **published manifest** for inversion / duplicate BANDWIDTH / tight (<1.5×) spacing. Overlap is **NOT** flagged (normal capped-VBR).

## Wired into all three runtimes (characterization **and** the built-in patterns)

- **tests/characterization** — `StandardLadderRates` replaces `VariantSweep`/`VariantRatesDesc`; `rampup`/`rampdown`/`pyramid`/`abort` + `startup` re-anchored to peak. Every rung is attributed to the variant a peak-keyed player should sustain at that cap, so the variant-aware sweep (`stepOnTarget`/pass-fail/`Finalize`) is unchanged. Knobs `CHAR_LADDER_BUMP_PCT` / `CHAR_LADDER_MAX_STEP`.
- **tools/harness-cli** — `shape --pattern ramp_up|ramp_down|pyramid` delegates to the shared builder; new `--max-step` to coarsen dense patterns (a pyramid over 34 rungs runs ~13 min/cycle).
- **dashboard** — `NetworkShapingPattern.vue` dual-rung presets + fill-density control + rung count; `Characterization.vue` shows rung source.

## Also

- `.claude/standards/abr-ladder.md` — the peak-vs-average model (per-player table + citations), the dual-rung convention, the manifest hazards.
- AVPlayer throttle-into-the-gap / inverted probe ladders split to **#615** (needs custom-manifest injection + n≥3 sim runs).

## Verification

- `go test ./go-proxy/pkg/ladder/...` — golden vectors reproduce the 34-rung sample, every step ≤1.15×, `ValidateLadder` flags injected inverted/duplicate/tight ladders and passes the deployed one.
- `go build` + `go vet` + `go test ./tests/characterization/runner/...` green across the joined modules; gofmt clean on all touched files.
- `npm run build` (vue-tsc + vite) green.
- **Not yet done:** live `harness shape --pattern` against test-dev and a sim sweep run to confirm behaviour end-to-end (the harness/CLI binaries need redeploy/rebuild).

Refs #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
