### PR TITLE
feat: add 60s / 120s pattern step-duration selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Linux-only (macOS Docker Desktop can't do this).
 
 - **Delay / Loss / Throughput** sliders — steady-state shaping (0–250 ms, 0–10%, 0–50 Mbps). Throughput is disabled when a pattern is active.
 - **Pattern mode**: `sliders` (static), `square_wave`, `ramp_up`, `ramp_down`, `pyramid`, `transient_shock` (hold the top cap, dip to each lower rung in turn — deepening — recovering to top between dips). Non-`sliders` modes drive throughput through a scripted sequence of steps.
-- **Step duration**: `6s` / `12s` / `18s` / `24s` — how long each pattern step holds.
+- **Step duration**: `6s` / `12s` / `18s` / `24s` / `60s` / `120s` — how long each pattern step holds (`60s` / `120s` give buffer-draining holds for `transient_shock`-style probes).
 - **Margin**: `Exact` / `+10%` / `+25%` / `+50%` — headroom added on top of each ladder bitrate when picking preset rates.
 - **Throughput presets** are generated from the current manifest's variants (video + audio, deduped). Effective rate:
   `shaping_mbps = variant_mbps × (1 + margin_pct/100) + overhead_mbps`

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1483,8 +1483,8 @@ components:
           items: { $ref: '#/components/schemas/PatternStep' }
         default_step_seconds:
           type: integer
-          enum: [6, 12, 18, 24]
-          description: 'Default per-step duration the dashboard chose when generating the step list.'
+          enum: [6, 12, 18, 24, 60, 120]
+          description: 'Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.'
         margin_pct:
           type: integer
           enum: [0, 5, 10, 25, 50]

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -53,7 +53,7 @@ const MARGIN_CHOICES = [0, 5, 10, 25, 50] as const;
 type Margin = (typeof MARGIN_CHOICES)[number];
 const DEFAULT_MARGIN_PCT: Margin = 5;
 
-const STEP_SECONDS_CHOICES = [6, 12, 18, 24] as const;
+const STEP_SECONDS_CHOICES = [6, 12, 18, 24, 60, 120] as const;
 type StepSeconds = (typeof STEP_SECONDS_CHOICES)[number];
 
 // #551 — fill density. The limit ladder carries BOTH a peak (BANDWIDTH)

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1833,10 +1833,10 @@ export interface components {
             template?: "sliders" | "square" | "square_wave" | "ramp_up" | "ramp_down" | "pyramid" | "transient_shock";
             steps: components["schemas"]["PatternStep"][];
             /**
-             * @description Default per-step duration the dashboard chose when generating the step list.
+             * @description Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
              * @enum {integer}
              */
-            default_step_seconds?: 6 | 12 | 18 | 24;
+            default_step_seconds?: 6 | 12 | 18 | 24 | 60 | 120;
             /**
              * @description Headroom percent above the variant rate used when sizing template steps. 0 = exact (deliberate-stall footgun). 5 = default — covers TCP/IP + TLS 1.3 + HTTP/2 framing overhead on a LAN. 10 = real WiFi with retransmits. 25 / 50 = stress-test over-headroom.
              * @enum {integer}

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1483,8 +1483,8 @@ components:
           items: { $ref: '#/components/schemas/PatternStep' }
         default_step_seconds:
           type: integer
-          enum: [6, 12, 18, 24]
-          description: 'Default per-step duration the dashboard chose when generating the step list.'
+          enum: [6, 12, 18, 24, 60, 120]
+          description: 'Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.'
         margin_pct:
           type: integer
           enum: [0, 5, 10, 25, 50]

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -186,10 +186,12 @@ func (e HeartbeatEventType) Valid() bool {
 
 // Defines values for PatternDefaultStepSeconds.
 const (
-	PatternDefaultStepSecondsN12 PatternDefaultStepSeconds = 12
-	PatternDefaultStepSecondsN18 PatternDefaultStepSeconds = 18
-	PatternDefaultStepSecondsN24 PatternDefaultStepSeconds = 24
-	PatternDefaultStepSecondsN6  PatternDefaultStepSeconds = 6
+	PatternDefaultStepSecondsN12  PatternDefaultStepSeconds = 12
+	PatternDefaultStepSecondsN18  PatternDefaultStepSeconds = 18
+	PatternDefaultStepSecondsN24  PatternDefaultStepSeconds = 24
+	PatternDefaultStepSecondsN6   PatternDefaultStepSeconds = 6
+	PatternDefaultStepSecondsN60  PatternDefaultStepSeconds = 60
+	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 )
 
 // Valid indicates whether the value is a known member of the PatternDefaultStepSeconds enum.
@@ -202,6 +204,10 @@ func (e PatternDefaultStepSeconds) Valid() bool {
 	case PatternDefaultStepSecondsN24:
 		return true
 	case PatternDefaultStepSecondsN6:
+		return true
+	case PatternDefaultStepSecondsN60:
+		return true
+	case PatternDefaultStepSecondsN120:
 		return true
 	default:
 		return false

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -22,7 +22,8 @@ Slider mode (any subset; omitted fields are not modified):
 
 Pattern mode (generates a step list from the player's current variants):
   --pattern NAME     pyramid | ramp_up | ramp_down | square_wave | transient_shock | sliders
-  --step-seconds N   per-step duration: 6 | 12 | 18 | 24 (default 12)
+  --step-seconds N   per-step duration: 6 | 12 | 18 | 24 | 60 | 120 (default 12;
+                     60/120 give buffer-draining holds for transient_shock)
   --margin PCT       flat headroom above each variant rate: 0|5|10|25|50
                      (default 5; covers TCP/IP+TLS+HTTP framing; 0 is a
                      deliberate-stall footgun)
@@ -72,7 +73,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	delay := fs.Float64("delay", -1, "delay ms")
 	loss := fs.Float64("loss", -1, "loss %")
 	pattern := fs.String("pattern", "", "pattern template (pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders)")
-	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24")
+	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24|60|120")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
 	topHeadroom := fs.Float64("top-headroom", ladder.DefaultTopHeadroomPct, "start the ladder this %% over the top variant's peak (default 50; 0 disables the headroom start rung)")
@@ -406,10 +407,10 @@ func parseTemplate(s string) (proxy.PatternTemplate, error) {
 
 func parseStepSeconds(n int) (proxy.PatternDefaultStepSeconds, error) {
 	switch n {
-	case 6, 12, 18, 24:
+	case 6, 12, 18, 24, 60, 120:
 		return proxy.PatternDefaultStepSeconds(n), nil
 	}
-	return 0, fmt.Errorf("invalid --step-seconds %d: must be 6|12|18|24", n)
+	return 0, fmt.Errorf("invalid --step-seconds %d: must be 6|12|18|24|60|120", n)
 }
 
 func parseMarginPct(n int) (proxy.PatternMarginPct, error) {

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -187,10 +187,12 @@ func (e HeartbeatEventType) Valid() bool {
 
 // Defines values for PatternDefaultStepSeconds.
 const (
-	PatternDefaultStepSecondsN12 PatternDefaultStepSeconds = 12
-	PatternDefaultStepSecondsN18 PatternDefaultStepSeconds = 18
-	PatternDefaultStepSecondsN24 PatternDefaultStepSeconds = 24
-	PatternDefaultStepSecondsN6  PatternDefaultStepSeconds = 6
+	PatternDefaultStepSecondsN12  PatternDefaultStepSeconds = 12
+	PatternDefaultStepSecondsN18  PatternDefaultStepSeconds = 18
+	PatternDefaultStepSecondsN24  PatternDefaultStepSeconds = 24
+	PatternDefaultStepSecondsN6   PatternDefaultStepSeconds = 6
+	PatternDefaultStepSecondsN60  PatternDefaultStepSeconds = 60
+	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 )
 
 // Valid indicates whether the value is a known member of the PatternDefaultStepSeconds enum.
@@ -203,6 +205,10 @@ func (e PatternDefaultStepSeconds) Valid() bool {
 	case PatternDefaultStepSecondsN24:
 		return true
 	case PatternDefaultStepSecondsN6:
+		return true
+	case PatternDefaultStepSecondsN60:
+		return true
+	case PatternDefaultStepSecondsN120:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## What
Adds **`60s`** and **`120s`** to the pattern step-duration selections (was `6 / 12 / 18 / 24`).

## Why
Follow-up to #729 (`transient_shock` pattern). The picker maxed at 24s, but a `transient_shock` dip needs to outlast the buffer coast + the wedge-or-recover window to actually surface a stall — the characterization test holds **120s at top / 90s at each dip** for exactly this reason. 24s is too short for the buffer to drain, so the pattern looked right but didn't reproduce the test's dynamics. 60/120 close that gap.

## Layers (the `default_step_seconds` vocabulary)
- `api/openapi/v2/proxy.yaml` — enum `[6,12,18,24]` → `+60,120`; `content/dashboard/api-docs/proxy-v2.yaml` mirror synced
- `go-proxy/pkg/v2oapigen` + `tools/harness-cli/internal/v2gen/proxy` `.gen.go` — `PatternDefaultStepSeconds` enum members
- `tools/harness-cli/cmd/harness/shape.go` — `--step-seconds` parse + help (`6|12|18|24|60|120`)
- `content/dashboard-v3/.../NetworkShapingPattern.vue` — `STEP_SECONDS_CHOICES`
- `content/dashboard-v3/src/types/v2.ts` — generated union (hand-synced; no `node_modules` in worktree)
- `README.md` — step-duration list

## Notes
- **No server change:** `go-proxy/cmd/server/main.go` already accepts any positive `default_step_seconds` (validates only `> 0`), so 60/120 were already accepted server-side — this PR exposes them in the pickers + typed clients.
- **Generated files:** hand-added the enum members surgically (gofmt-clean) rather than running a full regen, which would bundle the unrelated stale-gen drift flagged in #729. Still worth a dedicated gen-file refresh.

## Verification
`go build` (proxy + harness) green; `gofmt` clean on changed Go; harness help lists `… | 60 | 120`. Vue/TS by inspection (no JS build in worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
