### PR TITLE
fix(622): drop the redundant playback_start label

### DIFF
--- a/.claude/standards/abr-decision-model.md
+++ b/.claude/standards/abr-decision-model.md
@@ -30,7 +30,7 @@ A `timejump` between `buffering_start` and `buffering_end` is normal stall recov
 ## What triggers `restart`
 
 - Player explicitly tore down the AVPlayer instance and built a new one. Usually app-level (user navigated away and back) or recovery-from-fatal-error.
-- After `restart`, `playback_start` fires when the new instance has its first decoded frame.
+- After `restart`, `first_frame` fires when the new instance has its first decoded frame. (Rows ingested before #622 also carry a redundant `playback_start` label at the same moment — dropped because it duplicated `first_frame` and read like a play-open boundary, which is `play_start`'s job.)
 - A restart cluster (multiple restarts in <30s) suggests the player is in an unrecoverable state and the app/operator is repeatedly retrying.
 
 ## Variant ladder vs effective ladder

--- a/.claude/standards/hls-taxonomy.md
+++ b/.claude/standards/hls-taxonomy.md
@@ -64,7 +64,7 @@ These are what `harness ts --streams events` emits. Priority 1=critical → 4=lo
 | `http_4xx` / `request_incomplete` / `request_faulted` | 3 | cause | HAR-derived. |
 | `slow_request` (>2s wait) / `slow_segment` (>6s transfer) | 3 | cause | HAR-derived. |
 | `request_retry` (same URL refetched <4s) | 4 | cause | HAR-derived. Often noise. |
-| `upshift` / `playback_start` | 4 | effect | Routine player behaviour. |
+| `upshift` / `play_start` | 4 | effect | Routine player behaviour. (`playback_start` was the pre-#622 name of a redundant first-render label; historical rows still carry it.) |
 | `loop_server` | 4 | cause | Source content rotated back to start. Routine in our platform. |
 | `user_marked` | 1 | effect | Operator pressed the iOS "911" button (always P1). |
 

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -277,8 +277,13 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		ps.downshiftTimes = append(ps.downshiftTimes, now) // #553 qoe_downshift_storm window
 	case "video_first_frame":
 		out = []string{SevInfo + "=first_frame"}
-	case "video_start_time":
-		out = []string{SevInfo + "=playback_start"}
+	// #622 — `video_start_time` no longer derives a label. Its old
+	// `playback_start` relabel marked the VST/first-render moment,
+	// which `first_frame` already covers, and the name read like a
+	// play-level boundary — easily confused with the real play-open
+	// `play_start` (#603/#621). The video_start_time METRIC (startup
+	// latency) is untouched; only the derived label is gone.
+	// Forward-only: historical rows keep their playback_start labels.
 	case "play_start":
 		// #603 — explicit play-open boundary (symmetric to play_end).
 		// Distinct from `restart`, which is mid-session recovery only.

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -35,7 +35,10 @@ func TestEventSwitchUnchanged(t *testing.T) {
 		{"rate_shift_up", nil, []string{"info=shift_up"}},
 		{"rate_shift_down", nil, []string{"info=shift_down"}},
 		{"video_first_frame", nil, []string{"info=first_frame"}},
-		{"video_start_time", nil, []string{"info=playback_start"}},
+		// #622 — video_start_time no longer derives a label (its old
+		// `playback_start` relabel duplicated first_frame and read like
+		// a play boundary). The metric field is unaffected.
+		{"video_start_time", nil, nil},
 		{"play_start", nil, []string{"info=play_start"}}, // #603 play-open boundary
 		// warning — degraded but functioning
 		{"timejump", nil, []string{"warning=timejump"}},


### PR DESCRIPTION
Closes #622

## What

The forwarder relabeled the client's `video_start_time` event into `info=playback_start` — a redundant render-marker (`first_frame` lands at the same moment) whose name read like a play-open boundary, easily confused with the real `play_start` (#603, now emitted at every play-open via #621).

## Changes

- `labels.go` — the `video_start_time` arm no longer emits a label (the startup-latency **metric** is untouched).
- `labels_test.go` — pins the new behaviour (`want: nil`, same pattern as the pair-open arms).
- `.claude/standards/abr-decision-model.md` + `hls-taxonomy.md` — updated to point at `first_frame` / `play_start`, with a note that pre-#622 rows still carry `playback_start`.
- Dashboard: grep found zero consumers of the label; nothing to change.

Forward-only — historical rows keep their labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
