### PR TITLE
fix(go-proxy): invalidate shape-apply cache on port clear so config-on-connect re-applies the kernel cap

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -829,6 +829,21 @@ func (a *App) setShapeApplyState(port int, state ShapeApplyState) {
 	a.shapeApplyMu.Unlock()
 }
 
+// clearShapeApplyState forgets the last-applied shaping for a port. It MUST be
+// called whenever the port's kernel tc rule is wiped out-of-band (ClearPortShaping
+// at session-start / session-delete on a reused port). Otherwise the cached
+// state still matches a subsequent apply of the same rate and applyShapeIfChanged
+// SKIPS the re-install — leaving the port uncapped (config present, no kernel
+// rule). This bit config-on-connect (#712), which clears the port then re-applies
+// the materialized cap before the 302: on a reused port whose prior session had
+// the same rate (e.g. the pyramid's 1.048 Mbps floor every run), the re-apply was
+// skipped and the player cold-started unshaped on 4K.
+func (a *App) clearShapeApplyState(port int) {
+	a.shapeApplyMu.Lock()
+	delete(a.shapeApply, port)
+	a.shapeApplyMu.Unlock()
+}
+
 type NftShapeStep struct {
 	RateMbps        float64 `json:"rate_mbps"`
 	DurationSeconds float64 `json:"duration_seconds"`
@@ -3207,6 +3222,7 @@ func (a *App) handleSession(w http.ResponseWriter, r *http.Request) {
 			if a.traffic != nil {
 				_ = a.traffic.UpdateNetem(port, 0, 0)
 				a.traffic.ClearPortShaping(port)
+				a.clearShapeApplyState(port)
 			}
 		}
 		writeJSON(w, map[string]string{"message": "Session deleted successfully"})
@@ -5555,6 +5571,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			// fault_rules-only config) still gets the baseline cap — this
 			// supersedes the plain baseline apply in the else branch.
 			if port, err := strconv.Atoi(assignedInternalPort); err == nil {
+				// The session-start sweep (ClearPortShaping, above) wiped any
+				// leftover kernel tc rule on this reused port, but the
+				// apply-state cache still holds the prior session's rate.
+				// Invalidate it so the apply below actually fires tc instead of
+				// being skipped as "unchanged" — otherwise the player cold-starts
+				// unshaped (config present, no kernel rule). Regression from #712
+				// re-applying at session-start after #352's ClearPortShaping.
+				a.clearShapeApplyState(port)
 				if steps := v2server.PatternStepsFromSession(sessionData); len(steps) > 0 {
 					v1steps := make([]NftShapeStep, 0, len(steps))
 					for _, s := range steps {


### PR DESCRIPTION
## Problem

config-on-connect (#712) sets a session's rate config and, before the 302, re-drives the kernel via `applySessionShaping → applyShapeIfChanged`. That apply is **skipped** when the per-port apply-state cache (`a.shapeApply`) already equals the desired rate. But ports are reused across sessions, and `ClearPortShaping` (#352) wipes the kernel tc rule at session-start **without** invalidating that cache.

On a reused port whose prior session had the same rate — e.g. the pyramid's 1.048 Mbps cold-start floor every run:

1. prior session applied 1.048 → `shapeApply[port] = 1.048`
2. `ClearPortShaping(port)` deletes the kernel rule (cache untouched)
3. `applyShapeIfChanged(port, 1.048)` sees cache == desired → "unchanged" → **skip**

Result: kernel rule gone, never reinstalled → `effective_rate_limit_mbps=1.048` (config present) but `nftables_bandwidth_kernel_mbps=-1` (no kernel rule) → the player **cold-started unshaped on 4K**. Intermittent: only bit when the reused port's cached rate matched, which is why it worsened the more a fixed-floor test reran.

## Fix

`clearShapeApplyState(port)` invalidates the cache wherever the kernel rule is wiped out-of-band:
- the config-on-connect **session-start** apply path (using the post-mapping internal port, matching what the apply keys on)
- the **session-delete** teardown

so the immediately-following apply fires `tc` instead of being skipped.

Latent since #352; surfaced by #712 adding the session-start re-apply.

## Verification

Builds + vets clean. Behavioral confirmation (cold-start caps reliably across reused-port reruns) requires deploying the fixed proxy to test-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
