### PR TITLE
feat(678): typed Scenario object on /api/v2/plays + Session Viewer parity

### DIFF
--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -41,7 +41,15 @@ func FindPlays(ctx context.Context, b Backend, f PlayFilter) ([]map[string]any, 
 		limit = maxPlaysLimit
 	}
 
-	return runPlaysQuery(ctx, b, clauses, params, post, limit)
+	rows, err := runPlaysQuery(ctx, b, clauses, params, post, limit)
+	if err != nil {
+		return nil, err
+	}
+	// #678 — attach the typed scenario (run-identity) object built from the
+	// summary columns + testing= label tails. Single chokepoint: both the
+	// list and the single-play GetPlaySummary path flow through here.
+	enrichScenario(rows)
+	return rows, nil
 }
 
 // GetPlaySummary returns the single PlaySummary for play_id, or nil

--- a/analytics/go-forwarder/internal/plays/scenario.go
+++ b/analytics/go-forwarder/internal/plays/scenario.go
@@ -1,0 +1,114 @@
+package plays
+
+import (
+	"strconv"
+	"strings"
+)
+
+// enrichScenario adds a nested "scenario" object to each play row — the
+// run-IDENTITY of a play ("what it IS": test, platform, device, versions)
+// as opposed to the event labels ("what HAPPENED during it"). #678 promotes
+// this off the dashboard, which assembled it client-side in Sessions.vue,
+// into the API contract so the Sessions list, the Session Viewer header, and
+// chat tools all read one typed shape.
+//
+// Sourced as a hybrid, deliberately:
+//   - typed columns (device/player/app/os/content) — authoritative, already
+//     selected by the agg query; not lossy the way sanitized LowCardinality
+//     labels are.
+//   - testing= label tails (test/platform/run_id) — no typed column exists.
+//
+// The object is omitted entirely (rather than emitted as {}) when a play
+// carries none of these — e.g. a pre-#550 row with no device taxonomy and no
+// harness stamp.
+func enrichScenario(rows []map[string]any) {
+	for _, row := range rows {
+		sc := map[string]any{}
+		// Typed columns — authoritative.
+		putIfStr(sc, "device_class", row["device_class"])
+		putIfStr(sc, "device_model", row["device_model"])
+		putIfStr(sc, "player_tech", row["player_tech"])
+		putIfStr(sc, "app_version", row["app_version"])
+		putIfStr(sc, "content_id", row["content_id"])
+		if os := joinOSVersion(row["os_version_major"], row["os_version_minor"]); os != "" {
+			sc["os_version"] = os
+		}
+		// Harness identity — only present in the testing= label tier.
+		test, platform, runID := scenarioLabelTails(row["label_histogram"])
+		putIfStr(sc, "test", test)
+		putIfStr(sc, "platform", platform)
+		putIfStr(sc, "run_id", runID)
+
+		if len(sc) == 0 {
+			continue
+		}
+		row["scenario"] = sc
+	}
+}
+
+// scenarioLabelTails pulls the test / platform / run_id values out of the
+// testing= label tier of a play's label_histogram. The histogram arrives as
+// the JSON-decoded ClickHouse groupArray((label, n)): []any of []any{string,
+// number}. First occurrence wins (these keys are single-valued per play).
+func scenarioLabelTails(hist any) (test, platform, runID string) {
+	pairs, ok := hist.([]any)
+	if !ok {
+		return
+	}
+	for _, p := range pairs {
+		pair, ok := p.([]any)
+		if !ok || len(pair) == 0 {
+			continue
+		}
+		label, ok := pair[0].(string)
+		if !ok {
+			continue
+		}
+		switch {
+		case test == "" && strings.HasPrefix(label, "testing=test_"):
+			test = strings.TrimPrefix(label, "testing=test_")
+		case platform == "" && strings.HasPrefix(label, "testing=platform_"):
+			platform = strings.TrimPrefix(label, "testing=platform_")
+		case runID == "" && strings.HasPrefix(label, "testing=run_id_"):
+			runID = strings.TrimPrefix(label, "testing=run_id_")
+		}
+	}
+	return
+}
+
+// putIfStr sets m[key] only when v stringifies to a non-empty value, so the
+// scenario object never carries empty-string noise.
+func putIfStr(m map[string]any, key string, v any) {
+	if s := asString(v); s != "" {
+		m[key] = s
+	}
+}
+
+// asString coerces a JSON-decoded ClickHouse cell to a string. Numbers come
+// back as float64 (e.g. os_version_major as a UInt); integer-valued ones
+// render without a spurious ".0".
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	}
+	return ""
+}
+
+// joinOSVersion renders "major.minor" (or just "major" when minor is absent),
+// empty when there's no major.
+func joinOSVersion(maj, min any) string {
+	ma := asString(maj)
+	if ma == "" {
+		return ""
+	}
+	if mi := asString(min); mi != "" {
+		return ma + "." + mi
+	}
+	return ma
+}

--- a/analytics/go-forwarder/internal/plays/scenario_test.go
+++ b/analytics/go-forwarder/internal/plays/scenario_test.go
@@ -1,0 +1,79 @@
+package plays
+
+import "testing"
+
+func TestEnrichScenario_HybridSources(t *testing.T) {
+	rows := []map[string]any{{
+		"device_class":     "phone",
+		"device_model":     "iPhone15,2",
+		"player_tech":      "AVPlayer",
+		"app_version":      "1.4.0",
+		"content_id":       "tears-of-steel",
+		"os_version_major": float64(18), // JSON number, as ClickHouse UInt decodes
+		"os_version_minor": float64(1),
+		"label_histogram": []any{
+			[]any{"testing=test_rampup", float64(1)},
+			[]any{"testing=platform_ipad-sim", float64(1)},
+			[]any{"testing=run_id_20260524T070148Z", float64(1)},
+			[]any{"critical=qoe_stall", float64(3)}, // non-testing label ignored
+		},
+	}}
+	enrichScenario(rows)
+
+	sc, ok := rows[0]["scenario"].(map[string]any)
+	if !ok {
+		t.Fatalf("scenario not attached: %#v", rows[0]["scenario"])
+	}
+	want := map[string]string{
+		"device_class": "phone",
+		"device_model": "iPhone15,2",
+		"player_tech":  "AVPlayer",
+		"app_version":  "1.4.0",
+		"content_id":   "tears-of-steel",
+		"os_version":   "18.1",
+		"test":         "rampup",
+		"platform":     "ipad-sim",
+		"run_id":       "20260524T070148Z",
+	}
+	for k, v := range want {
+		if got, _ := sc[k].(string); got != v {
+			t.Errorf("scenario[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if _, leaked := sc["qoe_stall"]; leaked {
+		t.Errorf("non-testing label leaked into scenario: %#v", sc)
+	}
+}
+
+func TestEnrichScenario_OmittedWhenEmpty(t *testing.T) {
+	rows := []map[string]any{{
+		"play_id":         "abc",
+		"label_histogram": []any{[]any{"info=play_start", float64(1)}},
+	}}
+	enrichScenario(rows)
+	if _, present := rows[0]["scenario"]; present {
+		t.Errorf("scenario should be absent for a play with no identity fields, got %#v", rows[0]["scenario"])
+	}
+}
+
+func TestEnrichScenario_OSMajorOnly(t *testing.T) {
+	rows := []map[string]any{{"os_version_major": float64(17)}}
+	enrichScenario(rows)
+	sc := rows[0]["scenario"].(map[string]any)
+	if got, _ := sc["os_version"].(string); got != "17" {
+		t.Errorf("os_version = %q, want %q (no spurious .minor / .0)", got, "17")
+	}
+}
+
+func TestEnrichScenario_DeviceFromClassOnly(t *testing.T) {
+	// A play with device_class but no model still surfaces the class.
+	rows := []map[string]any{{"device_class": "tv"}}
+	enrichScenario(rows)
+	sc := rows[0]["scenario"].(map[string]any)
+	if got, _ := sc["device_class"].(string); got != "tv" {
+		t.Errorf("device_class = %q, want tv", got)
+	}
+	if _, hasModel := sc["device_model"]; hasModel {
+		t.Errorf("device_model should be absent: %#v", sc)
+	}
+}

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -993,6 +993,9 @@ components:
               oneOf:
                 - { type: string,  description: "label, e.g. 'warning=*manifest_failure'" }
                 - { type: integer, description: "occurrence count for this play" }
+        # ---- run identity (issue #678) ----
+        scenario:
+          $ref: '#/components/schemas/Scenario'
         # ---- tiered retention class ----
         classification:
           type: string
@@ -1008,6 +1011,31 @@ components:
             fault-induced | abandoned`) described in DESIGN.md are
             blocked on the `play_summaries` rollup table — they'll
             land here when that lands.
+
+    Scenario:
+      description: |
+        Run IDENTITY of a play — "what it IS" (test, platform, device,
+        versions), as distinct from the event labels which are "what
+        HAPPENED during it". Issue #678 promoted this off the dashboard
+        (it was assembled client-side in Sessions.vue) into the API so the
+        Sessions list, Session Viewer header, and chat tools share one shape.
+
+        Hybrid-sourced: device/player/app/os/content from the authoritative
+        typed summary columns; test/platform/run_id from the `testing=`
+        label tier (no typed column exists for those). Every field is
+        optional — a play absent all of them omits the whole object rather
+        than emitting `{}`.
+      type: object
+      properties:
+        test:         { type: string, description: "Characterization test mode, from testing=test_* (e.g. 'rampup'). Harness runs only." }
+        platform:     { type: string, description: "Harness-stamped platform, from testing=platform_* (e.g. 'ipad-sim'). Distinct from device_* below. Harness runs only." }
+        run_id:       { type: string, description: "Characterization run id, from testing=run_id_* (compact UTC, e.g. '20260524T070148Z'). Groups plays into a run. Harness runs only." }
+        device_class: { type: string, description: "Device taxonomy class (phone|tablet|tv|…). From the typed column (#550 Phase 4)." }
+        device_model: { type: string, description: "Device model identifier (e.g. 'iPhone15,2'). From the typed column." }
+        player_tech:  { type: string, description: "Player technology (e.g. 'AVPlayer'). From the typed column." }
+        app_version:  { type: string, description: "Client app version. From the typed column." }
+        os_version:   { type: string, description: "OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor." }
+        content_id:   { type: string, description: "Content identifier — duplicated here so the object is self-contained for the viewer header." }
 
     PlaySummaryPage:
       type: object

--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -84,6 +84,10 @@ const fields = computed(() => {
   const labels: Record<string, string> = (p as any).labels ?? {};
   const testLabel = typeof labels.test === 'string' ? labels.test : '';
   const runIDLabel = typeof labels.run_id === 'string' ? labels.run_id : '';
+  // #678 — platform completes the harness-identity trio (test / platform /
+  // run_id) so the viewer surfaces the same run-identity set as the Sessions
+  // list Scenario cell. Device/app/OS below already cover the typed half.
+  const platformLabel = typeof labels.platform === 'string' ? labels.platform : '';
   // Master URL is the manifest entry the player loaded; the legacy
   // page also showed the "Last Request URL" (the most-recent network
   // log entry's URL); we don't track that here yet so omit it.
@@ -157,6 +161,7 @@ const fields = computed(() => {
   // identifiers off-screen on narrow viewports, but still surface
   // when present.
   if (testLabel) out.push({ label: 'Test', value: testLabel });
+  if (platformLabel) out.push({ label: 'Platform', value: platformLabel });
   if (runIDLabel) out.push({ label: 'Run ID', value: runIDLabel });
   return out;
 });

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -12,7 +12,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import ChatPanel from '@/components/chat/ChatPanel.vue';
 import { sessionViewerURL } from '@/composables/urlTimeFormat';
-import { listPlays, patchPlayClassification, type PlaySummary } from '@/repo/v2-repo';
+import { listPlays, patchPlayClassification, type PlaySummary, type Scenario } from '@/repo/v2-repo';
 
 interface SessionRow {
   session_id: string;
@@ -31,6 +31,10 @@ interface SessionRow {
   app_version?: string;
   os_version_major?: number | string;
   os_version_minor?: number | string;
+  // #678 — typed run-identity object from /api/v2/plays (built server-side
+  // from the columns above + testing= label tails). Preferred by scenario();
+  // the loose columns remain for the rollout fallback.
+  scenario?: Scenario;
   started?: string;
   last_seen?: string;
   classification?: string;
@@ -187,7 +191,13 @@ function findLabelTail(r: SessionRow, key: string): string | null {
 function harnessRunId(r: SessionRow): string | null { return findLabelTail(r, 'run_id_'); }
 function harnessPlatform(r: SessionRow): string | null { return findLabelTail(r, 'platform_'); }
 function harnessTest(r: SessionRow): string | null { return findLabelTail(r, 'test_'); }
-function isHarnessRow(r: SessionRow): boolean { return harnessRunId(r) !== null; }
+function isHarnessRow(r: SessionRow): boolean { return rowRunId(r) !== ''; }
+// #678 — scenario-aware accessors: prefer the server `scenario` object, fall
+// back to the testing= label tails. Used by the Platform/Test facets so they
+// agree with the Scenario cell regardless of which source populated it.
+function rowTest(r: SessionRow): string { return r.scenario?.test ?? harnessTest(r) ?? ''; }
+function rowPlatform(r: SessionRow): string { return r.scenario?.platform ?? harnessPlatform(r) ?? ''; }
+function rowRunId(r: SessionRow): string { return r.scenario?.run_id ?? harnessRunId(r) ?? ''; }
 
 // Pretty-print the UTC compact run_id (20260524T070148Z) as local
 // hh:mm. Falls back to the raw string if it doesn't match the
@@ -205,41 +215,66 @@ function shortRunId(runID: string | null): string {
   return utc.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
-// #673 — Scenario (run-identity) cell. A play's *dimensions* — what it IS
-// (test, platform, device, content versions) — as opposed to the event
+// #673/#678 — Scenario (run-identity) cell. A play's *dimensions* — what it
+// IS (test, platform, device, content versions) — as opposed to the event
 // labels, which are what HAPPENED during it (stalls, faults, breaches, with
-// counts). They were intermingled in the testing= label tier; this pulls
-// the identity fields into one structured cell.
+// counts). They were intermingled in the testing= label tier; this surfaces
+// the identity fields as their own structured cell.
 //
-// Sourced as a HYBRID, deliberately:
-//   - typed columns (device/app/player/os) — authoritative, already on the
-//     summary, not lossy the way sanitized LowCardinality labels are.
-//   - testing= label tails (test/platform/run_id) — no typed column exists.
-// Content has its own column, so it's intentionally not duplicated here.
+// #678 moved the assembly server-side (forwarder /api/v2/plays now returns a
+// typed `scenario` object). We prefer that; scenarioFromRow() is the rollout
+// fallback for when the frontend ships ahead of the forwarder (separate
+// deploys) or for cached rows predating the field. Both paths feed the same
+// renderer, scenarioView(). Content has its own column, so content_id from
+// the object is intentionally not shown here.
 interface ScenarioField { key: string; label: string; value: string }
-function scenario(r: SessionRow): { fields: ScenarioField[]; tooltip: string } | null {
+// Render order + display labels, keyed by the typed Scenario field name.
+const SCENARIO_FIELDS: { src: keyof Scenario; key: string; label: string }[] = [
+  { src: 'test',         key: 'test',     label: 'test' },
+  { src: 'platform',     key: 'platform', label: 'platform' },
+  { src: 'device_model', key: 'device',   label: 'device' },
+  { src: 'player_tech',  key: 'player',   label: 'player' },
+  { src: 'app_version',  key: 'app',      label: 'app' },
+  { src: 'os_version',   key: 'os',       label: 'os' },
+  { src: 'run_id',       key: 'run',      label: 'run' },
+];
+// Build the render model from a typed Scenario object (server-supplied, #678).
+function scenarioView(sc: Scenario): { fields: ScenarioField[]; tooltip: string } | null {
+  const fields: ScenarioField[] = [];
+  for (const f of SCENARIO_FIELDS) {
+    let value = String(sc[f.src] ?? '');
+    if (!value && f.src === 'device_model') value = String(sc.device_class ?? '');
+    if (f.src === 'run_id' && value) value = shortRunId(value);
+    if (value) fields.push({ key: f.key, label: f.label, value });
+  }
+  if (fields.length === 0) return null;
+  const tooltip = fields.map((f) => `${f.label}: ${f.value}`).join('\n')
+    + (sc.run_id ? `\nrun_id: ${sc.run_id}` : '');
+  return { fields, tooltip };
+}
+// Rollout fallback: assemble a Scenario from the raw row (typed columns +
+// testing= label tails) the way #673 did client-side, for rows the forwarder
+// hasn't enriched yet.
+function scenarioFromRow(r: SessionRow): Scenario {
   const col = (k: string) => {
     const v = (r as any)[k];
     return v === undefined || v === null || v === '' ? '' : String(v);
   };
   const osMaj = col('os_version_major');
   const osMin = col('os_version_minor');
-  const runID = harnessRunId(r);
-  const candidates: ScenarioField[] = [
-    { key: 'test',     label: 'test',     value: harnessTest(r) ?? '' },
-    { key: 'platform', label: 'platform', value: harnessPlatform(r) ?? '' },
-    { key: 'device',   label: 'device',   value: col('device_model') || col('device_class') },
-    { key: 'player',   label: 'player',   value: col('player_tech') },
-    { key: 'app',      label: 'app',      value: col('app_version') },
-    { key: 'os',       label: 'os',       value: osMaj ? (osMin ? `${osMaj}.${osMin}` : osMaj) : '' },
-    { key: 'run',      label: 'run',      value: shortRunId(runID) },
-  ];
-  const fields = candidates.filter((f) => f.value);
-  if (fields.length === 0) return null;
-  const tooltip = fields
-    .map((f) => `${f.label}: ${f.value}`)
-    .join('\n') + (runID ? `\nrun_id: ${runID}` : '');
-  return { fields, tooltip };
+  return {
+    test: harnessTest(r) ?? '',
+    platform: harnessPlatform(r) ?? '',
+    run_id: harnessRunId(r) ?? '',
+    device_class: col('device_class'),
+    device_model: col('device_model'),
+    player_tech: col('player_tech'),
+    app_version: col('app_version'),
+    os_version: osMaj ? (osMin ? `${osMaj}.${osMin}` : osMaj) : '',
+  };
+}
+function scenario(r: SessionRow): { fields: ScenarioField[]; tooltip: string } | null {
+  return scenarioView(r.scenario ?? scenarioFromRow(r));
 }
 
 // rows / loading / error are computeds backed by playsQuery; declared
@@ -490,8 +525,8 @@ function matches(r: SessionRow): boolean {
     && (!f.group_id || r.group_id === f.group_id)
     && (!f.content_id || r.content_id === f.content_id)
     && (!f.play_id || r.play_id === f.play_id)
-    && (!f.platform || harnessPlatform(r) === f.platform)
-    && (!f.test || harnessTest(r) === f.test)
+    && (!f.platform || rowPlatform(r) === f.platform)
+    && (!f.test || rowTest(r) === f.test)
     && matchesClassification(r)
     && matchesHarness(r)
     && matchesLabels(r);
@@ -708,9 +743,9 @@ const playOptions = computed(() => distinctFor('play_id'));
 // can't build them; map each row through the harness label-tail readers and
 // dedupe. Independent of the four id selects — a platform spans many plays.
 const platformOptions = computed(() =>
-  Array.from(new Set(rows.value.map((r) => harnessPlatform(r)).filter(Boolean) as string[])).sort());
+  Array.from(new Set(rows.value.map((r) => rowPlatform(r)).filter(Boolean))).sort());
 const testOptions = computed(() =>
-  Array.from(new Set(rows.value.map((r) => harnessTest(r)).filter(Boolean) as string[])).sort());
+  Array.from(new Set(rows.value.map((r) => rowTest(r)).filter(Boolean))).sort());
 
 // When a parent filter narrows enough that the current value is no
 // longer in the visible set, clear it. Mirrors `fillSelect` in the

--- a/content/dashboard-v3/src/repo/v2-repo.ts
+++ b/content/dashboard-v3/src/repo/v2-repo.ts
@@ -305,7 +305,27 @@ export interface PlaySummary {
   label_histogram?: [string, number][];
   labels_total?: number;
   labels_distinct_count?: number;
+  // #678 — run-identity object, built server-side from the typed summary
+  // columns + testing= label tails. Absent when a play carries none of them.
+  scenario?: Scenario;
   [k: string]: unknown;
+}
+
+/**
+ * Run IDENTITY of a play — "what it IS" (test/platform/device/versions), as
+ * distinct from event labels ("what HAPPENED"). See forwarder.yaml § Scenario
+ * and analytics/go-forwarder/internal/plays/scenario.go. Every field optional.
+ */
+export interface Scenario {
+  test?: string;
+  platform?: string;
+  run_id?: string;
+  device_class?: string;
+  device_model?: string;
+  player_tech?: string;
+  app_version?: string;
+  os_version?: string;
+  content_id?: string;
 }
 
 export interface ListPlaysParams {

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -968,8 +968,21 @@ type PlayDetail struct {
 	ResolutionChanges *int               `json:"resolution_changes,omitempty"`
 
 	// RestartCount Mid-play player-recovery restarts.
-	RestartCount    *int `json:"restart_count,omitempty"`
-	SegmentFailures *int `json:"segment_failures,omitempty"`
+	RestartCount *int `json:"restart_count,omitempty"`
+
+	// Scenario Run IDENTITY of a play — "what it IS" (test, platform, device,
+	// versions), as distinct from the event labels which are "what
+	// HAPPENED during it". Issue #678 promoted this off the dashboard
+	// (it was assembled client-side in Sessions.vue) into the API so the
+	// Sessions list, Session Viewer header, and chat tools share one shape.
+	//
+	// Hybrid-sourced: device/player/app/os/content from the authoritative
+	// typed summary columns; test/platform/run_id from the `testing=`
+	// label tier (no typed column exists for those). Every field is
+	// optional — a play absent all of them omits the whole object rather
+	// than emitting `{}`.
+	Scenario        *Scenario `json:"scenario,omitempty"`
+	SegmentFailures *int      `json:"segment_failures,omitempty"`
 
 	// SegmentStallCount Stalls waiting on a segment fetch.
 	SegmentStallCount *int `json:"segment_stall_count,omitempty"`
@@ -1115,8 +1128,21 @@ type PlaySummary struct {
 	ResolutionChanges *int               `json:"resolution_changes,omitempty"`
 
 	// RestartCount Mid-play player-recovery restarts.
-	RestartCount    *int `json:"restart_count,omitempty"`
-	SegmentFailures *int `json:"segment_failures,omitempty"`
+	RestartCount *int `json:"restart_count,omitempty"`
+
+	// Scenario Run IDENTITY of a play — "what it IS" (test, platform, device,
+	// versions), as distinct from the event labels which are "what
+	// HAPPENED during it". Issue #678 promoted this off the dashboard
+	// (it was assembled client-side in Sessions.vue) into the API so the
+	// Sessions list, Session Viewer header, and chat tools share one shape.
+	//
+	// Hybrid-sourced: device/player/app/os/content from the authoritative
+	// typed summary columns; test/platform/run_id from the `testing=`
+	// label tier (no typed column exists for those). Every field is
+	// optional — a play absent all of them omits the whole object rather
+	// than emitting `{}`.
+	Scenario        *Scenario `json:"scenario,omitempty"`
+	SegmentFailures *int      `json:"segment_failures,omitempty"`
 
 	// SegmentStallCount Stalls waiting on a segment fetch.
 	SegmentStallCount *int `json:"segment_stall_count,omitempty"`
@@ -1211,6 +1237,46 @@ type SampleRow struct {
 	// Ts ms-precision DateTime64
 	Ts                   time.Time              `json:"ts"`
 	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// Scenario Run IDENTITY of a play — "what it IS" (test, platform, device,
+// versions), as distinct from the event labels which are "what
+// HAPPENED during it". Issue #678 promoted this off the dashboard
+// (it was assembled client-side in Sessions.vue) into the API so the
+// Sessions list, Session Viewer header, and chat tools share one shape.
+//
+// Hybrid-sourced: device/player/app/os/content from the authoritative
+// typed summary columns; test/platform/run_id from the `testing=`
+// label tier (no typed column exists for those). Every field is
+// optional — a play absent all of them omits the whole object rather
+// than emitting `{}`.
+type Scenario struct {
+	// AppVersion Client app version. From the typed column.
+	AppVersion *string `json:"app_version,omitempty"`
+
+	// ContentId Content identifier — duplicated here so the object is self-contained for the viewer header.
+	ContentId *string `json:"content_id,omitempty"`
+
+	// DeviceClass Device taxonomy class (phone|tablet|tv|…). From the typed column (#550 Phase 4).
+	DeviceClass *string `json:"device_class,omitempty"`
+
+	// DeviceModel Device model identifier (e.g. 'iPhone15,2'). From the typed column.
+	DeviceModel *string `json:"device_model,omitempty"`
+
+	// OsVersion OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor.
+	OsVersion *string `json:"os_version,omitempty"`
+
+	// Platform Harness-stamped platform, from testing=platform_* (e.g. 'ipad-sim'). Distinct from device_* below. Harness runs only.
+	Platform *string `json:"platform,omitempty"`
+
+	// PlayerTech Player technology (e.g. 'AVPlayer'). From the typed column.
+	PlayerTech *string `json:"player_tech,omitempty"`
+
+	// RunId Characterization run id, from testing=run_id_* (compact UTC, e.g. '20260524T070148Z'). Groups plays into a run. Harness runs only.
+	RunId *string `json:"run_id,omitempty"`
+
+	// Test Characterization test mode, from testing=test_* (e.g. 'rampup'). Harness runs only.
+	Test *string `json:"test,omitempty"`
 }
 
 // StreamErrorEvent Emitted on transport / CH failures after the initial `meta`


### PR DESCRIPTION
## What

Parts 1+2 of #677 (split out as #678). Promotes the run-identity **Scenario** assembly off the dashboard into the API contract, so the Sessions list, Session Viewer header, and chat tools share one typed shape instead of each re-deriving it client-side (#673 did it inline in `Sessions.vue`).

## Backend (forwarder)

- **`internal/plays/scenario.go`** — `enrichScenario()` attaches a nested `scenario` object to each play row at the single `FindPlays` chokepoint (covers both the list and `GetPlaySummary` detail paths). **Hybrid-sourced**: `device`/`player`/`app`/`os`/`content` from the authoritative typed summary columns; `test`/`platform`/`run_id` parsed from the `testing=` label tier. Omitted entirely (not `{}`) when a play has no identity fields.
- **`scenario_test.go`** — hybrid sources, omit-when-empty, os-major-only, device-class-only.

## API

- **`forwarder.yaml`** — new `Scenario` schema + optional `scenario` on `PlaySummary`.
- Regenerated **`tools/harness-cli`** forwarder client (`Scenario` type + field).

## Frontend

- **`v2-repo.ts`** — typed `Scenario` interface + `scenario?` on `PlaySummary`.
- **`Sessions.vue`** — `scenario()` now prefers the server object via `scenarioView()`; `scenarioFromRow()` is the rollout fallback (frontend may ship ahead of the forwarder — separate deploys). Platform/Test facets read scenario-first via `rowPlatform`/`rowTest`.
- **`SessionDetails.vue`** — adds the **Platform** tile alongside the existing Test/Run ID + device/app/OS tiles, so the viewer surfaces the same identity set as the Sessions Scenario cell.

## Test

- `go build` / `go vet` / `go test` clean (forwarder + harness-cli); new scenario tests pass.
- `vue-tsc --noEmit` clean; production `vite build` clean.

## Rollout note

The `scenario` object requires a **forwarder redeploy** (`make analytics-rebuild-forwarder`) to populate. Until then the frontend falls back to client-side assembly, so nothing regresses if the dashboard deploys first.

## Follow-up

Part 3 — stamp server/`go-live` build + manifest variant — tracked in #679 (design-gated).

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
