### PR TITLE
fix(664): bitrate chart Y-max buttons take effect on the rendered chart immediately

### DIFF
--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -200,7 +200,15 @@ function applyViewport(v: ChartViewport) {
 function applyYMax(v: number | undefined) {
   if (!chart || !chart.options?.scales?.y) return;
   chart.options.scales.y.max = v;
+  // #664: push the new scale to the rendered chart immediately ('none' =
+  // no animation), otherwise the Y-max buttons don't take effect until some
+  // other update fires.
+  try { chart.update('none'); } catch { /* ignore */ }
 }
+
+// #664: re-apply Y-max live when the prop changes (the buttons set
+// coord.bandwidthYMax → :y-max). Without this it's only read at chart init.
+watch(() => props.yMax, (v) => applyYMax(v));
 
 // Serialise init so concurrent watch callbacks don't each `new Chart()`
 // on the same canvas (Chart.js throws "Canvas is already in use" the


### PR DESCRIPTION
The bitrate-chart Y-max preset buttons (`BitrateChartPanelToolbar` → `coord.setBandwidthYMax`) updated the `:y-max` prop but the chart didn't change until some other re-render: `props.yMax` was only read at chart creation, `applyYMax` was never called, and there was no watcher.

Fix (`MetricsLineChart.vue`): `applyYMax` now calls `chart.update('none')`, and a `watch(() => props.yMax)` re-applies it on change — so the presets take effect on the rendered chart right away. `vue-tsc --noEmit` clean.

Closes #664
