### PR TITLE
feat(669): qoe_downshift_overshoot — flag over-correcting downshifts

### DIFF
--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -412,6 +412,42 @@ func TestQoERateCapBreach(t *testing.T) {
 	}
 }
 
+func TestQoEDownshiftOvershoot(t *testing.T) {
+	want := qoeLabel(SevWarning, "qoe_downshift_overshoot")
+	// 3-rung ladder: 1 / 5 / 8 Mbps. Cap 8 ⇒ ceiling = rung 2 (8 Mbps).
+	ladder := `[{"bandwidth":1000000},{"bandwidth":5000000},{"bandwidth":8000000}]`
+	mk := func(cap, sel float64) *row {
+		return &row{
+			Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+			ManifestVariants: ladder, EffectiveRateLimitMbps: float32(cap), VideoBitrateMbps: float32(sel),
+		}
+	}
+	// cap 8 (ceiling rung 2), playing rung 0 (1 Mbps) → 2 rungs below → fire.
+	if got := evalQoE(mk(8, 1)); !hasLabel(got, want) {
+		t.Fatalf("2-rung overshoot (cap 8, on 1) should fire: %v", got)
+	}
+	// cap 8 (ceiling rung 2), playing rung 1 (5 Mbps) → 1 rung below → no fire (normal conservative).
+	if got := evalQoE(mk(8, 5)); hasLabel(got, want) {
+		t.Fatalf("1-rung below ceiling is normal, must not fire: %v", got)
+	}
+	// cap 8, playing rung 2 (8 Mbps) → at ceiling → no fire.
+	if got := evalQoE(mk(8, 8)); hasLabel(got, want) {
+		t.Fatalf("at-ceiling selection must not fire: %v", got)
+	}
+	// cap 5 (ceiling rung 1), playing rung 0 (1 Mbps) → 1 rung below → no fire.
+	if got := evalQoE(mk(5, 1)); hasLabel(got, want) {
+		t.Fatalf("cap lowers the ceiling — 1 rung below it must not fire: %v", got)
+	}
+	// No cap → undefined ceiling → no fire even sitting on the floor.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", ManifestVariants: ladder, VideoBitrateMbps: 1}); hasLabel(got, want) {
+		t.Fatalf("no cap should not fire overshoot: %v", got)
+	}
+	// No ladder → can't define rungs → no fire.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", EffectiveRateLimitMbps: 8, VideoBitrateMbps: 1}); hasLabel(got, want) {
+		t.Fatalf("no ladder should not fire overshoot: %v", got)
+	}
+}
+
 func TestQoECMCDMTPDrift(t *testing.T) {
 	want := qoeLabel(SevWarning, "qoe_cmcd_mtp_drift")
 	// measured 10 vs actual 4 → 150% > 50% → drift.

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -160,6 +160,9 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 	if l := rateCapBreachLabel(cfg, r); l != "" {
 		current = append(current, l)
 	}
+	if l := downshiftOvershootLabel(cfg, r); l != "" {
+		current = append(current, l)
+	}
 	if l := cmcdMTPDriftLabel(cfg, r); l != "" {
 		current = append(current, l)
 	}
@@ -384,6 +387,55 @@ func rateCapBreachLabel(cfg *QoEThresholds, r *row) string {
 	}
 	if float64(r.NetworkBitrateMbps) > limit*cfg.Network.RateCapBreachFactor {
 		return qoeLabel(SevWarning, "qoe_rate_cap_breach")
+	}
+	return ""
+}
+
+// downshiftOvershootLabel fires when the SELECTED variant sits
+// DownshiftOvershootRungs or more rungs below the rung the applied cap
+// actually supports — i.e. the player over-corrected downward (#669).
+// One rung below the ceiling is normal conservative ABR; two or more is
+// the overshoot we want flagged on rampdown / pyramid-descent runs.
+//
+// All inputs are on the row: EffectiveRateLimitMbps (applied cap),
+// parseVariantLadder(ManifestVariants) (ascending rung rates),
+// VideoBitrateMbps (selected). With no cap or no parseable ladder we
+// can't define a ceiling, so we stay silent. A selection AT or ABOVE
+// the ceiling is fine here (an above-ceiling rate is qoe_rate_cap_breach's
+// concern, not this).
+func downshiftOvershootLabel(cfg *QoEThresholds, r *row) string {
+	cap := float64(r.EffectiveRateLimitMbps)
+	if cap <= 0 {
+		return ""
+	}
+	cur := float64(r.VideoBitrateMbps)
+	if cur <= 0 {
+		return ""
+	}
+	ladder := parseVariantLadder(r.ManifestVariants)
+	if len(ladder) < 2 {
+		return "" // need ≥2 rungs for "rungs below" to mean anything
+	}
+	// ceilingIdx: highest rung whose rate ≤ cap (the rung the cap
+	// supports). If even rung 0 exceeds the cap, the ceiling is rung 0 —
+	// the player has nowhere lower to go, so it can't overshoot.
+	ceilingIdx := 0
+	for i, m := range ladder { // ascending
+		if m <= cap*1.001 {
+			ceilingIdx = i
+		} else {
+			break
+		}
+	}
+	// curIdx: rung nearest the selected bitrate.
+	curIdx, best := 0, math.Abs(ladder[0]-cur)
+	for i, m := range ladder {
+		if d := math.Abs(m - cur); d < best {
+			curIdx, best = i, d
+		}
+	}
+	if ceilingIdx-curIdx >= cfg.ABR.DownshiftOvershootRungs {
+		return qoeLabel(SevWarning, "qoe_downshift_overshoot")
 	}
 	return ""
 }

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -100,6 +100,10 @@ type QoEThresholds struct {
 		// rung under high throughput is expected, not a defect — so those
 		// labels are suppressed to avoid startup false positives. #595.
 		StartupGraceMs uint32 `json:"startup_grace_ms"`
+		// Selected variant sitting ≥ this many rungs below the rung the
+		// applied cap supports ⇒ qoe_downshift_overshoot (#669). 1 rung
+		// below is normal conservative ABR; 2+ is over-correction.
+		DownshiftOvershootRungs int `json:"downshift_overshoot_rungs"`
 	} `json:"abr"`
 
 	// Live-edge label thresholds (#553). Margins are seconds BEYOND the
@@ -137,8 +141,9 @@ func qoeDefaults() *QoEThresholds {
 	t.ABR.DownshiftStormThreshold = 3
 	t.ABR.DownshiftStormWindowS = 30
 	t.ABR.MinVariantStuckS = 30
-	t.ABR.FPSDipRatio = 0.2      // displayed fps < 80% of nominal
-	t.ABR.StartupGraceMs = 10000 // suppress abr/throughput labels for the first 10s of playback
+	t.ABR.FPSDipRatio = 0.2           // displayed fps < 80% of nominal
+	t.ABR.StartupGraceMs = 10000      // suppress abr/throughput labels for the first 10s of playback
+	t.ABR.DownshiftOvershootRungs = 2 // ≥2 rungs below the cap-supported ceiling ⇒ overshoot (#669)
 	t.Live.OffsetConcerningMarginS = 3
 	t.Live.OffsetBreachMarginS = 10
 	t.Live.HoldbackDeviationS = 2


### PR DESCRIPTION
Closes #669

## What

A derived QoE label that flags when the **selected variant sits ≥2 rungs below the rung the applied cap supports** — the rampdown/pyramid-descent overshoot that had no queryable signal (shift_down = event count, qoe_downshift_storm = frequency; neither captures depth).

`downshiftOvershootLabel` (qoe_labels.go), modeled on `qoe_rate_cap_breach` — every input already on the row, no new ingest field, no client/schema change:
- `EffectiveRateLimitMbps` → ceiling rung (highest whose rate ≤ cap)
- `VideoBitrateMbps` → current rung (nearest ladder rate)
- fires `warning=*qoe_downshift_overshoot` when `ceiling - current ≥ ABR.DownshiftOvershootRungs` (default **2**; one rung below is normal conservative ABR)
- no cap / <2 rungs / at-or-above ceiling → silent

## Tests

`TestQoEDownshiftOvershoot`: 2-rung fire, 1-rung no-fire, at-ceiling, cap-lowered ceiling, no-cap, no-ladder. Full forwarder suite + vet green; gofmt clean.

## Scope notes

The issue listed dashboard-vocab + standards-catalogue updates — both are **no-ops**: nothing enumerates qoe labels (no per-label cause/effect map in dashboard-v3, nothing in `.claude/standards`). The `warning=*` chip renders and `--label-has` filters generically off the severity prefix.

## Deploy / verify

Forwarder-only: `make analytics-rebuild-forwarder` (no go-server restart). Then a rampdown/pyramid-descent run where the player drops ≥2 rungs below the cap ceiling carries `*qoe_downshift_overshoot`, queryable via `--label-has warning=*qoe_downshift_overshoot`. Complements the multi-cycle run from #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
