### PR TITLE
fix(558): add missing labels[] column to network_requests schema

### DIFF
--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -743,6 +743,16 @@ ALTER TABLE infinite_streaming.network_requests
 ALTER TABLE infinite_streaming.network_requests
     ADD COLUMN IF NOT EXISTS attempt_id UInt32 DEFAULT 0 CODEC(ZSTD(1));
 
+-- Issue #558 — per-row labels[] on HAR rows, same Array(LowCardinality)
+-- shape + `<severity>=<event>` vocab as session_events / control_events.
+-- The /api/v2/network_requests read API projects this column (forwarder
+-- #560), but this ALTER was never added — so a SELECT errors on a fresh
+-- ClickHouse host (the network chips are invisible / the endpoint 500s).
+-- Running clusters already ALTER'd it in by hand; IF NOT EXISTS makes this
+-- a no-op there.
+ALTER TABLE infinite_streaming.network_requests
+    ADD COLUMN IF NOT EXISTS labels Array(LowCardinality(String)) DEFAULT [] CODEC(ZSTD(1));
+
 -- session_markers retired in issue #474 Milestone C — replaced by
 -- per-row `labels[]` on session_events / network_requests and by
 -- discrete rows on control_events. The CREATE TABLE block previously


### PR DESCRIPTION
## Summary

Fixes #558: the forwarder's `/api/v2/network_requests` read API projects the `labels[]` column (shipped in #560), but `analytics/clickhouse/init.d/01-schema.sql` never got the matching `ALTER` for `network_requests` — only `classification` / `player_id` / `attempt_id` were added there. On a **fresh ClickHouse host** the `SELECT … labels …` therefore errors with *"Column labels not found"*, so the network chips are invisible / the endpoint 500s. Running clusters (test-dev) already had the column ALTER'd in by hand, so the gap only bites new deployments.

## Fix

One idempotent ALTER, mirroring the shared labels shape on `session_events` / `control_events`:
```sql
ALTER TABLE infinite_streaming.network_requests
    ADD COLUMN IF NOT EXISTS labels Array(LowCardinality(String)) DEFAULT [] CODEC(ZSTD(1));
```
`IF NOT EXISTS` makes it a no-op on hosts that already have it (test-dev), and it runs right after the `CREATE TABLE IF NOT EXISTS` so fresh hosts get the column before the forwarder connects. The schema comment at the `session_markers`-retirement note already says labels[] belongs on `network_requests` — this just adds the DDL that was missed.

## Verification

- **By construction:** every column the forwarder's `network_requests` query selects (`v2_handlers.go`, the inner `SELECT … faulted, fault_type, fault_action, fault_category, labels FROM network_requests`) now exists in the schema; `token` / `dl_arr` come from the derived-labels LEFT JOIN, not the table.
- **Live:** `GET /analytics/api/v2/network_requests?limit=1` on test-dev returns `200` with a `labels` field (validates the query against a labels-having schema).

Closes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
