### PR TITLE
fix(650): rampup tolerates dip-and-recover at thin-margin upshifts

### DIFF
--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -389,8 +389,14 @@ func runRampup(t *testing.T, p runner.Platform) {
 		if st.ExitReason == "skipped-player-wedged" {
 			continue
 		}
-		failed := st.StallsDelta > 0 || st.MinBufferS < runner.SustainableBufferS
-		if !failed {
+		// #650 (port of #632): only an ACTUAL stall fails a non-bottom rung.
+		// Rampup upshifts onto thin-margin peak rungs (+5% over the variant's
+		// peak), where the buffer transiently drains to min_buf=0 fetching the
+		// bigger segments and then refills without underrunning — expected ABR
+		// behaviour, not a defect. Key on real stalls, not the dip. (rampdown
+		// keeps the stricter min_buf check: a descent fills the buffer, so a
+		// dip there is genuinely suspicious.)
+		if st.StallsDelta == 0 {
 			continue
 		}
 		upperFailures = append(upperFailures, fmt.Sprintf(
@@ -399,7 +405,7 @@ func runRampup(t *testing.T, p runner.Platform) {
 			st.StallsDelta, st.MinBufferS))
 	}
 	if len(upperFailures) > 0 {
-		t.Errorf("player stalled / depleted buffer at %d non-bottom variant(s):\n  %s",
+		t.Errorf("player stalled at %d non-bottom variant(s):\n  %s",
 			len(upperFailures), joinLines(upperFailures))
 	}
 


### PR DESCRIPTION
Port of the #632 relaxation to rampup.

## Problem
`rampup_test.go:392` had the same too-strict non-bottom assertion the pyramid had before #632:
```go
failed := st.StallsDelta > 0 || st.MinBufferS < runner.SustainableBufferS
```
Rampup is an **ascent** — it upshifts onto thin-margin peak rungs (variant peak ×1.05), where the buffer transiently drains to `min_buf=0` fetching the bigger segments and then refills **without stalling** (`stalls=0`). #632 confirmed this is expected ABR behaviour, so rampup false-fails the same way the pyramid did.

## Fix
A non-bottom rung fails only on an **actual stall** (`StallsDelta > 0`), not on `min_buf < SustainableBufferS`. The shared `RunVariantSweep` guards (entry-grace + non-zero-buffer-stable) already landed via #632.

**rampdown deliberately keeps the stricter check** — a descent fills the buffer, so a dip at a non-bottom variant mid-descent is genuinely suspicious, not a benign upshift dip.

`go build` + `go vet` pass. Verification: a live rampup sim run should now pass through the upshift dips (separately, rampup shares the cold-start path tracked by #642).

Closes #650
Refs #632, #642
