### PR TITLE
feat(dashboard): "Keep every other (2×)" variant-thinning button (#762)

### DIFF
--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -89,6 +89,36 @@ function onVariantToggle(url: string, checked: boolean) {
   setContent({ allowed_variants: next } as Partial<Content>);
 }
 
+/** Adjacent BANDWIDTH ratios (ascending). A dense geometric ladder sits at
+ *  ~1.41× (√2); the legacy 2× ladder is ~2.0×. Used to gate "Keep every other"
+ *  so it only offers on this ladder or an equivalent (#762) — halving a 2×
+ *  ladder would create ~4× gaps. */
+const isGeometricLadder = computed(() => {
+  const asc = variants.value
+    .map((v) => v.bandwidth ?? 0)
+    .filter((b) => b > 0)
+    .sort((a, b) => a - b);
+  if (asc.length < 5) return false;
+  for (let i = 1; i < asc.length; i++) {
+    if (asc[i] / asc[i - 1] > 1.7) return false; // a ~2× gap ⇒ not geometric
+  }
+  return true;
+});
+
+/** Thin to the "skip every other" 2× subset: on the bandwidth-sorted ladder
+ *  keep indices 0,2,4,… plus the last, so floor AND ceiling are retained. On
+ *  this geometric ladder that yields exactly the original 2× rungs. Sets the
+ *  existing allowed_variants whitelist — the proxy already filters the master
+ *  to it, so no backend change (#762). */
+function keepEveryOther() {
+  const asc = variants.value
+    .slice()
+    .sort((a, b) => (a.bandwidth ?? 0) - (b.bandwidth ?? 0));
+  const n = asc.length;
+  const keep = asc.filter((_, i) => i % 2 === 0 || i === n - 1).map((v) => v.url);
+  setContent({ allowed_variants: keep } as Partial<Content>);
+}
+
 function heightOf(res?: string | null): string {
   if (!res) return '?';
   const m = res.match(/x(\d+)/i);
@@ -195,7 +225,21 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
     </p>
 
     <div class="variants">
-      <span class="label">Allowed variants <span class="muted">(All checked = allow every variant)</span></span>
+      <div class="variants-head">
+        <span class="label">Allowed variants <span class="muted">(All checked = allow every variant)</span></span>
+        <button
+          type="button"
+          class="thin-btn"
+          data-testid="content-keep-every-other"
+          :disabled="!isGeometricLadder"
+          :title="isGeometricLadder
+            ? 'Drop the ~1.41× fill rungs → keep the 2× subset (floor + ceiling retained)'
+            : 'Only on a dense ~1.41× geometric ladder — this content isn’t one'"
+          @click="keepEveryOther"
+        >
+          Keep every other (2×)
+        </button>
+      </div>
       <div v-if="!variants.length" class="muted">Play content once to populate variant list.</div>
       <div v-else class="variant-list">
         <label class="all">
@@ -323,6 +367,25 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
   display: grid;
   gap: 6px;
 }
+
+.variants-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.thin-btn {
+  border: 1px solid #d1d5db;
+  background: #fff;
+  color: #374151;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.thin-btn:hover:not(:disabled) { background: #f3f4f6; }
+.thin-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .variant-list {
   display: grid;


### PR DESCRIPTION
Part 3 of #762 — and it **supersedes** the planned `skip_alternate_variants` proxy flag.

## What
Adds a **"Keep every other (2×)"** button to the content-manipulation panel (`ContentManipulation.vue`). It thins the ABR ladder to the 2× "skip every other" subset by setting the **existing `allowed_variants` whitelist** — the proxy already filters the master to it, so **no backend / spec / proxy change**.

- Subset = variants **bandwidth-sorted, keep `i%2==0 || last`** → floor *and* ceiling retained. On the #762 geometric ladder that's exactly the original 2× rungs.
- **Gated to dense ~1.41× geometric ladders** (`isGeometricLadder`: ≥5 rungs, every adjacent BANDWIDTH ratio ≤ 1.7×) and **disabled otherwise**, so it can't halve a legacy 2× ladder into ~4× gaps. Tooltip explains why it's disabled.
- Explicit-URI selection (not a blind index-skip) means there's nothing to mangle on other content — the safety the earlier design needed a proxy guard for is now inherent.
- Existing **"All"** restores.

## Why this instead of a new flag
The proxy already drops variants via `content_allowed_variants` (`cmd/server/main.go:6489`) and the dashboard already has per-variant checkboxes wired to `allowed_variants`. "Skip every other" is just a specific selection — so it's a frontend convenience over proven machinery, not new server code.

## Testing
`vue-tsc --noEmit` clean. Manual: with the 11-rung ladder content, the button enables and ticks the 6 ★ rungs; on existing 6-rung 2× content it's disabled. (Not yet visually verified in a running dashboard.)

## Automation follow-up (Part 4)
The harness will set the same `allowed_variants` subset via `proxy.content.allowed_variants[…]` at connect for the A/B run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
