### PR TITLE
fix(643): v2 fault_rules translator also clears the window cursor

### DIFF
--- a/go-proxy/internal/v2/server/translate_faults.go
+++ b/go-proxy/internal/v2/server/translate_faults.go
@@ -106,6 +106,14 @@ func clearV1FaultSurfaces(s map[string]any) {
 		s[surface+"_failure_units"] = "requests"
 		s[surface+"_consecutive_units"] = "requests"
 		s[surface+"_frequency_units"] = "seconds"
+		// #643 — also clear the engine's persisted window cursor, or a
+		// re-armed rule RESUMES the previous arm's half-consumed
+		// fault/recover window and silently under-delivers. This is the
+		// v2 twin of resetFailureWindowState on the v1 PATCH path
+		// (cmd/server/main.go); the harness CLI arms faults through
+		// HERE, which is why the v1-side fix alone didn't take.
+		delete(s, surface+"_failure_at")
+		delete(s, surface+"_failure_recover_at")
 	}
 }
 

--- a/go-proxy/internal/v2/server/translate_faults_window_test.go
+++ b/go-proxy/internal/v2/server/translate_faults_window_test.go
@@ -1,0 +1,39 @@
+package server
+
+import "testing"
+
+// #643 — the v2 fault_rules translator must clear the failure engine's
+// persisted window cursor (<surface>_failure_at / _failure_recover_at)
+// on every re-translation, or a re-armed rule resumes the previous
+// arm's half-consumed window and silently under-delivers faults. This
+// is the path the harness CLI arms through; the v1 PATCH path has the
+// matching resetFailureWindowState (cmd/server/main.go).
+func TestTranslateFaultRulesClearsWindowCursor(t *testing.T) {
+	s := map[string]any{
+		// Cursor state left behind by a previous arm's request handling.
+		"master_manifest_failure_at":         8,
+		"master_manifest_failure_recover_at": 18,
+		"all_failure_at":                     2,
+		"all_failure_recover_at":             12,
+	}
+	rules := []any{
+		map[string]any{
+			"type":        "404",
+			"frequency":   float64(0),
+			"consecutive": float64(10),
+			"mode":        "requests",
+			"filter":      map[string]any{"request_kind": []any{"master_manifest"}},
+		},
+	}
+	if err := translateFaultRules(s, rules); err != nil {
+		t.Fatalf("translateFaultRules: %v", err)
+	}
+	for _, key := range []string{
+		"master_manifest_failure_at", "master_manifest_failure_recover_at",
+		"all_failure_at", "all_failure_recover_at",
+	} {
+		if _, ok := s[key]; ok {
+			t.Errorf("%s survived re-arm — stale window would resume", key)
+		}
+	}
+}


### PR DESCRIPTION
Second half of #643 (v1 PATCH path landed in #644).

`harness fault add` arms faults through the **v2** `fault_rules` translator, not `applySessionSettingsUpdate` — and `clearV1FaultSurfaces` (translate_faults.go) reset the rule config but left the engine's persisted window cursor (`<surface>_failure_at` / `_failure_recover_at`) intact. Verified live after deploying #644: arm ×10 → consume 4 → re-arm ×10 → still only 6 faults delivered (the old window's recover point).

Fix: delete both cursor keys per surface in `clearV1FaultSurfaces`, which runs on every fault_rules translation. Unit test pins it (cursor state survives → fail).

Live verification post-deploy: same curl probe must deliver a full 10 after re-arm, then `TestPlaybackEndsIPadSim` with the #641 app build → 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
