### PR TITLE
fix(dashboard): swap chart order — Buffer & live offset above RTT

### DIFF
--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1489,8 +1489,8 @@ function skipToEnd() {
       <BitrateChartPanelToolbar :player-id="archivePlayerId" />
       <div class="chart-stack">
         <BandwidthChart :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
-        <RTTChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
         <BufferChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
+        <RTTChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
         <FPSChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
       </div>
     </CollapsibleSection>


### PR DESCRIPTION
Reorders the session chart stack so **Buffer & live offset** sits above **RTT**: `Bandwidth → Buffer → RTT → FPS`.

Template-only swap of two sibling components in `SessionDisplay.vue:1492-1493` (shared by testing.html, session-viewer, and testing-session) — no logic/props change.

Hot-deploy to preview: `make test-deploy-frontend`.
