### PR TITLE
fix(643): fault re-arm opens a fresh consecutive window

### DIFF
--- a/go-proxy/cmd/server/failure_window_reset_test.go
+++ b/go-proxy/cmd/server/failure_window_reset_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// Covers resetFailureWindowState (#643) — re-arming an HTTP fault must
+// open a FRESH consecutive window, not resume the previous arm's
+// half-consumed one. Reproduced live 2026-06-06: arm master_manifest
+// 404 --consecutive 10, consume 4 requests, re-arm ×10 → only 6 more
+// faults fired before the OLD recover point silenced the rule.
+func TestResetFailureWindowState(t *testing.T) {
+	t.Run("config change clears the touched surface's cursor", func(t *testing.T) {
+		target := SessionData{
+			"master_manifest_failure_at":         8,
+			"master_manifest_failure_recover_at": 18,
+			"segment_failure_at":                 3,
+			"segment_failure_recover_at":         5,
+		}
+		payload := map[string]interface{}{
+			"master_manifest_failure_type":         "404",
+			"master_manifest_consecutive_failures": 10,
+		}
+		resetFailureWindowState(payload, target)
+		if _, ok := target["master_manifest_failure_at"]; ok {
+			t.Error("master_manifest_failure_at survived a re-arm")
+		}
+		if _, ok := target["master_manifest_failure_recover_at"]; ok {
+			t.Error("master_manifest_failure_recover_at survived a re-arm")
+		}
+		// Untouched surface keeps its cursor.
+		if got := intFromInterface(target["segment_failure_at"]); got != 3 {
+			t.Errorf("segment_failure_at = %d, want 3 (untouched surface must keep state)", got)
+		}
+	})
+
+	t.Run("all surface is covered", func(t *testing.T) {
+		target := SessionData{
+			"all_failure_at":         2,
+			"all_failure_recover_at": 12,
+		}
+		resetFailureWindowState(map[string]interface{}{"all_failure_type": "500"}, target)
+		if _, ok := target["all_failure_at"]; ok {
+			t.Error("all_failure_at survived a re-arm")
+		}
+	})
+
+	t.Run("non-fault payload leaves cursors alone", func(t *testing.T) {
+		target := SessionData{
+			"master_manifest_failure_at":         8,
+			"master_manifest_failure_recover_at": 18,
+		}
+		resetFailureWindowState(map[string]interface{}{"nftables_bandwidth_mbps": 5.0}, target)
+		if got := intFromInterface(target["master_manifest_failure_at"]); got != 8 {
+			t.Errorf("failure_at = %d, want 8 (shape-only PATCH must not reset fault windows)", got)
+		}
+	})
+}
+
+// End-to-end through the engine: a fresh window after re-arm delivers
+// the FULL consecutive count, mirroring the live curl reproduction.
+func TestReArmDeliversFullWindow(t *testing.T) {
+	session := SessionData{
+		"master_manifest_failure_type":         "404",
+		"master_manifest_failure_frequency":    0,
+		"master_manifest_consecutive_failures": 10,
+		"master_manifest_failure_units":        "requests",
+		"master_manifest_consecutive_units":    "requests",
+		"master_manifest_frequency_units":      "requests",
+		"master_manifest_failure_mode":         "requests",
+		"master_manifest_requests_count":       0,
+	}
+	now := time.Now()
+
+	fire := func(count int) string {
+		h := NewFailureHandler("master_manifest", session)
+		ft := h.HandleFailure(count, now)
+		session["master_manifest_failure_at"] = h.failureAt
+		session["master_manifest_failure_recover_at"] = h.failureRecoverAt
+		return ft
+	}
+
+	// First arm: consume 4 of the 10-request window.
+	for i := 1; i <= 4; i++ {
+		if got := fire(i); got != "404" {
+			t.Fatalf("first arm req %d: failureType = %q, want 404", i, got)
+		}
+	}
+
+	// Re-arm (same config PATCH) — must clear the cursor.
+	resetFailureWindowState(map[string]interface{}{
+		"master_manifest_failure_type":         "404",
+		"master_manifest_consecutive_failures": 10,
+	}, session)
+
+	// Second arm must deliver a FULL 10-request window. Pre-fix, requests
+	// 5..10 faulted (old recoverAt=11) and 11+ passed clean — only 6 of 10.
+	for i := 5; i <= 14; i++ {
+		if got := fire(i); got != "404" {
+			t.Fatalf("re-arm req %d: failureType = %q, want 404 (stale window resumed?)", i, got)
+		}
+	}
+	// And the window must still CLOSE: request 15 is past the fresh
+	// recover point (5 + 10), so it recovers to none.
+	if got := fire(15); got != "none" {
+		t.Fatalf("req 15: failureType = %q, want none (window must still close)", got)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -2705,6 +2705,7 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 			target[resetKey] = normalizeRequestFailureType(resetType)
 		}
 	}
+	resetFailureWindowState(payload, target)
 	targetPort = getString(target, "x_forwarded_port")
 	if transportUpdated {
 		typeRaw := getString(target, "transport_failure_type")
@@ -2849,6 +2850,7 @@ func (a *App) applySessionSettingsUpdate(id string, payload map[string]interface
 					session[resetKey] = normalizeRequestFailureType(resetType)
 				}
 			}
+			resetFailureWindowState(payload, session)
 			if transportUpdated && transportSnapshot != nil {
 				for key, value := range transportSnapshot {
 					session[key] = value
@@ -7442,6 +7444,36 @@ func (a *App) saveSessionByIDReturning(sessionID string, session SessionData) (S
 		return nil, false
 	}
 	return cloneSession(merged), true
+}
+
+// resetFailureWindowState clears the persisted per-surface failure
+// window cursor (`<prefix>_failure_at` / `<prefix>_failure_recover_at`)
+// for every surface whose fault CONFIG the incoming settings payload
+// touches (#643). The cursor is the engine's "where in the
+// fault/recover cycle am I" state, written back by the per-request
+// handlers; without this reset a re-arm RESUMES the previous arm's
+// half-consumed window — e.g. arm `--consecutive 10`, consume 4, re-arm
+// ×10 → only 6 more faults fire before the OLD recover point is hit and
+// the rule silently goes quiet. The next matching request after a
+// config change must always open a fresh window.
+//
+// Covers the `all` surface too — the normalization loops above it
+// historically listed only segment/manifest/master_manifest.
+func resetFailureWindowState(payload map[string]interface{}, target SessionData) {
+	for _, prefix := range []string{"segment", "manifest", "master_manifest", "all"} {
+		touched := false
+		for _, suffix := range []string{"_failure_type", "_failure_frequency", "_consecutive_failures", "_failure_mode"} {
+			if _, ok := payload[prefix+suffix]; ok {
+				touched = true
+				break
+			}
+		}
+		if !touched {
+			continue
+		}
+		delete(target, prefix+"_failure_at")
+		delete(target, prefix+"_failure_recover_at")
+	}
 }
 
 // resetPlayScopedServerCounters zeroes the proxy-ACCUMULATED counters that


### PR DESCRIPTION
Closes #643

## What

Re-arming an HTTP fault resumed the previous arm's half-consumed consecutive window: the engine's cursor (`<prefix>_failure_at` / `<prefix>_failure_recover_at`) persists on the session and the failure-settings PATCH paths never cleared it on config change. Observed as silently truncated fault delivery — on the long-lived iPad-sim session, a fresh `--consecutive 10` arm delivered a single 404 before going quiet, which is why `TestPlaybackEndsIPadSim/StartFailureManifest404` could never pass (and why #641's fallback-chain removal alone didn't fix it).

## Fix

`resetFailureWindowState(payload, target)` — deletes the cursor for every surface whose fault config (`_failure_type` / `_failure_frequency` / `_consecutive_failures` / `_failure_mode`) the incoming payload touches. Called from both PATCH paths in `applySessionSettingsUpdate` (single-session + group-member loops). Covers the **`all` surface**, which the adjacent normalization loops historically skipped.

## Tests

- Cursor cleared for touched surfaces only; untouched surfaces keep state; shape-only PATCHes don't reset fault windows.
- End-to-end through `NewFailureHandler`/`HandleFailure`: arm ×10 → consume 4 → re-arm → full 10 delivered → window still closes on schedule (pre-fix: only 6).
- Full go-proxy suite + vet green.

## Verification (live, post-deploy)

1. curl probe: arm ×10, consume 4, re-arm ×10 → 10 sustained 404s (currently 6).
2. `TestPlaybackEndsIPadSim` with the #641 app build → expect 4/4 (`start_failure` finally reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
