### PR TITLE
feat(char): Appium-Android play-start (harness + app accessibility nodes)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/HomeScreen.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/HomeScreen.kt
@@ -45,6 +45,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.Icon
 import androidx.tv.material3.Text
@@ -152,6 +156,18 @@ fun HomeScreen(
             .fillMaxSize()
             .background(Tokens.bg)
     ) {
+        // Harness hook — exposes player_id to Appium (accessibility id =
+        // content-desc "home-player-id"; the value is the node's text). The
+        // characterization rig reads it pre-playback to bind the shape cap
+        // to the right player. Mirrors iOS HomeScreen's hidden node.
+        Box(
+            modifier = Modifier
+                .size(1.dp)
+                .semantics {
+                    contentDescription = "home-player-id"
+                    text = AnnotatedString(vm.playerId)
+                },
+        )
         Column(modifier = Modifier.fillMaxSize().padding(Space.s7)) {
             // Header — big serif brand + monospace active-server label
             // on the left, a focusable gear on the right that opens
@@ -345,7 +361,14 @@ private fun Hero(
                 )
             }
             Row {
-                PrimaryButton("Resume", onClick = onResume, accent = true)
+                // contentDescription = Appium accessibility id on Android;
+                // ResumePlayback finds + clicks this to start the play.
+                PrimaryButton(
+                    "Resume",
+                    onClick = onResume,
+                    accent = true,
+                    modifier = Modifier.semantics { contentDescription = "home-continue-watching" },
+                )
             }
         }
     }

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/ServerPickerScreen.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/ServerPickerScreen.kt
@@ -536,9 +536,9 @@ private fun FieldRow(label: String, value: String, kt: KeyboardType, onChange: (
 }
 
 @Composable
-internal fun PrimaryButton(text: String, onClick: () -> Unit, accent: Boolean = false) {
+internal fun PrimaryButton(text: String, onClick: () -> Unit, accent: Boolean = false, modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .height(44.dp)
             .tvFocus(cornerRadius = Radius.pill)
             .clip(RoundedCornerShape(Radius.pill))

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -194,12 +194,14 @@ func (a *AppiumLauncher) ResumePlayback(ctx context.Context, d Device) error {
 		return errors.New("ResumePlayback: no active appium session for device")
 	}
 	switch d.Platform {
-	case PlatformIPhone, PlatformIPad, PlatformIPadSim:
-		// Wait for the continue-watching tile to render before tapping —
+	case PlatformIPhone, PlatformIPad, PlatformIPadSim, PlatformAndroidTV:
+		// Wait for the continue-watching control to render before tapping —
 		// the catalogue fetch is async, so a just-forced-to-Home screen
 		// can show an empty content row for a few seconds (observed after
 		// a fresh launch / segment-forced launch); tapping immediately
-		// 404s on the not-yet-rendered tile.
+		// 404s on the not-yet-rendered tile. On Android the id is the
+		// content-desc on the hero's Resume button — same "accessibility
+		// id" locator (UiAutomator2 maps it to content-desc).
 		elID, err := a.waitForAccessibilityID(ctx, sessID, "home-continue-watching", 30*time.Second)
 		if err != nil {
 			return fmt.Errorf("wait for home-continue-watching: %w", err)
@@ -454,7 +456,7 @@ func (a *AppiumLauncher) Close() error {
 // returns its `value` attribute. Used to read out the persistent
 // player_id from the iOS app's home screen BEFORE tapping into
 // playback — see ReadPlayerID below.
-func (a *AppiumLauncher) readAccessibilityValue(ctx context.Context, sessID, id string) (string, error) {
+func (a *AppiumLauncher) readAccessibilityValue(ctx context.Context, sessID, id, attr string) (string, error) {
 	findBody := map[string]any{"using": "accessibility id", "value": id}
 	raw, err := a.doRequest(ctx, "POST", "/session/"+sessID+"/element", findBody)
 	if err != nil {
@@ -474,8 +476,11 @@ func (a *AppiumLauncher) readAccessibilityValue(ctx context.Context, sessID, id 
 	if elementID == "" {
 		return "", fmt.Errorf("find element %q returned no id", id)
 	}
+	// Which attribute carries the value differs by driver: XCUITest exposes
+	// the iOS accessibilityValue under "value"; UiAutomator2 exposes the
+	// Compose node's text under "text".
 	raw, err = a.doRequest(ctx, "GET",
-		fmt.Sprintf("/session/%s/element/%s/attribute/value", sessID, elementID), nil)
+		fmt.Sprintf("/session/%s/element/%s/attribute/%s", sessID, elementID, attr), nil)
 	if err != nil {
 		return "", fmt.Errorf("read value %q: %w", id, err)
 	}
@@ -556,7 +561,13 @@ func (a *AppiumLauncher) ReadPlayerID(ctx context.Context, sess *Session) (strin
 	if sessID == "" {
 		return "", errors.New("ReadPlayerID: no active appium session for device")
 	}
-	pid, err := a.readAccessibilityValue(ctx, sessID, "home-player-id")
+	// XCUITest carries the value under "value"; UiAutomator2 (Android)
+	// exposes the Compose node's text under "text".
+	attr := "value"
+	if sess.Device.Platform == PlatformAndroidTV {
+		attr = "text"
+	}
+	pid, err := a.readAccessibilityValue(ctx, sessID, "home-player-id", attr)
 	if err != nil {
 		return "", err
 	}
@@ -776,9 +787,13 @@ func appiumCapabilities(d Device, bundleID string) map[string]any {
 		caps["platformName"] = "Android"
 		caps["appium:automationName"] = "UiAutomator2"
 		caps["appium:appPackage"] = bundleID
-		// Android's session needs an activity too; LAUNCHER is the
-		// portable choice that matches our CLI launcher's `monkey -c LAUNCHER`.
-		caps["appium:appActivity"] = "android.intent.category.LAUNCHER"
+		// The real launcher activity (matches the deploy's
+		// `am start -n <pkg>/.MainActivity`). An intent CATEGORY is not a
+		// valid appActivity — UiAutomator2 fails to start the app with it.
+		caps["appium:appActivity"] = ".MainActivity"
+		// Don't block session creation on a specific post-launch activity
+		// (splash → home transitions vary); any activity in our package is fine.
+		caps["appium:appWaitActivity"] = "*"
 	}
 	return caps
 }


### PR DESCRIPTION
## What

Enables the characterization **Appium launcher to drive the Android app** (Google TV) through a real play. The play-start path was iOS-only; this makes rampup / pyramid / transient_shock runnable on Android via Appium.

### Harness (`runner/appium.go`)
- **`ResumePlayback`** handles `PlatformAndroidTV` — finds + clicks the `home-continue-watching` control (UiAutomator2 maps the "accessibility id" locator to content-desc).
- **`ReadPlayerID`** reads the `text` attribute on Android (UiAutomator2) vs `value` on iOS (XCUITest) — `readAccessibilityValue` now takes the attribute name.
- **`appActivity`** fixed to `.MainActivity` (an intent *category* isn't a valid activity — UiAutomator2 couldn't start the app) + `appWaitActivity="*"` so splash→home transitions don't block session creation.

### Android app
- **`HomeScreen`**: `home-continue-watching` content-desc on the Resume button (the tap target) + a hidden `home-player-id` node (content-desc = the id, text = the player_id). Mirrors the iOS HomeScreen AX nodes.
- **`ServerPickerScreen`**: `PrimaryButton` takes a `modifier` so the Resume button can carry the content-desc.

## Validation

On a **Google TV Streamer**: Appium discovers the device, starts the app (appActivity fix), reads the player_id via the new node, clicks Resume to start the play, and the harness shapes the resulting player end-to-end.

## Notes

- Reusable infra: any mode can now drive Android via Appium. The transient_shock Android-path robustness (conservativeStart routing, non-fatal pre-resume cap, transient-content retries) rides in #694 and *functions* once this lands — **merge this first.**
- Android generates a fresh `player_id` per launch (not persisted like iOS); a follow-up could persist it for stable dashboard identity + cold-start parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
