### PR TITLE
feat(dashboard-v3): Displayed Variant (Sx) in compare-mode Bandwidth panel (#747)

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -25,7 +25,7 @@
 import { computed, ref, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
-import { useManifestVariants, nearestVariantByBitrate } from '@/composables/useManifestVariants';
+import { useManifestVariants, nearestVariantByBitrate, displayedVariantPeakMbps } from '@/composables/useManifestVariants';
 import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
 import { compareBandwidthSeries } from '@/composables/compareSeries';
@@ -339,26 +339,11 @@ const series = computed<SeriesSpec[]>(() => {
   // the displayed rung by the buffer; using it here would mislabel during
   // switches. Same-height variants therefore can't be told apart for the
   // displayed rung — this project's ladders have one rung per height.)
-  const heightOf = (res?: string | null): number | null => {
-    if (!res) return null;
-    const m = /(\d+)\s*[x×]\s*(\d+)/i.exec(res);
-    return m ? Number(m[2]) : null;
-  };
-  const rungs = ladder
-    .map((v) => ({ h: heightOf(v.resolution), peak: Number(v.bandwidth) / 1_000_000 }))
-    .filter((r) => r.h != null && Number.isFinite(r.peak) && r.peak > 0) as { h: number; peak: number }[];
   out.push({
     label: 'Displayed Variant',
     color: '#a855f7',
-    accessor: (p: PlayerRecord) => {
-      const h = heightOf(p.player_metrics?.video_resolution);
-      if (h == null || !rungs.length) return null;
-      let best = rungs[0];
-      for (const r of rungs) {
-        if (Math.abs(r.h - h) < Math.abs(best.h - h)) best = r;
-      }
-      return best.peak;
-    },
+    accessor: (p: PlayerRecord) =>
+      displayedVariantPeakMbps(ladder, p.player_metrics?.video_resolution),
     stepped: true,
   });
   // Mute the variant-line color so it doesn't out-shout the live

--- a/content/dashboard-v3/src/composables/chRowAdapter.ts
+++ b/content/dashboard-v3/src/composables/chRowAdapter.ts
@@ -250,6 +250,11 @@ export function chRowToPlayerRecord(
   // in the chart memory.
   const rawSession = {
     effective_rate_limit_mbps: num(row.effective_rate_limit_mbps),
+    // #747: the compare-mode "Displayed Variant (Sx)" series reads the
+    // sibling's ladder from here to map video_resolution → peak bitrate. It's
+    // already in the charts_minimal projection (the single-session chart reads
+    // it off the events rows); expose it on the sibling record too.
+    manifest_variants: row.manifest_variants,
     // Identity fields SessionDetails.vue reads from raw_session (port)
     // and group_id (top-level). Mirror the keys the live PlayerRecord
     // shape uses so the same component renders both paths.

--- a/content/dashboard-v3/src/composables/compareSeries.ts
+++ b/content/dashboard-v3/src/composables/compareSeries.ts
@@ -24,6 +24,7 @@
 import type { SeriesSpec } from '@/components/MetricsLineChart.vue';
 import type { CompareSeriesIdentity } from '@/composables/useCompareContext';
 import type { PlayerRecord } from '@/repo/v2-repo';
+import { displayedVariantPeakMbps, parseManifestVariants } from '@/composables/useManifestVariants';
 
 /** Metric colours — kept in lockstep with the primary chart series so a
  *  metric reads the same hue across the active session and every overlay.
@@ -35,6 +36,7 @@ const C = {
   playerNetRate: '#059669',
   servingVariant: '#b45309',
   fetchingVariant: '#ef4444',
+  displayedVariant: '#a855f7',
   limit: '#f59e0b',
   // BufferChart
   bufferDepth: '#4f46e5',
@@ -115,6 +117,20 @@ export function compareBandwidthSeries(id: CompareSeriesIdentity): SeriesSpec[] 
       label: tagged('Fetching Variant', id),
       color: C.fetchingVariant,
       accessor: (p: PlayerRecord) => p.player_metrics?.video_bitrate_mbps ?? null,
+      stepped: true,
+      borderDash: dash,
+    },
+    {
+      // Decoded rung's published peak bitrate, matched by frame height —
+      // mirrors the single-session "Displayed Variant" (BandwidthChart). The
+      // sibling's ladder rides on raw_session.manifest_variants (#747).
+      label: tagged('Displayed Variant', id),
+      color: C.displayedVariant,
+      accessor: (p: PlayerRecord) =>
+        displayedVariantPeakMbps(
+          parseManifestVariants((p as { raw_session?: { manifest_variants?: unknown } }).raw_session?.manifest_variants),
+          p.player_metrics?.video_resolution,
+        ),
       stepped: true,
       borderDash: dash,
     },

--- a/content/dashboard-v3/src/composables/useManifestVariants.ts
+++ b/content/dashboard-v3/src/composables/useManifestVariants.ts
@@ -27,13 +27,8 @@ export function useManifestVariants(playerId: Ref<string> | string) {
     const p = player.value;
     const typed = p?.current_play?.manifest?.variants;
     if (Array.isArray(typed) && typed.length) return typed;
-    let flat = (p as any)?.raw_session?.manifest_variants;
-    if (typeof flat === 'string') {
-      // raw_session may serialize the variant list as a JSON string
-      // when coming through the CH long-tail column. Parse if so.
-      try { flat = JSON.parse(flat); } catch { flat = undefined; }
-    }
-    if (Array.isArray(flat) && flat.length) return flat as ManifestVariant[];
+    const flat = parseManifestVariants((p as any)?.raw_session?.manifest_variants);
+    if (flat.length) return flat as ManifestVariant[];
     return [];
   });
 
@@ -77,6 +72,52 @@ export function nearestVariantByBitrate(
       bestDelta = delta;
       best = { resolution: String(v?.resolution ?? '').trim(), peakMbps };
     }
+  }
+  return best;
+}
+
+/** Coerce a raw `manifest_variants` value into `VariantLite[]`. The live
+ *  PlayerRecord carries it as an array; the CH long-tail column serialises it
+ *  as a JSON string. Returns `[]` for anything unusable. */
+export function parseManifestVariants(value: unknown): VariantLite[] {
+  let v = value;
+  if (typeof v === 'string') {
+    try { v = JSON.parse(v); } catch { return []; }
+  }
+  return Array.isArray(v) ? (v as VariantLite[]) : [];
+}
+
+/**
+ * Map a player's DECODED frame size (`player_metrics.video_resolution`, e.g.
+ * "640x360") to the published peak BANDWIDTH (Mbps) of the ladder rung it
+ * corresponds to — the "Displayed Variant" line on the bandwidth chart.
+ *
+ * Matched by nearest frame HEIGHT, not exact "WxH" and not by bitrate: the
+ * decoded size legitimately differs from the manifest RESOLUTION attribute
+ * (coded vs display, mod-16 padding, PAR / clean aperture, packager quirks),
+ * and `video_bitrate` is indicatedBitrate — the FETCHED rung, which leads the
+ * displayed one by the buffer during switches. This project's ladders have one
+ * rung per height. Returns null when there's no usable ladder or resolution.
+ */
+export function displayedVariantPeakMbps(
+  variants: ReadonlyArray<VariantLite> | null | undefined,
+  videoResolution: string | null | undefined,
+): number | null {
+  const heightOf = (res?: string | null): number | null => {
+    if (!res) return null;
+    const m = /(\d+)\s*[x×]\s*(\d+)/i.exec(res);
+    return m ? Number(m[2]) : null;
+  };
+  const h = heightOf(videoResolution);
+  if (h == null || !variants || variants.length === 0) return null;
+  let best: number | null = null;
+  let bestDelta = Infinity;
+  for (const v of variants) {
+    const rh = heightOf(v?.resolution);
+    const peak = Number(v?.bandwidth ?? 0) / 1_000_000;
+    if (rh == null || !Number.isFinite(peak) || peak <= 0) continue;
+    const delta = Math.abs(rh - h);
+    if (delta < bestDelta) { bestDelta = delta; best = peak; }
   }
   return best;
 }


### PR DESCRIPTION
`Closes #747`.

Adds the `Displayed Variant (Sx)` line to the compare-mode Bandwidth panel — the single-session chart already shows it; the compare overlay omitted it.

- `useManifestVariants.ts`: extract `displayedVariantPeakMbps(variants, video_resolution)` (nearest frame-**height** match) + `parseManifestVariants()` as the single source of truth.
- `BandwidthChart.vue`: single-session "Displayed Variant" now uses the shared helper (no behavior change).
- `chRowAdapter.ts`: expose `manifest_variants` on the compare sibling's `raw_session` (already in the `charts_minimal` projection the single-session chart reads — just wasn't surfaced on the adapted record).
- `compareSeries.ts`: add the tagged series (purple `#a855f7`, stepped, per-session dash), reading the sibling ladder from `raw_session.manifest_variants`.

`vue-tsc --noEmit` + `vite build` clean. dashboard-v3 has no unit-test harness (the single-session equivalent is untested too); visual verification pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
