### PR TITLE
feat(685): report all segment lengths a clip is available in (2s/6s + LL)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
@@ -23,9 +23,20 @@ data class ContentItem(
     /** "h264" / "hevc" / "av1" / "" — server-stripped codec hint. */
     val codec: String,
     /** Native segment duration the source was encoded at (seconds). null
-     *  when the server couldn't detect it. Used by the Stream picker to
-     *  honour the Segment Length preference. */
+     *  when the server couldn't detect it. Kept for display only — for
+     *  "can I play this at length N?" use [supportsSegment], which prefers
+     *  [segmentDurations]. */
     val segmentDuration: Int? = null,
+    /** All segment lengths (seconds) go-live can actually serve this clip
+     *  at — go-live synthesizes both a 2s and a 6s master from any HLS
+     *  source, so this is `[2, 6]` for HLS content regardless of the
+     *  native encode. null from a pre-#685 server (falls back to the
+     *  legacy single-[segmentDuration] match). */
+    val segmentDurations: List<Int>? = null,
+    /** Whether the LL (low-latency) variant is available — go-live can
+     *  only build it when the source carries on-disk partial-segment info.
+     *  null from a pre-#685 server (treated as available). */
+    val hasLL: Boolean? = null,
     /** Server-relative path to the 640-px-wide poster (default size for
      *  card / tile surfaces). Null when the server hasn't generated a
      *  thumbnail for this clip yet. */
@@ -121,28 +132,32 @@ data class UiState(
         get() = servers.getOrNull(activeServerIndex)
 
     /** Apply protocol + codec + segment-length filter to the raw content
-     *  list. Segment length is matched against the *native* encoding
-     *  duration (`segment_duration` from /api/content). go-live can serve
-     *  any segment variant for any source via subsegmentation, but the
-     *  Stream picker filters honour the user's preference so they can
-     *  reproducibly find content encoded at the chosen duration. Items
-     *  with no detected segment_duration (older content) pass through. */
+     *  list. Segment length is matched against the set go-live can actually
+     *  serve (`segment_durations` + `has_ll` from /api/content): go-live
+     *  synthesizes both a 2s and a 6s master from any HLS source, while LL
+     *  additionally needs on-disk partial info. Pre-#685 servers report
+     *  neither field, so we fall back to the legacy native-`segmentDuration`
+     *  match (and items with no detected duration pass through). */
     val filteredContent: List<ContentItem>
         get() = content.filter { c ->
             val protocolOk = if (protocol == Protocol.HLS) c.hasHls else c.hasDash
             if (!protocolOk) return@filter false
             if (codec != Codec.AUTO && inferCodec(c.name) != codec) return@filter false
-            val sd = c.segmentDuration
-            if (sd != null) {
-                val segOk = when (segment) {
-                    Segment.LL -> sd <= 1
-                    Segment.TWO -> sd == 2
-                    Segment.SIX -> sd == 6
-                }
-                if (!segOk) return@filter false
+            when (segment) {
+                Segment.LL -> c.hasLL ?: true
+                Segment.TWO -> c.supportsSegment(2)
+                Segment.SIX -> c.supportsSegment(6)
             }
-            true
         }
+}
+
+/** Whether go-live can serve this clip at the given integer segment length.
+ *  Prefers the server's [ContentItem.segmentDurations] set; falls back to the
+ *  legacy single [ContentItem.segmentDuration] (or shows the clip when the
+ *  server reports neither, so a pre-#685 server doesn't hide everything). */
+fun ContentItem.supportsSegment(seconds: Int): Boolean {
+    segmentDurations?.let { if (it.isNotEmpty()) return seconds in it }
+    return segmentDuration == seconds || segmentDuration == null
 }
 
 fun inferCodec(name: String): Codec {

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -575,6 +575,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                     codec = o.optString("codec", ""),
                     segmentDuration = if (o.isNull("segmentDuration")) null
                                       else o.optInt("segmentDuration", -1).takeIf { it >= 0 },
+                    segmentDurations = o.optJSONArray("segmentDurations")?.let { ja ->
+                        (0 until ja.length()).map { ja.getInt(it) }
+                    },
+                    hasLL = if (o.has("hasLL")) o.optBoolean("hasLL") else null,
                     thumbnailPath = o.optString("thumbnailPath", "").ifEmpty { null },
                     thumbnailPathSmall = o.optString("thumbnailPathSmall", "").ifEmpty { null },
                     thumbnailPathLarge = o.optString("thumbnailPathLarge", "").ifEmpty { null },
@@ -593,6 +597,8 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                 put("clipId", c.clipId)
                 put("codec", c.codec)
                 if (c.segmentDuration != null) put("segmentDuration", c.segmentDuration)
+                c.segmentDurations?.let { put("segmentDurations", JSONArray(it)) }
+                c.hasLL?.let { put("hasLL", it) }
                 c.thumbnailPath?.let { put("thumbnailPath", it) }
                 c.thumbnailPathSmall?.let { put("thumbnailPathSmall", it) }
                 c.thumbnailPathLarge?.let { put("thumbnailPathLarge", it) }
@@ -643,6 +649,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                         codec = o.optString("codec", "").lowercase(),
                         segmentDuration = if (o.isNull("segment_duration")) null
                                           else o.optInt("segment_duration", -1).takeIf { it >= 0 },
+                        segmentDurations = o.optJSONArray("segment_durations")?.let { ja ->
+                            (0 until ja.length()).map { ja.getInt(it) }
+                        },
+                        hasLL = if (o.has("has_ll")) o.optBoolean("has_ll") else null,
                         thumbnailPath = o.optString("thumbnail_url", "").ifEmpty { null },
                         thumbnailPathSmall = o.optString("thumbnail_url_small", "").ifEmpty { null },
                         thumbnailPathLarge = o.optString("thumbnail_url_large", "").ifEmpty { null },

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/Models.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/Models.swift
@@ -24,9 +24,21 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
     /// "h264" / "hevc" / "av1" / "" — server-stripped codec hint.
     let codec: String
     /// Native segment duration the source was encoded at (seconds).
-    /// `nil` when the server couldn't detect it. Used by the Stream
-    /// picker to honour the Segment Length preference.
+    /// `nil` when the server couldn't detect it. Kept for display only —
+    /// for "can I play this at length N?" use `supportsSegment(_:)`, which
+    /// prefers `segmentDurations`.
     let segmentDuration: Int?
+    /// All segment lengths (seconds) go-live can actually serve this clip
+    /// at — go-live synthesizes both a 2s and a 6s master from any HLS
+    /// source, so this is `[2, 6]` for HLS content regardless of the
+    /// native encode. `nil` from a pre-#685 server (falls back to the
+    /// legacy single-`segmentDuration` match).
+    let segmentDurations: [Int]?
+    /// Whether the LL (low-latency) variant is available — go-live can
+    /// only build it when the source carries on-disk partial-segment info.
+    /// `nil` from a pre-#685 server (treated as available, preserving the
+    /// prior show-all-for-LL behaviour).
+    let hasLL: Bool?
     /// Server-relative path (or absolute URL) to the 640-px-wide poster
     /// — the default size for card / tile surfaces. `nil` when the
     /// server hasn't generated a thumbnail for this clip yet.
@@ -42,6 +54,21 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
     /// identity stable across reloads.
     var id: String { name }
 
+    /// Whether go-live can serve this clip at the given integer segment
+    /// length. Prefers the server's `segmentDurations` set; falls back to
+    /// the legacy single `segmentDuration` (or shows the clip when the
+    /// server reports neither, so a pre-#685 server doesn't hide
+    /// everything when 2s/6s is selected).
+    func supportsSegment(_ seconds: Int) -> Bool {
+        if let set = segmentDurations, !set.isEmpty { return set.contains(seconds) }
+        return segmentDuration == seconds || segmentDuration == nil
+    }
+
+    /// Whether the LL (low-latency) variant is available. `true` when the
+    /// server doesn't report `has_ll` (older server), preserving the prior
+    /// show-all-for-LL behaviour.
+    var supportsLL: Bool { hasLL ?? true }
+
     enum CodingKeys: String, CodingKey {
         case name
         case hasHls = "has_hls"
@@ -49,6 +76,8 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
         case clipId = "clip_id"
         case codec
         case segmentDuration = "segment_duration"
+        case segmentDurations = "segment_durations"
+        case hasLL = "has_ll"
         case thumbnailPath = "thumbnail_url"
         case thumbnailPathSmall = "thumbnail_url_small"
         case thumbnailPathLarge = "thumbnail_url_large"
@@ -64,6 +93,8 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
         self.clipId = serverClip.isEmpty ? Self.deriveClipId(from: rawName) : serverClip
         self.codec = ((try? c.decode(String.self, forKey: .codec)) ?? "").lowercased()
         self.segmentDuration = try? c.decodeIfPresent(Int.self, forKey: .segmentDuration)
+        self.segmentDurations = try? c.decodeIfPresent([Int].self, forKey: .segmentDurations)
+        self.hasLL = try? c.decodeIfPresent(Bool.self, forKey: .hasLL)
         self.thumbnailPath = (try? c.decode(String.self, forKey: .thumbnailPath))?
             .nonEmpty
         self.thumbnailPathSmall = (try? c.decode(String.self, forKey: .thumbnailPathSmall))?
@@ -75,6 +106,8 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
     init(name: String, hasHls: Bool = true, hasDash: Bool = false,
          clipId: String? = nil, codec: String = "",
          segmentDuration: Int? = nil,
+         segmentDurations: [Int]? = nil,
+         hasLL: Bool? = nil,
          thumbnailPath: String? = nil,
          thumbnailPathSmall: String? = nil,
          thumbnailPathLarge: String? = nil) {
@@ -84,6 +117,8 @@ struct ContentItem: Decodable, Identifiable, Equatable, Hashable {
         self.clipId = clipId ?? Self.deriveClipId(from: name)
         self.codec = codec.lowercased()
         self.segmentDuration = segmentDuration
+        self.segmentDurations = segmentDurations
+        self.hasLL = hasLL
         self.thumbnailPath = thumbnailPath
         self.thumbnailPathSmall = thumbnailPathSmall
         self.thumbnailPathLarge = thumbnailPathLarge

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -574,9 +574,9 @@ final class PlayerViewModel: ObservableObject {
             case .dash: guard item.hasDash else { return false }
             }
             switch segment {
-            case .ll: return true
-            case .s2: return item.segmentDuration == 2 || item.segmentDuration == nil
-            case .s6: return item.segmentDuration == 6 || item.segmentDuration == nil
+            case .ll: return item.supportsLL
+            case .s2: return item.supportsSegment(2)
+            case .s6: return item.supportsSegment(6)
             }
         }
     }
@@ -598,9 +598,9 @@ final class PlayerViewModel: ObservableObject {
             case .dash: guard item.hasDash else { return false }
             }
             switch segment {
-            case .ll: return true
-            case .s2: return item.segmentDuration == 2 || item.segmentDuration == nil
-            case .s6: return item.segmentDuration == 6 || item.segmentDuration == nil
+            case .ll: return item.supportsLL
+            case .s2: return item.supportsSegment(2)
+            case .s6: return item.supportsSegment(6)
             }
         }
         // Dedupe by clipId. When multiple codec encodings exist for the
@@ -3110,6 +3110,8 @@ extension ContentItem: Encodable {
         try c.encode(clipId, forKey: .clipId)
         try c.encode(codec, forKey: .codec)
         try c.encodeIfPresent(segmentDuration, forKey: .segmentDuration)
+        try c.encodeIfPresent(segmentDurations, forKey: .segmentDurations)
+        try c.encodeIfPresent(hasLL, forKey: .hasLL)
         try c.encodeIfPresent(thumbnailPath, forKey: .thumbnailPath)
         try c.encodeIfPresent(thumbnailPathSmall, forKey: .thumbnailPathSmall)
         try c.encodeIfPresent(thumbnailPathLarge, forKey: .thumbnailPathLarge)

--- a/go-upload/internal/util/content.go
+++ b/go-upload/internal/util/content.go
@@ -33,9 +33,26 @@ type ContentInfo struct {
 	ThumbnailURLSmall string  `json:"thumbnail_url_small,omitempty"`
 	// 1280 px wide — Continue Watching hero / large surfaces.
 	ThumbnailURLLarge string  `json:"thumbnail_url_large,omitempty"`
-	SegmentDuration   *int    `json:"segment_duration"`
-	MaxResolution     *string `json:"max_resolution"`
-	MaxHeight         *int    `json:"max_height"`
+	// Native segment length (seconds) the source was encoded at, as
+	// detected from the on-disk playlists. Kept for display / upload
+	// config / forwarder Chromecast discovery. NOT the set of lengths the
+	// clip is *playable* at — see SegmentDurations.
+	SegmentDuration *int `json:"segment_duration"`
+	// All segment lengths (seconds) go-live can actually serve this clip
+	// at. go-live synthesizes both a 2s and a 6s master playlist on the
+	// fly from ANY HLS source master (RangeHLSGenerator composes virtual
+	// segment windows from the stored segments), so segment length is a
+	// presentation choice — every HLS clip is browsable at 2s AND 6s
+	// regardless of its native SegmentDuration. LL is reported separately
+	// via HasLL because it additionally needs on-disk partial info.
+	SegmentDurations []int `json:"segment_durations,omitempty"`
+	// True when the source carries the partial-segment info LL-HLS needs
+	// (#EXT-X-PART tags, or a .byteranges sidecar fallback) — the
+	// prerequisite for go-live to generate the low-latency master. 2s/6s
+	// never need partials; LL always does.
+	HasLL         bool    `json:"has_ll"`
+	MaxResolution *string `json:"max_resolution"`
+	MaxHeight     *int    `json:"max_height"`
 
 	// Internal — used for newest-wins dedup. Lowercase so encoding/json
 	// skips it. Set during ListContent from the encode-timestamp suffix
@@ -119,6 +136,8 @@ func ListContent(contentDir string) ([]ContentInfo, error) {
 			thumbnailURLLarge = base + "/thumbnail-large.jpg"
 		}
 		segmentDuration := detectSegmentDuration(itemPath)
+		segmentDurations := availableSegmentDurations(itemPath, hasHls, segmentDuration)
+		hasLL := hasHls && contentHasPartials(itemPath)
 		maxResolution, maxHeight := detectMaxResolution(itemPath)
 		clipID, codec, ts := splitClipIDAndCodec(name)
 		// If the name didn't carry an encode timestamp (older content),
@@ -141,6 +160,8 @@ func ListContent(contentDir string) ([]ContentInfo, error) {
 			ThumbnailURLSmall: thumbnailURLSmall,
 			ThumbnailURLLarge: thumbnailURLLarge,
 			SegmentDuration:   segmentDuration,
+			SegmentDurations:  segmentDurations,
+			HasLL:             hasLL,
 			MaxResolution:     maxResolution,
 			MaxHeight:         maxHeight,
 			encodeTS:          ts,
@@ -195,6 +216,80 @@ func detectSegmentDuration(contentPath string) *int {
 	}
 
 	return nil
+}
+
+// availableSegmentDurations reports the integer segment lengths go-live can
+// serve this clip at. go-live composes both a 2s and a 6s virtual master from
+// any HLS source master, so any HLS clip is available at both regardless of
+// its native encode. The natively-detected duration is folded in too so a
+// DASH-only clip (no HLS synthesis) still advertises something. LL is not an
+// integer length — it's reported separately via HasLL.
+func availableSegmentDurations(contentPath string, hasHls bool, native *int) []int {
+	set := map[int]bool{}
+	if hasHls {
+		set[2] = true
+		set[6] = true
+	}
+	if native != nil {
+		set[*native] = true
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(set))
+	for d := range set {
+		out = append(out, d)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// contentHasPartials reports whether the source carries the partial-segment
+// info LL-HLS needs. Mirrors go-live's LoadPlaylistInfoWithByteranges fallback
+// chain (parser/playlist.go, parser/byterange.go) so the catalogue's LL flag
+// matches what go-live can actually generate: prefer #EXT-X-PART tags in a
+// variant playlist, fall back to a sibling .byteranges file next to the media
+// segments. 2s/6s never need this; LL always does.
+func contentHasPartials(contentPath string) bool {
+	resDirs := []string{"1080p", "720p", "540p", "360p"}
+	for _, dir := range resDirs {
+		resPath := filepath.Join(contentPath, dir)
+		if playlistHasPartTags(filepath.Join(resPath, "playlist.m3u8")) {
+			return true
+		}
+		if dirHasByteranges(resPath) {
+			return true
+		}
+	}
+	return false
+}
+
+func playlistHasPartTags(path string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.HasPrefix(strings.TrimSpace(scanner.Text()), "#EXT-X-PART") {
+			return true
+		}
+	}
+	return false
+}
+
+func dirHasByteranges(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".byteranges") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseHlsPlaylistDuration(path string) *int {


### PR DESCRIPTION
## What

`/api/content` advertised a single native `segment_duration` (6) per clip, so the app's Home filter hid every clip when **2s** was selected — emptying Home (no hero, no previews, no `home-continue-watching`) and blocking the characterization segment axis. Selecting 6s/LL worked; 2s did not.

go-live actually synthesizes **both** a 2s and a 6s master from **any** HLS source master (`RangeHLSGenerator` composes virtual segment windows from the stored segments) — segment length is a presentation choice, not a stored property. **LL** is the lone exception: it needs on-disk partial-segment info to generate.

## Changes

**go-upload** (`internal/util/content.go`) — alongside the kept `segment_duration` (still read by the forwarder Chromecast path + upload config):
- `segment_durations: [2, 6]` — the lengths go-live can serve for any HLS clip
- `has_ll` — whether the LL master is generatable, mirroring go-live's `LoadPlaylistInfoWithByteranges` signal: **`#EXT-X-PART` preferred**, `.byteranges` sidecar as fallback

**iOS** (`Models.swift` + both `PlayerViewModel` filters) and **Android** (`PlayerState` filter + `PlayerViewModel` JSON parse/serialize) — match the selected segment against the set (`supportsSegment(_:)` / `hasLL`), falling back to the legacy single-value match when a pre-#685 server omits the new fields.

## Verification

- Live on test-dev :21000 — every clip reports `segment_durations=[2,6]` / `has_ll=true`; the on-disk playlists carry **3174 `#EXT-X-PART` tags** (+106 `.byteranges`), confirming `has_ll` is a real read, not a default.
- iPad sim with segment forced to **2s** now populates Home (hero + full preview rail) where it was previously empty — the segment-axis blocker is cleared.
- go-upload `go vet` clean; iOS build succeeds.

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
