### PR TITLE
fix(671): make session-less control events (server_start) readable by harness + AI

### DIFF
--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -1142,10 +1142,13 @@ server_start                 [auto]
                spike against: between boot and shape restoration, session
                ports run unshaped (no tc filter yet) → a spike landing
                just after a server_start is a redeploy artifact, not a
-               shaper bug (#671). Because it has no player_id,
-               `harness query control <play>` won't surface it — use
-               `harness raw GET "/analytics/api/v2/control_events?event=server_start"`
-               or filter plays by `--label-has info=*server_start`.
+               shaper bug (#671). It has no player_id, so query it by event
+               (the control_events read path no longer requires player_id
+               when an event/label filter is given, #671):
+                 `harness query control --event server_start`
+               or `harness raw GET "/analytics/api/v2/control_events?event=server_start"`.
+               (`harness query control <play>` is the per-player form; a
+               session-less event won't appear under any play.)
 
 control_change               [harness | proxy] [debug]
   meaning:     generic fallback when the changed field hasn't been

--- a/analytics/go-forwarder/internal/plays/control.go
+++ b/analytics/go-forwarder/internal/plays/control.go
@@ -7,13 +7,16 @@ import (
 	"strings"
 )
 
-// ControlEventsFilter narrows a control_events query. PlayerID is
-// required (the table is indexed on it and every operational view
-// scopes to a player); the other fields are optional narrowings.
+// ControlEventsFilter narrows a control_events query. At least one of
+// PlayerID / PlayID / Events / Labels.Has must be set (so the query can
+// never scan the whole table); the rest are optional narrowings. PlayerID
+// is the usual key, but a global / session-less event (e.g. server_start,
+// which carries no player_id, #671) is reachable via Events or Labels.Has.
 type ControlEventsFilter struct {
 	PlayerID string
 	PlayID   string
-	From     string // CH datetime string
+	Events   []string // filter to these event names (OR); enables session-less lookups
+	From     string   // CH datetime string
 	To       string
 	Labels   LabelFilter
 	Limit    int // 0 = use default (1000)
@@ -32,8 +35,9 @@ const (
 // order). Caller is expected to canonicalise PlayerID/PlayID before
 // calling — matches the HTTP handler's contract.
 func GetControlEvents(ctx context.Context, b Backend, f ControlEventsFilter) ([]map[string]any, error) {
-	if f.PlayerID == "" {
-		return nil, errors.New("player_id required")
+	// At least one discriminating predicate, else we'd scan the whole table.
+	if f.PlayerID == "" && f.PlayID == "" && len(f.Events) == 0 && len(f.Labels.Has) == 0 {
+		return nil, errors.New("one of player_id, play_id, event, or labels_has required")
 	}
 	limit := f.Limit
 	if limit <= 0 {
@@ -43,14 +47,24 @@ func GetControlEvents(ctx context.Context, b Backend, f ControlEventsFilter) ([]
 		limit = maxControlEventsLimit
 	}
 
-	params := map[string]string{
-		"player_id": f.PlayerID,
-		"limit":     fmt.Sprintf("%d", limit),
+	params := map[string]string{"limit": fmt.Sprintf("%d", limit)}
+	var where []string
+	if f.PlayerID != "" {
+		params["player_id"] = f.PlayerID
+		where = append(where, "player_id = {player_id:String}")
 	}
-	where := []string{"player_id = {player_id:String}"}
 	if f.PlayID != "" {
 		params["play_id"] = f.PlayID
 		where = append(where, "play_id = {play_id:String}")
+	}
+	if len(f.Events) > 0 {
+		names := make([]string, len(f.Events))
+		for i, ev := range f.Events {
+			key := "event_" + fmt.Sprintf("%d", i)
+			params[key] = ev
+			names[i] = "{" + key + ":String}"
+		}
+		where = append(where, "event IN ("+strings.Join(names, ", ")+")")
 	}
 	if f.From != "" {
 		params["from"] = f.From

--- a/analytics/go-forwarder/internal/plays/control_test.go
+++ b/analytics/go-forwarder/internal/plays/control_test.go
@@ -1,0 +1,22 @@
+package plays
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestGetControlEventsRequiresDiscriminator locks the safety invariant: a
+// control_events query with no discriminating predicate (player_id / play_id /
+// event / labels_has) is refused before it can scan the whole table. The
+// rejection returns before any ClickHouse call, so a zero-value Backend is
+// fine — we only exercise the guard. #671.
+func TestGetControlEventsRequiresDiscriminator(t *testing.T) {
+	_, err := GetControlEvents(context.Background(), Backend{}, ControlEventsFilter{})
+	if err == nil {
+		t.Fatal("empty filter must be rejected (would scan the whole control_events table)")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Fatalf("expected a 'required' guard error, got: %v", err)
+	}
+}

--- a/analytics/go-forwarder/llm_tools_tier1.go
+++ b/analytics/go-forwarder/llm_tools_tier1.go
@@ -161,18 +161,18 @@ func summarisePlays(rows []map[string]any) map[string]any {
 		}
 	}
 	return map[string]any{
-		"count":                  len(rows),
-		"mode":                   "summary",
-		"total_issues":           totalIssues,
-		"by_classification":      classCount,
-		"by_player":              playerCount,
-		"by_content":             contentCount,
-		"label_histogram":        labelCount,
-		"distinct_players":       len(playerCount),
-		"distinct_content":       len(contentCount),
-		"window_start":           earliest,
-		"window_end":             latest,
-		"_hint":                  "summary mode — call again with mode='rows' (optionally top_k=N, labels_has=[...]) to drill into specific plays.",
+		"count":             len(rows),
+		"mode":              "summary",
+		"total_issues":      totalIssues,
+		"by_classification": classCount,
+		"by_player":         playerCount,
+		"by_content":        contentCount,
+		"label_histogram":   labelCount,
+		"distinct_players":  len(playerCount),
+		"distinct_content":  len(contentCount),
+		"window_start":      earliest,
+		"window_end":        latest,
+		"_hint":             "summary mode — call again with mode='rows' (optionally top_k=N, labels_has=[...]) to drill into specific plays.",
 	}
 }
 
@@ -262,28 +262,31 @@ func getPlaySummaryTool(be plays.Backend) Tool {
 func getControlEventsTool(be plays.Backend) Tool {
 	return Tool{
 		Name: "get_control_events",
-		Description: "Get the operator / proxy / harness action log for a player. " +
-			"Rows include fault toggles, traffic-shape changes, pattern step advances, " +
-			"and any harness mutation. Crucial for forensics — was a fault injected " +
-			"at the time something broke?",
+		Description: "Get the operator / proxy / harness action log. Rows include fault " +
+			"toggles, traffic-shape changes, pattern step advances, any harness mutation, " +
+			"and server-lifecycle markers like server_start (proxy restart/boot). Crucial " +
+			"for forensics — was a fault injected, or the proxy restarted, when something " +
+			"broke? Scope with player_id for a player's log, or query a global/session-less " +
+			"event (e.g. server_start) by event name without a player_id.",
 		Tier: 1,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"player_id":  map[string]any{"type": "string", "description": "Player UUID (required)."},
+				"player_id":  map[string]any{"type": "string", "description": "Player UUID. One of player_id / play_id / event is required."},
 				"play_id":    map[string]any{"type": "string", "description": "Narrow to one play (optional)."},
+				"event":      map[string]any{"type": "string", "description": "Filter to one event name, e.g. 'server_start'. Use this (no player_id needed) to find global/session-less events."},
 				"from":       map[string]any{"type": "string", "description": "ISO timestamp lower bound (optional)."},
 				"to":         map[string]any{"type": "string", "description": "ISO timestamp upper bound (optional)."},
 				"labels_has": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
 				"labels_not": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
 				"limit":      map[string]any{"type": "integer", "minimum": 1, "maximum": 10000, "default": 1000},
 			},
-			"required": []string{"player_id"},
 		},
 		Execute: func(ctx context.Context, args json.RawMessage, _ ToolEmitter) (string, error) {
 			var a struct {
 				PlayerID  string   `json:"player_id"`
 				PlayID    string   `json:"play_id"`
+				Event     string   `json:"event"`
 				From      string   `json:"from"`
 				To        string   `json:"to"`
 				LabelsHas []string `json:"labels_has"`
@@ -293,9 +296,14 @@ func getControlEventsTool(be plays.Backend) Tool {
 			if err := json.Unmarshal(args, &a); err != nil {
 				return "", fmt.Errorf("parse args: %w", err)
 			}
+			var events []string
+			if a.Event != "" {
+				events = []string{a.Event}
+			}
 			rows, err := plays.GetControlEvents(ctx, be, plays.ControlEventsFilter{
 				PlayerID: a.PlayerID,
 				PlayID:   a.PlayID,
+				Events:   events,
 				From:     a.From,
 				To:       a.To,
 				Labels:   plays.LabelFilter{Has: a.LabelsHas, Not: a.LabelsNot},

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -84,26 +84,49 @@ func v2ControlEventsHandler(w http.ResponseWriter, r *http.Request, cfg config) 
 	// why this matters. An operator who curls the endpoint with
 	// an uppercase UUID would otherwise get an empty page.
 	playerID := canonicalV2ID(q.Get("player_id"))
-	if playerID == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"player_id required"}`))
-		return
-	}
 	playID := canonicalV2ID(q.Get("play_id"))
+	// `event` is repeatable. An event filter lets a global / session-less
+	// event (e.g. server_start, which has no player_id, #671) be listed
+	// without one — the read path no longer hard-requires player_id.
+	var events []string
+	for _, ev := range q["event"] {
+		if ev = strings.TrimSpace(ev); ev != "" {
+			events = append(events, ev)
+		}
+	}
 	from := q.Get("from")
 	to := q.Get("to")
 	limit := q.Get("limit")
 	if limit == "" {
 		limit = "1000"
 	}
-	params := map[string]string{
-		"player_id": playerID,
-		"limit":     limit,
+	// Tristate label filter — see label_filter.go.
+	labelHas, labelNot := readLabelFilters(q)
+	// Require at least one discriminating predicate so we never scan the
+	// whole control_events table.
+	if playerID == "" && playID == "" && len(events) == 0 && len(labelHas) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"one of player_id, play_id, event, or label_has required"}`))
+		return
 	}
-	where := []string{"player_id = {player_id:String}"}
+	params := map[string]string{"limit": limit}
+	var where []string
+	if playerID != "" {
+		params["player_id"] = playerID
+		where = append(where, "player_id = {player_id:String}")
+	}
 	if playID != "" {
 		params["play_id"] = playID
 		where = append(where, "play_id = {play_id:String}")
+	}
+	if len(events) > 0 {
+		names := make([]string, len(events))
+		for i, ev := range events {
+			key := "event_" + itoa(i)
+			params[key] = ev
+			names[i] = "{" + key + ":String}"
+		}
+		where = append(where, "event IN ("+strings.Join(names, ", ")+")")
 	}
 	if from != "" {
 		params["from"] = from
@@ -113,8 +136,6 @@ func v2ControlEventsHandler(w http.ResponseWriter, r *http.Request, cfg config) 
 		params["to"] = to
 		where = append(where, "ts <= parseDateTime64BestEffortOrNull({to:String}, 3)")
 	}
-	// Tristate label filter — see label_filter.go.
-	labelHas, labelNot := readLabelFilters(q)
 	where, params = applyLabelFilters(where, params, "labels", labelHas, labelNot)
 	query := "SELECT ts, player_id, play_id, attempt_id, session_id, source, event, info, labels, event_fingerprint, classification " +
 		"FROM " + cfg.chDatabase + ".control_events WHERE " +

--- a/tools/harness-cli/cmd/harness/query.go
+++ b/tools/harness-cli/cmd/harness/query.go
@@ -269,10 +269,15 @@ func cmdQueryEvents(client *api.Client, args []string, asJSON bool) error {
 // shortcut that expands to `--label-has info=*pattern_step_<mode>`
 // (the densest pattern-locality signal — one row per step advance).
 func cmdQueryControl(client *api.Client, args []string, asJSON bool) error {
-	if len(args) < 1 {
-		return errors.New("usage: harness query control <play_id> [--source S] [--event E] [--mode M] [--label-has L ...] [--label-not L ...] [--limit N]")
+	// play_id is an OPTIONAL leading positional — omit it to query global /
+	// session-less events (e.g. server_start) by --event or --label-has. A
+	// leading token starting with '-' is a flag, not a play_id.
+	var playID string
+	flagArgs := args
+	if len(args) >= 1 && !strings.HasPrefix(args[0], "-") {
+		playID = args[0]
+		flagArgs = args[1:]
 	}
-	playID := args[0]
 	fs := flag.NewFlagSet("query control", flag.ContinueOnError)
 	source := fs.String("source", "", "filter to one source (harness|proxy|auto)")
 	var events arrayFlag
@@ -282,15 +287,20 @@ func cmdQueryControl(client *api.Client, args []string, asJSON bool) error {
 	fs.Var(&labelHas, "label-has", "row must have this label (repeatable; AND semantics)")
 	fs.Var(&labelNot, "label-not", "row must NOT have this label (repeatable; AND semantics)")
 	limit := fs.Int("limit", 0, "max rows")
-	if err := fs.Parse(args[1:]); err != nil {
+	if err := fs.Parse(flagArgs); err != nil {
 		return err
+	}
+	if playID == "" && len(events) == 0 && len(labelHas) == 0 && *mode == "" {
+		return errors.New("usage: harness query control [<play_id>] [--event E] [--label-has L] [--source S] [--mode M] [--label-not L] [--limit N]\n  a play_id, --event, --label-has, or --mode is required")
 	}
 	params := &forwarder.GetApiV2ControlEventsParams{}
-	pid, err := parsePlayID(playID)
-	if err != nil {
-		return err
+	if playID != "" {
+		pid, err := parsePlayID(playID)
+		if err != nil {
+			return err
+		}
+		params.PlayId = &pid
 	}
-	params.PlayId = &pid
 	if *source != "" {
 		s := forwarder.GetApiV2ControlEventsParamsSource(*source)
 		if !s.Valid() {


### PR DESCRIPTION
Completes #671 part 1's visibility goal. The `server_start` boot marker (#672) was archived in ClickHouse with the right label, but **unreadable** through any operator/AI path — verified live: `GET /api/v2/control_events?event=server_start` returned `400 player_id required`.

Two root causes, both fixed:
1. The read path **hard-required `player_id`**, but `server_start` is deliberately session-less.
2. The handler **never read an `event` filter at all** — so `harness query control --event …` was a silent no-op (the generated client sent it; the server ignored it).

## Plumbed across all four read layers
A query now needs **≥1 discriminating predicate** (`player_id` | `play_id` | `event` | `label_has`) so it can never scan the whole table — but `player_id` is no longer mandatory.

- **`internal/plays/control.go`** — `ControlEventsFilter` gains `Events []string`; the player_id-required hard error becomes the discriminator guard (shared by AI + HTTP).
- **`v2_handlers.go`** — reads repeatable `?event=`, `player_id` optional, same guard.
- **`llm_tools_tier1.go`** — `get_control_events` gains an `event` arg, drops `required:[player_id]`; description tells the AI it can query `server_start` (and other global events) by event name with no player_id.
- **`tools/harness-cli/.../query.go`** — the positional `play_id` is now optional; omit it and pass `--event`/`--label-has` to query global events.
- **`.claude/standards/data-fields.md`** — corrected the `server_start` query examples to the now-working forms (`harness query control --event server_start`); the old `--label-has`-on-plays example couldn't surface a play-less event.

## Now works
```
harness query control --event server_start
GET /api/v2/control_events?event=server_start
get_control_events(event="server_start")   # AI tool, no player_id
```

## Tests
Guard rejection unit-tested (`internal/plays/control_test.go`). Forwarder + `plays` suites pass; harness-cli builds; `go vet` + gofmt clean. Positive path will be verified live post-deploy (query the `server_start` rows that already exist on test-dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
