### PR TITLE
fix(614): clamp ExoPlayer position/buffer/rate gauges to 0 (match iOS) to stop negative emissions

### DIFF
--- a/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
+++ b/android/ExoPlayerTestApp/app/src/main/java/com/jeoliver/exoplayertest/PlayerViewModel.kt
@@ -169,6 +169,13 @@ class PlayerViewModel : ViewModel() {
             bandwidthEstimate = appContext?.let { androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.getSingletonInstance(it).bitrateEstimate } ?: 0L
         }
 
+        // ExoPlayer reports C.TIME_UNSET (Long.MIN_VALUE) / -1 for position &
+        // buffered before the timeline is ready, and bufferedPosition can dip
+        // below currentPosition during a seek/discontinuity. iOS reports
+        // 0 = "not measured yet"; match that here so gauges never go negative (#614).
+        val safePositionMs = positionMs.coerceAtLeast(0L)
+        val safeBufferedMs = bufferedMs.coerceAtLeast(0L)
+
         val state = when (playbackState) {
             Player.STATE_IDLE -> "idle"
             Player.STATE_BUFFERING -> "buffering"
@@ -184,10 +191,10 @@ class PlayerViewModel : ViewModel() {
             "player_metrics_trigger_type" to eventType,
             "player_metrics_event_time" to reporter.nowISO(),
             "player_metrics_state" to state,
-            "player_metrics_position_s" to round3(positionMs / 1000.0),
-            "player_metrics_playback_rate" to speed.toDouble(),
-            "player_metrics_buffer_depth_s" to round3((bufferedMs - positionMs) / 1000.0),
-            "player_metrics_buffer_end_s" to round3(bufferedMs / 1000.0),
+            "player_metrics_position_s" to round3(safePositionMs / 1000.0),
+            "player_metrics_playback_rate" to speed.toDouble().coerceAtLeast(0.0),
+            "player_metrics_buffer_depth_s" to round3(((safeBufferedMs - safePositionMs).coerceAtLeast(0L)) / 1000.0),
+            "player_metrics_buffer_end_s" to round3(safeBufferedMs / 1000.0),
             "player_metrics_video_bitrate_mbps" to videoFormat?.bitrate?.let { round3(it / 1_000_000.0) },
             "player_metrics_video_resolution" to videoFormat?.let { "${it.width}x${it.height}" },
             // ExoPlayer's DefaultBandwidthMeter.bitrateEstimate is an averaged


### PR DESCRIPTION
## #614 — Android ExoPlayer emits negative gauges

### Symptom
121 archived `session_events` rows carried negative `buffer_depth_s`, `position_s`, or
`playback_rate`, **100% confined to the ExoPlayer/TV group** (`2.0.0 | os 14 | tv | ExoPlayer`)
— zero on any AVPlayer group. Surfaced by the #607 aberration crawl (`nonnegative-gauges` rule).

### Cause
ExoPlayer returns sentinel values that the Android metrics mapper forwarded raw:
- `currentPosition` / `bufferedPosition` are `C.TIME_UNSET` (`Long.MIN_VALUE`) or `-1` before
  the timeline is ready → negative `position_s` / `buffer_end_s`.
- `bufferedPosition` can briefly dip **below** `currentPosition` during a seek/discontinuity →
  negative `buffer_depth_s` (the difference).

iOS already treats `0` as "not measured yet"; Android did not match.

### Fix
Clamp at the source in `PlayerViewModel.kt`, before building the metrics map:
- `position` / `buffered` → `coerceAtLeast(0L)` (catches both `TIME_UNSET` and `-1`).
- `buffer_depth` → its own `coerceAtLeast(0L)` on the **difference** (the seek/discontinuity case).
- `playback_rate` → `coerceAtLeast(0.0)` defensively (listed on the issue; normally ≥ 0).

Scoped to one file, four metric fields — no reporter refactor. Brings Android gauges in line with
the iOS "0 = not measured yet" convention.

### Verification status
- **Build / device runtime proof are currently BLOCKED by a pre-existing, unrelated break** —
  `PlayerViewModel.kt:19` references `ServerEnvironment.UBUNTU`, an enum value removed in `bd7ccdcc`
  (now `LOCAL`/`LOCAL_DEV`/`LOCAL_TEST`). This fails `compileDebugKotlin` on `dev` today, independent
  of this change. Tracked separately — not fixed here to keep this PR scoped to #614.
- Once the build is restored, install on the Google TV / ExoPlayer device and drive startup + a seek
  to confirm no negative gauges are emitted.

### Follow-up (non-blocking)
The `tests/aberration_crawl` rule `nonnegative-gauges` is in census mode. After this deploys,
calibrate `applicable_since` and promote it to `mode: assert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
