### PR TITLE
fix(634): synthesized play_end no longer ties ts with the final heartbeat

### DIFF
--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -148,6 +148,13 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    playback_status, playback_reason,
 		    device_class, device_model, player_tech,
 		    app_version, os_version_major, os_version_minor,
+		    -- #634: tie-break key for the outcome argMaxes below. A
+		    -- play-terminal row that shares its ts with the final
+		    -- heartbeat (e.g. a pre-fix proxy-synthesized play_end,
+		    -- which cloned the dead session's event_time) must still
+		    -- win, or playback_status flaps between in_progress and
+		    -- the terminal value from one read to the next.
+		    last_event IN ('play_end', 'session_end') AS is_terminal_row,
 		    lagInFrame(video_bitrate_mbps, 1, video_bitrate_mbps) OVER w AS prev_bitrate,
 		    lagInFrame(video_resolution,   1, video_resolution)   OVER w AS prev_resolution
 		  FROM %s.%s
@@ -248,11 +255,13 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    argMax(stalling_time_ms, ts) AS stalling_time_ms,
 		    -- #550 Phase 2: outcome (argMax on terminal row; in_progress
 		    -- mid-play rows return last value seen, which is what we
-		    -- want for live sessions).
-		    argMax(playback_status, ts) AS playback_status,
-		    argMax(playback_reason, ts) AS playback_reason,
-		    argMax(terminal_error_code, ts)   AS terminal_error_code,
-		    argMax(terminal_error_domain, ts) AS terminal_error_domain,
+		    -- want for live sessions). #634: keyed on (ts, is_terminal_row)
+		    -- so a terminal row at the same ts as the final heartbeat
+		    -- still wins deterministically instead of flapping.
+		    argMax(playback_status, (ts, is_terminal_row)) AS playback_status,
+		    argMax(playback_reason, (ts, is_terminal_row)) AS playback_reason,
+		    argMax(terminal_error_code, (ts, is_terminal_row))   AS terminal_error_code,
+		    argMax(terminal_error_domain, (ts, is_terminal_row)) AS terminal_error_domain,
 		    argMax(error_code, ts)   AS last_error_code,
 		    argMax(error_domain, ts) AS last_error_domain,
 		    max(error_count) AS error_count,

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1030,6 +1030,20 @@ func terminalFrameForSession(session SessionData, reason string) (SessionData, b
 	frame := cloneSession(session)
 	frame["player_metrics_last_event"] = "play_end"
 	frame["player_metrics_trigger_type"] = "play_end"
+	// #634 — the cloned snapshot still carries the dead session's FINAL
+	// HEARTBEAT event_time. Emitting the terminal frame at that exact
+	// instant ties with the real heartbeat row in session_events (the
+	// forwarder anchors `ts` to event_time), and the plays aggregate's
+	// argMax(playback_status, ts) then breaks the tie arbitrarily —
+	// playback_status flaps between in_progress and user_stopped from
+	// one read to the next. Stamp the synthetic row 1ms after the
+	// snapshot so it strictly wins ordering, without distorting the
+	// play's timeline by the reap delay (~60s). Unparseable/missing
+	// event_time is left alone — the merge chokepoint and the forwarder
+	// fallback already stamp wall clock in that case.
+	if t, ok := parseEventTime(getString(session, "player_metrics_event_time")); ok {
+		frame["player_metrics_event_time"] = t.Add(time.Millisecond).UTC().Format(time.RFC3339Nano)
+	}
 	if status := getString(session, "player_metrics_playback_status"); status == "" || status == "in_progress" {
 		if getInt(session, "player_metrics_video_first_frame_time_ms") > 0 {
 			frame["player_metrics_playback_status"] = "user_stopped"

--- a/go-proxy/cmd/server/synthesize_terminal_test.go
+++ b/go-proxy/cmd/server/synthesize_terminal_test.go
@@ -101,4 +101,47 @@ func TestTerminalFrameForSession(t *testing.T) {
 			t.Fatalf("source mutated: last_event = %q, want playing", got)
 		}
 	})
+
+	// #634 — the frame must NOT reuse the snapshot's event_time verbatim:
+	// that ties with the final heartbeat row in session_events and the
+	// plays aggregate's argMax(playback_status, ts) flaps. The synthetic
+	// terminal row is stamped 1ms after the snapshot.
+	t.Run("event_time is bumped 1ms past the snapshot's", func(t *testing.T) {
+		src := SessionData{
+			"player_metrics_last_event":                "heartbeat",
+			"player_metrics_playback_status":           "in_progress",
+			"player_metrics_video_first_frame_time_ms": 1200,
+			"player_metrics_event_time":                "2026-06-06T16:46:38.903Z",
+		}
+		frame, ok := terminalFrameForSession(src, reason)
+		if !ok {
+			t.Fatal("expected a frame")
+		}
+		got, gok := parseEventTime(getString(frame, "player_metrics_event_time"))
+		if !gok {
+			t.Fatalf("frame event_time unparseable: %q", getString(frame, "player_metrics_event_time"))
+		}
+		want, _ := parseEventTime("2026-06-06T16:46:38.904Z")
+		if !got.Equal(want) {
+			t.Fatalf("frame event_time = %v, want %v (snapshot + 1ms)", got, want)
+		}
+		// Source stays untouched — the bump is on the clone only.
+		if got := getString(src, "player_metrics_event_time"); got != "2026-06-06T16:46:38.903Z" {
+			t.Fatalf("source event_time mutated: %q", got)
+		}
+	})
+
+	t.Run("missing event_time is left for downstream wall-clock stamping", func(t *testing.T) {
+		frame, ok := terminalFrameForSession(SessionData{
+			"player_metrics_last_event":                "heartbeat",
+			"player_metrics_playback_status":           "in_progress",
+			"player_metrics_video_first_frame_time_ms": 1200,
+		}, reason)
+		if !ok {
+			t.Fatal("expected a frame")
+		}
+		if got := getString(frame, "player_metrics_event_time"); got != "" {
+			t.Fatalf("event_time = %q, want empty (no fabricated stamp)", got)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #634

## What

A play closed by the #556 silent-death synthesizer flapped between `in_progress` and `user_stopped` in `/analytics/api/v2/plays` — the synthesized terminal frame cloned the dead session's final-heartbeat `event_time`, producing two `session_events` rows at the exact same `ts`, and the plays aggregate's `argMax(playback_status, ts)` broke the tie arbitrarily per query.

## Fix (two layers)

1. **go-proxy** — `terminalFrameForSession` stamps the synthetic frame's `event_time` 1ms after the snapshot's, so the terminal row strictly wins ordering without distorting the play's timeline by the reap delay (~60s). Missing/unparseable `event_time` is left for the existing downstream wall-clock fallbacks.
2. **go-forwarder** — the four outcome argMaxes (`playback_status`, `playback_reason`, `terminal_error_code`, `terminal_error_domain`) now key on `(ts, is_terminal_row)` where `is_terminal_row = last_event IN ('play_end','session_end')`. This makes reads deterministic for pre-fix rows already in ClickHouse and for any future client that lands a terminal row at a tied timestamp.

## Tests

- `TestTerminalFrameForSession` extended: event_time bumped exactly +1ms on the clone (source untouched); missing event_time left empty (no fabricated stamp). All pre-existing subtests pass.
- `go build` / `go vet` / full `./cmd/server` + forwarder suites green.

## Verification (live, pending deploy)

Plays `1ed43360` / `717a58fd` (2026-06-06, iPad sim) are the observed flapping rows; after forwarder redeploy they should read `user_stopped` on every query. Sibling issue #635 fixes the client-side delivery bug that made the synthesizer the de facto primary path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
