### PR TITLE
fix(dashboard): event auto-select no longer drops Live; archived rail clamps to end

### DIFF
--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -484,6 +484,13 @@ const timeRange = computed<{ min: number; max: number } | null>(() => {
   let min = ar?.min ?? 0;
   if (haveStart && (min === 0 || (playStart as number) < min)) min = playStart as number;
   let max = Math.max(ar?.max ?? 0, live);
+  // Archived view (explicit upper bound, not following live): clamp the
+  // rail's right edge to `to` — draw it from→to, not all the way to now.
+  // Without this, `live` (coord.lastSampleMs) can be a stale ~now value
+  // left in the per-player coord by a PRIOR live session on this same
+  // player_id, stretching an empty gap from `to` to now.
+  const upper = tsToMs.value;
+  if (!props.followLive && upper != null && upper > 0) max = upper;
   if (!min) min = max;
   if (!max) max = min;
   if (!min && !max) return null;

--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -215,23 +215,18 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
    *  prev/next navigator); use `setCursorMs` from callers that only
    *  know the timestamp. Issue #486. */
   function setCursor(ms: number | null, label: string | null) {
+    // Set the highlighted-event cursor only. Does NOT touch the live/pinned
+    // range: user event-navigation pins the window via recenterOnNav()
+    // (setRange) — that is what keeps a *user-selected* row on screen (#662).
+    // Previously (#663) setCursor itself dropped out of Live whenever ms was
+    // set while live; but the navigator AUTO-advances to each new event on a
+    // live view, so that fired on every incoming event and made the page
+    // unable to stay in Live (testing.html + in-progress session-viewer both
+    // snapped to a 10-min window around the oldest event). Auto-advance must
+    // not drop live; only explicit navigation (recenterOnNav) pins.
     const s = cur();
     s.cursorMs = ms;
     s.cursorLabel = ms == null ? null : label;
-    // #662: selecting an event means the operator is inspecting history, so
-    // drop out of Live — otherwise follow-latest keeps snapping the logs and
-    // charts back to the live tail and the highlighted row never stays on
-    // screen. Pin a window: keep the current one if it already contains the
-    // event (no jump), else center on the event so it's visible. The Live
-    // toggle resumes following. Only acts on a real selection (ms != null)
-    // while currently live; hover paths use setCursorMs and are unaffected.
-    if (ms != null && s.range === null) {
-      const end = s.lastSampleMs || Date.now();
-      const win = { min: end - s.liveSpan, max: end };
-      s.range = (ms >= win.min && ms <= win.max)
-        ? win
-        : { min: ms - s.liveSpan / 2, max: ms + s.liveSpan / 2 };
-    }
   }
 
   return {


### PR DESCRIPTION
## What

Two live-edge fixes in the shared `SessionDisplay` / `useChartCoordination` (testing.html + session-viewer.html).

### 1. `setCursor` no longer drops out of Live
`#663` made selecting an event drop Live (to keep a highlighted row on screen), but the event **navigator auto-advances to each new event** on a live view — so it fired on *every incoming event* and pinned a ~10-min window around the **oldest** event (≈ the `from` time). Result: testing.html and an in-progress session-viewer couldn't stay in Live — the focus bar kept snapping back to a 10-min window locked on `from`.

The drop was also **redundant**: explicit user event-navigation already pins via `recenterOnNav` (`setRange`), which is what actually keeps a user-selected row on screen (**#662 preserved**). Historic clipping is unaffected — finished plays pin to `[from,to]` from the URL params, never via `setCursor`.

### 2. Archived rail clamps its right edge to `to`
The brush-rail bounds extended `max` with `coord.lastSampleMs`. Since `coord` is per-player and module-level, that can be a **stale ~now value left by a prior live session on the same player_id** — stretching an empty gap from `to` all the way to now. When not following live and an explicit upper bound is set, draw `from→to`.

## Result
- testing.html **holds Live**.
- An **in-progress** play opened from the sessions list **follows the live edge** (10-min window ending at live, state = Live).
- **Finished** archives draw exactly their `[from,to]` window — no empty gap to now.

## Validation
Reproduced + verified on test-dev across testing.html (live), an in-progress play (play_id `5d3d572f`, follows live), and finished archives. Regression from #663.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
