### PR TITLE
fix(646): observe AVPlayerItem .failed + anchor the EBVS clock at the play boundary

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -544,10 +544,15 @@ final class PlaybackDiagnostics: ObservableObject {
         terminalErrorCode = 0
         terminalErrorDomain = ""
         terminalErrorDetails = ""
-        // Fresh play → restart the EBVS clock. Nil now so reset()'s
-        // nil-coalesce sets it to the new Date() at this fresh play
-        // boundary, not the prior play's start.
-        playStartAt = nil
+        // Fresh play → restart the EBVS clock AT THIS BOUNDARY — the
+        // moment the user committed to the new play — not at
+        // startPlayback's later reset(). Under a slow network the master
+        // preflight alone can outlast the EBVS threshold; a back-out
+        // during that window must classify abandoned_start, and with a
+        // nil clock endSessionForUserBack's `let startedAt` guard fell
+        // through to user_stopped (#646 verification fallout). reset()'s
+        // nil-coalesce in startPlayback now keeps this boundary stamp.
+        playStartAt = Date()
     }
 
     /// Add elapsed-since-last-transition to the *prior* state's

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -215,6 +215,17 @@ final class PlayerViewModel: ObservableObject {
     private var codecRetries = 0
     private let maxCodecRetries = 3
     private var statusObserver: NSKeyValueObservation?
+    /// #646 — per-item KVO on AVPlayerItem.status. `.failed` is the
+    /// canonical "item could not load" signal (404'd master, DNS, …);
+    /// nothing else fires for load-time failures, so without this
+    /// observer `start_failure` is unreachable. Replaced per item in
+    /// startPlayback (reassignment invalidates the old observation).
+    private var itemStatusObserver: NSKeyValueObservation?
+    /// One fatal escalation per item — a mid-stream failure can fire
+    /// BOTH AVPlayerItemFailedToPlayToEndTime and the .failed status
+    /// flip; without the latch the second arrival would double-schedule
+    /// auto-recovery. Reset in startPlayback alongside the observer.
+    private var itemFatalHandled = false
 
     // MARK: - Diagnostics + metrics pipeline (legacy iOS analytics)
     //
@@ -922,6 +933,22 @@ final class PlayerViewModel: ObservableObject {
         // (issue #486). Rebuilt per-item so the streams stay bound to the
         // playerItem that AVFoundation is actually observing.
         attachAVMetrics(to: item)
+        // #646 — observe the item's own status. `.failed` is the ONLY
+        // signal a load-time failure produces (a 404'd master never
+        // starts playing, so AVPlayerItemFailedToPlayToEndTime can't
+        // fire) — without this, such plays emit `error` events but no
+        // terminal row and `start_failure` is unreachable. Routes
+        // through handlePlayerError so the autoRecovery branch and the
+        // start_failure / mid_stream_failure classification stay in one
+        // place. Reassignment invalidates the previous item's observer.
+        itemFatalHandled = false
+        itemStatusObserver = item.observe(\.status, options: [.new]) { [weak self] observedItem, _ in
+            guard observedItem.status == .failed else { return }
+            let err = observedItem.error
+            Task { @MainActor [weak self] in
+                self?.handlePlayerError(err)
+            }
+        }
         player.isMuted = isMuted
         player.automaticallyWaitsToMinimizeStalling = true
         player.play()
@@ -1475,6 +1502,13 @@ final class PlayerViewModel: ObservableObject {
     }
 
     private func handlePlayerError(_ error: Error?) {
+        // #646 — one fatal escalation per item: a mid-stream failure can
+        // arrive via BOTH the FailedToPlayToEndTime notification and the
+        // item-status .failed flip; the second arrival would otherwise
+        // double-schedule auto-recovery (or re-run the terminal path).
+        // The latch resets in startPlayback with each new item.
+        if itemFatalHandled { return }
+        itemFatalHandled = true
         let message = error?.localizedDescription ?? "playback error"
         // Codec errors on Apple devices are extremely rare (the chips
         // hardware-decode H.264 / HEVC / AV1 with plenty of headroom),

--- a/tests/characterization/modes/playback_end_test.go
+++ b/tests/characterization/modes/playback_end_test.go
@@ -138,6 +138,11 @@ func runPlaybackEnds(t *testing.T, p runner.Platform) {
 			t.Fatalf("arm master_manifest 404: %v", err)
 		}
 		defer sess.ClearFaults(ctx)
+		// Settle: the fault PATCH acks 200 before the rule is active on
+		// the request path (#648) — a reload tapped immediately can slip
+		// its master fetch through unfaulted (~230ms window observed).
+		// Remove once #648 lands.
+		holdContext(ctx, 1*time.Second)
 
 		// Capture the prior play_id BEFORE the tap — the rotation lands
 		// within ~1s (faster since #621 emits play_start from the fresh
@@ -161,18 +166,31 @@ func runPlaybackEnds(t *testing.T, p runner.Platform) {
 		}
 	})
 
-	// — Abandoned start: arm an extreme delay on master_manifest so the
-	// player can't progress past startup, wait EBVS threshold + buffer,
-	// then tap back. The forwarder classifier should mark the play as
-	// abandoned_start (slow_startup) because the user quit before first
-	// frame with elapsed > ebvs_threshold_ms.
+	// — Abandoned start: crawl-rate shape so the player is STILL TRYING
+	// (data trickling, no error) when the user gives up. A request fault
+	// can't model this anymore: every hang/drop variant errors the item,
+	// and since #646 wired AVPlayerItem.status==.failed → start_failure,
+	// an errored item truthfully reports the PLAYER's failure, not the
+	// USER's abandonment. abandoned_start requires a pending-but-alive
+	// startup: the master/playlist (KBs) squeeze through the cap, the
+	// first segment (MBs) crawls, first frame never arrives, and the
+	// back-tap at EBVS+buffer lands while AVPlayer is still buffering —
+	// the client's endSessionForUserBack then classifies
+	// abandoned_start/slow_startup.
 	t.Run("AbandonedStartSlowStartup", func(t *testing.T) {
-		// 30s delay >> EBVS 10s default — long enough that even with
-		// fast retries the master_manifest never resolves in time.
-		if err := armSustainedFault(ctx, sess, "request_body_hang", "master_manifest", 10); err != nil {
-			t.Fatalf("arm master_manifest hang: %v", err)
+		// 0.05 Mbps ≈ 6 KB/s: manifests pass in ~1s, a multi-MB first
+		// segment needs minutes — comfortably outlasting EBVS+buffer.
+		if err := sess.ApplyRate(ctx, 0.05); err != nil {
+			t.Fatalf("apply crawl rate: %v", err)
 		}
-		defer sess.ClearFaults(ctx)
+		defer sess.ClearShape(ctx)
+		// Settle gap: PATCH /shape returns 200 once the proxy accepts the
+		// change, but tc rule installation lands slightly later (same gap
+		// rampup_test works around). Without it the reload's first segment
+		// races through at LAN speed, first frame renders, and the
+		// back-tap correctly classifies user_stopped instead of
+		// abandoned_start (EBVS is pre-first-frame only).
+		holdContext(ctx, 2500*time.Millisecond)
 
 		// Same pre-tap capture as StartFailureManifest404 — see comment there.
 		priorID := currentPlayID(ctx, sess)
@@ -203,12 +221,22 @@ func runPlaybackEnds(t *testing.T, p runner.Platform) {
 		}
 
 		// Recover playback for the final sub-test.
-		_ = sess.ClearFaults(ctx)
+		if err := sess.ClearShape(ctx); err != nil {
+			t.Logf("[AbandonedStartSlowStartup] clear shape: %v", err)
+		}
 		if err := appium.TapByAccessibilityID(ctx, sess, "home-continue-watching"); err != nil {
 			t.Logf("[AbandonedStartSlowStartup] re-enter via continue-watching failed: %v", err)
 		}
 		if !waitForState(t, ctx, sess, "playing", recoveryTimeout) {
-			t.Fatalf("post-recovery: player did not reach playing")
+			// A crawl-starved AVPlayer can wedge on its half-open media
+			// socket even after the shape clears (known stale-connection
+			// pattern). Reload replaces the AVPlayer instance entirely —
+			// same recovery an operator performs.
+			t.Logf("[AbandonedStartSlowStartup] still not playing post-shape-clear — reloading for a fresh AVPlayer")
+			tapReload(t, ctx, sess, appium)
+			if !waitForState(t, ctx, sess, "playing", recoveryTimeout) {
+				t.Fatalf("post-recovery: player did not reach playing (even after reload)")
+			}
 		}
 	})
 


### PR DESCRIPTION
Closes #646

## What

Two iOS classification gaps that made the failure half of the #550 terminal vocabulary unreachable:

1. **`start_failure`** — nothing observed `AVPlayerItem.status == .failed`, the only signal a load-time failure produces (`AVPlayerItemFailedToPlayToEndTime` requires playback to have started). New per-item KVO routes `.failed` through the existing `handlePlayerError` (autoRecovery honored, `start_failure` vs `mid_stream_failure` classified in one place), with a once-per-item latch so a mid-stream failure firing both the notification *and* the status flip can't double-schedule recovery.
2. **`abandoned_start`** — the EBVS clock was nil'd at the play boundary and only stamped in `startPlayback`'s `reset()`; under a slow network the master preflight alone outlasts the EBVS threshold, so a back-out during that window fell through to `user_stopped`. `resetForFreshPlay` now stamps the boundary time itself (its own comment already declared that intent).

## Test changes

- `AbandonedStartSlowStartup` models abandonment with a 0.05 Mbps crawl shape (player alive-but-pending) instead of `request_body_hang` — every hang/drop fault now truthfully errors the item → `start_failure`. Includes the tc-settle gap and a reload-fallback recovery for the crawl-starved AVPlayer wedge.
- `StartFailureManifest404` settles 1s after arming — workaround for #648 (fault PATCH acks before the rule is live on the request path).

## Verification (live, iPad sim)

`TestPlaybackEndsIPadSim` **4/4** — the suite's first full pass: `mid_stream_failure` (35s), `start_failure` (5.1s — first time reachable), `abandoned_start` (66s), `user_stopped` (0.6s).

Closes the stacked-cause chain: #641 (fallback chain) → #643/#644/#645 (fault window, two paths) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
