### PR TITLE
feat(551): raise ladder top-headroom 25% → 50% over top peak

### DIFF
--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -64,8 +64,10 @@ const maxStep = ref<number>(DEFAULT_MAX_STEP);
 
 // #551 — start the ladder this % over the top variant's peak (a headroom
 // start rung above the +bump top anchor) so playback settles at the top
-// variant before the pattern constrains it. Mirrors the Go default.
-const DEFAULT_TOP_HEADROOM = 25;
+// variant before the pattern constrains it. Mirrors the Go default
+// (ladder.DefaultTopHeadroomPct); 50% gives conservative upshift room to
+// reach the top rung.
+const DEFAULT_TOP_HEADROOM = 50;
 
 interface LadderVariant {
   avgBps: number;

--- a/go-proxy/pkg/ladder/ladder.go
+++ b/go-proxy/pkg/ladder/ladder.go
@@ -40,8 +40,10 @@ const (
 	// DefaultTopHeadroomPct prepends a starting rung at the top variant's
 	// peak × (1 + this/100), above the +bump top anchor, so a sweep settles
 	// the player comfortably at the top variant before constraining it.
-	// Over the RAW top peak, not compounded with the bump.
-	DefaultTopHeadroomPct = 25.0
+	// Over the RAW top peak, not compounded with the bump. 50% gives
+	// AVPlayer's conservative upshift enough room to actually reach the top
+	// (4K) rung — at +25% it lagged on the rung below until the apex.
+	DefaultTopHeadroomPct = 50.0
 )
 
 // Variant is one rung of a player's published manifest ladder, reduced to

--- a/go-proxy/pkg/ladder/ladder_test.go
+++ b/go-proxy/pkg/ladder/ladder_test.go
@@ -118,16 +118,16 @@ func TestStandardLadderTopHeadroom(t *testing.T) {
 	base := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, 0)
 	got := StandardLadder(tearsH264, DefaultBumpPct, DefaultMaxStep, DefaultTopHeadroomPct)
 	// Headroom adds a start rung above the +bump top anchor, plus the
-	// geometric fill(s) bridging the 1.25×→1.05× gap.
+	// geometric fill(s) bridging the 1.50×→1.05× gap.
 	if len(got) <= len(base) {
 		t.Fatalf("headroom ladder len %d should exceed base %d", len(got), len(base))
 	}
-	// Top rung = top peak (29.584915 Mbps) × 1.25 = 36.981.
+	// Top rung = top peak (29.584915 Mbps) × 1.50 = 44.377.
 	if got[0].Kind != "headroom" {
 		t.Errorf("top rung kind = %q, want headroom", got[0].Kind)
 	}
-	if got[0].Mbps < 36.97 || got[0].Mbps > 36.99 {
-		t.Errorf("headroom cap = %.3f, want ~36.981 (top peak × 1.25)", got[0].Mbps)
+	if got[0].Mbps < 44.36 || got[0].Mbps > 44.39 {
+		t.Errorf("headroom cap = %.3f, want ~44.377 (top peak × 1.50)", got[0].Mbps)
 	}
 	if got[0].Variant != "3840x2160" {
 		t.Errorf("headroom rung variant = %q, want 3840x2160", got[0].Variant)

--- a/tests/characterization/runner/variants_test.go
+++ b/tests/characterization/runner/variants_test.go
@@ -98,8 +98,8 @@ func TestStandardLadderRatesEnvBump(t *testing.T) {
 }
 
 func TestStandardLadderRatesTopHeadroom(t *testing.T) {
-	// Default 25% top-headroom: the top rung is the top variant's peak
-	// × 1.25, tagged source=headroom, above the +5% top anchor.
+	// Default 50% top-headroom: the top rung is the top variant's peak
+	// × 1.50, tagged source=headroom, above the +5% top anchor.
 	rec := mkPlayerWithVariants(t, []variantSeed{
 		{res: "640x360", avg: 724620, peak: 998009, url: "p.m3u8"},
 		{res: "3840x2160", avg: 10845181, peak: 15363854, url: "q.m3u8"},
@@ -112,9 +112,9 @@ func TestStandardLadderRatesTopHeadroom(t *testing.T) {
 	if top.Source != "headroom" {
 		t.Errorf("top rung source=%q want headroom", top.Source)
 	}
-	// 15363854 × 1.25 / 1e6 = 19.205.
-	if top.CapMbps < 19.19 || top.CapMbps > 19.22 {
-		t.Errorf("headroom cap=%.3f want ~19.205 (top peak × 1.25)", top.CapMbps)
+	// 15363854 × 1.50 / 1e6 = 23.046.
+	if top.CapMbps < 23.03 || top.CapMbps > 23.06 {
+		t.Errorf("headroom cap=%.3f want ~23.046 (top peak × 1.50)", top.CapMbps)
 	}
 	if top.Resolution != "3840x2160" {
 		t.Errorf("headroom rung attributed to %q, want 3840x2160", top.Resolution)

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -33,7 +33,7 @@ Pattern mode (generates a step list from the player's current variants):
                      gaps — raise --max-step to coarsen + shorten the pattern
                      (a pyramid over a dense ladder can run ~13 min/cycle)
   --top-headroom PCT start the ladder this %% over the top variant's peak
-                     (default 25; adds a headroom start rung above the
+                     (default 50; adds a headroom start rung above the
                      top anchor so playback settles before constraining;
                      0 disables it)
   --clear-pattern    stop any running pattern (back to slider rate)
@@ -73,7 +73,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
-	topHeadroom := fs.Float64("top-headroom", ladder.DefaultTopHeadroomPct, "start the ladder this %% over the top variant's peak (default 25; 0 disables the headroom start rung)")
+	topHeadroom := fs.Float64("top-headroom", ladder.DefaultTopHeadroomPct, "start the ladder this %% over the top variant's peak (default 50; 0 disables the headroom start rung)")
 	clearPattern := fs.Bool("clear-pattern", false, "stop any running pattern")
 	showPattern := fs.Bool("show-pattern", false, "print current pattern, don't modify")
 	clear := fs.Bool("clear", false, "send {shape:null}")


### PR DESCRIPTION
## What
Raise the ladder's top-headroom start rung from `top_peak × 1.25` to `top_peak × 1.50` (`ladder.DefaultTopHeadroomPct` 25 → 50), plus the dashboard JS mirror (`DEFAULT_TOP_HEADROOM`). The CLI `--top-headroom` flag and the characterization `CHAR_LADDER_TOP_HEADROOM_PCT` env inherit the new default.

## Why
The +25% headroom wasn't enough room for **AVPlayer's conservative upshift** to actually reach the top (4K) rung. In both the rampup and pyramid sim runs (n≥2) it lagged on the rung below — only committing to 4K at/after the apex. +50% gives playback room to settle on the top variant before the sweep constrains it. For the 4K h264 ladder the start rung goes ~37 → ~44.4 Mbps.

## Verification
`go test ./go-proxy/pkg/ladder/...` + `./tests/characterization/runner/...` green (golden tests updated: top rung = top_peak × 1.50); `go build` across modules; `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
