### PR TITLE
feat(682): content_variant_order — reorder master variants to probe AVPlayer startup pick

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1531,6 +1531,11 @@ components:
           type: array
           items: { type: string }
           description: 'When non-empty, only the listed variant URIs are kept in the master playlist.'
+        variant_order:
+          type: string
+          enum: [default, ascending, descending, first_4mbps]
+          default: default
+          description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
           enum: [0, 6, 18, 24]

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -23,6 +23,16 @@ const variants = computed(() => {
 const LIVE_OFFSET_CHOICES = [0, 6, 18, 24] as const;
 type LiveOffset = (typeof LIVE_OFFSET_CHOICES)[number];
 
+const VARIANT_ORDER_CHOICES = [
+  { value: 'default', label: 'Default' },
+  { value: 'ascending', label: 'Ascending' },
+  { value: 'descending', label: 'Descending' },
+  { value: 'first_4mbps', label: '4 Mbps first' },
+] as const;
+type VariantOrder = (typeof VARIANT_ORDER_CHOICES)[number]['value'];
+
+const variantOrder = computed<VariantOrder>(() => content.value?.variant_order ?? 'default');
+
 function onBoolChange(field: 'strip_codecs' | 'strip_average_bandwidth' | 'strip_resolution' | 'overstate_bandwidth', e: Event) {
   const v = (e.target as HTMLInputElement).checked;
   setContent({ [field]: v } as Partial<Content>);
@@ -30,6 +40,10 @@ function onBoolChange(field: 'strip_codecs' | 'strip_average_bandwidth' | 'strip
 
 function onLiveOffsetChange(value: LiveOffset) {
   setContent({ live_offset: value } as Partial<Content>);
+}
+
+function onVariantOrderChange(value: VariantOrder) {
+  setContent({ variant_order: value } as Partial<Content>);
 }
 
 /** Empty allowed_variants list means "all allowed" — `allChecked = true`
@@ -155,6 +169,31 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
       Pairs well with `delay_ms` to surface live-offset-driven stalls.
     </p>
 
+    <div class="order-row" data-testid="content-variant-order">
+      <span class="label">Variant order</span>
+      <div class="segmented" role="radiogroup" aria-label="Master playlist variant order">
+        <button
+          v-for="opt in VARIANT_ORDER_CHOICES"
+          :key="opt.value"
+          type="button"
+          role="radio"
+          class="seg"
+          :class="{ active: variantOrder === opt.value }"
+          :aria-checked="variantOrder === opt.value"
+          :data-testid="`content-variant-order-${opt.value}`"
+          @click="onVariantOrderChange(opt.value)"
+        >
+          {{ opt.label }}
+        </button>
+      </div>
+    </div>
+    <p class="note">
+      Re-sorts the master playlist's video variants by BANDWIDTH to probe how
+      AVPlayer picks its initial variant (#682). <strong>4 Mbps first</strong>
+      promotes the variant nearest 4 Mbps to first-listed. Audio/subtitle
+      renditions are untouched. Takes effect on the next master fetch.
+    </p>
+
     <div class="variants">
       <span class="label">Allowed variants <span class="muted">(All checked = allow every variant)</span></span>
       <div v-if="!variants.length" class="muted">Play content once to populate variant list.</div>
@@ -225,13 +264,37 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
   line-height: 1.4;
 }
 
-.offset-row {
+.offset-row,
+.order-row {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
   align-items: center;
   font-size: 13px;
   color: #374151;
+}
+
+.segmented {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.seg {
+  border: none;
+  border-left: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  font-size: 13px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.seg:first-child {
+  border-left: none;
+}
+.seg.active {
+  background: #2563eb;
+  color: #fff;
 }
 
 .label {

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1900,6 +1900,12 @@ export interface components {
             /** @description When non-empty, only the listed variant URIs are kept in the master playlist. */
             allowed_variants?: string[];
             /**
+             * @description Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.
+             * @default default
+             * @enum {string}
+             */
+            variant_order?: "default" | "ascending" | "descending" | "first_4mbps";
+            /**
              * @description Live edge offset window in seconds. 0 = no offset.
              * @default 0
              * @enum {integer}

--- a/go-proxy/cmd/server/content_variant_order_test.go
+++ b/go-proxy/cmd/server/content_variant_order_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// A small HLS master playlist authored ascending (lowest BANDWIDTH first),
+// mirroring our own ladder. URIs double as variant identifiers.
+const sampleMaster = `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-STREAM-INF:BANDWIDTH=800000,RESOLUTION=426x240
+v240.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2000000,RESOLUTION=854x480
+v480.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=4200000,RESOLUTION=1280x720
+v720.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=8000000,RESOLUTION=1920x1080
+v1080.m3u8
+`
+
+// streamInfURIOrder returns the variant URIs in the order they appear in the
+// (re-encoded) master playlist — i.e. the order AVPlayer reads them.
+func streamInfURIOrder(t *testing.T, body []byte) []string {
+	t.Helper()
+	var uris []string
+	expectURI := false
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#EXT-X-STREAM-INF:") {
+			expectURI = true
+			continue
+		}
+		if expectURI && line != "" && !strings.HasPrefix(line, "#") {
+			uris = append(uris, line)
+			expectURI = false
+		}
+	}
+	return uris
+}
+
+func TestManipulateHLSMaster_VariantOrder(t *testing.T) {
+	cases := []struct {
+		order string
+		want  []string
+	}{
+		// default / unset → passthrough, authored ascending order preserved.
+		{"", []string{"v240.m3u8", "v480.m3u8", "v720.m3u8", "v1080.m3u8"}},
+		{"default", []string{"v240.m3u8", "v480.m3u8", "v720.m3u8", "v1080.m3u8"}},
+		{"ascending", []string{"v240.m3u8", "v480.m3u8", "v720.m3u8", "v1080.m3u8"}},
+		{"descending", []string{"v1080.m3u8", "v720.m3u8", "v480.m3u8", "v240.m3u8"}},
+		// nearest 4 Mbps is the 4.2 Mbps 720p variant → first; rest ascending.
+		{"first_4mbps", []string{"v720.m3u8", "v240.m3u8", "v480.m3u8", "v1080.m3u8"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.order, func(t *testing.T) {
+			out, err := manipulateHLSMaster([]byte(sampleMaster), false, false, false, false, 0, nil, tc.order)
+			if err != nil {
+				t.Fatalf("manipulateHLSMaster(%q): %v", tc.order, err)
+			}
+			got := streamInfURIOrder(t, out)
+			if len(got) != len(tc.want) {
+				t.Fatalf("order %q: got %v variants, want %v", tc.order, got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("order %q: variant order = %v, want %v", tc.order, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6190,6 +6190,9 @@ func shouldApplyContentManipulation(session SessionData) bool {
 	if len(allowedVariants) > 0 {
 		return true
 	}
+	if vo := getString(session, "content_variant_order"); vo != "" && vo != "default" {
+		return true
+	}
 	return false
 }
 
@@ -6201,10 +6204,11 @@ func (a *App) applyContentManipulation(body []byte, session SessionData, content
 	overstateBandwidth := getBool(session, "content_overstate_bandwidth")
 	liveOffset := getInt(session, "content_live_offset")
 	allowedVariants := getStringSlice(session, "content_allowed_variants")
+	variantOrder := getString(session, "content_variant_order")
 
 	// Handle HLS master playlists
 	if strings.Contains(strings.ToLower(contentType), "mpegurl") || strings.Contains(strings.ToLower(contentType), "m3u8") {
-		result, err := manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, stripResolution, overstateBandwidth, liveOffset, allowedVariants)
+		result, err := manipulateHLSMaster(body, stripCodecs, stripAvgBandwidth, stripResolution, overstateBandwidth, liveOffset, allowedVariants, variantOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -6228,7 +6232,7 @@ func (a *App) applyContentManipulation(body []byte, session SessionData, content
 }
 
 // manipulateHLSMaster modifies an HLS master playlist
-func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, stripResolution bool, overstateBandwidth bool, liveOffset int, allowedVariants []string) ([]byte, error) {
+func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, stripResolution bool, overstateBandwidth bool, liveOffset int, allowedVariants []string, variantOrder string) ([]byte, error) {
 	playlist, listType, err := m3u8.DecodeFrom(bufio.NewReader(bytes.NewReader(body)), true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode HLS playlist: %w", err)
@@ -6319,6 +6323,27 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 		}
 	}
 
+	// Reorder video variants by BANDWIDTH (issue #682). Probes whether
+	// the master-playlist order biases AVPlayer's initial-variant pick —
+	// the pre-iOS-13 / startsOnFirstEligibleVariant path keys off
+	// first-listed. Re-sorts master.Variants in place; the m3u8 encoder
+	// emits EXT-X-STREAM-INF lines in slice order. EXT-X-MEDIA audio/
+	// subtitle renditions travel on each variant's Alternatives and stay
+	// glued to their owning variant, so they are unaffected.
+	switch variantOrder {
+	case "ascending":
+		sortVariantsByBandwidth(master.Variants, true)
+		modified = true
+	case "descending":
+		sortVariantsByBandwidth(master.Variants, false)
+		modified = true
+	case "first_4mbps":
+		// Promote the variant nearest 4 Mbps to first-listed (rest ascending)
+		// to force a mid-tier initial pick on the first-eligible-variant path.
+		promoteVariantNearestBandwidth(master.Variants, 4_000_000)
+		modified = true
+	}
+
 	// Inject #EXT-X-START with negative offset for live edge positioning
 	if liveOffset > 0 {
 		modified = true
@@ -6369,6 +6394,57 @@ func manipulateHLSMaster(body []byte, stripCodecs bool, stripAvgBandwidth bool, 
 	}
 
 	return buf.Bytes(), nil
+}
+
+// variantBandwidth returns a variant's BANDWIDTH (peak) as the sort key,
+// 0 for a nil variant.
+func variantBandwidth(v *m3u8.Variant) uint32 {
+	if v == nil {
+		return 0
+	}
+	return v.Bandwidth
+}
+
+// sortVariantsByBandwidth re-sorts the variants in place by BANDWIDTH,
+// ascending (lowest first) or descending. Stable so equal-bandwidth
+// variants keep their authored relative order.
+func sortVariantsByBandwidth(vs []*m3u8.Variant, ascending bool) {
+	sort.SliceStable(vs, func(i, j int) bool {
+		if ascending {
+			return variantBandwidth(vs[i]) < variantBandwidth(vs[j])
+		}
+		return variantBandwidth(vs[i]) > variantBandwidth(vs[j])
+	})
+}
+
+// promoteVariantNearestBandwidth orders the variants ascending, then moves
+// the one whose BANDWIDTH is closest to target to the front — leaving a
+// master playlist whose first-listed variant is the ~target-bitrate rendition.
+// Used by the "first_4mbps" probe (#682).
+func promoteVariantNearestBandwidth(vs []*m3u8.Variant, target uint32) {
+	if len(vs) < 2 {
+		return
+	}
+	sortVariantsByBandwidth(vs, true)
+	best, bestDelta := 0, absDiffUint32(variantBandwidth(vs[0]), target)
+	for i := 1; i < len(vs); i++ {
+		if d := absDiffUint32(variantBandwidth(vs[i]), target); d < bestDelta {
+			best, bestDelta = i, d
+		}
+	}
+	if best == 0 {
+		return
+	}
+	chosen := vs[best]
+	copy(vs[1:best+1], vs[0:best])
+	vs[0] = chosen
+}
+
+func absDiffUint32(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
 }
 
 // rewriteVariantLiveOffsetTags updates HOLD-BACK inside EXT-X-SERVER-CONTROL

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -493,6 +493,7 @@ func applyContentPatch(s map[string]any, c any) {
 		s["content_overstate_bandwidth"] = false
 		s["content_live_offset"] = 0
 		s["content_allowed_variants"] = []any{}
+		s["content_variant_order"] = "default"
 		return
 	}
 	m, ok := c.(map[string]any)
@@ -519,6 +520,13 @@ func applyContentPatch(s map[string]any, c any) {
 			s["content_allowed_variants"] = []any{}
 		} else if arr, ok := v.([]any); ok {
 			s["content_allowed_variants"] = arr
+		}
+	}
+	if v, present := m["variant_order"]; present {
+		if v == nil {
+			s["content_variant_order"] = "default"
+		} else if str, ok := v.(string); ok {
+			s["content_variant_order"] = str
 		}
 	}
 }

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -646,10 +646,39 @@ type ContentManipulation struct {
 
 	// StripResolution Remove RESOLUTION attribute from EXT-X-STREAM-INF lines. Apple HLS validator rejects this; AVPlayer plays but variant.video.size becomes empty (issue #486).
 	StripResolution *bool `json:"strip_resolution,omitempty"`
+
+	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
 // ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
 type ContentManipulationLiveOffset int
+
+// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+type ContentManipulationVariantOrder string
+
+// Defines values for ContentManipulationVariantOrder.
+const (
+	ContentManipulationVariantOrderAscending  ContentManipulationVariantOrder = "ascending"
+	ContentManipulationVariantOrderDefault    ContentManipulationVariantOrder = "default"
+	ContentManipulationVariantOrderDescending ContentManipulationVariantOrder = "descending"
+	ContentManipulationVariantOrderFirst4mbps ContentManipulationVariantOrder = "first_4mbps"
+)
+
+// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
+func (e ContentManipulationVariantOrder) Valid() bool {
+	switch e {
+	case ContentManipulationVariantOrderAscending:
+		return true
+	case ContentManipulationVariantOrderDefault:
+		return true
+	case ContentManipulationVariantOrderDescending:
+		return true
+	case ContentManipulationVariantOrderFirst4mbps:
+		return true
+	}
+	return false
+}
 
 // FaultCounters Read-only. Server-maintained; never appears in PATCH bodies.
 type FaultCounters map[string]int

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -191,7 +191,9 @@ func contentManipulationFromSession(s map[string]any) *oapigen.ContentManipulati
 	} else if raw, ok := s["content_allowed_variants"].([]string); ok {
 		allowed = append([]string{}, raw...)
 	}
-	if !stripCodecs && !stripAvgBw && !stripResolution && !overstate && offset == 0 && len(allowed) == 0 {
+	variantOrder, _ := s["content_variant_order"].(string)
+	hasVariantOrder := variantOrder != "" && variantOrder != "default"
+	if !stripCodecs && !stripAvgBw && !stripResolution && !overstate && offset == 0 && len(allowed) == 0 && !hasVariantOrder {
 		return nil
 	}
 	off := oapigen.ContentManipulationLiveOffset(offset)
@@ -204,6 +206,10 @@ func contentManipulationFromSession(s map[string]any) *oapigen.ContentManipulati
 	}
 	if allowed != nil {
 		out.AllowedVariants = &allowed
+	}
+	if hasVariantOrder {
+		vo := oapigen.ContentManipulationVariantOrder(variantOrder)
+		out.VariantOrder = &vo
 	}
 	return &out
 }

--- a/tools/harness-cli/cmd/harness/content.go
+++ b/tools/harness-cli/cmd/harness/content.go
@@ -24,6 +24,8 @@ Flags:
   --overstate-bandwidth        inflate BANDWIDTH by 10%
   --live-offset SEC            live-edge offset window
   --allowed-variants url[,url] whitelist variant URIs (others stripped)
+  --variant-order ORDER        reorder master variants by BANDWIDTH:
+                               default | ascending | descending | first_4mbps (#682)
   --show                       print current and exit
   --clear                      send {"content": null}
 `
@@ -38,6 +40,7 @@ func cmdContent(client *api.Client, args []string, asJSON bool) error {
 	overstateBw := fs.Bool("overstate-bandwidth", false, "")
 	liveOffset := fs.Int("live-offset", -1, "")
 	allowedCSV := fs.String("allowed-variants", "", "")
+	variantOrder := fs.String("variant-order", "", "")
 	show := fs.Bool("show", false, "")
 	clear := fs.Bool("clear", false, "")
 	if err := fs.Parse(args[1:]); err != nil {
@@ -89,6 +92,14 @@ func cmdContent(client *api.Client, args []string, asJSON bool) error {
 	if *allowedCSV != "" {
 		variants := strings.Split(*allowedCSV, ",")
 		cm.AllowedVariants = &variants
+		touched = true
+	}
+	if *variantOrder != "" {
+		vo := proxy.ContentManipulationVariantOrder(*variantOrder)
+		if !vo.Valid() {
+			return fmt.Errorf("invalid --variant-order %q (want default|ascending|descending|first_4mbps)", *variantOrder)
+		}
+		cm.VariantOrder = &vo
 		touched = true
 	}
 	if !touched {

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -647,10 +647,39 @@ type ContentManipulation struct {
 
 	// StripResolution Remove RESOLUTION attribute from EXT-X-STREAM-INF lines. Apple HLS validator rejects this; AVPlayer plays but variant.video.size becomes empty (issue #486).
 	StripResolution *bool `json:"strip_resolution,omitempty"`
+
+	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
 // ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
 type ContentManipulationLiveOffset int
+
+// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+type ContentManipulationVariantOrder string
+
+// Defines values for ContentManipulationVariantOrder.
+const (
+	ContentManipulationVariantOrderAscending  ContentManipulationVariantOrder = "ascending"
+	ContentManipulationVariantOrderDefault    ContentManipulationVariantOrder = "default"
+	ContentManipulationVariantOrderDescending ContentManipulationVariantOrder = "descending"
+	ContentManipulationVariantOrderFirst4mbps ContentManipulationVariantOrder = "first_4mbps"
+)
+
+// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
+func (e ContentManipulationVariantOrder) Valid() bool {
+	switch e {
+	case ContentManipulationVariantOrderAscending:
+		return true
+	case ContentManipulationVariantOrderDefault:
+		return true
+	case ContentManipulationVariantOrderDescending:
+		return true
+	case ContentManipulationVariantOrderFirst4mbps:
+		return true
+	}
+	return false
+}
 
 // FaultCounters Read-only. Server-maintained; never appears in PATCH bodies.
 type FaultCounters map[string]int


### PR DESCRIPTION
Closes #682.

## Why
iOS 13+ AVPlayer's startup variant is heuristic, but the **order** of `EXT-X-STREAM-INF` entries still feeds the `startsOnFirstEligibleVariant` / pre-iOS-13 path and may bias the modern heuristic. This adds a Content control to **experimentally** reorder the master playlist and watch whether Apple's first pick tracks list order.

## What
A new `content_variant_order` master-playlist mutation, riding the existing content-manipulation layer (`strip_codecs` / `overstate_bandwidth` / `allowed_variants`). Re-sorts the video `EXT-X-STREAM-INF` entries by `BANDWIDTH`:

| Mode | Effect |
|---|---|
| `default` | passthrough |
| `ascending` | lowest BANDWIDTH first (our authoring) |
| `descending` | highest first |
| `first_4mbps` | promote the variant **nearest 4 Mbps** to first-listed, rest ascending — a mid-tier initial-variant probe |

`EXT-X-MEDIA` audio/subtitle renditions are left untouched. `content: null` reset clears it.

## Layers
- **go-proxy**: reorder in `manipulateHLSMaster` (`sortVariantsByBandwidth` / `promoteVariantNearestBandwidth`); gate in `shouldApplyContentManipulation`.
- **v2 patch**: `applyContentPatch` (+ reset) and reverse `translate.go`; OpenAPI `variant_order` enum + generated structs (`v2oapigen`, harness-cli `v2gen`) with `Valid()`.
- **dashboard**: `ContentManipulation.vue` segmented control with `data-testid` selectors for Appium; `v2.ts` type.
- **harness CLI**: `harness content --variant-order default|ascending|descending|first_4mbps`.
- **test**: `content_variant_order_test.go` asserts all four orderings (passing).

## Verification
```
harness content <player> --variant-order descending   # cold-start iOS, note startup variant
harness content <player> --variant-order ascending    # repeat, compare
harness content <player> --variant-order first_4mbps   # force ~4 Mbps initial pick
```

## Notes
- The published `content/dashboard/api-docs/proxy-v2.yaml` copy is broadly stale (missing many already-merged fields); deliberately **not** re-synced here to avoid sweeping unrelated changes in. `make sync-api-docs` is a separate wholesale task.
- Pairs with #683 (iOS `preferredPeakBitRate` / `startsOnFirstEligibleVariant`) for the order × forced-first-variant startup experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
