### PR TITLE
chore: seed dashboard-v3 node_modules per worktree + harden test-deploy-dev

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,37 @@
+#!/bin/sh
+# post-checkout — ensure content/dashboard-v3/node_modules exists in this
+# worktree so `make test-deploy-dev` / `make test-deploy-frontend` can build
+# the Vue dashboard.
+#
+# node_modules is gitignored, so a fresh `git worktree add` never brings it.
+# That bit a #740 deploy on 2026-06-11: `make test-deploy-dev`'s rsync --delete
+# wiped the test-dev box, THEN the Vue build failed for lack of node_modules,
+# leaving the box half-updated. This hook seeds deps on every worktree add.
+#
+# Idempotent and quiet: no-op when deps are already present or when
+# dashboard-v3 isn't part of the checked-out tree. Never fails the checkout.
+#
+# Install into the active hooks dir with `make install-hooks`.
+
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+dir="$top/content/dashboard-v3"
+[ -f "$dir/package.json" ] || exit 0
+[ -d "$dir/node_modules/.bin" ] && exit 0
+
+# Prefer copying from a sibling worktree whose lockfile matches — fast
+# (same machine) and exact. Fall back to `npm ci` only when no match exists.
+git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}' | while read -r wt; do
+	[ "$wt" = "$top" ] && continue
+	src="$wt/content/dashboard-v3"
+	[ -d "$src/node_modules/.bin" ] || continue
+	if cmp -s "$src/package-lock.json" "$dir/package-lock.json" 2>/dev/null; then
+		echo "[post-checkout] seeding dashboard-v3/node_modules from $wt (lockfile match)"
+		cp -R "$src/node_modules" "$dir/node_modules" 2>/dev/null && exit 0
+	fi
+done
+# `exit 0` inside the while runs in a subshell (pipe), so check again here.
+[ -d "$dir/node_modules/.bin" ] && exit 0
+
+echo "[post-checkout] no matching sibling node_modules; running npm ci in dashboard-v3"
+( cd "$dir" && npm ci ) || echo "[post-checkout] npm ci failed — run it manually before deploying"
+exit 0

--- a/Makefile
+++ b/Makefile
@@ -420,6 +420,21 @@ test-go:
 	@echo "=== go-upload ==="
 	cd go-upload && go vet ./... && go test -race ./...
 
+# Install the repo's git hooks into the active hooks dir. The post-checkout
+# hook seeds content/dashboard-v3/node_modules (gitignored) on every
+# `git worktree add` so the Vue dashboard always builds — see #740. Honours
+# core.hooksPath when set, else the shared common hooks dir (which all
+# worktrees share). Re-run after pulling a hook change.
+.PHONY: install-hooks
+install-hooks:
+	@dest="$$(git config --get core.hooksPath || echo "$$(git rev-parse --git-common-dir)/hooks")"; \
+	mkdir -p "$$dest"; \
+	for h in .githooks/*; do \
+		[ -f "$$h" ] || continue; \
+		cp "$$h" "$$dest/$$(basename "$$h")" && chmod +x "$$dest/$$(basename "$$h")"; \
+	done; \
+	echo "Installed hooks from .githooks/ → $$dest"
+
 test-deploy-all: test-deploy-compose test-deploy-ghcr test-deploy-registry
 
 # Frontend-only hot deploy — rebuild the Vue dashboard locally, push
@@ -479,6 +494,10 @@ test-deploy-frontend: _ff-guard
 	@if [ ! -f content/dashboard-v3/package.json ]; then \
 		echo "dashboard-v3 not present — nothing to deploy"; exit 1; \
 	fi
+	@if [ ! -d content/dashboard-v3/node_modules/.bin ]; then \
+		echo "dashboard-v3/node_modules missing — npm ci..."; \
+		(cd content/dashboard-v3 && npm ci); \
+	fi
 	@echo "Building dashboard-v3 (Vue)..."
 	@cd content/dashboard-v3 && npm run --silent build
 	@echo "rsync → host:~/test-dev/content/dashboard/v3/ (bind-mounted into container)..."
@@ -488,6 +507,24 @@ test-deploy-frontend: _ff-guard
 
 test-deploy-dev: _ff-guard
 	@echo "=== Dev: local working tree (port 21000) ==="
+	@# Build the Vue dashboard FIRST, before any rsync --delete touches the
+	@# remote. A missing node_modules (the usual fresh-worktree state — it's
+	@# gitignored) or a failed build now aborts with test-dev UNTOUCHED.
+	@# Previously the working-tree rsync --delete ran first, so a build
+	@# failure half-wiped the box (lost the :21000 override + v3 bundle, no
+	@# container rebuild) — #740, 2026-06-11. `make install-hooks` adds a
+	@# post-checkout hook that seeds node_modules on worktree add; this
+	@# npm-ci fallback covers the case where the hook isn't installed.
+	@if [ -f content/dashboard-v3/package.json ]; then \
+		if [ ! -d content/dashboard-v3/node_modules/.bin ]; then \
+			echo "dashboard-v3/node_modules missing — npm ci..."; \
+			(cd content/dashboard-v3 && npm ci); \
+		fi; \
+		echo "Building dashboard-v3 (Vue)..."; \
+		(cd content/dashboard-v3 && npm run --silent build); \
+	else \
+		echo "dashboard-v3 not present, skipping Vue build"; \
+	fi
 	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev'
 	@echo "Syncing local working tree (excluding .git and .gitignore matches)..."
 	rsync -az --delete \
@@ -500,16 +537,13 @@ test-deploy-dev: _ff-guard
 	@# which is gitignored, so the --filter ':- .gitignore' rule above
 	@# hides it from rsync's source view and --delete then wipes it on
 	@# the remote (this bit you for the testing.html-→-dashboard.html
-	@# redirect on 2026-05-12). Build + push it as an extra rsync
-	@# whose source it can actually see. Skipped silently if
-	@# dashboard-v3 isn't set up yet.
+	@# redirect on 2026-05-12). Push the already-built bundle now (after the
+	@# tree sync, so --delete can't wipe it). Skipped when dashboard-v3 isn't
+	@# set up yet.
 	@if [ -f content/dashboard-v3/package.json ]; then \
-		echo "Building & pushing dashboard-v3 (Vue)..."; \
-		(cd content/dashboard-v3 && npm run --silent build) && \
+		echo "Pushing dashboard-v3 bundle..."; \
 		ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev/content/dashboard/v3' && \
 		rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev/content/dashboard/v3/; \
-	else \
-		echo "dashboard-v3 not present, skipping Vue build"; \
 	fi
 	ssh -n $(TEST_SSH) 'printf "CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=%s\nINFINITE_STREAM_ANNOUNCE_LABEL=%s\nINFINITE_STREAM_TLS=%s\nINFINITE_STREAM_TLS_SAN=%s\n" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(INFINITE_STREAM_ANNOUNCE_URL)" "$(INFINITE_STREAM_ANNOUNCE_LABEL)" "$(INFINITE_STREAM_TLS)" "$(INFINITE_STREAM_TLS_SAN)" > ~/test-dev/.env'
 	scp tests/deploy/override-dev.yml $(TEST_SSH):~/test-dev/docker-compose.override.yml


### PR DESCRIPTION
## Why
A fresh `git worktree add` never brings `content/dashboard-v3/node_modules` (gitignored), and `make test-deploy-dev` ran `rsync --delete` against the shared test-dev box **before** building the Vue dashboard — so a missing `node_modules` failed the build only *after* half-wiping the box (lost the `:21000` override + v3 bundle, no container rebuild). Hit on 2026-06-11 during a #740 branch deploy.

## What
- **`.githooks/post-checkout`** — seeds `content/dashboard-v3/node_modules` on every `git worktree add`: copies from a sibling worktree whose lockfile matches (fast, same machine), else `npm ci`. Idempotent, quiet, never fails the checkout.
- **`make install-hooks`** — installs `.githooks/*` into the active hooks dir (honours `core.hooksPath`, else the shared common hooks dir). Run once per clone.
- **`test-deploy-dev` / `test-deploy-frontend`** — build the Vue bundle (with an `npm ci` fallback when `node_modules` is absent) **before** any `rsync --delete`, so a failed build aborts with test-dev untouched. The built bundle is pushed after the working-tree sync.

## Test
- `make install-hooks` installs the hook; verified `git worktree add` auto-seeds `node_modules` from a lockfile-matching sibling.
- `make -n test-deploy-dev` confirms the recipe order is now npm ci → build → `rsync --delete` → push bundle → `docker compose build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
