### PR TITLE
feat(683): iOS Advanced settings — peak-bitrate cap + start-on-first-variant

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -44,6 +44,19 @@ final class PlayerViewModel: ObservableObject {
     @Published var developerMode: Bool = false
     /// Allow renditions above 1080p. Off → cap at 1080p.
     @Published var allow4K: Bool = true
+    /// Cap AVPlayer's selectable peak bitrate, in Mbps. 0 = no cap
+    /// (Apple's default). Maps to `AVPlayerItem.preferredPeakBitRate`,
+    /// which removes higher variants from ABR selection *including the
+    /// startup pick* — Apple's recommended lever for a deterministic
+    /// initial variant. Pairs with the Content variant-reorder probe
+    /// (#682) for the order × ceiling startup experiment (#683).
+    @Published var preferredPeakBitRateMbps: Int = 0
+    /// Force AVPlayer's startup variant to be the first-listed master
+    /// entry (`AVPlayerItem.startsOnFirstEligibleVariant`, iOS/tvOS 14+)
+    /// instead of its opaque throughput heuristic. Off → native heuristic.
+    /// Makes the startup pick deterministic, the primary lever for the
+    /// order × forced-first-variant experiment (#683, pairs with #682).
+    @Published var startsOnFirstEligibleVariant: Bool = false
     /// Stream URL goes through the per-session go-proxy port. Off → API port.
     @Published var localProxy: Bool = true
     /// Auto-retry the current stream on non-codec player errors.
@@ -448,6 +461,24 @@ final class PlayerViewModel: ObservableObject {
 
     func setDeveloperMode(_ on: Bool) { developerMode = on; persistFlags() }
     func setAllow4K(_ on: Bool) { allow4K = on; persistFlags() }
+    func setPreferredPeakBitRateMbps(_ mbps: Int) {
+        preferredPeakBitRateMbps = max(0, mbps)
+        persistFlags()
+        // preferredPeakBitRate is mutable mid-play — apply to the current
+        // item immediately so a characterization run can change the ceiling
+        // without a reload; AVPlayer re-evaluates ABR against it on the next
+        // segment. New items pick it up via apply4kPreference.
+        if let item = player.currentItem {
+            item.preferredPeakBitRate = preferredPeakBitRateBps
+        }
+    }
+    func setStartsOnFirstEligibleVariant(_ on: Bool) {
+        startsOnFirstEligibleVariant = on
+        persistFlags()
+        // Only affects the *initial* variant selection, so it's applied
+        // when the next AVPlayerItem is built (apply4kPreference) — setting
+        // it on an already-playing item has no retroactive effect.
+    }
     func setLocalProxy(_ on: Bool) {
         localProxy = on
         persistFlags()
@@ -1117,8 +1148,22 @@ final class PlayerViewModel: ObservableObject {
     /// is gone — sim now honours `allow4K`. If a particular host can't
     /// decode, AVPlayer surfaces `decodeFailedNotification` and the
     /// existing recovery pipeline kicks in (same path real devices use).
+    /// `preferredPeakBitRateMbps` expressed in bits/sec for
+    /// `AVPlayerItem.preferredPeakBitRate` (0 stays 0 = "no cap").
+    private var preferredPeakBitRateBps: Double {
+        preferredPeakBitRateMbps <= 0 ? 0 : Double(preferredPeakBitRateMbps) * 1_000_000
+    }
+
     private func apply4kPreference(to item: AVPlayerItem) {
-        item.preferredPeakBitRate = 0
+        // 0 = no cap (Apple default); otherwise the user-chosen Mbps ceiling
+        // from Advanced settings (#683). Applied to every fresh item.
+        item.preferredPeakBitRate = preferredPeakBitRateBps
+        // Deterministic startup variant (#683) — forces the first-listed
+        // master entry instead of AVPlayer's throughput heuristic. iOS/tvOS
+        // 14+; on older OSes the toggle is simply inert.
+        if #available(iOS 14.0, tvOS 14.0, *) {
+            item.startsOnFirstEligibleVariant = startsOnFirstEligibleVariant
+        }
         guard #available(iOS 15.0, tvOS 15.0, *) else { return }
         if allow4K {
             item.preferredMaximumResolution = CGSize(width: 3840, height: 2160)
@@ -1599,6 +1644,8 @@ final class PlayerViewModel: ObservableObject {
     private static let flagLiveOffset = "is.flag.live_offset_s"
     private static let flagPlayIdRotation = "is.flag.play_id_rotation_s"
     private static let flagPreviewVideoSlots = "is.flag.preview_video_slots"
+    private static let flagPeakBitrate = "is.flag.peak_bitrate_mbps"
+    private static let flagStartsFirstVariant = "is.flag.starts_first_variant"
     private static let lastPlayedKey = "is.lastPlayed"
     private static let viewCountsKey = "is.viewCounts"
     private static let codecKey = "is.codec"
@@ -1642,6 +1689,8 @@ final class PlayerViewModel: ObservableObject {
         isMuted = d.bool(forKey: Self.flagMuted)
         liveOffsetSeconds = d.object(forKey: Self.flagLiveOffset) as? Double ?? 0
         playIdRotationSeconds = max(0, d.object(forKey: Self.flagPlayIdRotation) as? Int ?? 0)
+        preferredPeakBitRateMbps = max(0, d.object(forKey: Self.flagPeakBitrate) as? Int ?? 0)
+        startsOnFirstEligibleVariant = d.bool(forKey: Self.flagStartsFirstVariant)
         // First launch: no key yet → use the device's hardware cap so
         // the user starts with the richest preview their hardware can
         // run. After that, persist whatever they've chosen.
@@ -1677,6 +1726,8 @@ final class PlayerViewModel: ObservableObject {
         d.set(liveOffsetSeconds, forKey: Self.flagLiveOffset)
         d.set(playIdRotationSeconds, forKey: Self.flagPlayIdRotation)
         d.set(previewVideoSlots, forKey: Self.flagPreviewVideoSlots)
+        d.set(preferredPeakBitRateMbps, forKey: Self.flagPeakBitrate)
+        d.set(startsOnFirstEligibleVariant, forKey: Self.flagStartsFirstVariant)
         d.set(codec.rawValue, forKey: Self.codecKey)
         d.set(segment.rawValue, forKey: Self.segmentKey)
         d.set(streamProtocol.rawValue, forKey: Self.protocolKey)

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
@@ -339,42 +339,49 @@ private struct PickerList: View {
             ToggleRow(label: "4K (allow >1080p)",
                       isOn: vm.allow4K, compact: compact, axID: "toggle-4k") { vm.setAllow4K($0) }
                 .focused($itemIdx, equals: 0)
+            PreferredPeakBitRateRow(mbps: vm.preferredPeakBitRateMbps, compact: compact) {
+                vm.setPreferredPeakBitRateMbps($0)
+            }
+            .focused($itemIdx, equals: 1)
+            ToggleRow(label: "Start on first variant",
+                      isOn: vm.startsOnFirstEligibleVariant, compact: compact, axID: "toggle-starts-first-variant") { vm.setStartsOnFirstEligibleVariant($0) }
+                .focused($itemIdx, equals: 2)
             ToggleRow(label: "Local Proxy",
                       isOn: vm.localProxy, compact: compact, axID: "toggle-local-proxy") { vm.setLocalProxy($0) }
-                .focused($itemIdx, equals: 1)
+                .focused($itemIdx, equals: 3)
             ToggleRow(label: "Auto-Recovery",
                       isOn: vm.autoRecovery, compact: compact, axID: "toggle-auto-recovery") { vm.setAutoRecovery($0) }
-                .focused($itemIdx, equals: 2)
+                .focused($itemIdx, equals: 4)
             ToggleRow(label: "Go Live",
                       isOn: vm.goLive, compact: compact, axID: "toggle-go-live") { vm.setGoLive($0) }
-                .focused($itemIdx, equals: 3)
+                .focused($itemIdx, equals: 5)
             LiveOffsetRow(seconds: vm.liveOffsetSeconds, compact: compact) {
                 vm.setLiveOffsetSeconds($0)
             }
-            .focused($itemIdx, equals: 4)
+            .focused($itemIdx, equals: 6)
             PlayIdRotationRow(seconds: vm.playIdRotationSeconds, compact: compact) {
                 vm.setPlayIdRotationSeconds($0)
             }
-            .focused($itemIdx, equals: 5)
+            .focused($itemIdx, equals: 7)
             ToggleRow(label: "Skip Home on launch",
                       isOn: vm.skipHomeOnLaunch, compact: compact, axID: "toggle-skip-home") { vm.setSkipHomeOnLaunch($0) }
-                .focused($itemIdx, equals: 6)
+                .focused($itemIdx, equals: 8)
             ToggleRow(label: "Mute audio",
                       isOn: vm.isMuted, compact: compact, axID: "toggle-mute") { vm.setIsMuted($0) }
-                .focused($itemIdx, equals: 7)
+                .focused($itemIdx, equals: 9)
             PreviewVideoSlotsRow(slots: vm.previewVideoSlots,
                                  hardwareCap: DecodeBudget.shared.hardwareCap,
                                  compact: compact) {
                 vm.setPreviewVideoSlots($0)
             }
-            .focused($itemIdx, equals: 8)
+            .focused($itemIdx, equals: 10)
             ToggleRow(label: "HUD",
                       isOn: vm.developerMode, compact: compact, axID: "toggle-hud") { vm.setDeveloperMode($0) }
-                .focused($itemIdx, equals: 9)
+                .focused($itemIdx, equals: 11)
             DestructiveRow(label: "Reset All Settings", compact: compact) {
                 showResetConfirm = true
             }
-            .focused($itemIdx, equals: 10)
+            .focused($itemIdx, equals: 12)
         }
     }
 }
@@ -523,6 +530,67 @@ private struct PlayIdRotationRow: View {
                             .cinematicFocusFollower(cornerRadius: 8)
                     }
                     .buttonStyle(.plain)
+                    #if os(tvOS)
+                    .focusEffectDisabled()
+                    #endif
+                }
+            }
+        }
+        .padding(.horizontal, compact ? Space.s3 : Space.s4)
+        .padding(.vertical, compact ? Space.s2 : Space.s3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Tokens.bgSoft)
+        .clipShape(RoundedRectangle(cornerRadius: Radius.row, style: .continuous))
+    }
+}
+
+/// Preset picker for `AVPlayerItem.preferredPeakBitRate` (#683). "Off" = no
+/// cap (Apple default); the Mbps presets cap the variants AVPlayer will
+/// select — including the startup pick — giving the characterization rig a
+/// deterministic ceiling to pair with the Content variant-reorder probe
+/// (#682). Same preset-button shape as `PlayIdRotationRow`; each button
+/// carries a stable accessibility id (`peak-bitrate-off` / `-2` / …) so the
+/// Appium harness can flip it per run (mirrors #630's segment picker AX ids).
+private struct PreferredPeakBitRateRow: View {
+    let mbps: Int
+    let compact: Bool
+    let onChange: (Int) -> Void
+
+    private static let presets: [(label: String, mbps: Int, axSuffix: String)] = [
+        ("Off", 0, "off"),
+        ("2", 2, "2"),
+        ("4", 4, "4"),
+        ("8", 8, "8"),
+        ("16", 16, "16"),
+    ]
+
+    private var subtitle: String {
+        mbps <= 0 ? "Off — AVPlayer's own ceiling" : "Cap selectable variants at \(mbps) Mbps"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Peak bitrate cap")
+                .font(compact ? AppType.body(size: 15) : AppType.body())
+                .foregroundColor(Tokens.fg)
+                .lineLimit(1)
+            Text(subtitle)
+                .font(AppType.monoSm())
+                .foregroundColor(Tokens.fgFaint)
+            HStack(spacing: Space.s2) {
+                ForEach(Self.presets, id: \.mbps) { preset in
+                    Button { onChange(preset.mbps) } label: {
+                        Text(preset.label)
+                            .font(AppType.monoSm())
+                            .foregroundColor(mbps == preset.mbps ? Tokens.bg : Tokens.fg)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .background(mbps == preset.mbps ? Tokens.accent : Tokens.bgCard)
+                            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                            .cinematicFocusFollower(cornerRadius: 8)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("peak-bitrate-\(preset.axSuffix)")
                     #if os(tvOS)
                     .focusEffectDisabled()
                     #endif


### PR DESCRIPTION
Closes #683.

## Why
iOS 13+ AVPlayer picks its startup variant via an opaque throughput heuristic — non-deterministic and the root of segment-switch startup starvation (finding `avplayer-startup-variant-selection-2026-06-07.md`). These two Advanced settings turn that into a controlled experiment, and pair with #682's content reorder for the **order × ceiling / forced-first-variant** matrix.

## What
Two settings in **Settings → Advanced**, mirroring the `allow4K` pattern:

- **Peak bitrate cap** (`AVPlayerItem.preferredPeakBitRate`): preset picker **Off / 2 / 4 / 8 / 16** Mbps. `0` = no cap (Apple default). Removes higher variants from ABR **including the startup pick** — Apple's recommended deterministic-startup lever.
- **Start on first variant** (`AVPlayerItem.startsOnFirstEligibleVariant`, iOS/tvOS 14+): forces the first-listed master entry instead of the throughput heuristic; inert on older OSes.

## How
- `PlayerViewModel`: `@Published preferredPeakBitRateMbps` (+ `preferredPeakBitRateBps` helper) and `startsOnFirstEligibleVariant`, with setters. Persisted as `is.flag.peak_bitrate_mbps` / `is.flag.starts_first_variant`, restored in `loadAdvancedFlags`, cleared by **Reset All Settings**.
- Applied on each fresh `AVPlayerItem` in `apply4kPreference` (called right before `replaceCurrentItem`); `apply4kPreference`'s previously-hardcoded `preferredPeakBitRate = 0` now reads the setting. The bitrate cap also applies live to the current item mid-play (re-evaluated on the next segment); the boolean only affects the next item's initial selection.
- `SettingsOverlay`: `PreferredPeakBitRateRow` (preset-button shape from `PlayIdRotationRow`) + a `ToggleRow`, inserted after the 4K toggle; focus indices renumbered. Stable AX ids — `peak-bitrate-off`/`-2`/`-4`/`-8`/`-16`, `toggle-starts-first-variant` — so the Appium harness can flip them per run.
- tvOS parity: free via the shared `SettingsOverlay`; no `#available` guard for `preferredPeakBitRate` (platform-common), iOS-14 guard for the boolean.

## Verification
With **Start on first variant** ON, a cold iOS play starts on the first-listed variant regardless of estimate; with #682's reorder we confirm "first variant" tracks list order. The peak-bitrate cap independently removes high variants from the initial pick. Together: startup-variant selection becomes a controlled two-axis experiment.

> **Not built here** — this environment has no Xcode/module context (SourceKit can't resolve the app's design tokens), so the Swift is unverified by compile. It mirrors the existing `allow4K` / `PlayIdRotationRow` patterns exactly; needs a real build to confirm.

Refs: #680, #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
