### PR TITLE
feat(671): emit archivable server_start control_event on boot

### DIFF
--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -990,8 +990,9 @@ source
                  'proxy'   = runtime auto-transition (fault loop, pattern
                              step advance, loop_server detection,
                              proxy-detected session_end)
-                 'auto'    = automated test runner (placeholder; no emit
-                             path yet)
+                 'auto'    = server-driven lifecycle, not operator or
+                             runtime-transition. Today: server_start
+                             (proxy boot marker, #671).
   gotchas:     'harness' events are the ones to subpoena when investigating
                "why did the network change at 15:42:30" — they're the
                operator-or-script-driven mutations. 'proxy' events are
@@ -1127,6 +1128,24 @@ session_start                [harness | proxy]
 session_end                  [harness | proxy]
   meaning:     session lifecycle ended. Last row for this session.
   label:       info=*session_end
+
+server_start                 [auto]
+  meaning:     the go-proxy process (re)started. Emitted once on boot
+               after shape restoration. GLOBAL — no player_id/play_id/
+               session_id, so it does NOT attach to any one play's
+               timeline; query it session-less (see gotchas).
+  info:        restored=N;skipped=M;baseline_mbps=B — the
+               restoreShapeApplication counts (how many sessions had
+               their tc cap re-installed on boot).
+  label:       info=*server_start
+  gotchas:     this is the marker to correlate a ~line-rate throughput
+               spike against: between boot and shape restoration, session
+               ports run unshaped (no tc filter yet) → a spike landing
+               just after a server_start is a redeploy artifact, not a
+               shaper bug (#671). Because it has no player_id,
+               `harness query control <play>` won't surface it — use
+               `harness raw GET "/analytics/api/v2/control_events?event=server_start"`
+               or filter plays by `--label-has info=*server_start`.
 
 control_change               [harness | proxy] [debug]
   meaning:     generic fallback when the changed field hasn't been

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -673,6 +673,11 @@ func computeControlLabels(r *ctrlRow) []string {
 		return out
 	case "content_changed":
 		return []string{SevInfo + "=" + synthMark + "content_changed"}
+	case "server_start":
+		// Proxy restart/boot marker (#671). Global (no player_id) — info
+		// carries restored/skipped/baseline_mbps. info-tier so it never
+		// tints a row, but is filterable via `--label-has info=*server_start`.
+		return []string{SevInfo + "=" + synthMark + "server_start"}
 	case "session_start":
 		return []string{SevInfo + "=" + synthMark + "session_start"}
 	case "session_end":

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -1164,7 +1164,8 @@ components:
           description: |
             Closed-set action name. See issue #474 for the full vocab —
             e.g. `fault_on`, `pattern_step`, `loop_server`,
-            `fault_rule_enabled`, `session_start`, `session_end`.
+            `fault_rule_enabled`, `session_start`, `session_end`,
+            `server_start`.
         info:
           type: string
           description: |

--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -1165,7 +1165,8 @@ components:
           description: |
             Closed-set action name. See issue #474 for the full vocab —
             e.g. `fault_on`, `pattern_step`, `loop_server`,
-            `fault_rule_enabled`, `session_start`, `session_end`.
+            `fault_rule_enabled`, `session_start`, `session_end`,
+            `server_start`.
         info:
           type: string
           description: |

--- a/go-proxy/cmd/server/control_server_start_test.go
+++ b/go-proxy/cmd/server/control_server_start_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestControlHubServerStartReplay verifies the boot marker is replayed to a
+// client that subscribes AFTER it was broadcast. The restart that produces the
+// marker is the same event that drops the forwarder's SSE subscription, so the
+// forwarder always reconnects after the marker is emitted — without sticky
+// replay the server_start would be lost and the restart unattributable. #671.
+func TestControlHubServerStartReplay(t *testing.T) {
+	h := NewControlEventHub()
+
+	// Restart just dropped every subscriber: broadcast into zero clients.
+	h.BroadcastServerStart(ControlEvent{
+		Ts:     time.Now().UTC(),
+		Source: "auto",
+		Event:  "server_start",
+		Info:   "restored=2;skipped=1;baseline_mbps=0",
+	})
+
+	// Forwarder reconnects afterwards — it must still receive the marker.
+	_, ch := h.AddClient(8)
+	select {
+	case ev := <-ch:
+		if ev.Event != "server_start" {
+			t.Fatalf("replayed event = %q, want server_start", ev.Event)
+		}
+		if ev.Source != "auto" {
+			t.Fatalf("replayed source = %q, want auto", ev.Source)
+		}
+		if ev.Info != "restored=2;skipped=1;baseline_mbps=0" {
+			t.Fatalf("replayed info = %q, want the boot counts", ev.Info)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("late subscriber did not receive replayed server_start marker")
+	}
+}
+
+// TestControlHubServerStartLiveBroadcast verifies an already-connected client
+// also receives the marker via the normal fanout (not only the replay path).
+func TestControlHubServerStartLiveBroadcast(t *testing.T) {
+	h := NewControlEventHub()
+	_, ch := h.AddClient(8)
+	h.BroadcastServerStart(ControlEvent{Ts: time.Now().UTC(), Source: "auto", Event: "server_start"})
+	select {
+	case ev := <-ch:
+		if ev.Event != "server_start" {
+			t.Fatalf("event = %q, want server_start", ev.Event)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("connected client did not receive server_start")
+	}
+}
+
+// TestControlHubOrdinaryNotSticky verifies ordinary control events are NOT
+// replayed to later subscribers — only the boot marker is sticky, so a
+// reconnecting forwarder doesn't get a stale flood of past session events.
+func TestControlHubOrdinaryNotSticky(t *testing.T) {
+	h := NewControlEventHub()
+	h.Broadcast(ControlEvent{Ts: time.Now().UTC(), Source: "proxy", Event: "session_start"})
+	_, ch := h.AddClient(8)
+	select {
+	case ev := <-ch:
+		t.Fatalf("late subscriber unexpectedly received %q; ordinary events must not be sticky", ev.Event)
+	case <-time.After(100 * time.Millisecond):
+		// expected: nothing replayed
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -552,6 +552,13 @@ type ControlEventHub struct {
 	mu      sync.Mutex
 	nextID  int
 	clients map[int]*ControlClient
+	// lastServerStart holds the most recent server_start boot marker so it
+	// can be replayed to clients that subscribe AFTER boot. The restart
+	// that produces the marker is the same event that drops the forwarder's
+	// SSE subscription, and Broadcast to zero clients is a no-op — so
+	// without replay the marker would be lost before the forwarder
+	// reconnects. Set via BroadcastServerStart, replayed in AddClient. #671.
+	lastServerStart *ControlEvent
 }
 
 type ControlClient struct {
@@ -586,6 +593,15 @@ func (h *ControlEventHub) AddClient(buffer int) (int, <-chan ControlEvent) {
 	id := h.nextID
 	c := &ControlClient{ch: make(chan ControlEvent, buffer)}
 	h.clients[id] = c
+	// Replay the sticky boot marker so a forwarder reconnecting after a
+	// restart still archives the server_start. The channel was just created
+	// with room, so this never blocks. #671.
+	if h.lastServerStart != nil {
+		select {
+		case c.ch <- *h.lastServerStart:
+		default:
+		}
+	}
 	return id, c.ch
 }
 
@@ -623,6 +639,18 @@ func (h *ControlEventHub) Broadcast(ev ControlEvent) {
 			}
 		}
 	}
+}
+
+// BroadcastServerStart records the boot marker as sticky (replayed to every
+// future subscriber by AddClient) and broadcasts it to any client already
+// connected. Separate from Broadcast so only the boot marker is retained —
+// ordinary control events are not stickied. #671.
+func (h *ControlEventHub) BroadcastServerStart(ev ControlEvent) {
+	h.mu.Lock()
+	stored := ev
+	h.lastServerStart = &stored
+	h.mu.Unlock()
+	h.Broadcast(ev)
 }
 
 // AVMetricEventHub fans out iOS 18 AVMetrics raw events (issue #486) to
@@ -1968,7 +1996,11 @@ func main() {
 	// survived the proxy restart. Without this, pre-existing sessions
 	// keep their session-map values but the kernel forgot — they end
 	// up uncapped. Issue #480.
-	app.restoreShapeApplication()
+	restoredShapes, skippedShapes := app.restoreShapeApplication()
+	// Record the restart as an archivable control_event so a cap-drop spike
+	// landing in the boot restore window is attributable to a redeploy rather
+	// than a shaper bug. Sticky-replayed to the forwarder on reconnect. #671.
+	app.emitServerStart(restoredShapes, skippedShapes)
 	// 100 ms TCP_INFO sampler — folds smoothed RTT / jitter / lifetime
 	// min / RTO into per-session windows that get drained on each
 	// snapshot broadcast (issue #401). Linux-only kernel read; the
@@ -2250,6 +2282,26 @@ func (a *App) emitControlEventForSession(sessionID, source, event, info string) 
 		Source:    source,
 		Event:     event,
 		Info:      info,
+	})
+}
+
+// emitServerStart records a global (session-less) boot marker into
+// control_events so a proxy restart is correlatable with the cap-drop spikes
+// it can produce (the restore window before restoreShapeApplication re-installs
+// each port's tc filter — see #671). source=auto: server-driven, not operator
+// or harness. Carries the shape-restoration counts so an operator can see how
+// many sessions were re-capped on boot. Goes through BroadcastServerStart so
+// the forwarder still archives it after its SSE reconnects post-restart.
+func (a *App) emitServerStart(restored, skipped int) {
+	if a == nil || a.controlHub == nil {
+		return
+	}
+	info := fmt.Sprintf("restored=%d;skipped=%d;baseline_mbps=%d", restored, skipped, a.defaultRateMbps)
+	a.controlHub.BroadcastServerStart(ControlEvent{
+		Ts:     time.Now().UTC(),
+		Source: "auto",
+		Event:  "server_start",
+		Info:   info,
 	})
 }
 
@@ -4319,12 +4371,11 @@ func (a *App) restoreTransportFaultSchedules() {
 // pre-existed the restart end up running uncapped, which silently
 // breaks both operator-set rate overrides and the deployment baseline
 // cap (issue #480). Matches restoreTransportFaultSchedules' pattern.
-func (a *App) restoreShapeApplication() {
+func (a *App) restoreShapeApplication() (restored, skipped int) {
 	if a.traffic == nil {
-		return
+		return 0, 0
 	}
 	seenPorts := map[int]struct{}{}
-	restored, skipped := 0, 0
 	for _, session := range a.getSessionList() {
 		portStr := getString(session, "x_forwarded_port")
 		if portStr == "" {
@@ -4350,6 +4401,7 @@ func (a *App) restoreShapeApplication() {
 		restored++
 	}
 	log.Printf("shape restoration on boot: restored=%d skipped=%d baseline_mbps=%d", restored, skipped, a.defaultRateMbps)
+	return restored, skipped
 }
 
 func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -545,7 +545,8 @@ type ControlEventRow struct {
 
 	// Event Closed-set action name. See issue #474 for the full vocab —
 	// e.g. `fault_on`, `pattern_step`, `loop_server`,
-	// `fault_rule_enabled`, `session_start`, `session_end`.
+	// `fault_rule_enabled`, `session_start`, `session_end`,
+	// `server_start`.
 	Event string `json:"event"`
 
 	// EventFingerprint FNV-64a hash over (player, play, ts_ms, source, event, info).


### PR DESCRIPTION
Part 1 of #671. Makes proxy restarts visible/archivable so a ~line-rate (≈100 Mbps) spike landing in the boot **restore window** is attributable to a redeploy rather than mistaken for a shaper bug.

## What changed
- **go-proxy** emits a global (session-less) `server_start` control_event on boot, `source=auto`, `info=restored=N;skipped=M;baseline_mbps=B` (the `restoreShapeApplication` counts).
- **Sticky-replay**: the restart drops the forwarder's SSE subscription, and `Broadcast` to zero clients is a no-op — so a naive emit at boot would be lost before the forwarder reconnects. `ControlEventHub` now retains the last `server_start` and replays it to each newly-subscribed client (`AddClient`). Ordinary events are *not* stickied.
- **forwarder** labels it `info=*server_start` (info-tier — filterable via `--label-has info=*server_start`, never tints a row).

## Why it's safe
- Empty `player_id` is archived fine (`entryToCtrlRow` → `canonicalV2ID("")`); the event persists, just unattached to a session timeline.
- `info` uses `;` separators and is only stored verbatim — `computeControlLabels` parses `info` only for `label_changed`, so no label-encoding pitfall.

## Tests
`TestControlHubServerStartReplay` (subscribe-after-broadcast still receives it), `TestControlHubServerStartLiveBroadcast` (connected client gets it live), `TestControlHubOrdinaryNotSticky` (ordinary events don't stick). go-proxy + forwarder `go build`/`go vet` clean.

## Not in this PR (remaining #671 scope)
2. default-class `1:999` hardening (bounds traffic during the restore window).
3. server_behavior restart-window cap-holds test.
4. (follow-up) dashboard rail-marker overlay for player_id-less global events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
