### PR TITLE
fix(dashboard): snap reported video_bitrate to nearest published peak (#619)

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -25,7 +25,7 @@
 import { computed, ref, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
-import { useManifestVariants } from '@/composables/useManifestVariants';
+import { useManifestVariants, nearestVariantByBitrate } from '@/composables/useManifestVariants';
 import { usePlayer } from '@/composables/usePlayer';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
@@ -277,16 +277,6 @@ const baseSeries: SeriesSpec[] = [
     accessor: (p: PlayerRecord) => p.player_metrics?.network_bitrate_mbps ?? null,
   },
   {
-    // video_bitrate_mbps == indicatedBitrate == the variant AVPlayer has
-    // SELECTED to fetch (the ABR pick). It leads the on-screen rung by the
-    // buffer depth — hence "Fetching", paired with "Displayed Variant"
-    // (the decoded/on-screen rung) added in the series computed below.
-    label: 'Fetching Variant',
-    color: '#ef4444',
-    accessor: (p: PlayerRecord) => p.player_metrics?.video_bitrate_mbps ?? null,
-    stepped: true,
-  },
-  {
     label: 'Serving Variant',
     color: '#b45309',
     accessor: (p: PlayerRecord) => p.server_metrics?.rendition_mbps ?? null,
@@ -309,6 +299,20 @@ const series = computed<SeriesSpec[]>(() => {
   const out = [...baseSeries];
   const ladder = variants.value;
   if (!ladder.length) return out;
+  // "Fetching Variant": video_bitrate_mbps == AVPlayer indicatedBitrate ==
+  // the rung it SELECTED to fetch (leads the screen by the buffer). It's a
+  // jittery EWMA, so plot the nearest published peak instead of the raw
+  // value — a clean stepped rung line, not a 29.6/29.9 wobble (#619).
+  out.push({
+    label: 'Fetching Variant',
+    color: '#ef4444',
+    accessor: (p: PlayerRecord) => {
+      const vb = p.player_metrics?.video_bitrate_mbps;
+      if (vb == null || vb <= 0) return null;
+      return nearestVariantByBitrate(ladder, vb)?.peakMbps ?? vb;
+    },
+    stepped: true,
+  });
   // "Displayed Variant": the same value that drives the player-state
   // "Video Res" line (player_metrics.video_resolution = the DECODED frame
   // size, presentationSize on iOS / videoWidth×videoHeight on web), plotted

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -31,6 +31,7 @@ import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import { ensureVisTimeline } from '@/composables/useChartJs';
 import { useChartCoordination, DEFAULT_FOCUS_MS } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import { nearestVariantByBitrate } from '@/composables/useManifestVariants';
 
 interface LaneCfg { label: string; color: string }
 const EVENT_LANES: Record<string, LaneCfg> = {
@@ -467,35 +468,6 @@ function manifestVariantForDisplayedRes(
   return best;
 }
 
-/** Find the canonical resolution for a given bitrate by consulting the
- *  manifest's variant ladder. Mirrors the legacy session-shell.js
- *  `manifestResolutionForBitrateFromVariants`: the bitrate match is
- *  tolerant (±max(0.5 Mbps, 5% of the variant's Mbps)) so EWMA drift
- *  doesn't lose the match. Returns '' if no variant is close enough,
- *  so the caller can fall back to the player-reported resolution. */
-function manifestResolutionForBitrate(
-  variants: IngestRow['manifestVariants'],
-  targetMbps: number,
-): string {
-  if (!Number.isFinite(targetMbps)) return '';
-  if (!variants || variants.length === 0) return '';
-  let best: string | null = null;
-  let bestDelta = Infinity;
-  for (const v of variants) {
-    const vBw = Number(v?.bandwidth ?? 0);
-    if (!Number.isFinite(vBw) || vBw <= 0) continue;
-    const vMbps = vBw / 1_000_000;
-    const delta = Math.abs(vMbps - targetMbps);
-    const tol = Math.max(0.5, vMbps * 0.05);
-    if (delta < tol && delta < bestDelta) {
-      bestDelta = delta;
-      const r = String(v?.resolution ?? '').trim();
-      if (r) best = r;
-    }
-  }
-  return best ?? '';
-}
-
 function laneClose(key: string, t: number) {
   const cur = openRanges[key];
   if (!cur) return;
@@ -756,28 +728,32 @@ function ingest(r: IngestRow) {
     });
   }
 
-  // VARIANT — keyed on the MANIFEST's canonical resolution for the
-  // rung so transient `video_resolution` flicker during a switch
-  // doesn't create phantom lanes.
+  // VARIANT — keyed on the MANIFEST's canonical rung (resolution AND peak
+  // Mbps), NOT the player's reported video_bitrate. video_bitrate is
+  // AVPlayer's indicatedBitrate — a jittery EWMA that wobbles around the
+  // true rung (e.g. 29.6/29.9 for a 29.86 Mbps 4K variant). Snapping to the
+  // nearest published peak collapses phantom near-duplicate lanes and kills
+  // jitter-driven SHIFT markers. Issue #619.
   const mbpsRaw = r.videoBitrateMbps;
   if (mbpsRaw != null && mbpsRaw > 0) {
-    const mbpsRounded = Math.round(mbpsRaw * 10) / 10;
-    const variantRes = manifestResolutionForBitrate(r.manifestVariants, mbpsRounded);
-    if (variantRes) {
+    const rung = nearestVariantByBitrate(r.manifestVariants, mbpsRaw);
+    if (rung && rung.resolution) {
+      const canonMbps = rung.peakMbps;
+      const variantRes = rung.resolution;
       if (prevVariantMbps != null) {
-        if (mbpsRaw > prevVariantMbps + 0.01) {
-          pushPoint('PLAYBACK', t, 'SHIFT UP', '#3b82f6', `\n${prevVariantMbps.toFixed(2)} → ${mbpsRaw.toFixed(2)} Mbps`);
-        } else if (mbpsRaw < prevVariantMbps - 0.01) {
-          pushPoint('PLAYBACK', t, 'SHIFT DOWN', '#ef4444', `\n${prevVariantMbps.toFixed(2)} → ${mbpsRaw.toFixed(2)} Mbps`);
+        if (canonMbps > prevVariantMbps + 0.01) {
+          pushPoint('PLAYBACK', t, 'SHIFT UP', '#3b82f6', `\n${prevVariantMbps.toFixed(2)} → ${canonMbps.toFixed(2)} Mbps`);
+        } else if (canonMbps < prevVariantMbps - 0.01) {
+          pushPoint('PLAYBACK', t, 'SHIFT DOWN', '#ef4444', `\n${prevVariantMbps.toFixed(2)} → ${canonMbps.toFixed(2)} Mbps`);
         }
       }
-      prevVariantMbps = mbpsRaw;
-      const key = variantLaneId(mbpsRounded, variantRes);
-      ensureVariantLane(mbpsRounded, variantRes);
+      prevVariantMbps = canonMbps;
+      const key = variantLaneId(canonMbps, variantRes);
+      ensureVariantLane(canonMbps, variantRes);
       statefulEvents.push({
         ts: t,
         type: 'VARIANT',
-        mbps: mbpsRounded,
+        mbps: canonMbps,
         variantRes,
         variantKey: key,
       });

--- a/content/dashboard-v3/src/composables/useManifestVariants.ts
+++ b/content/dashboard-v3/src/composables/useManifestVariants.ts
@@ -39,3 +39,44 @@ export function useManifestVariants(playerId: Ref<string> | string) {
 
   return { variants };
 }
+
+/** Minimal manifest-variant shape the snap helper needs. */
+export interface VariantLite {
+  bandwidth?: number;
+  resolution?: string;
+}
+
+/**
+ * Snap a player-reported bitrate (Mbps) to the manifest rung whose published
+ * peak BANDWIDTH is closest, returning that rung's resolution + peak Mbps.
+ *
+ * The player's `video_bitrate` is AVPlayer's `indicatedBitrate` — a jittery
+ * EWMA estimate that wobbles around the true rung (e.g. 29.6/29.9 for a
+ * 29.86 Mbps 4K variant). Anywhere a reported bitrate must identify a
+ * DISCRETE variant (the bandwidth chart's Fetching line, the timeline
+ * VARIANT lane) we snap it here so one rung doesn't fragment into phantom
+ * near-duplicates and jitter doesn't fire spurious up/down shifts. The raw
+ * value is left intact at the source — this is a display-time derivation.
+ *
+ * Returns null when there are no usable variants (e.g. pre-manifest
+ * heartbeats), so callers fall back to the raw value or skip. Issue #619.
+ */
+export function nearestVariantByBitrate(
+  variants: ReadonlyArray<VariantLite> | null | undefined,
+  reportedMbps: number,
+): { resolution: string; peakMbps: number } | null {
+  if (!variants || variants.length === 0 || !Number.isFinite(reportedMbps)) return null;
+  let best: { resolution: string; peakMbps: number } | null = null;
+  let bestDelta = Infinity;
+  for (const v of variants) {
+    const bw = Number(v?.bandwidth ?? 0);
+    if (!Number.isFinite(bw) || bw <= 0) continue;
+    const peakMbps = bw / 1_000_000;
+    const delta = Math.abs(peakMbps - reportedMbps);
+    if (delta < bestDelta) {
+      bestDelta = delta;
+      best = { resolution: String(v?.resolution ?? '').trim(), peakMbps };
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
Closes #619.

## Problem
`video_bitrate` (= AVPlayer `indicatedBitrate`) is a jittery EWMA that wobbles around the true rung — e.g. ~29.6/29.9 for one 29.86 Mbps 4K variant. Consumers that used it to identify a *discrete* variant fragmented one rung into phantom lanes and fired spurious shift markers. (Observed: two `3840x2160` lanes in the player-state timeline.)

## Fix — snap at the consumer, keep the source raw
- **`useManifestVariants.ts`** — new shared pure helper `nearestVariantByBitrate(variants, reportedMbps) → {resolution, peakMbps}` (closest published peak). Single source of truth.
- **EventsTimeline VARIANT lane** — snap the lane key/label *and* SHIFT detection to the nearest peak → collapses the 29.6/29.9 phantom lanes and kills jitter-driven SHIFT UP/DOWN. Drops the now-redundant local `manifestResolutionForBitrate`.
- **BandwidthChart "Fetching Variant"** — snap the accessor → clean stepped rung line instead of the raw wobble (moved into the ladder-aware computed).

`video_bitrate` stays raw at the source (honest measurement per the design discussion in #619); this is a display-time derivation, so it also fixes **historical** archived plays. PlayerMetrics "Video Bitrate" badge left raw (literal metric).

## Verification
`npm run build` (vue-tsc + vite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
