### PR TITLE
fix(go-proxy): serialize config-on-connect session allocation (concurrent-bootstrap port collision → nftk=100 leak)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -325,6 +325,10 @@ func (rb *NetworkLogRingBuffer) GetAll() []NetworkLogEntry {
 
 type App struct {
 	sessionsMu               sync.Mutex
+	// createMu serializes the snapshot→allocate→reserve section of new-session
+	// bootstrap so two concurrent config-on-connect requests (a fleet run)
+	// can't both allocate the same session number and collide on one port.
+	createMu                 sync.Mutex
 	sessionsSnap             atomic.Pointer[[]SessionData]
 	throughputMu             sync.RWMutex
 	throughputData           map[int]map[string]interface{}
@@ -5352,6 +5356,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		// #alloc-race: snapshot→allocate→reserve must be atomic. Two concurrent
+		// config-on-connect bootstraps (a fleet) otherwise read the same list,
+		// both allocateSessionNumber()→the SAME number, and collide on one port —
+		// one session's rate config lands on the other's port and the loser is
+		// created config-less, falling to the baseline cap (the nftk=100 bug).
+		// Hold createMu across a FRESH re-read + allocate + reserve
+		// (saveSessionList below) so each concurrent bootstrap gets a distinct
+		// slot; released at handler return, after the kernel apply.
+		a.createMu.Lock()
+		defer a.createMu.Unlock()
+		sessionList = a.getSessionList()
 		if len(sessionList) >= a.maxSessions {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return


### PR DESCRIPTION
## Problem

The new-session bootstrap allocates a session number via a **non-atomic read-modify-write**:

```go
sessionList := a.getSessionList()                    // snapshot (locked read)
allocated := allocateSessionNumber(sessionList, …)   // next free # from snapshot
sessionList = append(sessionList, sessionData)
a.saveSessionList(sessionList)                        // locked write
```

`getSessionList`/`saveSessionList` each take `sessionsMu` individually, but **the lock isn't held across read→allocate→write**. So two config-on-connect bootstraps firing at once (a fleet — N sims each minting a player_id + curling the shaper port simultaneously) both snapshot the same list, both compute the **same** `allocated`, and both redirect to the same port.

Net effect: one unit's `proxy.shape.rate_mbps` lands on the **other** unit's port, and the loser's real session is created later by its app's (config-stripped) replay bootstrap with **no rate config** → `applySessionShaping` resolves `effectiveRate(0)` → the deployment **baseline (100 Mbps)** → the player streams uncapped (the `nftk=100` cold-start wedge).

## Evidence (test-dev, 2-sim run)

```
CURL (config): player_id=869262ea…&proxy.shape.rate_mbps=1   → Redirect 21081 -> 21181  (unit-1's port!)
APP  (no cfg): player_id=869262ea…&play_id=…                 → Redirect 21081 -> 21281
NETSHAPE LEAK port=30281 configured_mbps=0.000 kernel_mbps=100.000 session_id=2
```

Reproduces at **2** concurrent bootstraps; absent at 1.

## Fix

A dedicated `createMu` serializes the snapshot→allocate→reserve section: hold it across a **fresh** `getSessionList()` re-read + `allocateSessionNumber` + the `saveSessionList` that reserves the slot (released at handler return, after the kernel apply). Concurrent bootstraps now observe each other's reservation and pick distinct session numbers.

A dedicated lock (not `sessionsMu`) because the handler does tc work + `parseProxyArgs` between read and write — this avoids over-serializing unrelated session reads and any re-entrancy.

Orthogonal to #738 (shape-apply cache) and the startup peak-bitrate clamp.

## Verification

Builds + vets. Behavioral confirmation (a 2/3-sim fleet pyramid where all units get `nftk=floor`, no `nftk=100`) requires deploying to test-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
