### PR TITLE
fix: bandwidth chart — default 5 server/player lines off (recovers uncommitted change)

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -174,6 +174,7 @@ const baseSeries: SeriesSpec[] = [
   {
     label: 'mbps_shaper_rate',
     color: '#0f766e',
+    hidden: true,
     accessor: (p: PlayerRecord) => p.server_metrics?.mbps_shaper_rate ?? null,
     stepped: true,
   },
@@ -185,11 +186,13 @@ const baseSeries: SeriesSpec[] = [
   {
     label: 'mbps_transfer_rate',
     color: '#f97316',
+    hidden: true,
     accessor: (p: PlayerRecord) => p.server_metrics?.mbps_transfer_rate ?? null,
   },
   {
     label: 'mbps_transfer_complete',
     color: '#dc2626',
+    hidden: true,
     accessor: (p: PlayerRecord) => p.server_metrics?.mbps_transfer_complete ?? null,
     stepped: true,
   },
@@ -274,11 +277,13 @@ const baseSeries: SeriesSpec[] = [
   {
     label: 'Player network_bitrate',
     color: '#059669',
+    hidden: true,
     accessor: (p: PlayerRecord) => p.player_metrics?.network_bitrate_mbps ?? null,
   },
   {
     label: 'Serving Variant',
     color: '#b45309',
+    hidden: true,
     accessor: (p: PlayerRecord) => p.server_metrics?.rendition_mbps ?? null,
     stepped: true,
   },


### PR DESCRIPTION
The intended bandwidth-chart legend defaults — `mbps_shaper_rate`, `mbps_transfer_rate`, `mbps_transfer_complete`, `Player network_bitrate`, and `Serving Variant` **off by default** (only `mbps_shaper_avg` + the variant peak lines on) — were never committed: the `hidden: true` edits lived only as uncommitted changes in a local worktree, so every deploy (built from branches off committed dev) rendered them on.

Confirmed via live browser inspection: the served `SessionDisplay-*.js` renders those 5 datasets `hidden:false` even after a cache-bypass reload, while `git diff origin/dev` showed the 5 `hidden:true` additions sitting uncommitted. This PR commits them.

`vue-tsc --noEmit` clean.
