### PR TITLE
fix(621): play_start fires at every play-open boundary, exactly once

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -145,6 +145,13 @@ final class PlayerViewModel: ObservableObject {
     /// - Soak rotation Task firing
     private var currentPlayID: String = UUID().uuidString
 
+    /// #621 — the play_id whose `play_start` boundary has already been
+    /// emitted. startPlayback's fresh branch compares against this so a
+    /// same-play re-prepare (settings tweak, double-prepare on launch)
+    /// doesn't double-stamp the boundary. Never reset — comparing ids
+    /// is sufficient because play_ids are never reused.
+    private var lastPlayStartEmittedPlayID: String?
+
     /// `start_time` (#587) — client-supplied, play-scoped play start
     /// (ISO-8601 UTC). Minted with `currentPlayID` and rotated at the
     /// SAME boundaries (`regeneratePlayID`); sent as `?start_time=` on
@@ -625,7 +632,15 @@ final class PlayerViewModel: ObservableObject {
         Array(previewContent.prefix(limit))
     }
 
-    private func applyContentFilter() {
+    /// `rebuildIfUnchanged` is the caller's intent when the filter does
+    /// NOT move the selection: settings changes (protocol / codec) map
+    /// the same content name to a DIFFERENT URL, so they must rebuild
+    /// anyway; a catalogue refresh whose filter leaves the selection
+    /// alone must NOT — at launch the fetchContentList completion used
+    /// to land ~77ms after setSelectedContent's load and re-run
+    /// startPlayback on the SAME play (double play_start + pointless
+    /// AVPlayer item churn). Issue #621.
+    private func applyContentFilter(rebuildIfUnchanged: Bool = true) {
         let wasPlaying = currentURL != nil
         let filtered = filteredContent
         guard !filtered.isEmpty else {
@@ -637,14 +652,15 @@ final class PlayerViewModel: ObservableObject {
         let pick = filtered.contains(where: { $0.name == selectedContent })
             ? selectedContent
             : (filtered.first?.name ?? "")
-        if pick != selectedContent {
+        let pickChanged = pick != selectedContent
+        if pickChanged {
             selectedContent = pick
             // Filter forced a content swap — same boundary as
             // setSelectedContent. New play, attempt resets to 1.
             regeneratePlayID()
             resetAttemptID()
         }
-        if wasPlaying { buildURLAndLoad() }
+        if wasPlaying && (pickChanged || rebuildIfUnchanged) { buildURLAndLoad() }
     }
 
     // MARK: - Content fetch
@@ -675,7 +691,9 @@ final class PlayerViewModel: ObservableObject {
                 self.content = items
                 self.statusText = "Loaded \(items.count) items"
                 self.writeContentCache(items, for: server)
-                self.applyContentFilter()
+                // Catalogue refresh: re-pick only if the filter moved the
+                // selection; never re-prepare an unchanged running play (#621).
+                self.applyContentFilter(rebuildIfUnchanged: false)
             } catch {
                 self.statusText = "Refresh failed: \(error.localizedDescription)"
             }
@@ -915,6 +933,7 @@ final class PlayerViewModel: ObservableObject {
             scheduleLiveOffsetSeek(reason: "playback started")
         }
         let playingEventAt = Date()
+        let wasRestart = resumingFromRestart
         if resumingFromRestart {
             // #603 — restart (retry / recovery) within the SAME play. Fold the
             // re-prepare wait (buffering accrued since the retry) into residency
@@ -946,11 +965,42 @@ final class PlayerViewModel: ObservableObject {
         metricsSessionId = nil
         metricsLastSessionLookup = nil
         let contentName = selectedContent
+        // #621 — play_start fires at EVERY play-open boundary, not just
+        // reload: cold start, re-enter-playback, reload, and the #403
+        // soak-rotation all mint a fresh play_id and route through this
+        // non-restart branch. retry / auto-recovery keeps play_id and is
+        // a `restart` (within-play), so it must NOT re-open the play.
+        // The play_id dedupe handles the OTHER same-play repeat:
+        // buildURLAndLoad also re-prepares on settings tweaks WITHOUT
+        // rotating play_id (per its doc comment), and the launch flow
+        // can run startPlayback twice for one play — emit only when this
+        // play_id hasn't had its boundary stamped yet (observed as
+        // play_start×2 on the launch play without this guard).
+        // Stamped 1ms before `playing` so ORDER BY ts renders the
+        // boundary first (an exact ms tie orders arbitrarily; both rows
+        // are non-terminal so nothing downstream else cares). Replaces
+        // the reload()-only emit from #603.
+        let isNewPlay = !wasRestart && currentPlayID != lastPlayStartEmittedPlayID
+        if isNewPlay {
+            lastPlayStartEmittedPlayID = currentPlayID
+        }
+        let playStartPayload: [String: Any]? = !isNewPlay ? nil : buildMetricsPayload(
+            event: "play_start",
+            at: playingEventAt.addingTimeInterval(-0.001),
+            extra: [
+                "player_metrics_content_url": url.absoluteString,
+                "player_metrics_content_name": contentName
+            ])
         let playingPayload = buildMetricsPayload(event: "playing", at: playingEventAt, extra: [
             "player_metrics_content_url": url.absoluteString,
             "player_metrics_content_name": contentName
         ])
         Task { [weak self] in
+            // Sequential awaits in ONE task pin the wire order:
+            // play_start strictly before playing.
+            if let playStartPayload {
+                await self?.sendPlayerMetrics(payload: playStartPayload)
+            }
             await self?.sendPlayerMetrics(payload: playingPayload)
         }
         // Restart the 1Hz heartbeat so its first tick lands exactly
@@ -1303,14 +1353,10 @@ final class PlayerViewModel: ObservableObject {
         // it's a within-play recovery attempt that must preserve counters.
         regeneratePlayID()
         resetAttemptID()
-        // #603 — a reload opens a NEW play, so emit play_start (the play-open
-        // boundary, symmetric to play_end), NOT restart. `restart` is reserved
-        // for mid-session streaming recovery (see the retry / auto-recovery
-        // path). play_start carries the new play_id just minted above.
-        let startPayload = buildMetricsPayload(event: "play_start", at: Date())
-        if let reloadBaseURL {
-            Task { [weak self] in await self?.sendPlayerMetrics(payload: startPayload, via: reloadBaseURL) }
-        }
+        // #621 — no explicit play_start here anymore: reload routes
+        // through buildURLAndLoad → startPlayback's fresh (non-restart)
+        // branch, which now emits play_start for EVERY play-open
+        // boundary. The reload-only emit from #603 would double-stamp.
         currentURL = nil
         buildURLAndLoad()
     }

--- a/tests/characterization/modes/playback_end_test.go
+++ b/tests/characterization/modes/playback_end_test.go
@@ -139,8 +139,13 @@ func runPlaybackEnds(t *testing.T, p runner.Platform) {
 		}
 		defer sess.ClearFaults(ctx)
 
+		// Capture the prior play_id BEFORE the tap — the rotation lands
+		// within ~1s (faster since #621 emits play_start from the fresh
+		// branch), so reading it after the tap races: the "prior" id is
+		// already the new one and waitForNewPlayID times out empty.
+		priorID := currentPlayID(ctx, sess)
 		tapReload(t, ctx, sess, appium)
-		preID := waitForNewPlayID(ctx, sess, currentPlayID(ctx, sess), 15*time.Second)
+		preID := waitForNewPlayID(ctx, sess, priorID, 15*time.Second)
 		t.Logf("[StartFailureManifest404] new play_id=%s — waiting for start_failure", preID)
 
 		got, src := awaitTerminalStatus(t, ctx, sess, preID, 60*time.Second, []string{"start_failure"})
@@ -169,8 +174,10 @@ func runPlaybackEnds(t *testing.T, p runner.Platform) {
 		}
 		defer sess.ClearFaults(ctx)
 
+		// Same pre-tap capture as StartFailureManifest404 — see comment there.
+		priorID := currentPlayID(ctx, sess)
 		tapReload(t, ctx, sess, appium)
-		preID := waitForNewPlayID(ctx, sess, currentPlayID(ctx, sess), 15*time.Second)
+		preID := waitForNewPlayID(ctx, sess, priorID, 15*time.Second)
 
 		// Wait EBVS + buffer so the elapsed-since-play-start unambiguously
 		// crosses the threshold from the classifier's perspective.


### PR DESCRIPTION
Closes #621

## What

`play_start` (the #603 play-open boundary) was emitted only from `reload()`. Now it fires at **every** play-open — cold start, re-enter-playback, reload, #403 soak-rotation — exactly once per `play_id`.

## Changes

- **`startPlayback` fresh branch** emits the boundary (1ms before `playing` so `ORDER BY ts` renders it first); reload()'s explicit emit removed (would double-stamp). `retry`/auto-recovery keeps `play_id` and stays `restart`.
- **Once-per-play gate** (`lastPlayStartEmittedPlayID`): legitimate same-play re-prepares (segment/protocol/codec tweaks) re-run `startPlayback` by design and must not re-stamp.
- **Path refinement** (launch double-prepare root cause): `applyContentFilter(rebuildIfUnchanged:)` — the `fetchContentList` completion no longer re-prepares a running play it didn't move (it landed ~77ms after the launch load and re-ran `startPlayback` on the same play → observed `play_start`×2 + pointless AVPlayer churn). Settings callers still rebuild (same content name → different URL).
- **Test-race fix** (`playback_end_test.go`): capture the prior `play_id` *before* tapping reload; rotation now lands fast enough that post-tap reads race and time out empty.

## Verification (live, iPad sim — full TestPlaybackEndsIPadSim)

Every play in the final run carries exactly **one** `play_start` — launch play, reload-minted plays, faulted opens — across all terminal flavors (`user_quit`, `reloaded`, `mid_stream_failure`, `abandoned_start`). MidStream / AbandonedStart / UserStopped subtests pass.

`StartFailureManifest404` still fails for a **pre-existing orthogonal** reason: the master-fallback chain rides out the armed 404s (`first_frame_s: 3.12` on the faulted play), so `start_failure` never occurs. Tracked separately — the chain itself is being removed (play-what-was-asked-or-fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
