### PR TITLE
feat(characterization): display-only group mode for startup fleet

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -5499,6 +5499,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		if g := r.URL.Query().Get("group_id"); g != "" {
 			groupID = g
 		}
+		// #fleet-group display-only: group_broadcast=false makes the group a
+		// pure DISPLAY link — members share group_id (so the dashboard charts
+		// them together and the archive groups them) but a member PATCH is NOT
+		// mirrored to the other members. Used by the startup fleet, where every
+		// device runs its own cold-start plan and a broadcast would corrupt the
+		// per-device measurements. Default (absent / any non-false value) keeps
+		// the pyramid-style auto-broadcast group.
+		groupBroadcast := true
+		if gb := r.URL.Query().Get("group_broadcast"); gb == "false" || gb == "0" {
+			groupBroadcast = false
+		}
 		var allocated int
 		_, reserved := a.mutateSessions(func(sessions []SessionData) ([]SessionData, bool) {
 			if len(sessions) >= a.maxSessions {
@@ -5575,6 +5586,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			"player_id":                      playerID,
 			"play_id":                        playID,
 			"group_id":                       groupID,
+			"group_broadcast":                groupBroadcast,
 			"control_revision":               newControlRevision(),
 			"headers_player_id":              playerHeader,
 			"headers_player-ID":              playerHeaderAlt,

--- a/go-proxy/internal/v2/server/handlers_integration_test.go
+++ b/go-proxy/internal/v2/server/handlers_integration_test.go
@@ -948,6 +948,40 @@ func TestPatch_GroupedMember_Broadcasts(t *testing.T) {
 	}
 }
 
+// TestPatch_DisplayOnlyGroup_NoBroadcast covers the connect-param display-only
+// group: two sessions share a group_id but were born with group_broadcast=false
+// (the startup fleet path). A PATCH to one member must NOT mirror to the other —
+// each device is shaped/labelled independently, even though the dashboard charts
+// them together by group_id.
+func TestPatch_DisplayOnlyGroup_NoBroadcast(t *testing.T) {
+	a, _, ts := newTestServer(t)
+	p1, p2 := uuid.New().String(), uuid.New().String()
+	rev := "2020-01-01T00:00:00.000000000Z"
+	// Born-grouped display-only (what the proxy's connect path writes when the
+	// bootstrap carries group_id=G1&group_broadcast=false).
+	a.addSession(map[string]any{
+		"player_id": p1, "session_id": "s1", "control_revision": rev,
+		"group_id": "G1", "group_broadcast": false,
+	})
+	a.addSession(map[string]any{
+		"player_id": p2, "session_id": "s2", "control_revision": rev,
+		"group_id": "G1", "group_broadcast": false,
+	})
+
+	// PATCH p1's labels — must NOT reach p2.
+	status, respBody, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+p1,
+		`{"labels":{"only":"p1"}}`,
+		map[string]string{"If-Match": `"` + rev + `"`})
+	if status != http.StatusOK {
+		t.Fatalf("PATCH p1 %d body=%s", status, respBody)
+	}
+	stored2, _ := a.SessionByPlayerID(p2)
+	l2, _ := stored2["_v2_labels"].(map[string]any)
+	if l2["only"] == "p1" {
+		t.Errorf("p2 received p1's label — display-only group still broadcast: %v", l2)
+	}
+}
+
 // ----- Plays --------------------------------------------------------------
 
 func TestGet_PlaysPlayId_404_Unknown(t *testing.T) {

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -211,7 +211,8 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 	// is empty when the player isn't in any group — broadcast becomes
 	// a no-op.
 	var groupID string
-	srv := s // capture the Server receiver before the closure shadows it
+	groupBroadcast := true // default; a display-only group sets group_broadcast=false at connect
+	srv := s               // capture the Server receiver before the closure shadows it
 	post, found, mErr := s.v1.MutatePlayer(pidStr, func(s map[string]any) error {
 		// Re-check under sessionsMu. Another v2 PATCH that won the
 		// outer race would have updated FieldRevisions before
@@ -228,6 +229,9 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 		s["control_revision"] = rev
 		fr.TouchWith(paths, rev)
 		groupID = getString(s, "group_id")
+		if v, ok := s["group_broadcast"].(bool); ok {
+			groupBroadcast = v
+		}
 		return nil
 	})
 	if mErr != nil {
@@ -261,9 +265,11 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 	// new control_revision and the same patch applied; their per-
 	// player FieldRevisions tracker is bumped to the same `rev` so a
 	// concurrent PATCHer reading from any member sees the latest
-	// revision uniformly.
+	// revision uniformly. Skipped when the group is display-only
+	// (group_broadcast=false at connect) — members share group_id for
+	// charting but are shaped/labelled independently (startup fleet).
 	var broadcastTouched []string
-	if groupID != "" {
+	if groupID != "" && groupBroadcast {
 		touched, bErr := s.v1.BroadcastPatch(groupID, pidStr, rev, func(member map[string]any) error {
 			return applyPatchToSession(srv, member, patch)
 		})
@@ -344,7 +350,9 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 // Phase D: labels.* only.
 // Phase H: + shape.{rate_mbps,delay_ms,loss_pct,transport_fault.*}
 // Phase I: + fault_rules (whole-array PATCH; the per-rule sub-resource
-//          endpoints have their own paths and don't run through here).
+//
+//	endpoints have their own paths and don't run through here).
+//
 // Phase K: + shape.pattern (drives v1's pattern step-engine).
 func unsupportedPaths(paths []string) []string {
 	var bad []string
@@ -825,4 +833,3 @@ func writePreconditionFailed(w http.ResponseWriter, currentRevision string, conf
 		},
 	)
 }
-

--- a/tests/characterization/modes/pyramid_test.go
+++ b/tests/characterization/modes/pyramid_test.go
@@ -175,7 +175,7 @@ func runPyramidOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 				floor = f
 			}
 		}
-		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID())
+		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID(), true)
 
 		s, lerr := appium.LaunchToHome(setupCtx, *picked)
 		if lerr != nil {

--- a/tests/characterization/modes/rampdown_test.go
+++ b/tests/characterization/modes/rampdown_test.go
@@ -122,7 +122,7 @@ func runRampdownOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bar
 		setupCtx, setupCancel := context.WithTimeout(context.Background(), setupTimeout)
 		defer setupCancel()
 		if gid := bars.fleetGroupID(); gid != "" {
-			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid)
+			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid, true)
 			t.Logf("rampdown: born-grouped (group=%s), uncapped — player_id=%s", gid, pid)
 		} else {
 			launchArgs := append(append([]string{}, cfg.launchArgs()...), "-is.player_id", pid)

--- a/tests/characterization/modes/rampup_test.go
+++ b/tests/characterization/modes/rampup_test.go
@@ -159,7 +159,7 @@ func runRampupOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars 
 				floor = f
 			}
 		}
-		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID())
+		wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, floor, cfg.xferTimeout, peakClampForCap(floor), bars.fleetGroupID(), true)
 
 		s, err := appium.LaunchToHome(setupCtx, *picked)
 		if err != nil {

--- a/tests/characterization/modes/startup_test.go
+++ b/tests/characterization/modes/startup_test.go
@@ -95,8 +95,13 @@ func runStartup(t *testing.T, p runner.Platform) {
 	// resolves the roster and either runs the single-device path unchanged or
 	// fans out one parallel subtest per device with the home + sweep barriers
 	// wired (see runStartupOnDevice).
-	// TODO(fleet): group mode like pyramid (CHAR_FLEET_GROUP) — parallel-
-	// independent + synchronized only for now.
+	//
+	// Group mode (CHAR_FLEET_GROUP=1): unlike pyramid's broadcast group (one
+	// leader drives, the proxy mirrors to all), startup forms a DISPLAY-ONLY
+	// group — every device runs its OWN cold-start plan independently and the
+	// shared group_id only groups the plays for the dashboard's side-by-side
+	// compare. A broadcast group would corrupt the per-device measurements, so
+	// each session is born with group_broadcast=false (see runStartupCycle).
 	runFleet(t, p, runStartupOnDevice)
 }
 
@@ -254,6 +259,15 @@ func runStartupOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 		t.Logf("SWEEP barrier released — beginning synchronized cap matrix")
 	}
 
+	// Display-only group id (empty for single-device / non-group runs). Each
+	// app_cold cycle's config-on-connect carries it so every fresh session is
+	// born into the group at connect (survives the per-cycle player_id churn),
+	// with group_broadcast=false so per-device shaping/labels don't mirror.
+	groupID := bars.fleetGroupID()
+	if groupID != "" {
+		t.Logf("display-only group %s — this device runs its own plan; grouped only for dashboard compare", groupID)
+	}
+
 	var allCycles []runner.StartupCycleResult
 	cycleIdx := 0
 
@@ -262,7 +276,7 @@ func runStartupOnDevice(t *testing.T, p runner.Platform, dev runner.Device, bars
 		for rep := 0; rep < reps; rep++ {
 			for _, boundary := range startupBoundaries {
 				cycleIdx++
-				result := runStartupCycle(ctx, t, sess, appium, *picked, boundary, target, setupClip, capMbps, cycleIdx, rep, bws)
+				result := runStartupCycle(ctx, t, sess, appium, *picked, boundary, target, setupClip, capMbps, cycleIdx, rep, bws, groupID)
 				allCycles = append(allCycles, result)
 				firstAnnot := runner.AnnotateVariant(bws, result.FirstVariantPicked, capMbps)
 				settledAnnot := runner.AnnotateVariant(bws, result.SettledVariant, capMbps)
@@ -351,7 +365,7 @@ func runStartupCycle(
 	ctx context.Context, t *testing.T,
 	sess *runner.Session, appium *runner.AppiumLauncher, dev runner.Device,
 	boundary startupBoundary, targetClip, setupClip string, capMbps float64, idx, rep int,
-	bws map[string]runner.VariantBandwidth,
+	bws map[string]runner.VariantBandwidth, groupID string,
 ) runner.StartupCycleResult {
 	result := runner.StartupCycleResult{
 		CycleIdx:      idx,
@@ -411,7 +425,10 @@ func runStartupCycle(
 		// URL): mint a fresh id and cap the session at capMbps before the
 		// first byte — replaces ReadPlayerID + post-launch ApplyRate + tc-settle.
 		pid := runner.NewPlayerID()
-		wireConfigOnConnect(ctx, t, appium, nil, pid, capMbps, 0, 0, "")
+		// groupID born-groups this fresh session at connect (display-only:
+		// group_broadcast=false ⇒ no cross-device mirroring). Empty for
+		// single-device / non-group runs, so no group_id param is sent.
+		wireConfigOnConnect(ctx, t, appium, nil, pid, capMbps, 0, 0, groupID, false)
 		s, err := appium.LaunchToHome(ctx, dev)
 		if err != nil {
 			t.Fatalf("[%d] LaunchToHome: %v", idx, err)

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -77,16 +77,21 @@ func resolveFloor(ctx context.Context, t *testing.T, preFloor float64, floorFn f
 // must pass 0 so they don't perturb what they measure.
 //
 // baseArgs are any other launch args (e.g. segment).
-func wireConfigOnConnect(ctx context.Context, t *testing.T, appium *runner.AppiumLauncher, baseArgs []string, pid string, capMbps float64, xferTimeout time.Duration, peakClampMbps int, groupID string) {
+// groupBroadcast selects the group semantics when groupID is set: true is the
+// pyramid-style auto-broadcast group (a member PATCH mirrors to all members);
+// false is a display-only group (members share a group_id for dashboard compare
+// but are shaped/labelled independently) — the startup fleet uses false.
+// Ignored when groupID is empty.
+func wireConfigOnConnect(ctx context.Context, t *testing.T, appium *runner.AppiumLauncher, baseArgs []string, pid string, capMbps float64, xferTimeout time.Duration, peakClampMbps int, groupID string, groupBroadcast bool) {
 	t.Helper()
 	launchArgs := append(append([]string{}, baseArgs...), "-is.player_id", pid)
 	if peakClampMbps > 0 {
 		launchArgs = append(launchArgs, "-is.flag.peak_bitrate_mbps", strconv.Itoa(peakClampMbps))
 	}
 	if os.Getenv("CHAR_PROXY_CONFIG") == "app" {
-		launchArgs = append(launchArgs, "-is.proxy_query", appProxyQuery(capMbps, xferTimeout, groupID))
+		launchArgs = append(launchArgs, "-is.proxy_query", appProxyQuery(capMbps, xferTimeout, groupID, groupBroadcast))
 		appium.SetLaunchArgs(launchArgs)
-		t.Logf("config-on-connect VIA APP URL: rate=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q (no curl); player_id=%s", capMbps, xferTimeout, peakClampMbps, groupID, pid)
+		t.Logf("config-on-connect VIA APP URL: rate=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q broadcast=%v (no curl); player_id=%s", capMbps, xferTimeout, peakClampMbps, groupID, groupBroadcast, pid)
 		return
 	}
 	appium.SetLaunchArgs(launchArgs)
@@ -97,10 +102,10 @@ func wireConfigOnConnect(ctx context.Context, t *testing.T, appium *runner.Appiu
 	if capMbps > 0 {
 		cfg = runner.ShapeConfig(capMbps, xferTimeout)
 	}
-	if err := runner.ConfigureOnConnect(ctx, pid, groupID, cfg); err != nil {
+	if err := runner.ConfigureOnConnect(ctx, pid, groupID, groupBroadcast, cfg); err != nil {
 		t.Fatalf("ConfigureOnConnect (player_id=%s cap=%.3f Mbps group=%q): %v", pid, capMbps, groupID, err)
 	}
-	t.Logf("config-on-connect VIA CURL (default): session %s cap=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q before launch", pid, capMbps, xferTimeout, peakClampMbps, groupID)
+	t.Logf("config-on-connect VIA CURL (default): session %s cap=%.3f Mbps xfer_timeout=%s peak_clamp=%dMbps group=%q broadcast=%v before launch", pid, capMbps, xferTimeout, peakClampMbps, groupID, groupBroadcast)
 }
 
 // peakClampForCap maps a network cap (Mbps) to the app's whole-Mbps startup
@@ -116,7 +121,7 @@ func peakClampForCap(capMbps float64) int {
 // appProxyQuery builds the -is.proxy_query value for CHAR_PROXY_CONFIG=app: the
 // rate cap plus, when xferTimeout>0, the segment transfer timeout. Mirrors the
 // curl-mode ShapeConfig so both drivers materialize the same session.
-func appProxyQuery(capMbps float64, xferTimeout time.Duration, groupID string) string {
+func appProxyQuery(capMbps float64, xferTimeout time.Duration, groupID string, groupBroadcast bool) string {
 	var parts []string
 	if capMbps > 0 {
 		parts = append(parts, fmt.Sprintf("proxy.shape.rate_mbps=%g", capMbps))
@@ -128,6 +133,9 @@ func appProxyQuery(capMbps float64, xferTimeout time.Duration, groupID string) s
 	}
 	if groupID != "" {
 		parts = append(parts, "group_id="+groupID)
+		if !groupBroadcast {
+			parts = append(parts, "group_broadcast=false")
+		}
 	}
 	return strings.Join(parts, "&")
 }

--- a/tests/characterization/modes/transient_shock_test.go
+++ b/tests/characterization/modes/transient_shock_test.go
@@ -126,7 +126,7 @@ func runTransientShockOnDevice(t *testing.T, p runner.Platform, dev runner.Devic
 		// shape), so the fleet is grouped at connect yet still uncapped. Player_id
 		// stays a clean UUID. Otherwise a bare launch (no pre-created session).
 		if gid := bars.fleetGroupID(); gid != "" {
-			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid)
+			wireConfigOnConnect(setupCtx, t, appium, cfg.launchArgs(), pid, 0, 0, 0, gid, true)
 			t.Logf("transient-shock: born-grouped (group=%s), uncapped — player_id=%s", gid, pid)
 		} else {
 			launchArgs := append(append([]string{}, cfg.launchArgs()...), "-is.player_id", pid)

--- a/tests/characterization/runner/bootstrap.go
+++ b/tests/characterization/runner/bootstrap.go
@@ -68,7 +68,7 @@ func ShapeConfig(rateMbps float64, xferTimeout time.Duration) BootstrapConfig {
 // BEFORE the app launches. Clip-agnostic: shape/fault config is session-scoped,
 // so any discoverable clip triggers the allocation; the app's real clip
 // reattaches by player_id.
-func ConfigureOnConnect(ctx context.Context, playerID, groupID string, cfg BootstrapConfig) error {
+func ConfigureOnConnect(ctx context.Context, playerID, groupID string, groupBroadcast bool, cfg BootstrapConfig) error {
 	if playerID == "" {
 		return fmt.Errorf("ConfigureOnConnect: empty playerID")
 	}
@@ -89,8 +89,14 @@ func ConfigureOnConnect(ctx context.Context, playerID, groupID string, cfg Boots
 	q.Set("player_id", playerID)
 	// #fleet-group: explicit group_id connect param (born-groups the session
 	// while player_id stays a clean UUID). Top-level, NOT a proxy.* arg.
+	// group_broadcast=false makes it a DISPLAY-ONLY group (members share a
+	// group_id for charting but are NOT mirrored to each other) — the startup
+	// fleet uses this so each device's cold-start plan stays independent.
 	if groupID != "" {
 		q.Set("group_id", groupID)
+		if !groupBroadcast {
+			q.Set("group_broadcast", "false")
+		}
 	}
 	for k, v := range cfg {
 		q.Set("proxy."+k, v)

--- a/tests/characterization/runner/bootstrap_test.go
+++ b/tests/characterization/runner/bootstrap_test.go
@@ -41,7 +41,7 @@ func TestConfigOnConnectCapacity(t *testing.T) {
 	for i := 0; i < iters; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		pid := NewPlayerID()
-		err := ConfigureOnConnect(ctx, pid, "", ShapeRateConfig(2.0))
+		err := ConfigureOnConnect(ctx, pid, "", true, ShapeRateConfig(2.0))
 		if err != nil && i == 0 {
 			cancel()
 			t.Skipf("ConfigureOnConnect unavailable (server down?): %v", err)


### PR DESCRIPTION
## What

Adds a **display-only (non-broadcasting) group** so the startup characterization fleet can be charted side-by-side in the dashboard without the auto-broadcast that would corrupt each device's independent cold-start measurement. This fulfils the existing `runStartup` TODO: *"group mode like pyramid (CHAR_FLEET_GROUP)"*.

## Why not just reuse the broadcast group?

Pyramid's group is the right model for pyramid: one leader drives, the proxy mirrors every member PATCH to the rest so the whole fleet feels identical shaping. Startup is the opposite — every device must run its *own* cold-start plan (its own caps, cycle timing, and cycle-band labels). A broadcast group would mirror one device's `ApplyRate`/labels onto the others and wreck the comparison. So startup needs grouping for *display* without *mirroring*.

## How

**Proxy** — a new `group_broadcast` connect param rides alongside the existing born-at-connect `group_id`:
- `main.go` parses `group_broadcast=false` and stores it on the session.
- `handlers_mutate.go` gates the auto-broadcast fan-out on it. Default (absent/true) preserves the pyramid broadcast group exactly.
- A display-only group still shares a `group_id`, so the dashboard's compare and the archive group members together — only the mirroring is suppressed.

**Characterization** — `groupBroadcast` threaded through `ConfigureOnConnect` / `wireConfigOnConnect` / `appProxyQuery`. Existing group callers (pyramid, rampup, rampdown, transient_shock) pass `true` (unchanged). Startup sends its run `group_id` + `group_broadcast=false` on every `app_cold` cycle's config-on-connect, so each fresh per-cycle session is born into the display-only group at connect — this rides the existing connect-param mechanism and survives startup's per-cycle `player_id` churn for free. Every device runs its full plan; grouping is for the dashboard only.

Run a grouped startup fleet with `CHAR_FLEET_COUNT=N CHAR_FLEET_GROUP=1` (or `CHAR_FLEET_UDIDS=...`).

## Testing

Compile + `go vet` (go-proxy, characterization) + go-proxy unit tests. New `TestPatch_DisplayOnlyGroup_NoBroadcast` proves a member PATCH does not mirror in a display-only group; the existing `TestPatch_GroupedMember_Broadcasts` still passes.

⚠️ **Not yet validated on hardware** — the multi-sim fleet/group path has not been exercised end-to-end on simulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
