### PR TITLE
feat(630): appium Segment Length switch + accessibility ids on settings dimensions

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
@@ -91,7 +91,10 @@ struct SettingsOverlay: View {
     private var panel: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: Space.s3) {
+                // #630: single-Back chevron — pops picker → main list →
+                // closes the drawer; appium taps it to exit settings.
                 BackChevronButton { handleBack() }
+                    .accessibilityIdentifier("settings-back-button")
                 Spacer()
             }
             Spacer().frame(height: isCompact ? Space.s2 : Space.s4)
@@ -164,26 +167,33 @@ private struct MainList: View {
                            compact: compact,
                            onTap: { onPick(.stream) })
                     .focused($rowIdx, equals: 1)
+                    .accessibilityIdentifier("settings-row-stream")
                 SettingRow(label: "Protocol",
                            value: vm.streamProtocol.label,
                            compact: compact,
                            onTap: { onPick(.proto) })
                     .focused($rowIdx, equals: 2)
+                    .accessibilityIdentifier("settings-row-protocol")
                 SettingRow(label: "Segment length",
                            value: vm.segment.label,
                            compact: compact,
                            onTap: { onPick(.segment) })
                     .focused($rowIdx, equals: 3)
+                    // #630: appium drives this row to switch 2s↔6s between
+                    // back-to-back characterization sweeps.
+                    .accessibilityIdentifier("settings-row-segment")
                 SettingRow(label: "Codec",
                            value: vm.codec.label,
                            compact: compact,
                            onTap: { onPick(.codec) })
                     .focused($rowIdx, equals: 4)
+                    .accessibilityIdentifier("settings-row-codec")
                 SettingRow(label: "Advanced",
                            value: "",
                            compact: compact,
                            onTap: { onPick(.advanced) })
                     .focused($rowIdx, equals: 5)
+                    .accessibilityIdentifier("settings-row-advanced")
             }
         }
         .onAppear {
@@ -300,37 +310,43 @@ private struct PickerList: View {
             }
         case .proto:
             ForEach(Array(StreamProtocol.allCases.enumerated()), id: \.element.id) { idx, p in
-                PickerItem(label: p.label, selected: p == vm.streamProtocol, compact: compact) {
+                PickerItem(label: p.label, selected: p == vm.streamProtocol, compact: compact,
+                           axID: "proto-\(p.rawValue)") {
                     vm.setProtocol(p); onBack()
                 }
                 .focused($itemIdx, equals: idx)
             }
         case .segment:
             ForEach(Array(SegmentLength.allCases.enumerated()), id: \.element.id) { idx, s in
-                PickerItem(label: s.label, selected: s == vm.segment, compact: compact) {
+                // #630: stable id ("segment-2s" / "segment-6s") so appium can
+                // pick a specific length; label text alone isn't a reliable
+                // WebDriver target.
+                PickerItem(label: s.label, selected: s == vm.segment, compact: compact,
+                           axID: "segment-\(s.label.lowercased())") {
                     vm.setSegment(s); onBack()
                 }
                 .focused($itemIdx, equals: idx)
             }
         case .codec:
             ForEach(Array(CodecFilter.allCases.enumerated()), id: \.element.id) { idx, c in
-                PickerItem(label: c.label, selected: c == vm.codec, compact: compact) {
+                PickerItem(label: c.label, selected: c == vm.codec, compact: compact,
+                           axID: "codec-\(c.rawValue)") {
                     vm.setCodec(c); onBack()
                 }
                 .focused($itemIdx, equals: idx)
             }
         case .advanced:
             ToggleRow(label: "4K (allow >1080p)",
-                      isOn: vm.allow4K, compact: compact) { vm.setAllow4K($0) }
+                      isOn: vm.allow4K, compact: compact, axID: "toggle-4k") { vm.setAllow4K($0) }
                 .focused($itemIdx, equals: 0)
             ToggleRow(label: "Local Proxy",
-                      isOn: vm.localProxy, compact: compact) { vm.setLocalProxy($0) }
+                      isOn: vm.localProxy, compact: compact, axID: "toggle-local-proxy") { vm.setLocalProxy($0) }
                 .focused($itemIdx, equals: 1)
             ToggleRow(label: "Auto-Recovery",
-                      isOn: vm.autoRecovery, compact: compact) { vm.setAutoRecovery($0) }
+                      isOn: vm.autoRecovery, compact: compact, axID: "toggle-auto-recovery") { vm.setAutoRecovery($0) }
                 .focused($itemIdx, equals: 2)
             ToggleRow(label: "Go Live",
-                      isOn: vm.goLive, compact: compact) { vm.setGoLive($0) }
+                      isOn: vm.goLive, compact: compact, axID: "toggle-go-live") { vm.setGoLive($0) }
                 .focused($itemIdx, equals: 3)
             LiveOffsetRow(seconds: vm.liveOffsetSeconds, compact: compact) {
                 vm.setLiveOffsetSeconds($0)
@@ -341,10 +357,10 @@ private struct PickerList: View {
             }
             .focused($itemIdx, equals: 5)
             ToggleRow(label: "Skip Home on launch",
-                      isOn: vm.skipHomeOnLaunch, compact: compact) { vm.setSkipHomeOnLaunch($0) }
+                      isOn: vm.skipHomeOnLaunch, compact: compact, axID: "toggle-skip-home") { vm.setSkipHomeOnLaunch($0) }
                 .focused($itemIdx, equals: 6)
             ToggleRow(label: "Mute audio",
-                      isOn: vm.isMuted, compact: compact) { vm.setIsMuted($0) }
+                      isOn: vm.isMuted, compact: compact, axID: "toggle-mute") { vm.setIsMuted($0) }
                 .focused($itemIdx, equals: 7)
             PreviewVideoSlotsRow(slots: vm.previewVideoSlots,
                                  hardwareCap: DecodeBudget.shared.hardwareCap,
@@ -353,7 +369,7 @@ private struct PickerList: View {
             }
             .focused($itemIdx, equals: 8)
             ToggleRow(label: "HUD",
-                      isOn: vm.developerMode, compact: compact) { vm.setDeveloperMode($0) }
+                      isOn: vm.developerMode, compact: compact, axID: "toggle-hud") { vm.setDeveloperMode($0) }
                 .focused($itemIdx, equals: 9)
             DestructiveRow(label: "Reset All Settings", compact: compact) {
                 showResetConfirm = true
@@ -367,6 +383,10 @@ private struct PickerItem: View {
     let label: String
     let selected: Bool
     let compact: Bool
+    // Optional stable accessibility id for UI automation (#630). When nil the
+    // item carries no identifier (SwiftUI default) — only the pickers a test
+    // needs to drive set one.
+    var axID: String? = nil
     let onTap: () -> Void
 
     var body: some View {
@@ -388,6 +408,7 @@ private struct PickerItem: View {
         .cinematicFocus(cornerRadius: Radius.row)
         .contentShape(Rectangle())
         .onTapGesture(perform: onTap)
+        .accessibilityIdentifier(axID ?? "")
     }
 }
 
@@ -597,6 +618,9 @@ private struct ToggleRow: View {
     let label: String
     let isOn: Bool
     let compact: Bool
+    // Optional stable accessibility id for UI automation (#630). nil ⇒ no
+    // identifier (SwiftUI default).
+    var axID: String? = nil
     let onChange: (Bool) -> Void
 
     var body: some View {
@@ -615,6 +639,7 @@ private struct ToggleRow: View {
         .cinematicFocus(cornerRadius: Radius.row)
         .contentShape(Rectangle())
         .onTapGesture { onChange(!isOn) }
+        .accessibilityIdentifier(axID ?? "")
     }
 
     private var switchGraphic: some View {

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -222,6 +222,43 @@ func (a *AppiumLauncher) Kill(ctx context.Context, d Device) error {
 	return err
 }
 
+// SetSegmentLength switches the app's Segment Length via the settings UI
+// (#630) so a sweep can run e.g. 6s then 2s back-to-back on one device.
+// value is "2s" / "6s" / "ll" — matching the segment-<value> accessibility
+// ids the app exposes (added in #630). Drives the real UI: settings button
+// → Segment-length row → the value → back out of the drawer. Changing the
+// segment rebuilds the manifest and rotates play_id, so the caller should
+// re-bind (WaitForBind) and treat what follows as a fresh play.
+//
+// iOS only. Returns an error if a tap target is missing — typically an app
+// that predates #630 (rebuild + redeploy so the AX ids are present).
+func (a *AppiumLauncher) SetSegmentLength(ctx context.Context, d Device, value string) error {
+	switch d.Platform {
+	case PlatformIPhone, PlatformIPad, PlatformIPadSim:
+	default:
+		return fmt.Errorf("SetSegmentLength: unsupported platform %s", d.Platform)
+	}
+	a.mu.Lock()
+	sessID := a.sessions[d.UDID]
+	a.mu.Unlock()
+	if sessID == "" {
+		return errors.New("SetSegmentLength: no active appium session for device")
+	}
+	steps := []struct{ what, id string }{
+		{"open settings", "playback-settings-button"},
+		{"open segment picker", "settings-row-segment"},
+		{"select " + value, "segment-" + value},
+		{"close settings", "settings-back-button"},
+	}
+	for _, s := range steps {
+		if err := a.tapByAccessibilityID(ctx, sessID, s.id); err != nil {
+			return fmt.Errorf("SetSegmentLength %q: %s (%s): %w", value, s.what, s.id, err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return nil
+}
+
 // Screenshot saves a PNG of the device's current screen to path.
 // Returns the path on success. Intended to be called from a sweep
 // runner to attach visual context to interesting steps.

--- a/tests/characterization/runner/appium_segment_test.go
+++ b/tests/characterization/runner/appium_segment_test.go
@@ -1,0 +1,72 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// #630: SetSegmentLength must drive the settings UI in order — settings
+// button → Segment-length row → the chosen value → back out — using the
+// accessibility ids the app exposes. This pins the find-element id sequence
+// against a mock Appium server.
+func TestSetSegmentLength(t *testing.T) {
+	var mu sync.Mutex
+	var findIDs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/element") {
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Value string `json:"value"`
+			}
+			_ = json.Unmarshal(body, &req)
+			mu.Lock()
+			findIDs = append(findIDs, req.Value)
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"value":{"element-6066-11e4-a52e-4f735466cecf":"elem-1"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"value":null}`))
+	}))
+	defer srv.Close()
+
+	l := NewAppiumLauncher()
+	l.URL = srv.URL
+	l.hc = srv.Client()
+	l.sessions = map[string]string{"udid-1": "sess-1"}
+
+	d := Device{Platform: PlatformIPadSim, UDID: "udid-1"}
+	if err := l.SetSegmentLength(context.Background(), d, "2s"); err != nil {
+		t.Fatalf("SetSegmentLength: %v", err)
+	}
+	mu.Lock()
+	got := append([]string(nil), findIDs...)
+	mu.Unlock()
+	want := []string{"playback-settings-button", "settings-row-segment", "segment-2s", "settings-back-button"}
+	if len(got) != len(want) {
+		t.Fatalf("found ids %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("step %d found %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSetSegmentLengthGuards(t *testing.T) {
+	l := NewAppiumLauncher()
+	// Unsupported platform → error (checked before session).
+	l.sessions = map[string]string{"a": "s"}
+	if err := l.SetSegmentLength(context.Background(), Device{Platform: PlatformAndroidTV, UDID: "a"}, "6s"); err == nil {
+		t.Error("expected error for unsupported platform")
+	}
+	// Supported platform but no active session → error.
+	if err := l.SetSegmentLength(context.Background(), Device{Platform: PlatformIPhone, UDID: "none"}, "6s"); err == nil {
+		t.Error("expected error with no active session")
+	}
+}


### PR DESCRIPTION
## Goal

Let a characterization sweep run **6s then 2s segments back-to-back** on one device via appium, instead of the operator manually flipping the in-app Segment Length control between runs. Also lays down accessibility ids across the rest of the settings dimensions so future test-matrix work (protocol / codec / 4K / proxy) doesn't each need its own app rebuild.

## iOS app (`SettingsOverlay.swift`)

Added stable `accessibilityIdentifier`s — convention `settings-row-<x>`, `<dimension>-<value>`, `toggle-<x>`:

- **Segment** (the immediate need): `settings-row-segment` + `segment-2s` / `segment-6s` / `segment-ll`
- Other menu rows: `settings-row-stream` / `-protocol` / `-codec` / `-advanced`
- Protocol & codec values: `proto-hls`/`-dash`, `codec-auto`/`-h264`/`-hevc`/`-av1`
- Advanced boolean toggles: `toggle-4k` / `-local-proxy` / `-auto-recovery` / `-go-live` / `-skip-home` / `-mute` / `-hud`
- `settings-back-button` (the single-Back chevron)

Mechanism: added an optional `axID` to the shared `PickerItem` / `ToggleRow` views (`nil` ⇒ no identifier, SwiftUI default). **Deliberately skipped** the numeric steppers (live-offset, play-id-rotation, preview-slots) — they need multi-tap stepper-driving logic; tag when a test needs them. Also skipped ServerPicker/Pairing (harness already lands on home; not a sweep dimension).

## Harness (`tests/characterization`)

- `AppiumLauncher.SetSegmentLength(ctx, d, "2s"|"6s"|"ll")` — taps settings button → segment row → value → back out. Changing the segment rotates `play_id` (new manifest), so callers re-bind.
- `TestSetSegmentLength` pins the find-element id sequence against a mock Appium server; `TestSetSegmentLengthGuards` covers unsupported-platform + no-session errors. `go build` + `go test ./runner` pass.

## Dependencies / sequencing

- **App rebuild required:** the AX ids ship in the app binary, so the iPad-sim / iPhone build must be rebuilt + redeployed in Xcode before `SetSegmentLength` resolves. Until then the harness method errors on the first missing tap target (by design).
- The **back-to-back pyramid test/knob** (`CHAR_SEGMENT_LENGTHS=6s,2s`) that chains two lengths is a fast follow on top of **#627** — it needs the clean UI play-close between segments. This PR ships the enablers.

## Verification (live, after app rebuild)

`LAUNCH_MODE=appium go test ./tests/characterization/modes -run TestPyramidIPadSim` then drive `SetSegmentLength` between two runs: confirm one play fetches `master_6s.m3u8`, the next `master_2s.m3u8`.

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)
