### PR TITLE
fix(662): selecting an event drops Live so the highlighted log row stays on screen

### DIFF
--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -218,6 +218,20 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     const s = cur();
     s.cursorMs = ms;
     s.cursorLabel = ms == null ? null : label;
+    // #662: selecting an event means the operator is inspecting history, so
+    // drop out of Live — otherwise follow-latest keeps snapping the logs and
+    // charts back to the live tail and the highlighted row never stays on
+    // screen. Pin a window: keep the current one if it already contains the
+    // event (no jump), else center on the event so it's visible. The Live
+    // toggle resumes following. Only acts on a real selection (ms != null)
+    // while currently live; hover paths use setCursorMs and are unaffected.
+    if (ms != null && s.range === null) {
+      const end = s.lastSampleMs || Date.now();
+      const win = { min: end - s.liveSpan, max: end };
+      s.range = (ms >= win.min && ms <= win.max)
+        ? win
+        : { min: ms - s.liveSpan / 2, max: ms + s.liveSpan / 2 };
+    }
   }
 
   return {


### PR DESCRIPTION
## Problem
On live dashboard pages, selecting an event highlights + scrolls the Network/Play logs to it, but the **follow-latest** auto-scroll fires every ~second as new rows arrive and snaps the log back to the tail — so the highlighted row only flashes (#662, the "some of the time" behaviour).

## Fix
`useChartCoordination.setCursor` now **drops out of Live** when a real event is selected while live: it pins `state.range` (keeping the current window if it already contains the event, else centering on it). `liveChecked` goes false → the follow-latest watchers bail → the cursor scroll holds the highlighted row on screen. The **Live** toggle resumes following; hover (`setCursorMs`) is untouched.

Centralized in `setCursor`, so it applies to every selection path on testing.html / session-viewer / testing-session. `vue-tsc --noEmit` clean.

Closes #662
