### PR TITLE
feat: fleet group mode — born-grouped sims, proxy group_id, harness 412-retry

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -803,16 +803,25 @@ type TcTrafficManager struct {
 	nlMu          sync.Mutex
 	nlHandle      *netlink.Handle // persistent netlink handle, created lazily
 	nlLink        netlink.Link    // resolved once from interfaceName
-	// rootMu serialises the shared-root ensure (root qdisc 1: + root class
-	// 1:1). Both are check-then-act on objects SHARED across all ports, so
-	// concurrent per-port applies otherwise race: two see "no root", both
-	// `tc … add`, the loser gets RTNETLINK "File exists" and bails before
-	// installing its per-port leaf class → that port runs uncapped. This was
-	// masked pre-#740 by the bootstrap createMu (held across the kernel apply);
-	// the reserve-then-fill that replaced it removed that serialization. The
-	// per-port leaf classes (distinct classid) don't collide, so only the
-	// shared root needs this lock. See #745.
-	rootMu sync.Mutex
+	// tcMu serialises ALL tc tree mutations — the shared-root ensure (root
+	// qdisc 1: + root class 1:1), the per-port leaf HTB class add/change, the
+	// per-port filter install, and the per-port clear sweep. Every one of these
+	// is a check-then-act against the SAME tc tree, so concurrent
+	// config-on-connects otherwise interleave and wipe each other's leaf
+	// classes: a leaf-class add racing a clear (or another port's root ensure)
+	// leaves that port running uncapped through the 10 Gbps default class.
+	// Guarding only the shared root (the pre-#746 scope) was not enough — the
+	// leaf add/change, filter install, and ClearPortShaping all ran OUTSIDE the
+	// lock and clobbered each other. This was masked pre-#740 by the bootstrap
+	// createMu (held across the kernel apply); the reserve-then-fill that
+	// replaced it removed that serialization. See #745 / #746.
+	//
+	// Deadlock-free by construction: Go sync.Mutex is NOT reentrant, so we use
+	// the public-wrapper / lock-free-core split. Public methods acquire tcMu
+	// once and delegate to a lock-free *Core helper; *Core helpers NEVER take
+	// the lock and only call other lock-free helpers — never a public (locking)
+	// method.
+	tcMu sync.Mutex
 	// Per-port ICMP filter state (issue #404). Tracks the last
 	// player_ip we installed an ICMP-routing filter for so the
 	// path-ping sampler's per-tick ApplyPlayerICMPFilter call
@@ -1167,18 +1176,21 @@ func tcAddAlreadyExists(out []byte) bool {
 	return strings.Contains(s, "file exists") || strings.Contains(s, "exclusivity flag on")
 }
 
-func (t *TcTrafficManager) EnsureRootQdisc() error {
-	// Serialise the shared-root check-then-act (#745): without this, two
-	// concurrent applies both see "no root" and both add, racing the kernel.
-	t.rootMu.Lock()
-	defer t.rootMu.Unlock()
+// ensureRootQdiscCore is the lock-free core of the root-qdisc ensure. The
+// caller MUST hold t.tcMu (#746). It NEVER takes the lock itself and is only
+// ever called from tcMu-holding paths (updateRateLimitCore, updateNetemCore,
+// EnsureClass).
+func (t *TcTrafficManager) ensureRootQdiscCore() error {
 	show := exec.Command("tc", "qdisc", "show", "dev", t.interfaceName)
 	if out, err := show.CombinedOutput(); err == nil {
 		if strings.Contains(string(out), "qdisc htb 1:") || strings.Contains(string(out), "root htb") {
 			return nil
 		}
 	}
-	_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "root").Run()
+	// NOTE: no `tc qdisc del root` here — deleting the root nukes EVERY port's
+	// leaf class + filter at once (the #746 footgun). The "root already exists"
+	// check above plus the idempotent add (tcAddAlreadyExists below) are
+	// sufficient to converge on a single shared root.
 	cmd := exec.Command("tc", "qdisc", "add", "dev", t.interfaceName, "root", "handle", "1:", "htb", "default", "999")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		// A concurrent installer (or an out-of-band one) won the race — the
@@ -1191,10 +1203,10 @@ func (t *TcTrafficManager) EnsureRootQdisc() error {
 	return nil
 }
 
-func (t *TcTrafficManager) EnsureRootClass() error {
-	// Serialise the shared root-class 1:1 check-then-act (#745).
-	t.rootMu.Lock()
-	defer t.rootMu.Unlock()
+// ensureRootClassCore is the lock-free core of the root-class 1:1 ensure. The
+// caller MUST hold t.tcMu (#746). It NEVER takes the lock itself and is only
+// ever called from tcMu-holding paths.
+func (t *TcTrafficManager) ensureRootClassCore() error {
 	cmd := exec.Command("tc", "class", "show", "dev", t.interfaceName)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1293,11 +1305,25 @@ func (t *TcTrafficManager) GetPortConfig(port int) (map[string]interface{}, erro
 	return config, nil
 }
 
+// UpdateRateLimit is the public, lock-acquiring entrypoint. It holds t.tcMu
+// for the whole leaf-class mutation (#746) so a concurrent config-on-connect
+// can't wipe this port's leaf class mid-apply, then delegates to the lock-free
+// core.
 func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
-	if err := t.EnsureRootQdisc(); err != nil {
+	t.tcMu.Lock()
+	defer t.tcMu.Unlock()
+	return t.updateRateLimitCore(port, rateMbps)
+}
+
+// updateRateLimitCore is the lock-free core of UpdateRateLimit. The caller MUST
+// hold t.tcMu. It only calls other lock-free helpers (ensureRootQdiscCore,
+// ensureRootClassCore, updateNetemCore, RemoveFilter, RemoveClass,
+// ensurePortFilter, ensurePrioLeafForPort) — never a public locking method.
+func (t *TcTrafficManager) updateRateLimitCore(port int, rateMbps float64) error {
+	if err := t.ensureRootQdiscCore(); err != nil {
 		return err
 	}
-	if err := t.EnsureRootClass(); err != nil {
+	if err := t.ensureRootClassCore(); err != nil {
 		return err
 	}
 	if rateMbps <= 0 {
@@ -1306,7 +1332,7 @@ func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
 			time.Now().UTC().Format(time.RFC3339Nano),
 			port,
 		)
-		_ = t.UpdateNetem(port, 0, 0)
+		_ = t.updateNetemCore(port, 0, 0)
 		_ = t.RemoveFilter(port)
 		_ = t.RemoveClass(port)
 		t.logTcState("rate_clear", port)
@@ -1398,6 +1424,14 @@ func (t *TcTrafficManager) RemoveClass(port int) error {
 //     about to belong to a fresh playback episode; whatever was
 //     there before is by definition leftover from a prior session.
 func (t *TcTrafficManager) ClearPortShaping(port int) {
+	// Hold tcMu for the whole clear sweep (#746): the class-del here otherwise
+	// races a concurrent leaf-class add/change on another port's apply against
+	// the shared tc tree. The icmpFilterMu acquired below is a DIFFERENT mutex
+	// (guards only the per-port ICMP tracking map) and never overlaps tcMu's
+	// scope, so no deadlock. This method runs raw tc commands only — no *Core
+	// split needed.
+	t.tcMu.Lock()
+	defer t.tcMu.Unlock()
 	portSuffix := fmt.Sprintf("%03d", port%1000)
 	classid := fmt.Sprintf("1:%s", portSuffix)
 	// First check if there's actually a class to clear — keeps the
@@ -1540,11 +1574,23 @@ func (t *TcTrafficManager) ensurePortFilter(port int, classid string) error {
 	return nil
 }
 
+// EnsureClass is a public, lock-acquiring entrypoint (App + updateNetemCore
+// callers). It holds t.tcMu for the whole ensure (#746) and delegates to
+// lock-free cores. NOTE: updateNetemCore calls ensureClassCore directly (it
+// already holds tcMu); only external/App callers go through this wrapper.
 func (t *TcTrafficManager) EnsureClass(port int, rateMbps float64) error {
-	if err := t.EnsureRootQdisc(); err != nil {
+	t.tcMu.Lock()
+	defer t.tcMu.Unlock()
+	return t.ensureClassCore(port, rateMbps)
+}
+
+// ensureClassCore is the lock-free core of EnsureClass. The caller MUST hold
+// t.tcMu. Only calls other lock-free helpers.
+func (t *TcTrafficManager) ensureClassCore(port int, rateMbps float64) error {
+	if err := t.ensureRootQdiscCore(); err != nil {
 		return err
 	}
-	if err := t.EnsureRootClass(); err != nil {
+	if err := t.ensureRootClassCore(); err != nil {
 		return err
 	}
 	cmd := exec.Command("tc", "class", "show", "dev", t.interfaceName)
@@ -1557,7 +1603,7 @@ func (t *TcTrafficManager) EnsureClass(port int, rateMbps float64) error {
 	if strings.Contains(string(output), classid) {
 		return t.ensurePortFilter(port, classid)
 	}
-	return t.UpdateRateLimit(port, rateMbps)
+	return t.updateRateLimitCore(port, rateMbps)
 }
 
 // ensurePrioLeafForPort installs the prio+netem-per-band leaf inside
@@ -1617,11 +1663,24 @@ func (t *TcTrafficManager) ensurePrioLeafForPort(port int) error {
 // installed (or confirmed present) before the netem replacements so
 // this works even when called on a class created by UpdateRateLimit
 // without netem ever previously being touched.
+// UpdateNetem is the public, lock-acquiring entrypoint. It holds t.tcMu for the
+// whole netem mutation (#746) and delegates to the lock-free core.
 func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) error {
-	if err := t.EnsureRootQdisc(); err != nil {
+	t.tcMu.Lock()
+	defer t.tcMu.Unlock()
+	return t.updateNetemCore(port, delayMs, lossPct)
+}
+
+// updateNetemCore is the lock-free core of UpdateNetem. The caller MUST hold
+// t.tcMu. Only calls other lock-free helpers (ensureRootQdiscCore,
+// ensureRootClassCore, ensureClassCore, ensurePrioLeafForPort) — never a public
+// locking method. (Also called directly from updateRateLimitCore's clear
+// branch, which already holds tcMu.)
+func (t *TcTrafficManager) updateNetemCore(port int, delayMs int, lossPct float64) error {
+	if err := t.ensureRootQdiscCore(); err != nil {
 		return err
 	}
-	if err := t.EnsureRootClass(); err != nil {
+	if err := t.ensureRootClassCore(); err != nil {
 		return err
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)
@@ -1636,7 +1695,7 @@ func (t *TcTrafficManager) UpdateNetem(port int, delayMs int, lossPct float64) e
 			return nil
 		}
 	} else {
-		if err := t.EnsureClass(port, 10000); err != nil {
+		if err := t.ensureClassCore(port, 10000); err != nil {
 			return err
 		}
 	}
@@ -5433,6 +5492,13 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		// no slot leaks.
 		createdAt := nowISO()
 		groupID := extractGroupId(playerID)
+		// #fleet-group: an explicit group_id connect param wins over the legacy
+		// `_G<num>` player_id suffix. Lets the harness born-group a fleet while
+		// keeping player_id a clean UUID — so the analytics layer doesn't derive
+		// a divergent v5 id from a non-UUID player_id (the suffix's fatal flaw).
+		if g := r.URL.Query().Get("group_id"); g != "" {
+			groupID = g
+		}
 		var allocated int
 		_, reserved := a.mutateSessions(func(sessions []SessionData) ([]SessionData, bool) {
 			if len(sessions) >= a.maxSessions {
@@ -8828,18 +8894,48 @@ func (a *App) removeInactiveSessions() {
 		a.disablePatternForPort(port)
 		a.armTransportFaultLoop(port, "none", 1, transportUnitsSeconds, 0)
 	}
-	// Auto-ungroup single-member groups
-	groupMembers := map[string][]string{}
+	// Auto-ungroup groups that have DECAYED to a single member — but never a
+	// group that is still ASSEMBLING. A fleet (token `_G<num>` suffix or
+	// CreateGroup) can pass through a transient 1-member state as its sims
+	// connect sequentially; clearing the group then would PERMANENTLY break it,
+	// because group_id is only derived at session creation and never re-derived.
+	// So we collapse a singleton ONLY if we've previously seen its group with ≥2
+	// concurrent members — tracked per-session via group_ever_multi. This is
+	// mechanism-agnostic: it protects suffix groups and operator/API groups
+	// alike while still cleaning up a real group that lost all but one member.
+	type groupMember struct {
+		sessionID string
+		everMulti bool
+	}
+	groupMembers := map[string][]groupMember{}
 	for _, session := range active {
 		gid := getString(session, "group_id")
 		if gid != "" {
-			groupMembers[gid] = append(groupMembers[gid], getString(session, "session_id"))
+			groupMembers[gid] = append(groupMembers[gid], groupMember{
+				sessionID: getString(session, "session_id"),
+				everMulti: getString(session, "group_ever_multi") == "1",
+			})
 		}
 	}
 	for _, members := range groupMembers {
-		if len(members) == 1 {
-			a.saveSessionByID(members[0], SessionData{
-				"session_id": members[0],
+		if len(members) >= 2 {
+			// A real multi-member group right now — stamp every member so a
+			// later decay-to-1 is distinguishable from a still-assembling group.
+			for _, m := range members {
+				if !m.everMulti {
+					a.saveSessionByID(m.sessionID, SessionData{
+						"session_id":       m.sessionID,
+						"group_ever_multi": "1",
+					})
+				}
+			}
+			continue
+		}
+		// Exactly one member: ungroup only if this group was previously ≥2
+		// (decayed). A never-multi singleton is still assembling — keep it.
+		if members[0].everMulti {
+			a.saveSessionByID(members[0].sessionID, SessionData{
+				"session_id": members[0].sessionID,
 				"group_id":   "",
 			})
 		}

--- a/tests/characterization/modes/fleet.go
+++ b/tests/characterization/modes/fleet.go
@@ -2,6 +2,7 @@ package modes
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -10,6 +11,44 @@ import (
 
 	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
 )
+
+// runFleet is the shared fleet dispatcher every fleet-aware mode funnels
+// through. It resolves the roster (1 device by default, N under CHAR_FLEET_*)
+// and either runs the single-device path unchanged or fans the work out as one
+// parallel subtest per device with shared sync barriers. `perDevice` does the
+// per-device work (mint its OWN launcher via runner.PickMode, use the PASSED
+// dev, wire the barriers when non-nil) — see runPyramidOnDevice for the
+// canonical shape. nil barriers ⇒ single-device run (no sync points).
+func runFleet(t *testing.T, p runner.Platform, perDevice func(*testing.T, runner.Platform, runner.Device, *fleetBarriers)) {
+	devs := resolveFleet(t, p)
+	switch len(devs) {
+	case 0:
+		return // resolveFleet already issued a Skip
+	case 1:
+		perDevice(t, p, devs[0], nil) // single-device path, unchanged
+		return
+	}
+	bars := newFleetBarriers(len(devs))
+	for _, dev := range devs {
+		dev := dev
+		t.Run(fleetSubtestName(dev), func(t *testing.T) {
+			t.Parallel()
+			perDevice(t, p, dev, bars)
+		})
+	}
+}
+
+// fleetSubtestName names a per-device subtest: prefer the device label, fall
+// back to its UDID, then to fleet<index>.
+func fleetSubtestName(dev runner.Device) string {
+	if dev.Label != "" {
+		return dev.Label
+	}
+	if dev.UDID != "" {
+		return dev.UDID
+	}
+	return fmt.Sprintf("fleet%d", dev.FleetIndex)
+}
 
 // resolveFleet resolves the roster of devices a fleet-aware mode runs
 // against, in priority order:
@@ -205,47 +244,49 @@ func newFleetStartBarrier(n int) *fleetStartBarrier {
 // the simultaneous playback start (every sim waits at the home screen, then all
 // tap play at once); `sweep` gates the simultaneous shaping start. When
 // `group` is set (CHAR_FLEET_GROUP=1) the fleet is driven as ONE player-group:
-// every sim registers its player_id, the leader (index 0) creates the group and
-// drives a single pyramid that the proxy broadcasts to all members, and the
-// other sims observe until the leader signals done. nil for single-device runs.
+// every sim is BORN into the group via the `_G<num>` token appended to its
+// player_id (the proxy's extractGroupId parses it at connect — grouped live AND
+// archived from row 1, no dynamic CreateGroup membership race), the leader
+// (index 0) drives a single sweep that the proxy broadcasts to all members by
+// group_id, and the other sims observe until the leader signals done. nil for
+// single-device runs.
 type fleetBarriers struct {
 	home  *fleetStartBarrier
 	sweep *fleetStartBarrier
 
-	group     bool          // drive the whole fleet as one broadcast group
-	done      chan struct{} // leader closes when its group sweep finishes
-	mu        sync.Mutex
-	playerIDs []string // collected as each sim binds (group members)
+	group   bool          // drive the whole fleet as one broadcast group
+	groupID string        // "G<num>" — passed as the explicit group_id connect param
+	done    chan struct{} // leader closes when its group sweep finishes
 }
 
 func newFleetBarriers(n int) *fleetBarriers {
+	group := strings.TrimSpace(os.Getenv("CHAR_FLEET_GROUP")) == "1"
+	groupID := ""
+	if group {
+		// One group_id per run, passed as the explicit `group_id` connect param
+		// (NOT a player_id suffix — a non-UUID player_id derives a divergent v5
+		// id in the analytics layer and breaks the archive). The proxy births
+		// each session into this group at connect while player_id stays a clean
+		// UUID. Unix seconds keeps distinct runs from colliding in the archive.
+		groupID = fmt.Sprintf("G%d", time.Now().Unix())
+	}
 	return &fleetBarriers{
-		home:  newFleetStartBarrier(n),
-		sweep: newFleetStartBarrier(n),
-		group: strings.TrimSpace(os.Getenv("CHAR_FLEET_GROUP")) == "1",
-		done:  make(chan struct{}),
+		home:    newFleetStartBarrier(n),
+		sweep:   newFleetStartBarrier(n),
+		group:   group,
+		groupID: groupID,
+		done:    make(chan struct{}),
 	}
 }
 
-// registerPlayer records a bound sim's player_id as a prospective group member.
-// Call before the sweep barrier so every member is present when the leader
-// reads them.
-func (b *fleetBarriers) registerPlayer(pid string) {
-	if b == nil || pid == "" {
-		return
+// fleetGroupID is the "G<num>" passed as the group_id connect param so the proxy
+// births the fleet into one group. Empty for single-device / non-group runs (so
+// no group_id param is sent and the session is ungrouped).
+func (b *fleetBarriers) fleetGroupID() string {
+	if b == nil {
+		return ""
 	}
-	b.mu.Lock()
-	b.playerIDs = append(b.playerIDs, pid)
-	b.mu.Unlock()
-}
-
-// members returns a snapshot of the collected member player_ids.
-func (b *fleetBarriers) members() []string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	out := make([]string, len(b.playerIDs))
-	copy(out, b.playerIDs)
-	return out
+	return b.groupID
 }
 
 // signalSweepDone releases the group observers once (leader calls it when its

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -64,37 +64,11 @@ func pyramidFloorFrom(desc []runner.VariantRate) float64 {
 }
 
 func runPyramid(t *testing.T, p runner.Platform) {
-	// Resolve the fleet roster (1 device by default, N under CHAR_FLEET_*).
-	devs := resolveFleet(t, p)
-	switch len(devs) {
-	case 0:
-		return // resolveFleet already issued a Skip
-	case 1:
-		runPyramidOnDevice(t, p, devs[0], nil) // today's single-device path, unchanged
-		return
-	}
-	// Fleet: run each sim as a parallel subtest. Each gets its own launcher
-	// (see runPyramidOnDevice) so the per-sim player_id can't race. Two sync
-	// points (sims get ready at different times; the test fires together):
-	//   - home  → every sim waits at the home screen, then all start playback
-	//             at the same instant.
-	//   - sweep → every sim is warmed up + ladder-read, then all begin the
-	//             pyramid shaping at the same instant.
-	bars := newFleetBarriers(len(devs))
-	for _, dev := range devs {
-		dev := dev
-		name := dev.Label
-		if name == "" {
-			name = dev.UDID
-		}
-		if name == "" {
-			name = fmt.Sprintf("fleet%d", dev.FleetIndex)
-		}
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			runPyramidOnDevice(t, p, dev, bars)
-		})
-	}
+	// Fleet dispatch (1 device by default, N under CHAR_FLEET_*). The shared
+	// runFleet helper resolves the roster and either runs the single-device
+	// path unchanged or fans out one parallel subtest per device with the home
+	// + sweep sync barriers wired (see runPyramidOnDevice).
+	runFleet(t, p, runPyramidOnDevice)
 }
 
 // runPyramidOnDevice runs the pyramid sweep against ONE explicit device.
@@ -201,7 +175,7 @@ func runPyramidOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 				floor = f
 			}
 		}
-		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor))
+		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID())
 
 		s, lerr := appium.LaunchToHome(setupCtx, *picked)
 		if lerr != nil {
@@ -398,12 +372,6 @@ func runPyramidOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 	// known). Hold here until every fleet member is ready too, so the actual
 	// streaming + shaping sweep starts on all sims at the same instant. Bounded
 	// so a sim that failed bring-up can't hang the rest. No-op for single runs.
-	// Register this sim as a prospective group member before the barrier so the
-	// leader sees every player_id once the fleet is assembled (#fleet group).
-	if bars != nil {
-		bars.registerPlayer(sess.PlayerID)
-	}
-
 	// Fleet sync #2 (sweep): this sim is warmed up with its ladder read. Hold
 	// until every sim is here, then all begin the pyramid shaping at once.
 	if bars != nil {
@@ -429,25 +397,13 @@ func runPyramidOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 			t.Logf("leader finished — observer done")
 			return
 		}
-		// Release the observers when the leader returns — registered FIRST so a
-		// failure in CreateGroup (or the sweep) can't leave them blocked.
+		// The proxy already grouped the fleet by the `_G<num>` token in each
+		// sim's player_id (born grouped at connect — no CreateGroup race). The
+		// leader just drives; the proxy fans every ApplyRate to the group by
+		// group_id. signalSweepDone (deferred FIRST) releases the observers when
+		// the leader returns, even if the sweep below fails.
 		defer bars.signalSweepDone()
-
-		gctx, gcancel := context.WithTimeout(ctx, 30*time.Second)
-		members := bars.members()
-		groupID, gerr := runner.CreateGroup(gctx, "pyramid-"+runID, members)
-		gcancel()
-		if gerr != nil {
-			t.Fatalf("create fleet group: %v", gerr)
-		}
-		t.Logf("created fleet group %s (%d members) — leader drives one broadcast pyramid", groupID, len(members))
-		t.Cleanup(func() {
-			cctx, c := context.WithTimeout(context.Background(), 10*time.Second)
-			defer c()
-			if err := runner.DisbandGroup(cctx, groupID); err != nil {
-				t.Logf("disband group: %v", err)
-			}
-		})
+		t.Logf("group leader — driving one broadcast pyramid for group %s", bars.groupID)
 	}
 
 	// #cycles — run the full up-then-down pyramid REPS times on the SAME

--- a/tests/characterization/modes/rampdown_test.go
+++ b/tests/characterization/modes/rampdown_test.go
@@ -49,7 +49,161 @@ func TestRampdownAndroidTV(t *testing.T) { runRampdown(t, runner.PlatformAndroid
 func TestRampdownWeb(t *testing.T)       { runRampdown(t, runner.PlatformWeb) }
 
 func runRampdown(t *testing.T, p runner.Platform) {
-	sess := OpenSession(t, p)
+	// Fleet dispatch (1 device by default, N under CHAR_FLEET_*). runFleet
+	// resolves the roster and either runs the single-device path unchanged or
+	// fans out one parallel subtest per device with the home + sweep barriers
+	// wired (see runRampdownOnDevice). Under CHAR_FLEET_GROUP=1 the leader drives
+	// one broadcast descent for the whole group (like transient_shock / pyramid).
+	runFleet(t, p, runRampdownOnDevice)
+}
+
+// runRampdownOnDevice runs the descending sweep against ONE explicit device.
+// Like transient_shock it mints its OWN launcher + per-sim player_id and uses
+// the PASSED dev; when bars != nil it syncs at the home barrier (all sims start
+// playback together) and the sweep barrier (all start shaping together).
+//
+// rampdown shares transient_shock's INIT CONFIG: it does NOT prime a cold-start
+// floor — it warms HIGH/uncapped to the top variant before descending, so a
+// floor prime would leave it pinned low. Under CHAR_FLEET_GROUP=1 the session is
+// born-grouped via a config-on-connect carrying ONLY player_id + group_id (no
+// shape), so the fleet is grouped at connect yet still uncapped; the leader
+// (index 0) then drives one broadcast descent and observers hold under it.
+func runRampdownOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars *fleetBarriers) {
+	// --- pick launcher (own instance per subtest) ----------------
+	mode, launcher, err := runner.PickMode()
+	if err != nil {
+		t.Skipf("PickMode: %v", err)
+	}
+	t.Logf("launch mode: %s", mode)
+	picked := &dev
+	t.Logf("device: %s (fleet index %d)", picked, dev.FleetIndex)
+
+	// If this sim dies before reaching a barrier, drop it from that barrier's
+	// expected set so the survivors still release together (home, sweep).
+	homeArrived, sweepArrived := false, false
+	if bars != nil {
+		defer func() {
+			if !homeArrived {
+				bars.home.giveUp()
+			}
+			if !sweepArrived {
+				bars.sweep.giveUp()
+			}
+		}()
+	}
+
+	// Spread parallel fleet launches so N sims don't cold-build WDA at once
+	// (no-op for index 0 / single-device runs).
+	staggerFleetLaunch(t, dev.FleetIndex)
+
+	appium, isAppium := launcher.(*runner.AppiumLauncher)
+
+	// #config — read the per-run configuration axes (segment, LocalProxy,
+	// transfer-timeout). The launch-arg ones plus the minted -is.player_id are
+	// forced on the cold launch in the Appium block below.
+	cfg := readRunConfig(t, isAppium)
+
+	var sess *runner.Session
+	if isAppium {
+		// #714: mint a per-sim player_id and force it onto the cold launch via
+		// the launch args — but DO NOT prime a config-on-connect rate cap. Like
+		// transient_shock, rampdown starts HIGH/uncapped (it warms to the top
+		// variant, then descends), so a cold-start floor would leave it pinned
+		// low. When grouping, born-group the session via a config-on-connect
+		// carrying ONLY player_id + group_id (capMbps=0 ⇒ no shape) so the fleet
+		// is grouped at connect yet still uncapped; player_id stays a clean UUID.
+		// Otherwise a bare launch (no pre-created session).
+		pid := runner.NewPlayerID()
+		// Generous budget — fleet runs hold at the home barrier until the last sim.
+		setupTimeout := 4 * time.Minute
+		if bars != nil {
+			setupTimeout = 12 * time.Minute
+		}
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), setupTimeout)
+		defer setupCancel()
+		if gid := bars.fleetGroupID(); gid != "" {
+			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid)
+			t.Logf("rampdown: born-grouped (group=%s), uncapped — player_id=%s", gid, pid)
+		} else {
+			launchArgs := append(append([]string{}, cfg.launchArgs()...), "-is.player_id", pid)
+			appium.SetLaunchArgs(launchArgs)
+			t.Logf("rampdown: bare launch (no rate prime) — player_id=%s, args=%v", pid, launchArgs)
+		}
+
+		s, lerr := appium.LaunchToHome(setupCtx, *picked)
+		if lerr != nil {
+			t.Fatalf("LaunchToHome: %v", lerr)
+		}
+		s.PlayerID = pid
+
+		// Fleet sync #1 (home): this sim is at home, not yet playing. Hold
+		// until every sim is at home, then all start playback at once.
+		if bars != nil {
+			homeArrived = true
+			t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
+			bars.home.arriveAndWait(setupCtx)
+			t.Logf("HOME barrier released — starting playback")
+		}
+		// Survive transient content-startup: right after a cold launch the
+		// catalogue can be briefly empty, so tapping Resume starts nothing.
+		// Retry resume → heartbeat until the play comes up.
+		var herr error
+		for attempt := 1; attempt <= 3; attempt++ {
+			if rerr := appium.ResumePlayback(setupCtx, *picked); rerr != nil {
+				t.Logf("resume attempt %d: %v", attempt, rerr)
+			}
+			if herr = s.WaitForHeartbeat(setupCtx, 50*time.Second); herr == nil {
+				break
+			}
+			t.Logf("no heartbeat after resume attempt %d — content may still be loading; retrying", attempt)
+		}
+		if herr != nil {
+			t.Fatalf("WaitForHeartbeat after resume retries: %v", herr)
+		}
+		sess = s
+		t.Cleanup(func() {
+			cleanCtx, c := context.WithTimeout(context.Background(), 15*time.Second)
+			defer c()
+			if cerr := sess.ClearShape(cleanCtx); cerr != nil {
+				t.Logf("clear shape: %v", cerr)
+			}
+			if cerr := sess.CloseViaUI(cleanCtx); cerr != nil {
+				t.Logf("close playback via UI: %v", cerr)
+			}
+			// #714: free the session slot immediately (don't wait for the 5-min
+			// reaper) — config-on-connect mints a fresh player_id per run.
+			if cerr := sess.Release(cleanCtx); cerr != nil {
+				t.Logf("release session: %v", cerr)
+			}
+			if cerr := launcher.Close(); cerr != nil {
+				t.Logf("close launcher: %v", cerr)
+			}
+			if cerr := sess.ReleaseDevice(cleanCtx); cerr != nil {
+				t.Logf("release device: %v", cerr)
+			}
+		})
+	} else {
+		t.Logf("config-on-connect unavailable (non-Appium launcher) — legacy path")
+		sess = OpenSession(t, p)
+	}
+
+	// #config — arm the server-side active transfer timeout for this run.
+	{
+		tctx, tcancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := cfg.applyServerSide(tctx, sess); err != nil {
+			t.Logf("set transfer timeout: %v (test continues)", err)
+		} else {
+			t.Logf("transfer timeout: %s on segments", cfg.labels()["xfer_timeout"])
+		}
+		tcancel()
+		t.Cleanup(func() {
+			cctx, c := context.WithTimeout(context.Background(), 10*time.Second)
+			defer c()
+			if err := sess.SetSegmentTimeout(cctx, 0); err != nil {
+				t.Logf("clear transfer timeout: %v", err)
+			}
+		})
+	}
 
 	// Tag the current play with searchable metadata BEFORE the sweep
 	// starts. If the test crashes mid-sweep these still survive — at
@@ -59,6 +213,9 @@ func runRampdown(t *testing.T, p runner.Platform) {
 		"test":     "rampdown",
 		"platform": string(p),
 		"run_id":   runID,
+	}
+	for k, v := range cfg.labels() {
+		startLabels[k] = v
 	}
 	if err := sess.LabelPlay(context.Background(), startLabels); err != nil {
 		t.Logf("label play (start): %v (test continues)", err)
@@ -120,6 +277,38 @@ func runRampdown(t *testing.T, p runner.Platform) {
 	for i, v := range sweep {
 		v := v
 		steps[i] = runner.Step{RateMbps: v.CapMbps, Hold: rampdownMaxHold, Variant: &v}
+	}
+
+	// Fleet sync #2 (sweep): this sim is warmed up with its ladder read. Hold
+	// until every sim is here, then all begin the rampdown shaping at once.
+	// Bounded so a sim that failed bring-up can't hang the rest. No-op single.
+	if bars != nil {
+		sweepArrived = true
+		t.Logf("ready — waiting at fleet SWEEP barrier (shaping starts together across the fleet)")
+		bctx, bcancel := context.WithTimeout(ctx, 5*time.Minute)
+		bars.sweep.arriveAndWait(bctx)
+		bcancel()
+		t.Logf("SWEEP barrier released — beginning synchronized sweep")
+	}
+
+	// Group mode (CHAR_FLEET_GROUP=1): drive ONE descent for the whole fleet.
+	// The leader (index 0) runs the cycled sweep below — every ApplyRate is
+	// broadcast by the proxy to all members by group_id, so the descent lands
+	// identically on every sim. Observers DON'T drive (concurrent drivers would
+	// collide); they hold playback under the broadcast until the leader is done.
+	// Their samples are archived + grouped for side-by-side comparison in the
+	// dashboard. Mirrors transient_shock / pyramid.
+	if bars != nil && bars.group {
+		if dev.FleetIndex != 0 {
+			t.Logf("group observer — holding playback under the leader's broadcast descent (compare in dashboard)")
+			bars.waitSweepDone(ctx)
+			t.Logf("leader finished — observer done")
+			return
+		}
+		// signalSweepDone (deferred FIRST) releases the observers when the leader
+		// returns, even if the sweep below fails.
+		defer bars.signalSweepDone()
+		t.Logf("group leader — driving one broadcast descent for group %s", bars.groupID)
 	}
 
 	// #cycles — run the descent REPS times on the SAME live play (default

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -37,35 +38,47 @@ func TestRampupAndroidTV(t *testing.T) { runRampup(t, runner.PlatformAndroidTV) 
 func TestRampupWeb(t *testing.T)       { runRampup(t, runner.PlatformWeb) }
 
 func runRampup(t *testing.T, p runner.Platform) {
-	// --- pick launcher + device ----------------------------------
+	// Fleet dispatch (1 device by default, N under CHAR_FLEET_*). runFleet
+	// resolves the roster and either runs the single-device path unchanged or
+	// fans out one parallel subtest per device with the home + sweep barriers
+	// wired (see runRampupOnDevice). Under CHAR_FLEET_GROUP=1 the leader drives
+	// one broadcast rampup for the whole group (like pyramid).
+	runFleet(t, p, runRampupOnDevice)
+}
+
+// runRampupOnDevice runs the rampup climb against ONE explicit device. Like
+// runPyramidOnDevice it mints its OWN launcher (so the per-sim player_id can't
+// race under t.Parallel()) and uses the PASSED dev. When bars != nil it syncs
+// at the home barrier (all sims start playback together) and the sweep barrier
+// (all start shaping together). dev.FleetIndex rides into the Appium caps to
+// pin distinct WDA ports.
+func runRampupOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars *fleetBarriers) {
+	// --- pick launcher (own instance per subtest) ----------------
 	mode, launcher, err := runner.PickMode()
 	if err != nil {
 		t.Skipf("PickMode: %v", err)
 	}
 	t.Logf("launch mode: %s", mode)
+	picked := &dev
+	t.Logf("device: %s (fleet index %d)", picked, dev.FleetIndex)
 
-	discCtx, discCancel := context.WithTimeout(context.Background(), 90*time.Second)
-	devs, err := launcher.Discover(discCtx)
-	discCancel()
-	if err != nil {
-		t.Fatalf("discover: %v", err)
+	// If this sim dies before reaching a barrier, drop it from that barrier's
+	// expected set so the survivors still release together (home, sweep).
+	homeArrived, sweepArrived := false, false
+	if bars != nil {
+		defer func() {
+			if !homeArrived {
+				bars.home.giveUp()
+			}
+			if !sweepArrived {
+				bars.sweep.giveUp()
+			}
+		}()
 	}
-	wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
-	var picked *runner.Device
-	for i := range devs {
-		if devs[i].Platform != p {
-			continue
-		}
-		if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
-			continue
-		}
-		picked = &devs[i]
-		break
-	}
-	if picked == nil {
-		t.Skipf("no %s device discovered (mode=%s)", p, mode)
-	}
-	t.Logf("picked device: %s", picked)
+
+	// Spread parallel fleet launches so N sims don't cold-build WDA at once
+	// (no-op for index 0 / single-device runs).
+	staggerFleetLaunch(t, dev.FleetIndex)
 
 	// --- bootstrap: read manifest BEFORE kill+launch -------------
 	bootCtx, bootCancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -110,6 +123,11 @@ func runRampup(t *testing.T, p runner.Platform) {
 	// player starts on them from frame 1; iOS folds them into UserDefaults
 	// (NSArgumentDomain). The transfer-timeout axis is applied server-side.
 	cfg := readRunConfig(t, isAppium)
+	// Pin the active transfer timeout to 6s (matching pyramid) unless the
+	// operator overrides — CHAR_TRANSFER_TIMEOUT still wins.
+	if os.Getenv("CHAR_TRANSFER_TIMEOUT") == "" {
+		cfg.xferTimeout = 6 * time.Second
+	}
 	segment := cfg.segment
 
 	var sess *runner.Session
@@ -121,16 +139,43 @@ func runRampup(t *testing.T, p runner.Platform) {
 		// proxy.* on its own bootstrap URL). Replaces the old coldStart /
 		// conservativeStart dance — the app streams under the cap from segment 0.
 		pid := runner.NewPlayerID()
-		setupCtx, setupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		// Fleet runs need a generous setup window: an early sim holds at the
+		// home barrier until the last (most-staggered) sim arrives. Single
+		// runs keep 2m.
+		setupTimeout := 2 * time.Minute
+		if bars != nil {
+			setupTimeout = 12 * time.Minute
+		}
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), setupTimeout)
 		defer setupCancel()
 		floor := resolveFloor(setupCtx, t, preFloor, rampupFloorFrom)
-		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, 0, 0)
+		// Pin the cold-start initial limit to the same value pyramid uses
+		// (overrides the manifest-derived rampup floor) so rampup cold-starts on
+		// the same low rung and climbs from there — identical init to pyramid
+		// (floor + transfer timeout + startup peak clamp). CHAR_PYRAMID_FLOOR wins.
+		floor = pyramidInitialLimitMbps
+		if v := os.Getenv("CHAR_PYRAMID_FLOOR"); v != "" {
+			if f, perr := strconv.ParseFloat(v, 64); perr == nil && f > 0 {
+				floor = f
+			}
+		}
+		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID())
 
 		s, err := appium.LaunchToHome(setupCtx, *picked)
 		if err != nil {
 			t.Fatalf("LaunchToHome: %v", err)
 		}
 		s.PlayerID = pid
+
+		// Fleet sync #1 (home): this sim is at home, not yet playing. Hold
+		// until every sim is at home, then all start playback at once.
+		if bars != nil {
+			homeArrived = true
+			t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
+			bars.home.arriveAndWait(setupCtx)
+			t.Logf("HOME barrier released — starting playback")
+		}
+
 		if err := appium.ResumePlayback(setupCtx, *picked); err != nil {
 			t.Fatalf("ResumePlayback: %v", err)
 		}
@@ -305,6 +350,33 @@ func runRampup(t *testing.T, p runner.Platform) {
 	for i, v := range asc {
 		v := v
 		steps[i] = runner.Step{RateMbps: v.CapMbps, Hold: rampdownMaxHold, Variant: &v}
+	}
+
+	// Fleet sync #2 (sweep): this sim is warmed up with its ladder read. Hold
+	// until every sim is here, then all begin the rampup shaping at once.
+	// Bounded so a sim that failed bring-up can't hang the rest. No-op single.
+	if bars != nil {
+		sweepArrived = true
+		t.Logf("ready — waiting at fleet SWEEP barrier (shaping starts together across the fleet)")
+		bctx, bcancel := context.WithTimeout(ctx, 5*time.Minute)
+		bars.sweep.arriveAndWait(bctx)
+		bcancel()
+		t.Logf("SWEEP barrier released — beginning synchronized sweep")
+	}
+
+	// Group mode: the leader (index 0) drives ONE broadcast rampup for the whole
+	// fleet; observers hold playback under it and DON'T drive — the proxy fans
+	// the leader's ApplyRate to every member by group_id, so concurrent drivers
+	// would collide. Mirrors pyramid / transient_shock.
+	if bars != nil && bars.group {
+		if dev.FleetIndex != 0 {
+			t.Logf("group observer — holding under the leader's broadcast rampup (compare in dashboard)")
+			bars.waitSweepDone(ctx)
+			t.Logf("leader finished — observer done")
+			return
+		}
+		defer bars.signalSweepDone()
+		t.Logf("group leader — driving one broadcast rampup for group %s", bars.groupID)
 	}
 
 	// #cycles — run the climb REPS times on the SAME live play (default 3,

--- a/tests/characterization/modes/startup_test.go
+++ b/tests/characterization/modes/startup_test.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -93,7 +91,44 @@ func TestStartupAndroidTV(t *testing.T) { runStartup(t, runner.PlatformAndroidTV
 func TestStartupWeb(t *testing.T)       { runStartup(t, runner.PlatformWeb) }
 
 func runStartup(t *testing.T, p runner.Platform) {
-	sess := OpenSession(t, p)
+	// Fleet dispatch (1 device by default, N under CHAR_FLEET_*). runFleet
+	// resolves the roster and either runs the single-device path unchanged or
+	// fans out one parallel subtest per device with the home + sweep barriers
+	// wired (see runStartupOnDevice).
+	// TODO(fleet): group mode like pyramid (CHAR_FLEET_GROUP) — parallel-
+	// independent + synchronized only for now.
+	runFleet(t, p, runStartupOnDevice)
+}
+
+// runStartupOnDevice runs the startup cap matrix against ONE explicit device.
+// startup KEEPS its existing per-cycle prime (each app_cold cycle mints a fresh
+// player_id and caps the session at capMbps before launch, inside
+// runStartupCycle) — fleet-awareness only changes WHICH device it targets and
+// adds the home/sweep sync barriers. The initial OpenSessionOnDevice warms a
+// player so we can read the manifest's variant bandwidths up front; the HOME
+// barrier is wired inside it, the SWEEP barrier (below) gates the cap matrix.
+func runStartupOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars *fleetBarriers) {
+	// The home barrier is owned by OpenSessionOnDevice. We own the sweep
+	// barrier — drop ourselves from it if we die before reaching it.
+	sweepArrived := false
+	if bars != nil {
+		defer func() {
+			if !sweepArrived {
+				bars.sweep.giveUp()
+			}
+		}()
+	}
+
+	// Spread parallel fleet launches so N sims don't cold-build WDA at once
+	// (no-op for index 0 / single-device runs).
+	staggerFleetLaunch(t, dev.FleetIndex)
+
+	// Device-explicit launch (HOME barrier wired inside when bars != nil).
+	var devPtr *runner.Device
+	if bars != nil {
+		devPtr = &dev
+	}
+	sess := OpenSessionOnDevice(t, p, devPtr, bars)
 
 	target := envOr("CHAR_STARTUP_CLIP_TARGET", defaultStartupClipTarget)
 	setupClip := envOr("CHAR_STARTUP_CLIP_SETUP", defaultStartupClipSetup)
@@ -205,6 +240,18 @@ func runStartup(t *testing.T, p runner.Platform) {
 		for res, bw := range bws {
 			t.Logf("  %-12s avg=%.3f peak=%.3f Mbps", res, bw.AvgMbps, bw.PeakMbps)
 		}
+	}
+
+	// Fleet sync #2 (sweep): this sim is warmed up with its manifest read. Hold
+	// until every sim is here, then all begin the cap matrix at once. Bounded
+	// so a sim that failed bring-up can't hang the rest. No-op single.
+	if bars != nil {
+		sweepArrived = true
+		t.Logf("ready — waiting at fleet SWEEP barrier (cap matrix starts together across the fleet)")
+		bctx, bcancel := context.WithTimeout(ctx, 5*time.Minute)
+		bars.sweep.arriveAndWait(bctx)
+		bcancel()
+		t.Logf("SWEEP barrier released — beginning synchronized cap matrix")
 	}
 
 	var allCycles []runner.StartupCycleResult
@@ -364,7 +411,7 @@ func runStartupCycle(
 		// URL): mint a fresh id and cap the session at capMbps before the
 		// first byte — replaces ReadPlayerID + post-launch ApplyRate + tc-settle.
 		pid := runner.NewPlayerID()
-		wireConfigOnConnect(ctx, t, appium, nil, pid, capMbps, 0, 0)
+		wireConfigOnConnect(ctx, t, appium, nil, pid, capMbps, 0, 0, "")
 		s, err := appium.LaunchToHome(ctx, dev)
 		if err != nil {
 			t.Fatalf("[%d] LaunchToHome: %v", idx, err)
@@ -802,55 +849,8 @@ func pickedDevice(s *runner.Session) *runner.Device {
 	return &d
 }
 
-func envOr(key, dflt string) string {
-	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
-		return v
-	}
-	return dflt
-}
-
-// envFloatList parses a comma-separated list of floats from env.
-// Empty / unset / malformed → returns dflt unchanged.
-func envFloatList(key string, dflt []float64) []float64 {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return dflt
-	}
-	out := []float64{}
-	for _, p := range strings.Split(v, ",") {
-		t := strings.TrimSpace(p)
-		if t == "" {
-			continue
-		}
-		f, err := strconv.ParseFloat(t, 64)
-		if err != nil {
-			return dflt
-		}
-		out = append(out, f)
-	}
-	if len(out) == 0 {
-		return dflt
-	}
-	return out
-}
-
-func envFloat(key string, dflt float64) float64 {
-	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil {
-			return f
-		}
-	}
-	return dflt
-}
-
-func envInt(key string, dflt int) int {
-	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
-	}
-	return dflt
-}
+// env helpers (envOr / envFloatList / envFloat / envInt) live in sweep.go so
+// the non-test fleet.go can reference envInt for CHAR_FLEET_COUNT etc.
 
 func countSettleMisses(cs []runner.StartupCycleResult) int {
 	n := 0

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -77,23 +77,30 @@ func resolveFloor(ctx context.Context, t *testing.T, preFloor float64, floorFn f
 // must pass 0 so they don't perturb what they measure.
 //
 // baseArgs are any other launch args (e.g. segment).
-func wireConfigOnConnect(ctx context.Context, t *testing.T, appium *runner.AppiumLauncher, baseArgs []string, pid string, capMbps float64, xferTimeout time.Duration, peakClampMbps int) {
+func wireConfigOnConnect(ctx context.Context, t *testing.T, appium *runner.AppiumLauncher, baseArgs []string, pid string, capMbps float64, xferTimeout time.Duration, peakClampMbps int, groupID string) {
 	t.Helper()
 	launchArgs := append(append([]string{}, baseArgs...), "-is.player_id", pid)
 	if peakClampMbps > 0 {
 		launchArgs = append(launchArgs, "-is.flag.peak_bitrate_mbps", strconv.Itoa(peakClampMbps))
 	}
 	if os.Getenv("CHAR_PROXY_CONFIG") == "app" {
-		launchArgs = append(launchArgs, "-is.proxy_query", appProxyQuery(capMbps, xferTimeout))
+		launchArgs = append(launchArgs, "-is.proxy_query", appProxyQuery(capMbps, xferTimeout, groupID))
 		appium.SetLaunchArgs(launchArgs)
-		t.Logf("config-on-connect VIA APP URL: rate=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps (no curl); player_id=%s", capMbps, xferTimeout, peakClampMbps, pid)
+		t.Logf("config-on-connect VIA APP URL: rate=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q (no curl); player_id=%s", capMbps, xferTimeout, peakClampMbps, groupID, pid)
 		return
 	}
 	appium.SetLaunchArgs(launchArgs)
-	if err := runner.ConfigureOnConnect(ctx, pid, runner.ShapeConfig(capMbps, xferTimeout)); err != nil {
-		t.Fatalf("ConfigureOnConnect (player_id=%s cap=%.3f Mbps): %v", pid, capMbps, err)
+	// capMbps<=0 ⇒ no shape (uncapped) — e.g. a born-grouped transient_shock
+	// whose curl carries only player_id + group_id, so the session joins the
+	// group at connect yet warms uncapped to its top variant.
+	var cfg runner.BootstrapConfig
+	if capMbps > 0 {
+		cfg = runner.ShapeConfig(capMbps, xferTimeout)
 	}
-	t.Logf("config-on-connect VIA CURL (default): session %s pre-capped at %.3f Mbps, xfer_timeout=%s, peak_clamp=%dMbps before launch", pid, capMbps, xferTimeout, peakClampMbps)
+	if err := runner.ConfigureOnConnect(ctx, pid, groupID, cfg); err != nil {
+		t.Fatalf("ConfigureOnConnect (player_id=%s cap=%.3f Mbps group=%q): %v", pid, capMbps, groupID, err)
+	}
+	t.Logf("config-on-connect VIA CURL (default): session %s cap=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q before launch", pid, capMbps, xferTimeout, peakClampMbps, groupID)
 }
 
 // peakClampForCap maps a network cap (Mbps) to the app's whole-Mbps startup
@@ -109,13 +116,20 @@ func peakClampForCap(capMbps float64) int {
 // appProxyQuery builds the -is.proxy_query value for CHAR_PROXY_CONFIG=app: the
 // rate cap plus, when xferTimeout>0, the segment transfer timeout. Mirrors the
 // curl-mode ShapeConfig so both drivers materialize the same session.
-func appProxyQuery(capMbps float64, xferTimeout time.Duration) string {
-	q := fmt.Sprintf("proxy.shape.rate_mbps=%g", capMbps)
-	if xferTimeout > 0 {
-		q += fmt.Sprintf("&proxy.transfer_timeouts.active_timeout_seconds=%d&proxy.transfer_timeouts.applies_segments=true",
-			int(xferTimeout.Seconds()))
+func appProxyQuery(capMbps float64, xferTimeout time.Duration, groupID string) string {
+	var parts []string
+	if capMbps > 0 {
+		parts = append(parts, fmt.Sprintf("proxy.shape.rate_mbps=%g", capMbps))
+		if xferTimeout > 0 {
+			parts = append(parts,
+				fmt.Sprintf("proxy.transfer_timeouts.active_timeout_seconds=%d", int(xferTimeout.Seconds())),
+				"proxy.transfer_timeouts.applies_segments=true")
+		}
 	}
-	return q
+	if groupID != "" {
+		parts = append(parts, "group_id="+groupID)
+	}
+	return strings.Join(parts, "&")
 }
 
 // OpenSession picks a launcher per $LAUNCH_MODE, discovers a device for
@@ -128,6 +142,28 @@ func appProxyQuery(capMbps float64, xferTimeout time.Duration) string {
 // On success registers a t.Cleanup that clears the shape so we don't
 // leave the proxy stuck in a degraded state between tests.
 func OpenSession(t *testing.T, platform runner.Platform) *runner.Session {
+	t.Helper()
+	return OpenSessionOnDevice(t, platform, nil, nil)
+}
+
+// OpenSessionOnDevice is the device-explicit, optionally fleet-synchronized
+// form of OpenSession. It is the launch path for modes that start the player
+// HIGH/uncapped (rampdown, startup) and need to run as a fleet.
+//
+//   - dev == nil  → resolve the single device the legacy way (Discover →
+//     first-match, honouring CHARACTERIZATION_DEVICE_UDID). This is exactly
+//     OpenSession's behaviour and keeps the single-device callers
+//     (abort / startup_caps / state_residency / playback_end) unchanged.
+//   - dev != nil  → launch against THAT explicit device (no Discover-pick).
+//
+// When bars != nil AND the launcher is Appium, the launch is split so the home
+// barrier gates the simultaneous playback start across the fleet:
+// LaunchToHome → bars.home.arriveAndWait → ResumePlayback → WaitForHeartbeat.
+// Otherwise it uses launcher.Launch (the single-shot home+resume+heartbeat),
+// byte-for-byte identical to the legacy path. The caller wires the SWEEP
+// barrier itself (right before its shaping sweep) — this helper owns the HOME
+// barrier (including dropping itself from it if bring-up fails).
+func OpenSessionOnDevice(t *testing.T, platform runner.Platform, dev *runner.Device, bars *fleetBarriers) *runner.Session {
 	t.Helper()
 	mode, launcher, err := runner.PickMode()
 	if err != nil {
@@ -147,38 +183,83 @@ func OpenSession(t *testing.T, platform runner.Platform) *runner.Session {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	devs, err := launcher.Discover(ctx)
-	if err != nil {
-		t.Fatalf("discover: %v", err)
-	}
-	// Device selection. When CHARACTERIZATION_DEVICE_UDID is set the test
-	// targets ONLY that specific device — required for parallel runs
-	// across multiple sims of the same platform (each terminal exports
-	// its own UDID, no race for the same device). When unset we fall
-	// back to "first matching platform" — the simple default.
-	wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
 	var picked *runner.Device
-	for i := range devs {
-		if devs[i].Platform != platform {
-			continue
+	if dev != nil {
+		// Device-explicit (fleet or honoured single dev) — no Discover pick.
+		d := *dev
+		picked = &d
+		t.Logf("device: %s (fleet index %d)", picked, d.FleetIndex)
+	} else {
+		devs, err := launcher.Discover(ctx)
+		if err != nil {
+			t.Fatalf("discover: %v", err)
 		}
-		if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
-			continue
+		// Device selection. When CHARACTERIZATION_DEVICE_UDID is set the test
+		// targets ONLY that specific device — required for parallel runs
+		// across multiple sims of the same platform (each terminal exports
+		// its own UDID, no race for the same device). When unset we fall
+		// back to "first matching platform" — the simple default.
+		wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
+		for i := range devs {
+			if devs[i].Platform != platform {
+				continue
+			}
+			if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
+				continue
+			}
+			picked = &devs[i]
+			break
 		}
-		picked = &devs[i]
-		break
+		if picked == nil {
+			if wantUDID != "" {
+				t.Skipf("no %s device with UDID=%s discovered (mode=%s)", platform, wantUDID, mode)
+			}
+			t.Skipf("no %s device discovered (mode=%s)", platform, mode)
+		}
+		t.Logf("picked device: %s", picked)
 	}
-	if picked == nil {
-		if wantUDID != "" {
-			t.Skipf("no %s device with UDID=%s discovered (mode=%s)", platform, wantUDID, mode)
-		}
-		t.Skipf("no %s device discovered (mode=%s)", platform, mode)
-	}
-	t.Logf("picked device: %s", picked)
 
-	sess, err := launcher.Launch(ctx, *picked)
-	if err != nil {
-		t.Fatalf("launch %s: %v", picked, err)
+	var sess *runner.Session
+	if appium, isAppium := launcher.(*runner.AppiumLauncher); isAppium && bars != nil {
+		// Fleet path: split the launch so the home barrier can gate the
+		// simultaneous playback start. The launcher already carries any launch
+		// args the caller set (none for the high-start modes). A generous
+		// setup window — an early sim holds at the home barrier until the last
+		// (most-staggered) sim arrives.
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), 12*time.Minute)
+		defer setupCancel()
+		// If we die before reaching the home barrier (e.g. LaunchToHome fails),
+		// drop ourselves from its expected set so the survivors still release
+		// together. t.Fatalf runs deferred funcs via runtime.Goexit.
+		homeArrived := false
+		defer func() {
+			if !homeArrived {
+				bars.home.giveUp()
+			}
+		}()
+		s, lerr := appium.LaunchToHome(setupCtx, *picked)
+		if lerr != nil {
+			t.Fatalf("LaunchToHome: %v", lerr)
+		}
+		// Fleet sync #1 (home): hold until every sim is at home, then all start
+		// playback at once.
+		homeArrived = true
+		t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
+		bars.home.arriveAndWait(setupCtx)
+		t.Logf("HOME barrier released — starting playback")
+		if rerr := appium.ResumePlayback(setupCtx, *picked); rerr != nil {
+			t.Fatalf("ResumePlayback: %v", rerr)
+		}
+		if herr := s.WaitForHeartbeat(setupCtx, 90*time.Second); herr != nil {
+			t.Fatalf("WaitForHeartbeat: %v", herr)
+		}
+		sess = s
+	} else {
+		s, lerr := launcher.Launch(ctx, *picked)
+		if lerr != nil {
+			t.Fatalf("launch %s: %v", picked, lerr)
+		}
+		sess = s
 	}
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -688,6 +769,60 @@ func RunMode(t *testing.T, platform runner.Platform, mode string,
 	if len(report.Steps) == 0 {
 		t.Errorf("no steps recorded")
 	}
+}
+
+// env helpers — small generic readers shared across modes. They live in this
+// NON-test file (not startup_test.go) so the non-test fleet.go can call envInt
+// for CHAR_FLEET_COUNT / CHAR_FLEET_STAGGER_SEC.
+
+func envOr(key, dflt string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return dflt
+}
+
+// envFloatList parses a comma-separated list of floats from env.
+// Empty / unset / malformed → returns dflt unchanged.
+func envFloatList(key string, dflt []float64) []float64 {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return dflt
+	}
+	out := []float64{}
+	for _, p := range strings.Split(v, ",") {
+		t := strings.TrimSpace(p)
+		if t == "" {
+			continue
+		}
+		f, err := strconv.ParseFloat(t, 64)
+		if err != nil {
+			return dflt
+		}
+		out = append(out, f)
+	}
+	if len(out) == 0 {
+		return dflt
+	}
+	return out
+}
+
+func envFloat(key string, dflt float64) float64 {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			return f
+		}
+	}
+	return dflt
+}
+
+func envInt(key string, dflt int) int {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return dflt
 }
 
 // timeoutForSteps adds a 60s slack on top of the planned sweep time so

--- a/tests/characterization/modes/transient_shock_test.go
+++ b/tests/characterization/modes/transient_shock_test.go
@@ -3,7 +3,6 @@ package modes
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,9 +10,9 @@ import (
 	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
 )
 
-// Transient-shock — graduated-drop staircase: cold-start at the floor,
-// then build a full 4K buffer under a high cap (headroom ABOVE the 4K peak)
-// and drop to a sequence of escalating depths — the peak cap (×1.05 TCP
+// Transient-shock — graduated-drop staircase: warm up UNCAPPED to the top
+// variant (4K), then build a full 4K buffer under a high cap (headroom ABOVE
+// the 4K peak) and drop to a sequence of escalating depths — the peak cap (×1.05 TCP
 // overhead) of the published variant 3/4, 1/2, 1/4 up from the bottom, and
 // the bottom variant — returning to the high cap between drops so the
 // buffer refills. Finds WHERE the player breaks, not just the worst case.
@@ -27,9 +26,11 @@ import (
 // and the AVMetrics feed (CoreMedia errors + variant-switch start/complete)
 // to see whether the link survives the drop and whether the player recovers.
 //
-// Shares all of rampup's machinery: cold-start bootstrap, the run-config
-// axes (CHAR_SEGMENT / CHAR_LOCAL_PROXY / CHAR_TRANSFER_TIMEOUT) forced at
-// launch + applied server-side, play labels, and UI-close teardown.
+// Shares most of rampup's machinery: the run-config axes (CHAR_SEGMENT /
+// CHAR_LOCAL_PROXY / CHAR_TRANSFER_TIMEOUT) forced at launch + applied
+// server-side, play labels, and UI-close teardown. It deliberately does NOT
+// cold-start at a floor (rampup/pyramid do) — it warms up uncapped so the
+// player reaches 4K before the first shock.
 //
 // Env axes (in addition to the shared CHAR_SEGMENT / CHAR_LOCAL_PROXY /
 // CHAR_TRANSFER_TIMEOUT):
@@ -46,54 +47,51 @@ func TestTransientShockAndroidTV(t *testing.T) { runTransientShock(t, runner.Pla
 func TestTransientShockWeb(t *testing.T)       { runTransientShock(t, runner.PlatformWeb) }
 
 func runTransientShock(t *testing.T, p runner.Platform) {
-	// --- pick launcher + device ----------------------------------
+	// Fleet dispatch (1 device by default, N under CHAR_FLEET_*). runFleet
+	// resolves the roster and either runs the single-device path unchanged or
+	// fans out one parallel subtest per device with the home + sweep barriers
+	// wired (see runTransientShockOnDevice). Under CHAR_FLEET_GROUP=1 the leader
+	// drives one broadcast staircase for the whole group (like pyramid).
+	runFleet(t, p, runTransientShockOnDevice)
+}
+
+// runTransientShockOnDevice runs the graduated-drop staircase against ONE
+// explicit device. Like runPyramidOnDevice it mints its OWN launcher and uses
+// the PASSED dev; when bars != nil it syncs at the home barrier (all sims start
+// playback together) and the sweep barrier (all start shaping together).
+//
+// UNLIKE rampup/pyramid, transient-shock does NOT prime a cold-start floor: the
+// probe must warm to the top variant (4K) UNCAPPED before the first shock, so
+// there's a full forward buffer to drop FROM. We still mint a per-sim player_id
+// and set the launch args (incl. the per-sim WDA ports via dev.FleetIndex) and
+// bind the session — just with no config-on-connect rate curl and no peak clamp.
+func runTransientShockOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars *fleetBarriers) {
+	// --- pick launcher (own instance per subtest) ----------------
 	mode, launcher, err := runner.PickMode()
 	if err != nil {
 		t.Skipf("PickMode: %v", err)
 	}
 	t.Logf("launch mode: %s", mode)
+	picked := &dev
+	t.Logf("device: %s (fleet index %d)", picked, dev.FleetIndex)
 
-	discCtx, discCancel := context.WithTimeout(context.Background(), 90*time.Second)
-	devs, err := launcher.Discover(discCtx)
-	discCancel()
-	if err != nil {
-		t.Fatalf("discover: %v", err)
+	// If this sim dies before reaching a barrier, drop it from that barrier's
+	// expected set so the survivors still release together (home, sweep).
+	homeArrived, sweepArrived := false, false
+	if bars != nil {
+		defer func() {
+			if !homeArrived {
+				bars.home.giveUp()
+			}
+			if !sweepArrived {
+				bars.sweep.giveUp()
+			}
+		}()
 	}
-	wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
-	var picked *runner.Device
-	for i := range devs {
-		if devs[i].Platform != p {
-			continue
-		}
-		if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
-			continue
-		}
-		picked = &devs[i]
-		break
-	}
-	if picked == nil {
-		t.Skipf("no %s device discovered (mode=%s)", p, mode)
-	}
-	t.Logf("picked device: %s", picked)
 
-	// --- bootstrap: read manifest BEFORE kill+launch so we cold-start
-	// at the floor (clean startup), then climb to the top under the high
-	// cap before the first shock. Same machinery rampup uses.
-	bootCtx, bootCancel := context.WithTimeout(context.Background(), 15*time.Second)
-	preRec, preErr := runner.PreLaunchInfo(bootCtx, *picked)
-	bootCancel()
-
-	var preFloor float64
-	if preErr != nil {
-		t.Logf("pre-launch info: %v (cold-start unavailable; conservative/fallback path)", preErr)
-	} else if preRec.CurrentPlay == nil || len(preRec.CurrentPlay.Manifest.Variants) == 0 {
-		t.Logf("pre-launch: no current play / no variants yet (cold-start unavailable)")
-	} else if preDesc, derr := runner.StandardLadderRates(preRec); derr != nil {
-		t.Logf("pre-launch StandardLadderRates: %v (cold-start unavailable)", derr)
-	} else {
-		preFloor = rampupFloorFrom(preDesc)
-		t.Logf("bootstrap: pre-launch floor = %.3f Mbps (from current player's manifest)", preFloor)
-	}
+	// Spread parallel fleet launches so N sims don't cold-build WDA at once
+	// (no-op for index 0 / single-device runs).
+	staggerFleetLaunch(t, dev.FleetIndex)
 
 	appium, isAppium := launcher.(*runner.AppiumLauncher)
 
@@ -105,24 +103,51 @@ func runTransientShock(t *testing.T, p runner.Platform) {
 
 	var sess *runner.Session
 	if isAppium {
-		// #714 config-on-connect: mint the player_id, resolve the cold-start
-		// floor, and wire the driver (default = harness pre-configures via a
-		// curl, so the variant ladder is known up front; CHAR_PROXY_CONFIG=app →
-		// the player emits proxy.* on its own bootstrap URL). Replaces the old
-		// coldStart / conservativeStart split — the Android special-casing is
-		// gone now that Android honors the launch arg.
+		// #714: mint a per-sim player_id and force it onto the cold launch via
+		// the launch args — but DO NOT prime a config-on-connect rate cap. This
+		// probe must warm to its top variant (4K) UNCAPPED before the first
+		// shock (so it has a full forward buffer to drop FROM); a floor prime
+		// would leave it pinned low. We wire the launch args (segment + the
+		// minted -is.player_id) directly, skipping the rate curl / peak clamp
+		// that rampup/pyramid use. The per-sim WDA ports come from
+		// dev.FleetIndex flowing into the Appium caps.
 		pid := runner.NewPlayerID()
-		// Generous budget — Android adds a catalogue-load settle on top of launch.
-		setupCtx, setupCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		// Generous budget — Android adds a catalogue-load settle on top of
+		// launch; fleet runs also hold at the home barrier until the last sim.
+		setupTimeout := 4 * time.Minute
+		if bars != nil {
+			setupTimeout = 12 * time.Minute
+		}
+		setupCtx, setupCancel := context.WithTimeout(context.Background(), setupTimeout)
 		defer setupCancel()
-		floor := resolveFloor(setupCtx, t, preFloor, rampupFloorFrom)
-		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, 0, 0)
+		// No rate prime (uncapped) — this probe must warm to its top variant (4K)
+		// before the first shock. When grouping, born-group the session via a
+		// config-on-connect carrying ONLY player_id + group_id (capMbps=0 ⇒ no
+		// shape), so the fleet is grouped at connect yet still uncapped. Player_id
+		// stays a clean UUID. Otherwise a bare launch (no pre-created session).
+		if gid := bars.fleetGroupID(); gid != "" {
+			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid)
+			t.Logf("transient-shock: born-grouped (group=%s), uncapped — player_id=%s", gid, pid)
+		} else {
+			launchArgs := append(append([]string{}, cfg.launchArgs()...), "-is.player_id", pid)
+			appium.SetLaunchArgs(launchArgs)
+			t.Logf("transient-shock: bare launch (no rate prime) — player_id=%s, args=%v", pid, launchArgs)
+		}
 
 		s, lerr := appium.LaunchToHome(setupCtx, *picked)
 		if lerr != nil {
 			t.Fatalf("LaunchToHome: %v", lerr)
 		}
 		s.PlayerID = pid
+
+		// Fleet sync #1 (home): this sim is at home, not yet playing. Hold
+		// until every sim is at home, then all start playback at once.
+		if bars != nil {
+			homeArrived = true
+			t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
+			bars.home.arriveAndWait(setupCtx)
+			t.Logf("HOME barrier released — starting playback")
+		}
 		// Survive transient content-startup: right after a cold launch the
 		// catalogue can be briefly empty ("No content available"), so tapping
 		// Resume starts nothing. Retry resume → heartbeat until the play comes up.
@@ -213,7 +238,7 @@ func runTransientShock(t *testing.T, p runner.Platform) {
 
 	// --- variant ladder (post-launch — definitive) --------------
 	if isAppium {
-		t.Logf("waiting %s for manifest to populate under config-on-connect cap", rampdownWarmupHold)
+		t.Logf("waiting %s for manifest to populate (uncapped warmup — no cold-start floor)", rampdownWarmupHold)
 		if err := holdContext(ctx, rampdownWarmupHold); err != nil {
 			t.Fatalf("manifest-fetch hold: %v", err)
 		}
@@ -287,6 +312,41 @@ func runTransientShock(t *testing.T, p runner.Platform) {
 
 	t.Logf("staircase: build@%.1f Mbps (%s); drops (variant peaks ×1.05, 3/4·1/2·1/4·bottom)=%.3f Mbps (hold %s each)",
 		high, highHold, drops, dipHold)
+
+	// Fleet sync #2 (sweep): this sim is warmed up with its ladder read. Hold
+	// until every sim is here, then all begin the staircase shaping at once.
+	// Bounded so a sim that failed bring-up can't hang the rest. No-op single.
+	if bars != nil {
+		sweepArrived = true
+		t.Logf("ready — waiting at fleet SWEEP barrier (shaping starts together across the fleet)")
+		bctx, bcancel := context.WithTimeout(ctx, 5*time.Minute)
+		bars.sweep.arriveAndWait(bctx)
+		bcancel()
+		t.Logf("SWEEP barrier released — beginning synchronized sweep")
+	}
+
+	// Group mode (CHAR_FLEET_GROUP=1): drive ONE staircase for the whole fleet.
+	// The leader (index 0) creates the player-group and runs the sweep below —
+	// every ApplyRate is broadcast by the proxy to all members, so the shock
+	// lands identically on every sim. Observers don't drive (that would collide);
+	// they hold playback under the broadcast until the leader is done. Their
+	// samples are archived + grouped for side-by-side comparison in the
+	// dashboard (#579 compare-charts).
+	if bars != nil && bars.group {
+		if dev.FleetIndex != 0 {
+			t.Logf("group observer — holding playback under the leader's broadcast staircase (compare in dashboard)")
+			bars.waitSweepDone(ctx)
+			t.Logf("leader finished — observer done")
+			return
+		}
+		// The proxy already grouped the fleet by the `_G<num>` token in each
+		// sim's player_id (born grouped at connect — no CreateGroup race). The
+		// leader just drives; the proxy fans every ApplyRate to the group by
+		// group_id. signalSweepDone (deferred FIRST) releases the observers when
+		// the leader returns, even if the sweep below fails.
+		defer bars.signalSweepDone()
+		t.Logf("group leader — driving one broadcast staircase for group %s", bars.groupID)
+	}
 
 	report := RunSweep(ctx, t, sess, "transient-shock", steps, time.Second)
 	report.Variants = unionRungs(desc)

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -144,6 +144,33 @@ func (a *AppiumLauncher) SetLaunchArgs(args []string) {
 	a.mu.Unlock()
 }
 
+// baselineTestFlags are config-on-startup flags EVERY characterization launch
+// forces to a known value, so a sim's stale persisted setting can't silently
+// leak into a run. These launch args land in NSArgumentDomain, which outranks
+// the app's persistent UserDefaults — so `-is.flag.4k true` overrides a sim
+// whose "4K" toggle was left off (it would otherwise cap itself at 1080p), and
+// `-is.flag.peak_bitrate_mbps 0` clears a leftover startup peak-bitrate clamp
+// from a prior capped run (e.g. pyramid's floor clamp). A mode that sets one of
+// these explicitly wins — withBaselineTestFlags only fills the ones it omitted.
+var baselineTestFlags = [][2]string{
+	{"-is.flag.4k", "true"},
+	{"-is.flag.peak_bitrate_mbps", "0"},
+}
+
+func withBaselineTestFlags(args []string) []string {
+	present := map[string]bool{}
+	for i := 0; i+1 < len(args); i += 2 {
+		present[args[i]] = true
+	}
+	out := append([]string{}, args...)
+	for _, kv := range baselineTestFlags {
+		if !present[kv[0]] {
+			out = append(out, kv[0], kv[1])
+		}
+	}
+	return out
+}
+
 // intentExtrasFromLaunchArgs converts `-is.X Y` launch-arg pairs into the
 // `--es is.X Y` form Android's appium:optionalIntentArguments expects (String
 // intent extras appended to the start intent). Values in the #714 vocab
@@ -169,19 +196,22 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 		return nil, fmt.Errorf("appium server not reachable at %s: %w (start with `appium`, or unset LAUNCH_MODE=appium)", a.URL, err)
 	}
 	caps := appiumCapabilities(d, bundleID)
-	if len(a.launchArgs) > 0 {
+	// Always fold in the baseline test flags (4K on, peak clamp off unless the
+	// mode set it) so a sim's stale persisted UserDefaults can't leak in.
+	effectiveArgs := withBaselineTestFlags(a.launchArgs)
+	if len(effectiveArgs) > 0 {
 		if d.Platform == PlatformAndroidTV {
 			// UiAutomator2 ignores processArguments. Deliver the launch args
 			// as intent extras appended to the start intent: `-is.X Y` →
 			// `--es is.X Y`. The Android app reads `is.player_id` off the
 			// launch intent (config-on-connect, #714), mirroring how iOS reads
 			// it from NSArgumentDomain.
-			caps["appium:optionalIntentArguments"] = intentExtrasFromLaunchArgs(a.launchArgs)
+			caps["appium:optionalIntentArguments"] = intentExtrasFromLaunchArgs(effectiveArgs)
 		} else {
 			// XCUITest passes these to the app on launch; iOS folds `-key value`
 			// pairs into UserDefaults (NSArgumentDomain). #segments forces the
 			// segment this way so a single cold launch lands on it.
-			caps["appium:processArguments"] = map[string]any{"args": a.launchArgs}
+			caps["appium:processArguments"] = map[string]any{"args": effectiveArgs}
 		}
 	}
 	sessID, err := a.createSession(ctx, caps)

--- a/tests/characterization/runner/bootstrap.go
+++ b/tests/characterization/runner/bootstrap.go
@@ -68,7 +68,7 @@ func ShapeConfig(rateMbps float64, xferTimeout time.Duration) BootstrapConfig {
 // BEFORE the app launches. Clip-agnostic: shape/fault config is session-scoped,
 // so any discoverable clip triggers the allocation; the app's real clip
 // reattaches by player_id.
-func ConfigureOnConnect(ctx context.Context, playerID string, cfg BootstrapConfig) error {
+func ConfigureOnConnect(ctx context.Context, playerID, groupID string, cfg BootstrapConfig) error {
 	if playerID == "" {
 		return fmt.Errorf("ConfigureOnConnect: empty playerID")
 	}
@@ -87,6 +87,11 @@ func ConfigureOnConnect(ctx context.Context, playerID string, cfg BootstrapConfi
 
 	q := url.Values{}
 	q.Set("player_id", playerID)
+	// #fleet-group: explicit group_id connect param (born-groups the session
+	// while player_id stays a clean UUID). Top-level, NOT a proxy.* arg.
+	if groupID != "" {
+		q.Set("group_id", groupID)
+	}
 	for k, v := range cfg {
 		q.Set("proxy."+k, v)
 	}

--- a/tests/characterization/runner/bootstrap_test.go
+++ b/tests/characterization/runner/bootstrap_test.go
@@ -41,7 +41,7 @@ func TestConfigOnConnectCapacity(t *testing.T) {
 	for i := 0; i < iters; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		pid := NewPlayerID()
-		err := ConfigureOnConnect(ctx, pid, ShapeRateConfig(2.0))
+		err := ConfigureOnConnect(ctx, pid, "", ShapeRateConfig(2.0))
 		if err != nil && i == 0 {
 			cancel()
 			t.Skipf("ConfigureOnConnect unavailable (server down?): %v", err)

--- a/tools/harness-cli/internal/api/client.go
+++ b/tools/harness-cli/internal/api/client.go
@@ -303,38 +303,84 @@ func (c *Client) postMutate(playerID, action, etagBefore, etagAfter string, befo
 	return nil
 }
 
-// PatchPlayer applies a JSON-merge-patch to a player record using
-// If-Match. The etag is fetched automatically if needed (or as part
-// of snapshot prep). Action is a short label written into the
-// snapshot for replay; empty disables snapshotting.
-func (c *Client) PatchPlayer(ctx context.Context, playerID, action string, patch proxy.PlayerPatch) (string, error) {
-	before, etag, err := c.preMutate(ctx, playerID, action)
-	if err != nil {
-		return "", err
-	}
-	if etag == "" {
-		_, e, err := c.Player(ctx, playerID)
+// patchETagMaxAttempts bounds the read-modify-write retry loop in
+// patchWithETagRetry. 5 attempts with the staged backoff below tolerates a
+// busy doc (N sims heartbeating + group fan-out) without hanging on a truly
+// stuck PATCH.
+const patchETagMaxAttempts = 5
+
+// patchWithETagRetry runs a read-modify-write PATCH under If-Match, retrying
+// on 412 (precondition failed). The player doc's control_revision bumps on
+// every heartbeat — and a born-group has N sims heartbeating PLUS the proxy's
+// group fan-out cross-writing every member — so a single etag read routinely
+// goes stale between the fetch and the PATCH. The server explicitly tells us
+// to "refetch the conflicting paths and retry"; this loop does exactly that:
+// a FRESH etag every attempt (via preMutate / Player) and a short staged
+// backoff so the concurrent writer settles. do() performs ONE PATCH attempt
+// with the supplied etag and returns the raw response; snapshotPatch is the
+// wire body recorded for undo.
+func (c *Client) patchWithETagRetry(
+	ctx context.Context,
+	playerID, action, errCtx string,
+	snapshotPatch any,
+	do func(etag string) (*http.Response, error),
+) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= patchETagMaxAttempts; attempt++ {
+		before, etag, err := c.preMutate(ctx, playerID, action)
 		if err != nil {
 			return "", err
 		}
-		etag = e
+		if etag == "" {
+			_, e, perr := c.Player(ctx, playerID)
+			if perr != nil {
+				return "", perr
+			}
+			etag = e
+		}
+		resp, err := do(etag)
+		if err != nil {
+			return "", err
+		}
+		if resp.StatusCode == http.StatusPreconditionFailed {
+			io.Copy(io.Discard, io.LimitReader(resp.Body, 32*1024))
+			resp.Body.Close()
+			lastErr = fmt.Errorf("%s: 412 revision conflict — doc moved under us (attempt %d/%d)",
+				errCtx, attempt, patchETagMaxAttempts)
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(time.Duration(attempt) * 75 * time.Millisecond):
+			}
+			continue
+		}
+		if cerr := checkProxyError(resp, errCtx); cerr != nil {
+			resp.Body.Close()
+			return "", cerr
+		}
+		newETag := strings.Trim(resp.Header.Get("ETag"), `"`)
+		resp.Body.Close()
+		if err := c.postMutate(playerID, action, etag, newETag, before, snapshotPatch); err != nil {
+			return newETag, err
+		}
+		return newETag, nil
 	}
-	params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
-	resp, err := c.proxy.PatchApiV2PlayersPlayerIdWithApplicationMergePatchPlusJSONBody(
-		ctx, proxy.PlayerId(playerID), params, patch,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if err := checkProxyError(resp, "PATCH /api/v2/players/"+playerID); err != nil {
-		return "", err
-	}
-	newETag := strings.Trim(resp.Header.Get("ETag"), `"`)
-	if err := c.postMutate(playerID, action, etag, newETag, before, patch); err != nil {
-		return newETag, err
-	}
-	return newETag, nil
+	return "", lastErr
+}
+
+// PatchPlayer applies a JSON-merge-patch to a player record using
+// If-Match (retrying on 412 via patchWithETagRetry). The etag is fetched
+// automatically if needed (or as part of snapshot prep). Action is a short
+// label written into the snapshot for replay; empty disables snapshotting.
+func (c *Client) PatchPlayer(ctx context.Context, playerID, action string, patch proxy.PlayerPatch) (string, error) {
+	return c.patchWithETagRetry(ctx, playerID, action,
+		"PATCH /api/v2/players/"+playerID, patch,
+		func(etag string) (*http.Response, error) {
+			params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
+			return c.proxy.PatchApiV2PlayersPlayerIdWithApplicationMergePatchPlusJSONBody(
+				ctx, proxy.PlayerId(playerID), params, patch,
+			)
+		})
 }
 
 // AddFaultRule POSTs a new fault rule onto a player. The proxy
@@ -417,35 +463,15 @@ func (c *Client) PatchShape(ctx context.Context, playerID, action string, shape 
 // means "omit the key"), so we ship the raw JSON via the body-reader
 // variant of the generated client.
 func (c *Client) ClearShape(ctx context.Context, playerID, action string) (string, error) {
-	before, etag, err := c.preMutate(ctx, playerID, action)
-	if err != nil {
-		return "", err
-	}
-	if etag == "" {
-		_, e, err := c.Player(ctx, playerID)
-		if err != nil {
-			return "", err
-		}
-		etag = e
-	}
-	params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
-	body := bytes.NewReader([]byte(`{"shape": null}`))
-	resp, err := c.proxy.PatchApiV2PlayersPlayerIdWithBody(
-		ctx, proxy.PlayerId(playerID), params,
-		"application/merge-patch+json", body,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if err := checkProxyError(resp, "PATCH /api/v2/players/"+playerID+" (clear shape)"); err != nil {
-		return "", err
-	}
-	newETag := strings.Trim(resp.Header.Get("ETag"), `"`)
-	if err := c.postMutate(playerID, action, etag, newETag, before, map[string]any{"shape": nil}); err != nil {
-		return newETag, err
-	}
-	return newETag, nil
+	return c.patchWithETagRetry(ctx, playerID, action,
+		"PATCH /api/v2/players/"+playerID+" (clear shape)", map[string]any{"shape": nil},
+		func(etag string) (*http.Response, error) {
+			params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
+			return c.proxy.PatchApiV2PlayersPlayerIdWithBody(
+				ctx, proxy.PlayerId(playerID), params,
+				"application/merge-patch+json", bytes.NewReader([]byte(`{"shape": null}`)),
+			)
+		})
 }
 
 // PatchShapeMap PATCHes the player's shape with an arbitrary map body,
@@ -456,38 +482,19 @@ func (c *Client) ClearShape(ctx context.Context, playerID, action string) (strin
 // pointer and leave the pattern running. Same body-reader path
 // ClearShape uses, just with a richer payload.
 func (c *Client) PatchShapeMap(ctx context.Context, playerID, action string, shape map[string]any) (string, error) {
-	before, etag, err := c.preMutate(ctx, playerID, action)
-	if err != nil {
-		return "", err
-	}
-	if etag == "" {
-		_, e, err := c.Player(ctx, playerID)
-		if err != nil {
-			return "", err
-		}
-		etag = e
-	}
 	body, err := json.Marshal(map[string]any{"shape": shape})
 	if err != nil {
 		return "", err
 	}
-	params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
-	resp, err := c.proxy.PatchApiV2PlayersPlayerIdWithBody(
-		ctx, proxy.PlayerId(playerID), params,
-		"application/merge-patch+json", bytes.NewReader(body),
-	)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if err := checkProxyError(resp, "PATCH /api/v2/players/"+playerID+" (shape map)"); err != nil {
-		return "", err
-	}
-	newETag := strings.Trim(resp.Header.Get("ETag"), `"`)
-	if err := c.postMutate(playerID, action, etag, newETag, before, map[string]any{"shape": shape}); err != nil {
-		return newETag, err
-	}
-	return newETag, nil
+	return c.patchWithETagRetry(ctx, playerID, action,
+		"PATCH /api/v2/players/"+playerID+" (shape map)", map[string]any{"shape": shape},
+		func(etag string) (*http.Response, error) {
+			params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
+			return c.proxy.PatchApiV2PlayersPlayerIdWithBody(
+				ctx, proxy.PlayerId(playerID), params,
+				"application/merge-patch+json", bytes.NewReader(body),
+			)
+		})
 }
 
 // CreatePlayer POSTs a new player. Does not snapshot (there's no


### PR DESCRIPTION
## What

Adds a **fleet group mode** to the characterization harness: N iOS sims are born
into one player-group, the leader (index 0) drives **one broadcast network sweep**,
and the other sims hold playback under it — so you get N synchronized plays to
compare side-by-side in the dashboard. Plus the two server/CLI fixes that make a
born-group actually survive bring-up.

Three commits, three concerns, but one runtime story — the modes can't run a fleet
without the proxy `group_id` support and the CLI 412-retry under them.

## Commits

### `feat(proxy)` — born-grouped fleets + serialized tc
- `group_id` connect param at config-on-connect: a fleet is grouped **at connect**
  while every `player_id` stays a clean UUID (the earlier `_G<n>` token broke
  analytics' strict UUID typing + `canonicalV2ID`). The leader's `ApplyRate` fans
  to every member port by `group_id`.
- Decay-based auto-ungroup: only ungroup a singleton that was *ever* multi-member,
  so an assembling group isn't torn down mid-bring-up.
- Serialize all `tc` mutations under `tcMu` (public-wrapper / lock-free-core
  pattern) and drop the `tc qdisc del root` footgun that wiped sibling leaf
  classes. Fixes concurrent multi-sim config-on-connects racing the shared HTB
  tree — the symptom was the cold-start network cap silently not enforcing
  (sims cold-starting at 4K under a 1 Mbps cap).

### `fix(harness-cli)` — retry If-Match PATCH on 412
The player doc's `control_revision` bumps on every heartbeat, so the CLI's
`read-etag → PATCH-with-If-Match` can lose the race and get a 412. With a born
group (N sims heartbeating + the proxy's group fan-out cross-writing members) the
race fires constantly — a fleet rampdown fatally lost its leader + a peer on the
warmup `shape --rate 100`. The package doc already promised "412-retry-once" but
no method implemented it. Adds `patchWithETagRetry` (fresh etag per attempt, 5
attempts, staged backoff) and routes `PatchPlayer` / `PatchShapeMap` / `ClearShape`
through it.

### `feat(characterization)` — fleet group mode for the sweep modes
- `runFleet` + `fleetBarriers` (home + sweep) fan one parallel subtest per sim;
  under `CHAR_FLEET_GROUP=1` the leader drives one broadcast sweep and observers
  hold under it.
- Born-group each fleet via a `group_id` config-on-connect (uncapped where the
  mode warms high); baseline launch flags force **4K-on + peak-clamp-off** so stale
  sim UserDefaults can't skew a run.
- `rampup` pinned to the pyramid init floor + leader/observer split; `rampdown`
  restructured off `OpenSessionOnDevice` onto the minted-pid born-group launch with
  `transient_shock`'s uncapped init config + leader/observer split.
- `fleet_test.go → fleet.go` (it's production harness code, not a `_test` helper).

## Test evidence

3-sim born-group rampdown on the iPhone-15 simulator fleet:
- All 3 born-grouped (`group=G…`), uncapped, peak-clamp off — clean UUID player_ids.
- Transfer-timeout + warmup shape applied on all 3 with **zero 412 fatals** (pre-fix
  this killed the leader + 1 peer).
- 1 leader driving the broadcast descent, 2 observers holding under it.

## Run it

```
LAUNCH_MODE=appium CHAR_FLEET_GROUP=1 \
CHAR_FLEET_UDIDS=<u1>,<u2>,<u3> \
go test ./tests/characterization/modes/ -run TestRampdownIPadSim -v -timeout 70m
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
