### PR TITLE
fix(613): lift total_ms to ttfb+transfer at the logEntry chokepoint

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -5168,6 +5168,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		if entry.AttemptID == 0 {
 			entry.AttemptID = attemptID
 		}
+		// #613: TotalMs is provisionally set at upstream-headers-complete
+		// (~TTFB) by the fetch helper, before the body transfer happens.
+		// Lift it to TTFB+Transfer here — the single chokepoint every
+		// logged row passes through — so no response-serving path can ship
+		// a row with the pre-transfer value. Idempotent (max), so paths
+		// that already set TotalMs ≥ TTFB+Transfer (e.g. fault rows) are
+		// untouched.
+		mergeTotalTiming(&entry)
 		a.addNetworkLogEntry(sessionID, entry)
 	}
 	filename := strings.TrimPrefix(r.URL.Path, "/")
@@ -5718,7 +5726,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				log.Printf("segment_corrupted write error session_id=%s err=%v", getString(sessionData, "session_id"), copyErr)
 			}
 			netEntry.TransferMs = transferMs
-			mergeTotalTiming(netEntry)
+			// TotalMs lift now happens uniformly in the logEntry closure (#613).
 			actionTaken = "segment_corrupted_zero_fill"
 			bumpFaultCounter(sessionData, failureType)
 			logFaultEvent(sessionData, externalPort, failureType, requestKind, actionTaken)

--- a/go-proxy/cmd/server/timing_test.go
+++ b/go-proxy/cmd/server/timing_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+// #613: mergeTotalTiming lifts the provisional headers-complete TotalMs to
+// TTFB+Transfer, but only when that is larger — so it's safe to call
+// uniformly from the logEntry closure regardless of which path produced the
+// row.
+func TestMergeTotalTiming(t *testing.T) {
+	cases := []struct {
+		name             string
+		ttfb, transfer   float64
+		total, wantTotal float64
+	}{
+		{
+			// The ~26% regression case: TotalMs was set at headers-complete
+			// (≈TTFB) before the body transferred; lift to TTFB+Transfer.
+			name: "lifts pre-transfer total", ttfb: 0.16, transfer: 103, total: 0.18, wantTotal: 103.16,
+		},
+		{
+			// Already complete (or larger) — leave it (idempotent re-call).
+			name: "idempotent when already combined", ttfb: 0.16, transfer: 103, total: 103.16, wantTotal: 103.16,
+		},
+		{
+			// Fault row: TTFB+Transfer are 0, TotalMs carries the latency to
+			// the status line — must not be clobbered to 0.
+			name: "fault row keeps wait total", ttfb: 0, transfer: 0, total: 12.5, wantTotal: 12.5,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := &NetworkLogEntry{TTFBMs: c.ttfb, TransferMs: c.transfer, TotalMs: c.total}
+			mergeTotalTiming(e)
+			if e.TotalMs != c.wantTotal {
+				t.Errorf("TotalMs = %.3f, want %.3f", e.TotalMs, c.wantTotal)
+			}
+		})
+	}
+}
+
+func TestMergeTotalTimingNil(t *testing.T) {
+	mergeTotalTiming(nil) // must not panic
+}


### PR DESCRIPTION
## Problem

~26% of archived `network_requests` rows (215,987 / 824,748) carried `total_ms ≈ ttfb_ms` while `transfer_ms` was ~100× larger (e.g. total=0.18ms, ttfb=0.16ms, transfer=103ms on shaped segment responses). Found by the #607 aberration crawl (`total-ms-composition` rule); uniform across all client versions → proxy-side.

## Cause

`doRequestWithTracing` sets `TotalMs` provisionally at upstream-headers-complete (≈TTFB), before the body transfers. `mergeTotalTiming()` is meant to lift it to `TTFB+Transfer` after the downstream write, but it was only called on *some* response-serving paths. Rows on the skipping paths shipped the pre-transfer value.

## Fix

Move the lift into the **`logEntry` closure** — the single chokepoint every row passes through (the only caller of `addNetworkLogEntry`). No response-serving path can now emit a pre-transfer `total_ms`.

- `mergeTotalTiming` is a `max()`, so fault rows (`TTFB+Transfer=0`, `total_ms`=latency-to-status-line) are left intact.
- Dropped the now-redundant explicit call on the `segment_corrupted_zero_fill` path.
- Added `TestMergeTotalTiming` (lift / idempotent / fault-row / nil).

## Verification

- `go build ./...` + `go test ./cmd/server/ -run TestMergeTotalTiming` pass.
- Post-deploy: the #607 `total-ms-composition` census rule should drop to ~0 new violations; can then promote it to `mode: assert` with a calibrated `applicable_since` (per the issue's verification plan).

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
