### PR TITLE
feat(char): run-config axes (transfer-timeout + LocalProxy) + revive transient_shock

### DIFF
--- a/.claude/standards/avmetrics-forensics.md
+++ b/.claude/standards/avmetrics-forensics.md
@@ -1,0 +1,91 @@
+# AVMetrics feed — detailed failure timings
+
+The iOS app (iOS 18+) subscribes to Apple's `AVMetrics` streams on the
+AVPlayerItem and POSTs them to `/api/session/{id}/avmetrics`; the forwarder
+writes them to ClickHouse `ios_avmetric_events`. This is a **second,
+higher-resolution telemetry channel** alongside the polled heartbeat/sample
+feed — and for failure forensics it routinely shows what the heartbeat feed
+**cannot**.
+
+## Why reach for it
+
+The heartbeat/sample feed is polled (~1s) and summarised. It misses
+sub-second events and, critically, **CoreMedia errors**: in the rampup
+sudden-drop wedge, `query play` reported `error_count=0` while the AVMetrics
+feed carried **6 distinct CoreMedia errors** plus the variant-switch that
+failed. If a play "stalled / unexpected_end" with no obvious cause, the
+AVMetrics feed is where the cause lives.
+
+## How to pull it
+
+Served via the timeseries multiplexer (stream token `avmetrics`):
+
+```sh
+curl -sk "https://$TEST_HOST:21000/analytics/api/v2/timeseries?streams=avmetrics&player_id=<PLR>&play_id=<PLY>&limit=4000"
+# SSE: each "data: {...}" line is one row; fields: event_type, ts,
+# event_ts_ms, raw_json (the full AVMetricEvent), labels, classification.
+```
+
+`player_id`/`play_id` must be **lowercase** (forwarder canonicalises; iOS
+emits uppercase — see case_sensitivity_ids).
+
+## Event types that carry timing/cause
+
+- `AVMetricErrorEvent` — `raw_json.error` is the full `NSError`. **The error
+  string names the failing resource and the timeout.** `NSURL=` is the
+  *parent playlist* (e.g. `playlist_2s_audio.m3u8`), but the message says
+  what actually failed: `map` (EXT-X-MAP init segment) / `media file`
+  (media segment) — i.e. **segments, not the playlist**. Classify
+  audio-vs-video from the NSURL (`playlist_2s_audio` vs `playlist_2s_2160p`).
+- `AVMetricHLSMediaSegmentRequestEvent` / `…PlaylistRequestEvent` — per-request
+  client-side timings: `derived_ttfb_ms`, `derived_mbps`, `derived_bytes`.
+  This is the **client's** view of delivery (vs the proxy network-request
+  view, which is the proxy→client send time).
+- `AVMetricPlayerItemVariantSwitchStartEvent` / `…VariantSwitchEvent` — a
+  switch has a **Start** and a **complete** (`…VariantSwitchEvent`). A
+  `Start` with **no matching complete** = a **failed ABR switch** (the
+  player tried to downshift and couldn't). `fromVariant`/`toVariant` give
+  the rungs (e.g. `2160p → 360p`).
+- `AVMetricPlayerItemStallEvent`, `…RateChangeEvent`,
+  `…LikelyToKeepUpEvent` — playback-engine state transitions.
+
+## CoreMedia error glossary (observed; Apple does not document these)
+
+| code | message | meaning |
+|------|---------|---------|
+| -12889 | "No response for map/media file in 2s" | segment fetch timed out — **live-edge timeout, scales with segment duration** (2s segments → "in 2s") |
+| -16830 | "Media file not received in 5s" | segment hard timeout (~2.5× segment duration) |
+| -16839 | "Unable to get playlist before long downshift" | couldn't reach a usable playlist state before a big switch |
+| -12880 | "Can not proceed after removing variants" | enough renditions marked unplayable that the switch can't complete → wedge. With a **single audio track**, the audio rendition's removal is fatal. |
+| -15628 | (generic) | seen alongside the above |
+| -12174 | content not updated | sim-only noise (#145), not a real error |
+
+Live-edge timeouts are **far shorter** than the ~30s VOD segment-fetch
+timeout in fault-injection-wire-contract.md — they track segment duration,
+so 2s content is much less tolerant of a slow/dead link than 6s.
+
+## Forensic recipe (sudden-drop wedge)
+
+1. Find the dead window in the **network-request view** (proxy→client
+   delivery): a gap where nothing is delivered = the link went away
+   (`transport_disconnect`).
+2. Overlay the **AVMetrics** errors on that window: segment timeouts
+   (`-12889`/`-16830`) → failed `VariantSwitchStart` (no complete) →
+   `-12880` → `StallEvent`.
+3. Read NSURL to confirm which segments (audio vs video) starved.
+
+## Caveat — batched over the same connection
+
+AVMetrics are **batched** before POST and travel the **same connection** as
+the heartbeats. A wedge that kills the connection can drop the **final
+batch** — so the very last events (e.g. the app-side `frozen` detection that
+would yield `stall_frozen`) may never land. Absence near the end is not
+proof of absence; corroborate with the proxy-side network/control feeds.
+
+## See also
+
+- `avplayer-quirks.md`, `abr-decision-model.md` — player behaviour these
+  events expose.
+- `data-fields.md` — heartbeat/sample schema (the lower-resolution feed).
+- memory: `reference_avmetric_exact_type_filter`, `reference_avmetric_byterange_zero`,
+  `reference_avplayer_stale_connection_localproxy`.

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -114,29 +114,18 @@ func runPyramid(t *testing.T, p runner.Platform) {
 	coldStart := isAppium && preFloor > 0
 	conservativeStart := isAppium && !coldStart
 
-	// #segments — force the segment via a launch argument so the single
-	// cold launch below lands on it deterministically. iOS folds
-	// `-is.segment <rawValue>` into UserDefaults (NSArgumentDomain,
-	// highest precedence); loadFlags reads `is.segment` at init, so the
-	// player cold-starts on this segment from frame 1 — bottom rung under
-	// the floor cap, no UI pre-set, no second Appium session, no warm-
-	// switch starvation. CHAR_SEGMENT is the label form (2s|6s|ll); the
-	// enum rawValue is s2|s6|ll. Appium iOS only. Run both segments as
-	// two invocations (CHAR_SEGMENT=6s then =2s); each cold-starts clean.
-	segment := strings.TrimSpace(os.Getenv("CHAR_SEGMENT"))
-	if segment != "" {
-		if isAppium {
-			raw := map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}[segment]
-			if raw == "" {
-				t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", segment)
-			}
-			appium.SetLaunchArgs([]string{"-is.segment", raw})
-			t.Logf("forcing segment=%s via launch arg -is.segment %s — cold start lands on it", segment, raw)
-		} else {
-			t.Logf("CHAR_SEGMENT=%s ignored — requires the Appium launcher", segment)
-			segment = ""
-		}
+	// #config — read the per-run configuration axes (segment, LocalProxy,
+	// transfer-timeout) and force the launch-arg ones (segment via
+	// -is.segment, LocalProxy via -is.flag.local_proxy) on the single cold
+	// launch below so the player starts on them from frame 1. iOS folds
+	// these into UserDefaults (NSArgumentDomain, highest precedence). The
+	// transfer-timeout axis is applied server-side after the player binds.
+	cfg := readRunConfig(t, isAppium)
+	if args := cfg.launchArgs(); len(args) > 0 {
+		appium.SetLaunchArgs(args)
+		t.Logf("forcing run config via launch args %v — cold start lands on it", args)
 	}
+	segment := cfg.segment
 
 	var sess *runner.Session
 	switch {
@@ -210,6 +199,28 @@ func runPyramid(t *testing.T, p runner.Platform) {
 		sess = OpenSession(t, p)
 	}
 
+	// #config — arm the server-side active transfer timeout for this run
+	// (CHAR_TRANSFER_TIMEOUT, default 20s; 0 clears). The proxy then cuts
+	// any segment still in flight past the window so the player downshifts
+	// instead of stalling — notably at the cyc→floor cap slam. Player is
+	// bound + heartbeating here. Cleared at teardown.
+	{
+		tctx, tcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := cfg.applyServerSide(tctx, sess); err != nil {
+			t.Logf("set transfer timeout: %v (test continues)", err)
+		} else {
+			t.Logf("transfer timeout: %s on segments", cfg.labels()["xfer_timeout"])
+		}
+		tcancel()
+		t.Cleanup(func() {
+			cctx, c := context.WithTimeout(context.Background(), 10*time.Second)
+			defer c()
+			if err := sess.SetSegmentTimeout(cctx, 0); err != nil {
+				t.Logf("clear transfer timeout: %v", err)
+			}
+		})
+	}
+
 	// --- labels + play_id ---------------------------------------
 	runID := time.Now().UTC().Format("20060102T150405Z")
 	startLabels := map[string]string{
@@ -217,8 +228,8 @@ func runPyramid(t *testing.T, p runner.Platform) {
 		"platform": string(p),
 		"run_id":   runID,
 	}
-	if segment != "" {
-		startLabels["segment"] = segment
+	for k, v := range cfg.labels() {
+		startLabels[k] = v
 	}
 	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
 		t.Logf("label play (start): %v (test continues)", err)

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -114,29 +114,18 @@ func runRampup(t *testing.T, p runner.Platform) {
 	coldStart := isAppium && preFloor > 0
 	conservativeStart := isAppium && !coldStart
 
-	// #segments — force the segment via a launch argument so the single
-	// cold launch below lands on it deterministically. iOS folds
-	// `-is.segment <rawValue>` into UserDefaults (NSArgumentDomain,
-	// highest precedence); loadFlags reads `is.segment` at init, so the
-	// player cold-starts on this segment from frame 1 — bottom rung under
-	// the floor cap, no UI pre-set, no second Appium session, no warm-
-	// switch starvation. CHAR_SEGMENT is the label form (2s|6s|ll); the
-	// enum rawValue is s2|s6|ll. Appium iOS only. Run both segments as
-	// two invocations (CHAR_SEGMENT=6s then =2s); each cold-starts clean.
-	segment := strings.TrimSpace(os.Getenv("CHAR_SEGMENT"))
-	if segment != "" {
-		if isAppium {
-			raw := map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}[segment]
-			if raw == "" {
-				t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", segment)
-			}
-			appium.SetLaunchArgs([]string{"-is.segment", raw})
-			t.Logf("forcing segment=%s via launch arg -is.segment %s — cold start lands on it", segment, raw)
-		} else {
-			t.Logf("CHAR_SEGMENT=%s ignored — requires the Appium launcher", segment)
-			segment = ""
-		}
+	// #config — read the per-run configuration axes (segment, LocalProxy,
+	// transfer-timeout) and force the launch-arg ones (segment via
+	// -is.segment, LocalProxy via -is.flag.local_proxy) on the single cold
+	// launch below so the player starts on them from frame 1. iOS folds
+	// these into UserDefaults (NSArgumentDomain, highest precedence). The
+	// transfer-timeout axis is applied server-side after the player binds.
+	cfg := readRunConfig(t, isAppium)
+	if args := cfg.launchArgs(); len(args) > 0 {
+		appium.SetLaunchArgs(args)
+		t.Logf("forcing run config via launch args %v — cold start lands on it", args)
 	}
+	segment := cfg.segment
 
 	var sess *runner.Session
 	switch {
@@ -248,6 +237,28 @@ func runRampup(t *testing.T, p runner.Platform) {
 		sess = OpenSession(t, p)
 	}
 
+	// #config — arm the server-side active transfer timeout for this run
+	// (CHAR_TRANSFER_TIMEOUT, default 20s; 0 clears). The proxy then cuts
+	// any segment still in flight past the window so the player downshifts
+	// instead of stalling — notably at the cyc→floor cap slam. Player is
+	// bound + heartbeating here. Cleared at teardown.
+	{
+		tctx, tcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := cfg.applyServerSide(tctx, sess); err != nil {
+			t.Logf("set transfer timeout: %v (test continues)", err)
+		} else {
+			t.Logf("transfer timeout: %s on segments", cfg.labels()["xfer_timeout"])
+		}
+		tcancel()
+		t.Cleanup(func() {
+			cctx, c := context.WithTimeout(context.Background(), 10*time.Second)
+			defer c()
+			if err := sess.SetSegmentTimeout(cctx, 0); err != nil {
+				t.Logf("clear transfer timeout: %v", err)
+			}
+		})
+	}
+
 	// --- labels + play_id ---------------------------------------
 	runID := time.Now().UTC().Format("20060102T150405Z")
 	startLabels := map[string]string{
@@ -255,8 +266,8 @@ func runRampup(t *testing.T, p runner.Platform) {
 		"platform": string(p),
 		"run_id":   runID,
 	}
-	if segment != "" {
-		startLabels["segment"] = segment
+	for k, v := range cfg.labels() {
+		startLabels[k] = v
 	}
 	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
 		t.Logf("label play (start): %v (test continues)", err)

--- a/tests/characterization/modes/runconfig.go
+++ b/tests/characterization/modes/runconfig.go
@@ -1,0 +1,135 @@
+package modes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
+)
+
+// runConfig captures the per-run TEST CONFIGURATION axes (not player
+// behaviour): which segment length to cold-start on, whether the on-device
+// LocalHTTPProxy hop is enabled, and the server-side active transfer timeout.
+// Each axis is forced deterministically (a launch arg or a proxy PATCH) and
+// stamped onto the play as a label so archived runs are self-describing and
+// queryable (e.g. `harness query plays --label-has info=xfer_timeout_off`).
+//
+// Env axes (all optional):
+//
+//	CHAR_SEGMENT          2s|6s|ll      default: app's current (Appium only)
+//	CHAR_LOCAL_PROXY      on|off        default: on        (Appium only)
+//	CHAR_TRANSFER_TIMEOUT <seconds>     default: 20        (0 = off)
+type runConfig struct {
+	segment     string        // label form: "" | 2s | 6s | ll
+	localProxy  bool          // default true
+	xferTimeout time.Duration // active transfer timeout on segments; 0 = off
+	appium      bool
+}
+
+var segmentRawValue = map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}
+
+// readRunConfig parses the CHAR_* axes. isAppium gates the launch-arg axes
+// (segment, LocalProxy) which need XCUITest processArguments — they're
+// logged-and-ignored on non-Appium launchers.
+func readRunConfig(t *testing.T, isAppium bool) runConfig {
+	t.Helper()
+	cfg := runConfig{localProxy: true, xferTimeout: 20 * time.Second, appium: isAppium}
+
+	if v := strings.TrimSpace(os.Getenv("CHAR_SEGMENT")); v != "" {
+		if _, ok := segmentRawValue[v]; !ok {
+			t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", v)
+		}
+		if isAppium {
+			cfg.segment = v
+		} else {
+			t.Logf("CHAR_SEGMENT=%s ignored — requires the Appium launcher", v)
+		}
+	}
+
+	if v := strings.TrimSpace(os.Getenv("CHAR_LOCAL_PROXY")); v != "" {
+		on, ok := parseOnOff(v)
+		if !ok {
+			t.Fatalf("CHAR_LOCAL_PROXY must be on|off (got %q)", v)
+		}
+		if isAppium {
+			cfg.localProxy = on
+		} else if !on {
+			t.Logf("CHAR_LOCAL_PROXY=%s ignored — requires the Appium launcher", v)
+		}
+	}
+
+	if v := strings.TrimSpace(os.Getenv("CHAR_TRANSFER_TIMEOUT")); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			t.Fatalf("CHAR_TRANSFER_TIMEOUT must be a non-negative integer (seconds), got %q", v)
+		}
+		cfg.xferTimeout = time.Duration(n) * time.Second
+	}
+	return cfg
+}
+
+// launchArgs returns the XCUITest processArguments that force this config at
+// cold launch: the segment (-is.segment) and, when LocalProxy is disabled,
+// -is.flag.local_proxy 0. iOS folds these into UserDefaults (NSArgumentDomain,
+// highest precedence) so loadFlags reads them at init. Empty ⇒ nothing forced.
+func (c runConfig) launchArgs() []string {
+	if !c.appium {
+		return nil
+	}
+	var args []string
+	if c.segment != "" {
+		args = append(args, "-is.segment", segmentRawValue[c.segment])
+	}
+	if !c.localProxy {
+		// LocalHTTPProxy is the on-device hop (rewrites origin → 127.0.0.1).
+		// Off ⇒ AVPlayer connects straight to the origin (still a go-proxy
+		// port, so the player stays visible + shapeable); tests whether that
+		// hop is implicated in mid-stream wedges.
+		args = append(args, "-is.flag.local_proxy", "0")
+	}
+	return args
+}
+
+// labels returns the config labels to stamp on the play. Values are single
+// tokens — the forwarder label encoding forbids ',' and '='.
+func (c runConfig) labels() map[string]string {
+	m := map[string]string{"localproxy": boolOnOff(c.localProxy)}
+	if c.segment != "" {
+		m["segment"] = c.segment
+	}
+	if c.xferTimeout > 0 {
+		m["xfer_timeout"] = fmt.Sprintf("%ds", int(c.xferTimeout.Seconds()))
+	} else {
+		m["xfer_timeout"] = "off"
+	}
+	return m
+}
+
+// applyServerSide arms (or clears, when xferTimeout == 0) the proxy-side
+// active transfer timeout on this player's segment fetches. Call after the
+// player is bound + heartbeating.
+func (c runConfig) applyServerSide(ctx context.Context, sess *runner.Session) error {
+	return sess.SetSegmentTimeout(ctx, c.xferTimeout)
+}
+
+func parseOnOff(v string) (on, ok bool) {
+	switch strings.ToLower(v) {
+	case "on", "true", "1", "yes":
+		return true, true
+	case "off", "false", "0", "no":
+		return false, true
+	}
+	return false, false
+}
+
+func boolOnOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
+}

--- a/tests/characterization/modes/transient_shock_test.go
+++ b/tests/characterization/modes/transient_shock_test.go
@@ -1,32 +1,363 @@
-//go:build disabled_unchecked
-// +build disabled_unchecked
-
 package modes
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
 )
 
-// Transient-shock: high → brief dip → high. Tests whether the player can
-// ride out a short bandwidth dip on buffered media without downshifting.
-// 30 s @ 8 Mbps, 10 s @ 0.5 Mbps, 60 s @ 8 Mbps.
+// Transient-shock — variant-derived square wave: cold-start at the floor,
+// climb to the TOP variant, then slam the cap down to a sub-floor "shock"
+// and hold, then restore the top cap and watch recovery. Repeated
+// CHAR_SHOCK_REPS times (each a fresh shock on the same live play).
 //
-// The dip is short enough that a well-buffered player should NOT downshift —
-// any profile_shifts >0 in the report is the player being too eager.
+// This is the purpose-built probe for the sudden-drop wedge: a hard
+// top→sub-floor drop while the player is warm on 4K is exactly the
+// transition that strands AVPlayer (segment fetches time out at the live-
+// edge 2s/5s limits, the connection can go dead for ~10s, the player
+// attempts a big downshift and can hit CoreMedia -12880 "Can not proceed
+// after removing variants"). Pair the run with the network-request view
+// (proxy→client delivery + the dead window) and the AVMetrics feed
+// (CoreMedia errors + variant-switch start/complete) to see whether the
+// link survives the drop and whether the player recovers.
+//
+// Shares all of rampup's machinery: cold-start bootstrap, the run-config
+// axes (CHAR_SEGMENT / CHAR_LOCAL_PROXY / CHAR_TRANSFER_TIMEOUT) forced at
+// launch + applied server-side, play labels, and UI-close teardown.
+//
+// Env axes (in addition to the shared CHAR_SEGMENT / CHAR_LOCAL_PROXY /
+// CHAR_TRANSFER_TIMEOUT):
+//
+//	CHAR_SHOCK_REPS        number of dips (default 2)
+//	CHAR_SHOCK_LOW_MBPS    the shock floor (default: the rampup floor)
+//	CHAR_SHOCK_HIGH_HOLD_S hold at the top cap, warm + recovery (default 120)
+//	CHAR_SHOCK_DIP_HOLD_S  hold at the shock floor (default 90; must outlast
+//	                       the buffer coast + wedge-cycle to see the outcome)
 
 func TestTransientShockIPadSim(t *testing.T)   { runTransientShock(t, runner.PlatformIPadSim) }
 func TestTransientShockIPhone(t *testing.T)    { runTransientShock(t, runner.PlatformIPhone) }
 func TestTransientShockAppleTV(t *testing.T)   { runTransientShock(t, runner.PlatformAppleTV) }
 func TestTransientShockAndroidTV(t *testing.T) { runTransientShock(t, runner.PlatformAndroidTV) }
+func TestTransientShockWeb(t *testing.T)       { runTransientShock(t, runner.PlatformWeb) }
 
 func runTransientShock(t *testing.T, p runner.Platform) {
-	steps := []runner.Step{
-		{RateMbps: 8.0, Hold: 30 * time.Second},
-		{RateMbps: 0.5, Hold: 10 * time.Second},
-		{RateMbps: 8.0, Hold: 60 * time.Second},
+	// --- pick launcher + device ----------------------------------
+	mode, launcher, err := runner.PickMode()
+	if err != nil {
+		t.Skipf("PickMode: %v", err)
 	}
-	RunMode(t, p, "transient-shock", steps, time.Second, 5*time.Second)
+	t.Logf("launch mode: %s", mode)
+
+	discCtx, discCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	devs, err := launcher.Discover(discCtx)
+	discCancel()
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
+	var picked *runner.Device
+	for i := range devs {
+		if devs[i].Platform != p {
+			continue
+		}
+		if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
+			continue
+		}
+		picked = &devs[i]
+		break
+	}
+	if picked == nil {
+		t.Skipf("no %s device discovered (mode=%s)", p, mode)
+	}
+	t.Logf("picked device: %s", picked)
+
+	// --- bootstrap: read manifest BEFORE kill+launch so we cold-start
+	// at the floor (clean startup), then climb to the top under the high
+	// cap before the first shock. Same machinery rampup uses.
+	bootCtx, bootCancel := context.WithTimeout(context.Background(), 15*time.Second)
+	preRec, preErr := runner.PreLaunchInfo(bootCtx, *picked)
+	bootCancel()
+
+	var preFloor float64
+	if preErr != nil {
+		t.Logf("pre-launch info: %v (cold-start unavailable; conservative/fallback path)", preErr)
+	} else if preRec.CurrentPlay == nil || len(preRec.CurrentPlay.Manifest.Variants) == 0 {
+		t.Logf("pre-launch: no current play / no variants yet (cold-start unavailable)")
+	} else if preDesc, derr := runner.StandardLadderRates(preRec); derr != nil {
+		t.Logf("pre-launch StandardLadderRates: %v (cold-start unavailable)", derr)
+	} else {
+		preFloor = rampupFloorFrom(preDesc)
+		t.Logf("bootstrap: pre-launch floor = %.3f Mbps (from current player's manifest)", preFloor)
+	}
+
+	appium, isAppium := launcher.(*runner.AppiumLauncher)
+	coldStart := isAppium && preFloor > 0
+	conservativeStart := isAppium && !coldStart
+
+	// #config — read the per-run configuration axes (segment, LocalProxy,
+	// transfer-timeout) and force the launch-arg ones on the cold launch.
+	cfg := readRunConfig(t, isAppium)
+	if args := cfg.launchArgs(); len(args) > 0 {
+		appium.SetLaunchArgs(args)
+		t.Logf("forcing run config via launch args %v — cold start lands on it", args)
+	}
+	segment := cfg.segment
+
+	var sess *runner.Session
+	switch {
+	case coldStart:
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer setupCancel()
+		s, lerr := appium.LaunchToHome(setupCtx, *picked)
+		if lerr != nil {
+			t.Fatalf("LaunchToHome: %v", lerr)
+		}
+		s.PlayerID = preRec.ID
+		t.Logf("parked on home; applying floor %.3f Mbps before resuming playback", preFloor)
+		if aerr := s.ApplyRate(setupCtx, preFloor); aerr != nil {
+			t.Fatalf("apply floor pre-resume: %v", aerr)
+		}
+		time.Sleep(2 * time.Second) // let tc engage before the first fetch
+		if rerr := appium.ResumePlayback(setupCtx, *picked); rerr != nil {
+			t.Fatalf("ResumePlayback: %v", rerr)
+		}
+		if herr := s.WaitForHeartbeat(setupCtx, 90*time.Second); herr != nil {
+			t.Fatalf("WaitForHeartbeat: %v", herr)
+		}
+		sess = s
+		t.Cleanup(func() {
+			cleanCtx, c := context.WithTimeout(context.Background(), 15*time.Second)
+			defer c()
+			if cerr := sess.ClearShape(cleanCtx); cerr != nil {
+				t.Logf("clear shape: %v", cerr)
+			}
+			if cerr := sess.CloseViaUI(cleanCtx); cerr != nil {
+				t.Logf("close playback via UI: %v", cerr)
+			}
+			if cerr := launcher.Close(); cerr != nil {
+				t.Logf("close launcher: %v", cerr)
+			}
+			if cerr := sess.ReleaseDevice(cleanCtx); cerr != nil {
+				t.Logf("release device: %v", cerr)
+			}
+		})
+	case conservativeStart:
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer setupCancel()
+		s, lerr := appium.LaunchToHome(setupCtx, *picked)
+		if lerr != nil {
+			t.Fatalf("LaunchToHome: %v", lerr)
+		}
+		pid, perr := appium.ReadPlayerID(setupCtx, s)
+		if perr != nil {
+			t.Fatalf("ReadPlayerID: %v (iOS app may predate the home-player-id AX node; rebuild app in Xcode)", perr)
+		}
+		s.PlayerID = pid
+		t.Logf("parked on home — discovered player_id %s via AX node", pid)
+		if aerr := s.ApplyRate(setupCtx, conservativeWarmupCap); aerr != nil {
+			t.Fatalf("apply conservative cap: %v", aerr)
+		}
+		time.Sleep(2 * time.Second)
+		if rerr := appium.ResumePlayback(setupCtx, *picked); rerr != nil {
+			t.Fatalf("ResumePlayback: %v", rerr)
+		}
+		if herr := s.WaitForHeartbeat(setupCtx, 90*time.Second); herr != nil {
+			t.Fatalf("WaitForHeartbeat: %v", herr)
+		}
+		sess = s
+		t.Cleanup(func() {
+			cleanCtx, c := context.WithTimeout(context.Background(), 15*time.Second)
+			defer c()
+			if cerr := sess.ClearShape(cleanCtx); cerr != nil {
+				t.Logf("clear shape: %v", cerr)
+			}
+			if cerr := sess.CloseViaUI(cleanCtx); cerr != nil {
+				t.Logf("close playback via UI: %v", cerr)
+			}
+			if cerr := launcher.Close(); cerr != nil {
+				t.Logf("close launcher: %v", cerr)
+			}
+			if cerr := sess.ReleaseDevice(cleanCtx); cerr != nil {
+				t.Logf("release device: %v", cerr)
+			}
+		})
+	default:
+		t.Logf("cold-start unavailable (non-Appium launcher) — legacy warmup path")
+		sess = OpenSession(t, p)
+	}
+
+	// #config — arm the server-side active transfer timeout for this run.
+	{
+		tctx, tcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := cfg.applyServerSide(tctx, sess); err != nil {
+			t.Logf("set transfer timeout: %v (test continues)", err)
+		} else {
+			t.Logf("transfer timeout: %s on segments", cfg.labels()["xfer_timeout"])
+		}
+		tcancel()
+		t.Cleanup(func() {
+			cctx, c := context.WithTimeout(context.Background(), 10*time.Second)
+			defer c()
+			if err := sess.SetSegmentTimeout(cctx, 0); err != nil {
+				t.Logf("clear transfer timeout: %v", err)
+			}
+		})
+	}
+
+	// --- labels + play_id ---------------------------------------
+	runID := time.Now().UTC().Format("20060102T150405Z")
+	startLabels := map[string]string{
+		"test":     "transient_shock",
+		"platform": string(p),
+		"run_id":   runID,
+	}
+	for k, v := range cfg.labels() {
+		startLabels[k] = v
+	}
+	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
+		t.Logf("label play (start): %v (test continues)", err)
+	} else {
+		t.Logf("labeled play with %v", startLabels)
+	}
+
+	playID, err := sess.CurrentPlayID(context.Background())
+	if err != nil {
+		t.Logf("CurrentPlayID: %v (test continues)", err)
+	} else {
+		t.Logf("play_id: %s   (find later: harness query play %s)", playID, playID)
+	}
+
+	overall := rampdownWarmupHold + 60*time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), overall)
+	defer cancel()
+
+	// --- variant ladder (post-launch — definitive) --------------
+	switch {
+	case conservativeStart:
+		t.Logf("waiting %s for manifest to populate under conservative cap", rampdownWarmupHold)
+		if err := holdContext(ctx, rampdownWarmupHold); err != nil {
+			t.Fatalf("manifest-fetch hold: %v", err)
+		}
+	case !coldStart:
+		if err := sess.ApplyRate(ctx, rampdownWarmupMbps); err != nil {
+			t.Fatalf("warmup apply: %v", err)
+		}
+		t.Logf("warmup: %d Mbps × %s", rampdownWarmupMbps, rampdownWarmupHold)
+		if err := holdContext(ctx, rampdownWarmupHold); err != nil {
+			t.Fatalf("warmup hold: %v", err)
+		}
+	}
+	rec, err := sess.PlayerState(ctx)
+	if err != nil {
+		t.Fatalf("PlayerState: %v", err)
+	}
+	// #segments — assert the cold start landed on the requested segment.
+	if segment != "" && rec.CurrentPlay != nil {
+		master := rec.CurrentPlay.Manifest.MasterURL
+		want := "master_" + segment + "."
+		if segment == "ll" {
+			want = "master.m3u8"
+		}
+		if !strings.Contains(master, want) {
+			t.Fatalf("requested segment %q but cold-started on %q (expected master to contain %q)",
+				segment, master, want)
+		}
+		t.Logf("confirmed cold start on segment=%s (master=%s)", segment, master)
+	}
+	desc, err := runner.StandardLadderRates(rec)
+	if err != nil {
+		t.Fatalf("StandardLadderRates: %v", err)
+	}
+	if len(desc) == 0 {
+		t.Fatal("StandardLadderRates returned no entries")
+	}
+
+	// --- square-wave step list ----------------------------------
+	// high = the TOP variant cap (desc is descending, so desc[0]). low =
+	// the shock floor: CHAR_SHOCK_LOW_MBPS if set, else the rampup floor
+	// (the exact top→floor drop we dissected). The player warms to the top
+	// under `high`, then each rep slams to `low` (the shock) and restores
+	// `high` (recovery window).
+	top := desc[0]
+	bottom := desc[len(desc)-1]
+	high := top.CapMbps
+	low := envFloat("CHAR_SHOCK_LOW_MBPS", rampupFloorFrom(desc))
+	highHold := time.Duration(envInt("CHAR_SHOCK_HIGH_HOLD_S", 120)) * time.Second
+	// The dip must outlast the buffer coast (~20s on a 4K buffer, during
+	// which the player just plays out buffered high-variant content and
+	// isn't yet operating at the low rate) PLUS the wedge-or-recover
+	// resolution (a wedge held position frozen ~54s before the player
+	// reset). 90s ≈ buffer-coast + wedge-cycle + margin, so we capture the
+	// full outcome — reset, or a downshift that sustains at the low variant.
+	dipHold := time.Duration(envInt("CHAR_SHOCK_DIP_HOLD_S", 90)) * time.Second
+	reps := envInt("CHAR_SHOCK_REPS", 2)
+	if reps < 1 {
+		reps = 1
+	}
+
+	// [warm-high] + reps × [dip-low, recover-high]
+	steps := make([]runner.Step, 0, 1+2*reps)
+	hi := top
+	lo := bottom
+	steps = append(steps, runner.Step{RateMbps: high, Hold: highHold, Variant: &hi})
+	for i := 0; i < reps; i++ {
+		steps = append(steps,
+			runner.Step{RateMbps: low, Hold: dipHold, Variant: &lo},
+			runner.Step{RateMbps: high, Hold: highHold, Variant: &hi})
+	}
+
+	t.Logf("square wave: warm→%.3f Mbps (%s), then %d × [shock→%.3f Mbps (%s) → recover→%.3f Mbps (%s)]",
+		high, highHold, reps, low, dipHold, high, highHold)
+
+	report := RunSweep(ctx, t, sess, "transient-shock", steps, time.Second)
+	report.Variants = unionRungs(desc)
+	if playID != "" {
+		report.PlayIDs = []string{playID}
+	}
+	report.Finalize(time.Now())
+
+	out := runner.DefaultOutDir(t.TempDir())
+	playerShort := sess.PlayerID
+	if len(playerShort) > 8 {
+		playerShort = playerShort[:8]
+	}
+	segTag := ""
+	if segment != "" {
+		segTag = "-" + segment
+	}
+	base := fmt.Sprintf("transient-shock-%s-%s%s-%s", p, playerShort, segTag, runID)
+	jsonPath, werr := runner.WriteReport(out, base, report)
+	if werr != nil {
+		t.Fatalf("write report: %v", werr)
+	}
+	LogReport(t, jsonPath)
+	if htmlPath, herr := runner.WriteChart(out, base, report); herr == nil {
+		t.Logf("chart: %s", htmlPath)
+	} else {
+		t.Logf("chart write skipped: %v", herr)
+	}
+
+	t.Logf("total stalls: %d / stall seconds: %.1f / profile shifts: %d",
+		report.Summary.TotalStalls, report.Summary.TotalStallSeconds, report.Summary.ProfileShifts)
+
+	if report.Summary.SampleCount == 0 {
+		t.Errorf("no samples collected")
+	}
+
+	if last := report; last != nil {
+		endLabels := map[string]string{
+			"completed":      time.Now().UTC().Format("20060102T150405Z"),
+			"shocks":         fmt.Sprintf("%d", reps),
+			"total_stalls":   fmt.Sprintf("%d", report.Summary.TotalStalls),
+			"profile_shifts": fmt.Sprintf("%d", report.Summary.ProfileShifts),
+		}
+		if err := sess.LabelPlay(context.Background(), endLabels); err != nil {
+			t.Logf("label play (end): %v", err)
+		}
+	}
 }


### PR DESCRIPTION
## What

Adds two test-run **configuration axes** alongside the existing segment axis, and **revives `transient_shock`** as the purpose-built sudden-drop probe.

### `runconfig.go` — shared per-run config (CHAR_* env → launch args / server-side / labels)
- **`CHAR_TRANSFER_TIMEOUT`** (default `20`s; `0`=off) → proxy active transfer timeout on segments (`SetSegmentTimeout`); label `xfer_timeout=20s|off`.
- **`CHAR_LOCAL_PROXY`** (default `on`) → `-is.flag.local_proxy 0` launch arg when off (AVPlayer connects straight to the go-proxy port, no on-device hop); label `localproxy=on|off`.
- **`CHAR_SEGMENT`** folded into the same helper; label `segment=`.

Every axis is stamped on the play so archived runs are self-describing (`harness query plays --label-has info=xfer_timeout_off`).

### rampup / pyramid
Replace the inline segment block with `readRunConfig()`; arm the transfer timeout after the player binds (cleared at teardown); merge config labels.

### transient_shock — revived from a disabled stub
Variant-derived square wave: cold-start at floor → climb to the **top variant** → slam to a **sub-floor shock** (default = the rampup floor; `CHAR_SHOCK_LOW_MBPS` override) → recover, ×`CHAR_SHOCK_REPS` (default 2). Dip hold default **90s** (`CHAR_SHOCK_DIP_HOLD_S`) — must outlast the ~20s buffer coast + ~54s wedge-cycle to capture the outcome. Full cold-start bootstrap + config axes + labels + UI-close teardown.

### `.claude/standards/avmetrics-forensics.md`
How to use the AVMetrics feed for detailed failure timings — CoreMedia error glossary (`-12889`/`-16830`/`-16839`/`-12880`), variant-switch start/complete, segment-vs-playlist NSURL classification, live-edge timeout scaling, and the batched-over-same-connection caveat. (The heartbeat feed reports `error_count=0` where AVMetrics shows the real cause.)

## Validation

iPad sim 2s: rampup cold-starts + climbs 540p→4K cleanly; transient_shock reproduces the sudden-drop degradation on demand — recovers via the `-16839` path, wedges only when `-12880 "removing variants"` fires. Builds on #689 / #691 / #692.

Related follow-up filed: #693 (make AVMetrics a first-class `harness query`/`ts` target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
