### PR TITLE
fix(dashboard): double Play Log panel height (480px → 960px)

### DIFF
--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -1304,7 +1304,7 @@ function onRowsWheel(e: WheelEvent) {
   /* position:relative makes this the offsetParent so the cursor
      auto-scroll's target.offsetTop is measured against THIS container. */
   position: relative;
-  max-height: 480px;
+  max-height: 960px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## What

Doubles the Play Log panel's scroll cap — `PlayLog.vue .rows` `max-height: 480px → 960px` — so ~2× the time-multiplexed events/network/control rows are visible before scrolling.

## Why

During characterization / wedge investigation the Play Log is the at-a-glance view of a sudden-drop sequence (downshift → CoreMedia errors → stall). 480px only showed a handful of rows; 960px makes the sequence readable without constant scrolling.

CSS-only; `overflow-y` stays `auto`. Deployed to test-dev and eyeballed.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
