### PR TITLE
feat(703): iOS application wedge detector → auto-restart on -12880 hard wedge

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -197,6 +197,23 @@ final class PlaybackDiagnostics: ObservableObject {
 
     @Published var frozenDetected: Bool = false
     @Published var segmentStallDetected: Bool = false
+    /// #703 — application wedge detector. Flips true when a CoreMedia
+    /// -12880 "Can not proceed after removing variants" was seen AND
+    /// playback then failed to advance for `wedgeConfirmSeconds`. That's
+    /// the hard-wedge signature characterized on 2026-06-08: -12880 +
+    /// sustained no-progress. A player that's merely recovering keeps
+    /// advancing and disarms it (AVPlayer's own `didRecover` flag is
+    /// unreliable — both wedged and recovered sessions reported
+    /// didRecover=1). Drives autoRecovery's `wedge_auto_recovery` restart.
+    @Published var wedgeDetected: Bool = false
+    /// Continuous no-progress (seconds) required AFTER a -12880 before
+    /// declaring a hard wedge — long enough to be sure AVPlayer won't
+    /// self-recover. Settable so the characterization harness can shorten
+    /// the confirm. Default 120s (also < the proxy's 5-min idle reaper, so
+    /// the app acts before the session is collected).
+    var wedgeConfirmSeconds: Double = 120
+    /// When the most recent -12880 was observed; nil = wedge watch disarmed.
+    private var wedgeArmedAt: Date?
 
     private var timeObserverToken: Any?
     /// The exact `AVPlayer` instance that vended `timeObserverToken`.
@@ -745,6 +762,8 @@ final class PlaybackDiagnostics: ObservableObject {
         lastVariantSummaryAt = nil
         lastAccessLogEventCount = 0
         segmentStallDetected = false
+        wedgeDetected = false
+        wedgeArmedAt = nil
         lastVariantDwellTotal = priorVariantDwellSeconds.values.reduce(0, +)
         lastVariantDwellChangeAt = nil
         // Don't clear: priorVariantDwellSeconds, priorDroppedVideoFrames,
@@ -1164,6 +1183,11 @@ final class PlaybackDiagnostics: ObservableObject {
             if frozenDetected {
                 frozenDetected = false
             }
+            // #703 — any advance proves the player is alive: a post-12880
+            // session that's actually recovering keeps progressing, so
+            // disarm the wedge watch and clear a prior detection.
+            wedgeArmedAt = nil
+            if wedgeDetected { wedgeDetected = false }
             return
         }
         guard state != "Idle" && state != "Paused" else {
@@ -1193,6 +1217,13 @@ final class PlaybackDiagnostics: ObservableObject {
                 frozenLoggedAt = now
                 print("[FROZEN] still frozen at time=\(String(format: "%.2f", time)) for \(String(format: "%.0fs", stalledFor)) state=\(state) rate=\(player?.rate ?? 0)")
             }
+        }
+        // #703 — hard wedge: armed by a -12880 AND no progress for
+        // wedgeConfirmSeconds. Distinct from frozenDetected (3s) — this is
+        // the "won't recover without help" threshold the wedge detector acts on.
+        if wedgeArmedAt != nil && stalledFor >= wedgeConfirmSeconds && !wedgeDetected {
+            wedgeDetected = true
+            print("[WEDGE] -12880 + no progress for \(String(format: "%.0fs", stalledFor)) — hard wedge (state=\(state))")
         }
     }
 
@@ -1431,6 +1462,12 @@ final class PlaybackDiagnostics: ObservableObject {
         lastErrorLog = parts.joined(separator: " ")
         if !lastErrorLog.isEmpty {
             print("Error log: \(lastErrorLog) \(playbackSnapshot())")
+        }
+        // #703 — arm the wedge watch on CoreMedia -12880 "Can not proceed
+        // after removing variants". If playback then fails to advance for
+        // wedgeConfirmSeconds, checkFrozenState() flips wedgeDetected.
+        if event.errorStatusCode == -12880 {
+            wedgeArmedAt = Date()
         }
 
         let comment = event.errorComment ?? ""

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1817,6 +1817,27 @@ extension PlayerViewModel {
                 }
             }
             .store(in: &cancellables)
+
+        // #703 — application wedge detector. A CoreMedia -12880 followed by
+        // sustained no-progress (PlaybackDiagnostics.wedgeConfirmSeconds, def
+        // 120s) is a hard wedge that won't self-heal — distinct from the
+        // frozen/segment-stall watchdogs. When auto-recovery is on, restart
+        // playback tagged `wedge_auto_recovery` (same retry() path, so the
+        // wedge + recovery stay on one play_id); otherwise just capture it.
+        diagnostics.$wedgeDetected
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] wedged in
+                guard let self, wedged else { return }
+                let payload = self.buildMetricsPayload(event: "wedge_detected", at: Date())
+                Task { await self.sendPlayerMetrics(payload: payload) }
+                if self.autoRecovery {
+                    self.scheduleAutoRecoveryRestart(reason: "wedge_auto_recovery")
+                } else {
+                    Task { await self.requestHARSnapshot(reason: "wedge_detected") }
+                }
+            }
+            .store(in: &cancellables)
     }
 
     fileprivate func bindMetricsReporting() {


### PR DESCRIPTION
Implements the iOS detector for the hard wedge characterized today (#703, motivated by the physical-iPhone wedge on the #701 staircase). **703a: iOS detector + emit.**

## Signature (the conjunction — each signal alone is unreliable)
- CoreMedia **`-12880`** "Can not proceed after removing variants" **arms** the watch (`updateErrorLog`, `errorStatusCode == -12880`).
- **Confirmed** only after `wedgeConfirmSeconds` (default **120s**) of no playback advance (`checkFrozenState`). Any advance **disarms** it — a recovering player keeps progressing (we proved `didRecover=1` is a lie: the sim recovered from `-12880`, the wedged iPhone reported `didRecover=1` while dead).

## Recovery
- `PlayerViewModel` subscribes to `diagnostics.$wedgeDetected` (mirrors the `frozen`/`segment_stall` watchdogs): emits a `wedge_detected` event, and when **`autoRecovery`** is on, restarts via the existing `scheduleAutoRecoveryRestart(reason: "wedge_auto_recovery")` → `retry()` (same `play_id`, `attempt_id++`).
- **No new toggle** — rides the existing `autoRecovery` switch; **default off** so characterization still observes wedges. `wedgeConfirmSeconds` is settable so the harness can shorten the confirm.
- 120s is deliberately **< the proxy's 5-min idle reaper (#692)** so the app acts before the session is collected.

## Notes
- The `wedge_auto_recovery` restart event is emitted by the existing recovery path (no new plumbing — `player_metrics_restart_reason` already exists). I left the pre-existing auto-recovery double-emit (`user_retry` + reason) untouched to keep blast radius minimal — it affects all auto-recovery paths equally; worth a separate cleanup.
- **Needs an Xcode rebuild** to take effect on device (SourceKit single-file diagnostics are false-positives — no SDK/module context).

## Follow-ups (703b)
- Forwarder label/chip for `wedge_detected` + the `wedge_auto_recovery` restart_reason (dashboard visibility).
- Characterization assertion: with `autoRecovery` ON + a shortened confirm, verify the detector fires and playback resumes (re-run today's staircase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
