### PR TITLE
feat: add transient_shock network-shaping pattern (deepening-drop staircase)

### DIFF
--- a/.claude/skills/CONVENTIONS.md
+++ b/.claude/skills/CONVENTIONS.md
@@ -94,6 +94,6 @@ The harness CLI surface has been refreshed:
 - `harness checkpoint list|show` — pre-mutation state captures (formerly `harness snapshot`).
 - `harness undo` — rolls back the last checkpoint.
 - `harness ts <target> --streams events,network,control` — live SSE multiplex (replaces the old per-stream subcommands).
-- `harness shape <target> --pattern pyramid|ramp_up|ramp_down|square_wave|sliders [--step-seconds N]` — pattern shaping (newer than the `--rate / --delay / --loss` static form, which still works for one-shot caps).
+- `harness shape <target> --pattern pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders [--step-seconds N]` — pattern shaping (newer than the `--rate / --delay / --loss` static form, which still works for one-shot caps).
 
 If a skill snippet still references `archive` or `snapshot`, it's stale.

--- a/.claude/standards/server-behavior.md
+++ b/.claude/standards/server-behavior.md
@@ -137,7 +137,7 @@ expected for loss-driven congestion-window collapse.
 **Test:** `tests/server_behavior/server_pattern_test.go::TestServerPattern`
 
 **Methodology:** Install a built-in pattern **template** (square_wave /
-ramp_up / ramp_down / pyramid) via `POST /api/nftables/pattern/{port}`, sweep
+ramp_up / ramp_down / pyramid / transient_shock) via `POST /api/nftables/pattern/{port}`, sweep
 the per-step duration (6s / 12s / 24s), pull segments continuously, and bucket
 each segment by the engine's **live** step (`nftables_pattern_step` /
 `nftables_pattern_rate_runtime_mbps`) — bucketing by the engine's own step

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Linux-only (macOS Docker Desktop can't do this).
 ### Network Shaping (per session)
 
 - **Delay / Loss / Throughput** sliders — steady-state shaping (0–250 ms, 0–10%, 0–50 Mbps). Throughput is disabled when a pattern is active.
-- **Pattern mode**: `sliders` (static), `square_wave`, `ramp_up`, `ramp_down`, `pyramid`. Non-`sliders` modes drive throughput through a scripted sequence of steps.
+- **Pattern mode**: `sliders` (static), `square_wave`, `ramp_up`, `ramp_down`, `pyramid`, `transient_shock` (hold the top cap, dip to each lower rung in turn — deepening — recovering to top between dips). Non-`sliders` modes drive throughput through a scripted sequence of steps.
 - **Step duration**: `6s` / `12s` / `18s` / `24s` — how long each pattern step holds.
 - **Margin**: `Exact` / `+10%` / `+25%` / `+50%` — headroom added on top of each ladder bitrate when picking preset rates.
 - **Throughput presets** are generated from the current manifest's variants (video + audio, deduped). Effective rate:

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1468,12 +1468,15 @@ components:
       properties:
         template:
           type: string
-          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid]
+          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, transient_shock]
           description: |
             Template that drove step-list generation. Stored verbatim
             so the dashboard can repaint the template radios. The kernel
             cycles through `steps` regardless of template; this field is
-            metadata, not a recompute trigger.
+            metadata, not a recompute trigger. `transient_shock` is the
+            deepening-drop staircase (hold top, dip to each lower rung in
+            turn, recover to top between dips) mirroring the transient_shock
+            characterization mode.
         steps:
           type: array
           minItems: 1

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -4,12 +4,15 @@
  * editor. Sits on `shape.pattern` (a typed nested struct of
  * `{ template, steps, margin_pct, default_step_seconds }`).
  *
- * Five template choices:
- *   - sliders     → pattern is null (rate slider drives the kernel)
- *   - square_wave → alternates high / low across variants
- *   - ramp_up     → ascending rates
- *   - ramp_down   → descending rates
- *   - pyramid     → up then down
+ * Template choices:
+ *   - sliders         → pattern is null (rate slider drives the kernel)
+ *   - square_wave     → alternates high / low across variants
+ *   - ramp_up         → ascending rates
+ *   - ramp_down       → descending rates
+ *   - pyramid         → up then down
+ *   - transient_shock → hold top, dip to each lower rung in turn
+ *     (deepening), recovering to top between dips — the deepening-drop
+ *     staircase mirroring the transient_shock characterization mode
  *
  * Picking a non-sliders template GENERATES a step list from the
  * manifest's variants. The user can then edit each row (rate /
@@ -24,15 +27,16 @@ import { usePlayer } from '@/composables/usePlayer';
 import { useManifestVariants } from '@/composables/useManifestVariants';
 import type { Pattern } from '@/repo/v2-repo';
 
-const TEMPLATES = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid'] as const;
+const TEMPLATES = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid', 'transient_shock'] as const;
 type Template = (typeof TEMPLATES)[number];
 
 const TEMPLATE_LABELS: Record<Template, string> = {
-  sliders:     '🎚 Sliders',
-  square_wave: '▁▔ Square wave',
-  ramp_up:     '↗ Ramp up',
-  ramp_down:   '↘ Ramp down',
-  pyramid:     '⛰ Pyramid',
+  sliders:         '🎚 Sliders',
+  square_wave:     '▁▔ Square wave',
+  ramp_up:         '↗ Ramp up',
+  ramp_down:       '↘ Ramp down',
+  pyramid:         '⛰ Pyramid',
+  transient_shock: '⤓ Transient shock',
 };
 
 function marginLabel(m: number): string {
@@ -213,6 +217,15 @@ function buildSteps(t: Template, marginPct: number, stepSecs: number): Pattern['
     seq = asc.slice().reverse();
   } else if (t === 'pyramid') {
     seq = asc.concat(asc.slice(0, -1).reverse()); // up then down, no apex dupe
+  } else if (t === 'transient_shock') {
+    // Deepening-dip staircase: hold top, dip to each lower rung
+    // shallowest-first down to the bottom, recovering to top between dips.
+    // seq = top, r[n-2], top, r[n-3], …, top, r[0], top.
+    const top = asc[asc.length - 1];
+    seq = [top];
+    for (let i = asc.length - 2; i >= 0; i--) {
+      seq.push(asc[i], top);
+    }
   } else {
     seq = [];
   }

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1824,10 +1824,13 @@ export interface components {
              * @description Template that drove step-list generation. Stored verbatim
              *     so the dashboard can repaint the template radios. The kernel
              *     cycles through `steps` regardless of template; this field is
-             *     metadata, not a recompute trigger.
+             *     metadata, not a recompute trigger. `transient_shock` is the
+             *     deepening-drop staircase (hold top, dip to each lower rung in
+             *     turn, recover to top between dips) mirroring the transient_shock
+             *     characterization mode.
              * @enum {string}
              */
-            template?: "sliders" | "square" | "square_wave" | "ramp_up" | "ramp_down" | "pyramid";
+            template?: "sliders" | "square" | "square_wave" | "ramp_up" | "ramp_down" | "pyramid" | "transient_shock";
             steps: components["schemas"]["PatternStep"][];
             /**
              * @description Default per-step duration the dashboard chose when generating the step list.

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1125,6 +1125,20 @@ components:
             Effective labels = player.labels merged with any play-specific
             additions/overrides. Snapshotted onto archive rows at insert.
         started_at:       { type: string, format: date-time }
+        start_time:
+          type: string
+          format: date-time
+          nullable: true
+          description: |
+            **Client-supplied** play start (ISO-8601 UTC), minted by the
+            player at the same boundary as `id` (play_id) and re-sent as a
+            `?start_time=` query param on every request. Unlike
+            `started_at` — which the proxy derives from the SESSION's first
+            request and therefore does NOT move when the play_id rotates —
+            this is play-scoped: a content switch yields a new play_id AND
+            a new start_time. Prefer this for "when did THIS play begin";
+            `started_at` is the connection/session start. Null for
+            non-instrumented clients (web, Roku) that don't send it.
         ended_at:         { type: string, format: date-time, nullable: true }
         manifest: { $ref: '#/components/schemas/Manifest' }
         fault_rules:
@@ -1454,12 +1468,15 @@ components:
       properties:
         template:
           type: string
-          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid]
+          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, transient_shock]
           description: |
             Template that drove step-list generation. Stored verbatim
             so the dashboard can repaint the template radios. The kernel
             cycles through `steps` regardless of template; this field is
-            metadata, not a recompute trigger.
+            metadata, not a recompute trigger. `transient_shock` is the
+            deepening-drop staircase (hold top, dip to each lower rung in
+            turn, recover to top between dips) mirroring the transient_shock
+            characterization mode.
         steps:
           type: array
           minItems: 1
@@ -1511,11 +1528,17 @@ components:
       properties:
         strip_codecs:             { type: boolean, default: false, description: 'Remove CODECS attribute from EXT-X-STREAM-INF lines.' }
         strip_average_bandwidth:  { type: boolean, default: false, description: 'Remove AVERAGE-BANDWIDTH attribute.' }
+        strip_resolution:         { type: boolean, default: false, description: 'Remove RESOLUTION attribute from EXT-X-STREAM-INF lines. Apple HLS validator rejects this; AVPlayer plays but variant.video.size becomes empty (issue #486).' }
         overstate_bandwidth:      { type: boolean, default: false, description: 'Inflate BANDWIDTH attribute by 10%.' }
         allowed_variants:
           type: array
           items: { type: string }
           description: 'When non-empty, only the listed variant URIs are kept in the master playlist.'
+        variant_order:
+          type: string
+          enum: [default, ascending, descending, first_4mbps]
+          default: default
+          description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
           enum: [0, 6, 18, 24]
@@ -1555,8 +1578,11 @@ components:
       properties:
         video_resolution:    { type: string,  nullable: true }
         display_resolution:  { type: string,  nullable: true, description: 'Player-reported window/display resolution (separate from the active video resolution).' }
+        fetching_resolution: { type: string,  nullable: true, description: 'WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event.' }
         video_bitrate_mbps:  { type: number, format: float, nullable: true }
-        video_quality_pct:   { type: number, format: float, nullable: true, description: 'video_bitrate_mbps as a percentage of the top variant in the active manifest' }
+        video_quality_pct:   { type: number, format: float, nullable: true, description: 'video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)' }
+        video_quality_60s_pct: { type: number, format: float, nullable: true, description: 'Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.' }
+        video_quality_avg_pct: { type: number, format: float, nullable: true, description: 'Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().' }
         avg_network_bitrate_mbps: { type: number, format: float, nullable: true, description: 'Player-computed avgNetworkBitrate.' }
         network_bitrate_mbps:     { type: number, format: float, nullable: true, description: 'Player-computed instantaneous networkBitrate.' }
         buffer_depth_s:      { type: number, format: float, nullable: true }
@@ -1577,16 +1603,70 @@ components:
         loop_count_player:   { type: integer, nullable: true, description: 'How many times the player has reported looping the content. Player-reported, may be 0 on platforms that do not count.' }
         loop_count_delta: { type: integer, nullable: true, description: 'Server-derived increment from the previous report.' }
         profile_shift_count: { type: integer, nullable: true, description: 'Number of ABR rendition shifts the player has reported.' }
-        last_event:          { type: string,  nullable: true, description: 'Most recent player-reported lifecycle event (playing, buffering_start, stall_start, etc.). The play-terminal event is `play_end` (issue #554); rows minted before the client rename carry the legacy `session_end` and are still classified. NOTE: distinct from the proxy session-lifecycle `session_end` control_event, which is unchanged.' }
+        last_event:          { type: string,  nullable: true, description: 'Most recent player-reported lifecycle event (playing, buffering_start, stall_start, etc.).' }
         trigger_type:        { type: string,  nullable: true, description: 'What triggered the most recent metrics tick (timer, event, etc.).' }
         state:               { type: string,  nullable: true, description: 'Player state machine label (idle, playing, paused, buffering, ended, error).' }
+        state_from:          { type: string,  nullable: true, description: 'On state_change events: the player_state before the transition. Empty / null on heartbeat rows.' }
+        state_to:            { type: string,  nullable: true, description: 'On state_change events: the player_state after the transition. Empty / null on heartbeat rows.' }
         waiting_reason:      { type: string,  nullable: true, description: 'AVFoundation reasonForWaitingToPlay (or platform equivalent) — split labels within `state` like `toMinimizeStalls` vs `evaluatingBufferingRate`.' }
+        content_name:        { type: string,  nullable: true, description: 'Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue.' }
+        user_marked_at:      { type: string,  nullable: true, description: 'On user_marked (911) events: wall-clock ISO-8601 instant the operator pressed the button. Empty on other rows.' }
+        frames_rate: { type: number, format: float, nullable: true, description: 'Active variant''s nominal frame rate (Hz). Sticky after first observation in the format-change event.' }
         playhead_wallclock_ms: { type: integer, nullable: true, description: 'Player-encoded PDT (milliseconds since Unix epoch) for the current playhead. Used by the chart engine to compute live offset against the server clock.' }
         browser_family:      { type: string,  nullable: true, description: 'Web-player browser family (e.g. `safari`, `chrome`). Drives native-rendition inference for HLS-on-Safari where bitrate is not directly reported.' }
         playback_engine:     { type: string,  nullable: true, description: 'Web-player engine (`native` for AVPlayer, `mse` for Media Source Extensions). Pairs with `browser_family` for the rendition inference.' }
         error:               { type: string,  nullable: true, description: 'Most recent player-reported error string.' }
         source:              { type: string,  nullable: true, description: 'Identifier for the metrics source (e.g. avplayer-ios, exoplayer-android).' }
         event_time:          { type: string,  format: date-time, nullable: true, description: 'Player-supplied wallclock for the most recent metrics tick.' }
+
+        # ── #550 Phase 1: state-residency accumulators + per-row deltas ──
+        # Cumulative-on-the-wire UInt32 milliseconds since play start.
+        # Forwarder computes the paired _delta fields server-side from
+        # a per-play state cache; the _delta fields are NOT sent by the
+        # client over the wire — they're populated only on the
+        # ClickHouse row. See #550 epic and `analytics/go-forwarder/
+        # residency_cache.go`.
+        playing_time_ms:        { type: integer, nullable: true, description: '#550 Phase 1: cumulative time in `playing` state (ms), since play start.' }
+        playing_count:          { type: integer, nullable: true, description: '#550 Phase 1: entries into `playing` state since play start.' }
+        pausing_time_ms:        { type: integer, nullable: true, description: '#550 Phase 1: cumulative time in `paused` state (ms).' }
+        pausing_count:          { type: integer, nullable: true, description: '#550 Phase 1: entries into `paused` state.' }
+        buffering_time_ms:      { type: integer, nullable: true, description: '#550 Phase 1: cumulative buffering time (ms).' }
+        buffering_count:        { type: integer, nullable: true, description: '#550 Phase 1: entries into `buffering` state.' }
+        stalling_time_ms:       { type: integer, nullable: true, description: '#550 Phase 1: cumulative stalling time (ms). Single canonical pair replacing legacy stall_count/stall_time_s during soft cutover.' }
+        stalling_count:         { type: integer, nullable: true, description: '#550 Phase 1: entries into `stalled` state.' }
+        idling_time_ms:         { type: integer, nullable: true, description: '#550 Phase 1: cumulative idle time (ms).' }
+        idling_count:           { type: integer, nullable: true, description: '#550 Phase 1: entries into `idle` state.' }
+        seeking_time_ms:        { type: integer, nullable: true, description: '#550 Phase 1: cumulative time spent in seek-induced refill (TimeJumped → next .playing). Conviva CIRR/CIRT pattern: `connection_buffering = buffering_time_ms - seeking_time_ms`.' }
+        seeking_count:          { type: integer, nullable: true, description: '#550 Phase 1: AVPlayerItemTimeJumped events since play start.' }
+        trickplaying_time_ms:   { type: integer, nullable: true, description: '#550 Phase 1: cumulative time at non-1× playback rate (FF / RW).' }
+        time_per_variant_s:     { type: string,  nullable: true, description: 'JSON-string-encoded map of variant-label → cumulative seconds spent at that variant (e.g. `{"2160p@29857kbps":65.28}`). Preserved across retry()-style restarts.' }
+        trickplaying_count:     { type: integer, nullable: true, description: '#550 Phase 1: entries into trickplay (rate ∉ {0, ~1}).' }
+        stall_duration_ms:      { type: integer, nullable: true, description: '#550 Phase 1: duration of the MOST RECENT stall event (sticky on subsequent heartbeats).' }
+        buffering_duration_ms:  { type: integer, nullable: true, description: '#550 Phase 1: duration of the MOST RECENT buffer event (sticky).' }
+        stall_stuck:            { type: boolean, nullable: true, description: '#550 Phase 1 ext: orthogonal "this stall won''t auto-recover" flag. True from the moment AVPlayer transitions stalled → .paused (give-up) until next .playing transition. State stays "stalled" for residency continuity; dashboards key on this flag to surface operator-actionable stalls.' }
+        video_first_frame_time_ms: { type: integer, nullable: true, description: '#550 Phase 1: TTFF in ms. Conviva/Mux/Bitmovin canonical units. Replaces legacy video_first_frame_time_s.' }
+        video_start_time_ms:    { type: integer, nullable: true, description: '#550 Phase 1: alternate startup-time measurement in ms.' }
+
+        # ── #550 Phase 2: outcome status + structured error fields ──
+        playback_status:        { type: string,  nullable: true, description: '#550 Phase 2: terminal outcome enum: `in_progress` / `completed` / `user_stopped` / `start_failure` (VSF) / `abandoned_start` (EBVS) / `mid_stream_failure` (MSF). Mid-session rows = `in_progress`.' }
+        playback_reason:        { type: string,  nullable: true, description: '#550 Phase 2: controlled vocab per status. During in_progress, mirrors `player_state`; on terminal rows, forwarder classifier derives from error_code+domain+kind.' }
+        error_code:             { type: integer, nullable: true, description: '#550 Phase 2: NSError.code / HTTP status / system errno. Populated on `error` events AND terminal failure rows. 0 = no error.' }
+        error_domain:           { type: string,  nullable: true, description: '#550 Phase 2: NSError.domain — `CoreMediaErrorDomain` / `NSURLErrorDomain` / `AVFoundationErrorDomain` / `http` etc.' }
+        error_details:          { type: string,  nullable: true, description: '#550 Phase 2: JSON blob with URL, underlying error chain, native message.' }
+        terminal_error_code:    { type: integer, nullable: true, description: '#550 Phase 2: error code populated ONLY on terminal failure rows. Querying `WHERE terminal_error_code != 0` is SQL-safe — never returns transient codes.' }
+        terminal_error_domain:  { type: string,  nullable: true, description: '#550 Phase 2: error domain on terminal failure rows.' }
+        terminal_error_details: { type: string,  nullable: true, description: '#550 Phase 2: error details JSON on terminal failure rows.' }
+        error_count:            { type: integer, nullable: true, description: '#550 Phase 2: cumulative observation counter. Ticks on every `error` event (transient or terminal). Forwarder computes per-row delta server-side.' }
+
+        # ── #550 Phase 4: device / platform / version taxonomy ──
+        os_version_major:       { type: integer, nullable: true, description: '#550 Phase 4: OS major version (e.g. 26 for iOS 26.0.1).' }
+        os_version_minor:       { type: integer, nullable: true, description: '#550 Phase 4: OS minor version.' }
+        app_version:            { type: string,  nullable: true, description: '#550 Phase 4: app marketing version from Bundle CFBundleShortVersionString.' }
+        device_class:           { type: string,  nullable: true, description: '#550 Phase 4: form-factor enum: `phone` / `tablet` / `tv` / `desktop` / `unknown`.' }
+        device_model:           { type: string,  nullable: true, description: '#550 Phase 4: hardware model identifier (e.g. iPhone15,3) via sysctl hw.machine.' }
+        player_tech:            { type: string,  nullable: true, description: '#550 Phase 4: playback engine: `AVPlayer` / `hls.js` / `shaka` / `native-roku` / `vlc` / `ffmpeg`.' }
+        player_tech_version:    { type: string,  nullable: true, description: 'Playback engine version, paired with player_tech. Android: Media3/ExoPlayer library version (app-bundled, independent of the OS). iOS: OS version (AVPlayer is part of the OS).' }
+        device_resolution:      { type: string,  nullable: true, description: 'Physical-pixel resolution of the device''s current orientation, formatted `"WxH"` to match video_resolution / display_resolution. Swaps integers on iPad rotation; static on Apple TV / orientation-locked clients. Supersedes screen_width_px / screen_height_px / screen_density (dropped 2026-05-30).' }
 
     ServerMetrics:
       description: |
@@ -1607,6 +1687,7 @@ components:
         rtt_var_ms:           { type: number, format: float, nullable: true, description: 'RTT variance.' }
         rto_ms:               { type: number, format: float, nullable: true, description: 'Current TCP retransmit timeout.' }
         path_ping_rtt_ms:     { type: number, format: float, nullable: true, description: 'ICMP path ping RTT measured server-side.' }
+        rtt_avmetrics_ms:     { type: number, format: float, nullable: true, description: 'Median TTFB (responseStart - requestEnd) from iOS 18 AVMetrics MediaResourceRequest events. Stream-level latency from URLSession pipeline; not a wire RTT on HTTP/2 keep-alive. Issue #486.' }
         rtt_stale:            { type: boolean, nullable: true, description: 'true when no fresh TCP_INFO sample is available (e.g. session idle).' }
         bytes_in_total:       { type: integer, nullable: true, description: 'Lifetime ingress bytes from the player to the proxy.' }
         bytes_out_total:      { type: integer, nullable: true, description: 'Lifetime egress bytes from the proxy to the player.' }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4440,7 +4440,7 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch payload.TemplateMode {
-	case "sliders", "square_wave", "ramp_up", "ramp_down", "pyramid":
+	case "sliders", "square_wave", "ramp_up", "ramp_down", "pyramid", "transient_shock":
 	default:
 		payload.TemplateMode = "sliders"
 	}

--- a/go-proxy/pkg/ladder/ladder_test.go
+++ b/go-proxy/pkg/ladder/ladder_test.go
@@ -163,6 +163,30 @@ func TestBuildPattern(t *testing.T) {
 	if len(sq) != 2 || sq[0].RateMbps != 0.833 || sq[1].RateMbps != 31.064 {
 		t.Errorf("square_wave = %v, want [0.833, 31.064]", sq)
 	}
+	// transient_shock: top + (n-1) deepening dips, each recovering to top →
+	// length 2n-1. Even indices are the top baseline; odd indices are the
+	// dips, deepening from the second-highest rung down to the bottom.
+	ts := BuildPattern(TransientShock, rungs, 12)
+	if len(ts) != 2*n-1 {
+		t.Errorf("transient_shock len %d, want %d (top + n-1 recover-to-top dips)", len(ts), 2*n-1)
+	}
+	top := down[0].RateMbps // ramp_down starts at the highest cap
+	for i := 0; i < len(ts); i += 2 {
+		if ts[i].RateMbps != top {
+			t.Errorf("transient_shock[%d] = %.3f, want top %.3f (recover-to-top between dips)", i, ts[i].RateMbps, top)
+		}
+	}
+	for i := 3; i < len(ts); i += 2 {
+		if ts[i].RateMbps >= ts[i-2].RateMbps {
+			t.Errorf("transient_shock dips not deepening at %d: %.3f then %.3f", i, ts[i-2].RateMbps, ts[i].RateMbps)
+		}
+	}
+	if ts[1].RateMbps != down[1].RateMbps {
+		t.Errorf("transient_shock first dip = %.3f, want second-highest rung %.3f", ts[1].RateMbps, down[1].RateMbps)
+	}
+	if ts[len(ts)-2].RateMbps != sq[0].RateMbps {
+		t.Errorf("transient_shock final dip = %.3f, want bottom %.3f", ts[len(ts)-2].RateMbps, sq[0].RateMbps)
+	}
 	if BuildPattern("sliders", rungs, 12) != nil {
 		t.Errorf("unknown template should return nil")
 	}

--- a/go-proxy/pkg/ladder/pattern.go
+++ b/go-proxy/pkg/ladder/pattern.go
@@ -6,10 +6,11 @@ import "sort"
 // PatternTemplate enum in go-proxy's v2 OpenAPI surface and the
 // dashboard's NetworkShapingPattern.vue.
 const (
-	RampUp     = "ramp_up"
-	RampDown   = "ramp_down"
-	Pyramid    = "pyramid"
-	SquareWave = "square_wave"
+	RampUp         = "ramp_up"
+	RampDown       = "ramp_down"
+	Pyramid        = "pyramid"
+	SquareWave     = "square_wave"
+	TransientShock = "transient_shock"
 )
 
 // Step is one entry of a shape pattern: hold RateMbps for DurationSeconds.
@@ -20,10 +21,14 @@ type Step struct {
 
 // BuildPattern orders a limit ladder into a shape-pattern step list:
 //
-//   - ramp_up     ascending caps (lowest → highest)
-//   - ramp_down   descending caps (highest → lowest)
-//   - pyramid     ascending then descending, without duplicating the apex
-//   - square_wave just the lowest and highest cap, alternating
+//   - ramp_up         ascending caps (lowest → highest)
+//   - ramp_down       descending caps (highest → lowest)
+//   - pyramid         ascending then descending, without duplicating the apex
+//   - square_wave     just the lowest and highest cap, alternating
+//   - transient_shock hold the top cap, then dip to each lower rung in turn
+//     (deepening), returning to the top between dips so the buffer refills —
+//     the deepening-drop staircase the transient_shock characterization mode
+//     uses to find where the player breaks.
 //
 // rungs may arrive in any order (StandardLadder returns them descending);
 // the ascending sequence is derived here. Every step holds for stepSecs.
@@ -49,6 +54,16 @@ func BuildPattern(template string, rungs []Rung, stepSecs int) []Step {
 		seq = append(append([]float64{}, asc...), down...)
 	case SquareWave:
 		seq = []float64{asc[0], asc[len(asc)-1]}
+	case TransientShock:
+		// Deepening-dip staircase: hold the top cap, dip to each lower rung
+		// shallowest-first down to the bottom, recovering to the top between
+		// dips. seq = top, r[n-2], top, r[n-3], …, top, r[0], top. With a
+		// single rung there are no dips, so it's just that one cap.
+		top := asc[len(asc)-1]
+		seq = append(seq, top)
+		for i := len(asc) - 2; i >= 0; i-- {
+			seq = append(seq, asc[i], top)
+		}
 	default:
 		return nil
 	}

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -237,12 +237,13 @@ func (e PatternMarginPct) Valid() bool {
 
 // Defines values for PatternTemplate.
 const (
-	Pyramid    PatternTemplate = "pyramid"
-	RampDown   PatternTemplate = "ramp_down"
-	RampUp     PatternTemplate = "ramp_up"
-	Sliders    PatternTemplate = "sliders"
-	Square     PatternTemplate = "square"
-	SquareWave PatternTemplate = "square_wave"
+	Pyramid        PatternTemplate = "pyramid"
+	RampDown       PatternTemplate = "ramp_down"
+	RampUp         PatternTemplate = "ramp_up"
+	Sliders        PatternTemplate = "sliders"
+	Square         PatternTemplate = "square"
+	SquareWave     PatternTemplate = "square_wave"
+	TransientShock PatternTemplate = "transient_shock"
 )
 
 // Valid indicates whether the value is a known member of the PatternTemplate enum.
@@ -259,6 +260,8 @@ func (e PatternTemplate) Valid() bool {
 	case Square:
 		return true
 	case SquareWave:
+		return true
+	case TransientShock:
 		return true
 	default:
 		return false

--- a/tests/server_behavior/server_pattern_test.go
+++ b/tests/server_behavior/server_pattern_test.go
@@ -114,6 +114,17 @@ func patternTemplateSeq(ratesAsc []float64, template string) []float64 {
 			out = append(out, ratesAsc[i])
 		}
 		return out
+	case "transient_shock":
+		// Deepening-dip staircase: top, r[n-2], top, …, top, r[0], top.
+		if len(ratesAsc) == 0 {
+			return nil
+		}
+		top := ratesAsc[len(ratesAsc)-1]
+		out := []float64{top}
+		for i := len(ratesAsc) - 2; i >= 0; i-- {
+			out = append(out, ratesAsc[i], top)
+		}
+		return out
 	default:
 		return nil
 	}

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -21,7 +21,7 @@ Slider mode (any subset; omitted fields are not modified):
   --loss FLOAT       packet loss %% (e.g. 0.5, range 0–100)
 
 Pattern mode (generates a step list from the player's current variants):
-  --pattern NAME     pyramid | ramp_up | ramp_down | square_wave | sliders
+  --pattern NAME     pyramid | ramp_up | ramp_down | square_wave | transient_shock | sliders
   --step-seconds N   per-step duration: 6 | 12 | 18 | 24 (default 12)
   --margin PCT       flat headroom above each variant rate: 0|5|10|25|50
                      (default 5; covers TCP/IP+TLS+HTTP framing; 0 is a
@@ -51,11 +51,13 @@ Examples:
   harness shape ipad --clear
 
 Pattern semantics:
-  pyramid       ascending variant rates, then descending (without apex dupe)
-  ramp_up       ascending rates, single sweep
-  ramp_down     descending rates, single sweep
-  square_wave   alternate lowest + highest variant
-  sliders       empty step list (kernel falls back to --rate)
+  pyramid          ascending variant rates, then descending (without apex dupe)
+  ramp_up          ascending rates, single sweep
+  ramp_down        descending rates, single sweep
+  square_wave      alternate lowest + highest variant
+  transient_shock  hold top, dip to each lower rung in turn (deepening),
+                   recovering to top between dips — the deepening-drop staircase
+  sliders          empty step list (kernel falls back to --rate)
 
 Every mutation is checkpointed to ~/.claude/state/harness/<repo>/.
 'harness undo' replays the prior shape verbatim.
@@ -69,7 +71,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	rate := fs.Float64("rate", -1, "rate cap Mbps")
 	delay := fs.Float64("delay", -1, "delay ms")
 	loss := fs.Float64("loss", -1, "loss %")
-	pattern := fs.String("pattern", "", "pattern template (pyramid|ramp_up|ramp_down|square_wave|sliders)")
+	pattern := fs.String("pattern", "", "pattern template (pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders)")
 	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
@@ -394,10 +396,12 @@ func parseTemplate(s string) (proxy.PatternTemplate, error) {
 		return proxy.RampDown, nil
 	case "square_wave":
 		return proxy.SquareWave, nil
+	case "transient_shock":
+		return proxy.TransientShock, nil
 	case "sliders":
 		return proxy.Sliders, nil
 	}
-	return "", fmt.Errorf("invalid --pattern %q: pyramid|ramp_up|ramp_down|square_wave|sliders", s)
+	return "", fmt.Errorf("invalid --pattern %q: pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders", s)
 }
 
 func parseStepSeconds(n int) (proxy.PatternDefaultStepSeconds, error) {

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -238,12 +238,13 @@ func (e PatternMarginPct) Valid() bool {
 
 // Defines values for PatternTemplate.
 const (
-	Pyramid    PatternTemplate = "pyramid"
-	RampDown   PatternTemplate = "ramp_down"
-	RampUp     PatternTemplate = "ramp_up"
-	Sliders    PatternTemplate = "sliders"
-	Square     PatternTemplate = "square"
-	SquareWave PatternTemplate = "square_wave"
+	Pyramid        PatternTemplate = "pyramid"
+	RampDown       PatternTemplate = "ramp_down"
+	RampUp         PatternTemplate = "ramp_up"
+	Sliders        PatternTemplate = "sliders"
+	Square         PatternTemplate = "square"
+	SquareWave     PatternTemplate = "square_wave"
+	TransientShock PatternTemplate = "transient_shock"
 )
 
 // Valid indicates whether the value is a known member of the PatternTemplate enum.
@@ -260,6 +261,8 @@ func (e PatternTemplate) Valid() bool {
 	case Square:
 		return true
 	case SquareWave:
+		return true
+	case TransientShock:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## What
Adds a new **`transient_shock`** network-shaping pattern template. Requested: "make the square_wave pattern work the same as the transient shock test, using more than 2 bitrates."

`square_wave` only used 2 bitrates (lowest + highest, alternating). `transient_shock` mirrors the **transient_shock characterization mode** over the full variant ladder: hold the top cap, then dip to each lower rung in turn — shallowest first, deepening to the bottom — **recovering to the top between dips** so the buffer refills. It finds *where* the player breaks under escalating sudden drops, not just the worst case.

For an N-rung ladder: `top, r[n-2], top, r[n-3], …, top, r[0], top` (length `2N-1`).

```
top ▔▔▔╮  ╭▔▔╮  ╭▔▔╮  ╭▔▔ top
        │  │    │  │    │  │
 r3 ────╰──╯    │  │    │  │
 r2 ───────────╰──╯    │  │
 bot ──────────────────╰──╯
```

`square_wave` is **unchanged** (stays the clean 2-level wave) — `transient_shock` is additive.

## Decisions (confirmed with the requester)
- **Shape:** deepening-dip staircase over **every** rung, recover-to-top between dips (not quartiles-only, not a no-recovery wave).
- **Naming:** a **new** template (kept `square_wave` intact) rather than redefining `square_wave`.

## Layers touched (the pattern-template vocabulary, end to end)
- `go-proxy/pkg/ladder/pattern.go` — core `BuildPattern` staircase + const (+ `ladder_test.go` assertions)
- `api/openapi/v2/proxy.yaml` — enum + description; `content/dashboard/api-docs/proxy-v2.yaml` mirror synced
- `go-proxy/pkg/v2oapigen` + `tools/harness-cli/internal/v2gen/proxy` `.gen.go` — `PatternTemplate` enum member (see note)
- `go-proxy/cmd/server/main.go` — accept `transient_shock` in template validation
- `tools/harness-cli/cmd/harness/shape.go` — `--pattern` parse + help
- `content/dashboard-v3/.../NetworkShapingPattern.vue` — template radio, label (`⤓ Transient shock`), `buildSteps` shape
- `content/dashboard-v3/src/types/v2.ts` — generated template union (hand-synced; no `node_modules` in worktree)
- `tests/server_behavior/server_pattern_test.go` — per-template verification arm
- `README.md`, `.claude/standards/server-behavior.md`, `.claude/skills/CONVENTIONS.md` — docs

## Note on generated files
The committed oapi-codegen `*.gen.go` files are **stale** vs the pinned toolchain — a clean `make gen-harness-cli-client` also renames unrelated `ContentManipulationVariantOrder*` constants and re-syncs descriptions. To keep this PR focused on the feature, I hand-added the `PatternTemplate` enum member surgically (gofmt-clean) instead of committing that unrelated regen drift. **Worth a separate gen-file refresh PR.**

## Verification
- `go build` (proxy + harness) green; `go vet` clean; `gofmt` clean on changed regions (pre-existing `main.go` drift left untouched).
- `ladder` `TestBuildPattern` extended: asserts length `2N-1`, top baseline on every even index, strictly deepening dips, first dip = second-highest rung, final dip = bottom.
- Harness CLI help lists the new template and `--pattern transient_shock` parses.
- Vue/TS changes follow the existing `buildSteps` pattern (no JS build available in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
