### PR TITLE
feat(579): restore grouped compare-mode chart overlays in v3

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -27,6 +27,8 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 import { useManifestVariants, nearestVariantByBitrate } from '@/composables/useManifestVariants';
 import { usePlayer } from '@/composables/usePlayer';
+import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
+import { compareBandwidthSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
@@ -300,7 +302,12 @@ const baseSeries: SeriesSpec[] = [
  *
  *  Defaults: peak ON (the rate ABR actually keys on — see abr-ladder
  *  standard), avg OFF (toggle on for the typical-body-bitrate reference). */
+const compareSelf = useCompareSelf();
 const series = computed<SeriesSpec[]>(() => {
+  // Compare mode: the active session shows the SAME canonical tagged set
+  // (solid, `S<id>`) the siblings overlay — not its full single-session
+  // series — so every session reads identically (issue #579).
+  if (compareSelf.value) return compareBandwidthSeries(compareSelf.value);
   const out = [...baseSeries];
   const ladder = variants.value;
   if (!ladder.length) return out;
@@ -389,6 +396,15 @@ const series = computed<SeriesSpec[]>(() => {
   }
   return out;
 });
+
+/** Grouped-sibling overlays (issue #579 compare mode). Empty unless the
+ *  active session is in a group AND the operator enabled Compare Charts;
+ *  resolved from the CompareContext SessionDisplay provides. Each sibling
+ *  overlays its tagged rate series (Player Network Rate + Player Variant
+ *  visible; Player Est / Server Variant / Shaper Avg legend-toggleable).
+ *  On the shared 'y' axis so the rate axis sizes across every overlaid
+ *  session (the #165 union-sizing fix). */
+const compareOverlays = useCompareOverlays(compareBandwidthSeries);
 </script>
 
 <template>
@@ -398,8 +414,9 @@ const series = computed<SeriesSpec[]>(() => {
     unit="Mbps"
     :series="series"
     :events-stream="eventsStream"
-    :markers="segmentMarkers"
-    :markers-label="segmentMarkersLabel"
+    :overlays="compareOverlays"
+    :markers="compareSelf ? [] : segmentMarkers"
+    :markers-label="compareSelf ? '' : segmentMarkersLabel"
     v-model:markers-visible="segmentMarkersVisible"
     :y-min="0"
     :y-max="yMax"

--- a/content/dashboard-v3/src/components/BufferChart.vue
+++ b/content/dashboard-v3/src/components/BufferChart.vue
@@ -6,7 +6,10 @@
  * while buffer depth is typically tens of seconds. Matches the
  * legacy two-axis layout.
  */
+import { computed } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
+import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
+import { compareBufferSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
@@ -15,7 +18,14 @@ defineProps<{
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
-const series: SeriesSpec[] = [
+/** Grouped-sibling buffer-depth overlays (issue #579). On the left ('y')
+ *  axis so the buffer-depth scale sizes across every overlaid grouped
+ *  session — the #165 requirement that a deeper-buffering sibling doesn't
+ *  clip. Empty unless compare mode is on (resolved from CompareContext). */
+const compareOverlays = useCompareOverlays(compareBufferSeries);
+const compareSelf = useCompareSelf();
+
+const baseSeries: SeriesSpec[] = [
   {
     label: 'Buffer depth (s)',
     color: '#4f46e5',
@@ -34,6 +44,11 @@ const series: SeriesSpec[] = [
     axis: 'y2',
   },
 ];
+// Compare mode: active session shows the same canonical tagged set
+// (buffer depth only, solid `S<id>`) the siblings overlay.
+const series = computed<SeriesSpec[]>(() =>
+  compareSelf.value ? compareBufferSeries(compareSelf.value) : baseSeries,
+);
 </script>
 
 <template>
@@ -43,6 +58,7 @@ const series: SeriesSpec[] = [
     unit="buffer (s)"
     :series="series"
     :events-stream="eventsStream"
+    :overlays="compareOverlays"
     :y-min="0"
     y2-title="offset (s)"
     :y2-min="0"

--- a/content/dashboard-v3/src/components/CollapsibleSection.vue
+++ b/content/dashboard-v3/src/components/CollapsibleSection.vue
@@ -26,6 +26,13 @@ const props = defineProps<{
    *  section folded — without this, opening the section after replay
    *  shows the chart with only the latest sample. */
   eager?: boolean;
+  /** External "default-collapse" signal (issue #579 compare mode). When
+   *  this transitions to true the section folds; when it returns to
+   *  false the section restores whatever open state it had before. The
+   *  operator can still toggle freely while it's active — this only sets
+   *  the default on each transition — and the auto-fold is NOT persisted,
+   *  so it never overwrites the operator's saved preference. */
+  forceCollapsed?: boolean;
 }>();
 
 const STORAGE_PREFIX = 'testing_session_collapse_';
@@ -108,6 +115,24 @@ onMounted(() => {
 watch(
   () => props.persistKey,
   () => { isOpen.value = resolveInitial(); },
+);
+
+// External default-collapse (issue #579). On false→true, remember the
+// current open state and fold; on true→false, restore it. The operator
+// can still toggle in between (toggle() writes isOpen + persists); the
+// auto-fold itself is deliberately NOT persisted.
+let savedOpenBeforeForce: boolean | null = null;
+watch(
+  () => props.forceCollapsed,
+  (v, old) => {
+    if (v && !old) {
+      savedOpenBeforeForce = isOpen.value;
+      isOpen.value = false;
+    } else if (!v && old) {
+      isOpen.value = savedOpenBeforeForce ?? resolveInitial();
+      savedOpenBeforeForce = null;
+    }
+  },
 );
 </script>
 

--- a/content/dashboard-v3/src/components/CompareSeriesSource.vue
+++ b/content/dashboard-v3/src/components/CompareSeriesSource.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+/**
+ * CompareSeriesSource.vue — renderless per-sibling time-series
+ * subscriber for the compare-charts overlay (issue #579).
+ *
+ * Vue composables can't be called in a dynamic loop, so to subscribe a
+ * variable number of grouped siblings we render one of these per sibling
+ * (v-for keyed by playerId). Each instance calls useSessionTimeSeries
+ * for its own player and registers the resulting `events` Stream with
+ * the parent via the register/unregister emits. When the sibling leaves
+ * the group the v-for drops this component, onScopeDispose inside
+ * useSessionTimeSeries closes the SSE, and we emit `unregister` so the
+ * parent stops overlaying its (now-stale) datasets.
+ *
+ * Scope is deliberately minimal — only the `events` stream with the
+ * charts_minimal bundle (the same projection BandwidthChart/BufferChart
+ * accessors read). No network/control/avmetrics: the overlay only plots
+ * rate + buffer lines, not the sibling's lanes or per-segment markers.
+ *
+ * playId is null so the sibling follows its own latest play and rotates
+ * with it — matching the live-comparison use case (two devices under
+ * test at once). The default 10-minute backfill + live tail aligns with
+ * the live edge the primary chart tracks. (The archive path — locking a
+ * sibling to a specific historical play_id — is a follow-up; this
+ * component takes a playId prop so that wiring is a one-line change.)
+ */
+import { computed, onMounted, onUnmounted } from 'vue';
+import { useSessionTimeSeries, type Stream } from '@/composables/useSessionTimeSeries';
+
+const props = defineProps<{ playerId: string; playId?: string | null }>();
+const emit = defineEmits<{
+  (e: 'register', playerId: string, stream: Stream<Record<string, unknown>>): void;
+  (e: 'unregister', playerId: string): void;
+}>();
+
+const playerIdRef = computed(() => props.playerId);
+const playIdRef = computed<string | null>(() => props.playId ?? null);
+
+const ts = useSessionTimeSeries(playerIdRef, playIdRef, {
+  streams: ['events'],
+  bundles: ['charts_minimal'],
+});
+
+onMounted(() => emit('register', props.playerId, ts.events));
+onUnmounted(() => emit('unregister', props.playerId));
+</script>
+
+<template>
+  <!-- renderless: this component only owns an SSE subscription -->
+</template>

--- a/content/dashboard-v3/src/components/CompareSessionLegend.vue
+++ b/content/dashboard-v3/src/components/CompareSessionLegend.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/**
+ * CompareSessionLegend.vue — the S1/S2/… chip row for compare mode
+ * (issue #579). One chip per grouped session; the chip's swatch shows
+ * that session's line style (solid = active session, dashed = siblings,
+ * matching the charts). Hovering a chip pops every line for that session
+ * across ALL charts and dims the rest; clicking toggles that session's
+ * lines on/off everywhere. Drives the shared CompareView the charts read.
+ */
+import type { CompareView } from '@/composables/useCompareContext';
+
+interface SessionChip {
+  tag: string;
+  label: string;
+  dash: number[];
+  isSelf: boolean;
+}
+
+const props = defineProps<{
+  sessions: SessionChip[];
+  view: CompareView;
+}>();
+
+function isHidden(tag: string): boolean {
+  return props.view.hidden.value.has(tag);
+}
+function toggle(tag: string) {
+  const next = new Set(props.view.hidden.value);
+  if (next.has(tag)) next.delete(tag); else next.add(tag);
+  props.view.hidden.value = next;
+}
+function enter(tag: string) { props.view.hovered.value = tag; }
+function leave() { props.view.hovered.value = null; }
+function dashArray(dash: number[]): string {
+  return dash.length ? dash.join(' ') : '';
+}
+</script>
+
+<template>
+  <div class="session-legend" @mouseleave="leave">
+    <span class="sl-label">Sessions</span>
+    <button
+      v-for="s in sessions"
+      :key="s.tag"
+      type="button"
+      class="sl-chip"
+      :class="{ off: isHidden(s.tag), self: s.isSelf }"
+      @mouseenter="enter(s.tag)"
+      @focus="enter(s.tag)"
+      @blur="leave"
+      @click="toggle(s.tag)"
+      :title="isHidden(s.tag)
+        ? `Show all ${s.tag} lines`
+        : `Hide all ${s.tag} lines · hover to highlight just this session`"
+    >
+      <svg class="sl-swatch" width="24" height="8" aria-hidden="true">
+        <line
+          x1="1" y1="4" x2="23" y2="4"
+          stroke="currentColor" stroke-width="2"
+          :stroke-dasharray="dashArray(s.dash)"
+        />
+      </svg>
+      <span class="sl-tag">{{ s.tag }}</span>
+      <span class="sl-name">{{ s.label }}</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.session-legend {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+}
+.sl-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-right: 2px;
+}
+.sl-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  font-size: 11px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 999px;
+  color: #1f2937;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.sl-chip:hover { border-color: #9ca3af; background: #f9fafb; }
+.sl-chip.self { border-color: #c7d2fe; }
+.sl-chip.off {
+  opacity: 0.5;
+  background: #f3f4f6;
+  text-decoration: line-through;
+}
+.sl-swatch { color: #475569; flex: none; }
+.sl-tag { font-weight: 700; font-variant-numeric: tabular-nums; }
+.sl-name { color: #6b7280; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+</style>

--- a/content/dashboard-v3/src/components/FPSChart.vue
+++ b/content/dashboard-v3/src/components/FPSChart.vue
@@ -18,11 +18,19 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow } from '@/composables/chRowAdapter';
 import type { PlayerRecord } from '@/repo/v2-repo';
+import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
+import { compareFpsSeries } from '@/composables/compareSeries';
 
 const props = defineProps<{
   playerId: string;
   eventsStream: Stream<Record<string, unknown>>;
 }>();
+
+/** Grouped-sibling FPS overlays (issue #579). Each sibling derives its
+ *  own displayed/dropped FPS (stateful per-sibling accessors) so the
+ *  overlay shows that device's frame rate, not the active session's. */
+const compareOverlays = useCompareOverlays(compareFpsSeries);
+const compareSelf = useCompareSelf();
 
 // per-instance state: previous frame counters + the derived rate to
 // surface to MetricsLineChart through the synthetic accessor below.
@@ -95,7 +103,12 @@ watch(
   },
 );
 
-const series = computed<SeriesSpec[]>(() => [
+const series = computed<SeriesSpec[]>(() => {
+  // Compare mode: active session shows the same canonical tagged FPS set
+  // (solid `S<id>`) the siblings overlay; its derived FPS comes from the
+  // per-session makeCounterRate accessors, not the component refs below.
+  if (compareSelf.value) return compareFpsSeries(compareSelf.value);
+  return [
   {
     label: 'Displayed FPS',
     color: '#10b981',
@@ -113,7 +126,8 @@ const series = computed<SeriesSpec[]>(() => [
     stepped: true,
     axis: 'y2',
   },
-]);
+  ];
+});
 
 </script>
 
@@ -124,6 +138,7 @@ const series = computed<SeriesSpec[]>(() => [
     unit="fps"
     :series="series"
     :events-stream="eventsStream"
+    :overlays="compareOverlays"
     :y-min="0"
     y2-title="dropped (count)"
     :y2-min="0"

--- a/content/dashboard-v3/src/components/GroupBanner.vue
+++ b/content/dashboard-v3/src/components/GroupBanner.vue
@@ -15,6 +15,7 @@ import { computed, toRef } from 'vue';
 import { usePlayer } from '@/composables/usePlayer';
 import { useGroups } from '@/composables/useGroups';
 import { usePlayers } from '@/composables/usePlayers';
+import { useCompareMode } from '@/composables/useCompareMode';
 import { deviceFromUA, groupNameFor } from '@/composables/useSessionLabels';
 import * as repo from '@/repo/v2-repo';
 
@@ -22,6 +23,14 @@ const props = defineProps<{ playerId: string }>();
 const { player } = usePlayer(toRef(props, 'playerId'));
 const { groups, disband, updateMembers } = useGroups();
 const { players } = usePlayers();
+
+// Compare-charts toggle (issue #579). Keyed on the raw player id so this
+// button and SessionDisplay's overlay consumer share the same module-
+// level flag. Only meaningful with ≥2 grouped members; the consumer
+// gates the overlay on that, so flipping it on a degenerate group is a
+// harmless no-op that "remembers" the choice for a later regrouping.
+const compareMode = useCompareMode(toRef(props, 'playerId'));
+const compareOn = computed(() => compareMode.state.enabled);
 
 // Identify the active player's group via membership rather than by
 // matching raw_session.group_id against PlayerGroup.id. The server
@@ -120,6 +129,23 @@ async function deleteSession() {
           🔗 Grouped with: <strong>{{ memberNames.join(', ') || '(only you)' }}</strong>
           <span class="chip">{{ groupName }}</span>
         </span>
+        <!-- Compare Charts (issue #579) — overlay each grouped member's
+             rate + buffer series (tagged S<id>) onto the shared charts so
+             two devices read against the same shaping target. Surfaced
+             only with ≥2 members; restores the legacy testing.html
+             compare-mode the v3 cutover dropped. -->
+        <button
+          v-if="memberCount >= 2"
+          type="button"
+          class="btn compare-toggle"
+          :class="{ checked: compareOn }"
+          @click="compareMode.toggle()"
+          :title="compareOn
+            ? 'Hide grouped sibling overlays from the charts'
+            : 'Overlay each grouped session\'s rate + buffer lines on the charts'"
+        >
+          {{ compareOn ? '●' : '○' }} Compare Charts
+        </button>
         <!-- "Ungroup" = this session leaves; "Delete Group" = drop the
              whole group. With only 2 members, leaving leaves a
              degenerate 1-member group, so we surface only "Delete
@@ -199,6 +225,16 @@ async function deleteSession() {
 .btn-secondary:hover { background: #d1d5db; }
 .btn-warn { background: #ef4444; color: white; border-color: #ef4444; font-size: 11px; padding: 4px 10px; }
 .btn-warn:hover { background: #dc2626; }
+/* Compare Charts toggle — filled violet when on (matches the overlay
+ * palette family), muted/outlined when off. */
+.compare-toggle { font-size: 11px; padding: 4px 10px; }
+.compare-toggle.checked {
+  background: #7c3aed;
+  border-color: #6d28d9;
+  color: #fff;
+  font-weight: 600;
+}
+.compare-toggle.checked:hover { background: #6d28d9; }
 .btn-danger { background: #fee2e2; color: #991b1b; border-color: #fca5a5; }
 .btn-danger:hover { background: #fecaca; }
 

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -16,8 +16,9 @@
  * to `windowMs * 2` ms on the older side so a zoom-out / pan-back still
  * has data to show. The chart never holds more than ~2× window worth.
  */
-import { computed, onBeforeUnmount, ref, toRef, watch, type PropType } from 'vue';
+import { computed, inject, onBeforeUnmount, ref, toRef, watch, type PropType } from 'vue';
 import { ensureChartJs } from '@/composables/useChartJs';
+import { CompareContextKey } from '@/composables/useCompareContext';
 import { useChartCoordination, fmtTickHMSms, DEFAULT_FOCUS_MS, type ChartViewport } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow, chRowToPlayerRecord } from '@/composables/chRowAdapter';
@@ -48,6 +49,33 @@ export interface SeriesSpec {
    *  any other set of N lines the operator thinks of as one
    *  conceptual overlay. Issue #486. */
   groupLegend?: string;
+  /** Compare mode (issue #579): the session this series belongs to (its
+   *  `Sx` tag). Lets the session-legend highlight / show / hide every line
+   *  for one session at once across all charts. */
+  sessionTag?: string;
+}
+
+/**
+ * ChartOverlaySource — one grouped-sibling's series overlaid onto this
+ * chart (issue #579 compare mode). Each source carries its OWN events
+ * stream (a separate per-player SSE) and its OWN tagged SeriesSpec[];
+ * the chart drains each source independently and renders its datasets
+ * alongside the primary `series`, on the same axes (so they share — and
+ * size — the y axis with the active session's lines, the #165 fix).
+ *
+ * Overlay datasets are drawn with `spanGaps: false` and explicit null
+ * points for missing samples, so a sibling lacking a wire metric shows
+ * a clean gap instead of an interpolated bridge.
+ */
+export interface ChartOverlaySource {
+  /** Stable identity (the sibling's player UUID) — drives dataset reuse
+   *  across reconciles so a sibling's accumulated history survives a
+   *  membership change elsewhere in the group. */
+  key: string;
+  /** The sibling's events stream (charts_minimal projection). */
+  eventsStream: Stream<Record<string, unknown>>;
+  /** Tagged, per-member-coloured series to overlay for this sibling. */
+  series: SeriesSpec[];
 }
 
 const props = defineProps({
@@ -80,6 +108,14 @@ const props = defineProps({
   markersLabel: { type: String, default: '' },
   /** Marker visibility (v-model). Default true. */
   markersVisible: { type: Boolean, default: true },
+  /** Grouped-sibling overlays (issue #579 compare mode). Each entry is
+   *  one sibling's stream + tagged series; drained independently and
+   *  rendered alongside the primary `series` on shared axes. Empty in
+   *  the normal single-session case — the primary path is untouched. */
+  overlays: {
+    type: Array as PropType<ChartOverlaySource[]>,
+    default: () => [],
+  },
 });
 
 const emit = defineEmits<{
@@ -90,6 +126,12 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 const wrap = ref<HTMLDivElement | null>(null);
 const canvasWrap = ref<HTMLDivElement | null>(null);
 const coord = useChartCoordination(toRef(props, 'playerId'));
+
+// Compare-mode session legend (issue #579). When mounted inside a
+// SessionDisplay that's in compare mode, the S1/S2 chips drive this
+// shared view; we highlight / show / hide this chart's datasets by their
+// `_sessionTag` in lockstep with every other chart. Null outside compare.
+const compareCtx = inject(CompareContextKey, null);
 
 let chart: any = null;
 let dataset: Array<Array<{ x: number; y: number }>> = [];
@@ -227,64 +269,202 @@ async function ensure(): Promise<any> {
   return ensurePromise;
 }
 
-/** Reconcile the live chart's dataset list against props.series
- *  (issue #486). The chart is built once at mount with whatever
- *  series existed then; series that come from a computed (e.g. the
- *  manifest variant overlay on BandwidthChart) may arrive late. This
- *  syncs the chart's `data.datasets` array + the backing `dataset`
- *  cache in place — no destroy/recreate, so accumulated history on
- *  the static series isn't lost. */
-function syncDatasetsFromSeriesProp() {
-  if (!chart || !chart.data?.datasets) return;
+/** Build one Chart.js dataset object from a SeriesSpec. `dsKey` is a
+ *  stable identity (`primary|<label>` for the active session's lines,
+ *  `<siblingPlayerId>|<label>` for a compare overlay) used to reuse the
+ *  same dataset object — and thus its accumulated `data` array — across
+ *  reconciles. `spanGaps` is true for the primary series (legacy
+ *  behaviour) and false for overlays so a sibling's missing samples
+ *  render as gaps, not interpolated bridges (issue #579). */
+function makeDsObj(
+  dsKey: string,
+  s: SeriesSpec,
+  data: Array<{ x: number; y: number | null }>,
+  spanGaps: boolean,
+): any {
+  return {
+    label: s.label,
+    borderColor: s.color,
+    backgroundColor: s.color + '22',
+    data,
+    tension: 0,
+    stepped: !!s.stepped,
+    pointRadius: 0,
+    borderWidth: 2,
+    borderDash: s.borderDash ?? [],
+    spanGaps,
+    yAxisID: s.axis === 'y2' ? 'y2' : 'y',
+    hidden: !!s.hidden,
+    _groupLegend: s.groupLegend ?? null,
+    _sessionTag: s.sessionTag ?? null,
+    _dsKey: dsKey,
+  };
+}
+
+/** Per-overlay runtime state (issue #579). One entry per grouped
+ *  sibling: its current series spec, the backing {x,y} arrays Chart.js
+ *  reads from, an ingest watermark, and the last-seen stream epoch (so a
+ *  sibling's play rotation / refetch wipes and re-drains cleanly). */
+interface OverlayRuntime {
+  datasets: Array<Array<{ x: number; y: number | null }>>;
+  watermark: number;
+  epoch: number;
+}
+const overlayRuntime = new Map<string, OverlayRuntime>();
+
+/** Build the primary (active-session) dataset objects, reconciling
+ *  against whatever is already on the chart by `_dsKey` so a stable
+ *  series keeps its accumulated history when the series list changes
+ *  (e.g. manifest variants arriving late, issue #486). Also keeps the
+ *  backing `dataset` cache 1:1 with these objects for pushSample. */
+function buildPrimaryDatasetObjs(): any[] {
   const target = props.series;
-  // Adjust backing `dataset` length first so pushSample's loop and
-  // chart.data.datasets stay 1:1.
   while (dataset.length < target.length) dataset.push([]);
   while (dataset.length > target.length) dataset.pop();
-  // Reconcile chart datasets in place. Match by label so a stable
-  // series keeps its in-memory data even if a new series is inserted
-  // before it.
-  const existing = chart.data.datasets;
-  const byLabel = new Map<string, any>();
-  for (const d of existing) if (d.label) byLabel.set(d.label, d);
-  const next: any[] = [];
+  const existing = chart?.data?.datasets ?? [];
+  const byKey = new Map<string, any>();
+  for (const d of existing) if (d._dsKey) byKey.set(d._dsKey, d);
+  const out: any[] = [];
   for (let i = 0; i < target.length; i++) {
     const s = target[i];
-    const prev = byLabel.get(s.label);
+    const dsKey = 'primary|' + s.label;
+    const prev = byKey.get(dsKey);
     if (prev) {
-      // Update mutable bits and reuse the data array (preserves history).
       prev.borderColor = s.color;
       prev.backgroundColor = s.color + '22';
       prev.stepped = !!s.stepped;
       prev.borderDash = s.borderDash ?? [];
       prev.yAxisID = s.axis === 'y2' ? 'y2' : 'y';
-      (prev as any)._groupLegend = s.groupLegend ?? null;
-      // Backing `dataset[i]` must point at the same array Chart.js
-      // is reading from. Reuse prev.data and reseat the cache slot.
+      prev.spanGaps = true;
+      prev._groupLegend = s.groupLegend ?? null;
+      prev._sessionTag = s.sessionTag ?? null;
       dataset[i] = prev.data;
-      next.push(prev);
+      out.push(prev);
     } else {
       const data: Array<{ x: number; y: number }> = [];
       dataset[i] = data;
-      next.push({
-        label: s.label,
-        borderColor: s.color,
-        backgroundColor: s.color + '22',
-        data,
-        tension: 0,
-        stepped: !!s.stepped,
-        pointRadius: 0,
-        borderWidth: 2,
-        borderDash: s.borderDash ?? [],
-        spanGaps: true,
-        yAxisID: s.axis === 'y2' ? 'y2' : 'y',
-        hidden: !!s.hidden,
-        _groupLegend: s.groupLegend ?? null,
-      });
+      out.push(makeDsObj(dsKey, s, data, true));
     }
   }
-  chart.data.datasets = next;
+  return out;
+}
+
+/** Build the compare-overlay dataset objects from `props.overlays`,
+ *  reconciling by `<key>|<label>` so a sibling's lines (and history)
+ *  survive a membership change. Prunes runtime for siblings that have
+ *  left the group. Issue #579. */
+function buildOverlayDatasetObjs(): any[] {
+  const sources = props.overlays ?? [];
+  const wantKeys = new Set(sources.map((s) => s.key));
+  for (const key of [...overlayRuntime.keys()]) {
+    if (!wantKeys.has(key)) overlayRuntime.delete(key);
+  }
+  const existing = chart?.data?.datasets ?? [];
+  const byKey = new Map<string, any>();
+  for (const d of existing) if (d._dsKey) byKey.set(d._dsKey, d);
+  const out: any[] = [];
+  for (const src of sources) {
+    let rt = overlayRuntime.get(src.key);
+    if (!rt) {
+      rt = { datasets: [], watermark: -Infinity, epoch: src.eventsStream.epoch.value };
+      overlayRuntime.set(src.key, rt);
+    }
+    while (rt.datasets.length < src.series.length) rt.datasets.push([]);
+    while (rt.datasets.length > src.series.length) rt.datasets.pop();
+    for (let i = 0; i < src.series.length; i++) {
+      const s = src.series[i];
+      const dsKey = src.key + '|' + s.label;
+      const prev = byKey.get(dsKey);
+      if (prev) {
+        prev.borderColor = s.color;
+        prev.backgroundColor = s.color + '22';
+        prev.stepped = !!s.stepped;
+        prev.borderDash = s.borderDash ?? [];
+        prev.yAxisID = s.axis === 'y2' ? 'y2' : 'y';
+        prev.spanGaps = false;
+        prev._groupLegend = s.groupLegend ?? null;
+        prev._sessionTag = s.sessionTag ?? null;
+        rt.datasets[i] = prev.data;
+        out.push(prev);
+      } else {
+        const data = rt.datasets[i] ?? [];
+        rt.datasets[i] = data;
+        out.push(makeDsObj(dsKey, s, data, false));
+      }
+    }
+  }
+  return out;
+}
+
+/** Recompose `chart.data.datasets` = [primary…, overlay…] from the
+ *  current `series` + `overlays` props. The single owner of the dataset
+ *  list; both the series-prop watcher and the overlays watcher route
+ *  through here so the two halves never clobber each other. */
+function rebuildAllDatasets() {
+  if (!chart || !chart.data) return;
+  const primary = buildPrimaryDatasetObjs();
+  const overlay = buildOverlayDatasetObjs();
+  chart.data.datasets = [...primary, ...overlay];
+  // Re-apply the session-legend hidden state so freshly (re)built
+  // datasets for a hidden session start hidden. No render here — the
+  // safeChartUpdate below paints it. Issue #579.
+  applySessionVisibility(false);
   safeChartUpdate();
+}
+
+/** Show/hide every dataset by its session's legend state (#579). When a
+ *  session is toggled off in the S1/S2 chip row, all its lines hide on
+ *  every chart at once. `doUpdate` is false when called from a path that
+ *  renders anyway (rebuildAllDatasets). */
+function applySessionVisibility(doUpdate = true) {
+  if (!chart || !compareCtx) return;
+  const hidden = compareCtx.view.hidden.value;
+  let changed = false;
+  chart.data.datasets.forEach((ds: any, idx: number) => {
+    if (!ds._sessionTag) return;
+    const shouldShow = !hidden.has(ds._sessionTag);
+    if (chart.isDatasetVisible(idx) !== shouldShow) {
+      chart.setDatasetVisibility(idx, shouldShow);
+      changed = true;
+    }
+  });
+  if (changed && doUpdate) { try { chart.update(); } catch { /* ignore */ } }
+}
+
+/** Hovering a session chip pops that session's lines and dims the rest
+ *  (#579). Mirrors the per-series legend hover but keyed on _sessionTag
+ *  so the whole session lights up across every chart. */
+function applySessionHover() {
+  if (!chart || !compareCtx) return;
+  const hov = compareCtx.view.hovered.value;
+  for (const ds of chart.data.datasets as any[]) {
+    if (ds._origBorderWidth == null) ds._origBorderWidth = ds.borderWidth ?? 2;
+    if (ds._origBorderColor == null) ds._origBorderColor = ds.borderColor;
+    if (!hov) {
+      ds.borderWidth = ds._origBorderWidth;
+      ds.borderColor = ds._origBorderColor;
+    } else if (ds._sessionTag === hov) {
+      ds.borderWidth = (ds._origBorderWidth ?? 2) + 2;
+      ds.borderColor = ds._origBorderColor;
+    } else {
+      ds.borderWidth = Math.max(1, (ds._origBorderWidth ?? 2) - 1);
+      const oc = ds._origBorderColor;
+      ds.borderColor = typeof oc === 'string' && oc.startsWith('#') && oc.length === 7 ? oc + '33' : oc;
+    }
+  }
+  try { chart.update('none'); } catch { /* ignore */ }
+}
+
+if (compareCtx) {
+  watch(() => compareCtx.view.hovered.value, () => applySessionHover());
+  watch(() => compareCtx.view.hidden.value, () => applySessionVisibility());
+}
+
+/** Reconcile the live chart's dataset list against props.series
+ *  (issue #486) — now delegates to rebuildAllDatasets so compare
+ *  overlays (#579) are preserved when the primary series list changes. */
+function syncDatasetsFromSeriesProp() {
+  rebuildAllDatasets();
 }
 
 function createChartInstance(Chart: any): any {
@@ -305,28 +485,14 @@ function createChartInstance(Chart: any): any {
   chart = new Chart(canvas.value, {
     type: 'line',
     data: {
-      datasets: props.series.map((s, i) => ({
-        label: s.label,
-        borderColor: s.color,
-        backgroundColor: s.color + '22',
-        data: dataset[i],
-        // Straight line segments between samples — no curve fitting.
-        // Stepped series (player state) keep tension 0 too. Smoothing
-        // implies measurements that weren't taken; for instrumentation
-        // data, straight-line is the truthful representation.
-        tension: 0,
-        stepped: !!s.stepped,
-        pointRadius: 0,
-        borderWidth: 2,
-        borderDash: s.borderDash ?? [],
-        spanGaps: true,
-        yAxisID: s.axis === 'y2' ? 'y2' : 'y',
-        hidden: !!s.hidden,
-        // Marker for the legend group-collapse logic (issue #486).
-        // Datasets that share a `_groupLegend` value collapse to a
-        // single legend entry; clicking it toggles all members.
-        _groupLegend: s.groupLegend ?? null,
-      })),
+      // Straight line segments between samples — no curve fitting.
+      // Stepped series keep tension 0 too. Smoothing implies
+      // measurements that weren't taken; for instrumentation data,
+      // straight-line is the truthful representation. makeDsObj stamps
+      // `_dsKey` (primary|<label>) so later reconciles reuse these
+      // objects — and their accumulated history — by identity, and
+      // `_groupLegend` for the legend group-collapse logic (issue #486).
+      datasets: props.series.map((s, i) => makeDsObj('primary|' + s.label, s, dataset[i], true)),
     },
     /**
      * Inline plugin: vertical "selected event" cursor.
@@ -505,6 +671,21 @@ function createChartInstance(Chart: any): any {
             const c = leg?.chart;
             if (!c || typeof item?.datasetIndex !== 'number') return;
             const hovered = item.datasetIndex;
+            // Compare mode (#579): also give a medium highlight to the
+            // SAME metric on other sessions — hovering `Fetching Variant
+            // (S2)` lifts `Fetching Variant (S1)` too, just less. Metric
+            // identity is the label with its trailing ` (Sx)` stripped.
+            const stripTag = (l: string) => l.replace(/\s*\(S[^)]*\)\s*$/, '');
+            const hoveredDs0 = c.data.datasets[hovered];
+            const sameMetric = new Set<number>();
+            if (hoveredDs0?._sessionTag) {
+              const mk = stripTag(hoveredDs0.label ?? '');
+              c.data.datasets.forEach((ds: any, i: number) => {
+                if (i !== hovered && ds._sessionTag && stripTag(ds.label ?? '') === mk) {
+                  sameMetric.add(i);
+                }
+              });
+            }
             // If the hovered legend entry represents a group (issue
             // #486 — `Variant avg bandwidth` / `Variant peak bandwidth`
             // each stand in for N member series), build a Set of every
@@ -524,7 +705,14 @@ function createChartInstance(Chart: any): any {
               if (ds._origBorderWidth == null) ds._origBorderWidth = ds.borderWidth ?? 2;
               if (ds._origBorderColor == null) ds._origBorderColor = ds.borderColor;
               if (highlighted.has(i)) {
+                // Strongest: the hovered line (or its group).
                 ds.borderWidth = (ds._origBorderWidth ?? 2) + 2;
+                ds.borderColor = ds._origBorderColor;
+              } else if (sameMetric.has(i)) {
+                // Medium: same metric on another session — keep full
+                // colour, a touch bolder than baseline so the eye pairs
+                // it with the hovered line (#579).
+                ds.borderWidth = (ds._origBorderWidth ?? 2) + 1;
                 ds.borderColor = ds._origBorderColor;
               } else {
                 ds.borderWidth = Math.max(1, (ds._origBorderWidth ?? 2) - 1);
@@ -666,6 +854,13 @@ function createChartInstance(Chart: any): any {
   installLeftClickLiveToggle();
   installCursorHoverTooltip();
   installMarkerHoverTooltip();
+  // If compare overlays were already present at mount, compose + drain
+  // them now (the overlays watcher's immediate run may have fired before
+  // the chart existed). Issue #579.
+  if ((props.overlays ?? []).length) {
+    try { rebuildAllDatasets(); } catch { /* ignore */ }
+    void drainOverlays();
+  }
   return chart;
 }
 
@@ -955,7 +1150,10 @@ function installLiveWheelAnchor() {
  *  Duplicate x values overwrite — last write wins for that timestamp.
  *  O(log n) lookup + O(n) shift; chart pushSample is dominated by
  *  Chart.js update() cost anyway. */
-function insertByX(data: { x: number; y: number }[], point: { x: number; y: number }) {
+function insertByX(
+  data: { x: number; y: number | null }[],
+  point: { x: number; y: number | null },
+) {
   if (!data.length || point.x >= data[data.length - 1].x) {
     if (data.length && data[data.length - 1].x === point.x) {
       data[data.length - 1] = point;
@@ -1218,6 +1416,91 @@ watch(
   { immediate: true },
 );
 
+/* ─── Compare-overlay drain (issue #579) ───────────────────────────
+ *
+ * Each grouped sibling has its OWN events stream + tagged series. Drain
+ * them independently of the primary path: per overlay we keep an ingest
+ * watermark and append only NEW rows. Missing accessor values become an
+ * explicit `{x, y:null}` point so the `spanGaps:false` overlay datasets
+ * render a gap (not an interpolated bridge) where a sibling lacks a wire
+ * metric. Overlays never drive the viewport — the active session owns
+ * the brush; siblings just paint onto the shared x/y scales.
+ */
+function drainOverlays() {
+  if (!chart) return;
+  const sources = props.overlays ?? [];
+  let mutated = false;
+  for (const src of sources) {
+    const rt = overlayRuntime.get(src.key);
+    if (!rt) continue;
+    // A sibling re-subscribe (play rotation / refetch-on-pan) bumps its
+    // stream epoch — wipe and re-drain from scratch so we don't splice a
+    // new window's rows onto a stale watermark.
+    const ep = src.eventsStream.epoch.value;
+    if (ep !== rt.epoch) {
+      rt.epoch = ep;
+      rt.watermark = -Infinity;
+      for (const arr of rt.datasets) arr.length = 0;
+    }
+    const fromMs = rt.watermark === -Infinity ? 0 : rt.watermark + 1;
+    const rows = src.eventsStream.inRange(fromMs, Number.MAX_SAFE_INTEGER);
+    if (!rows.length) continue;
+    let hw = rt.watermark;
+    for (const row of rows) {
+      const x = tsOfRow(row);
+      if (!Number.isFinite(x)) continue;
+      if (rt.watermark !== -Infinity && x <= rt.watermark) continue;
+      const p = chRowToPlayerRecord(row);
+      for (let i = 0; i < src.series.length; i++) {
+        const arr = rt.datasets[i];
+        if (!arr) continue;
+        let y: number | null | undefined;
+        try { y = src.series[i].accessor(p); } catch { y = null; }
+        const yVal = (y == null || !Number.isFinite(y)) ? null : Number(y);
+        insertByX(arr, { x, y: yVal });
+      }
+      if (x > hw) hw = x;
+      mutated = true;
+    }
+    rt.watermark = hw;
+    // Same hard per-series memory bound the primary path uses (#582).
+    for (const arr of rt.datasets) {
+      if (arr.length > MAX_POINTS_PER_SERIES) arr.splice(0, arr.length - MAX_POINTS_PER_SERIES);
+    }
+  }
+  if (mutated) safeChartUpdate();
+}
+
+// Structure changes (compare toggled, a sibling joined/left, or its
+// series set changed) → recompose datasets, then drain. Reading
+// props.overlays in the getter tracks the prop so a new membership array
+// re-fires this. immediate so an at-mount overlay set composes once the
+// chart exists.
+watch(
+  () => (props.overlays ?? [])
+    .map((o) => o.key + ':' + o.series.map((s) => s.label).join(',')).join('|'),
+  () => {
+    try { rebuildAllDatasets(); } catch (err) { console.warn('overlay rebuild skipped:', err); }
+    void drainOverlays();
+  },
+  { immediate: true },
+);
+
+// Data changes — any sibling stream version/epoch bump drains new rows.
+// Reading each stream's version/epoch inside the getter establishes the
+// reactive deps; reading props.overlays re-tracks them on a membership
+// swap. Kept separate from the structure watcher so a per-second tick
+// doesn't recompose the dataset list, only appends points.
+watch(
+  () => {
+    const ovs = props.overlays ?? [];
+    let v = 0;
+    for (const o of ovs) v += o.eventsStream.version.value + o.eventsStream.epoch.value;
+    return ovs.length + ':' + v;
+  },
+  () => { void drainOverlays(); },
+);
+
 // Resume drain — flush any samples that arrived while pinned in
 // chronological order, so the chart catches up to the live edge in
 // one pass. insertByX dedupes by x so re-runs stay safe.
@@ -1239,6 +1522,9 @@ watch(
     lastIngestedMs = -Infinity;
     ++backfillToken; // abort any in-flight backfill for the old player
     for (const arr of dataset) arr.length = 0;
+    // Drop compare-overlay state too (#579) so a picker swap doesn't
+    // leave a previous group's sibling lines on the new session.
+    overlayRuntime.clear();
     safeChartUpdate();
   },
 );

--- a/content/dashboard-v3/src/components/RTTChart.vue
+++ b/content/dashboard-v3/src/components/RTTChart.vue
@@ -11,11 +11,19 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import { usePlayer } from '@/composables/usePlayer';
+import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
+import { compareRttSeries } from '@/composables/compareSeries';
 
 const props = defineProps<{
   playerId: string;
   eventsStream: Stream<Record<string, unknown>>;
 }>();
+
+/** Grouped-sibling RTT overlays (issue #579). Empty unless compare mode
+ *  is on; shares the ms 'y' axis (and 'y2' for RTO) so the scales size
+ *  across every overlaid session. */
+const compareOverlays = useCompareOverlays(compareRttSeries);
+const compareSelf = useCompareSelf();
 
 // AVMetrics is iOS-only (AVPlayer ≥ iOS 18); other players will never
 // populate client_rtt_avmetrics_ms, so we hide the TTFB (client) line
@@ -27,7 +35,11 @@ const isAVPlayer = computed(() => {
   return tech === 'AVPlayer';
 });
 
-const series = computed<SeriesSpec[]>(() => [
+const series = computed<SeriesSpec[]>(() => {
+  // Compare mode: active session shows the same canonical tagged RTT set
+  // (solid `S<id>`) the siblings overlay.
+  if (compareSelf.value) return compareRttSeries(compareSelf.value);
+  return [
   {
     label: 'RTT (ms)',
     color: '#4f46e5',
@@ -68,7 +80,8 @@ const series = computed<SeriesSpec[]>(() => [
     accessor: (p: PlayerRecord) => p.server_metrics?.rto_ms ?? null,
     axis: 'y2',
   },
-]);
+  ];
+});
 </script>
 
 <template>
@@ -78,6 +91,7 @@ const series = computed<SeriesSpec[]>(() => [
     unit="ms"
     :series="series"
     :events-stream="eventsStream"
+    :overlays="compareOverlays"
     :y-min="0"
     y2-title="RTO (ms)"
     :y2-min="0"

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -26,7 +26,7 @@
  * Composables run unconditionally; if sessionId is empty (live mode
  * before historical resolution), they short-circuit and return empty.
  */
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { ref, shallowRef, computed, watch, onMounted, onBeforeUnmount, provide } from 'vue';
 import { useQueryClient } from '@tanstack/vue-query';
 import CollapsibleSection from '@/components/CollapsibleSection.vue';
 import SessionDetails from '@/components/SessionDetails.vue';
@@ -61,7 +61,12 @@ interface SessionEvent {
   [k: string]: unknown;
 }
 import { usePlayer } from '@/composables/usePlayer';
-import { useSessionTimeSeries } from '@/composables/useSessionTimeSeries';
+import { useSessionTimeSeries, type Stream } from '@/composables/useSessionTimeSeries';
+import { useCompareMode } from '@/composables/useCompareMode';
+import { useGroupSiblings } from '@/composables/useGroupSiblings';
+import { CompareContextKey, sessionDash, type CompareSibling, type CompareSeriesIdentity } from '@/composables/useCompareContext';
+import CompareSeriesSource from '@/components/CompareSeriesSource.vue';
+import CompareSessionLegend from '@/components/CompareSessionLegend.vue';
 import { chRowToPlayerRecord, tsOfRow } from '@/composables/chRowAdapter';
 import {
   setArchivePlayer,
@@ -114,6 +119,94 @@ const playIdRef = computed(() => props.playId);
 // this subscription only matters for mutation-side consumers.
 const livePlayerIdRef = computed(() => props.playerId);
 const { player: livePlayer } = usePlayer(livePlayerIdRef);
+
+/* ─── Compare-charts overlay (issue #579) ───────────────────────────
+ * When the active session is in a group (≥2 members) and the operator
+ * flips "Compare Charts" (the GroupBanner toggle), overlay each grouped
+ * sibling's tagged rate/buffer series onto the shared charts. The toggle
+ * + sibling resolution are keyed on the RAW player id (props.playerId)
+ * so GroupBanner's button and this consumer share state via the
+ * module-level useCompareMode / useGroupSiblings maps. Each sibling's
+ * SSE is owned by one renderless CompareSeriesSource (rendered in the
+ * template); we register its events stream here and publish the assembled
+ * CompareContext so BandwidthChart / BufferChart can pull their overlays
+ * via useCompareOverlays(). */
+const compareMode = useCompareMode(livePlayerIdRef);
+const { siblings: groupSiblings } = useGroupSiblings(livePlayerIdRef);
+const compareEnabled = computed(
+  () => compareMode.state.enabled && groupSiblings.value.length >= 1,
+);
+// Registered sibling streams keyed by player_id. shallowRef + whole-Map
+// replace so add/remove triggers the computed WITHOUT deep-reactive
+// wrapping the Stream (which holds refs + functions).
+const siblingStreams = shallowRef(new Map<string, Stream<Record<string, unknown>>>());
+function registerSibling(pid: string, stream: Stream<Record<string, unknown>>) {
+  const m = new Map(siblingStreams.value);
+  m.set(pid, stream);
+  siblingStreams.value = m;
+}
+function unregisterSibling(pid: string) {
+  if (!siblingStreams.value.has(pid)) return;
+  const m = new Map(siblingStreams.value);
+  m.delete(pid);
+  siblingStreams.value = m;
+}
+// Renderless subscribers to mount — only while compare is on, so a fresh
+// SSE per sibling isn't opened until the operator asks for the overlay.
+const compareSources = computed(() => (compareEnabled.value ? groupSiblings.value : []));
+const compareSiblings = computed<CompareSibling[]>(() => {
+  if (!compareEnabled.value) return [];
+  return groupSiblings.value
+    .filter((s) => siblingStreams.value.has(s.playerId))
+    .map((s) => ({
+      playerId: s.playerId,
+      tag: s.tag,
+      label: s.label,
+      index: s.index,
+      // Each sibling gets a stable dash by index; the active session is
+      // solid (below). Colour is per-metric, assigned in compareSeries.
+      dash: sessionDash(s.index),
+      stream: siblingStreams.value.get(s.playerId)!,
+    }));
+});
+// The active session's own compare identity — tag `S<display_id>` (so it
+// reads as one of the grouped sessions) and a SOLID line (empty dash) to
+// stand out from the dashed siblings. Charts build their primary `series`
+// from this in compare mode so the active session's lines are tagged +
+// slimmed to the same canonical set the siblings show.
+const compareSelf = computed<CompareSeriesIdentity | null>(() => {
+  if (!compareEnabled.value) return null;
+  const did = livePlayer.value?.display_id;
+  const tag = did != null ? `S${did}` : `S${props.playerId.slice(0, 4)}`;
+  return { tag, dash: [] };
+});
+// Shared session-legend view (S1/S2 chips → hover-highlight + show/hide
+// per session across all charts). Cleared when compare mode turns off so
+// a stale hidden set doesn't blank a session on re-entry.
+const compareHovered = ref<string | null>(null);
+const compareHidden = ref<Set<string>>(new Set());
+const compareView = { hovered: compareHovered, hidden: compareHidden };
+watch(compareEnabled, (on) => {
+  if (!on) { compareHovered.value = null; compareHidden.value = new Set(); }
+});
+// The chip list: the active session first (solid, "This session"), then
+// each grouped sibling with its dash + label.
+const compareSessions = computed(() => {
+  if (!compareEnabled.value) return [];
+  const out: Array<{ tag: string; label: string; dash: number[]; isSelf: boolean }> = [];
+  const selfTag = compareSelf.value?.tag;
+  if (selfTag) out.push({ tag: selfTag, label: 'This session', dash: [], isSelf: true });
+  for (const s of compareSiblings.value) {
+    out.push({ tag: s.tag, label: s.label, dash: s.dash, isSelf: false });
+  }
+  return out;
+});
+provide(CompareContextKey, {
+  enabled: compareEnabled,
+  self: compareSelf,
+  siblings: compareSiblings,
+  view: compareView,
+});
 
 // Defensive: only adopt usePlayer's canonical-case id when it
 // matches props.playerId case-insensitively. The shared TanStack
@@ -1271,6 +1364,17 @@ function skipToEnd() {
 
 <template>
   <div class="session-display">
+    <!-- Compare-charts overlay (issue #579): one renderless SSE
+         subscriber per grouped sibling, mounted only while compare mode
+         is on. Each registers its events stream with the CompareContext
+         the charts consume. -->
+    <CompareSeriesSource
+      v-for="sib in compareSources"
+      :key="sib.playerId"
+      :player-id="sib.playerId"
+      @register="registerSibling"
+      @unregister="unregisterSibling"
+    />
     <!-- Test-run metadata — off the event axis (see docs/EVENT_TAXONOMY.md);
          shown here so the viewer still says "this play was harness run X". -->
     <div v-if="testRun" class="test-run-chip" :title="`Harness run ${testRun.run_id}`">
@@ -1585,7 +1689,7 @@ function skipToEnd() {
       <PlayerMetrics :player-id="archivePlayerId" />
     </CollapsibleSection>
 
-    <CollapsibleSection title="Player State" :open="true" eager persist-key="player-state">
+    <CollapsibleSection title="Player State" :open="true" eager persist-key="player-state" :force-collapsed="compareEnabled">
       <!-- Cycle-band overlay — visible only when control_events for
            this play include at least one label_changed row carrying
            a cycle_id (characterization runs only). Aligned with the
@@ -1601,6 +1705,13 @@ function skipToEnd() {
 
     <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">
       <BitrateChartPanelToolbar :player-id="archivePlayerId" />
+      <!-- Compare mode: S1/S2 session chips — hover to highlight a whole
+           session across all charts, click to show/hide it (#579). -->
+      <CompareSessionLegend
+        v-if="compareEnabled"
+        :sessions="compareSessions"
+        :view="compareView"
+      />
       <div class="chart-stack">
         <BandwidthChart :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
         <BufferChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
@@ -1609,7 +1720,7 @@ function skipToEnd() {
       </div>
     </CollapsibleSection>
 
-    <CollapsibleSection title="Network Log" persist-key="network-log">
+    <CollapsibleSection title="Network Log" persist-key="network-log" :force-collapsed="compareEnabled">
       <!-- The page-level brush in SessionDisplay is the only scrub
            surface — archive shows it always, live shows it once
            paused. NetworkLog's own in-panel brush would duplicate it
@@ -1618,7 +1729,7 @@ function skipToEnd() {
       <NetworkLog :player-id="archivePlayerId" :network-stream="timeseries.network" />
     </CollapsibleSection>
 
-    <CollapsibleSection title="Play Log" persist-key="play-log">
+    <CollapsibleSection title="Play Log" persist-key="play-log" :force-collapsed="compareEnabled">
       <!-- Time-multiplexed view of snapshots + network rows + events
            interleaved on one chronological scroll, with checkbox
            filters per source. The three streams come from the same

--- a/content/dashboard-v3/src/composables/compareSeries.ts
+++ b/content/dashboard-v3/src/composables/compareSeries.ts
@@ -1,0 +1,289 @@
+/**
+ * compareSeries — per-chart SeriesSpec builders for the compare-charts
+ * overlay (issue #579). Each builder takes one grouped sibling and
+ * returns its overlay series, reusing the SAME PlayerRecord accessors as
+ * the primary single-session series so the overlaid values mean exactly
+ * what the active session's lines mean.
+ *
+ * Visual encoding (operator's spec):
+ *   - COLOUR encodes the METRIC, matching the primary chart's colour for
+ *     that series — so "Player network_bitrate" is the same green on the
+ *     active session and on every sibling, and the eye pairs them at a
+ *     glance.
+ *   - DASH encodes the SESSION — the active session is solid, each
+ *     sibling gets a distinct dash pattern by its stable index — so two
+ *     devices' same-colour lines stay tellable apart.
+ *   - LABEL is the primary series' exact name + ` (Sx)`, so the legend
+ *     reads identically across sessions bar the tag.
+ *
+ * The full set ships default-visible, mirroring the legacy testing.html
+ * compare overlay. (Some players don't emit every field — e.g.
+ * network_bitrate needs the client LocalProxy — so that line may be all
+ * gaps; the others still render.)
+ */
+import type { SeriesSpec } from '@/components/MetricsLineChart.vue';
+import type { CompareSeriesIdentity } from '@/composables/useCompareContext';
+import type { PlayerRecord } from '@/repo/v2-repo';
+
+/** Metric colours — kept in lockstep with the primary chart series so a
+ *  metric reads the same hue across the active session and every overlay.
+ *  Update alongside the matching `color:` in the chart components. */
+const C = {
+  // BandwidthChart
+  shaperAvg: '#0d9488',
+  playerAvgRate: '#6366f1',
+  playerNetRate: '#059669',
+  servingVariant: '#b45309',
+  fetchingVariant: '#ef4444',
+  limit: '#f59e0b',
+  // BufferChart
+  bufferDepth: '#4f46e5',
+  liveOffset: '#f59e0b',
+  trueOffset: '#10b981',
+  // RTTChart
+  rtt: '#4f46e5',
+  rttMin: '#10b981',
+  rttMax: '#ef4444',
+  pathPing: '#f59e0b',
+  rto: '#a855f7',
+  // FPSChart
+  displayedFps: '#10b981',
+  droppedFps: '#ef4444',
+  droppedTotal: '#7c2d12',
+} as const;
+
+/** Append the session tag to a primary series label, matching it across
+ *  sessions: `Player network_bitrate` → `Player network_bitrate (S2)`. */
+function tagged(label: string, id: CompareSeriesIdentity): string {
+  return `${label} (${id.tag})`;
+}
+
+/** Stamp the session tag onto every series so MetricsLineChart can group
+ *  them for the S1/S2 session legend (hover-highlight + show/hide a whole
+ *  session). Without this the legend can't match any line to a session. */
+function withTag(id: CompareSeriesIdentity, series: SeriesSpec[]): SeriesSpec[] {
+  return series.map((s) => ({ ...s, sessionTag: id.tag }));
+}
+
+/** Effective enforced shaper ceiling at a sample — mirrors
+ *  BandwidthChart's "Limit (rate_mbps)" accessor so each session's limit
+ *  overlays with the same meaning: pattern runtime rate when a pattern is
+ *  active, else the active step's rate, else the static rate, else 0. The
+ *  sibling's charts_minimal projection carries the nftables_* fields the
+ *  chRow adapter folds into p.shape. */
+function limitAccessor(p: PlayerRecord): number | null {
+  const sh = p.shape as {
+    rate_mbps?: number | null;
+    pattern?: { steps?: { rate_mbps?: number }[] } | null;
+    pattern_rate_runtime_mbps?: number | null;
+    pattern_step?: number | null;
+    pattern_step_runtime?: number | null;
+  } | undefined;
+  if (!sh) return 0;
+  const runtime = sh.pattern_rate_runtime_mbps;
+  if (sh.pattern && Number.isFinite(runtime as number) && (runtime as number) >= 0) {
+    return runtime as number;
+  }
+  const stepIdx = Number(sh.pattern_step_runtime ?? sh.pattern_step ?? 0);
+  const steps = sh.pattern?.steps ?? [];
+  if (stepIdx > 0 && stepIdx <= steps.length) {
+    const r = Number(steps[stepIdx - 1]?.rate_mbps);
+    if (Number.isFinite(r) && r >= 0) return r;
+  }
+  if (Number.isFinite(sh.rate_mbps as number)) return sh.rate_mbps as number;
+  return 0;
+}
+
+/**
+ * Bandwidth (rate) chart overlay — the primary comparison target. Only
+ * the series the active chart shows BY DEFAULT are overlaid; lines that
+ * are hidden-by-default there (Player network_bitrate, Serving Variant)
+ * are omitted entirely rather than shipped as legend clutter. All on the
+ * left ('y') axis so they auto-size alongside the active session's own
+ * lines (#165 union).
+ */
+export function compareBandwidthSeries(id: CompareSeriesIdentity): SeriesSpec[] {
+  const dash = id.dash;
+  return withTag(id, [
+    {
+      label: tagged('Player avg_network_bitrate', id),
+      color: C.playerAvgRate,
+      accessor: (p: PlayerRecord) => p.player_metrics?.avg_network_bitrate_mbps ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('Fetching Variant', id),
+      color: C.fetchingVariant,
+      accessor: (p: PlayerRecord) => p.player_metrics?.video_bitrate_mbps ?? null,
+      stepped: true,
+      borderDash: dash,
+    },
+    {
+      label: tagged('Limit (rate_mbps)', id),
+      color: C.limit,
+      accessor: limitAccessor,
+      stepped: true,
+      borderDash: dash,
+    },
+    {
+      label: tagged('mbps_shaper_avg', id),
+      color: C.shaperAvg,
+      accessor: (p: PlayerRecord) => p.server_metrics?.mbps_shaper_avg ?? null,
+      borderDash: dash,
+    },
+  ]);
+}
+
+/**
+ * Buffer chart overlay — buffer depth per session on the left ('y') axis
+ * (sized across all sessions, #165), plus live + true offset on the right
+ * ('y2') axis. Several sessions' offset lines share the y2 scale, which
+ * auto-sizes across them, so `Live offset (S1)` / `Live offset (S2)` /
+ * `True offset (…)` all read on the right axis at once.
+ */
+export function compareBufferSeries(id: CompareSeriesIdentity): SeriesSpec[] {
+  const dash = id.dash;
+  return withTag(id, [
+    {
+      label: tagged('Buffer depth (s)', id),
+      color: C.bufferDepth,
+      accessor: (p: PlayerRecord) => p.player_metrics?.buffer_depth_s ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('Live offset (s)', id),
+      color: C.liveOffset,
+      accessor: (p: PlayerRecord) => p.player_metrics?.live_offset_s ?? null,
+      borderDash: dash,
+      axis: 'y2',
+    },
+    {
+      label: tagged('True offset (s)', id),
+      color: C.trueOffset,
+      accessor: (p: PlayerRecord) => p.player_metrics?.true_offset_s ?? null,
+      borderDash: dash,
+      axis: 'y2',
+    },
+  ]);
+}
+
+/**
+ * RTT chart overlay — the TCP_INFO RTT family per sibling (left 'y'
+ * axis, ms) plus RTO on the right ('y2') axis, mirroring the primary
+ * layout. TTFB (client) is omitted: it's iOS-AVPlayer-only (AVMetrics)
+ * and we don't carry the sibling's player_tech here, so it would just
+ * add an always-empty line for non-iOS peers.
+ */
+export function compareRttSeries(id: CompareSeriesIdentity): SeriesSpec[] {
+  const dash = id.dash;
+  return withTag(id, [
+    {
+      label: tagged('RTT (ms)', id),
+      color: C.rtt,
+      accessor: (p: PlayerRecord) => p.server_metrics?.rtt_ms ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('RTT min (ms)', id),
+      color: C.rttMin,
+      accessor: (p: PlayerRecord) => p.server_metrics?.rtt_min_ms ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('RTT max (ms)', id),
+      color: C.rttMax,
+      accessor: (p: PlayerRecord) => p.server_metrics?.rtt_max_ms ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('Path ping (ms)', id),
+      color: C.pathPing,
+      accessor: (p: PlayerRecord) => p.server_metrics?.path_ping_rtt_ms ?? null,
+      borderDash: dash,
+    },
+    {
+      label: tagged('RTO (ms)', id),
+      color: C.rto,
+      accessor: (p: PlayerRecord) => p.server_metrics?.rto_ms ?? null,
+      borderDash: dash,
+      axis: 'y2',
+    },
+  ]);
+}
+
+/** Parse a synthetic PlayerRecord's sample timestamp (ms) from the
+ *  event_time the chRow adapter projects onto player_metrics. Accepts
+ *  the CH "YYYY-MM-DD HH:MM:SS.fff" form (UTC, no Z) and ISO-8601. */
+function tsOfRecord(p: PlayerRecord): number {
+  const et = p.player_metrics?.event_time;
+  if (typeof et !== 'string' || !et) return NaN;
+  if (et.length > 10 && et.charAt(10) === ' ') return Date.parse(et.replace(' ', 'T') + 'Z');
+  return Date.parse(et);
+}
+
+/**
+ * Build a stateful per-sibling rate accessor: instantaneous Δcount/Δt of
+ * a monotonic counter (frames displayed / dropped). FPSChart derives
+ * these per-component from the primary stream, so a stateless overlay
+ * accessor would mis-plot the active session's FPS against the sibling's
+ * samples. This closure keeps its OWN prev (count, ts, play) — resetting
+ * on the sibling's play rotation, exactly like the primary chart — so
+ * each overlaid device shows its own frame rate. One closure per sibling
+ * (the SeriesSpec set is rebuilt only when the sibling list changes).
+ */
+function makeCounterRate(read: (p: PlayerRecord) => number | null): (p: PlayerRecord) => number | null {
+  let prevVal: number | null = null;
+  let prevTs: number | null = null;
+  let prevPlay: string | null = null;
+  return (p: PlayerRecord) => {
+    const t = tsOfRecord(p);
+    const v = read(p);
+    const play = p.current_play?.id ?? null;
+    // New play → reseat the baseline, emit no rate for the first sample
+    // (avoids a spurious huge delta against the prior play's counter).
+    if (play !== prevPlay) {
+      prevPlay = play;
+      prevVal = v;
+      prevTs = Number.isFinite(t) ? t : null;
+      return null;
+    }
+    let out: number | null = null;
+    if (prevTs != null && prevVal != null && v != null && Number.isFinite(t) && t > prevTs) {
+      const dt = (t - prevTs) / 1000;
+      out = dt > 0 ? Math.max(0, (v - prevVal) / dt) : null;
+    }
+    if (Number.isFinite(t)) { prevVal = v; prevTs = t; }
+    return out;
+  };
+}
+
+/**
+ * FPS chart overlay — derived displayed/dropped FPS per sibling (left
+ * 'y' axis) + the raw dropped-frames counter (right 'y2' axis). The two
+ * derived series each own their delta state via makeCounterRate.
+ */
+export function compareFpsSeries(id: CompareSeriesIdentity): SeriesSpec[] {
+  const dash = id.dash;
+  return withTag(id, [
+    {
+      label: tagged('Displayed FPS', id),
+      color: C.displayedFps,
+      accessor: makeCounterRate((p) => p.player_metrics?.frames_displayed ?? null),
+      borderDash: dash,
+    },
+    {
+      label: tagged('Dropped FPS', id),
+      color: C.droppedFps,
+      accessor: makeCounterRate((p) => p.player_metrics?.frames_dropped ?? null),
+      borderDash: dash,
+    },
+    {
+      label: tagged('Dropped frames (total)', id),
+      color: C.droppedTotal,
+      accessor: (p: PlayerRecord) => p.player_metrics?.frames_dropped ?? null,
+      stepped: true,
+      borderDash: dash,
+      axis: 'y2',
+    },
+  ]);
+}

--- a/content/dashboard-v3/src/composables/useCompareContext.ts
+++ b/content/dashboard-v3/src/composables/useCompareContext.ts
@@ -1,0 +1,114 @@
+/**
+ * Compare-charts context (issue #579) — the bridge between SessionDisplay
+ * (which owns the grouped-session identities + sibling time-series
+ * subscriptions) and the individual chart components.
+ *
+ * In compare mode every session — the active one included — renders the
+ * SAME canonical line set, each series tagged with its session's `(Sx)`
+ * and told apart by dash pattern (the active session is solid, each
+ * sibling gets a stable dash). SessionDisplay publishes:
+ *   - `self`     — the active session's identity (tag + solid dash); the
+ *                  charts build their primary `series` from it.
+ *   - `siblings` — each grouped peer's identity + registered events
+ *                  stream; the charts build their `overlays` from these.
+ *
+ * Colours are assigned per METRIC (in compareSeries), not per session, so
+ * a metric reads the same hue on every session and the eye pairs them.
+ */
+import { computed, inject, type ComputedRef, type InjectionKey, type Ref } from 'vue';
+import type { Stream } from '@/composables/useSessionTimeSeries';
+import type { ChartOverlaySource, SeriesSpec } from '@/components/MetricsLineChart.vue';
+
+/** The minimum a compareSeries builder needs to tag + style one
+ *  session's lines: a short legend tag and the dash that identifies the
+ *  session ([] = solid, used for the active session). */
+export interface CompareSeriesIdentity {
+  /** Short legend tag, e.g. `S3`. */
+  tag: string;
+  /** Dash pattern that identifies this session across all its lines.
+   *  Empty array = solid (the active session). */
+  dash: number[];
+}
+
+export interface CompareSibling extends CompareSeriesIdentity {
+  /** Canonical player UUID of the sibling. */
+  playerId: string;
+  /** Human label, e.g. `#3 iPhone`. */
+  label: string;
+  /** Stable index among siblings — drives dash assignment. */
+  index: number;
+  /** This sibling's events stream (charts_minimal projection). */
+  stream: Stream<Record<string, unknown>>;
+}
+
+/** Shared session-legend view state (issue #579). The S1/S2 chip row in
+ *  SessionDisplay writes these; every chart reads them and highlights /
+ *  shows / hides all lines for a session by its `Sx` tag, in lockstep. */
+export interface CompareView {
+  /** Tag of the session currently hovered in the legend (null = none).
+   *  Charts pop that session's lines and dim the rest. */
+  hovered: Ref<string | null>;
+  /** Tags of sessions toggled off in the legend; charts hide all lines
+   *  for those sessions. */
+  hidden: Ref<Set<string>>;
+}
+
+export interface CompareContext {
+  /** Is compare mode on for the active session? */
+  enabled: Ref<boolean>;
+  /** The active session's own identity (tag + solid dash), or null when
+   *  compare mode is off. Charts build their primary `series` from this
+   *  so the active session's lines get tagged + slimmed to match. */
+  self: Ref<CompareSeriesIdentity | null>;
+  /** Grouped siblings with registered streams (empty when off). */
+  siblings: Ref<CompareSibling[]>;
+  /** Session-legend hover/hide state, applied across every chart. */
+  view: CompareView;
+}
+
+export const CompareContextKey: InjectionKey<CompareContext> = Symbol('compareContext');
+
+/** Per-session dash patterns. The active session is solid (`[]`); each
+ *  sibling takes one of these by its stable index so a device keeps its
+ *  dash as peers come and go. */
+export const SESSION_DASH: ReadonlyArray<number[]> = [
+  [6, 4],          // dashed
+  [2, 3],          // dotted
+  [10, 4, 2, 4],   // dash-dot
+  [4, 4],          // even dash
+  [1, 3],          // fine dot
+  [9, 3, 3, 3],    // long dash-dot
+];
+export function sessionDash(index: number): number[] {
+  const n = SESSION_DASH.length;
+  return SESSION_DASH[((index % n) + n) % n];
+}
+
+/**
+ * useCompareOverlays — turn the provided compare context into a chart's
+ * `overlays` prop. `specsFor` maps one session identity to the
+ * SeriesSpec[] that chart wants (its own accessors, tagged + styled per
+ * session). Returns [] when compare mode is off or no context is
+ * provided (so a chart mounted outside SessionDisplay is unaffected).
+ */
+export function useCompareOverlays(
+  specsFor: (id: CompareSeriesIdentity) => SeriesSpec[],
+): ComputedRef<ChartOverlaySource[]> {
+  const ctx = inject(CompareContextKey, null);
+  return computed<ChartOverlaySource[]>(() => {
+    if (!ctx || !ctx.enabled.value) return [];
+    return ctx.siblings.value.map((sib) => ({
+      key: sib.playerId,
+      eventsStream: sib.stream,
+      series: specsFor(sib),
+    }));
+  });
+}
+
+/** Inject the active session's compare identity (null when compare mode
+ *  is off / outside a SessionDisplay). Charts use it to retag + slim
+ *  their primary `series` so the active session matches the overlays. */
+export function useCompareSelf(): ComputedRef<CompareSeriesIdentity | null> {
+  const ctx = inject(CompareContextKey, null);
+  return computed(() => (ctx && ctx.enabled.value ? ctx.self.value : null));
+}

--- a/content/dashboard-v3/src/composables/useCompareMode.ts
+++ b/content/dashboard-v3/src/composables/useCompareMode.ts
@@ -1,0 +1,59 @@
+/**
+ * useCompareMode(playerId) — shared "Compare Charts" toggle, keyed by
+ * the active player UUID. Mirrors the useChartCoordination(playerId)
+ * module-level Map pattern so the toggle rendered in GroupBanner and the
+ * overlay consumed by SessionDisplay/BandwidthChart read the same
+ * reactive flag without prop-drilling (issue #579).
+ *
+ * Compare mode overlays each grouped sibling session's rate/buffer
+ * series onto the bandwidth + buffer charts — restoring the legacy
+ * testing.html compare-mode the v3 cutover dropped. It only does
+ * anything when the active player is in a group with ≥2 members; the
+ * flag is just remembered per player so flipping it on a degenerate
+ * (ungrouped) session is harmless and survives a later regrouping.
+ *
+ * State is intentionally NOT persisted to localStorage — compare mode is
+ * a transient investigation gesture, and defaulting it off on reload
+ * matches how the legacy checkbox behaved (unchecked on page load).
+ */
+import { isRef, reactive, ref, type Ref } from 'vue';
+
+interface CompareModeState {
+  enabled: boolean;
+}
+
+const states = new Map<string, CompareModeState>();
+
+function ensureState(pid: string): CompareModeState {
+  let s = states.get(pid);
+  if (!s) {
+    s = reactive<CompareModeState>({ enabled: false });
+    states.set(pid, s);
+  }
+  return s;
+}
+
+export function useCompareMode(playerIdInput: string | Ref<string>) {
+  const playerIdRef: Ref<string> = isRef(playerIdInput)
+    ? playerIdInput
+    : ref(playerIdInput);
+
+  function cur(): CompareModeState {
+    return ensureState(playerIdRef.value);
+  }
+
+  return {
+    /** Reactive state object — read `state.enabled` inside a computed
+     *  or template to track the toggle. */
+    get state(): CompareModeState {
+      return cur();
+    },
+    toggle() {
+      const s = cur();
+      s.enabled = !s.enabled;
+    },
+    setEnabled(v: boolean) {
+      cur().enabled = v;
+    },
+  };
+}

--- a/content/dashboard-v3/src/composables/useGroupSiblings.ts
+++ b/content/dashboard-v3/src/composables/useGroupSiblings.ts
@@ -1,0 +1,78 @@
+/**
+ * useGroupSiblings(playerId) — the OTHER members of the active player's
+ * group, for the compare-charts overlay (issue #579).
+ *
+ * Resolves the active player's group via membership (the same v5-derived
+ * group id reasoning as GroupBanner: g.id never equals the raw v1
+ * group_id, so we match on member_player_ids.includes(self)), then
+ * returns every member that isn't `self`, each with a stable display
+ * label and a palette index so overlay colours stay put as the brush
+ * pans or peers come and go.
+ *
+ * Empty unless the active player is in a group with ≥2 members. Reuses
+ * useGroups() (polling) + usePlayers() (SSE-invalidated) so the sibling
+ * list tracks link/unlink without its own subscription.
+ */
+import { computed, isRef, ref, type Ref } from 'vue';
+import { useGroups } from '@/composables/useGroups';
+import { usePlayers } from '@/composables/usePlayers';
+import { deviceFromUA } from '@/composables/useSessionLabels';
+
+export interface GroupSibling {
+  /** Canonical player UUID of the sibling. */
+  playerId: string;
+  /** Short human label — `#<display_id> <device>` when known, else a
+   *  truncated UUID. Used in the per-member legend group name + tooltips. */
+  label: string;
+  /** Short tag for legend series, e.g. `S3` from display_id 3, falling
+   *  back to the first UUID octet. Kept compact so the chart legend
+   *  stays readable with several overlaid sessions. */
+  tag: string;
+  /** Stable 0-based index among the siblings (sorted by player id) so a
+   *  given sibling keeps the same overlay colour across renders. */
+  index: number;
+}
+
+export function useGroupSiblings(playerIdInput: string | Ref<string>) {
+  const playerIdRef: Ref<string> = isRef(playerIdInput)
+    ? playerIdInput
+    : ref(playerIdInput);
+  const { groups } = useGroups();
+  const { players } = usePlayers();
+
+  const groupInfo = computed(() => {
+    const self = playerIdRef.value;
+    return (
+      (groups.value ?? []).find(
+        (g) =>
+          Array.isArray(g.member_player_ids) && g.member_player_ids.includes(self),
+      ) ?? null
+    );
+  });
+
+  const siblings = computed<GroupSibling[]>(() => {
+    const g = groupInfo.value;
+    if (!g || !Array.isArray(g.member_player_ids)) return [];
+    // Only meaningful as a comparison when the group has ≥2 members
+    // (self + at least one peer).
+    if (g.member_player_ids.length < 2) return [];
+    const self = playerIdRef.value;
+    // Sort for a stable colour assignment regardless of membership
+    // emission order.
+    const otherIds = g.member_player_ids
+      .filter((id) => id !== self)
+      .slice()
+      .sort();
+    return otherIds.map((id, index) => {
+      const p = (players.value ?? []).find((x) => x.id === id);
+      const displayId = p?.display_id;
+      const tag = displayId != null ? `S${displayId}` : `S${id.slice(0, 4)}`;
+      const num = displayId != null ? `#${displayId}` : id.slice(0, 8);
+      const device = deviceFromUA(p?.user_agent ?? null);
+      const label = device ? `${num} ${device}` : num;
+      return { playerId: id, label, tag, index };
+    });
+  });
+
+  return { siblings, groupInfo };
+}


### PR DESCRIPTION
## What

Restores grouped **compare-mode chart overlays** in the v3 dashboard — the "Compare Charts" view the v3 cutover (#458) dropped. When 2+ devices are linked in a player group, every chart overlays each grouped session's lines so you can read multiple devices' achieved/played bitrate (and buffer / RTT / FPS) against the same shaping target.

Restores #139 (Player Network Rate in the overlay) and #165 (axes size across all grouped sessions) behaviour in the Vue pipeline.

**Scope:** live path (Testing / TestingSession). Archive comparison (sessions.html → session-viewer) and a split-sessions layout are planned follow-ups — the overlay seam is shared, so both are additive.

## Behaviour

- **Toggle** in `GroupBanner` (shown with ≥2 grouped members).
- In compare mode **every session — the active one included — shows the same canonical line set**, each series tagged `(Sx)`. Active session = `S<display_id>` + solid; siblings dashed (stable per index).
- **Colour = metric** (matches the active chart's colour, so a metric reads the same hue on every session); **dash + tag = session**.
- Only the active chart's **default-visible** metrics are overlaid; the active chart slims to that same set in compare mode so all sessions match, and returns to its full single-session view when off.
- All four charts overlay:
  - **Bandwidth** — Player avg_network_bitrate, Fetching Variant, Limit (rate_mbps), mbps_shaper_avg. Per-segment AVMetrics markers suppressed in compare mode.
  - **Buffer** — Buffer depth (left), Live + True offset (right `y2`; multiple sessions share + auto-size the right axis).
  - **RTT** — RTT / min / max / Path ping (left), RTO (right `y2`).
  - **FPS** — Displayed / Dropped FPS + Dropped frames total; each sibling derives its own FPS from per-session counter deltas.
- y-axes size across the union of overlaid series (#165); `spanGaps:false` + explicit nulls so a session missing a metric shows a **gap**, not an interpolated bridge.
- **Session legend (S1/S2 chips)** above the chart stack: hover pops a whole session across all charts and dims the rest; click shows/hides all of that session's lines everywhere. Per-line legend hover is 3-tier — hovered line strongest, the **same metric on other sessions** medium, the rest dimmed.
- **Player State / Network Log / Play Log** auto-collapse on entering compare mode (restored on exit; never overwrites the operator's saved fold preference).

## Seam

- `MetricsLineChart` gains an `overlays` prop (per-session stream + tagged series), drained independently of the **untouched** single-session path, plus `sessionTag` on series for legend grouping.
- `useCompareContext` provides `{enabled, self, siblings, view}`; charts pull series/overlays via `useCompareSelf` / `useCompareOverlays`. `useCompareMode` is the toggle, `useGroupSiblings` resolves peers, `CompareSeriesSource` owns one SSE per sibling (`charts_minimal` — carries every compare field).

## Verify

`cd content/dashboard-v3 && npm run build` (runs `vue-tsc --noEmit` + vite) — clean. Exercised on test-dev (`:21000`) with two grouped browser sessions across all four charts, the session legend, panel collapse, and per-line metric-pairing hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
