### PR TITLE
fix(660): ClosePlaybackViaUI verifies the close took — tap, probe, retry

### DIFF
--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -41,6 +41,11 @@ type AppiumLauncher struct {
 	// BundleIDs maps Platform → app bundle id. Same defaults as
 	// CLILauncher; override for TestFlight / local-dev builds.
 	BundleIDs map[Platform]string
+	// closeBeat — pause after each close tap / back press so the app
+	// can navigate and fire its terminal metrics POST before the next
+	// probe (and before session teardown). 800ms in production; tests
+	// shrink it. #627/#660.
+	closeBeat time.Duration
 
 	mu       sync.Mutex
 	sessions map[string]string // device UDID → Appium session id
@@ -56,6 +61,7 @@ func NewAppiumLauncher() *AppiumLauncher {
 	return &AppiumLauncher{
 		URL:              url,
 		HeartbeatTimeout: 90 * time.Second,
+		closeBeat:        800 * time.Millisecond,
 		BundleIDs: map[Platform]string{
 			PlatformIPhone:    "com.jeoliver.InfiniteStreamPlayer",
 			PlatformIPad:      "com.jeoliver.InfiniteStreamPlayer",
@@ -277,25 +283,53 @@ func (a *AppiumLauncher) ClosePlaybackViaUI(ctx context.Context, d Device) error
 	if sessID == "" {
 		return nil // never launched; nothing to close
 	}
-	var err error
 	switch d.Platform {
 	case PlatformIPhone, PlatformIPad, PlatformIPadSim:
 		// The iOS playback overlay's back chevron — the same element
 		// LaunchToHome taps — invokes vm.endSessionForUserBack() before
 		// navigating home, which is what emits play_end.
-		err = a.tapByAccessibilityID(ctx, sessID, "playback-back-button")
+		//
+		// #660 — tap-verify-retry: the chevron stays FINDABLE in the AX
+		// tree while the controls overlay is auto-hidden, so a click can
+		// "succeed" yet only reveal the overlay instead of activating
+		// the button (observed at the end of a 36-min pyramid run; the
+		// play kept streaming and dangled in_progress). The chevron does
+		// NOT exist on the home screen, so find-fails is the reliable
+		// "screen closed" probe — the same property LaunchToHome's
+		// best-effort tap relies on. Tap, give the app a beat, re-probe;
+		// still findable means the previous tap only woke the overlay,
+		// so tap again (now hittable). Surface an error if the screen
+		// never closes so the cleanup logs instead of silently no-opping.
+		const maxCloseAttempts = 3
+		for attempt := 1; attempt <= maxCloseAttempts; attempt++ {
+			elementID, ferr := a.findByAccessibilityID(ctx, sessID, "playback-back-button")
+			if ferr != nil {
+				// Chevron not in the tree: already on home (first probe)
+				// or the previous tap closed the screen. Either way the
+				// post-tap beat below has already let the terminal
+				// metrics POST fire.
+				return nil
+			}
+			if cerr := a.clickElement(ctx, sessID, elementID); cerr != nil {
+				return fmt.Errorf("close playback: click attempt %d: %w", attempt, cerr)
+			}
+			// Give the app a beat to navigate + fire its terminal metrics
+			// POST before the re-probe (and before the caller tears the
+			// Appium session and the app's network path down).
+			time.Sleep(a.closeBeat)
+		}
+		return fmt.Errorf("close playback: screen still open after %d back taps (hidden-controls overlay?)", maxCloseAttempts)
 	case PlatformAndroidTV:
 		// Android has no visible back button; the playback screen's
 		// Compose BackHandler calls endSessionForUserBack() on system
 		// Back, so drive the W3C/UiAutomator2 back press.
-		err = a.pressBack(ctx, sessID)
+		err := a.pressBack(ctx, sessID)
+		// Same post-close beat as iOS — terminal POST before teardown.
+		time.Sleep(a.closeBeat)
+		return err
 	default:
 		return nil // tvOS (onExitCommand) / web not driven here yet
 	}
-	// Give the app a beat to fire its terminal metrics POST before the
-	// caller tears the Appium session (and the app's network path) down.
-	time.Sleep(800 * time.Millisecond)
-	return err
 }
 
 // pressBack issues the W3C "back" navigation (Android system Back) on the
@@ -505,6 +539,20 @@ func (a *AppiumLauncher) ReadPlayerID(ctx context.Context, sess *Session) (strin
 // caller decides whether that's fatal). Used by Launch to drive the
 // app's UI from playback → home → playback for a clean per-test state.
 func (a *AppiumLauncher) tapByAccessibilityID(ctx context.Context, sessID, id string) error {
+	elementID, err := a.findByAccessibilityID(ctx, sessID, id)
+	if err != nil {
+		return err
+	}
+	if err := a.clickElement(ctx, sessID, elementID); err != nil {
+		return fmt.Errorf("click element %q: %w", id, err)
+	}
+	return nil
+}
+
+// findByAccessibilityID resolves an accessibility id to a W3C element id.
+// Errors when the element is not in the AX tree — which doubles as the
+// "screen not showing this element" probe (#660).
+func (a *AppiumLauncher) findByAccessibilityID(ctx context.Context, sessID, id string) (string, error) {
 	// POST /session/{id}/element — find the element
 	findBody := map[string]any{
 		"using": "accessibility id",
@@ -512,13 +560,13 @@ func (a *AppiumLauncher) tapByAccessibilityID(ctx context.Context, sessID, id st
 	}
 	raw, err := a.doRequest(ctx, "POST", "/session/"+sessID+"/element", findBody)
 	if err != nil {
-		return err
+		return "", err
 	}
 	var findResp struct {
 		Value map[string]string `json:"value"`
 	}
 	if err := json.Unmarshal(raw, &findResp); err != nil {
-		return fmt.Errorf("decode find element %q: %w", id, err)
+		return "", fmt.Errorf("decode find element %q: %w", id, err)
 	}
 	// W3C WebDriver returns the element under key "element-6066-11e4-a52e-4f735466cecf".
 	var elementID string
@@ -527,15 +575,16 @@ func (a *AppiumLauncher) tapByAccessibilityID(ctx context.Context, sessID, id st
 		break
 	}
 	if elementID == "" {
-		return fmt.Errorf("find element %q returned no id", id)
+		return "", fmt.Errorf("find element %q returned no id", id)
 	}
-	// POST /session/{id}/element/{el}/click
-	_, err = a.doRequest(ctx, "POST",
+	return elementID, nil
+}
+
+// clickElement issues the W3C click on a previously-found element.
+func (a *AppiumLauncher) clickElement(ctx context.Context, sessID, elementID string) error {
+	_, err := a.doRequest(ctx, "POST",
 		fmt.Sprintf("/session/%s/element/%s/click", sessID, elementID), map[string]any{})
-	if err != nil {
-		return fmt.Errorf("click element %q: %w", id, err)
-	}
-	return nil
+	return err
 }
 
 // --- WebDriver protocol plumbing -------------------------------------------

--- a/tests/characterization/runner/appium_close_test.go
+++ b/tests/characterization/runner/appium_close_test.go
@@ -7,24 +7,40 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
-// #627: ClosePlaybackViaUI must drive the app's OWN UI close so the app
-// emits its real client play_end — iOS taps the playback-back-button
-// element (find + click), Android presses system Back. This pins the
-// WebDriver call sequence per platform against a mock Appium server.
+// #627/#660: ClosePlaybackViaUI must drive the app's OWN UI close so the
+// app emits its real client play_end — iOS taps the playback-back-button
+// element and VERIFIES the screen closed (the chevron stays findable while
+// the controls overlay is auto-hidden, so a click can "succeed" yet only
+// reveal the overlay; find-fails is the closed-screen probe). Android
+// presses system Back. Pins the WebDriver call sequence per platform
+// against a mock Appium server whose find-element responses are scripted.
 func TestClosePlaybackViaUI(t *testing.T) {
 	var mu sync.Mutex
 	var paths []string
+	// findFound scripts the find-element responses, one bool per call:
+	// true → element id returned; false → W3C no-such-element error.
+	// Finds past the end of the script report not-found.
+	var findFound []bool
+	var findCalls int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		paths = append(paths, r.Method+" "+r.URL.Path)
-		mu.Unlock()
-		// find-element returns a W3C element id; everything else returns null.
 		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/element") {
-			_, _ = w.Write([]byte(`{"value":{"element-6066-11e4-a52e-4f735466cecf":"elem-1"}}`))
+			found := findCalls < len(findFound) && findFound[findCalls]
+			findCalls++
+			mu.Unlock()
+			if found {
+				_, _ = w.Write([]byte(`{"value":{"element-6066-11e4-a52e-4f735466cecf":"elem-1"}}`))
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"value":{"error":"no such element","message":"not located"}}`))
+			}
 			return
 		}
+		mu.Unlock()
 		_, _ = w.Write([]byte(`{"value":null}`))
 	}))
 	defer srv.Close()
@@ -33,25 +49,83 @@ func TestClosePlaybackViaUI(t *testing.T) {
 		l := NewAppiumLauncher()
 		l.URL = srv.URL
 		l.hc = srv.Client()
+		l.closeBeat = time.Millisecond
 		l.sessions = map[string]string{"udid-1": "sess-1"}
 		return l
 	}
-	reset := func() { mu.Lock(); paths = nil; mu.Unlock() }
+	reset := func(script ...bool) {
+		mu.Lock()
+		paths = nil
+		findFound = script
+		findCalls = 0
+		mu.Unlock()
+	}
 	got := func() []string { mu.Lock(); defer mu.Unlock(); return append([]string(nil), paths...) }
+	wantSeq := func(t *testing.T, want []string) {
+		t.Helper()
+		g := got()
+		if len(g) != len(want) {
+			t.Fatalf("close hit %v, want %v", g, want)
+		}
+		for i := range want {
+			if g[i] != want[i] {
+				t.Fatalf("close hit %v, want %v", g, want)
+			}
+		}
+	}
 
-	t.Run("iOS taps back button", func(t *testing.T) {
-		reset()
+	t.Run("iOS taps back button and verifies closed", func(t *testing.T) {
+		reset(true, false) // chevron present; gone after one tap
 		l := newL()
 		d := Device{Platform: PlatformIPhone, UDID: "udid-1"}
 		if err := l.ClosePlaybackViaUI(context.Background(), d); err != nil {
 			t.Fatalf("ClosePlaybackViaUI: %v", err)
 		}
-		want := []string{
+		wantSeq(t, []string{
 			"POST /session/sess-1/element",              // find playback-back-button
 			"POST /session/sess-1/element/elem-1/click", // tap it
+			"POST /session/sess-1/element",              // probe: gone → closed
+		})
+	})
+
+	t.Run("iOS hidden-controls overlay needs a second tap (#660)", func(t *testing.T) {
+		// First tap lands on the hidden-overlay surface and only reveals
+		// the controls: chevron still findable. Second tap closes.
+		reset(true, true, false)
+		l := newL()
+		d := Device{Platform: PlatformIPhone, UDID: "udid-1"}
+		if err := l.ClosePlaybackViaUI(context.Background(), d); err != nil {
+			t.Fatalf("ClosePlaybackViaUI: %v", err)
 		}
-		if g := got(); len(g) != 2 || g[0] != want[0] || g[1] != want[1] {
-			t.Errorf("iOS close hit %v, want %v", g, want)
+		wantSeq(t, []string{
+			"POST /session/sess-1/element",              // find
+			"POST /session/sess-1/element/elem-1/click", // tap (only reveals overlay)
+			"POST /session/sess-1/element",              // probe: still open
+			"POST /session/sess-1/element/elem-1/click", // tap again (hits)
+			"POST /session/sess-1/element",              // probe: gone → closed
+		})
+	})
+
+	t.Run("iOS already on home is a no-op", func(t *testing.T) {
+		reset(false) // chevron never present
+		l := newL()
+		d := Device{Platform: PlatformIPhone, UDID: "udid-1"}
+		if err := l.ClosePlaybackViaUI(context.Background(), d); err != nil {
+			t.Fatalf("expected nil when already on home, got %v", err)
+		}
+		wantSeq(t, []string{"POST /session/sess-1/element"}) // single probe, no click
+	})
+
+	t.Run("iOS errors loudly when the screen never closes (#660)", func(t *testing.T) {
+		reset(true, true, true, true) // chevron survives every tap
+		l := newL()
+		d := Device{Platform: PlatformIPhone, UDID: "udid-1"}
+		err := l.ClosePlaybackViaUI(context.Background(), d)
+		if err == nil {
+			t.Fatal("expected an error when the playback screen never closes")
+		}
+		if !strings.Contains(err.Error(), "still open") {
+			t.Fatalf("error %q should name the still-open screen", err)
 		}
 	})
 


### PR DESCRIPTION
Closes #660

## What

The #627 test-end UI close could silently not close: the iOS back chevron stays **findable while the controls overlay is auto-hidden**, so the click "succeeds" but only reveals the overlay. Observed at the end of a 36-min pyramid run — close reported success, app kept streaming, play dangled `in_progress`.

## Fix

iOS close is now **tap → beat → re-probe → retry** (≤3 attempts), using "chevron findable?" as the screen-open probe (it doesn't exist on Home — the property `LaunchToHome` already relies on). Never-closes returns an error so the cleanup logs instead of silently no-opping; already-on-home stays a clean single-probe no-op. Android (system Back) unchanged.

Plumbing: `tapByAccessibilityID` split into `findByAccessibilityID` + `clickElement`; the post-tap beat is a field (800ms prod, 1ms tests).

## Tests

Mock-Appium sequences pinned for all four shapes: immediate close, hidden-overlay double-tap, already-home no-op, never-closes error. Full runner package green.

## Verification (live)

- Mechanism proven **before** coding, from the real failure state: the dangling pyramid play (`dde7e6ee`, still streaming 3+ min post-suite) was closed via manual find→click→probe and flipped to `user_stopped / user_quit`.
- Integration: `TestPlaybackEndsIPadSim/UserStopped` passes through the new path (cleanup takes the already-home branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
