### PR TITLE
feat(metrics): log player_tech_version (ExoPlayer/Media3 lib version)

### DIFF
--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -193,6 +193,7 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.session_events
     device_class            LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
     device_model            String                 DEFAULT ''            CODEC(ZSTD(1)),
     player_tech             LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
+    player_tech_version     LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
     -- Orientation-aware physical-pixel resolution, formatted "WxH" to
     -- match video_resolution / display_resolution. Supersedes
     -- screen_width_px / screen_height_px / screen_density (dropped
@@ -490,6 +491,7 @@ ALTER TABLE infinite_streaming.session_events
     ADD COLUMN IF NOT EXISTS device_class            LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS device_model            String                 DEFAULT ''            CODEC(ZSTD(1)),
     ADD COLUMN IF NOT EXISTS player_tech             LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS player_tech_version     LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),
     -- device_resolution supersedes screen_width_px / screen_height_px /
     -- screen_density (2026-05-30 cleanup).
     ADD COLUMN IF NOT EXISTS device_resolution       LowCardinality(String) DEFAULT ''            CODEC(ZSTD(1)),

--- a/analytics/go-forwarder/internal/plays/find.go
+++ b/analytics/go-forwarder/internal/plays/find.go
@@ -154,7 +154,7 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    error_count, error_code, error_domain,
 		    terminal_error_code, terminal_error_domain,
 		    playback_status, playback_reason,
-		    device_class, device_model, player_tech,
+		    device_class, device_model, player_tech, player_tech_version,
 		    app_version, os_version_major, os_version_minor,
 		    -- #634: tie-break key for the outcome argMaxes below. A
 		    -- play-terminal row that shares its ts with the final
@@ -301,6 +301,7 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		    argMax(device_class, ts) AS device_class,
 		    argMax(device_model, ts) AS device_model,
 		    argMax(player_tech, ts)  AS player_tech,
+		    argMax(player_tech_version, ts) AS player_tech_version,
 		    argMax(app_version, ts)  AS app_version,
 		    argMax(os_version_major, ts) AS os_version_major,
 		    argMax(os_version_minor, ts) AS os_version_minor
@@ -329,7 +330,7 @@ func runPlaysQuery(ctx context.Context, b Backend, clauses []string, params map[
 		  agg.playback_status, agg.playback_reason,
 		  agg.terminal_error_code, agg.terminal_error_domain,
 		  agg.last_error_code, agg.last_error_domain, agg.error_count,
-		  agg.device_class, agg.device_model, agg.player_tech,
+		  agg.device_class, agg.device_model, agg.player_tech, agg.player_tech_version,
 		  agg.app_version, agg.os_version_major, agg.os_version_minor,
 		  agg.classification,
 		  -- #679: scenario sources — master manifest URL (variant derived in

--- a/analytics/go-forwarder/internal/plays/scenario.go
+++ b/analytics/go-forwarder/internal/plays/scenario.go
@@ -28,6 +28,7 @@ func enrichScenario(rows []map[string]any) {
 		putIfStr(sc, "device_class", row["device_class"])
 		putIfStr(sc, "device_model", row["device_model"])
 		putIfStr(sc, "player_tech", row["player_tech"])
+		putIfStr(sc, "player_tech_version", row["player_tech_version"])
 		putIfStr(sc, "app_version", row["app_version"])
 		putIfStr(sc, "content_id", row["content_id"])
 		if os := joinOSVersion(row["os_version_major"], row["os_version_minor"]); os != "" {

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -307,6 +307,10 @@ type row struct {
 	DeviceClass              string  `json:"device_class"`
 	DeviceModel              string  `json:"device_model"`
 	PlayerTech               string  `json:"player_tech"`
+	// Playback engine version, paired with PlayerTech. Android: Media3/
+	// ExoPlayer library version (app-bundled, independent of the OS).
+	// iOS: OS version (AVPlayer is part of the OS).
+	PlayerTechVersion        string  `json:"player_tech_version"`
 	// Orientation-aware "WxH" — supersedes the three screen_* fields
 	// dropped on 2026-05-30.
 	DeviceResolution         string  `json:"device_resolution"`
@@ -843,6 +847,7 @@ func toRow(ts string, revision uint64, sessionID string, s map[string]interface{
 		DeviceClass:              getStr(s, "player_metrics_device_class"),
 		DeviceModel:              getStr(s, "player_metrics_device_model"),
 		PlayerTech:                getStr(s, "player_metrics_player_tech"),
+		PlayerTechVersion:         getStr(s, "player_metrics_player_tech_version"),
 		DeviceResolution:          getStr(s, "player_metrics_device_resolution"),
 		PositionS:                getF32(s, "player_metrics_position_s"),
 		LiveEdgeS:                getF32(s, "player_metrics_live_edge_s"),

--- a/analytics/go-forwarder/streambundles.go
+++ b/analytics/go-forwarder/streambundles.go
@@ -289,7 +289,7 @@ var bundleRegistry = map[string]bundleDef{
 			// fields. SessionDetails.vue renders them alongside
 			// identity tiles. Costs are minimal: LowCardinality
 			// columns compress repeats to near-nothing.
-			"device_class", "device_model", "player_tech",
+			"device_class", "device_model", "player_tech", "player_tech_version",
 			"app_version", "os_version_major", "os_version_minor",
 		},
 	},

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/DeviceInfo.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/DeviceInfo.java
@@ -5,6 +5,8 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.util.DisplayMetrics;
 
+import androidx.media3.common.MediaLibraryInfo;
+
 // #550 Phase 4 — device / platform / version taxonomy.
 //
 // Android counterpart to the Swift DeviceInfo in the Apple build.
@@ -68,6 +70,19 @@ public final class DeviceInfo {
      *  Media3-based build. */
     public static String playerTech() {
         return "ExoPlayer";
+    }
+
+    /** Playback engine VERSION — the Media3/ExoPlayer library version,
+     *  e.g. "1.2.1". Read at runtime from MediaLibraryInfo so it tracks
+     *  the bundled dependency automatically (no hardcoding, survives a
+     *  gradle bump). Crucially this is INDEPENDENT of the OS version:
+     *  ExoPlayer is an app-bundled library, so two devices on the same
+     *  Android release can run different player versions. (Contrast iOS,
+     *  where AVPlayer IS the OS and the OS version is its version.)
+     *  Pairs with player_tech for per-engine-version A/B + regression
+     *  attribution. */
+    public static String playerTechVersion() {
+        return MediaLibraryInfo.VERSION == null ? "" : MediaLibraryInfo.VERSION;
     }
 
     /** Orientation-aware physical pixels of the device screen, "WxH".

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -1018,6 +1018,7 @@ public final class PlaybackMetrics {
             p.put("player_metrics_device_class", DeviceInfo.deviceClass(ctx));
             p.put("player_metrics_device_model", DeviceInfo.deviceModel());
             p.put("player_metrics_player_tech", DeviceInfo.playerTech());
+            p.put("player_metrics_player_tech_version", DeviceInfo.playerTechVersion());
             // device_resolution supersedes the trio of screen_width_px /
             // screen_height_px / screen_density. Single tile, orientation-
             // aware. Mirrors iOS DeviceInfo.deviceResolution() — same

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -1068,6 +1068,7 @@ components:
         device_class: { type: string, description: "Device taxonomy class (phone|tablet|tv|…). From the typed column (#550 Phase 4)." }
         device_model: { type: string, description: "Device model identifier (e.g. 'iPhone15,2'). From the typed column." }
         player_tech:  { type: string, description: "Player technology (e.g. 'AVPlayer'). From the typed column." }
+        player_tech_version: { type: string, description: "Player engine version, paired with player_tech (Media3/ExoPlayer lib version on Android; OS version on iOS). From the typed column." }
         app_version:  { type: string, description: "Client app version. From the typed column." }
         os_version:   { type: string, description: "OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor." }
         content_id:   { type: string, description: "Content identifier — duplicated here so the object is self-contained for the viewer header." }

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1657,6 +1657,7 @@ components:
         device_class:           { type: string,  nullable: true, description: '#550 Phase 4: form-factor enum: `phone` / `tablet` / `tv` / `desktop` / `unknown`.' }
         device_model:           { type: string,  nullable: true, description: '#550 Phase 4: hardware model identifier (e.g. iPhone15,3) via sysctl hw.machine.' }
         player_tech:            { type: string,  nullable: true, description: '#550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`.' }
+        player_tech_version:    { type: string,  nullable: true, description: 'Playback engine version, paired with player_tech. Android: Media3/ExoPlayer library version (app-bundled, independent of the OS). iOS: OS version (AVPlayer is part of the OS).' }
         device_resolution:      { type: string,  nullable: true, description: 'Physical-pixel resolution of the device''s current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30).' }
 
     ServerMetrics:

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DeviceInfo.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/DeviceInfo.swift
@@ -74,6 +74,17 @@ enum DeviceInfo {
     /// it to "hls.js" / "shaka" / "native-roku" etc.
     static let playerTech: String = "AVPlayer"
 
+    /// Playback engine VERSION. On Apple platforms AVPlayer IS part of
+    /// the OS — unlike Android's app-bundled ExoPlayer (Media3), which
+    /// is versioned independently of the OS — so AVPlayer's version is
+    /// the OS version. Reported as "major.minor.patch" to pair with
+    /// player_tech for per-engine-version attribution; mirrors the
+    /// Android DeviceInfo.playerTechVersion() (the Media3 library version).
+    static let playerTechVersion: String = {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+    }()
+
     /// Physical-pixel resolution of the device's current orientation,
     /// formatted as `"WxH"` to match `video_resolution` /
     /// `display_resolution` for side-by-side comparison. On iPad this

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -2642,6 +2642,7 @@ extension PlayerViewModel {
             "player_metrics_device_class": DeviceInfo.deviceClass,
             "player_metrics_device_model": DeviceInfo.deviceModel,
             "player_metrics_player_tech": DeviceInfo.playerTech,
+            "player_metrics_player_tech_version": DeviceInfo.playerTechVersion,
             // Orientation-aware physical pixels — replaces the prior
             // screen_width_px / screen_height_px / screen_density
             // taxonomy fields (which were static portrait-only).

--- a/content/dashboard-v3/src/components/PlayerMetrics.vue
+++ b/content/dashboard-v3/src/components/PlayerMetrics.vue
@@ -86,6 +86,7 @@ type PMExt = NonNullable<typeof pm.value> & {
   device_class?: string | null;
   device_model?: string | null;
   player_tech?: string | null;
+  player_tech_version?: string | null;
   // Orientation-aware physical-pixel resolution (e.g. "2752x2064").
   // Replaces the prior screen_width_px / _height_px / _density tile.
   device_resolution?: string | null;

--- a/content/dashboard-v3/src/components/SessionDetails.vue
+++ b/content/dashboard-v3/src/components/SessionDetails.vue
@@ -109,6 +109,7 @@ const fields = computed(() => {
   const osMajor = typeof pm.os_version_major === 'number' ? pm.os_version_major : null;
   const osMinor = typeof pm.os_version_minor === 'number' ? pm.os_version_minor : null;
   const playerTech = typeof pm.player_tech === 'string' ? pm.player_tech : '';
+  const playerTechVersion = typeof pm.player_tech_version === 'string' ? pm.player_tech_version : '';
   const out: { label: string; value: string }[] = [
     { label: 'Player ID', value: p.id ?? '—' },
     { label: 'Display ID', value: String(p.display_id ?? '—') },
@@ -150,6 +151,7 @@ const fields = computed(() => {
     { label: 'Device Class', value: deviceClass || '—' },
     { label: 'Device Model', value: deviceModel || '—' },
     { label: 'Player Tech', value: playerTech || '—' },
+    { label: 'Player Version', value: playerTechVersion || '—' },
     { label: 'OS Version', value: (osMajor != null || osMinor != null) ? `${osMajor ?? 0}.${osMinor ?? 0}` : '—' },
     { label: 'App Version', value: appVersion || '—' },
   ];

--- a/content/dashboard-v3/src/composables/chRowAdapter.ts
+++ b/content/dashboard-v3/src/composables/chRowAdapter.ts
@@ -163,6 +163,7 @@ export function chRowToPlayerRecord(
     device_class: typeof row.device_class === 'string' ? row.device_class : '',
     device_model: typeof row.device_model === 'string' ? row.device_model : '',
     player_tech: typeof row.player_tech === 'string' ? row.player_tech : '',
+    player_tech_version: typeof row.player_tech_version === 'string' ? row.player_tech_version : '',
     // Orientation-aware "WxH"; supersedes screen_width_px / _height_px / _density.
     device_resolution: typeof row.device_resolution === 'string' ? row.device_resolution : '',
     // panel_v1 bundle additions — populated only when the request

--- a/content/dashboard-v3/src/repo/v2-repo.ts
+++ b/content/dashboard-v3/src/repo/v2-repo.ts
@@ -323,6 +323,7 @@ export interface Scenario {
   device_class?: string;
   device_model?: string;
   player_tech?: string;
+  player_tech_version?: string;
   app_version?: string;
   os_version?: string;
   content_id?: string;

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -2131,6 +2131,8 @@ export interface components {
             device_model?: string | null;
             /** @description #550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`. */
             player_tech?: string | null;
+            /** @description Playback engine version, paired with player_tech. Android: Media3/ExoPlayer library version (app-bundled, independent of the OS). iOS: OS version (AVPlayer is part of the OS). */
+            player_tech_version?: string | null;
             /** @description Physical-pixel resolution of the device's current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30). */
             device_resolution?: string | null;
         };

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -1333,6 +1333,9 @@ type PlayerMetrics struct {
 	// PlayerTech #550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`.
 	PlayerTech *string `json:"player_tech,omitempty"`
 
+	// PlayerTechVersion Playback engine version, paired with player_tech. Android: Media3/ExoPlayer library version (app-bundled, independent of the OS). iOS: OS version (AVPlayer is part of the OS).
+	PlayerTechVersion *string `json:"player_tech_version,omitempty"`
+
 	// PlayheadWallclockMs Player-encoded PDT (milliseconds since Unix epoch) for the current playhead. Used by the chart engine to compute live offset against the server clock.
 	PlayheadWallclockMs *int `json:"playhead_wallclock_ms,omitempty"`
 

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -249,6 +249,7 @@ func playerMetricsFromSession(s map[string]any) *oapigen.PlayerMetrics {
 		{"player_metrics_device_class", &pm.DeviceClass},
 		{"player_metrics_device_model", &pm.DeviceModel},
 		{"player_metrics_player_tech", &pm.PlayerTech},
+		{"player_metrics_player_tech_version", &pm.PlayerTechVersion},
 		// Per-variant dwell map — iOS emits as JSON-string for compactness.
 		// Dashboard parses on the client side via JSON.parse.
 		{"player_metrics_time_per_variant_s", &pm.TimePerVariantS},

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -1363,6 +1363,9 @@ type Scenario struct {
 	// PlayerTech Player technology (e.g. 'AVPlayer'). From the typed column.
 	PlayerTech *string `json:"player_tech,omitempty"`
 
+	// PlayerTechVersion Player engine version, paired with player_tech (Media3/ExoPlayer lib version on Android; OS version on iOS). From the typed column.
+	PlayerTechVersion *string `json:"player_tech_version,omitempty"`
+
 	// RunId Characterization run id, from testing=run_id_* (compact UTC, e.g. '20260524T070148Z'). Groups plays into a run. Harness runs only.
 	RunId *string `json:"run_id,omitempty"`
 

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -1334,6 +1334,9 @@ type PlayerMetrics struct {
 	// PlayerTech #550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`.
 	PlayerTech *string `json:"player_tech,omitempty"`
 
+	// PlayerTechVersion Playback engine version, paired with player_tech. Android: Media3/ExoPlayer library version (app-bundled, independent of the OS). iOS: OS version (AVPlayer is part of the OS).
+	PlayerTechVersion *string `json:"player_tech_version,omitempty"`
+
 	// PlayheadWallclockMs Player-encoded PDT (milliseconds since Unix epoch) for the current playhead. Used by the chart engine to compute live offset against the server clock.
 	PlayheadWallclockMs *int `json:"playhead_wallclock_ms,omitempty"`
 


### PR DESCRIPTION
## Why

The playback-engine version is **not derivable from the OS version** on Android: ExoPlayer/Media3 is an **app-bundled library**, versioned independently of the OS — two devices on the same Android release can run different player versions. (iOS is the opposite: AVPlayer *is* the OS, so its version is the OS version.) `player_tech` records the engine *name*; without a *version* we can't attribute ABR/regression behaviour to a specific player build.

## What — new `player_tech_version`, paired with `player_tech`, plumbed end-to-end

- **Android** — `DeviceInfo.playerTechVersion()` = `androidx.media3.common.MediaLibraryInfo.VERSION` (runtime, e.g. `"1.2.1"`; tracks the gradle dep automatically, survives a bump) → `PlaybackMetrics`.
- **iOS** — `DeviceInfo.playerTechVersion` = OS version `major.minor.patch` (AVPlayer is the OS) → `PlayerViewModel` payload.
- **Specs** — `proxy.yaml` + `forwarder.yaml`; mirrored into the 3 generated clients (go-proxy `oapigen`, harness-cli `proxy` + `forwarder`).
- **Forwarder** — `row` struct + json tag + `getStr` mapping (JSONEachRow insert); `find.go` play-summary query (base + argMax + final select); `streambundles` bundle columns; `scenario` builder.
- **ClickHouse** — `player_tech_version LowCardinality(String)` on `session_events` (CREATE + idempotent ALTER). Timeseries reads via `SELECT *` so it surfaces automatically.
- **Dashboard** — `chRowAdapter`, a **"Player Version"** row in SessionDetails, `PlayerMetrics` + `v2-repo` types, generated `v2.ts`.

## Deploy state (test-dev)
CH column migrated; forwarder rebuilt+redeployed; dashboard deployed; harness CLI rebuilt; **Android app rebuilt + installed on the Google TV Streamer** (emits `1.2.1`). iOS app build pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
