### PR TITLE
feat(693): make AVMetrics a first-class harness query/stream target

### DIFF
--- a/.claude/skills/forensics/SKILL.md
+++ b/.claude/skills/forensics/SKILL.md
@@ -80,9 +80,24 @@ timeout 8 harness --insecure raw GET \
   | grep '^data: ' | sed 's/^data: //' \
   | jq -c 'select(.ts >= "<FROM>" and .ts <= "<TO>")' \
   > /tmp/forensics-sam-<t>.jsonl
+
+# AVMetrics for the window — the highest-resolution failure-timing feed
+# (CoreMedia error codes, VariantSwitchStart-without-complete). The
+# heartbeat/sample feed is BLIND to these, so on a "stalled, cause
+# unknown" wedge this is the evidence that decides it (e.g. -12880 =
+# wedges permanently vs -16839 = ugly-but-recovers). Bounded query —
+# closes on its own, no SSE --max-time hack. iOS-only. #693.
+harness --insecure --json query avmetrics <PLAY> --from <FROM_ISO> --to <TO_ISO> --limit 2000 2>/dev/null \
+  | jq -c 'select(.ts >= "<FROM>" and .ts <= "<TO>")' \
+  > /tmp/forensics-avm-<t>.jsonl
+# (No play scoped? Pull error-bearing events across the window instead:
+#  harness --insecure --json query avmetrics --event-type ErrorEvent --from <FROM_ISO> --to <TO_ISO>)
 ```
 
-(Same SSE-bleed-through guard as `investigate` — always filter ts in jq.)
+(Same SSE-bleed-through guard as `investigate` — always filter ts in jq.
+The AVMetrics query is bounded NDJSON, so it needs no `timeout` wrapper.)
+See `.claude/standards/avmetrics-forensics.md` for which event types carry
+which signal and how to read the CoreMedia codes.
 
 ### 4. Identify applicable standards
 
@@ -92,6 +107,7 @@ Based on the user's question, name the standards docs the subagent should read:
 - ABR / variant choice / downshift / upshift → `.claude/standards/abr-decision-model.md`
 - m3u8 / manifest behaviour → `.claude/standards/hls-taxonomy.md`
 - codec rejection / playback init failure → `.claude/standards/codec-strings.md`
+- iOS wedge / "stalled, cause unknown" / CoreMedia error reading → `.claude/standards/avmetrics-forensics.md` (pairs with the `/tmp/forensics-avm-<t>.jsonl` evidence)
 
 ### 5. Dispatch to the subagent
 
@@ -111,6 +127,7 @@ Pre-gathered evidence (already filtered to the window — DON'T re-query):
 - /tmp/forensics-events-<t>.jsonl ({N} events)
 - /tmp/forensics-net-<t>.jsonl ({M} network rows)
 - /tmp/forensics-sam-<t>.jsonl ({K} samples at 1Hz)
+- /tmp/forensics-avm-<t>.jsonl ({A} AVMetrics events — iOS only; CoreMedia errors + variant-switch events)
 
 Findings library hits (already grepped):
 - <file1.md>: <one-line summary>

--- a/.claude/skills/forensics/SKILL.md
+++ b/.claude/skills/forensics/SKILL.md
@@ -91,7 +91,7 @@ harness --insecure --json query avmetrics <PLAY> --from <FROM_ISO> --to <TO_ISO>
   | jq -c 'select(.ts >= "<FROM>" and .ts <= "<TO>")' \
   > /tmp/forensics-avm-<t>.jsonl
 # (No play scoped? Pull error-bearing events across the window instead:
-#  harness --insecure --json query avmetrics --event-type ErrorEvent --from <FROM_ISO> --to <TO_ISO>)
+#  harness --insecure --json query avmetrics --event-type AVMetricErrorEvent --from <FROM_ISO> --to <TO_ISO>)
 ```
 
 (Same SSE-bleed-through guard as `investigate` — always filter ts in jq.

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -23,7 +23,7 @@ These have all bitten real conversations; the operational reference is at [`.cla
 
 - **Label filters are `--label-has` / `--label-not`** (repeatable, AND semantics), NOT `--label`.
 - **No `harness archive …` subcommand exists.** Forwarder archive reads live under `harness query …` (alias `q`).
-- **`harness query control <play_id>` is broken in current main** — the underlying endpoint requires `player_id`. Workaround: `harness raw GET "/analytics/api/v2/control_events?player_id=<PLR>&play_id=<PLY>&limit=N"`.
+- **`harness query control <play_id>` works** (fixed in #684 — the endpoint now accepts any one of `player_id` / `play_id` / `event` / `label_has`, not just `player_id`). The session-less `server_start` marker is reachable via `harness query control --event server_start` (no play_id needed).
 - **Operator labels round-trip through encoding.** `harness labels set <player> test=foo` lands as `info=test_foo` on the play's `labels[]`. The filter form is `--label-has info=test_foo`, NOT `--label-has test=foo`.
 
 ## When to use this vs sibling skills
@@ -57,8 +57,14 @@ harness --insecure --json query plays \
 # One play's events + label histogram
 harness --insecure --json query play <play_id>
 
-# Tail combined SSE for one player
-harness --insecure ts <player> --streams events,network,control
+# Tail combined SSE for one player (add avmetrics for iOS failure timing)
+harness --insecure ts <player> --streams events,network,control,avmetrics
+
+# iOS AVMetrics — highest-resolution failure-timing feed (CoreMedia error
+# codes, variant-switch start/complete). Bounded query, closes on its own
+# (no SSE --max-time hack). #693; technique in standards/avmetrics-forensics.md
+harness --insecure --json query avmetrics <play_id> --limit 500
+harness --insecure --json query avmetrics --event-type ErrorEvent --from <ISO> --to <ISO>
 
 # Mutate (snapshot is automatic — undo replays the most recent)
 harness --insecure labels set <player> k=v
@@ -70,4 +76,5 @@ harness --insecure undo
 
 - [`tools/harness-cli/README.md`](../../../tools/harness-cli/README.md) — full subcommand surface + flags
 - [`.claude/standards/harness-cli.md`](../../standards/harness-cli.md) — canonical gotchas, single source of truth
+- [`.claude/standards/avmetrics-forensics.md`](../../standards/avmetrics-forensics.md) — reading the iOS AVMetrics feed (`query avmetrics` / `ts --streams avmetrics`): which event types carry which signal, the CoreMedia error-code key
 - [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md) — first-token rule + no-guessing

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -64,7 +64,7 @@ harness --insecure ts <player> --streams events,network,control,avmetrics
 # codes, variant-switch start/complete). Bounded query, closes on its own
 # (no SSE --max-time hack). #693; technique in standards/avmetrics-forensics.md
 harness --insecure --json query avmetrics <play_id> --limit 500
-harness --insecure --json query avmetrics --event-type ErrorEvent --from <ISO> --to <ISO>
+harness --insecure --json query avmetrics --event-type AVMetricErrorEvent --from <ISO> --to <ISO>
 
 # Mutate (snapshot is automatic — undo replays the most recent)
 harness --insecure labels set <player> k=v

--- a/.claude/standards/avmetrics-forensics.md
+++ b/.claude/standards/avmetrics-forensics.md
@@ -1,0 +1,39 @@
+# AVMetrics forensics (iOS 18+)
+
+The iOS `AVMetricEvent` feed (`ios_avmetric_events`) is the highest-resolution failure-timing telemetry we have. The heartbeat/sample feed is **blind** to it — when a play "stalled, cause unknown," this is the evidence that decides it.
+
+## How to pull it
+
+- `harness query avmetrics <play_id> [--event-type T] [--from --to] [--limit N]` — bounded read, **closes on its own** (no `curl --max-time` SSE hack). Returns `event_type, ts, event_ts_ms, raw_json, classification`.
+- `harness ts <player> --streams avmetrics` — live SSE tail; rows render `A <ts> <event_type> <raw preview>`.
+- Session-less / cross-play sweep: `harness query avmetrics --event-type ErrorEvent --from <ISO> --to <ISO>` (no play_id needed).
+- iOS-only. Android/ExoPlayer and Roku emit nothing here.
+
+## What each event type tells you
+
+- **ErrorEvent** — carries the CoreMedia error code in `raw_json`. The single most decisive field on a wedge (see the code key below).
+- **`VariantSwitchStartEvent` WITHOUT a matching complete** — the player *tried* to downshift and **couldn't**. This is the fingerprint of the sudden-drop wedge: heartbeats show `error_count=0` and a frozen rendition, AVMetrics shows the attempted-but-stuck switch.
+- **HLSPlaylistRequestEvent / HLSMediaSegmentRequestEvent** — per-request timing for playlists vs media segments, separately. A playlist request that never completes ≠ a segment request that stalls.
+- **ContentKeyRequestEvent** — DRM/key fetch timing (rarely the cause in our test rig, but rules it in/out).
+
+## CoreMedia error-code key (from `raw_json`)
+
+The split here is literally "wedges permanently" vs "ugly-but-recovers" — read the code, don't guess from the stall:
+
+- **`-12880`** "cannot proceed after removing variants" → **wedges permanently.** The player exhausted the ladder and gave up.
+- **`-16839`** "unable to get playlist" → ugly **but usually recovers** once the playlist fetch succeeds.
+- **`-12889`** "no response in 2s" / **`-16830`** "media not received in 5s" → transient delivery stalls; recover if delivery resumes.
+- `-12174` is documented sim-only noise (#145), not a real error — don't attribute a wedge to it.
+
+## Common mistakes
+
+- **`metrics(forType:)` is exact-type, not is-a.** You must subscribe to each subclass individually (`HLSMediaSegmentRequestEvent`, `HLSPlaylistRequestEvent`, `ContentKeyRequestEvent`, …) — subscribing to the base type yields **zero** events. (`[[reference_avmetric_exact_type_filter]]`)
+- **`byteRange.length` is 0 for non-ranged GETs.** Use `networkTransactionMetrics.countOfResponseBodyBytesReceived` + response start/end dates for actual bytes & duration. (`[[reference_avmetric_byterange_zero]]`)
+- **Stream-level TTFB ≠ network RTT.** `responseStart - requestEnd` on an HTTP/2 keep-alive connection is sub-ms while real TCP RTT is ~100ms — label client series as TTFB, not RTT. (`[[reference_ttfb_vs_rtt_http2]]`)
+- **`total_stalls` under-counts these wedges** — a "fetching-but-frozen" degradation never emits `stall_frozen`, so the heartbeat stall count reads 0. Trust AVMetrics over the stall counter on iOS wedges.
+
+## See also
+
+- `.claude/standards/avplayer-quirks.md` — the rest of the AVPlayer reporting gaps.
+- `.claude/standards/abr-decision-model.md` — why a downshift attempt happens (and stalls).
+- `forensics` skill — gathers `/tmp/forensics-avm-<t>.jsonl` as a first-class evidence file.

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -73,7 +73,88 @@ func mountV2Handlers(mux *http.ServeMux, cfg config) {
 		v2ControlEventsHandler(w, r, cfg)
 	})
 
+	// /api/v2/avmetric_events — issue #693. Bounded read of the iOS 18
+	// AVMetrics feed (ios_avmetric_events), the highest-resolution
+	// failure-timing telemetry we have. Mirrors control_events' shape +
+	// discriminator guard; `event_type` is the AVMetric subclass filter.
+	mux.HandleFunc("/api/v2/avmetric_events", func(w http.ResponseWriter, r *http.Request) {
+		v2AVMetricEventsHandler(w, r, cfg)
+	})
+
 	mountV2PlaysHandlers(mux, cfg)
+}
+
+// v2AVMetricEventsHandler returns ios_avmetric_events rows as NDJSON
+// keyed by ?player_id=, ?play_id=, ?event_type= (repeatable), ?from=,
+// ?to=, ?limit=, plus label_has/label_not. Bounded (LIMIT) so it closes
+// — unlike the timeseries SSE. Issue #693.
+func v2AVMetricEventsHandler(w http.ResponseWriter, r *http.Request, cfg config) {
+	q := r.URL.Query()
+	playerID := canonicalV2ID(q.Get("player_id"))
+	playID := canonicalV2ID(q.Get("play_id"))
+	// event_type is repeatable (the AVMetric subclass name, e.g.
+	// HLSPlaylistRequestEvent). Filtering by it lets an operator pull just
+	// the error-bearing events without a player_id.
+	var eventTypes []string
+	for _, et := range q["event_type"] {
+		if et = strings.TrimSpace(et); et != "" {
+			eventTypes = append(eventTypes, et)
+		}
+	}
+	from := q.Get("from")
+	to := q.Get("to")
+	limit := q.Get("limit")
+	if limit == "" {
+		limit = "1000"
+	}
+	labelHas, labelNot := readLabelFilters(q)
+	// Require at least one discriminating predicate so we never scan the
+	// whole ios_avmetric_events table.
+	if playerID == "" && playID == "" && len(eventTypes) == 0 && len(labelHas) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"one of player_id, play_id, event_type, or label_has required"}`))
+		return
+	}
+	params := map[string]string{"limit": limit}
+	var where []string
+	if playerID != "" {
+		params["player_id"] = playerID
+		where = append(where, "player_id = {player_id:String}")
+	}
+	if playID != "" {
+		params["play_id"] = playID
+		where = append(where, "play_id = {play_id:String}")
+	}
+	if len(eventTypes) > 0 {
+		names := make([]string, len(eventTypes))
+		for i, et := range eventTypes {
+			key := "event_type_" + itoa(i)
+			params[key] = et
+			names[i] = "{" + key + ":String}"
+		}
+		where = append(where, "event_type IN ("+strings.Join(names, ", ")+")")
+	}
+	if from != "" {
+		params["from"] = from
+		where = append(where, "ts >= parseDateTime64BestEffortOrNull({from:String}, 3)")
+	}
+	if to != "" {
+		params["to"] = to
+		where = append(where, "ts <= parseDateTime64BestEffortOrNull({to:String}, 3)")
+	}
+	where, params = applyLabelFilters(where, params, "labels", labelHas, labelNot)
+	query := "SELECT ts, player_id, play_id, attempt_id, session_id, event_type, event_ts_ms, raw_json, labels, event_fingerprint, classification " +
+		"FROM " + cfg.chDatabase + ".ios_avmetric_events WHERE " +
+		strings.Join(where, " AND ") +
+		" ORDER BY ts ASC LIMIT {limit:UInt32} FORMAT JSONEachRow"
+	body, err := chQueryBytes(r.Context(), cfg, query, params)
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":"upstream query failed"}`))
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	_, _ = w.Write(body)
 }
 
 // v2ControlEventsHandler returns control_events rows as NDJSON keyed

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -326,6 +326,41 @@ paths:
             application/x-ndjson:
               schema: { $ref: '#/components/schemas/ControlEventRow' }
 
+  /api/v2/avmetric_events:
+    get:
+      tags: [archive]
+      summary: iOS AVMetrics event log
+      description: |
+        One row per iOS 18 AVMetrics event (`ios_avmetric_events`) — the
+        highest-resolution failure-timing telemetry available (CoreMedia
+        error codes, variant-switch start/complete, playlist/segment request
+        events). Bounded read (LIMIT) so it closes, unlike the timeseries
+        SSE. Issue #693. Requires at least one of `player_id`, `play_id`,
+        `event_type`, or `label_has`.
+      parameters:
+        - $ref: '#/components/parameters/PlayerIdFilter'
+        - $ref: '#/components/parameters/PlayIdFilter'
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - in: query
+          name: event_type
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+          description: |
+            Filter to specific AVMetric subclass names. Multiple values OR'd.
+            Examples: `event_type=HLSPlaylistRequestEvent&event_type=VariantSwitchStartEvent`.
+        - $ref: '#/components/parameters/LabelHasFilter'
+        - $ref: '#/components/parameters/LabelNotFilter'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: AVMetric event rows (NDJSON)
+          content:
+            application/x-ndjson:
+              schema: { $ref: '#/components/schemas/AVMetricEventRow' }
+
   /api/v2/session_heatmap:
     get:
       tags: [archive]
@@ -1214,6 +1249,64 @@ components:
           description: |
             FNV-64a hash over (player, play, ts_ms, source, event, info).
             Stable dedupe key for SSE reconnects.
+        classification:
+          type: string
+          enum: [other, interesting, favourite]
+          description: Retention tier — same lifecycle as the parent session.
+
+    AVMetricEventRow:
+      description: |
+        One archived `ios_avmetric_events` row — a single iOS 18 AVMetrics
+        event. Issue #693.
+      type: object
+      required: [ts, event_type]
+      properties:
+        ts:
+          type: string
+          format: date-time
+          description: Forwarder ingest time.
+        player_id:
+          type: string
+          format: uuid
+          description: Owning player.
+        play_id:
+          type: string
+          description: Owning play (empty when not yet stamped).
+        attempt_id:
+          type: integer
+          format: int64
+          description: Sticky per-attempt counter. 0 when unknown.
+        session_id:
+          type: string
+          description: Owning proxy session.
+        event_type:
+          type: string
+          description: |
+            AVMetric subclass name as published by AVFoundation —
+            e.g. `HLSPlaylistRequestEvent`, `HLSMediaSegmentRequestEvent`,
+            `VariantSwitchStartEvent`, `ContentKeyRequestEvent`.
+        event_ts_ms:
+          type: integer
+          format: int64
+          description: |
+            AVMetrics-side timeline stamp (ms), separate from `ts` so
+            causality plots don't mix clocks. 0 when absent.
+        raw_json:
+          type: string
+          description: |
+            Unmodified SDK payload as a JSON string — parse client-side.
+            Carries the CoreMedia error code, byte ranges, etc.
+        labels:
+          type: array
+          items: { type: string }
+          description: |
+            Severity-tagged `<severity>=<event>` strings (same vocab as the
+            other tables). Empty until an AVMetric classifier lands.
+        event_fingerprint:
+          type: string
+          description: |
+            FNV-64a hash over (session, event_ts_ms, event_type). Stable
+            dedupe key for SSE reconnects.
         classification:
           type: string
           enum: [other, interesting, favourite]

--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -326,6 +326,41 @@ paths:
             application/x-ndjson:
               schema: { $ref: '#/components/schemas/ControlEventRow' }
 
+  /api/v2/avmetric_events:
+    get:
+      tags: [archive]
+      summary: iOS AVMetrics event log
+      description: |
+        One row per iOS 18 AVMetrics event (`ios_avmetric_events`) — the
+        highest-resolution failure-timing telemetry available (CoreMedia
+        error codes, variant-switch start/complete, playlist/segment request
+        events). Bounded read (LIMIT) so it closes, unlike the timeseries
+        SSE. Issue #693. Requires at least one of `player_id`, `play_id`,
+        `event_type`, or `label_has`.
+      parameters:
+        - $ref: '#/components/parameters/PlayerIdFilter'
+        - $ref: '#/components/parameters/PlayIdFilter'
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - in: query
+          name: event_type
+          explode: true
+          schema:
+            type: array
+            items: { type: string }
+          description: |
+            Filter to specific AVMetric subclass names. Multiple values OR'd.
+            Examples: `event_type=HLSPlaylistRequestEvent&event_type=VariantSwitchStartEvent`.
+        - $ref: '#/components/parameters/LabelHasFilter'
+        - $ref: '#/components/parameters/LabelNotFilter'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: AVMetric event rows (NDJSON)
+          content:
+            application/x-ndjson:
+              schema: { $ref: '#/components/schemas/AVMetricEventRow' }
+
   /api/v2/session_heatmap:
     get:
       tags: [archive]
@@ -622,9 +657,7 @@ components:
         Row-level label inclusion filter. Repeatable; every value
         must be present in the row's `labels[]` (AND-within-includes).
         Format `<severity>=<event>` (with `*` prefix for synthesized
-        labels). Severities: `critical|error|warning|info`, plus the
-        unranked `testing` tier for operator/test-harness KV metadata
-        (e.g. `testing=run_id_...`). Example:
+        labels). Example:
         `?label_has=warning%3Dhttp_4xx&label_has=info%3D%2Apattern_step`.
     LabelNotFilter:
       in: query
@@ -921,6 +954,7 @@ components:
         content_id:        { type: string }
         # ---- timing ----
         started_at:        { type: string, format: date-time }
+        start_time:        { type: string, format: date-time, nullable: true, description: "Client-supplied play start (ISO-8601 UTC), play-scoped — minted by the player with play_id and rotated with it. See PlayRecord.start_time in proxy.yaml. Null when the client didn't send it (web/Roku)." }
         last_seen_at:      { type: string, format: date-time }
         labels:
           type: object
@@ -994,6 +1028,9 @@ components:
               oneOf:
                 - { type: string,  description: "label, e.g. 'warning=*manifest_failure'" }
                 - { type: integer, description: "occurrence count for this play" }
+        # ---- run identity (issue #678) ----
+        scenario:
+          $ref: '#/components/schemas/Scenario'
         # ---- tiered retention class ----
         classification:
           type: string
@@ -1009,6 +1046,33 @@ components:
             fault-induced | abandoned`) described in DESIGN.md are
             blocked on the `play_summaries` rollup table — they'll
             land here when that lands.
+
+    Scenario:
+      description: |
+        Run IDENTITY of a play — "what it IS" (test, platform, device,
+        versions), as distinct from the event labels which are "what
+        HAPPENED during it". Issue #678 promoted this off the dashboard
+        (it was assembled client-side in Sessions.vue) into the API so the
+        Sessions list, Session Viewer header, and chat tools share one shape.
+
+        Hybrid-sourced: device/player/app/os/content from the authoritative
+        typed summary columns; test/platform/run_id from the `testing=`
+        label tier (no typed column exists for those). Every field is
+        optional — a play absent all of them omits the whole object rather
+        than emitting `{}`.
+      type: object
+      properties:
+        test:         { type: string, description: "Characterization test mode, from testing=test_* (e.g. 'rampup'). Harness runs only." }
+        platform:     { type: string, description: "Harness-stamped platform, from testing=platform_* (e.g. 'ipad-sim'). Distinct from device_* below. Harness runs only." }
+        run_id:       { type: string, description: "Characterization run id, from testing=run_id_* (compact UTC, e.g. '20260524T070148Z'). Groups plays into a run. Harness runs only." }
+        device_class: { type: string, description: "Device taxonomy class (phone|tablet|tv|…). From the typed column (#550 Phase 4)." }
+        device_model: { type: string, description: "Device model identifier (e.g. 'iPhone15,2'). From the typed column." }
+        player_tech:  { type: string, description: "Player technology (e.g. 'AVPlayer'). From the typed column." }
+        app_version:  { type: string, description: "Client app version. From the typed column." }
+        os_version:   { type: string, description: "OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor." }
+        content_id:   { type: string, description: "Content identifier — duplicated here so the object is self-contained for the viewer header." }
+        manifest_variant: { type: string, enum: ['ll', '2s', '6s'], description: "Manifest the player loaded, derived from the master URL: 'll' (low-latency), '2s', or '6s'. Issue #679." }
+        server_build:     { type: string, description: "go-live build that served the play, from the X-Served-By response header (the build the proxy captured). Empty for dev builds with no -ldflags stamp. Issue #679." }
 
     PlaySummaryPage:
       type: object
@@ -1185,6 +1249,64 @@ components:
           description: |
             FNV-64a hash over (player, play, ts_ms, source, event, info).
             Stable dedupe key for SSE reconnects.
+        classification:
+          type: string
+          enum: [other, interesting, favourite]
+          description: Retention tier — same lifecycle as the parent session.
+
+    AVMetricEventRow:
+      description: |
+        One archived `ios_avmetric_events` row — a single iOS 18 AVMetrics
+        event. Issue #693.
+      type: object
+      required: [ts, event_type]
+      properties:
+        ts:
+          type: string
+          format: date-time
+          description: Forwarder ingest time.
+        player_id:
+          type: string
+          format: uuid
+          description: Owning player.
+        play_id:
+          type: string
+          description: Owning play (empty when not yet stamped).
+        attempt_id:
+          type: integer
+          format: int64
+          description: Sticky per-attempt counter. 0 when unknown.
+        session_id:
+          type: string
+          description: Owning proxy session.
+        event_type:
+          type: string
+          description: |
+            AVMetric subclass name as published by AVFoundation —
+            e.g. `HLSPlaylistRequestEvent`, `HLSMediaSegmentRequestEvent`,
+            `VariantSwitchStartEvent`, `ContentKeyRequestEvent`.
+        event_ts_ms:
+          type: integer
+          format: int64
+          description: |
+            AVMetrics-side timeline stamp (ms), separate from `ts` so
+            causality plots don't mix clocks. 0 when absent.
+        raw_json:
+          type: string
+          description: |
+            Unmodified SDK payload as a JSON string — parse client-side.
+            Carries the CoreMedia error code, byte ranges, etc.
+        labels:
+          type: array
+          items: { type: string }
+          description: |
+            Severity-tagged `<severity>=<event>` strings (same vocab as the
+            other tables). Empty until an AVMetric classifier lands.
+        event_fingerprint:
+          type: string
+          description: |
+            FNV-64a hash over (session, event_ts_ms, event_type). Stable
+            dedupe key for SSE reconnects.
         classification:
           type: string
           enum: [other, interesting, favourite]

--- a/tools/harness-cli/cmd/harness/query.go
+++ b/tools/harness-cli/cmd/harness/query.go
@@ -54,6 +54,12 @@ Subcommands:
   control  <play_id> [--source S] [--event E] [--mode M]
            [--label-has L ...] [--label-not L ...] [--limit N]
                                   proxy / harness action log
+  avmetrics [<play_id>] [--event-type T ...] [--from ISO] [--to ISO]
+           [--label-has L ...] [--label-not L ...] [--limit N]
+                                  iOS AVMetrics events (highest-resolution
+                                  failure-timing feed: CoreMedia error
+                                  codes, variant-switch start/complete).
+                                  Bounded read — closes (no SSE hack).
   heatmap  <play_id>
   bundle   <play_id> --out PATH   download play bundle ZIP
 
@@ -88,6 +94,8 @@ func cmdQuery(client *api.Client, args []string, asJSON bool) error {
 	// proxy/harness actions live on control_events.
 	case "control":
 		return cmdQueryControl(client, args[1:], asJSON)
+	case "avmetrics":
+		return cmdQueryAVMetrics(client, args[1:], asJSON)
 	case "heatmap":
 		return cmdQueryHeatmap(client, args[1:], asJSON)
 	case "bundle":
@@ -328,6 +336,78 @@ func cmdQueryControl(client *api.Client, args []string, asJSON bool) error {
 		params.LabelNot = &v
 	}
 	body, err := client.ArchiveControlEvents(context.Background(), params)
+	if err != nil {
+		return err
+	}
+	return printOrJSON(body, asJSON)
+}
+
+// cmdQueryAVMetrics queries the iOS AVMetrics event log (#693) — the
+// highest-resolution failure-timing feed. Mirrors cmdQueryControl: the
+// play_id positional is optional, so an operator can pull by --event-type
+// / --label-has alone (e.g. every error-bearing AVMetric in a window).
+// Bounded read, so it closes — no curl --max-time hack.
+func cmdQueryAVMetrics(client *api.Client, args []string, asJSON bool) error {
+	var playID string
+	flagArgs := args
+	if len(args) >= 1 && !strings.HasPrefix(args[0], "-") {
+		playID = args[0]
+		flagArgs = args[1:]
+	}
+	fs := flag.NewFlagSet("query avmetrics", flag.ContinueOnError)
+	var eventTypes arrayFlag
+	fs.Var(&eventTypes, "event-type", "filter to AVMetric subclass name, e.g. HLSPlaylistRequestEvent (repeatable; OR)")
+	from := fs.String("from", "", "ISO lower bound on ts (inclusive)")
+	to := fs.String("to", "", "ISO upper bound on ts (exclusive)")
+	var labelHas, labelNot arrayFlag
+	fs.Var(&labelHas, "label-has", "row must have this label (repeatable; AND semantics)")
+	fs.Var(&labelNot, "label-not", "row must NOT have this label (repeatable; AND semantics)")
+	limit := fs.Int("limit", 0, "max rows")
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	if playID == "" && len(eventTypes) == 0 && len(labelHas) == 0 {
+		return errors.New("usage: harness query avmetrics [<play_id>] [--event-type T] [--label-has L] [--from ISO] [--to ISO] [--label-not L] [--limit N]\n  a play_id, --event-type, or --label-has is required")
+	}
+	params := &forwarder.GetApiV2AvmetricEventsParams{}
+	if playID != "" {
+		pid, err := parsePlayID(playID)
+		if err != nil {
+			return err
+		}
+		params.PlayId = &pid
+	}
+	if len(eventTypes) > 0 {
+		et := []string(eventTypes)
+		params.EventType = &et
+	}
+	if *from != "" {
+		t, err := time.Parse(time.RFC3339, *from)
+		if err != nil {
+			return fmt.Errorf("invalid --from %q (need RFC3339, e.g. 2026-05-17T00:00:00Z): %w", *from, err)
+		}
+		params.From = &t
+	}
+	if *to != "" {
+		t, err := time.Parse(time.RFC3339, *to)
+		if err != nil {
+			return fmt.Errorf("invalid --to %q (need RFC3339): %w", *to, err)
+		}
+		params.To = &t
+	}
+	if *limit > 0 {
+		l := *limit
+		params.Limit = &l
+	}
+	if len(labelHas) > 0 {
+		v := forwarder.LabelHasFilter(labelHas)
+		params.LabelHas = &v
+	}
+	if len(labelNot) > 0 {
+		v := forwarder.LabelNotFilter(labelNot)
+		params.LabelNot = &v
+	}
+	body, err := client.ArchiveAVMetricEvents(context.Background(), params)
 	if err != nil {
 		return err
 	}

--- a/tools/harness-cli/cmd/harness/ts.go
+++ b/tools/harness-cli/cmd/harness/ts.go
@@ -18,10 +18,12 @@ const tsUsage = `harness ts <target|all> [flags]
 
 Combined timeseries — samples + network — from /api/v2/timeseries.
 Network rows render like 'tail'; sample rows render the headline
-ABR/buffer/RTT/FPS values on a single line.
+ABR/buffer/RTT/FPS values on a single line; avmetric rows ('A ...')
+render the AVMetric subclass + a raw-payload preview.
 
 Flags:
-  --streams S      override default 'samples,network' (CSV)
+  --streams S      override default 'samples,network' (CSV). Tokens:
+                   samples,network,events,control,avmetrics
   --bundles B      override default per-stream bundles (CSV)
   --max-hz N       rate-limit live deltas (default 0 = uncapped)
   --raw            print raw frame JSON
@@ -30,24 +32,25 @@ Examples:
   harness ts ipad
   harness ts ipad --max-hz 10
   harness ts all --streams samples
+  harness ts ipad --streams samples,network,avmetrics
 `
 
 // tailSampleRow is the projection used when ts renders a sample
 // frame. Like tailNetworkRow, every variable-shape field is `any`
 // because CH JSONEachRow returns inconsistent JSON types per column.
 type tailSampleRow struct {
-	Ts                  string `json:"ts"`
-	PlayerID            string `json:"player_id"`
-	PlayID              string `json:"play_id"`
-	State               any    `json:"state,omitempty"`
-	BandwidthEstMbps    any    `json:"bandwidth_estimate_mbps,omitempty"`
-	BufferSeconds       any    `json:"buffer_seconds,omitempty"`
-	RttMs               any    `json:"rtt_ms,omitempty"`
-	RenditionMbps       any    `json:"rendition_mbps,omitempty"`
-	ShaperLimitMbps     any    `json:"shaper_limit_mbps,omitempty"`
-	FpsRunning          any    `json:"fps_running,omitempty"`
-	FramesDroppedDelta  any    `json:"frames_dropped_delta,omitempty"`
-	Downshifts          any    `json:"downshifts,omitempty"`
+	Ts                 string `json:"ts"`
+	PlayerID           string `json:"player_id"`
+	PlayID             string `json:"play_id"`
+	State              any    `json:"state,omitempty"`
+	BandwidthEstMbps   any    `json:"bandwidth_estimate_mbps,omitempty"`
+	BufferSeconds      any    `json:"buffer_seconds,omitempty"`
+	RttMs              any    `json:"rtt_ms,omitempty"`
+	RenditionMbps      any    `json:"rendition_mbps,omitempty"`
+	ShaperLimitMbps    any    `json:"shaper_limit_mbps,omitempty"`
+	FpsRunning         any    `json:"fps_running,omitempty"`
+	FramesDroppedDelta any    `json:"frames_dropped_delta,omitempty"`
+	Downshifts         any    `json:"downshifts,omitempty"`
 }
 
 func cmdTs(client *api.Client, args []string, asJSON bool) error {
@@ -85,6 +88,8 @@ func cmdTs(client *api.Client, args []string, asJSON bool) error {
 				bundlesList = append(bundlesList, "network")
 			case "events":
 				bundlesList = append(bundlesList, "events")
+			case "avmetrics":
+				bundlesList = append(bundlesList, "avmetrics")
 			}
 		}
 	}
@@ -121,6 +126,11 @@ func cmdTs(client *api.Client, args []string, asJSON bool) error {
 			if err := json.Unmarshal([]byte(f.Data), &row); err == nil {
 				fmt.Println("S " + formatSampleRow(row))
 			}
+		case "avmetric", "avmetrics":
+			var row tailAVMetricRow
+			if err := json.Unmarshal([]byte(f.Data), &row); err == nil {
+				fmt.Println("A " + formatAVMetricRow(row))
+			}
 		default:
 			preview := f.Data
 			if len(preview) > 140 {
@@ -130,6 +140,33 @@ func cmdTs(client *api.Client, args []string, asJSON bool) error {
 		}
 		return nil
 	})
+}
+
+// tailAVMetricRow is the projection used when ts renders an AVMetrics
+// frame (issue #693). raw_json carries the CoreMedia error code etc.;
+// we preview it rather than parse, matching the verbatim-passthrough
+// the rest of the pipeline uses.
+type tailAVMetricRow struct {
+	Ts             string `json:"ts"`
+	PlayID         string `json:"play_id"`
+	EventType      string `json:"event_type"`
+	EventTsMs      any    `json:"event_ts_ms,omitempty"`
+	RawJSON        string `json:"raw_json,omitempty"`
+	Classification string `json:"classification,omitempty"`
+}
+
+// formatAVMetricRow renders one AVMetrics event: ts, subclass name, and
+// a preview of the raw SDK payload (where the CoreMedia error code lives).
+func formatAVMetricRow(r tailAVMetricRow) string {
+	raw := strings.TrimSpace(r.RawJSON)
+	if len(raw) > 100 {
+		raw = raw[:97] + "..."
+	}
+	cls := ""
+	if r.Classification != "" && r.Classification != "other" {
+		cls = " [" + r.Classification + "]"
+	}
+	return fmt.Sprintf("%s  %-32s%s %s", formatTs(r.Ts), r.EventType, cls, raw)
 }
 
 // formatSampleRow renders one ABR/buffer/RTT/FPS sample. Empty cells

--- a/tools/harness-cli/internal/api/client.go
+++ b/tools/harness-cli/internal/api/client.go
@@ -2,14 +2,14 @@
 // (internal/v2gen/{proxy,forwarder}). It exists because oapi-codegen
 // produces verbose method names + raw *http.Response returns:
 //
-//   resp, err := c.proxy.GetApiV2Players(ctx, nil)
-//   defer resp.Body.Close()
-//   var out []proxy.PlayerRecord
-//   json.NewDecoder(resp.Body).Decode(&out)
+//	resp, err := c.proxy.GetApiV2Players(ctx, nil)
+//	defer resp.Body.Close()
+//	var out []proxy.PlayerRecord
+//	json.NewDecoder(resp.Body).Decode(&out)
 //
 // vs what callers want:
 //
-//   players, err := c.Players(ctx)
+//	players, err := c.Players(ctx)
 //
 // The facade also owns:
 //   - the HTTP client (timeouts, optional self-signed-cert tolerance)
@@ -789,6 +789,15 @@ func (c *Client) ArchiveControlEvents(ctx context.Context, params *forwarder.Get
 	return c.archiveGET(func() (*http.Response, error) {
 		return c.forwarder.GetApiV2ControlEvents(ctx, params)
 	}, "GET /analytics/api/v2/control_events")
+}
+
+// ArchiveAVMetricEvents returns the iOS AVMetrics event log
+// (ios_avmetric_events) — the highest-resolution failure-timing feed.
+// Bounded read, so it closes (no SSE --max-time hack). Issue #693.
+func (c *Client) ArchiveAVMetricEvents(ctx context.Context, params *forwarder.GetApiV2AvmetricEventsParams) ([]byte, error) {
+	return c.archiveGET(func() (*http.Response, error) {
+		return c.forwarder.GetApiV2AvmetricEvents(ctx, params)
+	}, "GET /analytics/api/v2/avmetric_events")
 }
 
 // ArchiveSessionHeatmap returns the bucketed heatmap.

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -23,6 +23,27 @@ const (
 	BasicAuthScopes basicAuthContextKey = "basicAuth.Scopes"
 )
 
+// Defines values for AVMetricEventRowClassification.
+const (
+	AVMetricEventRowClassificationFavourite   AVMetricEventRowClassification = "favourite"
+	AVMetricEventRowClassificationInteresting AVMetricEventRowClassification = "interesting"
+	AVMetricEventRowClassificationOther       AVMetricEventRowClassification = "other"
+)
+
+// Valid indicates whether the value is a known member of the AVMetricEventRowClassification enum.
+func (e AVMetricEventRowClassification) Valid() bool {
+	switch e {
+	case AVMetricEventRowClassificationFavourite:
+		return true
+	case AVMetricEventRowClassificationInteresting:
+		return true
+	case AVMetricEventRowClassificationOther:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for BundleCatalogueStreamsStream.
 const (
 	BundleCatalogueStreamsStreamControl BundleCatalogueStreamsStream = "control"
@@ -451,27 +472,73 @@ func (e GetApiV2PlaysAggregateParamsClassification) Valid() bool {
 
 // Defines values for PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification.
 const (
-	PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationAuto        PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "auto"
-	PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationFavourite   PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "favourite"
-	PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationInteresting PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "interesting"
-	PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationOther       PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "other"
+	Auto        PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "auto"
+	Favourite   PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "favourite"
+	Interesting PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "interesting"
+	Other       PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification = "other"
 )
 
 // Valid indicates whether the value is a known member of the PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification enum.
 func (e PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassification) Valid() bool {
 	switch e {
-	case PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationAuto:
+	case Auto:
 		return true
-	case PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationFavourite:
+	case Favourite:
 		return true
-	case PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationInteresting:
+	case Interesting:
 		return true
-	case PatchApiV2PlaysPlayIdApplicationMergePatchPlusJSONBodyClassificationOther:
+	case Other:
 		return true
 	default:
 		return false
 	}
 }
+
+// AVMetricEventRow One archived `ios_avmetric_events` row — a single iOS 18 AVMetrics
+// event. Issue #693.
+type AVMetricEventRow struct {
+	// AttemptId Sticky per-attempt counter. 0 when unknown.
+	AttemptId *int64 `json:"attempt_id,omitempty"`
+
+	// Classification Retention tier — same lifecycle as the parent session.
+	Classification *AVMetricEventRowClassification `json:"classification,omitempty"`
+
+	// EventFingerprint FNV-64a hash over (session, event_ts_ms, event_type). Stable
+	// dedupe key for SSE reconnects.
+	EventFingerprint *string `json:"event_fingerprint,omitempty"`
+
+	// EventTsMs AVMetrics-side timeline stamp (ms), separate from `ts` so
+	// causality plots don't mix clocks. 0 when absent.
+	EventTsMs *int64 `json:"event_ts_ms,omitempty"`
+
+	// EventType AVMetric subclass name as published by AVFoundation —
+	// e.g. `HLSPlaylistRequestEvent`, `HLSMediaSegmentRequestEvent`,
+	// `VariantSwitchStartEvent`, `ContentKeyRequestEvent`.
+	EventType string `json:"event_type"`
+
+	// Labels Severity-tagged `<severity>=<event>` strings (same vocab as the
+	// other tables). Empty until an AVMetric classifier lands.
+	Labels *[]string `json:"labels,omitempty"`
+
+	// PlayId Owning play (empty when not yet stamped).
+	PlayId *string `json:"play_id,omitempty"`
+
+	// PlayerId Owning player.
+	PlayerId *openapi_types.UUID `json:"player_id,omitempty"`
+
+	// RawJson Unmodified SDK payload as a JSON string — parse client-side.
+	// Carries the CoreMedia error code, byte ranges, etc.
+	RawJson *string `json:"raw_json,omitempty"`
+
+	// SessionId Owning proxy session.
+	SessionId *string `json:"session_id,omitempty"`
+
+	// Ts Forwarder ingest time.
+	Ts time.Time `json:"ts"`
+}
+
+// AVMetricEventRowClassification Retention tier — same lifecycle as the parent session.
+type AVMetricEventRowClassification string
 
 // AggregateResult Group-by output. `groups` is one row per distinct combination of
 // the requested `group_by` keys; each group has the requested metrics
@@ -1401,6 +1468,41 @@ type Problem = ProblemDetails
 
 // basicAuthContextKey is the context key for basicAuth security scheme
 type basicAuthContextKey string
+
+// GetApiV2AvmetricEventsParams defines parameters for GetApiV2AvmetricEvents.
+type GetApiV2AvmetricEventsParams struct {
+	PlayerId *PlayerIdFilter `form:"player_id,omitempty" json:"player_id,omitempty"`
+
+	// PlayId Filter to one play. Player-supplied UUID; rotates only on
+	// content-selection / fresh app or page load. Stable across
+	// in-app restart events.
+	PlayId *PlayIdFilter `form:"play_id,omitempty" json:"play_id,omitempty"`
+
+	// From ISO 8601 lower bound on the row timestamp. Inclusive.
+	From *From `form:"from,omitempty" json:"from,omitempty"`
+
+	// To ISO 8601 upper bound on the row timestamp. Exclusive.
+	To *To `form:"to,omitempty" json:"to,omitempty"`
+
+	// EventType Filter to specific AVMetric subclass names. Multiple values OR'd.
+	// Examples: `event_type=HLSPlaylistRequestEvent&event_type=VariantSwitchStartEvent`.
+	EventType *[]string `form:"event_type,omitempty" json:"event_type,omitempty"`
+
+	// LabelHas Row-level label inclusion filter. Repeatable; every value
+	// must be present in the row's `labels[]` (AND-within-includes).
+	// Format `<severity>=<event>` (with `*` prefix for synthesized
+	// labels). Example:
+	// `?label_has=warning%3Dhttp_4xx&label_has=info%3D%2Apattern_step`.
+	LabelHas *LabelHasFilter `form:"label_has,omitempty" json:"label_has,omitempty"`
+
+	// LabelNot Row-level label exclusion filter. Repeatable; none of the
+	// values may be present in the row's `labels[]`
+	// (AND-within-excludes). Combine with `label_has` for queries
+	// like *"has http_4xx AND has-not fault_rule_enabled"*. Same
+	// format as `label_has`.
+	LabelNot *LabelNotFilter `form:"label_not,omitempty" json:"label_not,omitempty"`
+	Limit    *Limit          `form:"limit,omitempty" json:"limit,omitempty"`
+}
 
 // GetApiV2ControlEventsParams defines parameters for GetApiV2ControlEvents.
 type GetApiV2ControlEventsParams struct {
@@ -2777,6 +2879,9 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// GetApiV2AvmetricEvents request
+	GetApiV2AvmetricEvents(ctx context.Context, params *GetApiV2AvmetricEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetBundles request
 	GetBundles(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -2817,6 +2922,18 @@ type ClientInterface interface {
 
 	// GetTimeseries request
 	GetTimeseries(ctx context.Context, params *GetTimeseriesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) GetApiV2AvmetricEvents(ctx context.Context, params *GetApiV2AvmetricEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetApiV2AvmetricEventsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) GetBundles(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -2985,6 +3102,144 @@ func (c *Client) GetTimeseries(ctx context.Context, params *GetTimeseriesParams,
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewGetApiV2AvmetricEventsRequest generates requests for GetApiV2AvmetricEvents
+func NewGetApiV2AvmetricEventsRequest(server string, params *GetApiV2AvmetricEventsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/avmetric_events")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.PlayerId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "player_id", *params.PlayerId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: "uuid"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.PlayId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "play_id", *params.PlayId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: "uuid"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "from", *params.From, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: "date-time"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: "date-time"}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.EventType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "event_type", *params.EventType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.LabelHas != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "label_has", *params.LabelHas, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.LabelNot != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "label_not", *params.LabelNot, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewGetBundlesRequest generates requests for GetBundles
@@ -4395,6 +4650,9 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// GetApiV2AvmetricEventsWithResponse request
+	GetApiV2AvmetricEventsWithResponse(ctx context.Context, params *GetApiV2AvmetricEventsParams, reqEditors ...RequestEditorFn) (*GetApiV2AvmetricEventsResponse, error)
+
 	// GetBundlesWithResponse request
 	GetBundlesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetBundlesResponse, error)
 
@@ -4435,6 +4693,35 @@ type ClientWithResponsesInterface interface {
 
 	// GetTimeseriesWithResponse request
 	GetTimeseriesWithResponse(ctx context.Context, params *GetTimeseriesParams, reqEditors ...RequestEditorFn) (*GetTimeseriesResponse, error)
+}
+
+type GetApiV2AvmetricEventsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r GetApiV2AvmetricEventsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetApiV2AvmetricEventsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetApiV2AvmetricEventsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type GetBundlesResponse struct {
@@ -4831,6 +5118,15 @@ func (r GetTimeseriesResponse) ContentType() string {
 	return ""
 }
 
+// GetApiV2AvmetricEventsWithResponse request returning *GetApiV2AvmetricEventsResponse
+func (c *ClientWithResponses) GetApiV2AvmetricEventsWithResponse(ctx context.Context, params *GetApiV2AvmetricEventsParams, reqEditors ...RequestEditorFn) (*GetApiV2AvmetricEventsResponse, error) {
+	rsp, err := c.GetApiV2AvmetricEvents(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetApiV2AvmetricEventsResponse(rsp)
+}
+
 // GetBundlesWithResponse request returning *GetBundlesResponse
 func (c *ClientWithResponses) GetBundlesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetBundlesResponse, error) {
 	rsp, err := c.GetBundles(ctx, reqEditors...)
@@ -4954,6 +5250,22 @@ func (c *ClientWithResponses) GetTimeseriesWithResponse(ctx context.Context, par
 		return nil, err
 	}
 	return ParseGetTimeseriesResponse(rsp)
+}
+
+// ParseGetApiV2AvmetricEventsResponse parses an HTTP response from a GetApiV2AvmetricEventsWithResponse call
+func ParseGetApiV2AvmetricEventsResponse(rsp *http.Response) (*GetApiV2AvmetricEventsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetApiV2AvmetricEventsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
 }
 
 // ParseGetBundlesResponse parses an HTTP response from a GetBundlesWithResponse call


### PR DESCRIPTION
Closes #693. The iOS AVMetrics feed (`ios_avmetric_events`) is the highest-resolution failure-timing telemetry we have — CoreMedia error codes, `VariantSwitchStart`-without-complete — but was only reachable via a raw SSE `GET` + `curl --max-time` hack, which pushed live debugging off the CLI rails. This promotes it to a first-class operator surface.

## Ask → delivery
1. **`harness query avmetrics [<play>]`** ✅ — bounded, read-only forwarder query. New `GET /api/v2/avmetric_events` (mirrors `control_events`: discriminator guard, `--label-has`, `--from/--to`, JSON), returning `event_type, ts, event_ts_ms, raw_json, classification`. `--event-type` filter; positional play_id is **optional** so you can sweep by event type alone.
2. **`harness ts --streams avmetrics`** ✅ — accepts the token (the forwarder timeseries already served `streams=avmetrics`); renders `A <ts> <event_type> <raw preview>`.
3. **Bounded read closes** ✅ — no `--max-time` hack; the query is bounded NDJSON.
4. **Forensics + harness skill wiring** ✅ — forensics gathers `/tmp/forensics-avm-<t>.jsonl` as first-class evidence; both skills reference the new `.claude/standards/avmetrics-forensics.md` (event-type → signal map + the CoreMedia code key: `-12880` wedges-permanently vs `-16839` ugly-but-recovers, plus the exact-type-subscribe / byteRange-zero / TTFB-not-RTT gotchas).

## Layers touched (the usual plumb-everywhere set)
forwarder handler → OpenAPI spec (+ synced dashboard docs) → regenerated harness-cli client → `api.Client` wrapper → CLI `query avmetrics` + `ts` token → forensics/harness skills + new standard.

Also fixes the now-stale harness-skill note claiming `query control` is broken/requires player_id (#684 fixed that).

## Verification
Forwarder + harness-cli `go build` / `go vet` / gofmt clean. CLI usage smoke-tested: `query` lists `avmetrics`, the discriminator guard rejects an argument-less call before any network I/O, `ts` usage lists the token. Live read-path verification to follow on deploy (query the `ios_avmetric_events` rows on test-dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
