### PR TITLE
feat(dashboard-v3): compare grouped plays from sessions.html in session-viewer (#736)

### DIFF
--- a/content/dashboard-v3/src/components/CollapsibleSection.vue
+++ b/content/dashboard-v3/src/components/CollapsibleSection.vue
@@ -104,9 +104,13 @@ function toggle() {
   if (props.persistKey) writeStored(props.persistKey, isOpen.value);
 }
 
-// If `persistKey` arrives async (rare), re-resolve once it's set.
+// If `persistKey` arrives async (rare), re-resolve once it's set. But NOT
+// when forceCollapsed is active — the immediate forceCollapsed watch (below)
+// already folded us during setup, and re-resolving here to the persisted/open
+// default would silently re-open a section that compare mode wants folded
+// (#736: Player State defaults `:open="true"`, so it kept popping back open).
 onMounted(() => {
-  if (props.persistKey) {
+  if (props.persistKey && !props.forceCollapsed) {
     isOpen.value = resolveInitial();
   }
 });

--- a/content/dashboard-v3/src/components/CollapsibleSection.vue
+++ b/content/dashboard-v3/src/components/CollapsibleSection.vue
@@ -125,6 +125,11 @@ let savedOpenBeforeForce: boolean | null = null;
 watch(
   () => props.forceCollapsed,
   (v, old) => {
+    // `immediate` so a section that mounts with forceCollapsed ALREADY true
+    // still folds — the archive compare view (#736) defaults compare on, so
+    // there's no false→true transition to catch otherwise. On the immediate
+    // tick `old` is undefined; treat that like `false` so true folds and
+    // false is a no-op.
     if (v && !old) {
       savedOpenBeforeForce = isOpen.value;
       isOpen.value = false;
@@ -133,6 +138,7 @@ watch(
       savedOpenBeforeForce = null;
     }
   },
+  { immediate: true },
 );
 </script>
 

--- a/content/dashboard-v3/src/components/CompareSeriesSource.vue
+++ b/content/dashboard-v3/src/components/CompareSeriesSource.vue
@@ -17,17 +17,27 @@
  * accessors read). No network/control/avmetrics: the overlay only plots
  * rate + buffer lines, not the sibling's lanes or per-segment markers.
  *
- * playId is null so the sibling follows its own latest play and rotates
- * with it — matching the live-comparison use case (two devices under
- * test at once). The default 10-minute backfill + live tail aligns with
- * the live edge the primary chart tracks. (The archive path — locking a
- * sibling to a specific historical play_id — is a follow-up; this
- * component takes a playId prop so that wiring is a one-line change.)
+ * Live use (issue #579): playId is null so the sibling follows its own
+ * latest play and rotates with it (two devices under test at once); the
+ * default 10-minute backfill + live tail aligns with the live edge the
+ * primary chart tracks.
+ *
+ * Archive use (issue #736): pass a locked `playId` AND the active play's
+ * `fromMs`/`toMs` window. The playId pins the sibling to that historical
+ * play; the window is REQUIRED because useSessionTimeSeries otherwise
+ * backfills only the last 10 minutes — useless for a play hours/days old.
+ * Grouped fleet plays share a wall-clock window, so the active play's
+ * bounds cover every sibling.
  */
 import { computed, onMounted, onUnmounted } from 'vue';
 import { useSessionTimeSeries, type Stream } from '@/composables/useSessionTimeSeries';
 
-const props = defineProps<{ playerId: string; playId?: string | null }>();
+const props = defineProps<{
+  playerId: string;
+  playId?: string | null;
+  fromMs?: number | null;
+  toMs?: number | null;
+}>();
 const emit = defineEmits<{
   (e: 'register', playerId: string, stream: Stream<Record<string, unknown>>): void;
   (e: 'unregister', playerId: string): void;
@@ -35,10 +45,14 @@ const emit = defineEmits<{
 
 const playerIdRef = computed(() => props.playerId);
 const playIdRef = computed<string | null>(() => props.playId ?? null);
+const fromMsRef = computed<number | null>(() => props.fromMs ?? null);
+const toMsRef = computed<number | null>(() => props.toMs ?? null);
 
 const ts = useSessionTimeSeries(playerIdRef, playIdRef, {
   streams: ['events'],
   bundles: ['charts_minimal'],
+  fromMs: fromMsRef,
+  toMs: toMsRef,
 });
 
 onMounted(() => emit('register', props.playerId, ts.events));

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -106,6 +106,11 @@ const props = defineProps<{
    *  identically to startMs!=null && endMs==null but without forcing
    *  a startMs anchor. Default: false (legacy archive behaviour). */
   followLive?: boolean;
+  /** #736 archive compare: the grouped set (incl. the active play) to
+   *  overlay, each member pinned to a specific historical play_id. When
+   *  present (≥2 members) compare mode is forced on and siblings resolve
+   *  from here instead of the live useGroupSiblings path. */
+  comparePlays?: Array<{ playerId: string; playId: string; tag?: string }>;
 }>();
 
 const playIdRef = computed(() => props.playId);
@@ -133,8 +138,30 @@ const { player: livePlayer } = usePlayer(livePlayerIdRef);
  * via useCompareOverlays(). */
 const compareMode = useCompareMode(livePlayerIdRef);
 const { siblings: groupSiblings } = useGroupSiblings(livePlayerIdRef);
+// #736 archive compare: when the viewer is opened with a grouped set
+// (comparePlays from the URL), siblings come from there — each pinned to a
+// specific historical play_id — instead of the live group resolution, and
+// compare mode is forced on. Tag from the carried session number so the
+// legend reads S1/S2/S3 without a live player lookup.
+type EffSibling = { playerId: string; label: string; tag: string; index: number; playId?: string };
+const archiveCompare = computed(() => (props.comparePlays?.length ?? 0) >= 2);
+const archiveSiblings = computed<EffSibling[]>(() =>
+  (props.comparePlays ?? [])
+    .filter((m) => m.playerId !== props.playerId)
+    .map((m, index) => ({
+      playerId: m.playerId,
+      playId: m.playId,
+      tag: m.tag ? `S${m.tag}` : `S${m.playerId.slice(0, 4)}`,
+      label: m.tag ? `#${m.tag}` : m.playerId.slice(0, 8),
+      index,
+    })),
+);
+const effectiveSiblings = computed<EffSibling[]>(() =>
+  archiveCompare.value ? archiveSiblings.value : groupSiblings.value,
+);
 const compareEnabled = computed(
-  () => compareMode.state.enabled && groupSiblings.value.length >= 1,
+  () => effectiveSiblings.value.length >= 1 &&
+        (archiveCompare.value || compareMode.state.enabled),
 );
 // Registered sibling streams keyed by player_id. shallowRef + whole-Map
 // replace so add/remove triggers the computed WITHOUT deep-reactive
@@ -153,10 +180,10 @@ function unregisterSibling(pid: string) {
 }
 // Renderless subscribers to mount — only while compare is on, so a fresh
 // SSE per sibling isn't opened until the operator asks for the overlay.
-const compareSources = computed(() => (compareEnabled.value ? groupSiblings.value : []));
+const compareSources = computed(() => (compareEnabled.value ? effectiveSiblings.value : []));
 const compareSiblings = computed<CompareSibling[]>(() => {
   if (!compareEnabled.value) return [];
-  return groupSiblings.value
+  return effectiveSiblings.value
     .filter((s) => siblingStreams.value.has(s.playerId))
     .map((s) => ({
       playerId: s.playerId,
@@ -176,6 +203,13 @@ const compareSiblings = computed<CompareSibling[]>(() => {
 // slimmed to the same canonical set the siblings show.
 const compareSelf = computed<CompareSeriesIdentity | null>(() => {
   if (!compareEnabled.value) return null;
+  if (archiveCompare.value) {
+    // Archive: tag from the active member's carried session number (no live
+    // player record to read display_id from).
+    const self = (props.comparePlays ?? []).find((m) => m.playerId === props.playerId);
+    const tag = self?.tag ? `S${self.tag}` : `S${props.playerId.slice(0, 4)}`;
+    return { tag, dash: [] };
+  }
   const did = livePlayer.value?.display_id;
   const tag = did != null ? `S${did}` : `S${props.playerId.slice(0, 4)}`;
   return { tag, dash: [] };
@@ -1372,6 +1406,9 @@ function skipToEnd() {
       v-for="sib in compareSources"
       :key="sib.playerId"
       :player-id="sib.playerId"
+      :play-id="sib.playId ?? null"
+      :from-ms="archiveCompare ? startMs : null"
+      :to-ms="archiveCompare ? endMs : null"
       @register="registerSibling"
       @unregister="unregisterSibling"
     />

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -160,9 +160,14 @@ const effectiveSiblings = computed<EffSibling[]>(() =>
   archiveCompare.value ? archiveSiblings.value : groupSiblings.value,
 );
 const compareEnabled = computed(
-  () => effectiveSiblings.value.length >= 1 &&
-        (archiveCompare.value || compareMode.state.enabled),
+  () => effectiveSiblings.value.length >= 1 && compareMode.state.enabled,
 );
+// #736: arriving via the sessions "Compare group" link defaults the Compare
+// Charts toggle ON — the archive view has no live GroupBanner to flip it, so
+// SessionDisplay renders its own toggle (below) and seeds it here. The user
+// can still uncheck it; driving everything through compareMode (not a forced
+// flag) keeps the panel collapse + overlay consistent with the live page.
+if (archiveCompare.value) compareMode.setEnabled(true);
 // Registered sibling streams keyed by player_id. shallowRef + whole-Map
 // replace so add/remove triggers the computed WITHOUT deep-reactive
 // wrapping the Stream (which holds refs + functions).
@@ -1412,6 +1417,23 @@ function skipToEnd() {
       @register="registerSibling"
       @unregister="unregisterSibling"
     />
+    <!-- #736 archive compare: the live page surfaces the Compare Charts
+         toggle via GroupBanner, but the session-viewer has no live group, so
+         render it here when opened over a grouped set. Defaults ON (seeded in
+         setup); unchecking it expands the per-session panels again. -->
+    <div v-if="archiveCompare" class="archive-compare-bar">
+      <button
+        type="button"
+        class="btn compare-toggle"
+        :class="{ checked: compareMode.state.enabled }"
+        @click="compareMode.toggle()"
+        :title="compareMode.state.enabled
+          ? 'Hide grouped overlays and re-expand the per-session panels'
+          : 'Overlay every grouped play\'s rate + buffer lines on the charts'"
+      >
+        {{ compareMode.state.enabled ? '●' : '○' }} Compare Charts ({{ effectiveSiblings.length + 1 }} sessions)
+      </button>
+    </div>
     <!-- Test-run metadata — off the event axis (see docs/EVENT_TAXONOMY.md);
          shown here so the viewer still says "this play was harness run X". -->
     <div v-if="testRun" class="test-run-chip" :title="`Harness run ${testRun.run_id}`">
@@ -1787,6 +1809,22 @@ function skipToEnd() {
 
 <style scoped>
 .session-display { display: contents; }
+/* #736 archive Compare Charts toggle — mirrors GroupBanner's compare-toggle
+ * (violet when on) so the archive view reads like the live page. */
+.archive-compare-bar {
+  display: flex; align-items: center; gap: 10px;
+  background: #f8fafc; border: 1px solid #e5e7eb; border-radius: 10px;
+  padding: 8px; margin-bottom: 12px;
+}
+.archive-compare-bar .compare-toggle {
+  background: #f1f3f4; border: 1px solid #dadce0; border-radius: 6px;
+  padding: 4px 12px; font-size: 12px; font-weight: 500; color: #202124; cursor: pointer;
+}
+.archive-compare-bar .compare-toggle:hover { background: #e8eaed; }
+.archive-compare-bar .compare-toggle.checked {
+  background: #7c3aed; border-color: #6d28d9; color: #fff; font-weight: 600;
+}
+.archive-compare-bar .compare-toggle.checked:hover { background: #6d28d9; }
 
 /* Empty-state for the Focus Window before archive snapshots land. */
 .brush-empty {

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -136,7 +136,16 @@ const { player: livePlayer } = usePlayer(livePlayerIdRef);
  * template); we register its events stream here and publish the assembled
  * CompareContext so BandwidthChart / BufferChart can pull their overlays
  * via useCompareOverlays(). */
-const compareMode = useCompareMode(livePlayerIdRef);
+// Compare-toggle key. Live: per-player, so it shares state with GroupBanner's
+// checkbox. Archive (#736): a STABLE group key — switching the active-member
+// tab rail changes props.playerId, and we don't want that to land on a fresh
+// (off) toggle and silently drop compare mode.
+const compareKey = computed<string>(() => {
+  const cps = props.comparePlays ?? [];
+  if (cps.length >= 2) return 'archive-group:' + cps.map((m) => m.playerId).slice().sort().join(',');
+  return props.playerId;
+});
+const compareMode = useCompareMode(compareKey);
 const { siblings: groupSiblings } = useGroupSiblings(livePlayerIdRef);
 // #736 archive compare: when the viewer is opened with a grouped set
 // (comparePlays from the URL), siblings come from there — each pinned to a

--- a/content/dashboard-v3/src/composables/urlTimeFormat.ts
+++ b/content/dashboard-v3/src/composables/urlTimeFormat.ts
@@ -86,11 +86,24 @@ export function canonicalUUID(s: string | null | undefined): string {
  * shape consistent and gives us one chokepoint to lengthen / shorten
  * the format later.
  */
+/** One member of an archive compare set (#736). `tag` is the short
+ *  session number used for the legend (`S<tag>`); kept in the URL so the
+ *  viewer doesn't need a live player lookup to label historical overlays. */
+export interface CompareMember {
+  playerId: string;
+  playId: string;
+  tag?: string;
+}
+
 export function sessionViewerURL(opts: {
   playerId: string;
   playId?: string | null;
   fromMs?: number | null;
   toMs?: number | null;
+  /** #736: the whole grouped set (including the active play) to overlay in
+   *  compare mode. Serialised as `compare=<player>~<play>~<tag>,…` — `~`
+   *  needs no percent-encoding, keeping the URL clean. */
+  compare?: CompareMember[];
 }): string {
   if (!opts.playerId) return '#';
   const p = new URLSearchParams();
@@ -102,8 +115,29 @@ export function sessionViewerURL(opts: {
   if (opts.toMs != null && Number.isFinite(opts.toMs)) {
     p.set('to', formatTimeCompact(opts.toMs));
   }
+  if (opts.compare && opts.compare.length > 1) {
+    const enc = opts.compare
+      .filter((m) => m.playerId && m.playId)
+      .map((m) => `${canonicalUUID(m.playerId)}~${canonicalUUID(m.playId)}~${m.tag ?? ''}`)
+      .join(',');
+    if (enc) p.set('compare', enc);
+  }
   // URLSearchParams encodes the `:` we'd otherwise smuggle through;
   // because the compact form has no `:` at all, the resulting URL is
   // free of `%3A` clutter.
   return `/dashboard/session-viewer.html?${p.toString()}`;
+}
+
+/** parseCompareParam — inverse of sessionViewerURL's `compare=` encoding.
+ *  Returns [] for a missing/empty/garbled param so the viewer simply skips
+ *  compare mode. */
+export function parseCompareParam(raw: string | null | undefined): CompareMember[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((seg) => {
+      const [playerId, playId, tag] = seg.split('~');
+      return { playerId: canonicalUUID(playerId), playId: canonicalUUID(playId), tag: tag || undefined };
+    })
+    .filter((m) => m.playerId && m.playId);
 }

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -29,12 +29,23 @@ const qs = new URLSearchParams(window.location.search);
 // the v3 timeseries endpoint and the SSE pool both key by player_id.
 // UUIDs are lowercased — CH stores them lowercase and iOS sometimes
 // emits uppercase (case_sensitivity_ids memory).
-const playerId = ref<string>(canonicalUUID(qs.get('player_id') ?? ''));
-const playId = ref<string | null>(qs.get('play_id') ? canonicalUUID(qs.get('play_id')!) : null);
 // #736: `compare=<player>~<play>~<tag>,…` — the grouped set to overlay in
-// archive compare mode (the active play is included; SessionDisplay picks self
-// vs siblings). Empty ⇒ ordinary single-play view.
+// archive compare mode (the active play is included). Like testing.html's
+// session-tab pill rail, the active member is switchable: player_id / play_id
+// FOLLOW the selected tab, SessionDisplay re-keys reactively, and it
+// re-derives self vs siblings from the (unchanged) compare set. Empty
+// `compare` ⇒ ordinary single-play view.
 const comparePlays = parseCompareParam(qs.get('compare'));
+const urlPlayerId = canonicalUUID(qs.get('player_id') ?? '');
+const urlPlayId = qs.get('play_id') ? canonicalUUID(qs.get('play_id')!) : null;
+// Active tab index — defaults to the play the user clicked (the URL player_id).
+const activeIdx = ref(Math.max(0, comparePlays.findIndex((m) => m.playerId === urlPlayerId)));
+const playerId = computed<string>(() =>
+  comparePlays.length ? comparePlays[activeIdx.value].playerId : urlPlayerId,
+);
+const playId = computed<string | null>(() =>
+  comparePlays.length ? (comparePlays[activeIdx.value].playId ?? null) : urlPlayId,
+);
 
 /** Initial time window. New canonical param names are `from` / `to`
  *  (shorter, no `:` in compact ISO → no `%3A` clutter). Legacy
@@ -187,6 +198,23 @@ const backHref = '/dashboard/sessions.html';
                   ? `${playId ?? '(all plays)'} — filter disabled while showing context`
                   : (playId ?? '(all plays)')"
               >{{ playId ?? '(all plays)' }}</code>
+            </div>
+            <!-- #736 member tab rail — like testing.html's session pills.
+                 Click a tab to make that grouped play active (its panels show,
+                 its line goes solid); the overlay set stays the same. -->
+            <div v-if="comparePlays.length" class="member-tabs" role="tablist" aria-label="Grouped sessions">
+              <span class="member-tabs-label">compare:</span>
+              <button
+                v-for="(m, i) in comparePlays"
+                :key="m.playerId"
+                type="button"
+                role="tab"
+                class="member-tab"
+                :class="{ active: i === activeIdx }"
+                :aria-selected="i === activeIdx"
+                :title="m.playerId"
+                @click="activeIdx = i"
+              >{{ m.tag ? `S${m.tag}` : m.playerId.slice(0, 6) }}</button>
             </div>
             <div class="banner-actions">
               <button
@@ -342,6 +370,16 @@ const backHref = '/dashboard/sessions.html';
 }
 
 .banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+/* #736 member tab rail — mirrors testing.html's session pills. */
+.member-tabs { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.member-tabs-label { font-size: 11px; color: #6b7280; margin-right: 2px; }
+.member-tab {
+  padding: 2px 10px; border-radius: 999px; cursor: pointer;
+  font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace;
+  color: #4338ca; background: #eef2ff; border: 1px solid #c7d2fe;
+}
+.member-tab:hover { background: #e0e7ff; }
+.member-tab.active { color: #fff; background: #6366f1; border-color: #4f46e5; }
 .banner-btn {
   display: inline-flex;
   align-items: center;

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -119,6 +119,23 @@ const starred = computed<boolean>(
   () => String(playQuery.data.value?.classification ?? '') === 'favourite',
 );
 
+// #736 member-tab labels — mirror testing.html's `Session #N (Port …) · device
+// · content`. Port is derived from the session number (external band 21<sid>81,
+// the third-from-last digit carrying the session); device · content + the group
+// badge come off the active play summary (fleet members share them).
+function portForTag(tag?: string): string {
+  return tag && /^\d$/.test(tag) ? `21${tag}81` : '';
+}
+function memberLabel(m: { tag?: string }): string {
+  const port = portForTag(m.tag);
+  return `Session #${m.tag ?? '?'}${port ? ` (Port ${port})` : ''}`;
+}
+const memberTail = computed<string>(() => {
+  const p = playQuery.data.value;
+  return [p?.device_class, p?.content_id].filter(Boolean).join(' · ');
+});
+const groupBadge = computed<string>(() => String(playQuery.data.value?.group_id ?? ''));
+
 const starMutation = useMutation({
   mutationFn: (next: boolean) =>
     patchPlayClassification(playId.value as string, next ? 'favourite' : 'auto'),
@@ -202,19 +219,21 @@ const backHref = '/dashboard/sessions.html';
             <!-- #736 member tab rail — like testing.html's session pills.
                  Click a tab to make that grouped play active (its panels show,
                  its line goes solid); the overlay set stays the same. -->
-            <div v-if="comparePlays.length" class="member-tabs" role="tablist" aria-label="Grouped sessions">
-              <span class="member-tabs-label">compare:</span>
+            <div v-if="comparePlays.length" class="session-tabs" role="tablist" aria-label="Grouped sessions">
               <button
                 v-for="(m, i) in comparePlays"
                 :key="m.playerId"
                 type="button"
                 role="tab"
-                class="member-tab"
+                class="session-tab grouped"
                 :class="{ active: i === activeIdx }"
                 :aria-selected="i === activeIdx"
                 :title="m.playerId"
                 @click="activeIdx = i"
-              >{{ m.tag ? `S${m.tag}` : m.playerId.slice(0, 6) }}</button>
+              >
+                <span class="st-label">{{ memberLabel(m) }}<span v-if="memberTail" class="st-tail"> · {{ memberTail }}</span></span>
+                <span v-if="groupBadge" class="group-badge">{{ groupBadge }}</span>
+              </button>
             </div>
             <div class="banner-actions">
               <button
@@ -370,16 +389,25 @@ const backHref = '/dashboard/sessions.html';
 }
 
 .banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
-/* #736 member tab rail — mirrors testing.html's session pills. */
-.member-tabs { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
-.member-tabs-label { font-size: 11px; color: #6b7280; margin-right: 2px; }
-.member-tab {
-  padding: 2px 10px; border-radius: 999px; cursor: pointer;
-  font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace;
-  color: #4338ca; background: #eef2ff; border: 1px solid #c7d2fe;
+/* #736 member tab rail — matches testing.html's session pills exactly. */
+.session-tabs { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
+.session-tab {
+  display: inline-flex; align-items: center; gap: 8px; max-width: 380px;
+  border: 1px solid #c7d2fe; background: #eef2ff; color: #1e1b4b;
+  padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600;
+  cursor: pointer; transition: transform 0.08s ease, box-shadow 0.15s ease, background 0.15s ease;
 }
-.member-tab:hover { background: #e0e7ff; }
-.member-tab.active { color: #fff; background: #6366f1; border-color: #4f46e5; }
+.session-tab:hover { background: #e0e7ff; box-shadow: 0 4px 12px rgba(59,130,246,0.18); transform: translateY(-1px); }
+.session-tab.active { background: #1e40af; color: #fff; border-color: #1e40af; box-shadow: 0 6px 14px rgba(30,64,175,0.32); }
+.session-tab.grouped { border-left: 4px solid #10b981; padding-left: 10px; }
+.session-tab.grouped.active { border-left-color: #34d399; }
+.session-tab .st-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-tab .st-tail { font-weight: 500; opacity: 0.85; }
+.session-tab .group-badge {
+  flex: none; background: #10b981; color: #fff; font-size: 10px; font-weight: 700;
+  padding: 1px 8px; border-radius: 8px; font-family: ui-monospace, monospace;
+}
+.session-tab.active .group-badge { background: #34d399; }
 .banner-btn {
   display: inline-flex;
   align-items: center;

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -18,7 +18,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import SessionDisplay from '@/components/SessionDisplay.vue';
 import ChatPanel from '@/components/chat/ChatPanel.vue';
-import { parseTimeAny, canonicalUUID } from '@/composables/urlTimeFormat';
+import { parseTimeAny, canonicalUUID, parseCompareParam } from '@/composables/urlTimeFormat';
 import { getPlay, patchPlayClassification, type PlaySummary } from '@/repo/v2-repo';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 import type { ChatScope } from '@/types/chat';
@@ -31,6 +31,10 @@ const qs = new URLSearchParams(window.location.search);
 // emits uppercase (case_sensitivity_ids memory).
 const playerId = ref<string>(canonicalUUID(qs.get('player_id') ?? ''));
 const playId = ref<string | null>(qs.get('play_id') ? canonicalUUID(qs.get('play_id')!) : null);
+// #736: `compare=<player>~<play>~<tag>,…` — the grouped set to overlay in
+// archive compare mode (the active play is included; SessionDisplay picks self
+// vs siblings). Empty ⇒ ordinary single-play view.
+const comparePlays = parseCompareParam(qs.get('compare'));
 
 /** Initial time window. New canonical param names are `from` / `to`
  *  (shorter, no `:` in compact ISO → no `%3A` clutter). Legacy
@@ -218,6 +222,7 @@ const backHref = '/dashboard/sessions.html';
             :show-context="showContext"
             :start-ms="startMs"
             :end-ms="endMs"
+            :compare-plays="comparePlays"
           />
         </template>
       </main>

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -11,7 +11,7 @@ import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import ChatPanel from '@/components/chat/ChatPanel.vue';
-import { sessionViewerURL } from '@/composables/urlTimeFormat';
+import { sessionViewerURL, type CompareMember } from '@/composables/urlTimeFormat';
 import { listPlays, patchPlayClassification, type PlaySummary, type Scenario } from '@/repo/v2-repo';
 
 interface SessionRow {
@@ -883,6 +883,53 @@ function viewerHref(r: SessionRow): string {
     toMs: stillLive ? undefined : (Number.isFinite(lastSeen) ? lastSeen : undefined),
   });
 }
+// #736 — grouped plays by group_id (born-grouped runs carry a unique
+// G<num> from row 1). One play per player_id; tag = the session number so
+// the viewer's overlay legend reads S1/S2/S3. Computed once per render so
+// the per-row "Compare group" check stays O(rows), not O(rows²).
+const groupsById = computed(() => {
+  const byGroup = new Map<string, CompareMember[]>();
+  const seen = new Map<string, Set<string>>();
+  for (const r of rows.value) {
+    const gid = r.group_id;
+    if (!gid || !r.player_id || !r.play_id || r.play_id === '—') continue;
+    if (!byGroup.has(gid)) { byGroup.set(gid, []); seen.set(gid, new Set()); }
+    const players = seen.get(gid)!;
+    if (players.has(r.player_id)) continue;
+    players.add(r.player_id);
+    byGroup.get(gid)!.push({ playerId: r.player_id, playId: r.play_id, tag: r.session_id });
+  }
+  return byGroup;
+});
+function groupMembers(r: SessionRow): CompareMember[] {
+  return (r.group_id ? groupsById.value.get(r.group_id) : undefined) ?? [];
+}
+function canCompareGroup(r: SessionRow): boolean {
+  return groupMembers(r).length >= 2;
+}
+// Open the session-viewer in compare mode over every play in this row's
+// group, windowed to the union of all members' bounds so no sibling's data
+// is clipped.
+function compareGroupHref(r: SessionRow): string {
+  const members = groupMembers(r);
+  if (members.length < 2 || !r.player_id) return '#';
+  let minStart = Infinity, maxEnd = -Infinity, anyLive = false;
+  for (const m of rows.value) {
+    if (m.group_id !== r.group_id) continue;
+    const s = m.started ? parseChIsoMs(m.started) : NaN;
+    const e = m.last_seen ? parseChIsoMs(m.last_seen) : NaN;
+    if (Number.isFinite(s)) minStart = Math.min(minStart, s);
+    if (Number.isFinite(e)) maxEnd = Math.max(maxEnd, e);
+    if (isStillLive(m)) anyLive = true;
+  }
+  return sessionViewerURL({
+    playerId: r.player_id,
+    playId: r.play_id && r.play_id !== '—' ? r.play_id : undefined,
+    fromMs: Number.isFinite(minStart) ? minStart : undefined,
+    toMs: anyLive ? undefined : (Number.isFinite(maxEnd) ? maxEnd : undefined),
+    compare: members,
+  });
+}
 function bundleHref(r: SessionRow): string {
   if (!r.player_id) return '#';
   const qs = new URLSearchParams({ player_id: r.player_id });
@@ -1630,6 +1677,13 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
                   <td class="cell-play-id">
                     <a v-if="r.play_id && r.player_id" :href="viewerHref(r)" class="play-id-link">{{ r.play_id }}</a>
                     <template v-else>{{ r.play_id || '' }}</template>
+                    <a
+                      v-if="canCompareGroup(r)"
+                      :href="compareGroupHref(r)"
+                      class="compare-group-link"
+                      :title="`Compare all ${groupMembers(r).length} grouped plays side-by-side`"
+                      @click.stop
+                    >⊞ compare</a>
                   </td>
                   <td>{{ r.last_state || '' }}</td>
                   <td><span :style="{ color: endOutcome(r).color, fontWeight: 600 }" :title="endOutcome(r).tip">{{ endOutcome(r).label }}</span></td>
@@ -1931,6 +1985,12 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
 .cell-play-id { font-weight: 600; color: #1d4ed8; }
 .play-id-link { color: #1d4ed8; text-decoration: none; font-weight: 600; }
 .play-id-link:hover { text-decoration: underline; }
+.compare-group-link {
+  margin-left: 8px; padding: 1px 6px; border-radius: 4px;
+  font-size: 0.72rem; font-weight: 600; white-space: nowrap;
+  color: #6d28d9; background: #ede9fe; text-decoration: none;
+}
+.compare-group-link:hover { background: #ddd6fe; }
 
 .issue-badge, .health-badge {
   display: inline-block;

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -1213,6 +1213,7 @@ const COLUMNS = [
   { key: 'content_id',       label: 'Content',    type: 'string' as const,  sortable: true },
   { key: 'scenario',         label: 'Scenario',   type: 'string' as const,  sortable: false },
   { key: 'play_id',          label: 'Play ID',    type: 'string' as const,  sortable: true },
+  { key: 'group_id',         label: 'Group',      type: 'string' as const,  sortable: true },
   { key: 'last_state',       label: 'State',      type: 'string' as const,  sortable: true },
   { key: 'playback_status',  label: 'Outcome',    type: 'string' as const,  sortable: true },
   { key: 'issues_count',     label: 'Issues',     type: 'number' as const,  sortable: true },
@@ -1677,13 +1678,17 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
                   <td class="cell-play-id">
                     <a v-if="r.play_id && r.player_id" :href="viewerHref(r)" class="play-id-link">{{ r.play_id }}</a>
                     <template v-else>{{ r.play_id || '' }}</template>
+                  </td>
+                  <td class="cell-group-id">
                     <a
                       v-if="canCompareGroup(r)"
                       :href="compareGroupHref(r)"
-                      class="compare-group-link"
-                      :title="`Compare all ${groupMembers(r).length} grouped plays side-by-side`"
+                      class="group-compare-link"
+                      :title="`Open all ${groupMembers(r).length} grouped plays in compare mode`"
                       @click.stop
-                    >⊞ compare</a>
+                    >{{ r.group_id }}</a>
+                    <span v-else-if="r.group_id" class="group-id-plain" :title="r.group_id">{{ r.group_id }}</span>
+                    <span v-else class="dash">—</span>
                   </td>
                   <td>{{ r.last_state || '' }}</td>
                   <td><span :style="{ color: endOutcome(r).color, fontWeight: 600 }" :title="endOutcome(r).tip">{{ endOutcome(r).label }}</span></td>
@@ -1985,12 +1990,15 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
 .cell-play-id { font-weight: 600; color: #1d4ed8; }
 .play-id-link { color: #1d4ed8; text-decoration: none; font-weight: 600; }
 .play-id-link:hover { text-decoration: underline; }
-.compare-group-link {
-  margin-left: 8px; padding: 1px 6px; border-radius: 4px;
-  font-size: 0.72rem; font-weight: 600; white-space: nowrap;
+.cell-group-id { max-width: 170px; }
+.group-compare-link {
+  display: inline-block; max-width: 100%; padding: 1px 6px; border-radius: 4px;
+  font-family: ui-monospace, monospace; font-size: 0.72rem; font-weight: 600;
   color: #6d28d9; background: #ede9fe; text-decoration: none;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom;
 }
-.compare-group-link:hover { background: #ddd6fe; }
+.group-compare-link:hover { background: #ddd6fe; text-decoration: underline; }
+.group-id-plain { font-family: ui-monospace, monospace; font-size: 0.72rem; color: #6b7280; }
 
 .issue-badge, .health-badge {
   display: inline-block;

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -1918,7 +1918,10 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
 .btn-secondary { background: var(--bg-secondary, #f9fafb); }
 
 .table-wrap {
-  max-height: 60vh;
+  /* Fill the viewport below the page chrome (header + filter bar) instead of
+     the old fixed 60vh, so far more rows are visible before scrolling. */
+  max-height: calc(100vh - 180px);
+  min-height: 320px;
   overflow: auto;
   background: var(--bg-primary);
   border: 1px solid var(--border-color, #e5e7eb);


### PR DESCRIPTION
`Closes #736`. Archive path for compare mode (follow-up to #579/#735, live-only). Now that born-grouped runs carry `group_id` from row 1 (#750), grouped plays can be compared from the archive.

## What
- **Sessions list**: a **Group** column after Play ID. Grouped rows (≥2 members) render `group_id` as a real `<a href>` to the compare URL — left-click opens, ⌘/middle-click new tab, right-click native menu. Table now fills the viewport (60vh → `calc(100vh-180px)`).
- **session-viewer compare**: opens with all grouped plays overlaid (reusing the #735 seam), a **Compare Charts** toggle (default-on, keyed to a stable group id so it survives tab switches), and a **testing.html-style member tab rail** (`Session #N (Port …) · device · group`) to switch the active play reactively. Per-session panels (Player State / Network Log / Play Log) collapse in compare mode.
- **CompareSeriesSource**: forwards `fromMs`/`toMs` — required for archive (siblings would otherwise backfill only 10 min).
- **CollapsibleSection**: `forceCollapsed` now folds on mount (`immediate`) and `onMounted` no longer re-opens a force-collapsed section.

## Verified
End-to-end in a real browser against a born-grouped archived run: tabs render, compare overlay shows S1/S4/S3, all per-session panels collapse, group_id column links through.

`vue-tsc --noEmit` + `vite build` clean. No backend change — `group_id` is archived (#750) and surfaced via `chRowAdapter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
