### PR TITLE
feat(dashboard): 4-category event taxonomy (viewer + sessions list)

### DIFF
--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -45,12 +45,17 @@ import { useChartCoordination } from '@/composables/useChartCoordination';
 // derives its event list from `labels[]` on rows across all three
 // streams (events / network / control_events) instead of a dedicated
 // markers table. See `sessionEvents` computed below.
+// Event category — replaces the old binary effect/cause axis. Four
+// causal roles keyed on stream + the proxy's fault_category. See
+// docs/EVENT_TAXONOMY.md for the model and the full mapping.
+type Category = 'action' | 'injected' | 'condition' | 'reaction';
+
 interface SessionEvent {
   ts?: string;
   event_time?: string;
   type?: string;
   info?: string;
-  kind?: 'effect' | 'cause';
+  category?: Category;
   priority?: 1 | 2 | 3 | 4;
   severity?: string;
   [k: string]: unknown;
@@ -147,13 +152,40 @@ const archivePlayerId = computed(() =>
 // useArchivedSessionMarkers fetch against the retired session_markers
 // table. One synthetic event per label; ts/severity/type come straight
 // from the row + label string.
+// Network-row → category, keyed on the proxy's fault_category (the same
+// signal that drives the waterfall's clock-vs-scissors glyph). A transfer
+// timeout is a guard firing on a real slow transfer, NOT an injected
+// fault — see docs/EVENT_TAXONOMY.md.
+function categoryForNetworkRow(r: Record<string, unknown>): Category {
+  const cat = String((r as { fault_category?: unknown }).fault_category ?? '').toLowerCase();
+  switch (cat) {
+    case 'http':
+    case 'corruption':
+    case 'socket':
+    case 'transport':
+      return 'injected';
+    case 'transfer_timeout':
+      return 'condition';
+    case 'client_disconnect':
+      return 'reaction';
+    default:
+      return hasDegradationLabel(r) ? 'condition' : 'reaction';
+  }
+}
+function hasDegradationLabel(r: Record<string, unknown>): boolean {
+  const labels = Array.isArray((r as { labels?: unknown }).labels)
+    ? ((r as { labels: unknown[] }).labels as string[])
+    : [];
+  return labels.some((l) => /=\*?(slow_|qoe_ttfb_breach|qoe_transfer_stall)/.test(l));
+}
+
 const sessionEvents = computed<SessionEvent[]>(() => {
   // Trigger reactivity on each stream's version ref.
   void timeseries.events.version.value;
   void timeseries.network.version.value;
   void timeseries.control.version.value;
   const out: SessionEvent[] = [];
-  function emit(row: Record<string, unknown>, kind: 'effect' | 'cause') {
+  function emit(row: Record<string, unknown>, category: Category) {
     const labels = Array.isArray((row as { labels?: unknown }).labels)
       ? ((row as { labels: unknown[] }).labels as string[])
       : null;
@@ -168,29 +200,86 @@ const sessionEvents = computed<SessionEvent[]>(() => {
       // filter UI treats `*manifest_failure` and `manifest_failure`
       // as the same bucket type.
       if (type.startsWith('*')) type = type.slice(1);
-      if (sev !== 'error' && sev !== 'critical' && sev !== 'warning' && sev !== 'info' && sev !== 'testing') continue;
-      out.push({ ts, type, severity: sev, kind });
+      // Off-axis: the `testing` tier is harness run metadata (run_id,
+      // total_stalls, …). It lives on the Characterization page + the
+      // session "Test run" chip, never in the event filter.
+      if (sev === 'testing') continue;
+      if (sev !== 'error' && sev !== 'critical' && sev !== 'warning' && sev !== 'info') continue;
+      out.push({ ts, type, severity: sev, category });
     }
   }
-  // Cause / effect axis (post-#474 redefinition):
-  //   - cause  = something the operator / proxy deliberately introduced
-  //              to provoke a reaction. Every control_events row counts
-  //              (fault enables, pattern toggles, shaper edits, the
-  //              pattern_step ticks themselves). On network rows, only
-  //              the proxy-flagged `faulted=1` responses count — those
-  //              are the 1-in-10 HTTP 4xx/5xx returned by the fault
-  //              rules. An organic upstream 5xx the proxy didn't fault
-  //              stays an effect.
-  //   - effect = the player's / network's reaction. All session_events
-  //              rows (stalls, restarts, ABR shifts, errors) and the
-  //              clean network rows.
-  for (const r of timeseries.events.inRange(0, Number.MAX_SAFE_INTEGER)) emit(r, 'effect');
-  for (const r of timeseries.network.inRange(0, Number.MAX_SAFE_INTEGER)) {
-    const faulted = Number((r as { faulted?: unknown }).faulted) || 0;
-    emit(r, faulted ? 'cause' : 'effect');
-  }
-  for (const r of timeseries.control.inRange(0, Number.MAX_SAFE_INTEGER)) emit(r, 'cause');
+  // Four-category axis — see docs/EVENT_TAXONOMY.md:
+  //   action    — operator/proxy/harness config + lifecycle (control_events)
+  //   injected  — proxy fabricated/destroyed a response (http / corruption /
+  //               socket / transport fault categories)
+  //   condition — a guard/threshold fired on a real degraded transfer
+  //               (transfer_timeout) or a clean-row slow_*/qoe_* breach
+  //   reaction  — player behaviour (session_events) + client_disconnect
+  for (const r of timeseries.events.inRange(0, Number.MAX_SAFE_INTEGER)) emit(r, 'reaction');
+  for (const r of timeseries.network.inRange(0, Number.MAX_SAFE_INTEGER)) emit(r, categoryForNetworkRow(r));
+  for (const r of timeseries.control.inRange(0, Number.MAX_SAFE_INTEGER)) emit(r, 'action');
   return out;
+});
+
+// "Test run" chip — harness run metadata is off the event axis (it isn't a
+// cause/effect), so it surfaces in the session header instead. Derived from
+// the same `testing=<key>_<value>` labels Characterization.vue reads. Null
+// when the play isn't part of a harness run. See docs/EVENT_TAXONOMY.md.
+const TEST_RUN_KEYS = ['run_id', 'test', 'platform', 'total_stalls', 'profile_shifts', 'shocks', 'completed'];
+const testRun = computed<Record<string, string> | null>(() => {
+  void timeseries.events.version.value;
+  void timeseries.network.version.value;
+  void timeseries.control.version.value;
+  const found: Record<string, string> = {};
+  const scan = (rows: Record<string, unknown>[]) => {
+    for (const r of rows) {
+      const labels = Array.isArray((r as { labels?: unknown }).labels)
+        ? ((r as { labels: unknown[] }).labels as string[])
+        : [];
+      for (const l of labels) {
+        if (!l.startsWith('testing=')) continue;
+        const body = l.slice('testing='.length);
+        for (const k of TEST_RUN_KEYS) {
+          if (found[k] === undefined && body.startsWith(k + '_')) {
+            found[k] = body.slice(k.length + 1);
+          }
+        }
+      }
+    }
+  };
+  scan(timeseries.events.inRange(0, Number.MAX_SAFE_INTEGER));
+  scan(timeseries.control.inRange(0, Number.MAX_SAFE_INTEGER));
+  scan(timeseries.network.inRange(0, Number.MAX_SAFE_INTEGER));
+  return found.run_id !== undefined ? found : null;
+});
+
+// Numeric run summaries, in display order, skipping any that are absent
+// (mid-run only run_id exists; summaries are stamped at run end).
+const testRunMetrics = computed<Array<{ label: string; value: string }>>(() => {
+  const tr = testRun.value;
+  if (!tr) return [];
+  const defs: Array<[string, string]> = [
+    ['total_stalls', 'stalls'],
+    ['profile_shifts', 'shifts'],
+    ['shocks', 'shocks'],
+  ];
+  return defs
+    .filter(([k]) => tr[k] !== undefined)
+    .map(([k, label]) => ({ label, value: tr[k] }));
+});
+
+// `completed` arrives as a compact basic-ISO stamp (20260608T175144Z);
+// render it in local time like every other timestamp on the page.
+function compactTsToMs(s: string): number {
+  const m = /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/.exec(s);
+  if (!m) return NaN;
+  return Date.parse(`${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`);
+}
+const testRunCompletedLabel = computed<string>(() => {
+  const c = testRun.value?.completed;
+  if (!c) return '';
+  const ms = compactTsToMs(c);
+  return Number.isFinite(ms) ? fmtTime(ms) : c;
 });
 
 // v3 unified time-series model. Single subscription per
@@ -520,11 +609,24 @@ function eventMs(ev: SessionEvent): number {
   return Number.isFinite(v) ? v : NaN;
 }
 
-// L0 — Kind toggle (orthogonal: effect vs cause)
-const enabledKind = ref<Record<'effect' | 'cause', boolean>>({
-  effect: true,
-  cause: false,
+// L0 — Category toggle (replaces the old effect/cause binary; see
+// docs/EVENT_TAXONOMY.md). The fault signal (injected / condition) and
+// player reactions default on; operator actions default off to keep the
+// config / pattern churn out of the way until asked for.
+const enabledKind = ref<Record<Category, boolean>>({
+  action: false,
+  injected: true,
+  condition: true,
+  reaction: true,
 });
+
+const CATEGORY_META: Record<Category, { label: string; title: string }> = {
+  action: { label: 'Actions', title: 'Actions — operator/proxy/harness configured something (faults, patterns, shaper, lifecycle)' },
+  injected: { label: 'Injected', title: 'Injected faults — the proxy fabricated or destroyed a response (404/5xx, corrupted, socket, transport)' },
+  condition: { label: 'Conditions', title: 'Conditions & results — a guard/threshold fired on a real degraded transfer (transfer timeout, slow segment)' },
+  reaction: { label: 'Reactions', title: 'Reactions — what the player did (stalls, ABR shifts, QoE breaches)' },
+};
+const CATEGORY_ORDER: Category[] = ['action', 'injected', 'condition', 'reaction'];
 
 // L1 — Severity tier (issue #473, replaces numeric Priority 1..4).
 // String tiers, worst-first. Same vocabulary the forwarder writes to
@@ -533,7 +635,9 @@ const enabledKind = ref<Record<'effect' | 'cause', boolean>>({
 // breakage like qoe_stall_severe_midplay / frozen / restart_auto_recovery); Error
 // sits next for system-detected error states (player_error).
 type Severity = 'error' | 'critical' | 'warning' | 'info' | 'testing';
-const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info', 'testing'];
+// `testing` is intentionally omitted — harness run metadata is off-axis
+// (Characterization page + session "Test run" chip), not an event tier.
+const SEVERITY_ORDER: Severity[] = ['critical', 'error', 'warning', 'info'];
 const SEVERITY_META: Record<Severity, { label: string; color: string; bg: string; border: string }> = {
   // Critical wears the red palette (worst-looking — user-visible
   // playback breakage); Error wears the orange palette. Swapped
@@ -634,8 +738,8 @@ function eventSeverity(ev: SessionEvent): Severity {
   }
   return 'warning';
 }
-function eventKindCE(ev: SessionEvent): 'effect' | 'cause' {
-  return ev.kind === 'cause' ? 'cause' : 'effect';
+function eventCategory(ev: SessionEvent): Category {
+  return ev.category ?? 'reaction';
 }
 
 interface AnnotatedEvent extends SessionEvent {
@@ -645,7 +749,7 @@ interface AnnotatedEvent extends SessionEvent {
 
 const kindFilteredEvents = computed<AnnotatedEvent[]>(() =>
   sessionEvents.value
-    .filter((ev) => enabledKind.value[eventKindCE(ev)])
+    .filter((ev) => enabledKind.value[eventCategory(ev)])
     .map((ev) => ({ ...ev, _ts: eventMs(ev), _p: eventSeverity(ev) }))
     .filter((ev) => Number.isFinite(ev._ts))
     .sort((a, b) => a._ts - b._ts),
@@ -666,9 +770,9 @@ const tierCounts = computed<Record<Severity, number>>(() => {
   return c;
 });
 
-function kindCount(k: 'effect' | 'cause'): number {
+function kindCount(k: Category): number {
   let n = 0;
-  for (const ev of sessionEvents.value) if (eventKindCE(ev) === k) n++;
+  for (const ev of sessionEvents.value) if (eventCategory(ev) === k) n++;
   return n;
 }
 
@@ -806,7 +910,7 @@ const railMarkers = computed(() => {
     return {
       leftPct: pct,
       color: SEVERITY_META[ev._p].color,
-      opacity: eventKindCE(ev) === 'effect' ? 1 : 0.4,
+      opacity: eventCategory(ev) === 'reaction' ? 1 : 0.55,
       isCurrent,
       ts: ev._ts,
       ev,
@@ -1167,6 +1271,16 @@ function skipToEnd() {
 
 <template>
   <div class="session-display">
+    <!-- Test-run metadata — off the event axis (see docs/EVENT_TAXONOMY.md);
+         shown here so the viewer still says "this play was harness run X". -->
+    <div v-if="testRun" class="test-run-chip" :title="`Harness run ${testRun.run_id}`">
+      <span class="trc-icon">🧪</span>
+      <span class="trc-key">Test run</span>
+      <span v-if="testRun.test" class="trc-scenario">{{ testRun.test }}</span>
+      <span class="trc-run">run {{ testRun.run_id }}</span>
+      <span v-for="m in testRunMetrics" :key="m.label" class="trc-metric">{{ m.value }} {{ m.label }}</span>
+      <span v-if="testRunCompletedLabel" class="trc-metric">completed {{ testRunCompletedLabel }}</span>
+    </div>
     <!-- Brush + event filter + nav-bar live in a persistent fold so
          the operator can collapse them out of the way without losing
          the live view to a pause-state toggle. Pause-gated visibility
@@ -1274,22 +1388,15 @@ function skipToEnd() {
         <div class="kind-row">
           <span class="chips-label">Show:</span>
           <button
+            v-for="c in CATEGORY_ORDER"
+            :key="c"
             type="button"
-            class="kind-pill effect"
-            :class="{ off: !enabledKind.effect }"
-            @click="enabledKind.effect = !enabledKind.effect"
-            title="Effects — what the player or user saw"
+            class="kind-pill"
+            :class="[c, { off: !enabledKind[c] }]"
+            @click="enabledKind[c] = !enabledKind[c]"
+            :title="CATEGORY_META[c].title"
           >
-            {{ enabledKind.effect ? '✓' : '○' }} Effects · {{ kindCount('effect') }}
-          </button>
-          <button
-            type="button"
-            class="kind-pill cause"
-            :class="{ off: !enabledKind.cause }"
-            @click="enabledKind.cause = !enabledKind.cause"
-            title="Causes — proxy/system actions"
-          >
-            {{ enabledKind.cause ? '✓' : '○' }} Causes · {{ kindCount('cause') }}
+            {{ enabledKind[c] ? '✓' : '○' }} {{ CATEGORY_META[c].label }} · {{ kindCount(c) }}
           </button>
         </div>
 
@@ -1741,6 +1848,20 @@ function skipToEnd() {
 
 /* Event filter ─── L0 / L1 / L2 / L3 */
 .chips-label { font-size: 11px; color: #6b7280; font-weight: 500; margin-right: 2px; }
+.test-run-chip {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
+  font-size: 12px; color: #475569;
+  background: #f1f5f9; border: 1px solid #cbd5e1; border-radius: 6px;
+  padding: 5px 10px; margin: 0 0 10px;
+}
+.test-run-chip .trc-icon { font-size: 13px; }
+.test-run-chip .trc-key { font-weight: 600; color: #334155; }
+.test-run-chip .trc-scenario { font-weight: 600; color: #0f766e; }
+.test-run-chip .trc-run, .test-run-chip .trc-metric { color: #64748b; }
+.test-run-chip .trc-scenario::before,
+.test-run-chip .trc-run::before,
+.test-run-chip .trc-metric::before { content: '·'; margin-right: 6px; color: #cbd5e1; }
+
 .kind-row { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin: 10px 0 0; }
 .kind-pill {
   display: inline-flex;
@@ -1754,9 +1875,11 @@ function skipToEnd() {
   cursor: pointer;
   line-height: 1.4;
 }
-.kind-pill.effect { background: #dbeafe; border-color: #93c5fd; color: #1d4ed8; }
-.kind-pill.cause  { background: #fed7aa; border-color: #fdba74; color: #7c2d12; }
-.kind-pill.off    { opacity: 0.4; background: #f3f4f6; border-color: #d1d5db; color: #6b7280; }
+.kind-pill.action    { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
+.kind-pill.injected  { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
+.kind-pill.condition { background: #fef3c7; border-color: #fcd34d; color: #92400e; }
+.kind-pill.reaction  { background: #dbeafe; border-color: #93c5fd; color: #1d4ed8; }
+.kind-pill.off       { opacity: 0.4; background: #f3f4f6; border-color: #d1d5db; color: #6b7280; }
 
 .event-filter {
   margin: 10px 0 0;

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -159,12 +159,16 @@ const filters = ref<{
   // like "has http_404 AND has-not fault_rule_enabled".
   labels: string[];
   labelsExclude: string[];
+  // 4-category facet (docs/EVENT_TAXONOMY.md). Empty = no constraint; else
+  // OR-semantics: keep plays that contain ≥1 label in any selected category.
+  categories: Category[];
 }>({
   player_id: '', group_id: '', content_id: '', play_id: '',
   classification: 'all',
   harness: 'all',
   platform: '', test: '',
   labels: [], labelsExclude: [],
+  categories: [],
 });
 
 // Test-harness label extraction. The characterization framework
@@ -521,6 +525,19 @@ function matchesHarness(r: SessionRow): boolean {
   }
 }
 
+// Category facet — OR-semantics: with any category selected, keep plays
+// that contain ≥1 label in any of them. Empty selection = no constraint.
+function matchesCategories(r: SessionRow): boolean {
+  const cats = filters.value.categories;
+  if (!cats.length) return true;
+  const byCat = chipsByCategory(r);
+  return cats.some((c) => byCat[c].length > 0);
+}
+function toggleCategoryFilter(c: Category) {
+  const cur = filters.value.categories;
+  filters.value.categories = cur.includes(c) ? cur.filter((x) => x !== c) : [...cur, c];
+}
+
 function matches(r: SessionRow): boolean {
   const f = filters.value;
   return (!f.player_id || r.player_id === f.player_id)
@@ -531,6 +548,7 @@ function matches(r: SessionRow): boolean {
     && (!f.test || rowTest(r) === f.test)
     && matchesClassification(r)
     && matchesHarness(r)
+    && matchesCategories(r)
     && matchesLabels(r);
 }
 
@@ -1035,21 +1053,48 @@ function labelChips(r: SessionRow): LabelChip[] {
   return allLabelChips(r).filter((c) => c.cls !== 'testing');
 }
 
-// #656: cause/effect split. CAUSE = things the operator/harness deliberately
-// injected (fault toggles, shaper/pattern edits, lifecycle); EFFECT =
-// everything else, i.e. how the player reacted (qoe_*, stalls, downshifts,
-// breaches, transport/segment failures). Classify by label family; the
-// `*` synthMark prefix is stripped first.
-const CAUSE_RE = /^(fault|pattern|shaper_config|timeouts_changed|loop_server|session_start|session_end|content_changed|label_changed|control_change)/;
-function isCauseLabel(name: string): boolean {
-  const n = name.startsWith('*') ? name.slice(1) : name;
-  return CAUSE_RE.test(n);
+// 4-category classification — mirrors the viewer's axis (see
+// docs/EVENT_TAXONOMY.md): Actions / Injected / Conditions / Reactions.
+// The list only has label strings (no per-row `fault_category`), so the
+// synthesized failure rollups (segment/manifest) are ambiguous; they're
+// disambiguated by a co-occurring unambiguous sibling on the same play
+// (every `*segment_failure` row also carries an http_*/timeout label,
+// and both land in the histogram). The `*` synthMark prefix is stripped.
+type Category = 'action' | 'injected' | 'condition' | 'reaction';
+const CAT_ACTION_RE    = /^(fault_on|fault_off|fault_rule|pattern_|shaper_|timeouts_changed|loop_server|session_start|session_end|server_start|content_changed|label_changed|control_change)/;
+const CAT_CONDITION_RE = /^(fault_timeout|transfer_active_timeout|transfer_idle_timeout|slow_request|slow_segment|qoe_ttfb_breach|qoe_transfer_stall)/;
+const CAT_INJECTED_RE  = /^(http_4xx|http_5xx|fault_other|fault_incomplete|corrupted|transport_socket)/;
+const CAT_AMBIGUOUS_RE = /^(segment_failure|manifest_failure|master_manifest_failure)/;
+function baseLabelName(name: string): string { return name.startsWith('*') ? name.slice(1) : name; }
+function labelCategory(name: string, playTypes: Set<string>): Category {
+  const n = baseLabelName(name);
+  if (CAT_ACTION_RE.test(n)) return 'action';
+  if (CAT_CONDITION_RE.test(n)) return 'condition';
+  if (CAT_INJECTED_RE.test(n)) return 'injected';
+  if (CAT_AMBIGUOUS_RE.test(n)) {
+    for (const t of playTypes) if (CAT_INJECTED_RE.test(t)) return 'injected';
+    for (const t of playTypes) if (CAT_CONDITION_RE.test(t)) return 'condition';
+    return 'injected'; // a failure with no disambiguating sibling
+  }
+  return 'reaction';
 }
-function causeChips(r: SessionRow): LabelChip[] {
-  return labelChips(r).filter((c) => isCauseLabel(c.name));
+const CATEGORY_ORDER: Category[] = ['action', 'injected', 'condition', 'reaction'];
+const CATEGORY_TAG: Record<Category, { tag: string; title: string }> = {
+  action:    { tag: 'act',  title: 'Actions — operator/proxy/harness config (faults, patterns, shaper, lifecycle)' },
+  injected:  { tag: 'inj',  title: 'Injected faults — fabricated/destroyed responses (4xx/5xx, corrupted, socket)' },
+  condition: { tag: 'cond', title: 'Conditions & results — transfer timeouts, slow segments, QoE network breaches' },
+  reaction:  { tag: 'rxn',  title: 'Reactions — player behaviour (QoE, stalls, shifts)' },
+};
+function playTypeSet(r: SessionRow): Set<string> {
+  const s = new Set<string>();
+  for (const c of labelChips(r)) s.add(baseLabelName(c.name));
+  return s;
 }
-function effectChips(r: SessionRow): LabelChip[] {
-  return labelChips(r).filter((c) => !isCauseLabel(c.name));
+function chipsByCategory(r: SessionRow): Record<Category, LabelChip[]> {
+  const types = playTypeSet(r);
+  const out: Record<Category, LabelChip[]> = { action: [], injected: [], condition: [], reaction: [] };
+  for (const c of labelChips(r)) out[labelCategory(c.name, types)].push(c);
+  return out;
 }
 
 // #653/#656: per-group cap before the "+N more" toggle collapses the tail.
@@ -1062,19 +1107,15 @@ function toggleLabelRow(playId: string) {
   if (s.has(playId)) s.delete(playId); else s.add(playId);
   expandedLabelRows.value = s;
 }
-// Visible head of each group: all when expanded, else the capped head.
-function visibleCauseChips(r: SessionRow): LabelChip[] {
-  const all = causeChips(r);
+// Visible head of one category group: all when expanded, else capped.
+function visibleCategoryChips(r: SessionRow, cat: Category): LabelChip[] {
+  const all = chipsByCategory(r)[cat];
   return expandedLabelRows.value.has(String(r.play_id)) ? all : all.slice(0, LABEL_CHIP_CAP);
 }
-function visibleEffectChips(r: SessionRow): LabelChip[] {
-  const all = effectChips(r);
-  return expandedLabelRows.value.has(String(r.play_id)) ? all : all.slice(0, LABEL_CHIP_CAP);
-}
-// Combined hidden count across both groups (drives the "+N more" label).
+// Combined hidden count across all category groups (drives "+N more").
 function hiddenLabelCount(r: SessionRow): number {
-  return Math.max(0, causeChips(r).length - LABEL_CHIP_CAP)
-    + Math.max(0, effectChips(r).length - LABEL_CHIP_CAP);
+  const byCat = chipsByCategory(r);
+  return CATEGORY_ORDER.reduce((sum, c) => sum + Math.max(0, byCat[c].length - LABEL_CHIP_CAP), 0);
 }
 
 // #563 — human-readable "how did this play end?" from the Phase 2
@@ -1375,6 +1416,19 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
               >{{ c.label }}</button>
             </div>
 
+            <div class="class-chip-wrap" title="Filter by event category (docs/EVENT_TAXONOMY.md). Multi-select; keeps plays containing ≥1 label in any selected category.">
+              <span class="ctrl-label-text">Category:</span>
+              <button
+                v-for="cat in CATEGORY_ORDER"
+                :key="cat"
+                type="button"
+                class="class-chip"
+                :class="['cat-chip-' + cat, { active: filters.categories.includes(cat) }]"
+                :title="CATEGORY_TAG[cat].title"
+                @click="toggleCategoryFilter(cat)"
+              >{{ CATEGORY_TAG[cat].tag }}</button>
+            </div>
+
             <!-- #673 — Scenario facets. Only rendered when the current rows
                  carry harness-stamped platform/test metadata, so manual-only
                  views aren't cluttered with empty selects. -->
@@ -1587,25 +1641,17 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
                     <span v-if="flagChips(r).length === 0" class="dash">—</span>
                   </td>
                   <td class="cell-labels">
-                    <template v-if="visibleEffectChips(r).length">
-                      <span class="label-group-tag" title="Player reaction (QoE, stalls, shifts, breaches)">plyr</span>
-                      <span
-                        v-for="chip in visibleEffectChips(r)"
-                        :key="'e-' + chip.label"
-                        class="label-chip"
-                        :class="'label-' + chip.cls"
-                        :title="chip.label"
-                      >{{ chip.count }}× {{ chip.name }}</span>
-                    </template>
-                    <template v-if="visibleCauseChips(r).length">
-                      <span class="label-group-tag" title="Operator / harness injected (faults, shaping, patterns)">inj</span>
-                      <span
-                        v-for="chip in visibleCauseChips(r)"
-                        :key="'c-' + chip.label"
-                        class="label-chip"
-                        :class="'label-' + chip.cls"
-                        :title="chip.label"
-                      >{{ chip.count }}× {{ chip.name }}</span>
+                    <template v-for="cat in CATEGORY_ORDER" :key="cat">
+                      <template v-if="visibleCategoryChips(r, cat).length">
+                        <span class="label-group-tag" :class="'cat-tag-' + cat" :title="CATEGORY_TAG[cat].title">{{ CATEGORY_TAG[cat].tag }}</span>
+                        <span
+                          v-for="chip in visibleCategoryChips(r, cat)"
+                          :key="cat + '-' + chip.label"
+                          class="label-chip"
+                          :class="['label-' + chip.cls, 'cat-' + cat]"
+                          :title="chip.label"
+                        >{{ chip.count }}× {{ chip.name }}</span>
+                      </template>
                     </template>
                     <button
                       v-if="hiddenLabelCount(r) > 0 && !expandedLabelRows.has(String(r.play_id))"
@@ -1930,6 +1976,21 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
 .label-critical { background: #fee2e2; color: #7f1d1d; border-color: #fca5a5; }
 .label-error    { background: #ffedd5; color: #7c2d12; border-color: #fdba74; }
 .label-testing  { background: #f1f5f9; color: #475569; border-color: #cbd5e1; }
+/* Category accent (docs/EVENT_TAXONOMY.md) — a left border tints each chip
+   by causal role while the background keeps the severity tint. The group
+   tags + filter facet chips share the same four accents. */
+.label-chip.cat-action    { border-left: 3px solid #8b5cf6; }
+.label-chip.cat-injected  { border-left: 3px solid #ef4444; }
+.label-chip.cat-condition { border-left: 3px solid #f59e0b; }
+.label-chip.cat-reaction  { border-left: 3px solid #3b82f6; }
+.cat-tag-action    { color: #7c3aed; }
+.cat-tag-injected  { color: #dc2626; }
+.cat-tag-condition { color: #d97706; }
+.cat-tag-reaction  { color: #2563eb; }
+.class-chip.cat-chip-action    { border-left: 3px solid #8b5cf6; }
+.class-chip.cat-chip-injected  { border-left: 3px solid #ef4444; }
+.class-chip.cat-chip-condition { border-left: 3px solid #f59e0b; }
+.class-chip.cat-chip-reaction  { border-left: 3px solid #3b82f6; }
 /* #653: "+N more" / "show less" toggle for the capped label list. */
 .label-more {
   display: inline-block;

--- a/docs/EVENT_TAXONOMY.md
+++ b/docs/EVENT_TAXONOMY.md
@@ -1,0 +1,294 @@
+# Event taxonomy reclassification — spec
+
+Status: **partially implemented** (branch `fix/fault-timeout-surfacing`).
+Replaces the 2-way "cause / effect" axis the session dashboards use today.
+
+- ✅ **Viewer classifier (§ Classifier change + § Testing-tier handling)** —
+  done in `SessionDisplay.vue`, typechecks + builds, deployed to test-dev.
+  The viewer now shows the 4-pill axis (Actions / Injected / Conditions /
+  Reactions) and drops the `testing` tier off-axis.
+- ✅ **"Test run" chip** — done in `SessionDisplay.vue`, deployed; renders on
+  any play carrying `run_id` (viewer + live `testing.html`), so it also covers
+  the live-banner case.
+- ✅ **Sessions-list facet (§ below)** — client-side v1 done in `Sessions.vue`
+  (4-category chip grouping + tint + filter facet). Reliable because the
+  disambiguating sibling label co-occurs in the histogram.
+- ⤓ **Forwarder `category_histogram`** — **optional / deferred (probably skip).**
+  Only buys precise count badges (not built); even those are approximable
+  client-side except on plays mixing injected + timeout faults. Backend redeploy
+  not worth it unless exact badges are specifically wanted.
+
+## Problem
+
+The dashboard's event filter splits every labelled row into **cause** vs
+**effect**, defined entirely by three `emit()` calls in
+`content/dashboard-v3/src/components/SessionDisplay.vue` (≈187-192):
+
+```js
+session_events   → always 'effect'
+network_requests → faulted ? 'cause' : 'effect'
+control_events   → always 'cause'
+```
+
+This conflates four genuinely different causal roles into two buckets, and
+sweeps in a fifth thing (harness metadata) that isn't causal at all. Concrete
+symptoms:
+
+- Filtering the Sessions list for `error=fault_timeout`, then opening the
+  session viewer, shows **nothing** — fault rows land in "cause", and the
+  Causes lane defaults **off** (`enabledKind = { effect: true, cause: false }`,
+  SessionDisplay.vue ~524).
+- A server-enforced **transfer timeout** (a guard firing on an already-slow
+  transfer) is filed identically to a **deliberately injected 404** — even
+  though `categorizeFaultType()` in `go-proxy` already separates them
+  ("clock glyph" vs "scissors").
+- `testing`-tier harness metadata (`run_id_*`, `total_stalls_0`,
+  `profile_shifts_16`, `shocks_2`, `completed_*`) shows up as bogus "causes".
+
+## Model: 4 tiers + a metadata side-channel
+
+| Tier | Meaning | Source signal |
+|---|---|---|
+| **1 · Actions** | what the operator / proxy / harness *did* (stimuli) | `control_events` (config + lifecycle) |
+| **2 · Injected faults** | proxy *actively fabricated or destroyed* a response / connection | network row, `fault_category ∈ {http, corruption, socket, transport}` |
+| **3 · Conditions & results** | emergent outcomes / policy guards firing on a *real* degraded transfer — not fabricated | network row, `fault_category = transfer_timeout`; or clean-row degradation labels |
+| **4 · Reactions** | what the player did | `session_events`; plus `fault_category = client_disconnect` (player hung up) |
+| *(off-axis)* | **Metadata** — harness run annotations, not causal | the `testing` severity tier (#571) |
+
+## Authoritative mapping (all source-confirmed)
+
+**Tier 1 — Actions** — `control_events.event` (`computeControlLabels`,
+`labels.go`):
+`fault_on`, `fault_off`, `fault_rule_enabled`, `fault_rule_disabled`,
+`fault_rule_config_change`, `pattern_step`, `pattern_enabled`,
+`pattern_disabled`, `pattern_config_change`, `shaper_changed`,
+`shaper_config_change`, `timeouts_changed`, `loop_server`, `content_changed`,
+`server_start`, `session_start`, `session_end`, `control_change`.
+
+**Tier 2 — Injected faults** — `categorizeFaultType()` (`go-proxy`):
+- `http` — 404 / 5xx injection
+- `corruption` — `corrupted`
+- `socket` — every `request_*` (`connect`/`first_byte`/`body` ×
+  `hang`/`reset`/`delayed`). **`delay_body` / `delay_header` live here.**
+- `transport` — `transport_*` (nftables DROP / REJECT)
+
+**Tier 3 — Conditions & results**:
+- `transfer_timeout` — `transfer_active_timeout`, `transfer_idle_timeout`.
+  These are **passive guards**: the proxy passes the real transfer through and
+  cancels it once the timer elapses (`fault-injection-wire-contract.md`). They
+  fire *because* the transfer was already slow (e.g. a big 2160p segment under
+  active bandwidth shaping), not because the proxy injected an error.
+- clean-row degradation labels (`faulted=0`, `labels.go`): `slow_request`,
+  `slow_segment`, `qoe_ttfb_breach`, `qoe_transfer_stall`.
+
+**Tier 4 — Reactions**:
+- all `session_events` labels: `play_start`, `first_frame`, `shift_up`/
+  `shift_down`, `stall_frozen`, `timejump`, player `qoe_*` breaches,
+  `unexpected_startup` / `unexpected_end`.
+- `fault_category = client_disconnect` — the player gave up mid-transfer.
+
+**Off-axis — Metadata** (`testing` tier, `labels.go:44`, deliberately
+unranked): `run_id_*`, `total_stalls_*`, `profile_shifts_*`, `shocks_*`,
+`completed_*`, and any `label_changed`-carried KV. **Never** counts as cause or
+effect. See "Testing-tier handling" below.
+
+> Per-row, not per-label. A single network row carries several labels from one
+> tier (`error=fault_timeout`, `warning=*segment_failure`,
+> `warning=*transfer_active_timeout`). Tier the **row** by `fault_category`;
+> every label on it inherits that tier. This matches `emit()`'s existing
+> row-at-a-time shape and avoids the ambiguity that synthesized rollups like
+> `*segment_failure` (which fire for *both* injected and timeout faults) would
+> create under per-label tiering.
+
+## Classifier change
+
+Replace the `faulted`-int predicate in `SessionDisplay.vue` `emit()`:
+
+```js
+function tierForNetworkRow(r) {
+  switch (r.fault_category) {
+    case 'http': case 'corruption': case 'socket': case 'transport':
+      return 'injected_fault';                 // Tier 2
+    case 'transfer_timeout':
+      return 'condition';                       // Tier 3
+    case 'client_disconnect':
+      return 'reaction';                        // Tier 4
+    default:
+      return hasDegradationLabel(r) ? 'condition' : 'reaction';
+  }
+}
+// control        → 'action'   (Tier 1)  — UNLESS testing tier → metadata facet
+// session_events → 'reaction' (Tier 4)
+```
+
+`hasDegradationLabel(r)` = row carries any `slow_*` / `qoe_*_breach` label.
+
+### Minimal variant (keep the 2-way toggle)
+
+If the 4-lane UI is too big a first step, map the tiers onto the existing
+binary so it's a one-function edit:
+
+- **Causes** = Tier 1 (Actions) + Tier 2 (Injected faults)
+- **Effects** = Tier 3 (Conditions & results) + Tier 4 (Reactions)
+- **Metadata** = excluded (see below)
+
+This alone puts transfer timeouts on the **Effects** side (visible by default)
+and removes the harness metadata — which fixes the original
+"filtered `fault_timeout`, saw nothing" report.
+
+## Testing-tier handling (folded in)
+
+The `testing` severity tier is harness run metadata, written by the
+characterization / server-behavior tests (`run_id` at run start; `total_stalls`
+/ `profile_shifts` / `shocks` / `completed_*` as summaries at run end). It has a
+purpose-built consumer already: **`Characterization.vue`**, which groups plays
+by `run_id_<ts>` from each play's `label_histogram` and renders summary cards
+(its `findLabel` reads the `testing=` prefix first, then legacy `info=`).
+
+It does **not** belong in the cause/effect event filter. Two changes:
+
+1. **Exclude `testing` from the cause/effect axis.** In `SessionDisplay.vue`,
+   the tier filter (`SEVERITY_ORDER` / `tierTypes` / `tierCounts`, ~520-700)
+   must skip `severity === 'testing'`; `emit()` must not assign these rows a
+   cause/effect kind. Net effect: the empty/clutter `testing` lane disappears
+   from the filter on the viewer, `testing.html`, and `testing-session.html`.
+
+2. **Render run metadata as a session-header "Test run" chip.** Source it from
+   the *same* labels `Characterization.vue` reads (`testing=run_id_`,
+   `testing=total_stalls`, `testing=profile_shifts`, `testing=shocks`,
+   `testing=completed_`). Show a compact chip in the session header on:
+   - the **session viewer** (archived runs — full summary available), and
+   - `testing.html` once a run is associated.
+
+   This is the off-axis home that replaces the bogus "cause" rows.
+
+### Separate small task — live `run_id` banner on `testing.html`
+
+`testing.html` (`Testing.vue`) follows the **live** active player. End-of-run
+summaries don't exist mid-run, so they can't populate live — but the
+**`run_id`** (stamped at run start) can. Add a small run-context banner
+("Run `…174229Z` · characterization in progress") sourced from the live
+player's `run_id` label. Tracked separately from the reclassification because it
+touches only `Testing.vue` and the live player record, not the classifier.
+
+## Validation — this session, re-sorted
+
+Play `8ca12887` (player `a45a161d`), window 17:42:28–17:51:45Z. Old model: 36
+"causes". New model:
+
+- **Actions (11):** `shaper_config_change` ·5, `pattern_disabled` ·4,
+  `loop_server` ·2, `timeouts_changed` ·1, `label_changed` ·2
+- **Injected faults (0):** none — no http/socket/corruption/transport injection
+  in this play
+- **Conditions & results (→ now Effects):** `transfer_active_timeout` ·2,
+  `*segment_failure` ·2, `fault_timeout` ·2
+- **Metadata (→ off-axis chip):** `run_id_*` ·2, `total_stalls_0`,
+  `profile_shifts_16`, `shocks_2`, `completed_*`
+
+This play had **zero deliberately-injected faults** — the "faults" were the
+active-transfer-timeout policy firing because 2160p segments couldn't complete
+under bandwidth shaping. Under the new model that reads correctly:
+shaper/pattern/timeout *actions* (Tier 1) → over-long transfers hit the timeout
+guard (Tier 3) → visible by default; metadata off-axis.
+
+## Sessions-list category facet (follow-up)
+
+The viewer change above is the per-event timeline classifier. The **Sessions
+list** (`Sessions.vue` / `sessions.html`) is a different job — *finding* a
+session among many — and should adopt the same vocabulary without cloning the
+per-event toggle.
+
+### What the list does today
+
+Filters by **raw label strings** (`filters.labels` / `labelsExclude`, the
+tristate AND include/exclude — this is the `error=fault_timeout` filter), plus
+scenario facets (`platform`/`test` from the `testing=` tier), a harness-origin
+filter, and a time range. Each row carries only the play's **label histogram**
+(`labels: [string, count][]`) — *not* per-row `fault_category`.
+
+### What was built — client-side v1 (✅ done, `Sessions.vue`)
+
+1. **4-category chip grouping.** The Labels column's old `plyr`/`inj` split
+   becomes four groups — `act` / `inj` / `cond` / `rxn` — same vocabulary as
+   the viewer (`labelCategory()` + `chipsByCategory()`).
+2. **Chip tint.** Each label chip gets a category-colored left accent; the
+   background keeps the severity tint.
+3. **Category filter facet.** A multi-select `act / inj / cond / rxn` toggle row
+   (`filters.categories`, OR-semantics), AND-combined with the existing label
+   filter — which stays.
+
+All three are pure-derived from the play's existing `label_histogram`; **no
+forwarder change**.
+
+### Ambiguity — resolved client-side, not via the forwarder
+
+The synthesized rollups (`*segment_failure`, `manifest_failure`) can't be mapped
+from the label string alone. But the histogram is reliable anyway because the
+**disambiguating sibling always co-occurs**: every `*segment_failure` row also
+carries an `http_*` (→injected) or `fault_timeout`/transfer (→condition) label,
+and both land in the play's histogram. So `labelCategory()` disambiguates an
+ambiguous label by scanning the play's other labels (defaulting to `injected`
+only if nothing else applies). The **facet, grouping, and tint are therefore
+reliable client-side** — the forwarder rollup is not required for them.
+
+### Forwarder `category_histogram` — optional, deferred (probably skip)
+
+The rollup would only buy **precise per-play count badges** (a literal
+"Conditions · 8" per row), which aren't built. Even those are approximable
+client-side; the *only* inaccuracy is the ambiguous labels on a play that mixes
+**both** an injected fault **and** a transfer timeout (rare) — those chips bucket
+to one category instead of splitting per-row. Given it's a backend redeploy
+(heavier, riskier) for a rare edge case in an unbuilt feature, **skip unless
+exact count badges are specifically wanted.** If built later: add a per-play
+`category_histogram` to the `query plays` aggregate (`CASE` over `fault_category`
++ source stream, mirroring the viewer's `categoryForNetworkRow`); this doc is the
+canonical `fault_category → category` contract for both sides.
+
+### Label-family → category (the client-side mapping, `Sessions.vue`)
+
+| Label family | Category |
+|---|---|
+| `http_4xx`, `http_5xx`, `fault_other` | injected |
+| `*master_manifest_failure`, `*manifest_failure` *(on injected rows)* | injected |
+| `*transport_socket`, `corrupted` | injected |
+| `fault_timeout`, `*transfer_active_timeout`, `*transfer_idle_timeout` | condition |
+| `slow_request`, `slow_segment`, `qoe_ttfb_breach`, `qoe_transfer_stall` | condition |
+| `*transport_disconnect` (client_disconnect), player `qoe_*`, `shift_*`, `stall_*`, `play_start`, `first_frame`, `unexpected_*` | reaction |
+| any `control_events` event (`fault_on`, `pattern_*`, `shaper_*`, …) | action |
+| **`*segment_failure`, `fault_incomplete`** | **ambiguous** — needs row `fault_category`; chip falls back to severity tint until the rollup lands |
+
+### Scope
+
+Done: grouping + tint + facet in `Sessions.vue` (frontend-only, ships via the
+safe hot-deploy). Deferred/optional: the forwarder `category_histogram` for
+exact count badges (backend redeploy — probably skip).
+
+## Open items
+
+1. **`unexpected_fault`** — an anomaly/expectation label generated by a build
+   *newer than `dev` HEAD* (no generator in `dev` source). It rides on the
+   timeout rows. Decide: inherit the host row's tier (→ Tier 3), or give
+   anomalies their own overlay facet.
+2. **Deployed-build drift** — the running test-dev classifier already diverges
+   from `dev` source (it treats `faulted=0` fault rows as causes, which `dev`'s
+   `emit()` would not). Confirm the actually-deployed predicate before
+   implementing, or implement on `dev` and redeploy the frontend.
+
+## Files touched
+
+- ✅ `content/dashboard-v3/src/components/SessionDisplay.vue` — classifier
+  (`emit`/`sessionEvents` → `categoryForNetworkRow`), 4-pill axis,
+  `enabledKind` defaults, `testing` off-axis (`SEVERITY_ORDER`). *(done)*
+- ⬜ `content/dashboard-v3/src/components/SessionDisplay.vue` — "Test run"
+  header chip (sourced from the `testing=` labels Characterization reads).
+- ⬜ `content/dashboard-v3/src/pages/Testing.vue` — live `run_id` banner.
+- ✅ `content/dashboard-v3/src/pages/Sessions.vue` — 4-category chip grouping +
+  tint + filter facet (`labelCategory` / `chipsByCategory` / `matchesCategories`).
+- ⤓ `analytics/go-forwarder/` — `category_histogram` on `query plays`
+  (OPTIONAL; only for exact count badges; probably skip).
+- (reference, no change) `content/dashboard-v3/src/pages/Characterization.vue` —
+  existing run-grouped consumer of the same `testing=` labels.
+- (reference) `go-proxy/cmd/server/main.go` `categorizeFaultType()` — the
+  `fault_category` source of truth the classifier keys on.
+- (reference) `analytics/go-forwarder/labels.go` — label vocabulary +
+  `SevTesting`.


### PR DESCRIPTION
## What

Replaces the binary **cause/effect** event axis with four causal roles — **Actions / Injected / Conditions / Reactions** — keyed on the proxy's `fault_category`, across the session viewer **and** the Sessions list.

## Why

Filtering the Sessions list for `error=fault_timeout` then opening the viewer showed **nothing** — fault rows landed in "cause", and the Causes lane defaults off. Root cause: a **transfer timeout** is a policy guard firing on an already-slow transfer (a *condition/result*), not a deliberately injected fault, yet it was filed identically to an injected 404. The new taxonomy puts it in **Conditions** (visible by default).

## Changes

- **`SessionDisplay.vue`** — per-event classifier keyed on `fault_category` (`categoryForNetworkRow`); the 4-pill axis; the `testing` tier pulled **off-axis** into a new **"Test run" chip** in the session header (sourced from the same `testing=` labels the Characterization page reads).
- **`Sessions.vue`** — same taxonomy on the list: 4-category chip **grouping** (`act/inj/cond/rxn`) + category **tint** + a category **filter facet**, all derived client-side from the label histogram (the disambiguating sibling label always co-occurs, so no backend change needed).
- **`docs/EVENT_TAXONOMY.md`** — the model, source-confirmed `fault_category → category` mapping, and the **optional/deferred** forwarder `category_histogram` rollup (only buys exact count badges, not built).

## Verification

- `vue-tsc --noEmit` + `vite build` clean.
- Deployed to test-dev and verified live: viewer shows the 4-pill axis with `fault_timeout`/`transfer_active_timeout` in Conditions (visible by default), 0 injected; Test-run chip renders; Sessions list shows the facet, group tags, and tinted chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
