### PR TITLE
fix(go-proxy): clear nftables transport faults on session-start sweep (#716)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4950,6 +4950,24 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			assignedInternalPort = replaceThirdFromLastDigit("30081", allocated)
 			log.Printf("PORT_MAP_DERIVE external=%s internal=%s allocated=%d", assignedExternalPort, assignedInternalPort, allocated)
 		}
+		// Sweep any leftover nftables transport fault (drop/reject) on the
+		// assigned internal port — the symmetric counterpart to the tc
+		// ClearPortShaping above (issue #716). A prior session whose
+		// teardown was skipped (crash / Ctrl-C / timeout before
+		// Session.Release fired) can leave a transport-fault rule armed on
+		// this port; without this sweep it would silently corrupt the new
+		// session via port reuse inside the 5-min idle-reap window.
+		// armTransportFaultLoop(…, "none", …) is the same teardown used on
+		// session DELETE (above): it cancels any still-running fault-loop
+		// goroutine (which would otherwise re-arm the rule after a bare
+		// clear) AND deletes the leftover rule. Idempotent and quiet on a
+		// clean port. Unlike the tc sweep (which keys on port%1000), this
+		// must run *after* the external→internal mapping, because faults
+		// are armed on x_forwarded_port (the internal port) — see the arm
+		// calls keyed on x_forwarded_port elsewhere in this file.
+		if internalPortInt, err := strconv.Atoi(assignedInternalPort); err == nil {
+			a.armTransportFaultLoop(internalPortInt, "none", 1, transportUnitsSeconds, 0)
+		}
 		groupID := extractGroupId(playerID)
 		// Optional play_id from the client. iOS/tvOS/Roku don't mint one
 		// (the v2 read path derives a stable fallback), but the v3 web

--- a/go-proxy/cmd/server/transport_fault_sweep_test.go
+++ b/go-proxy/cmd/server/transport_fault_sweep_test.go
@@ -1,0 +1,120 @@
+package main
+
+// transport_fault_sweep_test.go — issue #716.
+//
+// Regression guard for the session-start kernel sweep being made symmetric:
+// it must clear leftover *nftables transport faults* (drop/reject), not just
+// tc rate/delay/loss. Before the fix, a transport fault left on a port by a
+// prior session whose teardown was skipped (crash / Ctrl-C / timeout) could
+// carry over to the next session that reused the port — `ClearPortShaping`
+// swept tc but nothing swept nftables.
+//
+// The fix wires `armTransportFaultLoop(port, "none", …)` into the new-session
+// allocation branch (cmd/server/main.go, next to `ClearPortShaping`). These
+// tests exercise that exact sweep call against a real nftables environment.
+//
+// Requires CAP_NET_ADMIN + an `nft` binary; SKIPS cleanly where the kernel
+// surface isn't available (dev laptops, unprivileged CI). The companion
+// black-box TestTransportFaults (tests/server_behavior/) can't set up this
+// precondition — it has no way to drop a session record WITHOUT running the
+// clean teardown that already clears the fault, which is the very path this
+// issue is NOT about.
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// transportRulePresent reports whether a transport-fault rule is currently
+// installed on `port`, by looking for the port's entry in the live nftables
+// counter map (present even at zero packets — the rule line still parses).
+func transportRulePresent(port int) bool {
+	_, ok := getTransportFaultRuleCounters()[port]
+	return ok
+}
+
+// newSweepTestApp builds the minimal App the sweep call touches: just the
+// fault-loop registry. With an empty session snapshot, setTransportFaultSessionState
+// matches no session and is a no-op, so none of the heavier App wiring
+// (hubs, traffic manager, session store) is needed.
+func newSweepTestApp() *App {
+	return &App{faultLoops: map[int]context.CancelFunc{}}
+}
+
+// requireNftables arms the fault chain and skips the test if the kernel
+// surface isn't reachable (no nft binary, or no CAP_NET_ADMIN).
+func requireNftables(t *testing.T) {
+	t.Helper()
+	if err := ensureTransportFaultChain(); err != nil {
+		t.Skipf("nftables transport-fault chain unavailable (need nft + CAP_NET_ADMIN): %v", err)
+	}
+}
+
+// TestSessionStartSweepClearsLeftoverTransportFault is the core #716 guard:
+// a leftover drop rule on a port (as a crashed session would leave) is gone
+// after the session-start sweep runs on that port.
+func TestSessionStartSweepClearsLeftoverTransportFault(t *testing.T) {
+	requireNftables(t)
+	const port = 39911 // outside the 30181–30881 session range; won't collide
+	app := newSweepTestApp()
+	t.Cleanup(func() { _ = clearTransportFaultRule(port) })
+
+	// Stand in for the fault a prior (crashed) session left armed on this port.
+	if err := applyTransportFaultRule(port, "drop"); err != nil {
+		t.Fatalf("seed leftover drop rule: %v", err)
+	}
+	if !transportRulePresent(port) {
+		t.Fatalf("precondition failed: seeded drop rule not present on port %d", port)
+	}
+
+	// The exact sweep the fix runs when a fresh session is allocated on a port.
+	app.armTransportFaultLoop(port, "none", 1, transportUnitsSeconds, 0)
+
+	if transportRulePresent(port) {
+		t.Errorf("session-start sweep did NOT clear leftover transport fault on port %d", port)
+	}
+}
+
+// TestSessionStartSweepStopsLeakedFaultLoop covers the subtle half of the
+// fix: when the prior session armed an on/off cadence loop, a still-running
+// loop goroutine would RE-ARM the rule after a bare clear. The sweep uses
+// armTransportFaultLoop("none", …) precisely because it also cancels that
+// goroutine — a plain clearTransportFaultRule would not have been enough.
+func TestSessionStartSweepStopsLeakedFaultLoop(t *testing.T) {
+	requireNftables(t)
+	const port = 39912
+	app := newSweepTestApp()
+	t.Cleanup(func() {
+		app.stopTransportFaultLoop(port)
+		_ = clearTransportFaultRule(port)
+	})
+
+	// A prior session's on/off drop loop (1s on, 1s off) — spawns a goroutine
+	// that keeps re-applying the rule. This is the leak the bare-clear path
+	// would lose to.
+	app.armTransportFaultLoop(port, "drop", 1, transportUnitsSeconds, 1)
+	app.faultMu.Lock()
+	_, running := app.faultLoops[port]
+	app.faultMu.Unlock()
+	if !running {
+		t.Fatalf("precondition failed: fault loop goroutine not registered for port %d", port)
+	}
+
+	// Session-start sweep on the reused port.
+	app.armTransportFaultLoop(port, "none", 1, transportUnitsSeconds, 0)
+
+	app.faultMu.Lock()
+	_, stillRunning := app.faultLoops[port]
+	app.faultMu.Unlock()
+	if stillRunning {
+		t.Errorf("session-start sweep left the prior fault loop goroutine running on port %d", port)
+	}
+
+	// Give the (now-cancelled) goroutine more than one on/off cycle to prove
+	// it can't re-arm the rule behind the sweep's back.
+	time.Sleep(2500 * time.Millisecond)
+	if transportRulePresent(port) {
+		t.Errorf("transport fault re-armed on port %d after sweep — leaked loop goroutine still active", port)
+	}
+}


### PR DESCRIPTION
## Summary

The session-start kernel sweep (the #352 fix, `ClearPortShaping`) clears **tc** rate/delay/loss but never swept **nftables** transport-fault rules. A drop/reject left on a port by a prior session whose teardown was skipped (crash / Ctrl-C / timeout) could carry over to the next session that reused the port — silently corrupting the new run inside the 5-min idle-reap window. Clean teardowns were already covered (session DELETE / `DeletePlayer` clear the fault); this closes the **crash / no-cleanup** path the session-start sweep should backstop.

## Fix

Make the sweep symmetric — call `armTransportFaultLoop(port, "none", …)` in the new-session allocation branch, next to `ClearPortShaping`. Two deliberate choices:

- **Uses `armTransportFaultLoop("none")`, not a bare `clearTransportFaultRule`.** The crash case is the *client* dying while the *proxy* keeps running, so an on/off fault-loop **goroutine** can still be alive and would re-arm the rule right after a bare clear. `armTransportFaultLoop("none")` cancels that goroutine *and* deletes the rule — the same teardown already used on session DELETE.
- **Runs *after* the external→internal port mapping.** Transport faults are armed on the internal `x_forwarded_port` and nftables matches the exact `dport`. tc gets away with running pre-mapping because it keys on `port % 1000`; nftables does not.

## Test

`go-proxy/cmd/server/transport_fault_sweep_test.go` (white-box, package `main`), two cases:
- leftover drop rule is cleared by the sweep;
- a leaked on/off loop goroutine is cancelled *and* can't re-arm the rule over the next cycle.

Both **skip cleanly** without `nft` + CAP_NET_ADMIN (dev laptops, unprivileged CI) and run on the Linux/nftables deploy. The black-box `tests/server_behavior/` suite can't set up this precondition — it has no way to drop a session record *without* the clean teardown that already clears the fault, which is precisely the path this issue is *not* about.

`go build`, `go vet`, and the full `cmd/server` test package pass.

Note: config-on-connect (#712/#714) isn't in this branch, but the new-session allocation branch edited here is the same code path the issue points at, so the fix composes when those merge.

Fixes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
