### PR TITLE
fix(proxy): raise inactive-session timeout 60s → 5m

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -8357,6 +8357,14 @@ func (a *App) removeInactiveSessions() {
 	active := make([]SessionData, 0, len(sessions))
 	now := time.Now()
 	removedPorts := map[int]struct{}{}
+	// A player that makes no request for this long is treated as gone and
+	// its session synthesized to a terminal inactive_timeout. Kept generous
+	// (5m) so a *legitimately rebuffering* play isn't evicted mid-stream: a
+	// characterization sweep that slams the cap from a 4K rung back to the
+	// ~2 Mbps floor between cycles can stall ~50s+ while AVPlayer drains a
+	// stranded 4K segment — well under any real abandonment but over the old
+	// 60s window, which killed the play (and orphaned later cycles).
+	const inactiveWindow = 5 * time.Minute
 	for _, session := range sessions {
 		lastRequest := getString(session, "last_request")
 		if lastRequest == "" {
@@ -8366,7 +8374,7 @@ func (a *App) removeInactiveSessions() {
 		if err != nil {
 			continue
 		}
-		if now.Sub(lastTime) < 60*time.Second {
+		if now.Sub(lastTime) < inactiveWindow {
 			active = append(active, session)
 		} else {
 			a.recordSessionEnd(session, "inactive_timeout")


### PR DESCRIPTION
## What

`removeInactiveSessions` synthesizes a terminal `inactive_timeout` for any session whose last request is older than the window, then frees its port. At **60s** this evicted plays that were merely **rebuffering**.

## Why

A characterization cycled sweep slams the cap from a 4K rung (~44 Mbps) straight back to the ~2 Mbps floor between cycles. AVPlayer, stranded mid-4K-segment, stalls ~50s+ draining and refilling the buffer — well under any real abandonment, but over the 60s window. The proxy killed the play, returned the app to Home, and every cycle after the first ran empty (observed in a 3-cycle 2s rampup: cyc1 climbed cleanly to 4K, then the cyc1→cyc2 floor slam stalled ~53s → `playback_reason: inactive_timeout`).

## Change

Window 60s → **5m**, pulled into a named `const inactiveWindow` so the value and rationale live together. 5m comfortably covers a legitimate downshift-rebuffer while still reaping genuinely-gone devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
