### PR TITLE
feat(char): segment axis for rampup/pyramid — cold-start on 2s/6s/LL

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -499,6 +499,14 @@ final class PlayerViewModel: ObservableObject {
     }
     func setSegment(_ s: SegmentLength) {
         segment = s
+        // Persist like every other Advanced setting (loadFlags restores
+        // `is.segment` at launch, persistFlags writes it) — setSegment
+        // was the lone setter that skipped persistence, so a segment
+        // choice silently reverted on relaunch. The characterization
+        // rig's relaunch-per-segment cold start depends on this: the
+        // segment must survive the cold-launch so the player starts on
+        // the chosen segment from frame 1.
+        persistFlags()
         buildURLAndLoad()
     }
     func setCodec(_ c: CodecFilter) {

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -114,6 +114,30 @@ func runPyramid(t *testing.T, p runner.Platform) {
 	coldStart := isAppium && preFloor > 0
 	conservativeStart := isAppium && !coldStart
 
+	// #segments — force the segment via a launch argument so the single
+	// cold launch below lands on it deterministically. iOS folds
+	// `-is.segment <rawValue>` into UserDefaults (NSArgumentDomain,
+	// highest precedence); loadFlags reads `is.segment` at init, so the
+	// player cold-starts on this segment from frame 1 — bottom rung under
+	// the floor cap, no UI pre-set, no second Appium session, no warm-
+	// switch starvation. CHAR_SEGMENT is the label form (2s|6s|ll); the
+	// enum rawValue is s2|s6|ll. Appium iOS only. Run both segments as
+	// two invocations (CHAR_SEGMENT=6s then =2s); each cold-starts clean.
+	segment := strings.TrimSpace(os.Getenv("CHAR_SEGMENT"))
+	if segment != "" {
+		if isAppium {
+			raw := map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}[segment]
+			if raw == "" {
+				t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", segment)
+			}
+			appium.SetLaunchArgs([]string{"-is.segment", raw})
+			t.Logf("forcing segment=%s via launch arg -is.segment %s — cold start lands on it", segment, raw)
+		} else {
+			t.Logf("CHAR_SEGMENT=%s ignored — requires the Appium launcher", segment)
+			segment = ""
+		}
+	}
+
 	var sess *runner.Session
 	switch {
 	case coldStart:
@@ -193,6 +217,9 @@ func runPyramid(t *testing.T, p runner.Platform) {
 		"platform": string(p),
 		"run_id":   runID,
 	}
+	if segment != "" {
+		startLabels["segment"] = segment
+	}
 	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
 		t.Logf("label play (start): %v (test continues)", err)
 	} else {
@@ -235,6 +262,25 @@ func runPyramid(t *testing.T, p runner.Platform) {
 	rec, err := sess.PlayerState(ctx)
 	if err != nil {
 		t.Fatalf("PlayerState: %v", err)
+	}
+	// #segments — assert the cold start actually landed on the requested
+	// segment. master_2s.m3u8 / master_6s.m3u8 / master.m3u8 (ll). If the
+	// segment didn't persist across the relaunch we'd silently sweep the
+	// wrong segment — fail loudly instead.
+	if segment != "" && rec.CurrentPlay != nil {
+		master := rec.CurrentPlay.Manifest.MasterURL
+		var want string
+		switch segment {
+		case "ll":
+			want = "master.m3u8"
+		default:
+			want = "master_" + segment + "."
+		}
+		if !strings.Contains(master, want) {
+			t.Fatalf("requested segment %q but cold-started on %q (expected master to contain %q) — did the segment persist across relaunch?",
+				segment, master, want)
+		}
+		t.Logf("confirmed cold start on segment=%s (master=%s)", segment, master)
 	}
 	desc, err := runner.StandardLadderRates(rec)
 	if err != nil {
@@ -306,11 +352,15 @@ func runPyramid(t *testing.T, p runner.Platform) {
 	if len(playerShort) > 8 {
 		playerShort = playerShort[:8]
 	}
+	segTag := ""
+	if segment != "" {
+		segTag = "-" + segment
+	}
 	var last *runner.Report
 	for ri, report := range reports {
 		cyc := ri + 1
 		last = report
-		base := fmt.Sprintf("pyramid-%s-%s-%s-cyc%d", p, playerShort, runID, cyc)
+		base := fmt.Sprintf("pyramid-%s-%s%s-%s-cyc%d", p, playerShort, segTag, runID, cyc)
 		jsonPath, err := runner.WriteReport(out, base, report)
 		if err != nil {
 			t.Fatalf("cyc%d write report: %v", cyc, err)

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -114,6 +114,30 @@ func runRampup(t *testing.T, p runner.Platform) {
 	coldStart := isAppium && preFloor > 0
 	conservativeStart := isAppium && !coldStart
 
+	// #segments — force the segment via a launch argument so the single
+	// cold launch below lands on it deterministically. iOS folds
+	// `-is.segment <rawValue>` into UserDefaults (NSArgumentDomain,
+	// highest precedence); loadFlags reads `is.segment` at init, so the
+	// player cold-starts on this segment from frame 1 — bottom rung under
+	// the floor cap, no UI pre-set, no second Appium session, no warm-
+	// switch starvation. CHAR_SEGMENT is the label form (2s|6s|ll); the
+	// enum rawValue is s2|s6|ll. Appium iOS only. Run both segments as
+	// two invocations (CHAR_SEGMENT=6s then =2s); each cold-starts clean.
+	segment := strings.TrimSpace(os.Getenv("CHAR_SEGMENT"))
+	if segment != "" {
+		if isAppium {
+			raw := map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}[segment]
+			if raw == "" {
+				t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", segment)
+			}
+			appium.SetLaunchArgs([]string{"-is.segment", raw})
+			t.Logf("forcing segment=%s via launch arg -is.segment %s — cold start lands on it", segment, raw)
+		} else {
+			t.Logf("CHAR_SEGMENT=%s ignored — requires the Appium launcher", segment)
+			segment = ""
+		}
+	}
+
 	var sess *runner.Session
 	switch {
 	case coldStart:
@@ -231,6 +255,9 @@ func runRampup(t *testing.T, p runner.Platform) {
 		"platform": string(p),
 		"run_id":   runID,
 	}
+	if segment != "" {
+		startLabels["segment"] = segment
+	}
 	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
 		t.Logf("label play (start): %v (test continues)", err)
 	} else {
@@ -275,6 +302,25 @@ func runRampup(t *testing.T, p runner.Platform) {
 	rec, err := sess.PlayerState(ctx)
 	if err != nil {
 		t.Fatalf("PlayerState: %v", err)
+	}
+	// #segments — assert the cold start actually landed on the requested
+	// segment. master_2s.m3u8 / master_6s.m3u8 / master.m3u8 (ll). If the
+	// segment didn't persist across the relaunch we'd silently sweep the
+	// wrong segment — fail loudly instead.
+	if segment != "" && rec.CurrentPlay != nil {
+		master := rec.CurrentPlay.Manifest.MasterURL
+		var want string
+		switch segment {
+		case "ll":
+			want = "master.m3u8"
+		default:
+			want = "master_" + segment + "."
+		}
+		if !strings.Contains(master, want) {
+			t.Fatalf("requested segment %q but cold-started on %q (expected master to contain %q) — did the segment persist across relaunch?",
+				segment, master, want)
+		}
+		t.Logf("confirmed cold start on segment=%s (master=%s)", segment, master)
 	}
 	desc, err := runner.StandardLadderRates(rec)
 	if err != nil {
@@ -334,11 +380,15 @@ func runRampup(t *testing.T, p runner.Platform) {
 	if len(playerShort) > 8 {
 		playerShort = playerShort[:8]
 	}
+	segTag := ""
+	if segment != "" {
+		segTag = "-" + segment
+	}
 	var last *runner.Report
 	for ri, report := range reports {
 		cyc := ri + 1
 		last = report
-		base := fmt.Sprintf("rampup-%s-%s-%s-cyc%d", p, playerShort, runID, cyc)
+		base := fmt.Sprintf("rampup-%s-%s%s-%s-cyc%d", p, playerShort, segTag, runID, cyc)
 		jsonPath, err := runner.WriteReport(out, base, report)
 		if err != nil {
 			t.Fatalf("cyc%d write report: %v", cyc, err)

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -47,6 +47,14 @@ type AppiumLauncher struct {
 	// shrink it. #627/#660.
 	closeBeat time.Duration
 
+	// launchArgs — process arguments passed to the app on launch
+	// (XCUITest `appium:processArguments`). iOS maps `-key value` args
+	// into UserDefaults' NSArgumentDomain (highest precedence), so the
+	// segment axis forces e.g. `-is.segment s2` for a single, deterministic
+	// cold launch on that segment — no UI pre-set, no second session.
+	// Set via SetLaunchArgs before the launch. #segments.
+	launchArgs []string
+
 	mu       sync.Mutex
 	sessions map[string]string // device UDID → Appium session id
 	hc       *http.Client
@@ -129,6 +137,15 @@ func (a *AppiumLauncher) Launch(ctx context.Context, d Device) (*Session, error)
 // Use case: rampup / pyramid where the test wants to ApplyRate(floor)
 // BEFORE the first segment fetch, so playback starts cold under the
 // constraint instead of cliff-diving from "no cap" to a low cap.
+// SetLaunchArgs sets process arguments applied to every subsequent app
+// launch (see the launchArgs field). Pass nil to clear. #segments uses
+// this to force the segment via `-is.segment <rawValue>` on cold launch.
+func (a *AppiumLauncher) SetLaunchArgs(args []string) {
+	a.mu.Lock()
+	a.launchArgs = args
+	a.mu.Unlock()
+}
+
 func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, error) {
 	bundleID := a.BundleIDs[d.Platform]
 	if bundleID == "" {
@@ -138,6 +155,12 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 		return nil, fmt.Errorf("appium server not reachable at %s: %w (start with `appium`, or unset LAUNCH_MODE=appium)", a.URL, err)
 	}
 	caps := appiumCapabilities(d, bundleID)
+	if len(a.launchArgs) > 0 {
+		// XCUITest passes these to the app on launch; iOS folds `-key value`
+		// pairs into UserDefaults (NSArgumentDomain). #segments forces the
+		// segment this way so a single cold launch lands on it.
+		caps["appium:processArguments"] = map[string]any{"args": a.launchArgs}
+	}
 	sessID, err := a.createSession(ctx, caps)
 	if err != nil {
 		return nil, fmt.Errorf("appium create session: %w", err)
@@ -172,7 +195,16 @@ func (a *AppiumLauncher) ResumePlayback(ctx context.Context, d Device) error {
 	}
 	switch d.Platform {
 	case PlatformIPhone, PlatformIPad, PlatformIPadSim:
-		if err := a.tapByAccessibilityID(ctx, sessID, "home-continue-watching"); err != nil {
+		// Wait for the continue-watching tile to render before tapping —
+		// the catalogue fetch is async, so a just-forced-to-Home screen
+		// can show an empty content row for a few seconds (observed after
+		// a fresh launch / segment-forced launch); tapping immediately
+		// 404s on the not-yet-rendered tile.
+		elID, err := a.waitForAccessibilityID(ctx, sessID, "home-continue-watching", 30*time.Second)
+		if err != nil {
+			return fmt.Errorf("wait for home-continue-watching: %w", err)
+		}
+		if err := a.clickElement(ctx, sessID, elID); err != nil {
 			return fmt.Errorf("tap home-continue-watching: %w", err)
 		}
 	}
@@ -585,6 +617,32 @@ func (a *AppiumLauncher) clickElement(ctx context.Context, sessID, elementID str
 	_, err := a.doRequest(ctx, "POST",
 		fmt.Sprintf("/session/%s/element/%s/click", sessID, elementID), map[string]any{})
 	return err
+}
+
+// waitForAccessibilityID polls for an element by accessibility id until
+// it appears or the deadline passes, then returns its element id. Rides
+// out async UI population — e.g. the Home content row renders its
+// continue-watching tile only after the catalogue fetch completes, so a
+// freshly-launched Home can be empty for a few seconds; tapping into it
+// immediately 404s. Poll instead of racing.
+func (a *AppiumLauncher) waitForAccessibilityID(ctx context.Context, sessID, id string, timeout time.Duration) (string, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		elID, err := a.findByAccessibilityID(ctx, sessID, id)
+		if err == nil {
+			return elID, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("element %q not present after %s: %w", id, timeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
 }
 
 // --- WebDriver protocol plumbing -------------------------------------------


### PR DESCRIPTION
## What

Adds a `CHAR_SEGMENT={2s|6s|ll}` configuration axis to the **rampup** and **pyramid** characterization tests, so a single deterministic cold launch lands on the chosen segment length. Pairs with #685 (which made `/api/content` advertise all available segment lengths so Home isn't empty when 2s is selected).

## Changes

- **`runner/appium.go`** — `SetLaunchArgs` passes XCUITest `processArguments`; iOS folds `-is.segment <rawValue>` into UserDefaults (NSArgumentDomain, highest precedence) so the player cold-starts on that segment from frame 1 — no UI pre-set, no second Appium session, no warm-switch starvation. `ResumePlayback` now **waits** for the `home-continue-watching` tile (`waitForAccessibilityID`) instead of racing the async catalogue fetch (which can leave Home empty for a few seconds after a fresh/segment-forced launch).
- **`modes/rampup_test.go`, `modes/pyramid_test.go`** — read `CHAR_SEGMENT` (label `2s|6s|ll` → enum rawValue `s2|s6|ll`), force it via the launch arg, **assert** the cold start landed on the requested master (`master_2s`/`master_6s`/`master.m3u8`) and fail loudly otherwise, label the play `segment=<v>`, and tag the report filename.
- **`PlayerViewModel.setSegment`** — persist the choice (`persistFlags`) like every other Advanced setter; it was the lone setter that skipped persistence, so a segment choice silently reverted on relaunch.

## Validation

End-to-end on the iPad sim: `CHAR_SEGMENT=2s` cold-started on `master_2s.m3u8` and laddered the full rampup **540p→720p→1080p→4K with zero stalls**. (A separate inter-cycle inactivity-timeout issue surfaced for multi-cycle runs — addressed independently.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
