### PR TITLE
fix: drop tests/aberration_crawl from go.work in the forwarder image build

### DIFF
--- a/analytics/go-forwarder/Dockerfile
+++ b/analytics/go-forwarder/Dockerfile
@@ -17,6 +17,7 @@ COPY analytics/go-forwarder/ ./analytics/go-forwarder/
 RUN go work edit -dropuse ./tools/harness-cli || true
 RUN go work edit -dropuse ./tests/characterization || true
 RUN go work edit -dropuse ./tests/server_behavior || true
+RUN go work edit -dropuse ./tests/aberration_crawl || true
 WORKDIR /src/analytics/go-forwarder
 RUN CGO_ENABLED=0 GOFLAGS=-trimpath go build -o /out/forwarder .
 


### PR DESCRIPTION
#611 added `./tests/aberration_crawl` to `go.work`, but the forwarder Dockerfile copies only `go-proxy/` + `analytics/go-forwarder/` into the build context and drops the dev-only modules from `go.work` by enumeration — the list was never updated. Any forwarder image rebuild since #611 fails with:

```
go: cannot load module /src/tests/aberration_crawl listed in go.work file: open /src/tests/aberration_crawl/go.mod: no such file or directory
```

Surfaced by the first `make test-deploy-dev` since #611 (deploying #636/#637). One line: add the missing `go work edit -dropuse` mirroring the three existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
