### PR TITLE
fix(703): drive freeze/wedge detection from wall-clock timer, not playback observer

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -397,6 +397,15 @@ final class PlaybackDiagnostics: ObservableObject {
         bitrateSampleTimer?.invalidate()
         bitrateSampleTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             self?.emitBitrateSample()
+            // #703 fix — freeze/wedge detection MUST run on this wall-clock
+            // timer, not the periodic time observer. AVPlayer's periodic
+            // observer fires off the playback clock and goes silent the
+            // instant the playhead freezes — i.e. exactly when a frozen/
+            // wedge state begins — so a detector hung off it can never see
+            // the freeze (observed live 2026-06-08: frozen_count=0 and no
+            // wedge_detected across a 5-min hard wedge). This timer ticks
+            // on wall-clock regardless of playback progress.
+            self?.checkFrozenState()
         }
     }
 
@@ -1063,7 +1072,10 @@ final class PlaybackDiagnostics: ObservableObject {
             self.currentTime = time.seconds
             self.updateBufferMetrics()
             self.updateItemState()
-            self.checkFrozenState()
+            // checkFrozenState() is driven by the wall-clock bitrateSampleTimer
+            // (see startBitrateSampleTimer) — NOT here. This observer stops
+            // firing when the playhead freezes, which would blind the freeze/
+            // wedge detector to the very state it exists to catch (#703).
             self.periodicVariantSummary()
             self.maybeLogOffsetHeartbeat()
         }
@@ -1190,7 +1202,13 @@ final class PlaybackDiagnostics: ObservableObject {
             if wedgeDetected { wedgeDetected = false }
             return
         }
-        guard state != "Idle" && state != "Paused" else {
+        // States are lowercase ("idle"/"paused"/"stalled"/"buffering"/
+        // "playing"). A genuine pause/idle is not a freeze — reset the
+        // stall clock so neither the frozen nor the wedge detector fires
+        // on it. A hard wedge presents as "stalled"/"buffering", which
+        // passes this guard. (Previously compared against capitalized
+        // "Idle"/"Paused", so it never matched — dead code, #703.)
+        guard state != "idle" && state != "paused" else {
             lastAdvancingAt = now
             return
         }


### PR DESCRIPTION
## Problem

The #703 application wedge detector (merged in #704) **never fires during an actual hard wedge** — and neither does the pre-existing frozen detector.

Characterized live on **2026-06-08 14:15 PDT (21:15 UTC)**: an iPhone `transient_shock` staircase run (`play_id f697069f-…`) hit a textbook hard wedge — `-12880` "removing variants" + `PlayerItemStallEvent`, playhead frozen at 559292 ms for ~5 minutes, no recovery when the cap lifted back to 60 Mbps. Result in the forwarder: **`frozen_count: 0`** and **no `wedge_detected`**.

## Root cause

`checkFrozenState()` was invoked **only** from `AVPlayer.addPeriodicTimeObserver`, whose callback fires off the **playback clock** — it goes silent the instant the playhead stops, i.e. exactly when a freeze begins. So:

- The `-12880` **arming** worked (it's on the KVO `AVPlayerItemNewErrorLogEntry` path, which keeps firing).
- The **no-progress confirm** timer was starved — `checkFrozenState()` stopped being called, so `stalledFor` never climbed to the 120s threshold and the wedge check was never evaluated.

A freeze detector hung off the playback clock can't detect a freeze: the freeze stops its own clock.

## Fix

- Move `checkFrozenState()` onto the existing **10 Hz wall-clock `bitrateSampleTimer`**, which ticks regardless of playback progress (it's the same kind of wall-clock cadence that kept the metrics heartbeat POSTing — `last_seen` advanced while frozen). Removed the call from the periodic observer (kept the `currentTime` cache update there).
- Fixed the dead `state != "Idle" && state != "Paused"` guard → lowercase `"idle"/"paused"` (the actual state strings). Necessary now that the check runs on wall-clock: a genuine pause must reset the stall clock so it doesn't accumulate toward a false wedge. A real hard wedge is `"stalled"/"buffering"`, which still passes the guard.

## Verification

- iOS build succeeds (`InfiniteStreamPlayer (iOS)`, no errors).
- **Live fire+recover validation** (re-run the staircase with auto-recovery ON + shortened `wedgeConfirmSeconds`, assert `wedge_detected` fires and recovery follows) is tracked in #705 — needs an Xcode rebuild onto the device first.

Refs #703, #704, #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
