### PR TITLE
feat(712): config-on-connect — proxy.* URL args materialize session before 302

### DIFF
--- a/.claude/standards/server-behavior.md
+++ b/.claude/standards/server-behavior.md
@@ -425,6 +425,32 @@ failure surfaces as a decode error, not a truncated transfer.
 
 ---
 
+## 1.11 Config-on-connect (#712)
+
+`sb_config_on_connect_test.go` — `TestConfigOnConnect_Shape` /
+`TestConfigOnConnect_FaultRule`.
+
+Instead of bootstrap → PATCH, the bootstrap manifest URL itself carries the
+session config as `proxy.*` args. The base-port handler materializes the config
+atomically, then 302s to the session port with the args **stripped**:
+
+```
+GET …:30081/go-live/<content>/master_6s.m3u8
+      ?player_id=<uuid>&proxy.shape.rate_mbps=2.5&proxy.labels.test=cfg712
+  → 302 …:301N1/go-live/<content>/master_6s.m3u8?player_id=<uuid>   # proxy.* gone
+```
+
+The tests assert (a) the redirected URL carries no `proxy.*`, (b) the session
+record on `/api/sessions` already reflects the config (`nftables_bandwidth_mbps`,
+`segment_failure_type`, …) **before any PATCH**. Full vocabulary + tier
+precedence + the "segment length is the filename, not an arg" rule live in
+[`api/openapi/v2/DESIGN.md` § 5b](../../api/openapi/v2/DESIGN.md). Config-on-
+connect rides the **same** v2→v1 translator as PATCH, so it accepts exactly the
+PATCH-supported field set (no `filter.variant`/`.codec` yet) and rejects the
+rest with 400.
+
+---
+
 ## 2. Future server-behavior tests (proposed)
 
 Each row below is an as-yet-unwritten test in `tests/server_behavior/`.

--- a/api/openapi/v2/DESIGN.md
+++ b/api/openapi/v2/DESIGN.md
@@ -272,6 +272,66 @@ This is request-routing on the streaming path, not an API v2 endpoint.
 The control plane (everything under `/api/v2/...`) is on the base
 origin only.
 
+### 5b. Config-on-connect — URL-arg control vocabulary (#712)
+
+The bootstrap manifest request can carry the session's whole proxy config
+as `proxy.*` URL args. The base-port handler parses them, **materializes the
+session config atomically** (live before the first byte), then `302`s to the
+session-bound port URL **with the `proxy.*` args stripped**. AVPlayer follows
+the redirect and resolves every child request against the clean URL, so config
+is live from segment 0 with no separate PATCH round-trip. The control plane
+stays for *mid-play* mutation.
+
+**Encoding — bracket/dotted notation** (the de-facto `qs`/Rails/PHP convention,
+also what `go-playground/form` / `gorilla/schema` implement). Arg paths mirror
+the `PlayerPatch` merge-patch shape exactly, so the vocabulary **is** the API
+model — there is no second config grammar to drift:
+
+```
+proxy.shape.rate_mbps=2.5
+proxy.shape.delay_ms=120
+proxy.shape.pattern.template=pyramid
+proxy.fault_rules[0].type=corrupted
+proxy.fault_rules[0].filter.request_kind[0]=segment
+proxy.content.variant_order=ascending
+proxy.labels.test=steady_cap
+proxy.cfg=<base64url(JSON of a full PlayerPatch)>   # escape hatch / base tier
+```
+
+- **Tier precedence:** `proxy.cfg` is the base; individual `proxy.<path>` args
+  override it per-field. Bracket notation lives in the **key**, so values stay
+  clean — no `,`/`=` dodging.
+- **Value typing** is best-effort from the string: a finite number → JSON
+  number, `true`/`false` → bool, everything else → string. This matches every
+  field in the model (`rate_mbps`→number, `strip_resolution`→bool,
+  `type`→string, `resolutions[0]`=`1080p`→string).
+- **`labels.<k>`** takes everything after `labels.` as one key verbatim (v2
+  label keys may contain `.`/`/`/`-`); use `proxy.cfg` for anything exotic.
+- **Segment length is NOT an arg** — it is the manifest filename
+  (`master_6s.m3u8` / `master_2s.m3u8` / `master_ll.m3u8`). Requesting the URL
+  you want *is* selecting the segment cadence.
+
+**Same translator as PATCH.** Materialization runs the identical v2→v1
+translator the PATCH API uses (`applyPatchToSession`), so config-on-connect
+supports **exactly** what PATCH supports today — `shape` (rate/delay/loss/
+pattern/transport_fault), `fault_rules` (types `none`/`404`/`500`/`503`/
+`timeout`/`corrupted`, `filter.request_kind`, `filter.url_match`), `content`,
+`transfer_timeouts`, `labels`. Fields the v1 surface can't yet express
+(`fault_rules[].filter.variant` / `.codec`, the extended request-* fault types)
+are **rejected with 400** on the bootstrap request — the same boundary the
+PATCH endpoint enforces, not a config-on-connect-specific gap.
+
+**Idempotency / reattach.** Materialization happens **only** in the
+new-session branch. A loop or auto-recovery restart re-hitting the base port
+with the same `player_id` takes the existing-session branch → a plain 302 to
+the live port, **no re-apply**. `proxy.*` are stripped from both redirects so
+they never reach a session port or the child-request space.
+
+**Exposure.** Available on all deploys, no auth gate. Args are validated
+(parse/type/range via the translator) and fail-closed — a malformed config is a
+400 that consumes no session slot. Accepted risk: on a reachable deploy any URL
+can configure faults/shaping; acceptable for this test rig.
+
 ### 6. Consistent SSE envelope
 
 Every SSE frame is `{ type, data }`:

--- a/go-proxy/cmd/server/configconnect.go
+++ b/go-proxy/cmd/server/configconnect.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Config-on-connect (#712): parse `proxy.*` URL args on the bootstrap request
+// into a JSON-Merge-Patch-shaped map[string]any, so the session can be
+// materialized atomically at allocation time and the patch fed through the
+// SAME translator the PATCH API uses (v2server.ApplyConfigPatch). The URL-arg
+// vocabulary therefore rides the API model and cannot drift from it.
+//
+// Encoding (bracket/dotted notation, the de-facto qs/Rails/PHP convention,
+// also what go-playground/form and gorilla/schema implement):
+//
+//	proxy.shape.rate_mbps=2.5
+//	proxy.fault_rules[0].type=corrupted
+//	proxy.fault_rules[0].filter.request_kind[1]=segment
+//	proxy.cfg=<base64url(JSON)>            # full-fidelity escape hatch / base tier
+//
+// Tier precedence: proxy.cfg is the base; individual proxy.<path> args override
+// it per-field. Bracket notation lives in the KEY, so values stay clean — no
+// comma/equals dodging.
+
+// proxyArgPrefix is the namespace every config-on-connect URL arg lives under.
+const proxyArgPrefix = "proxy."
+
+// proxyCfgKey is the base64url(JSON) escape-hatch key (full PlayerPatch body).
+const proxyCfgKey = "proxy.cfg"
+
+// segmentRe splits a path segment into its base key and trailing bracket
+// indices, e.g. `request_kind[1]` → ("request_kind", "[1]"), `filter` →
+// ("filter", "").
+var segmentRe = regexp.MustCompile(`^([^\[\]]+)((?:\[[^\[\]]*\])*)$`)
+
+// bracketRe extracts each `[...]` index body from a segment's bracket suffix.
+var bracketRe = regexp.MustCompile(`\[([^\]]*)\]`)
+
+// pathStep is one hop in a parsed arg path — either a map key or an array index.
+type pathStep struct {
+	key     string
+	index   int
+	isIndex bool
+}
+
+// parseProxyArgs reads every `proxy.*` query arg into a nested merge-patch map.
+// Returns hasProxy=false (and a nil patch) when no proxy.* args are present, so
+// the bootstrap handler can skip materialization entirely. A malformed arg
+// (bad base64, bad JSON, non-numeric array index, path type conflict) returns
+// an error so the caller can reject the request with 400 rather than allocate a
+// half-configured session.
+func parseProxyArgs(q url.Values) (patch map[string]any, hasProxy bool, err error) {
+	patch = map[string]any{}
+
+	// Tier 1 (base): proxy.cfg = base64url(JSON) of a full PlayerPatch.
+	if cfg := q.Get(proxyCfgKey); cfg != "" {
+		hasProxy = true
+		raw, derr := decodeBase64URL(cfg)
+		if derr != nil {
+			return nil, false, fmt.Errorf("proxy.cfg base64url decode: %w", derr)
+		}
+		if jerr := json.Unmarshal(raw, &patch); jerr != nil {
+			return nil, false, fmt.Errorf("proxy.cfg JSON unmarshal: %w", jerr)
+		}
+		if patch == nil { // explicit JSON null
+			patch = map[string]any{}
+		}
+	}
+
+	// Tier 2 (overrides): individual proxy.<path> args, per-field overlaying cfg.
+	for key, vals := range q {
+		if key == proxyCfgKey || !strings.HasPrefix(key, proxyArgPrefix) {
+			continue
+		}
+		if len(vals) == 0 {
+			continue
+		}
+		hasProxy = true
+		path := strings.TrimPrefix(key, proxyArgPrefix)
+		steps, perr := parseArgPath(path)
+		if perr != nil {
+			return nil, false, fmt.Errorf("proxy arg %q: %w", key, perr)
+		}
+		// Last value wins for a repeated key (arrays are expressed via [i],
+		// not repetition, so this only matters for accidental duplicates).
+		if _, serr := setPath(patch, steps, coerceURLValue(vals[len(vals)-1])); serr != nil {
+			return nil, false, fmt.Errorf("proxy arg %q: %w", key, serr)
+		}
+	}
+
+	if !hasProxy {
+		return nil, false, nil
+	}
+	return patch, true, nil
+}
+
+// parseArgPath tokenizes a dotted/bracketed arg path into ordered steps.
+//
+// `labels` is special-cased: v2 label keys may themselves contain `.` / `/` /
+// `-` (`[a-z][a-z0-9_./-]{0,62}`), so everything after `labels.` is taken as a
+// single key verbatim rather than split further. Dotted label keys via the flat
+// form would otherwise be mis-nested; use proxy.cfg for anything exotic.
+func parseArgPath(path string) ([]pathStep, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	if rest, ok := strings.CutPrefix(path, "labels."); ok {
+		if rest == "" {
+			return nil, fmt.Errorf("empty label key")
+		}
+		return []pathStep{{key: "labels"}, {key: rest}}, nil
+	}
+
+	var steps []pathStep
+	for _, seg := range strings.Split(path, ".") {
+		m := segmentRe.FindStringSubmatch(seg)
+		if m == nil {
+			return nil, fmt.Errorf("malformed segment %q", seg)
+		}
+		steps = append(steps, pathStep{key: m[1]})
+		for _, b := range bracketRe.FindAllStringSubmatch(m[2], -1) {
+			idx, err := strconv.Atoi(b[1])
+			if err != nil || idx < 0 {
+				return nil, fmt.Errorf("non-numeric array index %q in %q", b[1], seg)
+			}
+			steps = append(steps, pathStep{index: idx, isIndex: true})
+		}
+	}
+	return steps, nil
+}
+
+// setPath walks/creates the nested container described by steps and writes
+// value at the leaf, returning the (possibly newly created) container so the
+// caller can reassign it (slices grow by value in Go). Type conflicts — a path
+// that expects an object where an array already exists, or vice versa — error.
+func setPath(cur any, steps []pathStep, value any) (any, error) {
+	if len(steps) == 0 {
+		return value, nil
+	}
+	head := steps[0]
+	if head.isIndex {
+		arr, ok := cur.([]any)
+		if cur == nil {
+			arr = []any{}
+		} else if !ok {
+			return nil, fmt.Errorf("path type conflict: array expected at index %d", head.index)
+		}
+		for len(arr) <= head.index {
+			arr = append(arr, nil)
+		}
+		child, err := setPath(arr[head.index], steps[1:], value)
+		if err != nil {
+			return nil, err
+		}
+		arr[head.index] = child
+		return arr, nil
+	}
+	m, ok := cur.(map[string]any)
+	if cur == nil {
+		m = map[string]any{}
+	} else if !ok {
+		return nil, fmt.Errorf("path type conflict: object expected at key %q", head.key)
+	}
+	child, err := setPath(m[head.key], steps[1:], value)
+	if err != nil {
+		return nil, err
+	}
+	m[head.key] = child
+	return m, nil
+}
+
+// coerceURLValue maps a raw string URL value to the JSON type the translator
+// expects: "true"/"false" → bool, a finite number → float64 (json.Unmarshal's
+// numeric type), everything else stays a string. This matches every field in
+// the #712 vocab — rate_mbps→float, strip_resolution→bool, type→string,
+// resolutions[0]="1080p"→string. Non-finite tokens ("inf"/"nan") stay strings
+// so they can't slip through as numbers.
+func coerceURLValue(s string) any {
+	switch s {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil && !math.IsInf(f, 0) && !math.IsNaN(f) {
+		return f
+	}
+	return s
+}
+
+// decodeBase64URL accepts base64url with or without padding.
+func decodeBase64URL(s string) ([]byte, error) {
+	if raw, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return raw, nil
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+// stripProxyArgs rebuilds a raw query string with every proxy.* arg removed,
+// preserving the original order and verbatim encoding of the kept pairs
+// (player_id, play_id, any passthrough). Used so the 302 redirect to the
+// session port carries no config args — config has already been materialized,
+// and a clean redirect URL keeps proxy.* off the session port and out of the
+// child-request space.
+func stripProxyArgs(rawQuery string) string {
+	if rawQuery == "" {
+		return ""
+	}
+	parts := strings.Split(rawQuery, "&")
+	kept := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		name := p
+		if eq := strings.IndexByte(p, '='); eq >= 0 {
+			name = p[:eq]
+		}
+		if decoded, err := url.QueryUnescape(name); err == nil {
+			name = decoded
+		}
+		if strings.HasPrefix(name, proxyArgPrefix) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return strings.Join(kept, "&")
+}

--- a/go-proxy/cmd/server/configconnect_test.go
+++ b/go-proxy/cmd/server/configconnect_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/url"
+	"reflect"
+	"testing"
+
+	v2server "github.com/jonathaneoliver/infinite-streaming/go-proxy/internal/v2/server"
+)
+
+// mustQuery parses a raw query string into url.Values, failing the test on
+// error.
+func mustQuery(t *testing.T, raw string) url.Values {
+	t.Helper()
+	q, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatalf("ParseQuery(%q): %v", raw, err)
+	}
+	return q
+}
+
+func TestConfigOnConnect_NoProxyArgs(t *testing.T) {
+	patch, has, err := parseProxyArgs(mustQuery(t, "player_id=abc&play_id=def"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Fatalf("hasProxy = true, want false for a query with no proxy.* args")
+	}
+	if patch != nil {
+		t.Fatalf("patch = %v, want nil when no proxy.* args present", patch)
+	}
+}
+
+func TestConfigOnConnect_ParseScalarShape(t *testing.T) {
+	patch, has, err := parseProxyArgs(mustQuery(t,
+		"player_id=abc&proxy.shape.rate_mbps=2.5&proxy.shape.delay_ms=120&proxy.shape.loss_pct=1.5"))
+	if err != nil || !has {
+		t.Fatalf("parse: has=%v err=%v", has, err)
+	}
+	want := map[string]any{
+		"shape": map[string]any{
+			"rate_mbps": 2.5,
+			"delay_ms":  120.0,
+			"loss_pct":  1.5,
+		},
+	}
+	if !reflect.DeepEqual(patch, want) {
+		t.Fatalf("patch mismatch\n got: %#v\nwant: %#v", patch, want)
+	}
+}
+
+func TestConfigOnConnect_ParseNestedAndArrays(t *testing.T) {
+	patch, _, err := parseProxyArgs(mustQuery(t,
+		"proxy.fault_rules[0].type=corrupted"+
+			"&proxy.fault_rules[0].mode=requests"+
+			"&proxy.fault_rules[0].frequency=3"+
+			"&proxy.fault_rules[0].filter.request_kind[0]=segment"+
+			"&proxy.fault_rules[0].filter.request_kind[1]=partial"))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	rules, ok := patch["fault_rules"].([]any)
+	if !ok || len(rules) != 1 {
+		t.Fatalf("fault_rules shape wrong: %#v", patch["fault_rules"])
+	}
+	rule := rules[0].(map[string]any)
+	if rule["type"] != "corrupted" || rule["mode"] != "requests" || rule["frequency"] != 3.0 {
+		t.Fatalf("rule scalars wrong: %#v", rule)
+	}
+	filter := rule["filter"].(map[string]any)
+	kinds := filter["request_kind"].([]any)
+	if !reflect.DeepEqual(kinds, []any{"segment", "partial"}) {
+		t.Fatalf("request_kind array wrong: %#v", kinds)
+	}
+}
+
+func TestConfigOnConnect_BoolAndStringCoercion(t *testing.T) {
+	patch, _, err := parseProxyArgs(mustQuery(t,
+		"proxy.content.strip_resolution=true&proxy.content.variant_order=ascending"))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	content := patch["content"].(map[string]any)
+	if content["strip_resolution"] != true {
+		t.Fatalf("strip_resolution = %#v, want bool true", content["strip_resolution"])
+	}
+	if content["variant_order"] != "ascending" {
+		t.Fatalf("variant_order = %#v, want string", content["variant_order"])
+	}
+}
+
+func TestConfigOnConnect_LabelsKeyVerbatim(t *testing.T) {
+	// Label keys may contain dots — everything after labels. is one key.
+	patch, _, err := parseProxyArgs(mustQuery(t,
+		"proxy.labels.test=steady_cap&proxy.labels.ci.run=42"))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	labels := patch["labels"].(map[string]any)
+	if labels["test"] != "steady_cap" {
+		t.Fatalf("labels.test = %#v", labels["test"])
+	}
+	if labels["ci.run"] != "42" && labels["ci.run"] != 42.0 {
+		// "42" parses as a number; either is acceptable as a label value.
+		t.Fatalf("labels[ci.run] = %#v, want the dotted key preserved", labels["ci.run"])
+	}
+}
+
+func TestConfigOnConnect_CfgBase64BaseWithOverride(t *testing.T) {
+	cfg := base64.RawURLEncoding.EncodeToString([]byte(`{"shape":{"rate_mbps":1.0,"delay_ms":50}}`))
+	patch, has, err := parseProxyArgs(mustQuery(t,
+		"proxy.cfg="+cfg+"&proxy.shape.rate_mbps=9"))
+	if err != nil || !has {
+		t.Fatalf("parse: has=%v err=%v", has, err)
+	}
+	shape := patch["shape"].(map[string]any)
+	// Flat arg overrides cfg per-field; untouched cfg field survives.
+	if shape["rate_mbps"] != 9.0 {
+		t.Fatalf("rate_mbps = %#v, want 9 (flat arg overrides cfg)", shape["rate_mbps"])
+	}
+	if shape["delay_ms"] != 50.0 {
+		t.Fatalf("delay_ms = %#v, want 50 (from cfg, untouched)", shape["delay_ms"])
+	}
+}
+
+func TestConfigOnConnect_ParseErrors(t *testing.T) {
+	cases := map[string]string{
+		"bad base64":      "proxy.cfg=!!!not-base64!!!",
+		"bad json in cfg": "proxy.cfg=" + base64.RawURLEncoding.EncodeToString([]byte(`{not json}`)),
+		"non-numeric idx": "proxy.fault_rules[x].type=corrupted",
+		"type conflict":   "proxy.shape=2&proxy.shape.rate_mbps=3",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := parseProxyArgs(mustQuery(t, raw)); err == nil {
+				t.Fatalf("expected error for %q, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestConfigOnConnect_CoerceURLValue(t *testing.T) {
+	cases := []struct {
+		in   string
+		want any
+	}{
+		{"true", true},
+		{"false", false},
+		{"2.5", 2.5},
+		{"6000000", 6000000.0},
+		{"1080p", "1080p"},
+		{"avc1", "avc1"},
+		{"inf", "inf"},
+		{"NaN", "NaN"},
+		{"ascending", "ascending"},
+	}
+	for _, c := range cases {
+		if got := coerceURLValue(c.in); got != c.want {
+			t.Errorf("coerceURLValue(%q) = %#v, want %#v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestConfigOnConnect_StripProxyArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"keeps non-proxy, drops proxy", "player_id=abc&proxy.shape.rate_mbps=2.5&play_id=def", "player_id=abc&play_id=def"},
+		{"drops cfg too", "proxy.cfg=ABC&player_id=x", "player_id=x"},
+		{"preserves order", "a=1&proxy.x=2&b=3&proxy.y=4&c=5", "a=1&b=3&c=5"},
+		{"all proxy", "proxy.a=1&proxy.b=2", ""},
+		{"empty", "", ""},
+		{"nothing to strip", "player_id=abc", "player_id=abc"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := stripProxyArgs(c.in); got != c.want {
+				t.Errorf("stripProxyArgs(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestConfigOnConnect_MaterializeEndToEnd parses proxy.* args and runs them
+// through the SAME translator the PATCH API uses (v2server.ApplyConfigPatch),
+// asserting the flat v1 SessionData keys the request path reads. This proves
+// the URL vocabulary lands on the real session model end-to-end.
+func TestConfigOnConnect_MaterializeEndToEnd(t *testing.T) {
+	patch, has, err := parseProxyArgs(mustQuery(t,
+		"proxy.shape.rate_mbps=2.5"+
+			"&proxy.shape.delay_ms=120"+
+			"&proxy.shape.loss_pct=1.5"+
+			"&proxy.content.variant_order=ascending"+
+			"&proxy.content.strip_resolution=true"+
+			"&proxy.labels.test=cfg712"+
+			"&proxy.fault_rules[0].type=corrupted"+
+			"&proxy.fault_rules[0].mode=requests"+
+			"&proxy.fault_rules[0].frequency=3"+
+			"&proxy.fault_rules[0].filter.request_kind[0]=segment"))
+	if err != nil || !has {
+		t.Fatalf("parse: has=%v err=%v", has, err)
+	}
+	sess := SessionData{}
+	if aerr := v2server.ApplyConfigPatch(sess, patch); aerr != nil {
+		t.Fatalf("ApplyConfigPatch: %v", aerr)
+	}
+	// shape → nftables_*
+	if got := getFloat(sess, "nftables_bandwidth_mbps"); got != 2.5 {
+		t.Errorf("nftables_bandwidth_mbps = %v, want 2.5", got)
+	}
+	if got := getInt(sess, "nftables_delay_ms"); got != 120 {
+		t.Errorf("nftables_delay_ms = %v, want 120", got)
+	}
+	if got := getFloat(sess, "nftables_packet_loss"); got != 1.5 {
+		t.Errorf("nftables_packet_loss = %v, want 1.5", got)
+	}
+	// content → content_*
+	if got := getString(sess, "content_variant_order"); got != "ascending" {
+		t.Errorf("content_variant_order = %q, want ascending", got)
+	}
+	if !getBool(sess, "content_strip_resolution") {
+		t.Errorf("content_strip_resolution = false, want true")
+	}
+	// fault_rules[segment] → segment_*
+	if got := getString(sess, "segment_failure_type"); got != "corrupted" {
+		t.Errorf("segment_failure_type = %q, want corrupted", got)
+	}
+	if got := getInt(sess, "segment_failure_frequency"); got != 3 {
+		t.Errorf("segment_failure_frequency = %v, want 3", got)
+	}
+	if got := getString(sess, "segment_failure_mode"); got != "requests" {
+		t.Errorf("segment_failure_mode = %q, want requests", got)
+	}
+	// labels → _v2_labels
+	labels, ok := sess["_v2_labels"].(map[string]any)
+	if !ok || labels["test"] != "cfg712" {
+		t.Errorf("_v2_labels = %#v, want test=cfg712", sess["_v2_labels"])
+	}
+}
+
+// TestConfigOnConnect_MaterializeRejectsVariantFilter documents that config-on-
+// connect inherits the PATCH translator's limits: filter.variant has no v1
+// surface yet, so it is rejected at materialization (→ 400 on the bootstrap).
+func TestConfigOnConnect_MaterializeRejectsVariantFilter(t *testing.T) {
+	patch, _, err := parseProxyArgs(mustQuery(t,
+		"proxy.fault_rules[0].type=corrupted"+
+			"&proxy.fault_rules[0].filter.variant.bandwidth_above=6000000"))
+	if err != nil {
+		t.Fatalf("parse should succeed (translation is where it's rejected): %v", err)
+	}
+	if aerr := v2server.ApplyConfigPatch(SessionData{}, patch); aerr == nil {
+		t.Fatalf("expected ApplyConfigPatch to reject filter.variant, got nil")
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -5300,13 +5300,28 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				// content. Plain HTTP requests redirect to http://.
 				scheme := requestScheme(r)
 				newURL := fmt.Sprintf("%s://%s:%s/%s", scheme, host, newPort, escapedPath)
-				if r.URL.RawQuery != "" {
-					newURL = newURL + "?" + r.URL.RawQuery
+				// #712: drop any proxy.* config args on reattach — config is
+				// materialized once on first bind; a loop/auto-recovery restart
+				// re-hitting the base port must never re-apply or leak proxy.*
+				// onto the session port.
+				if stripped := stripProxyArgs(r.URL.RawQuery); stripped != "" {
+					newURL = newURL + "?" + stripped
 				}
 				log.Printf("Redirecting to existing session URL: %s %s -> %s", newURL, externalPort, newPort)
 				http.Redirect(w, r, newURL, http.StatusFound)
 				return
 			}
+		}
+		// #712 config-on-connect: parse proxy.* args before allocating a
+		// session so a malformed config is a 400 that consumes no session
+		// slot. Reattach (existing-session) requests already redirected above
+		// and never reach here, so config is materialized exactly once — on
+		// the player's first bind.
+		configPatch, hasConfig, cfgErr := parseProxyArgs(r.URL.Query())
+		if cfgErr != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSON(w, map[string]interface{}{"error": "invalid proxy config args", "detail": cfgErr.Error()})
+			return
 		}
 		if isExternalIP(requesterIP) {
 			activeForRequester := countActiveSessionsForIP(sessionList, requesterIP)
@@ -5492,6 +5507,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			// Issue #480.
 			"nftables_bandwidth_mbps":                  float64(0),
 		}
+		// #712: materialize proxy.* config onto the fresh SessionData before
+		// it's published. ApplyConfigPatch runs the SAME translator the PATCH
+		// API uses, so the URL-arg vocabulary can't drift from the API model.
+		// Translation only — the kernel is driven below, after the save.
+		if hasConfig {
+			if aerr := v2server.ApplyConfigPatch(sessionData, configPatch); aerr != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				writeJSON(w, map[string]interface{}{"error": "proxy config rejected", "detail": aerr.Error()})
+				return
+			}
+		}
 		a.resetServerLoopState(fmt.Sprintf("%d", allocated))
 		sessionList = append(sessionList, sessionData)
 		a.saveSessionList(sessionList)
@@ -5501,7 +5527,46 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// uncapped. effectiveRate(0) returns the baseline (or 0 on
 		// prod-style deployments). No-op when traffic is nil
 		// (non-Linux dev). Issue #480.
-		if a.defaultRateMbps > 0 && a.traffic != nil {
+		if hasConfig {
+			// #712: drive the kernel from the just-materialized config before
+			// the redirect fires — the client reconnects on the new port
+			// immediately and the first segment burst would otherwise run
+			// unshaped. applySessionShaping resolves the deployment baseline
+			// via effectiveRate, so the no-rate-override case (e.g. labels- or
+			// fault_rules-only config) still gets the baseline cap — this
+			// supersedes the plain baseline apply in the else branch.
+			if port, err := strconv.Atoi(assignedInternalPort); err == nil {
+				if steps := v2server.PatternStepsFromSession(sessionData); len(steps) > 0 {
+					v1steps := make([]NftShapeStep, 0, len(steps))
+					for _, s := range steps {
+						v1steps = append(v1steps, NftShapeStep{
+							RateMbps:        s.RateMbps,
+							DurationSeconds: s.DurationSeconds,
+							Enabled:         s.Enabled,
+						})
+					}
+					delayMs := getInt(sessionData, "nftables_delay_ms")
+					lossPct := getFloat(sessionData, "nftables_packet_loss")
+					if perr := a.applyShapePattern(port, v1steps, delayMs, lossPct); perr != nil {
+						log.Printf("config-on-connect pattern apply failed port=%d: %v", port, perr)
+					}
+				} else {
+					a.applySessionShaping(sessionData, port)
+				}
+				if ft := getString(sessionData, "transport_failure_type"); ft != "" && ft != "none" {
+					consec := getInt(sessionData, "transport_consecutive_failures")
+					if consec < 1 {
+						consec = 1
+					}
+					units := getString(sessionData, "transport_consecutive_units")
+					if units == "" {
+						units = "seconds"
+					}
+					freq := getInt(sessionData, "transport_failure_frequency")
+					a.armTransportFaultLoop(port, ft, consec, units, freq)
+				}
+			}
+		} else if a.defaultRateMbps > 0 && a.traffic != nil {
 			if internalPortInt, err := strconv.Atoi(assignedInternalPort); err == nil {
 				effective := a.effectiveRate(0)
 				if err := a.traffic.UpdateRateLimit(internalPortInt, effective); err != nil {
@@ -5519,8 +5584,12 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		host := hostWithoutPort(r.Host)
 		scheme := requestScheme(r)
 		newURL := fmt.Sprintf("%s://%s:%s/%s", scheme, host, assignedExternalPort, escapedPath)
-		if r.URL.RawQuery != "" {
-			newURL = newURL + "?" + r.URL.RawQuery
+		// #712: strip proxy.* config args from the redirect — config is already
+		// materialized on the session; the player follows this clean URL and
+		// resolves all child requests against it, so proxy.* never reach the
+		// session port or the child-request space.
+		if stripped := stripProxyArgs(r.URL.RawQuery); stripped != "" {
+			newURL = newURL + "?" + stripped
 		}
 		log.Printf("Redirecting to new URL with port: %s %s -> %s", newURL, externalPort, assignedExternalPort)
 		http.Redirect(w, r, newURL, http.StatusFound)

--- a/go-proxy/internal/v2/server/configconnect.go
+++ b/go-proxy/internal/v2/server/configconnect.go
@@ -1,0 +1,30 @@
+package server
+
+// Config-on-connect (#712) bridge into the PATCH-API translator.
+//
+// The bootstrap/redirect handler in package main parses `proxy.*` URL args
+// into a JSON-Merge-Patch-shaped map and needs to project it onto the v1
+// SessionData map at session-allocation time. The translation logic already
+// lives here (applyPatchToSession + extractPatternSteps), but is unexported
+// because the PATCH flow is the only in-package caller. These thin wrappers
+// expose exactly what package main needs, so the URL-arg vocabulary rides the
+// same translator as the PATCH API and cannot drift from the API model.
+
+// ApplyConfigPatch projects a merge-patch map onto a v1 SessionData map. Pure
+// translation — it mutates the map in place and drives no kernel state (that
+// is the caller's job, mirroring the PATCH handler's post-write kernel apply).
+//
+// Called with srv=nil: the only branch that takes a *Server is applyShapePatch,
+// which currently ignores it (`_ = srv`); every other branch is srv-free. A
+// translate error (e.g. a fault_rule the v1 surface can't express) is returned
+// verbatim so the caller can reject the bootstrap request.
+func ApplyConfigPatch(sess map[string]any, patch map[string]any) error {
+	return applyPatchToSession(nil, sess, patch)
+}
+
+// PatternStepsFromSession returns the v1 pattern step slice stashed on the
+// session map by a shape.pattern patch, so package main can drive the kernel
+// step-engine after materializing config. Returns nil when no pattern is set.
+func PatternStepsFromSession(sess map[string]any) []ShapePatternStep {
+	return extractPatternSteps(sess)
+}

--- a/tests/server_behavior/sb_config_on_connect_test.go
+++ b/tests/server_behavior/sb_config_on_connect_test.go
@@ -1,0 +1,100 @@
+// sb_config_on_connect_test.go exercises #712 config-on-connect: the
+// bootstrap playback URL carries proxy.* args, the proxy materializes the
+// session config atomically and 302s to a session-bound URL with the args
+// stripped — so config is live before the first segment, with no separate
+// PATCH round-trip. Mirrors newProbe's bootstrap but injects proxy.* args and
+// asserts the resulting session state directly off /api/sessions.
+package server_behavior
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// configProbe runs the bootstrap with a caller-supplied proxy.* query suffix
+// and returns the post-redirect final URL plus the materialized session map.
+func configProbe(t *testing.T, proxyArgs string) (*url.URL, map[string]any, string) {
+	t.Helper()
+	host := env("THROUGHPUT_HOST", defaultHost)
+	apiPort := env("THROUGHPUT_API_PORT", defaultAPIPort)
+	insecure := envBool("THROUGHPUT_INSECURE", defaultInsecure)
+	apiBase := host + ":" + apiPort
+	shaperBase := host + ":" + shaperPortFromUI(apiPort)
+	c := newClient(insecure)
+
+	content, err := discoverContent(c, apiBase)
+	if err != nil {
+		t.Fatalf("discover content: %v", err)
+	}
+	playerID := uuid.New().String()
+
+	masterURL := fmt.Sprintf(
+		"https://%s/go-live/%s/master_6s.m3u8?player_id=%s&%s",
+		shaperBase, url.PathEscape(content), url.QueryEscape(playerID), proxyArgs,
+	)
+	_, finalURL, err := httpGet(c, masterURL)
+	if err != nil {
+		t.Fatalf("master fetch: %v", err)
+	}
+	sess, err := getSessionMap(c, apiBase, playerID)
+	if err != nil {
+		t.Fatalf("get session map: %v", err)
+	}
+	return finalURL, sess, playerID
+}
+
+// TestConfigOnConnect_Shape: a rate cap supplied on the bootstrap URL is live
+// on the session before any PATCH, and the redirect URL is clean of proxy.*.
+func TestConfigOnConnect_Shape(t *testing.T) {
+	finalURL, sess, playerID := configProbe(t,
+		"proxy.shape.rate_mbps=2.5&proxy.shape.delay_ms=120&proxy.labels.test=cfg712")
+
+	// The 302 must land on a session port with no proxy.* leaking through.
+	if strings.Contains(finalURL.RawQuery, "proxy.") {
+		t.Errorf("redirect URL still carries proxy.* args: %s", finalURL.String())
+	}
+	if !strings.Contains(finalURL.RawQuery, "player_id=") {
+		t.Errorf("redirect URL dropped player_id: %s", finalURL.String())
+	}
+
+	// Config is materialized on the session BEFORE any control-plane PATCH.
+	if got := asFloat(sess["nftables_bandwidth_mbps"]); got != 2.5 {
+		t.Errorf("nftables_bandwidth_mbps = %v, want 2.5 (player_id=%s)", sess["nftables_bandwidth_mbps"], playerID)
+	}
+	if got := asFloat(sess["nftables_delay_ms"]); got != 120 {
+		t.Errorf("nftables_delay_ms = %v, want 120", sess["nftables_delay_ms"])
+	}
+}
+
+// TestConfigOnConnect_FaultRule: a corrupted-segment fault rule supplied on the
+// bootstrap URL lands on the v1 segment surface before the first fetch.
+func TestConfigOnConnect_FaultRule(t *testing.T) {
+	_, sess, _ := configProbe(t,
+		"proxy.fault_rules[0].type=corrupted"+
+			"&proxy.fault_rules[0].mode=requests"+
+			"&proxy.fault_rules[0].frequency=3"+
+			"&proxy.fault_rules[0].filter.request_kind[0]=segment")
+
+	if got, _ := sess["segment_failure_type"].(string); got != "corrupted" {
+		t.Errorf("segment_failure_type = %q, want corrupted", got)
+	}
+	if got := asFloat(sess["segment_failure_frequency"]); got != 3 {
+		t.Errorf("segment_failure_frequency = %v, want 3", sess["segment_failure_frequency"])
+	}
+}
+
+// asFloat coerces a JSON-decoded numeric (float64) session field to float64,
+// returning a sentinel that won't match any expected value on type mismatch.
+func asFloat(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

Server-side **config-on-connect** (#712): the bootstrap manifest request can carry the whole session config as `proxy.*` URL args. The base-port handler parses them into a JSON-Merge-Patch-shaped map, materializes the config onto the session atomically, drives the kernel (shape / pattern / transport-fault) **before** the 302 fires, and redirects to the session port with the `proxy.*` args stripped. Config is live from segment 0 with no separate control-plane PATCH round-trip.

## How it works

- **Same translator as PATCH.** The parser feeds the exact `applyPatchToSession` translator the PATCH API uses (exposed via new `ApplyConfigPatch` / `PatternStepsFromSession` wrappers), so the URL-arg vocabulary cannot drift from the API model and inherits exactly the PATCH-supported field set (`shape`, `fault_rules`, `content`, `transfer_timeouts`, `labels`; `filter.variant`/`.codec` rejected as today, with a 400).
- **Map-direct parser** (`parseProxyArgs`): bracket/dotted notation (`proxy.fault_rules[0].filter.request_kind[1]=segment`), a `proxy.cfg=<base64url(JSON)>` base tier overridden per-field by flat args, best-effort value typing.
- **Idempotent / reattach-safe.** Materialization runs only in the new-session branch, so a loop / auto-recovery restart re-hitting the base port reattaches (existing-session 302) without re-applying. Both redirects strip `proxy.*` so they never reach a session port or the child-request space.

## Files

- `go-proxy/internal/v2/server/configconnect.go` — exported translator wrappers
- `go-proxy/cmd/server/configconnect.go` — `parseProxyArgs` + `stripProxyArgs`
- `go-proxy/cmd/server/main.go` — wire into the `handleProxy` new-session branch
- tests: 21 unit tests + a server-behavior integration test
- docs: `DESIGN.md` §5b, `server-behavior.md` §1.11

## Verification

- `go build ./...`, `go vet` clean; `go test ./cmd/server ./internal/v2/server` pass.
- **Deployed to test-dev and verified live:** config materializes before any PATCH, the 302 strips `proxy.*`, and `TestServerFault` / `TestServerDelay` confirm the normal (no-`proxy.*`) bootstrap path didn't regress.

## Follow-up

Harness + iOS wiring to actually retire the `coldStart` / `conservativeStart` choreography is tracked in #714 (curl-configure → inherit-by-`player_id`).

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
