### PR TITLE
fix(657): clear-cooldown re-arm + server-rate re-base for loud QoE labels

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -135,6 +135,12 @@ type playLabelState struct {
 	// The terminal row force-emits the still-true set so the summary +
 	// qoe_tier_* reflect end state. nil until first use.
 	qoeActive map[string]struct{}
+	// #657 — clear-cooldown re-arm. qoeLastOn records the last row-time each
+	// qoe label was TRUE. A rising edge re-fires only if the label has been
+	// off for ≥ RefireCooldownS since that time, so a condition that flaps
+	// above/below its threshold within the cooldown counts as one episode
+	// (one chip) instead of re-chipping on every re-crossing. nil until use.
+	qoeLastOn map[string]time.Time
 	// LRU touch for GC.
 	seen time.Time
 }

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -365,13 +365,19 @@ func TestQoEThroughputDivergence(t *testing.T) {
 	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 10, MbpsTransferRate: 10}); hasLabel(got, want) {
 		t.Fatalf("matching throughput should not diverge: %v", got)
 	}
-	// nb 5 vs peak 10 → 50% > 15% → diverge.
+	// nb 5 under server peak 10 → client under-read by 50% > 15% → diverge.
 	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 5, MbpsTransferRate: 10}); !hasLabel(got, want) {
-		t.Fatalf("nb 5 vs peak 10 should diverge: %v", got)
+		t.Fatalf("nb 5 under server peak 10 should diverge: %v", got)
 	}
-	// nb 5 vs cap 10 (no server peak) → diverge via limit branch.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 5, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
-		t.Fatalf("nb 5 vs cap 10 should diverge: %v", got)
+	// #657: the over-read direction (nb 30 >> server peak 10, the AVPlayer
+	// burst quirk) is no longer divergence — it was the per-heartbeat noise.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 30, MbpsTransferRate: 10}); hasLabel(got, want) {
+		t.Fatalf("over-read (nb 30 vs peak 10) must not diverge post-#657: %v", got)
+	}
+	// #657: with no server peak (transfer rate 0) the cap is no longer a
+	// divergence baseline — there's nothing server-side to compare against.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", PlayingTimeMs: 10000, NetworkBitrateMbps: 5, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
+		t.Fatalf("cap-only comparison dropped in #657; should not diverge: %v", got)
 	}
 }
 
@@ -402,13 +408,22 @@ func TestQoEAbrStartupGate(t *testing.T) {
 
 func TestQoERateCapBreach(t *testing.T) {
 	want := qoeLabel(SevWarning, "qoe_rate_cap_breach")
-	// 12 > 10*1.10=11 → breach.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
-		t.Fatalf("12 over cap 10 should breach: %v", got)
+	// #657: gate on the kernel-measured served rate. 12 > 10*1.10=11 → breach.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("served 12 over cap 10 should breach: %v", got)
+	}
+	// Fallback to the proxy per-segment transfer rate when nftables is absent.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", MbpsTransferRate: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("transfer-rate fallback 12 over cap 10 should breach: %v", got)
 	}
 	// 10.5 < 11 → no breach.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 10.5, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
-		t.Fatalf("10.5 within factor should not breach: %v", got)
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 10.5, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
+		t.Fatalf("served 10.5 within factor should not breach: %v", got)
+	}
+	// #657: a client network_bitrate over-read (30) must NOT breach when the
+	// server actually delivered under the cap (the whole point of the re-base).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NetworkBitrateMbps: 30, MbpsTransferRate: 9, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
+		t.Fatalf("client over-read must not breach post-#657: %v", got)
 	}
 }
 
@@ -647,9 +662,18 @@ func TestQoEReFiresOnNewInstance(t *testing.T) {
 	if got := computeEventLabelsWithState(s, cold("2026-06-03 00:00:03.000")); hasLabel(got, want) {
 		t.Fatalf("cleared row must not emit %s: %v", want, got)
 	}
-	// Cleared then true again = a new instance → re-emit.
-	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:04.000")); !hasLabel(got, want) {
-		t.Fatalf("recurrence after clearing should re-emit %s: %v", want, got)
+	// #657: a recurrence WITHIN the 30s clear-cooldown is the same episode
+	// flapping (last true at :02, recurs at :10 = 8s clear) → stay suppressed.
+	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:10.000")); hasLabel(got, want) {
+		t.Fatalf("recurrence within cooldown must stay suppressed %s: %v", want, got)
+	}
+	// Clear again, then recur AFTER the cooldown elapses (last true at :10,
+	// recurs at :45 = 35s clear ≥ 30s) → genuinely new episode → re-emit.
+	if got := computeEventLabelsWithState(s, cold("2026-06-03 00:00:11.000")); hasLabel(got, want) {
+		t.Fatalf("cleared row must not emit %s: %v", want, got)
+	}
+	if got := computeEventLabelsWithState(s, hot("2026-06-03 00:00:45.000")); !hasLabel(got, want) {
+		t.Fatalf("recurrence after cooldown should re-emit %s: %v", want, got)
 	}
 }
 

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -164,14 +164,23 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 		current = append(current, l)
 	}
 
-	// ── Edge-trigger: emit rising edges, re-arm the active set ─────────
-	// A label not in qoeActive is a new occurrence (first determination,
-	// or a recurrence after it cleared) → emit. One already active is the
-	// same instance persisting → suppress. Rebuild qoeActive from `current`
-	// so a condition going false re-arms it for next time. #595.
+	// ── Edge-trigger + clear-cooldown re-arm ──────────────────────────
+	// A label not in qoeActive is a rising edge (first determination, or a
+	// recurrence after it cleared). Edge-triggering alone (#595) still
+	// re-chips on EVERY rising edge, so a noisy condition that flaps above/
+	// below its threshold spawns a chip per re-crossing. The cooldown gates
+	// re-fires: a rising edge emits only if the label has been off for
+	// ≥ RefireCooldownS since it was last true (qoeLastOn) — so a flapping
+	// episode is one chip, not dozens. A continuously-true label stays
+	// suppressed; a condition going false re-arms it once the cooldown
+	// elapses. #595, #657.
 	if ps.qoeActive == nil {
 		ps.qoeActive = make(map[string]struct{})
 	}
+	if ps.qoeLastOn == nil {
+		ps.qoeLastOn = make(map[string]time.Time)
+	}
+	cooldown := time.Duration(cfg.RefireCooldownS) * time.Second
 	prevActive := ps.qoeActive
 	next := make(map[string]struct{}, len(current))
 	var out []string
@@ -181,18 +190,27 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 		}
 		next[l] = struct{}{}
 		if _, on := prevActive[l]; !on {
-			out = append(out, l)
+			// Rising edge — emit only if never fired or clear for ≥ cooldown.
+			if last, seen := ps.qoeLastOn[l]; !seen || now.Sub(last) >= cooldown {
+				out = append(out, l)
+			}
 		}
+		ps.qoeLastOn[l] = now // true on this row — extend the episode
 	}
 	ps.qoeActive = next
 
 	// ── Terminal row: summary (current-at-end) + outcome + tier ────────
 	if firstTerminal {
-		// Force-emit the still-true conditions that edge-triggering
-		// suppressed above, so the summary row carries the full
-		// current-at-end set and qoe_tier_* below reads a correct set.
+		// Force-emit every still-true condition not already emitted this row
+		// (edge-trigger AND cooldown both suppress repeats), so the summary
+		// row carries the full current-at-end set and qoe_tier_* reads it right.
+		emitted := make(map[string]struct{}, len(out))
+		for _, l := range out {
+			emitted[l] = struct{}{}
+		}
 		for _, l := range current {
-			if _, on := prevActive[l]; on {
+			if _, e := emitted[l]; !e {
+				emitted[l] = struct{}{}
 				out = append(out, l)
 			}
 		}
@@ -350,11 +368,16 @@ func fpsDipLabel(cfg *QoEThresholds, r *row) string {
 	return ""
 }
 
-// throughputDivergenceLabel fires when the client-reported network
-// bitrate diverges by more than ThroughputDivergenceFactor from EITHER
-// the recent-peak server-measured throughput OR the provisioned cap.
-// Always records the current server throughput into the windowed peak
-// trail (even when network_bitrate is absent, so the peak is warm).
+// throughputDivergenceLabel fires when the client measured MATERIALLY LESS
+// throughput than the server actually delivered — nb < recent server-peak ×
+// (1 - ThroughputDivergenceFactor). Only this under-read direction is kept:
+// the over-read direction (client bitrate >> server, the AVPlayer burst quirk;
+// see reference_ios_avg_bitrate_overreads) was the bulk of the per-heartbeat
+// noise and is not a delivery problem, so it no longer trips this label. The
+// under-read is a genuine client/server disagreement — the client believes it
+// has less bandwidth than was delivered, which can drive over-conservative ABR.
+// Always records the current server throughput into the windowed peak trail
+// (even when network_bitrate is absent) so the peak stays warm. #657.
 func throughputDivergenceLabel(cfg *QoEThresholds, ps *playLabelState, r *row, now time.Time) string {
 	window := time.Duration(cfg.ABR.ThroughputPeakWindowS) * time.Second
 	var peak float64
@@ -365,24 +388,34 @@ func throughputDivergenceLabel(cfg *QoEThresholds, ps *playLabelState, r *row, n
 		return "" // no responsive client measurement to compare
 	}
 	factor := cfg.ABR.ThroughputDivergenceFactor
-	if peak > 0 && math.Abs(nb-peak)/peak > factor {
-		return qoeLabel(SevWarning, "qoe_throughput_divergence")
-	}
-	if limit := float64(r.EffectiveRateLimitMbps); limit > 0 && math.Abs(nb-limit)/limit > factor {
+	if peak > 0 && nb < peak*(1-factor) {
 		return qoeLabel(SevWarning, "qoe_throughput_divergence")
 	}
 	return ""
 }
 
-// rateCapBreachLabel fires when the observed client network bitrate
-// exceeds the effective cap by more than RateCapBreachFactor. Uses the
-// instantaneous network_bitrate (not the iOS avg, which over-reads).
+// rateCapBreachLabel fires when the SERVER actually delivered above the
+// effective cap by more than RateCapBreachFactor. The cap is kernel-enforced
+// (tc/nftables), so it can't be breached at the wire by the client — the
+// client's network_bitrate over-reads 2-3× the cap on AVPlayer burst (a known
+// quirk, not a breach; see reference_ios_avg_bitrate_overreads). So we gate on
+// the kernel-measured served rate (nftables_bandwidth_mbps), falling back to
+// the proxy's per-segment transfer rate — making this a real over-delivery /
+// shaping-failure detector (e.g. the boot restore-window spike, #671) instead
+// of a per-heartbeat over-read alarm. #657.
 func rateCapBreachLabel(cfg *QoEThresholds, r *row) string {
 	limit := float64(r.EffectiveRateLimitMbps)
 	if limit <= 0 {
 		return ""
 	}
-	if float64(r.NetworkBitrateMbps) > limit*cfg.Network.RateCapBreachFactor {
+	served := float64(r.NftablesBandwidthMbps)
+	if served <= 0 {
+		served = float64(r.MbpsTransferRate)
+	}
+	if served <= 0 {
+		return ""
+	}
+	if served > limit*cfg.Network.RateCapBreachFactor {
 		return qoeLabel(SevWarning, "qoe_rate_cap_breach")
 	}
 	return ""

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -32,6 +32,15 @@ import (
 type QoEThresholds struct {
 	Version string `json:"version"`
 
+	// RefireCooldownS — a level/sticky qoe_* label that has fired won't
+	// re-fire until its condition has stayed FALSE for at least this many
+	// seconds. Edge-triggering alone (#595) still re-chips on every rising
+	// edge, so a noisy condition that flaps above/below its threshold (e.g.
+	// the AVPlayer bitrate over-read crossing the cap repeatedly) produces
+	// dozens of chips for ONE episode. The cooldown collapses a flapping
+	// episode into a single label. 0 disables (pure edge-trigger). #657.
+	RefireCooldownS uint32 `json:"refire_cooldown_s"`
+
 	Outcomes struct {
 		// EBVSThresholdMs — wait (in ms) before an in-progress
 		// startup session is classified as abandoned_start (EBVS).
@@ -115,6 +124,7 @@ type QoEThresholds struct {
 // Override values in qoe_thresholds.json or via env var.
 func qoeDefaults() *QoEThresholds {
 	t := &QoEThresholds{Version: "1.0"}
+	t.RefireCooldownS = 30                        // one chip per episode; re-fire only after 30s clear
 	t.Outcomes.EBVSThresholdMs = 10000            // Conviva "good"
 	t.Outcomes.UserStoppedAfterThresholdMs = 5000 // 5s = substantial-watch threshold
 	t.Startup.VSTConcerningMs = 5000              // Conviva "best"
@@ -175,6 +185,9 @@ func loadQoEThresholds(path string) *QoEThresholds {
 		log.Printf("[QoE] override version mismatch (got %q, expected %q) — using compiled defaults", override.Version, cfg.Version)
 		logQoEResolved(cfg)
 		return cfg
+	}
+	if override.RefireCooldownS != 0 {
+		cfg.RefireCooldownS = override.RefireCooldownS
 	}
 	if override.Outcomes.EBVSThresholdMs != 0 {
 		cfg.Outcomes.EBVSThresholdMs = override.Outcomes.EBVSThresholdMs
@@ -263,6 +276,7 @@ func loadQoEThresholds(path string) *QoEThresholds {
 }
 
 func logQoEResolved(cfg *QoEThresholds) {
+	log.Printf("[QoE]   refire_cooldown_s=%d", cfg.RefireCooldownS)
 	log.Printf("[QoE]   outcomes.ebvs_threshold_ms=%d", cfg.Outcomes.EBVSThresholdMs)
 	log.Printf("[QoE]   outcomes.user_stopped_after_threshold_ms=%d", cfg.Outcomes.UserStoppedAfterThresholdMs)
 	log.Printf("[QoE]   startup.vst_concerning_ms=%d vst_breach_ms=%d", cfg.Startup.VSTConcerningMs, cfg.Startup.VSTBreachMs)


### PR DESCRIPTION
Recalibrates the three loudest QoE labels at the source (`qoe_rate_cap_breach`, `qoe_throughput_divergence`, `qoe_live_offset_concerning`). Backend-only (forwarder). Improves every label surface — sessions chips, SessionDisplay, classification — at once.

## Why they were loud
They were *already* edge-triggered (#595 `qoeActive`), so "filed before #595" — the residual problem was **flapping**: they key off noisy instantaneous signals (the AVPlayer bitrate over-read crossing the cap repeatedly), and edge-triggering re-fires on *every* re-crossing → dozens of chips for one episode.

## Fix 1 — clear-cooldown re-arm
A fired label can't re-fire until its condition has stayed FALSE for ≥ `refire_cooldown_s` (new threshold knob, default 30s). A flapping episode → one chip. New `qoeLastOn` state tracks last-true time; the terminal summary now force-emits the full current-at-end set so cooldown-suppressed conditions still appear on the summary row + feed `qoe_tier_*`.

## Fix 2 — re-base on server-measured rate
The cap is kernel-enforced (tc/nftables), so the client `network_bitrate` over-reading 2-3× the cap is a known AVPlayer burst quirk, not a breach (`reference_ios_avg_bitrate_overreads`).
- **`qoe_rate_cap_breach`** now gates on `nftables_bandwidth_mbps` (fallback `mbps_transfer_rate`) > cap — a real over-delivery / shaping-failure detector (e.g. the #671 boot restore-window spike) instead of a per-heartbeat over-read alarm.
- **`qoe_throughput_divergence`** keeps only the actionable **under-read** direction (client measured materially less than the server delivered → can drive over-conservative ABR); the over-read direction that produced the bulk of the noise no longer fires.

## Tests
`labels_test.go` updated to the new contract: throughput over-read suppressed + cap-only dropped; rate-cap gated on served rate with transfer-rate fallback + a client-over-read-must-not-breach guard; re-fires test now covers within-cooldown suppression AND post-cooldown re-fire. Full forwarder suite + `go vet` + gofmt clean.

## Relationship to #671
This is the dashboard-label side; #671 is the server side (emit the restart marker + bound the restore window). Together: #671 makes the restart visible, #657 surfaces the resulting over-delivery as a chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
