### PR TITLE
feat(679): stamp manifest variant + go-live build into play scenario

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,19 @@ RUN npm run gen-types && npm run build
 FROM golang:1.26-alpine AS go-builder
 RUN apk add git
 WORKDIR /build
+# #679: stamp the build into go-live so its X-Served-By header carries it and
+# the forwarder can record which build served each play. Same VERSION arg
+# go-proxy already uses (the release string from the VERSION file).
+ARG VERSION=unknown
 COPY go-live /build/go-live
 RUN cd /build/go-live && \
-    go build -o /out/go-live cmd/server/main.go
+    go build -ldflags "-X main.Version=${VERSION}" -o /out/go-live cmd/server/main.go
 
 COPY go-upload /build/go-upload
 RUN cd /build/go-upload && \
     go mod download && \
     go build -o /out/go-upload ./cmd/server
 
-ARG VERSION=unknown
 COPY go-proxy /build/go-proxy
 RUN cd /build/go-proxy && \
     go build -ldflags "-X main.versionString=${VERSION}" -o /out/go-proxy ./cmd/server

--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -136,7 +136,7 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		WITH base AS (
 		  SELECT
 		    session_id, play_id, attempt_id, ts,
-		    player_id, group_id, content_id,
+		    player_id, group_id, content_id, master_manifest_url,
 		    player_state, player_error, last_event,
 		    stall_count, frames_dropped, frames_displayed,
 		    video_bitrate_mbps, video_resolution, video_quality_pct,
@@ -176,6 +176,24 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		         countIf(faulted = 1)  AS net_faults
 		  FROM %s.network_requests
 		  %s
+		  GROUP BY play_id
+		),
+		-- #679: the go-live build that served this play, read from the
+		-- X-Served-By response header the proxy already captures into
+		-- response_headers (a JSON array of {name,value}). go-live emits
+		-- "go-live/<build>" once it's built with -ldflags; the forwarder
+		-- strips the prefix. anyIf(non-empty) since it's constant per play.
+		server_builds AS (
+		  SELECT play_id, anyIf(sb, sb != '') AS served_by
+		  FROM (
+		    SELECT play_id,
+		           JSONExtractString(
+		             arrayFirst(h -> JSONExtractString(h, 'name') = 'X-Served-By',
+		                        JSONExtractArrayRaw(response_headers)),
+		             'value') AS sb
+		    FROM %s.network_requests
+		    %s
+		  )
 		  GROUP BY play_id
 		),
 		-- Per-play label histogram across all three source tables.
@@ -223,6 +241,10 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    any(player_id) AS player_id,
 		    any(group_id) AS group_id,
 		    any(content_id) AS content_id,
+		    -- #679: the master manifest the player loaded — non-empty only on
+		    -- master-playlist fetches, so pick any non-empty value (constant
+		    -- per play). The forwarder derives the LL/2s/6s variant from it.
+		    anyIf(master_manifest_url, master_manifest_url != '') AS master_manifest_url,
 		    min(ts) AS started_at,
 		    max(ts) AS last_seen_at,
 		    count() AS metric_events,
@@ -310,6 +332,10 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		  agg.device_class, agg.device_model, agg.player_tech,
 		  agg.app_version, agg.os_version_major, agg.os_version_minor,
 		  agg.classification,
+		  -- #679: scenario sources — master manifest URL (variant derived in
+		  -- the forwarder) + go-live build from the captured X-Served-By header.
+		  agg.master_manifest_url,
+		  ifNull(server_builds.served_by, '') AS served_by,
 		  ifNull(net_counts.net_rows,   0) AS net_events,
 		  ifNull(net_counts.net_errors, 0) AS net_errors,
 		  ifNull(net_counts.net_faults, 0) AS net_faults,
@@ -318,13 +344,15 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		  ifNull(labels_agg.label_pairs,           []) AS label_histogram
 		FROM agg
 		LEFT JOIN net_counts ON agg.play_id = net_counts.play_id
+		LEFT JOIN server_builds ON agg.play_id = server_builds.play_id
 		LEFT JOIN labels_agg ON lowerUTF8(agg.play_id) = labels_agg.play_id
 		%s
 		ORDER BY agg.started_at DESC
 		LIMIT %d
 		FORMAT JSONEachRow`,
 		b.Database, b.EventsTable, where,
-		b.Database, netWhere,
+		b.Database, netWhere, // net_counts
+		b.Database, netWhere, // #679 server_builds
 		b.Database, b.EventsTable, where,
 		b.Database, netWhere,
 		b.Database, netWhere,

--- a/analytics/go-forwarder/internal/plays/scenario.go
+++ b/analytics/go-forwarder/internal/plays/scenario.go
@@ -38,12 +38,51 @@ func enrichScenario(rows []map[string]any) {
 		putIfStr(sc, "test", test)
 		putIfStr(sc, "platform", platform)
 		putIfStr(sc, "run_id", runID)
+		// #679 — server-side identity: manifest variant (derived from the
+		// master manifest the player loaded) + the go-live build that served
+		// the play (from the X-Served-By header the proxy captured).
+		if v := manifestVariant(asString(row["master_manifest_url"])); v != "" {
+			sc["manifest_variant"] = v
+		}
+		if b := serverBuild(asString(row["served_by"])); b != "" {
+			sc["server_build"] = b
+		}
 
 		if len(sc) == 0 {
 			continue
 		}
 		row["scenario"] = sc
 	}
+}
+
+// manifestVariant classifies the LL / 2s / 6s manifest from the master
+// playlist URL the player loaded. go-live names the slower variants with a
+// "2s"/"6s" path segment or filename suffix (e.g. .../2s/master.m3u8 or
+// .../master_6s.m3u8); the low-latency variant has neither marker. Empty
+// when no master URL was captured (can't tell).
+func manifestVariant(masterURL string) string {
+	if masterURL == "" {
+		return ""
+	}
+	switch {
+	case strings.Contains(masterURL, "/2s/") || strings.Contains(masterURL, "_2s"):
+		return "2s"
+	case strings.Contains(masterURL, "/6s/") || strings.Contains(masterURL, "_6s"):
+		return "6s"
+	default:
+		return "ll"
+	}
+}
+
+// serverBuild extracts the build tag from the X-Served-By header value.
+// go-live emits "go-live/<build>" once compiled with -ldflags; a plain
+// "go-live" (dev build, no ldflags) carries no build info, so returns "".
+func serverBuild(servedBy string) string {
+	const prefix = "go-live/"
+	if strings.HasPrefix(servedBy, prefix) {
+		return strings.TrimPrefix(servedBy, prefix)
+	}
+	return ""
 }
 
 // scenarioLabelTails pulls the test / platform / run_id values out of the

--- a/analytics/go-forwarder/internal/plays/scenario_test.go
+++ b/analytics/go-forwarder/internal/plays/scenario_test.go
@@ -77,3 +77,50 @@ func TestEnrichScenario_DeviceFromClassOnly(t *testing.T) {
 		t.Errorf("device_model should be absent: %#v", sc)
 	}
 }
+
+func TestEnrichScenario_ServerSideFields(t *testing.T) {
+	rows := []map[string]any{{
+		"master_manifest_url": "http://h/go-live/bbb/2s/master.m3u8",
+		"served_by":           "go-live/v2.0.0",
+	}}
+	enrichScenario(rows)
+	sc := rows[0]["scenario"].(map[string]any)
+	if got, _ := sc["manifest_variant"].(string); got != "2s" {
+		t.Errorf("manifest_variant = %q, want 2s", got)
+	}
+	if got, _ := sc["server_build"].(string); got != "v2.0.0" {
+		t.Errorf("server_build = %q, want v2.0.0", got)
+	}
+}
+
+func TestManifestVariant(t *testing.T) {
+	cases := map[string]string{
+		"":                                       "",
+		"http://h/go-live/c/master.m3u8":         "ll",
+		"http://h/go-live/c/2s/master.m3u8":      "2s",
+		"http://h/go-live/c/master_2s.m3u8":      "2s",
+		"http://h/go-live/c/6s/master.m3u8":      "6s",
+		"http://h/go-live/c/master_6s.m3u8":      "6s",
+		"http://h/go-live/c/1080p/index.m3u8":    "ll",
+	}
+	for url, want := range cases {
+		if got := manifestVariant(url); got != want {
+			t.Errorf("manifestVariant(%q) = %q, want %q", url, got, want)
+		}
+	}
+}
+
+func TestServerBuild(t *testing.T) {
+	cases := map[string]string{
+		"go-live/v2.0.0": "v2.0.0",
+		"go-live/abc123": "abc123",
+		"go-live":        "", // dev build, no ldflags — no build info
+		"":               "",
+		"nginx":          "",
+	}
+	for hdr, want := range cases {
+		if got := serverBuild(hdr); got != want {
+			t.Errorf("serverBuild(%q) = %q, want %q", hdr, got, want)
+		}
+	}
+}

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -1036,6 +1036,8 @@ components:
         app_version:  { type: string, description: "Client app version. From the typed column." }
         os_version:   { type: string, description: "OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor." }
         content_id:   { type: string, description: "Content identifier — duplicated here so the object is self-contained for the viewer header." }
+        manifest_variant: { type: string, enum: ['ll', '2s', '6s'], description: "Manifest the player loaded, derived from the master URL: 'll' (low-latency), '2s', or '6s'. Issue #679." }
+        server_build:     { type: string, description: "go-live build that served the play, from the X-Served-By response header (the build the proxy captured). Empty for dev builds with no -ldflags stamp. Issue #679." }
 
     PlaySummaryPage:
       type: object

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -236,6 +236,8 @@ const SCENARIO_FIELDS: { src: keyof Scenario; key: string; label: string }[] = [
   { src: 'player_tech',  key: 'player',   label: 'player' },
   { src: 'app_version',  key: 'app',      label: 'app' },
   { src: 'os_version',   key: 'os',       label: 'os' },
+  { src: 'manifest_variant', key: 'variant', label: 'variant' }, // #679
+  { src: 'server_build', key: 'build',    label: 'build' },      // #679
   { src: 'run_id',       key: 'run',      label: 'run' },
 ];
 // Build the render model from a typed Scenario object (server-supplied, #678).

--- a/content/dashboard-v3/src/repo/v2-repo.ts
+++ b/content/dashboard-v3/src/repo/v2-repo.ts
@@ -326,6 +326,9 @@ export interface Scenario {
   app_version?: string;
   os_version?: string;
   content_id?: string;
+  // #679 — server-side run identity.
+  manifest_variant?: string; // 'll' | '2s' | '6s'
+  server_build?: string;
 }
 
 export interface ListPlaysParams {

--- a/go-live/cmd/server/main.go
+++ b/go-live/cmd/server/main.go
@@ -33,8 +33,21 @@ func requestLogger(next http.Handler) http.Handler {
 	})
 }
 
+// Version is the build identifier, injected via -ldflags "-X main.Version=<sha>".
+// Empty on a plain `go build`. #679: handed to the api package so it rides the
+// X-Served-By header.
+var Version string
+
+func buildLabel() string {
+	if Version == "" {
+		return "dev"
+	}
+	return Version
+}
+
 func main() {
-	fmt.Println("Starting go-live LL-HLS server...")
+	api.BuildVersion = Version
+	fmt.Printf("Starting go-live LL-HLS server (build %q)...\n", buildLabel())
 	mgr := manager.NewProcessManager()
 	tracker := api.NewStreamTracker()
 	h := &api.Handler{Manager: mgr, Tracker: tracker}

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -28,6 +28,22 @@ var (
 	goLiveDir          = getEnv("GO_LIVE_OUTPUT_DIR", filepath.Join(infiniteContentDir, "go-live"))
 )
 
+// BuildVersion is the go-live build identifier (git SHA), injected at compile
+// time via -ldflags "-X .../internal/api.BuildVersion=<sha>". Empty on a
+// plain `go build` (local dev). #679: it rides the X-Served-By response
+// header so the proxy captures it and the forwarder can stamp each play's
+// scenario.server_build with the build that served it.
+var BuildVersion string
+
+// servedBy is the X-Served-By header value: "go-live" for an un-stamped dev
+// build, "go-live/<build>" once compiled with the ldflags above.
+func servedBy() string {
+	if BuildVersion == "" {
+		return "go-live"
+	}
+	return "go-live/" + BuildVersion
+}
+
 var llhlsGen = &generator.LLHLSGenerator{}
 
 type dashCacheEntry struct {
@@ -166,7 +182,7 @@ type Handler struct {
 }
 
 func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write([]byte("go-live OK"))
 }
 
@@ -212,7 +228,7 @@ func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	json.NewEncoder(w).Encode(response)
 }
 
@@ -229,7 +245,7 @@ func (h *Handler) TickStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	json.NewEncoder(w).Encode(stats)
 }
 
@@ -251,7 +267,7 @@ func (h *Handler) DashTickStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	json.NewEncoder(w).Encode(stats)
 }
 
@@ -1028,7 +1044,7 @@ func (h *Handler) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Accept-Ranges", "bytes")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	http.ServeFile(w, r, segmentPath)
 }
 
@@ -1095,7 +1111,7 @@ func (h *Handler) OnDemandDashManifest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(cached)))
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write(cached)
 }
 
@@ -1341,7 +1357,7 @@ func (h *Handler) ServeDashSegment(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Accept-Ranges", "bytes")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	http.ServeFile(w, r, segmentPath)
 }
 
@@ -1393,7 +1409,7 @@ func (h *Handler) OnDemandMasterPlaylist(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write(data)
 }
 
@@ -1449,7 +1465,7 @@ func (h *Handler) OnDemandMasterPlaylistDuration(w http.ResponseWriter, r *http.
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write(data)
 }
 
@@ -1515,7 +1531,7 @@ func (h *Handler) OnDemandVariantPlaylist(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write(data)
 }
 
@@ -1548,7 +1564,7 @@ func (h *Handler) OnDemandVariantPlaylistDuration(w http.ResponseWriter, r *http
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Header().Set("X-Served-By", "go-live")
+	w.Header().Set("X-Served-By", servedBy())
 	w.Write(data)
 }
 

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -278,6 +278,27 @@ func (e PlaySummaryClassification) Valid() bool {
 	}
 }
 
+// Defines values for ScenarioManifestVariant.
+const (
+	Ll  ScenarioManifestVariant = "ll"
+	N2s ScenarioManifestVariant = "2s"
+	N6s ScenarioManifestVariant = "6s"
+)
+
+// Valid indicates whether the value is a known member of the ScenarioManifestVariant enum.
+func (e ScenarioManifestVariant) Valid() bool {
+	switch e {
+	case Ll:
+		return true
+	case N2s:
+		return true
+	case N6s:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for Classification.
 const (
 	ClassificationFavourite   Classification = "favourite"
@@ -1263,6 +1284,9 @@ type Scenario struct {
 	// DeviceModel Device model identifier (e.g. 'iPhone15,2'). From the typed column.
 	DeviceModel *string `json:"device_model,omitempty"`
 
+	// ManifestVariant Manifest the player loaded, derived from the master URL: 'll' (low-latency), '2s', or '6s'. Issue #679.
+	ManifestVariant *ScenarioManifestVariant `json:"manifest_variant,omitempty"`
+
 	// OsVersion OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor.
 	OsVersion *string `json:"os_version,omitempty"`
 
@@ -1275,9 +1299,15 @@ type Scenario struct {
 	// RunId Characterization run id, from testing=run_id_* (compact UTC, e.g. '20260524T070148Z'). Groups plays into a run. Harness runs only.
 	RunId *string `json:"run_id,omitempty"`
 
+	// ServerBuild go-live build that served the play, from the X-Served-By response header (the build the proxy captured). Empty for dev builds with no -ldflags stamp. Issue #679.
+	ServerBuild *string `json:"server_build,omitempty"`
+
 	// Test Characterization test mode, from testing=test_* (e.g. 'rampup'). Harness runs only.
 	Test *string `json:"test,omitempty"`
 }
+
+// ScenarioManifestVariant Manifest the player loaded, derived from the master URL: 'll' (low-latency), '2s', or '6s'. Issue #679.
+type ScenarioManifestVariant string
 
 // StreamErrorEvent Emitted on transport / CH failures after the initial `meta`
 // frame. The connection closes shortly after; the client may


### PR DESCRIPTION
## What

Part 3 of #677 (split out as #679). Adds the two **server-side** run-identity fields to the Scenario object from #678 — `manifest_variant` (LL/2s/6s) and `server_build` (which go-live build served the play). Per the design decision: build tag rides go-live's existing **X-Served-By** header via `-ldflags`, which the proxy **already captures**, so **no ClickHouse migration** — both fields derive from data already on the rows.

## manifest_variant (`ll` | `2s` | `6s`)

- `find.go` surfaces `master_manifest_url` on the play summary (`anyIf` non-empty — constant per play).
- `scenario.go` derives the variant from its path (`/2s/`·`_2s` → 2s, `/6s/`·`_6s` → 6s, else LL).

## server_build

- **go-live**: `main.Version` (set via `-ldflags -X`) → `api.BuildVersion` → `X-Served-By` becomes `go-live/<build>` (was static `go-live`). All 11 header sites now call `servedBy()`.
- **Dockerfile**: go-live builds with `-ldflags "-X main.Version=${VERSION}"`, reusing the **same `VERSION` build-arg go-proxy already consumes**.
- **forwarder**: the proxy already captures `X-Served-By` into `network_requests.response_headers`; `find.go` extracts it per play via a `server_builds` CTE (JSON header parse), and `scenario.go` strips the `go-live/` prefix (empty for un-stamped dev builds).

## Plumbed through

`forwarder.yaml` Scenario (+`manifest_variant` enum, +`server_build`) → regenerated `harness-cli` client → `v2-repo.ts` Scenario → `Sessions.vue` scenario chips (`variant`, `build`).

## Test

- Table tests for `manifestVariant` + `serverBuild`; server-side-fields enrich test.
- `go build`/`vet`/`test` (forwarder, harness-cli, go-live), `vue-tsc`, `vite build` all clean.
- ldflags injection verified end-to-end (binary prints `build "v2.0.0-test"` → header `go-live/v2.0.0-test`).
- `find.go` Sprintf verb/arg count re-balanced (17 = 17) after adding the CTE.

## Rollout

- **Forwarder rebuild** (`make analytics-rebuild-forwarder`) lights up `manifest_variant` immediately — derived from existing rows.
- **`server_build`** needs a **container rebuild** (so go-live starts emitting the stamped header) and then populates for plays served afterward; older plays show no build (correct — that build info wasn't captured at the time).

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
