### PR TITLE
fix(dashboard): archived-session viewer clamps to [from,to] instead of following live

### DIFF
--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -735,10 +735,28 @@ function parseChIsoMs(v: string | null | undefined): number {
  *  Threshold is generous (60 s) so a heartbeat that's a few seconds
  *  late doesn't kick us into archive mode. */
 const LIVE_TAIL_MS = 60_000;
+
+/** A play is "still live" — viewer follows the live edge instead of
+ *  pinning to a fixed end_time — only if its last_seen is within
+ *  LIVE_TAIL_MS of now AND it has not reached a terminal outcome.
+ *  A play_end (any non-in_progress playback_status) means the play is
+ *  OVER: clamp to [from,to] no matter how recently it ended, otherwise
+ *  a just-finished archive opens following live (the 60 s tail alone
+ *  misclassifies it for its first minute). Mirrors endOutcome's
+ *  in_progress test. */
+function isTerminal(r: SessionRow): boolean {
+  const status = String(r.playback_status ?? '').trim();
+  return status !== '' && status !== 'in_progress';
+}
+function isStillLive(r: SessionRow): boolean {
+  if (isTerminal(r)) return false;
+  const lastSeen = parseChIsoMs(r.last_seen);
+  return Number.isFinite(lastSeen) && (Date.now() - lastSeen) < LIVE_TAIL_MS;
+}
 function endTimeFor(r: SessionRow): string {
   const lastSeen = parseChIsoMs(r.last_seen);
   if (!Number.isFinite(lastSeen)) return 'live';
-  if (Date.now() - lastSeen < LIVE_TAIL_MS) return 'live';
+  if (isStillLive(r)) return 'live';
   return new Date(lastSeen).toISOString();
 }
 
@@ -750,7 +768,7 @@ function viewerHref(r: SessionRow): string {
   // the upper bound and follows the live edge.
   const startMs = r.started ? parseChIsoMs(r.started) : NaN;
   const lastSeen = r.last_seen ? parseChIsoMs(r.last_seen) : NaN;
-  const stillLive = Number.isFinite(lastSeen) && (Date.now() - lastSeen) < LIVE_TAIL_MS;
+  const stillLive = isStillLive(r);
   return sessionViewerURL({
     playerId: r.player_id,
     playId: r.play_id && r.play_id !== '—' ? r.play_id : undefined,


### PR DESCRIPTION
## Problem

Opening an archived (not in-progress) session from the sessions list with a `from`/`to` range opened the viewer **following the live edge** instead of scoping to that range.

## Root cause

`viewerHref` (Sessions.vue) computed `stillLive` purely from the 60s `last_seen` tail:

```ts
const stillLive = Number.isFinite(lastSeen) && (Date.now() - lastSeen) < LIVE_TAIL_MS;
```

When `stillLive`, it drops `toMs`, and the viewer treats an absent upper bound as "follow live." So a play that had already ended (terminal `playback_status`) but was last seen <60s ago was misclassified — for its first minute after ending, the archive opened in live-follow mode. The function's own doc comment already promised "within LIVE_TAIL_MS **AND no terminal-state marker is set**"; only the recency half was implemented.

## Fix

`isStillLive` now also requires a non-terminal `playback_status` (empty or `in_progress`) — a `play_end` means the play is over, so clamp to `[from,to]` regardless of recency. Same `in_progress` test `endOutcome` already uses. The unused `endTimeFor` routes through the same helper for consistency.

## Verification

`npm run build` clean. Behaviour: a terminal play opened from the list now pins the brush/x-domain to `[started, last_seen]`; in-progress plays (no terminal status, recent heartbeat) still drop `toMs` and follow live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
