### PR TITLE
fix(go-proxy): clone-free session reads via sessionsView (#740 Commit B)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3298,7 +3298,7 @@ func (a *App) handleGetNetworkLog(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleGetExternalIPs(w http.ResponseWriter, r *http.Request) {
-	sessionList := a.getSessionList()
+	sessionList := a.sessionsView() // #740 read-only: builds ExternalIPEntry view, no mutation
 	if shouldScopeSessionsByRequesterIP(r) {
 		requesterIP := extractClientIP(r.RemoteAddr, r.Header.Get("X-Forwarded-For"))
 		sessionList = filterSessionsByOriginationIP(sessionList, requesterIP)
@@ -3606,7 +3606,7 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, delayMs int, los
 		// the session update above so applySessionShaping sees the
 		// freshly cleared pattern_enabled flag and doesn't no-op via
 		// its "pattern owns the rate" guard.
-		for _, sess := range a.getSessionList() {
+		for _, sess := range a.sessionsView() { // #740 read-only: applySessionShaping reads sess, drives kernel
 			if portStr := getString(sess, "x_forwarded_port"); portStr != "" {
 				if p, err := strconv.Atoi(portStr); err == nil && p == port {
 					a.applySessionShaping(sess, port)
@@ -3654,7 +3654,7 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, delayMs int, los
 	// above when the caller included it in the payload, so any session
 	// on this port has the freshest value.
 	mode := ""
-	for _, sess := range a.getSessionList() {
+	for _, sess := range a.sessionsView() { // #740 read-only: reads pattern template mode
 		if portStr := getString(sess, "x_forwarded_port"); portStr != "" {
 			if pn, err := strconv.Atoi(portStr); err == nil && pn == port {
 				mode = getString(sess, "nftables_pattern_template_mode")
@@ -3749,7 +3749,7 @@ func (a *App) runShapePatternLoop(ctx context.Context, port int, steps []NftShap
 		// this port (issue #474 Milestone B). Info is a tiny JSON
 		// blob so downstream (graphs, harness archive) can read
 		// step / rate / duration without re-fetching pattern config.
-		for _, sess := range a.getSessionList() {
+		for _, sess := range a.sessionsView() { // #740 read-only: builds control-event info string
 			if portStr := getString(sess, "x_forwarded_port"); portStr != "" {
 				if pn, err := strconv.Atoi(portStr); err == nil && pn == port {
 					info := fmt.Sprintf(`{"step":%d,"rate_mbps":%.3f,"duration_s":%.1f}`,
@@ -3976,7 +3976,7 @@ func (a *App) emitControlEventForPort(port int, source, event, info string) {
 	if a == nil || a.controlHub == nil || event == "" {
 		return
 	}
-	for _, sess := range a.getSessionList() {
+	for _, sess := range a.sessionsView() { // #740 read-only: matches port, emits control event
 		portStr := getString(sess, "x_forwarded_port")
 		if portStr == "" {
 			continue
@@ -4166,9 +4166,11 @@ func transportFaultConfigFromSession(session SessionData) (string, int, string, 
 
 func (a *App) getFirstSessionByPort(port int) SessionData {
 	portStr := strconv.Itoa(port)
-	for _, session := range a.getSessionList() {
+	// #740: scan the no-clone view, but return a clone of the single match —
+	// callers may mutate the result, so it must not alias the live snapshot.
+	for _, session := range a.sessionsView() {
 		if getString(session, "x_forwarded_port") == portStr {
-			return session
+			return cloneSession(session)
 		}
 	}
 	return nil
@@ -4383,7 +4385,7 @@ func (a *App) runTransportFaultLoop(ctx context.Context, port int, faultType str
 
 func (a *App) restoreTransportFaultSchedules() {
 	seenPorts := map[int]struct{}{}
-	for _, session := range a.getSessionList() {
+	for _, session := range a.sessionsView() { // #740 read-only: re-arms transport faults from config
 		portStr := getString(session, "x_forwarded_port")
 		if portStr == "" {
 			continue
@@ -4419,7 +4421,7 @@ func (a *App) restoreShapeApplication() (restored, skipped int) {
 		return 0, 0
 	}
 	seenPorts := map[int]struct{}{}
-	for _, session := range a.getSessionList() {
+	for _, session := range a.sessionsView() { // #740 read-only: re-applies shape from config
 		portStr := getString(session, "x_forwarded_port")
 		if portStr == "" {
 			skipped++
@@ -4523,7 +4525,7 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 	}, "")
 
 	// Propagate to group members
-	snap := a.getSessionList()
+	snap := a.sessionsView() // #740 read-only: group/port lookups only
 	groupID := a.getGroupIdByPort(port, snap)
 	if groupID != "" {
 		groupPorts := a.getPortsForGroup(groupID, snap)
@@ -4738,7 +4740,7 @@ func (a *App) handleNftShape(w http.ResponseWriter, r *http.Request) {
 	}, "")
 
 	// Propagate to group members
-	snap2 := a.getSessionList()
+	snap2 := a.sessionsView() // #740 read-only: group/port lookups only
 	groupID := a.getGroupIdByPort(port, snap2)
 	if groupID != "" {
 		groupPorts := a.getPortsForGroup(groupID, snap2)
@@ -7050,7 +7052,7 @@ func (a *App) trackPortThroughput() {
 	for {
 		tickNow := time.Now()
 		if lastPortsRefresh.IsZero() || tickNow.Sub(lastPortsRefresh) >= time.Second {
-			sessions := a.getSessionList()
+			sessions := a.sessionsView() // #740 read-only: collects ports for throughput refresh
 			refreshed := map[int]struct{}{}
 			addPort := func(portStr string) {
 				if portStr == "" {
@@ -7127,10 +7129,12 @@ func (a *App) getSessionData(identifier string) SessionData {
 	if identifier == "" {
 		return nil
 	}
-	sessions := a.getSessionList()
-	for _, session := range sessions {
+	// #740: scan the no-clone view, return a clone of the single match —
+	// callers mutate this (and feed it to normalizeSessionsForResponse, which
+	// writes in place), so it must not alias the live snapshot.
+	for _, session := range a.sessionsView() {
 		if getString(session, "session_id") == identifier {
-			return session
+			return cloneSession(session)
 		}
 	}
 	return nil
@@ -7645,6 +7649,27 @@ func (a *App) getSessionList() []SessionData {
 		return []SessionData{}
 	}
 	return cloneSessionList(*snap)
+}
+
+// sessionsView returns the current session snapshot WITHOUT cloning — a
+// read-only borrow of the immutable published slice (issue #740 Commit B).
+// The dominant per-read cost was cloneSession (a deep copy of ~110 fields × N
+// sessions) on every getSessionList, and ~half the call sites only read.
+//
+// CONTRACT — callers MUST treat the result, and every map inside it, as
+// read-only. This is sound only because writers never mutate in place:
+// mutateSessions always copy-on-writes and CAS-publishes a fresh slice, so the
+// snapshot a caller borrows is frozen for its lifetime (a concurrent writer
+// publishes a new slice; it never touches this one). A caller that needs to
+// mutate a session — or hands maps to normalizeSessionsForResponse, which
+// writes in place — must use getSessionList (which clones) or cloneSession the
+// specific map it retains.
+func (a *App) sessionsView() []SessionData {
+	snap := a.sessionsSnap.Load()
+	if snap == nil {
+		return nil
+	}
+	return *snap
 }
 
 // mutateSessions is the lock-free read-modify-write primitive for the
@@ -9471,7 +9496,7 @@ func refreshFailureStateFromLatest(a *App, dst SessionData, sessionID string) {
 	if a == nil || dst == nil || sessionID == "" {
 		return
 	}
-	latest := a.getSessionList()
+	latest := a.sessionsView() // #740 read-only: reads matched session into dst, never writes the snapshot
 	for _, s := range latest {
 		if getString(s, "session_id") != sessionID {
 			continue
@@ -9798,7 +9823,7 @@ func (a *App) resolveSessionList(sessions [][]SessionData) []SessionData {
 	if len(sessions) > 0 && sessions[0] != nil {
 		return sessions[0]
 	}
-	return a.getSessionList()
+	return a.sessionsView() // #740 read-only: callers (getGroupIdByPort/getPortsForGroup) only read
 }
 
 // updateSessionGroup updates all sessions in a group with the given updates

--- a/go-proxy/cmd/server/main_race_test.go
+++ b/go-proxy/cmd/server/main_race_test.go
@@ -348,3 +348,95 @@ func TestSessionListNoLostUpdatesUnderConcurrency(t *testing.T) {
 			len(seen), totalAppends, transientLeft)
 	}
 }
+
+// TestSessionsViewBorrowsAndStaysRaceFree covers #740 Commit B. sessionsView
+// returns the published snapshot WITHOUT cloning, which is sound only because
+// every writer copy-on-writes (mutateSessions never mutates a published map in
+// place). The test proves both halves:
+//   - borrow: a mutation to the published map is visible through the view
+//     (getSessionList, which clones, would not show it), and
+//   - safety: readers ranging the no-clone view concurrently with writers
+//     mutating + appending never trip the race detector — because writers only
+//     ever touch their own fresh clone before CAS-publishing it.
+//
+// Run with `go test -race`; a writer that mutated a published map in place
+// (breaking the sessionsView contract) would fail here under -race.
+func TestSessionsViewBorrowsAndStaysRaceFree(t *testing.T) {
+	app := &App{}
+	seed := []SessionData{{"session_id": "0", "marker": int64(0)}}
+	app.sessionsSnap.Store(&seed)
+
+	// Borrow, not clone: mutating the published map is visible through the view.
+	view := app.sessionsView()
+	seed[0]["probe"] = "borrowed"
+	if view[0]["probe"] != "borrowed" {
+		t.Fatalf("sessionsView cloned the snapshot; expected a borrow (probe not visible)")
+	}
+
+	const writers = 4
+	const appendsPer = 200
+	var wgW, wgR sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: each appends uniquely-keyed sessions and increments the shared
+	// marker via mutateSessions (copy-on-write + CAS).
+	for g := 0; g < writers; g++ {
+		g := g
+		wgW.Add(1)
+		go func() {
+			defer wgW.Done()
+			for i := 0; i < appendsPer; i++ {
+				id := fmt.Sprintf("w%d-%d", g, i)
+				app.mutateSessions(func(s []SessionData) ([]SessionData, bool) {
+					for _, m := range s {
+						if getString(m, "session_id") == "0" {
+							m["marker"] = int64FromInterface(m["marker"]) + 1
+						}
+					}
+					return append(s, SessionData{"session_id": id}), true
+				})
+			}
+		}()
+	}
+
+	// Readers: range the no-clone view and read fields. If any writer mutated a
+	// borrowed map in place, -race flags the concurrent read/write here.
+	for g := 0; g < writers; g++ {
+		wgR.Add(1)
+		go func() {
+			defer wgR.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					for _, s := range app.sessionsView() {
+						_ = getString(s, "session_id")
+						_ = int64FromInterface(s["marker"])
+					}
+				}
+			}
+		}()
+	}
+
+	wgW.Wait()
+	close(stop)
+	wgR.Wait()
+
+	final := app.sessionsView()
+	var marker int64
+	appended := 0
+	for _, s := range final {
+		if getString(s, "session_id") == "0" {
+			marker = int64FromInterface(s["marker"])
+		} else {
+			appended++
+		}
+	}
+	if marker != int64(writers*appendsPer) {
+		t.Errorf("lost increments through CAS: marker=%d want=%d", marker, writers*appendsPer)
+	}
+	if appended != writers*appendsPer {
+		t.Errorf("lost appends: got %d want %d", appended, writers*appendsPer)
+	}
+}

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -117,7 +117,7 @@ func (a *v2Adapter) NetworkLogForPlayer(playerID string, limit int) []map[string
 		limit = 5000
 	}
 	var sessionID string
-	for _, s := range a.app.getSessionList() {
+	for _, s := range a.app.sessionsView() { // #740 read-only: matches player, reads port/fields
 		if !matchesPlayerID(getString(s, "player_id"), playerID) {
 			continue
 		}
@@ -574,7 +574,7 @@ func (a *v2Adapter) ApplyShapeToPlayer(playerID string) error {
 	if a == nil || a.app == nil {
 		return nil
 	}
-	for _, s := range a.app.getSessionList() {
+	for _, s := range a.app.sessionsView() { // #740 read-only: matches player, reads port/fields
 		if !matchesPlayerID(getString(s, "player_id"), playerID) {
 			continue
 		}
@@ -598,7 +598,7 @@ func (a *v2Adapter) ApplyPatternToPlayer(playerID string, steps []server.ShapePa
 	if a == nil || a.app == nil {
 		return nil
 	}
-	for _, s := range a.app.getSessionList() {
+	for _, s := range a.app.sessionsView() { // #740 read-only: matches player, reads port/fields
 		if !matchesPlayerID(getString(s, "player_id"), playerID) {
 			continue
 		}
@@ -629,7 +629,7 @@ func (a *v2Adapter) ApplyTransportFaultToPlayer(playerID, faultType string, cons
 	if a == nil || a.app == nil {
 		return nil
 	}
-	for _, s := range a.app.getSessionList() {
+	for _, s := range a.app.sessionsView() { // #740 read-only: matches player, reads port/fields
 		if !matchesPlayerID(getString(s, "player_id"), playerID) {
 			continue
 		}
@@ -729,7 +729,7 @@ func (a *v2Adapter) GroupMembers(groupID string) []string {
 		return nil
 	}
 	var out []string
-	for _, s := range a.app.getSessionList() {
+	for _, s := range a.app.sessionsView() { // #740 read-only: collects group members' player_ids
 		if getString(s, "group_id") == groupID {
 			if pid := getString(s, "player_id"); pid != "" {
 				out = append(out, pid)


### PR DESCRIPTION
**Commit B of #740** (the perf win), stacked on Commit A (#742, merged). `Closes #740`.

## Why
Commit A made every writer copy-on-write + CAS-publish, so the published session snapshot is immutable for its lifetime. That makes a no-clone read a sound *borrow*. Until now every read went through `getSessionList`, which deep-copies ~110 fields × N sessions on every call — and ~half the call sites only read.

## Change
- **`sessionsView() []SessionData`** — returns the published slice with **no clone**. Contract: callers treat it (and its maps) as read-only; writers never mutate in place, so a borrowed snapshot is frozen even as a concurrent writer publishes a new one.
- Audited **all 27** `getSessionList` call sites; flipped the **20 verified read-only** ones to `sessionsView`. `getFirstSessionByPort` / `getSessionData` now scan the view but `cloneSession` only the single match they return (callers mutate it) — 1 clone instead of N.
- **Kept `getSessionList` (clone)** at the 7 sites that mutate or feed `normalizeSessionsForResponse` (writes in place): `handleGetSessions`, `handleSessionStream`, `applySessionSettingsUpdate`, the `handleProxy` request path, and the v2 `SessionList` / `SessionByPlayerID` / `SubscribeSessions` paths.
- Verified the helpers called from flipped loops (`applySessionShaping`, `getGroupIdByPort`, `getPortsForGroup`, restore/arm paths) read the session map and never write it.

## Test
- New `TestSessionsViewBorrowsAndStaysRaceFree`: proves the view *borrows* (a mutation to the published map is visible through it, unlike a clone) and that readers ranging the no-clone view concurrently with writers appending + incrementing never trip `-race`. Stable across 5× under `-race`.
- `go vet` + `go test -race ./...` + `go build` clean.

## Verification context
The #740 CAS approach (Commit A) was validated end-to-end on test-dev via the 3-sim grouped pyramid: no `nftk=100`, all units capped, kernel held, only the 360p floor fetched under cap. Commit B is read-path-only (no shaping behavior change); the `-race` suite is the core guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
