### PR TITLE
feat(characterization): multi-cycle rampup/rampdown/pyramid on one live play

### DIFF
--- a/tests/characterization/README.md
+++ b/tests/characterization/README.md
@@ -150,6 +150,9 @@ The CLI launcher expects each player app to be built with `skipHomeOnLaunch=true
 | `LAUNCH_MODE` | `cli` | `manual` \| `cli` \| `appium` |
 | `CHARACTERIZATION_OUTDIR` | `t.TempDir()` | persistent artifacts directory (set for CI / aggregator use) |
 | `CHARACTERIZATION_DEVICE_UDID` | unset = first-match | target a specific device by UDID. Use to run parallel tests across multiple sims of the same platform — each terminal exports its own UDID, no race for the same device. |
+| `CHAR_RAMPUP_REPS` | `3` | rampup cycles per run, on ONE live play. Between cycles the cap drops top→floor and the player re-climbs — the inter-cycle transition is the instructive part. |
+| `CHAR_RAMPDOWN_REPS` | `3` | rampdown cycles per run, on ONE live play. Between cycles the cap jumps floor→top and the player re-descends (buffer + variant carry across). |
+| `CHAR_PYRAMID_REPS` | `2` | pyramid (up-then-down) cycles per run, on ONE live play. Confirms climb/descent behaviour is stable run-to-run. |
 | `CHAR_OTEL_ENDPOINT` | unset | OTLP HTTP collector URL — e.g. `http://localhost:4318`. When set, every cycle emits an OpenTelemetry span to the configured backend (alongside the cycle_id label PATCH). See **Tracing** below. |
 | `CHAR_OTEL_STDOUT` | unset | non-empty enables the stdout span exporter (verbose, debug only). |
 | `CHAR_OTEL_DISABLE` | unset | non-empty forces the no-op tracer regardless of `CHAR_OTEL_ENDPOINT`. |

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -291,94 +291,105 @@ func runPyramid(t *testing.T, p runner.Platform) {
 		steps[i] = runner.Step{RateMbps: v.CapMbps, Hold: rampdownMaxHold, Variant: &v}
 	}
 
-	report := RunVariantSweep(ctx, t, sess, "pyramid", steps, time.Second,
+	// #cycles — run the full up-then-down pyramid REPS times on the SAME
+	// live play (default 2, CHAR_PYRAMID_REPS). Between cycles the cap
+	// returns floor→floor; the player carries its state across, so the
+	// second traverse shows whether the climb/descent behaviour is stable
+	// run-to-run (n=1 isn't a pattern).
+	reps := envInt("CHAR_PYRAMID_REPS", 2)
+	reports := RunCycledVariantSweep(ctx, t, sess, "pyramid", steps, reps,
+		unionRungs(desc), playID, time.Second,
 		rampdownMinHold, rampdownMaxHold, rampdownEarlyExitWindow, rampdownEarlyExitTol)
-	report.Variants = unionRungs(desc)
-	if playID != "" {
-		report.PlayIDs = []string{playID}
-	}
-	report.Finalize(time.Now())
 
 	out := runner.DefaultOutDir(t.TempDir())
 	playerShort := sess.PlayerID
 	if len(playerShort) > 8 {
 		playerShort = playerShort[:8]
 	}
-	base := fmt.Sprintf("pyramid-%s-%s-%s", p, playerShort, runID)
-	jsonPath, err := runner.WriteReport(out, base, report)
-	if err != nil {
-		t.Fatalf("write report: %v", err)
-	}
-	LogReport(t, jsonPath)
-	if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
-		t.Logf("chart: %s", htmlPath)
-	} else {
-		t.Logf("chart write skipped: %v", err)
-	}
-
-	t.Logf("lowest sustainable cap: %.3f Mbps", report.Summary.LowestSustainableCapMbps)
-	if report.Summary.HighestStallingCapMbps > 0 {
-		t.Logf("highest stalling cap:   %.3f Mbps", report.Summary.HighestStallingCapMbps)
-	}
-	t.Logf("total stalls: %d / stall seconds: %.1f / profile shifts: %d",
-		report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
-
-	endLabels := map[string]string{
-		"completed":            time.Now().UTC().Format("20060102T150405Z"),
-		"lowest_sustainable":   fmt.Sprintf("%.3f", report.Summary.LowestSustainableCapMbps),
-		"bottom_variant_floor": fmt.Sprintf("%.3f", report.Summary.BottomVariantFloorMbps),
-		"total_stalls":         fmt.Sprintf("%d", report.Summary.TotalStalls),
-		"profile_shifts":       fmt.Sprintf("%d", report.Summary.ProfileShifts),
-	}
-	if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
-		t.Logf("label play (end): %v", err)
-	}
-
-	// Pass criteria — same shape as rampdown/rampup.
-	if report.Summary.SampleCount == 0 {
-		t.Fatal("no samples collected")
-	}
-	missing := []string{}
-	for i, v := range report.Variants {
-		if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
-			missing = append(missing, v.Resolution)
+	var last *runner.Report
+	for ri, report := range reports {
+		cyc := ri + 1
+		last = report
+		base := fmt.Sprintf("pyramid-%s-%s-%s-cyc%d", p, playerShort, runID, cyc)
+		jsonPath, err := runner.WriteReport(out, base, report)
+		if err != nil {
+			t.Fatalf("cyc%d write report: %v", cyc, err)
 		}
-	}
-	if len(missing) > 0 {
-		t.Errorf("player did not visit every variant — missing: %v", missing)
-	}
-	t.Logf("variants visited (samples per rung): %v", report.Summary.VariantSampleCounts)
+		LogReport(t, jsonPath)
+		if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
+			t.Logf("chart: %s", htmlPath)
+		} else {
+			t.Logf("chart write skipped: %v", err)
+		}
 
-	bottomReportRes := ""
-	if n := len(report.Variants); n > 0 {
-		bottomReportRes = report.Variants[n-1].Resolution
-	}
-	upperFailures := []string{}
-	for i := range report.Steps {
-		st := &report.Steps[i]
-		if st.Variant == nil || st.Variant.Resolution == bottomReportRes {
+		t.Logf("cyc%d lowest sustainable cap: %.3f Mbps", cyc, report.Summary.LowestSustainableCapMbps)
+		if report.Summary.HighestStallingCapMbps > 0 {
+			t.Logf("cyc%d highest stalling cap:   %.3f Mbps", cyc, report.Summary.HighestStallingCapMbps)
+		}
+		t.Logf("cyc%d total stalls: %d / stall seconds: %.1f / profile shifts: %d",
+			cyc, report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
+
+		// Pass criteria — same shape as rampdown/rampup.
+		if report.Summary.SampleCount == 0 {
+			t.Errorf("cyc%d: no samples collected", cyc)
 			continue
 		}
-		if st.ExitReason == "skipped-player-wedged" {
-			continue
+		missing := []string{}
+		for i, v := range report.Variants {
+			if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
+				missing = append(missing, v.Resolution)
+			}
 		}
-		// #632: only an ACTUAL stall fails a non-bottom rung. A transient
-		// min_buf=0 with stalls=0 is the expected dip-and-recover when the
-		// player upshifts onto a thin-margin peak rung (+5% over the
-		// variant's peak): it drains the buffer fetching the bigger
-		// segments, then refills without ever underrunning. Climbing from
-		// the 360p floor exposes this (modest buffers); a warm 4K start
-		// masked it. We tolerate the dip and key on real stalls.
-		if st.StallsDelta == 0 {
-			continue
+		if len(missing) > 0 {
+			t.Errorf("cyc%d: player did not visit every variant — missing: %v", cyc, missing)
 		}
-		upperFailures = append(upperFailures, fmt.Sprintf(
-			"step %d cap=%.3f Mbps %s/%+d%%: stalls=%d min_buf=%.1fs",
-			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.MarginPct,
-			st.StallsDelta, st.MinBufferS))
+		t.Logf("cyc%d variants visited (samples per rung): %v", cyc, report.Summary.VariantSampleCounts)
+
+		bottomReportRes := ""
+		if n := len(report.Variants); n > 0 {
+			bottomReportRes = report.Variants[n-1].Resolution
+		}
+		upperFailures := []string{}
+		for i := range report.Steps {
+			st := &report.Steps[i]
+			if st.Variant == nil || st.Variant.Resolution == bottomReportRes {
+				continue
+			}
+			if st.ExitReason == "skipped-player-wedged" {
+				continue
+			}
+			// #632: only an ACTUAL stall fails a non-bottom rung. A transient
+			// min_buf=0 with stalls=0 is the expected dip-and-recover when the
+			// player upshifts onto a thin-margin peak rung (+5% over the
+			// variant's peak): it drains the buffer fetching the bigger
+			// segments, then refills without ever underrunning. Climbing from
+			// the 360p floor exposes this (modest buffers); a warm 4K start
+			// masked it. We tolerate the dip and key on real stalls.
+			if st.StallsDelta == 0 {
+				continue
+			}
+			upperFailures = append(upperFailures, fmt.Sprintf(
+				"step %d cap=%.3f Mbps %s/%+d%%: stalls=%d min_buf=%.1fs",
+				i+1, st.RateMbps, st.Variant.Resolution, st.Variant.MarginPct,
+				st.StallsDelta, st.MinBufferS))
+		}
+		if len(upperFailures) > 0 {
+			t.Errorf("cyc%d: player stalled at %d non-bottom variant(s):\n  %s",
+				cyc, len(upperFailures), joinLines(upperFailures))
+		}
 	}
-	if len(upperFailures) > 0 {
-		t.Errorf("player stalled at %d non-bottom variant(s):\n  %s",
-			len(upperFailures), joinLines(upperFailures))
+
+	if last != nil {
+		endLabels := map[string]string{
+			"completed":            time.Now().UTC().Format("20060102T150405Z"),
+			"cycles":               fmt.Sprintf("%d", len(reports)),
+			"lowest_sustainable":   fmt.Sprintf("%.3f", last.Summary.LowestSustainableCapMbps),
+			"bottom_variant_floor": fmt.Sprintf("%.3f", last.Summary.BottomVariantFloorMbps),
+			"total_stalls":         fmt.Sprintf("%d", last.Summary.TotalStalls),
+			"profile_shifts":       fmt.Sprintf("%d", last.Summary.ProfileShifts),
+		}
+		if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
+			t.Logf("label play (end): %v", err)
+		}
 	}
 }

--- a/tests/characterization/modes/rampdown_test.go
+++ b/tests/characterization/modes/rampdown_test.go
@@ -122,108 +122,118 @@ func runRampdown(t *testing.T, p runner.Platform) {
 		steps[i] = runner.Step{RateMbps: v.CapMbps, Hold: rampdownMaxHold, Variant: &v}
 	}
 
-	report := RunVariantSweep(ctx, t, sess, "rampdown", steps, time.Second,
+	// #cycles — run the descent REPS times on the SAME live play (default
+	// 3, CHAR_RAMPDOWN_REPS). Between cycles the cap jumps floor→top; the
+	// player carries its buffer + current variant across that jump, so we
+	// see how it re-converges on the descent each time (the instructive
+	// part — a single pass can't show it).
+	reps := envInt("CHAR_RAMPDOWN_REPS", 3)
+	reports := RunCycledVariantSweep(ctx, t, sess, "rampdown", steps, reps,
+		unionRungs(sweep), playID, time.Second,
 		rampdownMinHold, rampdownMaxHold, rampdownEarlyExitWindow, rampdownEarlyExitTol)
-	// We need the per-variant rung list (not the per-step list) for
-	// Finalize's classify-by-variant pass.
-	report.Variants = unionRungs(sweep)
-	if playID != "" {
-		report.PlayIDs = []string{playID}
-	}
-	report.Finalize(time.Now())
 
 	out := runner.DefaultOutDir(t.TempDir())
-	// Filename pattern: rampdown-<platform>-<player8>-<run_id>.<ext>
-	// Including the 8-char player_id prefix makes parallel runs on
-	// different devices land in distinct files without collision.
+	// Filename pattern: rampdown-<platform>-<player8>-<run_id>-cyc<n>.<ext>.
+	// The 8-char player_id prefix keeps parallel device runs distinct; the
+	// cycle suffix keeps each cycle's report in its own file.
 	playerShort := sess.PlayerID
 	if len(playerShort) > 8 {
 		playerShort = playerShort[:8]
 	}
-	base := fmt.Sprintf("rampdown-%s-%s-%s", p, playerShort, runID)
-	jsonPath, err := runner.WriteReport(out, base, report)
-	if err != nil {
-		t.Fatalf("write report: %v", err)
-	}
-	LogReport(t, jsonPath)
-	if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
-		t.Logf("chart: %s", htmlPath)
-	} else {
-		t.Logf("chart write skipped: %v", err)
-	}
-
-	// Headline findings.
-	t.Logf("lowest sustainable cap: %.3f Mbps", report.Summary.LowestSustainableCapMbps)
-	if report.Summary.HighestStallingCapMbps > 0 {
-		t.Logf("highest stalling cap:   %.3f Mbps", report.Summary.HighestStallingCapMbps)
-	}
-	t.Logf("total stalls: %d / stall seconds: %.1f / profile shifts: %d",
-		report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
-
-	// Post-sweep labels — record headline numbers on the play so they
-	// appear next to the metadata when queried later.
-	endLabels := map[string]string{
-		"completed":            time.Now().UTC().Format("20060102T150405Z"),
-		"lowest_sustainable":   fmt.Sprintf("%.3f", report.Summary.LowestSustainableCapMbps),
-		"bottom_variant_floor": fmt.Sprintf("%.3f", report.Summary.BottomVariantFloorMbps),
-		"total_stalls":         fmt.Sprintf("%d", report.Summary.TotalStalls),
-		"profile_shifts":       fmt.Sprintf("%d", report.Summary.ProfileShifts),
-	}
-	if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
-		t.Logf("label play (end): %v", err)
-	}
-
-	// Pass criteria.
-	if report.Summary.SampleCount == 0 {
-		t.Fatal("no samples collected")
-	}
-	// (1) Every variant must have been observed at some point during the
-	// sweep — proves the player actually walked the ladder.
-	missing := []string{}
-	for i, v := range report.Variants {
-		if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
-			missing = append(missing, v.Resolution)
+	var last *runner.Report
+	for ri, report := range reports {
+		cyc := ri + 1
+		last = report
+		base := fmt.Sprintf("rampdown-%s-%s-%s-cyc%d", p, playerShort, runID, cyc)
+		jsonPath, err := runner.WriteReport(out, base, report)
+		if err != nil {
+			t.Fatalf("cyc%d write report: %v", cyc, err)
 		}
-	}
-	if len(missing) > 0 {
-		t.Errorf("player did not visit every variant — missing: %v", missing)
-	}
-	t.Logf("variants visited (samples per rung): %v", report.Summary.VariantSampleCounts)
+		LogReport(t, jsonPath)
+		if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
+			t.Logf("chart: %s", htmlPath)
+		} else {
+			t.Logf("chart write skipped: %v", err)
+		}
 
-	// (2) Any stall or buffer depletion on a step whose target variant
-	// is NOT the bottom rung is a failure. At the bottom rung the player
-	// has no escape downshift, so failures there are expected when the
-	// cap drops below what that variant needs. At higher rungs a failure
-	// means the player couldn't recover fast enough by downshifting —
-	// that's the bug. We don't short-circuit; we want the recovery data
-	// in the report.
-	bottomRes := ""
-	if n := len(report.Variants); n > 0 {
-		bottomRes = report.Variants[n-1].Resolution
-	}
-	upperFailures := []string{}
-	for i := range report.Steps {
-		st := &report.Steps[i]
-		if st.Variant == nil || st.Variant.Resolution == bottomRes {
+		// Headline findings (per cycle).
+		t.Logf("cyc%d lowest sustainable cap: %.3f Mbps", cyc, report.Summary.LowestSustainableCapMbps)
+		if report.Summary.HighestStallingCapMbps > 0 {
+			t.Logf("cyc%d highest stalling cap:   %.3f Mbps", cyc, report.Summary.HighestStallingCapMbps)
+		}
+		t.Logf("cyc%d total stalls: %d / stall seconds: %.1f / profile shifts: %d",
+			cyc, report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
+
+		// Pass criteria (per cycle).
+		if report.Summary.SampleCount == 0 {
+			t.Errorf("cyc%d: no samples collected", cyc)
 			continue
 		}
-		// Skipped steps didn't actually run — zero MinBuffer is the
-		// default value, not a measured stall. Don't flag them.
-		if st.ExitReason == "skipped-player-wedged" {
-			continue
+		// (1) Every variant must have been observed at some point during the
+		// sweep — proves the player actually walked the ladder.
+		missing := []string{}
+		for i, v := range report.Variants {
+			if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
+				missing = append(missing, v.Resolution)
+			}
 		}
-		failed := st.StallsDelta > 0 || st.MinBufferS < runner.SustainableBufferS
-		if !failed {
-			continue
+		if len(missing) > 0 {
+			t.Errorf("cyc%d: player did not visit every variant — missing: %v", cyc, missing)
 		}
-		upperFailures = append(upperFailures, fmt.Sprintf(
-			"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
-			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
-			st.StallsDelta, st.MinBufferS))
+		t.Logf("cyc%d variants visited (samples per rung): %v", cyc, report.Summary.VariantSampleCounts)
+
+		// (2) Any stall or buffer depletion on a step whose target variant
+		// is NOT the bottom rung is a failure. At the bottom rung the player
+		// has no escape downshift, so failures there are expected when the
+		// cap drops below what that variant needs. At higher rungs a failure
+		// means the player couldn't recover fast enough by downshifting —
+		// that's the bug. We don't short-circuit; we want the recovery data
+		// in the report.
+		bottomRes := ""
+		if n := len(report.Variants); n > 0 {
+			bottomRes = report.Variants[n-1].Resolution
+		}
+		upperFailures := []string{}
+		for i := range report.Steps {
+			st := &report.Steps[i]
+			if st.Variant == nil || st.Variant.Resolution == bottomRes {
+				continue
+			}
+			// Skipped steps didn't actually run — zero MinBuffer is the
+			// default value, not a measured stall. Don't flag them.
+			if st.ExitReason == "skipped-player-wedged" {
+				continue
+			}
+			failed := st.StallsDelta > 0 || st.MinBufferS < runner.SustainableBufferS
+			if !failed {
+				continue
+			}
+			upperFailures = append(upperFailures, fmt.Sprintf(
+				"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
+				i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
+				st.StallsDelta, st.MinBufferS))
+		}
+		if len(upperFailures) > 0 {
+			t.Errorf("cyc%d: player stalled / depleted buffer at %d non-bottom variant(s):\n  %s",
+				cyc, len(upperFailures), joinLines(upperFailures))
+		}
 	}
-	if len(upperFailures) > 0 {
-		t.Errorf("player stalled / depleted buffer at %d non-bottom variant(s):\n  %s",
-			len(upperFailures), joinLines(upperFailures))
+
+	// Post-sweep labels — headline numbers from the LAST cycle on the play
+	// (one play, so the labels reflect the final cycle; the per-cycle
+	// reports + cycle bands carry the rest).
+	if last != nil {
+		endLabels := map[string]string{
+			"completed":            time.Now().UTC().Format("20060102T150405Z"),
+			"cycles":               fmt.Sprintf("%d", len(reports)),
+			"lowest_sustainable":   fmt.Sprintf("%.3f", last.Summary.LowestSustainableCapMbps),
+			"bottom_variant_floor": fmt.Sprintf("%.3f", last.Summary.BottomVariantFloorMbps),
+			"total_stalls":         fmt.Sprintf("%d", last.Summary.TotalStalls),
+			"profile_shifts":       fmt.Sprintf("%d", last.Summary.ProfileShifts),
+		}
+		if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
+			t.Logf("label play (end): %v", err)
+		}
 	}
 }
 

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -319,94 +319,105 @@ func runRampup(t *testing.T, p runner.Platform) {
 		steps[i] = runner.Step{RateMbps: v.CapMbps, Hold: rampdownMaxHold, Variant: &v}
 	}
 
-	report := RunVariantSweep(ctx, t, sess, "rampup", steps, time.Second,
+	// #cycles — run the climb REPS times on the SAME live play (default 3,
+	// CHAR_RAMPUP_REPS). Cycle 1 is the cold-start climb set up above; on
+	// each subsequent cycle the cap drops top→floor and the player climbs
+	// again, carrying its buffer + current variant across the drop. That
+	// inter-cycle drop is the instructive transition a single pass misses.
+	reps := envInt("CHAR_RAMPUP_REPS", 3)
+	reports := RunCycledVariantSweep(ctx, t, sess, "rampup", steps, reps,
+		unionRungs(desc), playID, time.Second,
 		rampdownMinHold, rampdownMaxHold, rampdownEarlyExitWindow, rampdownEarlyExitTol)
-	report.Variants = unionRungs(desc)
-	if playID != "" {
-		report.PlayIDs = []string{playID}
-	}
-	report.Finalize(time.Now())
 
 	out := runner.DefaultOutDir(t.TempDir())
 	playerShort := sess.PlayerID
 	if len(playerShort) > 8 {
 		playerShort = playerShort[:8]
 	}
-	base := fmt.Sprintf("rampup-%s-%s-%s", p, playerShort, runID)
-	jsonPath, err := runner.WriteReport(out, base, report)
-	if err != nil {
-		t.Fatalf("write report: %v", err)
-	}
-	LogReport(t, jsonPath)
-	if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
-		t.Logf("chart: %s", htmlPath)
-	} else {
-		t.Logf("chart write skipped: %v", err)
-	}
-
-	t.Logf("lowest sustainable cap: %.3f Mbps", report.Summary.LowestSustainableCapMbps)
-	if report.Summary.HighestStallingCapMbps > 0 {
-		t.Logf("highest stalling cap:   %.3f Mbps", report.Summary.HighestStallingCapMbps)
-	}
-	t.Logf("total stalls: %d / stall seconds: %.1f / profile shifts: %d",
-		report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
-
-	endLabels := map[string]string{
-		"completed":            time.Now().UTC().Format("20060102T150405Z"),
-		"lowest_sustainable":   fmt.Sprintf("%.3f", report.Summary.LowestSustainableCapMbps),
-		"bottom_variant_floor": fmt.Sprintf("%.3f", report.Summary.BottomVariantFloorMbps),
-		"total_stalls":         fmt.Sprintf("%d", report.Summary.TotalStalls),
-		"profile_shifts":       fmt.Sprintf("%d", report.Summary.ProfileShifts),
-	}
-	if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
-		t.Logf("label play (end): %v", err)
-	}
-
-	if report.Summary.SampleCount == 0 {
-		t.Fatal("no samples collected")
-	}
-	missing := []string{}
-	for i, v := range report.Variants {
-		if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
-			missing = append(missing, v.Resolution)
+	var last *runner.Report
+	for ri, report := range reports {
+		cyc := ri + 1
+		last = report
+		base := fmt.Sprintf("rampup-%s-%s-%s-cyc%d", p, playerShort, runID, cyc)
+		jsonPath, err := runner.WriteReport(out, base, report)
+		if err != nil {
+			t.Fatalf("cyc%d write report: %v", cyc, err)
 		}
-	}
-	if len(missing) > 0 {
-		t.Errorf("player did not visit every variant — missing: %v", missing)
-	}
-	t.Logf("variants visited (samples per rung): %v", report.Summary.VariantSampleCounts)
+		LogReport(t, jsonPath)
+		if htmlPath, err := runner.WriteChart(out, base, report); err == nil {
+			t.Logf("chart: %s", htmlPath)
+		} else {
+			t.Logf("chart write skipped: %v", err)
+		}
 
-	bottomReportRes := ""
-	if n := len(report.Variants); n > 0 {
-		bottomReportRes = report.Variants[n-1].Resolution
-	}
-	upperFailures := []string{}
-	for i := range report.Steps {
-		st := &report.Steps[i]
-		if st.Variant == nil || st.Variant.Resolution == bottomReportRes {
+		t.Logf("cyc%d lowest sustainable cap: %.3f Mbps", cyc, report.Summary.LowestSustainableCapMbps)
+		if report.Summary.HighestStallingCapMbps > 0 {
+			t.Logf("cyc%d highest stalling cap:   %.3f Mbps", cyc, report.Summary.HighestStallingCapMbps)
+		}
+		t.Logf("cyc%d total stalls: %d / stall seconds: %.1f / profile shifts: %d",
+			cyc, report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
+
+		if report.Summary.SampleCount == 0 {
+			t.Errorf("cyc%d: no samples collected", cyc)
 			continue
 		}
-		if st.ExitReason == "skipped-player-wedged" {
-			continue
+		missing := []string{}
+		for i, v := range report.Variants {
+			if i >= len(report.Summary.VariantSampleCounts) || report.Summary.VariantSampleCounts[i] == 0 {
+				missing = append(missing, v.Resolution)
+			}
 		}
-		// #650 (port of #632): only an ACTUAL stall fails a non-bottom rung.
-		// Rampup upshifts onto thin-margin peak rungs (+5% over the variant's
-		// peak), where the buffer transiently drains to min_buf=0 fetching the
-		// bigger segments and then refills without underrunning — expected ABR
-		// behaviour, not a defect. Key on real stalls, not the dip. (rampdown
-		// keeps the stricter min_buf check: a descent fills the buffer, so a
-		// dip there is genuinely suspicious.)
-		if st.StallsDelta == 0 {
-			continue
+		if len(missing) > 0 {
+			t.Errorf("cyc%d: player did not visit every variant — missing: %v", cyc, missing)
 		}
-		upperFailures = append(upperFailures, fmt.Sprintf(
-			"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
-			i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
-			st.StallsDelta, st.MinBufferS))
+		t.Logf("cyc%d variants visited (samples per rung): %v", cyc, report.Summary.VariantSampleCounts)
+
+		bottomReportRes := ""
+		if n := len(report.Variants); n > 0 {
+			bottomReportRes = report.Variants[n-1].Resolution
+		}
+		upperFailures := []string{}
+		for i := range report.Steps {
+			st := &report.Steps[i]
+			if st.Variant == nil || st.Variant.Resolution == bottomReportRes {
+				continue
+			}
+			if st.ExitReason == "skipped-player-wedged" {
+				continue
+			}
+			// #650 (port of #632): only an ACTUAL stall fails a non-bottom rung.
+			// Rampup upshifts onto thin-margin peak rungs (+5% over the variant's
+			// peak), where the buffer transiently drains to min_buf=0 fetching the
+			// bigger segments and then refills without underrunning — expected ABR
+			// behaviour, not a defect. Key on real stalls, not the dip. (rampdown
+			// keeps the stricter min_buf check: a descent fills the buffer, so a
+			// dip there is genuinely suspicious.)
+			if st.StallsDelta == 0 {
+				continue
+			}
+			upperFailures = append(upperFailures, fmt.Sprintf(
+				"step %d cap=%.3f Mbps %s/%s: stalls=%d min_buf=%.1fs",
+				i+1, st.RateMbps, st.Variant.Resolution, st.Variant.Source,
+				st.StallsDelta, st.MinBufferS))
+		}
+		if len(upperFailures) > 0 {
+			t.Errorf("cyc%d: player stalled at %d non-bottom variant(s):\n  %s",
+				cyc, len(upperFailures), joinLines(upperFailures))
+		}
 	}
-	if len(upperFailures) > 0 {
-		t.Errorf("player stalled at %d non-bottom variant(s):\n  %s",
-			len(upperFailures), joinLines(upperFailures))
+
+	if last != nil {
+		endLabels := map[string]string{
+			"completed":            time.Now().UTC().Format("20060102T150405Z"),
+			"cycles":               fmt.Sprintf("%d", len(reports)),
+			"lowest_sustainable":   fmt.Sprintf("%.3f", last.Summary.LowestSustainableCapMbps),
+			"bottom_variant_floor": fmt.Sprintf("%.3f", last.Summary.BottomVariantFloorMbps),
+			"total_stalls":         fmt.Sprintf("%d", last.Summary.TotalStalls),
+			"profile_shifts":       fmt.Sprintf("%d", last.Summary.ProfileShifts),
+		}
+		if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
+			t.Logf("label play (end): %v", err)
+		}
 	}
 
 	// Quiet the linter — preDesc is only used to compute preFloor

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -266,6 +266,61 @@ func RunVariantSweep(ctx context.Context, t *testing.T, sess *runner.Session, mo
 	return r
 }
 
+// RunCycledVariantSweep runs `steps` as a variant sweep `reps` times on the
+// SAME live play — no relaunch between cycles. Each cycle is bracketed by
+// StartCycle/EndCycle so the dashboard's cycle-band overlay separates the
+// reps, and the cap jump between the last step of one cycle and the first
+// step of the next is a real, observable transition: rampup drops top→floor,
+// rampdown jumps floor→top, pyramid floor→floor. Watching the player
+// re-converge across that jump — with buffer + current variant carried over,
+// not reset by a relaunch — is the point of running multiple cycles.
+//
+// Returns one *Report per cycle, each with its own samples (RunVariantSweep
+// starts/stops a fresh Sampler per call). `variants` is applied to every
+// report's .Variants; `playID` (when non-empty) to .PlayIDs. Finalize runs
+// per cycle. The caller writes + validates each returned report — the
+// per-mode pass criteria differ, so they stay out here.
+func RunCycledVariantSweep(
+	ctx context.Context, t *testing.T, sess *runner.Session, mode string,
+	steps []runner.Step, reps int, variants []runner.VariantRate, playID string,
+	samplePeriod, minHold, maxHold, earlyExitWindow time.Duration, earlyExitTol float64,
+) []*runner.Report {
+	t.Helper()
+	if reps < 1 {
+		reps = 1
+	}
+	reports := make([]*runner.Report, 0, reps)
+	for rep := 1; rep <= reps; rep++ {
+		// cap_mbps is "none" at the cycle level — the cap VARIES within
+		// the sweep, so the cycle label can't pin one value. Idx and Rep
+		// both track the rep counter (these cycles repeat the same sweep,
+		// not a (boundary,fault,cap) tuple).
+		if _, err := runner.StartCycle(ctx, sess, runner.CycleID{
+			Test: mode, Idx: rep, Rep: rep,
+		}); err != nil {
+			t.Logf("[%s cycle %d/%d] StartCycle: %v (band may be missing)", mode, rep, reps, err)
+		}
+		t.Logf("════ %s cycle %d/%d ════", mode, rep, reps)
+		// Fresh copy per cycle — RunVariantSweep mutates Step timing /
+		// exit fields in place, so reps must not share the backing array.
+		cycleSteps := make([]runner.Step, len(steps))
+		copy(cycleSteps, steps)
+		report := RunVariantSweep(ctx, t, sess, mode, cycleSteps, samplePeriod,
+			minHold, maxHold, earlyExitWindow, earlyExitTol)
+		report.Variants = variants
+		if playID != "" {
+			report.PlayIDs = []string{playID}
+		}
+		report.Finalize(time.Now())
+		reports = append(reports, report)
+	}
+	// Close the trailing cycle band so the archive shows a definite edge.
+	if err := runner.EndCycle(ctx, sess); err != nil {
+		t.Logf("EndCycle: %v", err)
+	}
+	return reports
+}
+
 // playerWedged returns true when the player has given up and isn't
 // recovering — distinct from "currently stalled but climbing back".
 // Two-signal check:


### PR DESCRIPTION
## Why

rampup/rampdown/pyramid each ran a **single sweep**, so the moment the player is most interesting — re-converging after the cap snaps back the other way — was never captured. Per request: default to **3 cycles** rampup/rampdown and **2** pyramid, on **one continuous play** so the inter-cycle cap jump is a real, observable transition (buffer + current variant carry across, not reset by a relaunch).

## What

- New `RunCycledVariantSweep` (sweep.go): brackets each cycle with the existing `StartCycle`/`EndCycle` labeling (cycle-band overlay separates reps), runs the sweep on a fresh per-cycle `Step` copy, returns one `*Report` per cycle.
- `CHAR_RAMPUP_REPS=3`, `CHAR_RAMPDOWN_REPS=3`, `CHAR_PYRAMID_REPS=2` (env-overridable; clamped ≥1).
- Inter-cycle transitions: rampup top→floor, rampdown floor→top, pyramid floor→floor.
- Each mode writes a per-cycle report (`…-cyc<n>.json/html`) and applies its pass criteria per cycle; end-labels carry `cycles=<n>` + the last cycle's headline numbers.
- README env-var table updated.

## Verified

`go build` + `go vet` clean across `modes/` + `runner/`; touched files gofmt-clean. Cycle labeling reuses the same `StartCycle`/`EndCycle` path already proven by startup/abort.

## Note

Runtimes scale with reps (rampdown ×3 ≈ 3× a single descent). Live multi-cycle confirmation run pending — that run is also the answer to the open "rampdown overshoot" question, since 3 descents on one play is exactly what surfaces whether the overshoot is consistent or first-cycle-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
