### PR TITLE
perf(characterization): persistent + prebuilt WDA for real iOS devices

### DIFF
--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -880,6 +880,22 @@ func appiumCapabilities(d Device, bundleID string) map[string]any {
 		caps["platformName"] = "iOS"
 		caps["appium:automationName"] = "XCUITest"
 		setXCUITestFleetPorts(caps, d.FleetIndex)
+		// Real-device WDA bring-up is the slow part: by default Appium runs
+		// xcodebuild + deploys WebDriverAgent into a throwaway DerivedData dir
+		// every session. Pin a STABLE derivedDataPath so the build persists
+		// across runs — xcodebuild goes incremental and the WDA app stays
+		// installed, cutting per-session bring-up. Always safe (still builds on
+		// first run). Per fleet index so parallel real devices don't share one
+		// build dir. (Sims are fast enough not to need this.)
+		caps["appium:derivedDataPath"] = iosWDADerivedDataPath(d.FleetIndex)
+		// CHAR_IOS_PREBUILT_WDA=1 skips the xcodebuild step entirely and reuses
+		// the WDA already built at derivedDataPath — the big speedup. Off by
+		// default because Appium ERRORS when usePrebuiltWDA is set but nothing
+		// has been built there yet: run once WITHOUT it to populate the path,
+		// then flip it on. (See the run-prebuilt-wda guide.)
+		if os.Getenv("CHAR_IOS_PREBUILT_WDA") == "1" {
+			caps["appium:usePrebuiltWDA"] = true
+		}
 	case PlatformIPadSim:
 		caps["platformName"] = "iOS"
 		caps["appium:automationName"] = "XCUITest"
@@ -915,4 +931,22 @@ func appiumCapabilities(d Device, bundleID string) map[string]any {
 func setXCUITestFleetPorts(caps map[string]any, fleetIndex int) {
 	caps["appium:wdaLocalPort"] = 8100 + fleetIndex
 	caps["appium:mjpegServerPort"] = 9100 + fleetIndex
+}
+
+// iosWDADerivedDataPath returns a STABLE DerivedData dir for the real-device
+// WebDriverAgent build so it persists across runs (incremental builds, and
+// prebuilt reuse under CHAR_IOS_PREBUILT_WDA=1) instead of Appium's default
+// throwaway temp dir. Base overridable via CHAR_IOS_WDA_DERIVED_DATA; default
+// ~/.appium-wda-deriveddata. Suffixed by fleet index so parallel real devices
+// each build into their own dir (no concurrent-xcodebuild conflict).
+func iosWDADerivedDataPath(fleetIndex int) string {
+	base := strings.TrimSpace(os.Getenv("CHAR_IOS_WDA_DERIVED_DATA"))
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			home = os.TempDir()
+		}
+		base = filepath.Join(home, ".appium-wda-deriveddata")
+	}
+	return filepath.Join(base, fmt.Sprintf("wda-%d", fleetIndex))
 }


### PR DESCRIPTION
## What

Speeds up Appium real-device (`PlatformIPhone`/`PlatformIPad`) bring-up, where rebuilding + redeploying WebDriverAgent every session is the slow part.

- **`appium:derivedDataPath`** — pinned to a stable per-fleet-index dir (`~/.appium-wda-deriveddata/wda-<idx>`, base overridable via `CHAR_IOS_WDA_DERIVED_DATA`). The WDA build persists across runs → xcodebuild goes incremental and WDA stays installed. Always safe (still builds on the first run); per-index so parallel real devices don't share one build dir.
- **`CHAR_IOS_PREBUILT_WDA=1`** → sets `appium:usePrebuiltWDA=true`, skipping the xcodebuild step entirely and reusing the prebuilt WDA. Off by default because Appium **errors** if `usePrebuiltWDA` is set with nothing built at the path yet — so run once without it to populate `derivedDataPath`, then flip it on.

Sims (`PlatformIPadSim`) are untouched — already fast.

## Usage

```
# first run populates derivedDataPath (still builds)
LAUNCH_MODE=appium go test ./modes -run TestStartupIPhone ...
# fast runs afterwards
CHAR_IOS_PREBUILT_WDA=1 LAUNCH_MODE=appium go test ./modes -run TestStartupIPhone ...
```

## Notes

- `usePrebuiltWDA` + `derivedDataPath` can be Xcode-version-fragile (`.xctestrun` handling). If it gets flaky, drop `CHAR_IOS_PREBUILT_WDA` and keep the `derivedDataPath` incremental-build win. The newer `usePreinstalledWDA` (iOS 17+) is a more robust alternative if needed.
- Verified by `go vet`; not exercised on a physical device in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
