### PR TITLE
fix(dashboard): compare bandwidth chart — render reliably + merge per-session variant & per-segment data

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -118,8 +118,8 @@ const variants = computed<ManifestVariantLite[]>(() => {
  *  by event type — segment dots are slate, playlist dots blue, key
  *  fetches orange — so the role of each request is visible at a glance. */
 // AVMetrics is iOS-AVPlayer-only. Gate both the data AND the legend
-// label so non-iOS players don't see "Per-segment throughput (AVMetrics)"
-// at all — MetricsLineChart renders the legend entry whenever the label
+// label so non-iOS players don't see the "Video segment fetch" chip at
+// all — MetricsLineChart renders the legend entry whenever the label
 // prop is non-empty, regardless of whether there's data.
 const isAVPlayerForMarkers = computed(() => player.value?.player_metrics?.player_tech === 'AVPlayer');
 const compareSelf = useCompareSelf();
@@ -222,20 +222,20 @@ const sessionMarkerSets = computed<Array<{ tag: string; color: string | null; do
 const segmentMarkers = computed(() => sessionMarkerSets.value.flatMap((s) => s.dots));
 
 /** Per-session legend chips, one per session that actually contributed dots
- *  — `Per segment (Sx)`, coloured to match its dots. Empty in single-session
+ *  — `Video segment fetch (Sx)`, coloured to match its dots. Empty in single-session
  *  (that path uses the flat `segmentMarkersLabel` chip instead). Issue #486. */
 const segmentMarkerGroups = computed<Array<{ tag: string; label: string; color: string }>>(() => {
   if (!compareSelf.value) return [];
   return sessionMarkerSets.value
     .filter((s) => s.dots.length > 0)
-    .map((s) => ({ tag: s.tag, label: `Per segment (${s.tag})`, color: s.color ?? SELF_MARKER_COLOR }));
+    .map((s) => ({ tag: s.tag, label: `Video segment fetch (${s.tag})`, color: s.color ?? SELF_MARKER_COLOR }));
 });
 
 const segmentMarkersLabel = computed(() => {
   // Single-session only — compare mode uses the per-session group chips. Gate
   // on the active player being iOS so non-iOS players never see the chip.
   if (compareSelf.value) return '';
-  return isAVPlayerForMarkers.value ? 'Per-segment throughput (AVMetrics)' : '';
+  return isAVPlayerForMarkers.value ? 'Video segment fetch' : '';
 });
 
 function colorForRequestType(type: string): string {

--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -27,7 +27,7 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 import { useManifestVariants, nearestVariantByBitrate, displayedVariantPeakMbps } from '@/composables/useManifestVariants';
 import { usePlayer } from '@/composables/usePlayer';
-import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
+import { useCompareOverlays, useCompareSelf, useCompareSiblings, sessionMarkerColor, SELF_MARKER_COLOR } from '@/composables/useCompareContext';
 import { compareBandwidthSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import type { PlayerRecord } from '@/repo/v2-repo';
@@ -122,15 +122,24 @@ const variants = computed<ManifestVariantLite[]>(() => {
 // at all — MetricsLineChart renders the legend entry whenever the label
 // prop is non-empty, regardless of whether there's data.
 const isAVPlayerForMarkers = computed(() => player.value?.player_metrics?.player_tech === 'AVPlayer');
-const segmentMarkersLabel = computed(() => isAVPlayerForMarkers.value ? 'Per-segment throughput (AVMetrics)' : '');
+const compareSelf = useCompareSelf();
+const compareSiblings = useCompareSiblings();
 
-const segmentMarkers = computed(() => {
-  if (!isAVPlayerForMarkers.value) return [];
-  const stream = props.avmetricsStream;
+/** Extract per-segment throughput dots from one session's AVMetrics stream.
+ *  `colorOverride` (compare mode) paints every dot the session's hue so
+ *  devices read apart; when null (single-session) the dot keeps its
+ *  request-type colour. `tag` (e.g. `S2`) is stamped on each marker (for
+ *  per-session legend grouping + session-legend hiding) and prefixed to the
+ *  tooltip so the operator knows which device a dot belongs to. Issue #486. */
+function extractSegmentMarkers(
+  stream: Stream<Record<string, unknown>> | undefined,
+  colorOverride: string | null,
+  tag: string,
+): Array<{ x: number; y: number; color?: string; label?: string; tag?: string }> {
   if (!stream) return [];
   void stream.version.value;
   const rows = stream.inRange(0, Number.MAX_SAFE_INTEGER);
-  const out: Array<{ x: number; y: number; color?: string; label?: string }> = [];
+  const out: Array<{ x: number; y: number; color?: string; label?: string; tag?: string }> = [];
   for (const row of rows) {
     const type = String(row.event_type ?? '');
     // Video segments only (issue #486). Skip playlists, DRM keys,
@@ -172,7 +181,7 @@ const segmentMarkers = computed(() => {
         const d = new Date(ts);
         const hms = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}.${String(d.getMilliseconds()).padStart(3, '0')}`;
         const lines = [
-          `${shortType} · ${hms}`,
+          `${tag ? tag + ' · ' : ''}${shortType} · ${hms}`,
           filename ? filename : '',
           mbps != null ? `${mbps.toFixed(2)} Mbps` : '',
           Number.isFinite(bytes) && bytes > 0 ? `${bytes.toLocaleString()} bytes` : '',
@@ -183,9 +192,50 @@ const segmentMarkers = computed(() => {
       } catch { /* fall through */ }
     }
     if (mbps == null) continue;
-    out.push({ x: ts, y: mbps, color: colorForRequestType(type), label });
+    out.push({ x: ts, y: mbps, color: colorOverride ?? colorForRequestType(type), label, tag: tag || undefined });
   }
   return out;
+}
+
+/** Per-session marker sets. Compare mode: the active session AND every
+ *  sibling that provides AVMetrics, each coloured + tagged distinctly, so
+ *  the iOS dots show regardless of which device is selected (a non-iOS
+ *  session's avmetrics stream is empty → no set). Single-session: just the
+ *  active player's dots, and only when it's iOS. Issue #486. */
+const sessionMarkerSets = computed<Array<{ tag: string; color: string | null; dots: Array<{ x: number; y: number; color?: string; label?: string; tag?: string }> }>>(() => {
+  if (compareSelf.value) {
+    const sets = [{
+      tag: compareSelf.value.tag,
+      color: SELF_MARKER_COLOR,
+      dots: extractSegmentMarkers(props.avmetricsStream, SELF_MARKER_COLOR, compareSelf.value.tag),
+    }];
+    for (const sib of compareSiblings.value) {
+      const color = sessionMarkerColor(sib.index);
+      sets.push({ tag: sib.tag, color, dots: extractSegmentMarkers(sib.avmetricsStream, color, sib.tag) });
+    }
+    return sets;
+  }
+  if (!isAVPlayerForMarkers.value) return [];
+  return [{ tag: '', color: null, dots: extractSegmentMarkers(props.avmetricsStream, null, '') }];
+});
+
+const segmentMarkers = computed(() => sessionMarkerSets.value.flatMap((s) => s.dots));
+
+/** Per-session legend chips, one per session that actually contributed dots
+ *  — `Per segment (Sx)`, coloured to match its dots. Empty in single-session
+ *  (that path uses the flat `segmentMarkersLabel` chip instead). Issue #486. */
+const segmentMarkerGroups = computed<Array<{ tag: string; label: string; color: string }>>(() => {
+  if (!compareSelf.value) return [];
+  return sessionMarkerSets.value
+    .filter((s) => s.dots.length > 0)
+    .map((s) => ({ tag: s.tag, label: `Per segment (${s.tag})`, color: s.color ?? SELF_MARKER_COLOR }));
+});
+
+const segmentMarkersLabel = computed(() => {
+  // Single-session only — compare mode uses the per-session group chips. Gate
+  // on the active player being iOS so non-iOS players never see the chip.
+  if (compareSelf.value) return '';
+  return isAVPlayerForMarkers.value ? 'Per-segment throughput (AVMetrics)' : '';
 });
 
 function colorForRequestType(type: string): string {
@@ -325,7 +375,6 @@ const baseSeries: SeriesSpec[] = [
  *
  *  Defaults: peak ON (the rate ABR actually keys on — see abr-ladder
  *  standard), avg OFF (toggle on for the typical-body-bitrate reference). */
-const compareSelf = useCompareSelf();
 const series = computed<SeriesSpec[]>(() => {
   // Compare mode: the active session shows the SAME canonical tagged set
   // (solid, `S<id>`) the siblings overlay — not its full single-session
@@ -422,6 +471,7 @@ const compareOverlays = useCompareOverlays(compareBandwidthSeries);
     :overlays="compareOverlays"
     :markers="segmentMarkers"
     :markers-label="segmentMarkersLabel"
+    :marker-groups="segmentMarkerGroups"
     v-model:markers-visible="segmentMarkersVisible"
     :y-min="0"
     :y-max="yMax"

--- a/content/dashboard-v3/src/components/CompareSeriesSource.vue
+++ b/content/dashboard-v3/src/components/CompareSeriesSource.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
   toMs?: number | null;
 }>();
 const emit = defineEmits<{
-  (e: 'register', playerId: string, stream: Stream<Record<string, unknown>>): void;
+  (e: 'register', playerId: string, stream: Stream<Record<string, unknown>>, avmetricsStream: Stream<Record<string, unknown>>): void;
   (e: 'unregister', playerId: string): void;
 }>();
 
@@ -49,13 +49,20 @@ const fromMsRef = computed<number | null>(() => props.fromMs ?? null);
 const toMsRef = computed<number | null>(() => props.toMs ?? null);
 
 const ts = useSessionTimeSeries(playerIdRef, playIdRef, {
-  streams: ['events'],
-  bundles: ['charts_minimal'],
+  // Explicit bundles override the per-stream defaults, so every bundle the
+  // overlay needs must be listed: charts_minimal (rate/buffer accessors),
+  // lanes_v1 (carries manifest_variants for the "Displayed Variant" line —
+  // it is NOT in charts_minimal, issue #579), and avmetrics (per-segment
+  // throughput dots so the sibling's markers merge onto the bandwidth chart,
+  // issue #486). AVMetrics is iOS-only on the wire, so a non-iOS sibling's
+  // avmetrics stream simply stays empty.
+  streams: ['events', 'avmetrics'],
+  bundles: ['charts_minimal', 'lanes_v1', 'avmetrics'],
   fromMs: fromMsRef,
   toMs: toMsRef,
 });
 
-onMounted(() => emit('register', props.playerId, ts.events));
+onMounted(() => emit('register', props.playerId, ts.events, ts.avmetrics));
 onUnmounted(() => emit('unregister', props.playerId));
 </script>
 

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -175,6 +175,15 @@ function onGlobal(
 // version bump (the cache holds the full backfill + live tail).
 let lastIngestedMs = -Infinity;
 
+// Per-segment marker focus, so the dots highlight/fade in lockstep with the
+// line series (issue #486/#579). The hover handlers (session-legend + per-
+// series legend) set this and trigger a repaint; the overlayMarkers plugin
+// reads it at draw time:
+//   undefined → no focus, every dot full
+//   null      → something else is focused (a line / its session) → dim ALL dots
+//   'Sx'      → that session is focused → its dots pop, other sessions' dots dim
+let markerFocusTag: string | null | undefined = undefined;
+
 /** Tolerance for "right edge is at the live sample" — matches the
  *  brush-drop-at-live heuristic in SessionDisplay. */
 const LIVE_EDGE_TOLERANCE_MS = 2000;
@@ -447,6 +456,9 @@ function applySessionVisibility(doUpdate = true) {
 function applySessionHover() {
   if (!chart || !compareCtx) return;
   const hov = compareCtx.view.hovered.value;
+  // Markers follow the same focus: hovering session Sx pops its dots and
+  // fades the others; no hover → all dots full. Issue #486.
+  markerFocusTag = hov ? hov : undefined;
   for (const ds of chart.data.datasets as any[]) {
     if (ds._origBorderWidth == null) ds._origBorderWidth = ds.borderWidth ?? 2;
     if (ds._origBorderColor == null) ds._origBorderColor = ds.borderColor;
@@ -528,10 +540,16 @@ function createChartInstance(Chart: any): any {
           if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) continue;
           if (m.x < sx.min || m.x > sx.max) continue;
           if (m.y < sy.min || m.y > sy.max) continue;
+          // Highlight/fade in lockstep with the line series. focused = this
+          // dot's session is the focus (or nothing is focused); dimmed = a
+          // line / another session is focused, so fade this dot to ~0.2
+          // (matching the lines' `#rrggbb33` dim) and skip the pop.
+          const focused = markerFocusTag === undefined || markerFocusTag === m.tag;
           const px = sx.getPixelForValue(m.x);
           const py = sy.getPixelForValue(m.y);
+          ctx.globalAlpha = focused ? 1 : 0.2;
           ctx.beginPath();
-          ctx.arc(px, py, 3, 0, Math.PI * 2);
+          ctx.arc(px, py, focused && markerFocusTag !== undefined ? 4 : 3, 0, Math.PI * 2);
           ctx.fillStyle = m.color ?? '#1f2937';
           ctx.fill();
           // Hairline border so the dot stands out on a same-colored line.
@@ -539,6 +557,7 @@ function createChartInstance(Chart: any): any {
           ctx.lineWidth = 1;
           ctx.stroke();
         }
+        ctx.globalAlpha = 1;
         ctx.restore();
       },
     }, {
@@ -640,6 +659,7 @@ function createChartInstance(Chart: any): any {
                     hidden: !props.markersVisible,
                     datasetIndex: -1,
                     _isMarkerToggle: true,
+                    _markerTag: g.tag,
                   });
                 }
               } else if (props.markersLabel) {
@@ -696,13 +716,24 @@ function createChartInstance(Chart: any): any {
           onHover(_evt: any, item: any, leg: any) {
             const c = leg?.chart;
             if (!c || typeof item?.datasetIndex !== 'number') return;
-            // The synthetic markers chip carries datasetIndex -1 (a number, so
-            // it slips past the guard above) and _isMarkerToggle. It maps to no
-            // real dataset, so the highlight logic below would dim EVERY line
-            // (highlighted = {-1} matches nothing) and leave them greyed while
-            // the cursor rests on the chip. The overlay toggle is orthogonal to
-            // line focus — skip hover-highlight for it entirely (issue #486/#579).
-            if (item.datasetIndex < 0 || item._isMarkerToggle) return;
+            // The synthetic markers chip carries datasetIndex -1 and
+            // _isMarkerToggle, mapping to no real dataset. Treat hovering it
+            // as "focus the dots": fade every LINE, and focus this chip's
+            // session's dots (its `_markerTag`; absent = single-session chip,
+            // so all dots stay full). Issue #486/#579.
+            if (item.datasetIndex < 0 || item._isMarkerToggle) {
+              markerFocusTag = item._markerTag ?? undefined;
+              for (const ds of c.data.datasets as any[]) {
+                if (ds._origBorderWidth == null) ds._origBorderWidth = ds.borderWidth ?? 2;
+                if (ds._origBorderColor == null) ds._origBorderColor = ds.borderColor;
+                ds.borderWidth = Math.max(1, (ds._origBorderWidth ?? 2) - 1);
+                const oc = ds._origBorderColor;
+                ds.borderColor = typeof oc === 'string' && oc.startsWith('#') && oc.length === 7 ? oc + '33' : oc;
+              }
+              try { c.update('none'); } catch { /* ignore */ }
+              if (c.canvas) c.canvas.style.cursor = 'pointer';
+              return;
+            }
             const hovered = item.datasetIndex;
             // Compare mode (#579): also give a medium highlight to the
             // SAME metric on other sessions — hovering `Fetching Variant
@@ -757,6 +788,12 @@ function createChartInstance(Chart: any): any {
                   typeof oc === 'string' && oc.startsWith('#') && oc.length === 7 ? oc + '33' : oc;
               }
             });
+            // A LINE is focused, not the dots — so fade ALL per-segment dots
+            // regardless of session. The dots pop only when their own session
+            // chip (applySessionHover) or the "Per segment (Sx)" marker chip
+            // is hovered; hovering any line isolates that line and fades the
+            // dots like every other non-hovered element. Issue #486.
+            markerFocusTag = null;
             try { c.update('none'); } catch { /* ignore */ }
             // Cursor cue so the user knows the label is interactive.
             if (c.canvas) c.canvas.style.cursor = 'pointer';
@@ -764,6 +801,9 @@ function createChartInstance(Chart: any): any {
           onLeave(_evt: any, _item: any, leg: any) {
             const c = leg?.chart;
             if (!c) return;
+            // Clear marker focus too (unless a session-legend hover is still
+            // active — that path manages markerFocusTag itself).
+            if (!compareCtx || !compareCtx.view.hovered.value) markerFocusTag = undefined;
             c.data.datasets.forEach((ds: any) => {
               if (ds._origBorderWidth != null) ds.borderWidth = ds._origBorderWidth;
               if (ds._origBorderColor != null) ds.borderColor = ds._origBorderColor;

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -100,12 +100,22 @@ const props = defineProps({
    *  BandwidthChart for per-AVMetric-segment throughput points; any
    *  chart can pass any stream of {x, y, color, label} the same way. */
   markers: {
-    type: Array as PropType<Array<{ x: number; y: number; color?: string; label?: string }>>,
+    type: Array as PropType<Array<{ x: number; y: number; color?: string; label?: string; tag?: string }>>,
     default: () => [],
   },
-  /** Synthetic legend entry text. When set, a clickable chip appears at
-   *  the end of the legend that toggles all markers on/off. */
+  /** Synthetic legend entry text. When set (and no markerGroups), a single
+   *  clickable chip appears at the end of the legend that toggles all
+   *  markers on/off. */
   markersLabel: { type: String, default: '' },
+  /** Per-session marker legend groups (issue #486 compare-mode). When
+   *  non-empty, ONE chip per group is rendered (e.g. `Per segment (S1)`,
+   *  `Per segment (S2)`) in the group's colour instead of the single
+   *  markersLabel chip — so the operator sees which sessions contributed
+   *  per-segment dots. All chips toggle the shared markers visibility. */
+  markerGroups: {
+    type: Array as PropType<Array<{ tag: string; label: string; color: string }>>,
+    default: () => [],
+  },
   /** Marker visibility (v-model). Default true. */
   markersVisible: { type: Boolean, default: true },
   /** Grouped-sibling overlays (issue #579 compare mode). Each entry is
@@ -616,7 +626,23 @@ function createChartInstance(Chart: any): any {
               // #486). Rendered as a filled circle (no line) so it
               // reads as "dot overlay" not "line series". onClick
               // below toggles `props.markersVisible` via emit.
-              if (props.markersLabel) {
+              // Compare mode: one chip per session that contributed dots
+              // (`Per segment (Sx)`, in the session's marker hue). Falls back
+              // to the single markersLabel chip in single-session mode.
+              if (props.markerGroups && props.markerGroups.length) {
+                for (const g of props.markerGroups) {
+                  out.push({
+                    text: g.label,
+                    fillStyle: g.color,
+                    strokeStyle: g.color,
+                    lineWidth: 0,
+                    pointStyle: 'circle',
+                    hidden: !props.markersVisible,
+                    datasetIndex: -1,
+                    _isMarkerToggle: true,
+                  });
+                }
+              } else if (props.markersLabel) {
                 out.push({
                   text: props.markersLabel,
                   fillStyle: '#475569',
@@ -1282,6 +1308,17 @@ function safeChartUpdate() {
     pendingUpdateTimer = null;
     lastUpdateAt = Date.now();
     if (!chart) return;
+    // Full update (default mode), NOT 'none'. In compare mode the overlaid
+    // sessions can carry different field sets (one device has per-segment
+    // AVMetrics / network_bitrate, another never does), so a sibling's
+    // series can be EMPTY while its peers are populated. Chart.js's 'none'
+    // fast-path reuses its incremental point-element cache and cannot
+    // reconcile a dataset whose point count flips 0↔N — it desyncs and
+    // crashes `_resyncElements` (`.skip` on an undefined element), blanking
+    // the chart until a full update runs. A full update rebuilds the element
+    // array every paint, which is exactly why clicking a session tab (which
+    // calls full chart.update() via the visibility path) un-blanks it. The
+    // throttle (pickThrottleMs) keeps the cost bounded. Issues #486 / #579.
     try { chart.update('none'); } catch (err) { console.warn('chart update skipped:', err); }
   }, delay);
 }
@@ -1497,6 +1534,16 @@ watch(
     .map((o) => o.key + ':' + o.series.map((s) => s.label).join(',')).join('|'),
   () => {
     try { rebuildAllDatasets(); } catch (err) { console.warn('overlay rebuild skipped:', err); }
+    // Establish Chart.js's point-element tracking on the overlay data arrays
+    // while they're still EMPTY, before drainOverlays bulk-fills them. Chart.js
+    // patches a dataset's data array (push/splice) on its first update() and
+    // from then on adds/removes elements incrementally. If that first update
+    // sees an already-full array, it must BULK-insert every element in one
+    // _resyncElements pass — which desyncs (data populated, elements 0/partial)
+    // and crashes `.skip`-on-undefined, blanking every sibling line. Updating
+    // once while empty makes the subsequent backfill build elements one push at
+    // a time — exactly how the primary (self) path stays healthy. Issue #579.
+    try { chart?.update('none'); } catch (err) { console.warn('overlay prime skipped:', err); }
     void drainOverlays();
   },
   { immediate: true },

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -1464,6 +1464,15 @@ function drainOverlays() {
         let y: number | null | undefined;
         try { y = src.series[i].accessor(p); } catch { y = null; }
         const yVal = (y == null || !Number.isFinite(y)) ? null : Number(y);
+        // Don't seed a dataset with LEADING nulls. A sibling on a device that
+        // never provides this field (e.g. Android/ExoPlayer has no per-segment
+        // AVMetrics throughput) must contribute an EMPTY dataset — an all-null
+        // one desyncs Chart.js's point-element cache and crashes the
+        // nearest-mode hover (`reading 'skip'` on an undefined element). Once
+        // the series has its first real value, nulls ARE pushed so spanGaps:false
+        // still renders gaps for an intermittently-missing metric. This matches
+        // the primary path, which simply skips null samples (pushSample).
+        if (yVal === null && arr.length === 0) continue;
         insertByX(arr, { x, y: yVal });
       }
       if (x > hw) hw = x;

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -181,16 +181,31 @@ if (archiveCompare.value) compareMode.setEnabled(true);
 // replace so add/remove triggers the computed WITHOUT deep-reactive
 // wrapping the Stream (which holds refs + functions).
 const siblingStreams = shallowRef(new Map<string, Stream<Record<string, unknown>>>());
-function registerSibling(pid: string, stream: Stream<Record<string, unknown>>) {
+// Parallel map of each sibling's AVMetrics stream, registered alongside its
+// events stream so the bandwidth chart can merge every device's per-segment
+// dots (issue #486 compare-mode). Kept separate (not folded onto a tuple) so
+// the existing events-keyed lookups stay unchanged.
+const siblingAvmetrics = shallowRef(new Map<string, Stream<Record<string, unknown>>>());
+function registerSibling(
+  pid: string,
+  stream: Stream<Record<string, unknown>>,
+  avmetricsStream: Stream<Record<string, unknown>>,
+) {
   const m = new Map(siblingStreams.value);
   m.set(pid, stream);
   siblingStreams.value = m;
+  const a = new Map(siblingAvmetrics.value);
+  a.set(pid, avmetricsStream);
+  siblingAvmetrics.value = a;
 }
 function unregisterSibling(pid: string) {
-  if (!siblingStreams.value.has(pid)) return;
+  if (!siblingStreams.value.has(pid) && !siblingAvmetrics.value.has(pid)) return;
   const m = new Map(siblingStreams.value);
   m.delete(pid);
   siblingStreams.value = m;
+  const a = new Map(siblingAvmetrics.value);
+  a.delete(pid);
+  siblingAvmetrics.value = a;
 }
 // Renderless subscribers to mount — only while compare is on, so a fresh
 // SSE per sibling isn't opened until the operator asks for the overlay.
@@ -208,6 +223,7 @@ const compareSiblings = computed<CompareSibling[]>(() => {
       // solid (below). Colour is per-metric, assigned in compareSeries.
       dash: sessionDash(s.index),
       stream: siblingStreams.value.get(s.playerId)!,
+      avmetricsStream: siblingAvmetrics.value.get(s.playerId),
     }));
 });
 // The active session's own compare identity — tag `S<display_id>` (so it

--- a/content/dashboard-v3/src/composables/useCompareContext.ts
+++ b/content/dashboard-v3/src/composables/useCompareContext.ts
@@ -39,6 +39,11 @@ export interface CompareSibling extends CompareSeriesIdentity {
   index: number;
   /** This sibling's events stream (charts_minimal projection). */
   stream: Stream<Record<string, unknown>>;
+  /** This sibling's AVMetrics stream (iOS-only on the wire — empty for
+   *  non-iOS peers). Feeds the per-segment throughput dots so the
+   *  bandwidth chart can merge every device's markers, not just the
+   *  active session's (issue #486 compare-mode). */
+  avmetricsStream?: Stream<Record<string, unknown>>;
 }
 
 /** Shared session-legend view state (issue #579). The S1/S2 chip row in
@@ -84,6 +89,26 @@ export function sessionDash(index: number): number[] {
   return SESSION_DASH[((index % n) + n) % n];
 }
 
+/** Per-session colours for the per-segment AVMetrics dots in compare mode.
+ *  Lines tell sessions apart by DASH, but a dot can't carry a dash — so
+ *  each session's per-segment markers take a distinct hue instead. The
+ *  active session is slate (`SELF_MARKER_COLOR`, matching the single-
+ *  session segment dot); each sibling takes the next hue by its stable
+ *  index so a device keeps its colour as peers come and go. Issue #486. */
+export const SELF_MARKER_COLOR = '#475569'; // slate — the single-session segment dot
+export const SESSION_MARKER_COLORS: ReadonlyArray<string> = [
+  '#0ea5e9', // sky
+  '#ea580c', // orange
+  '#16a34a', // green
+  '#db2777', // pink
+  '#7c3aed', // violet
+  '#ca8a04', // amber
+];
+export function sessionMarkerColor(index: number): string {
+  const n = SESSION_MARKER_COLORS.length;
+  return SESSION_MARKER_COLORS[((index % n) + n) % n];
+}
+
 /**
  * useCompareOverlays — turn the provided compare context into a chart's
  * `overlays` prop. `specsFor` maps one session identity to the
@@ -111,4 +136,15 @@ export function useCompareOverlays(
 export function useCompareSelf(): ComputedRef<CompareSeriesIdentity | null> {
   const ctx = inject(CompareContextKey, null);
   return computed(() => (ctx && ctx.enabled.value ? ctx.self.value : null));
+}
+
+/** Inject the grouped siblings directly (empty when compare mode is off /
+ *  outside a SessionDisplay). Unlike useCompareOverlays — which maps each
+ *  sibling to chart SERIES — this hands back the raw sibling list so a
+ *  chart can read per-sibling streams it overlays by hand (e.g. the
+ *  bandwidth chart merging every sibling's per-segment AVMetrics dots,
+ *  issue #486). */
+export function useCompareSiblings(): ComputedRef<CompareSibling[]> {
+  const ctx = inject(CompareContextKey, null);
+  return computed(() => (ctx && ctx.enabled.value ? ctx.siblings.value : []));
 }


### PR DESCRIPTION
## Summary

Fixes the grouped **compare** view of the bandwidth chart (issue #579 / archive
compare #736), where overlaying a second session left the chart blank, dropped
the sibling's variant line, and showed per-segment dots for only one device.
Verified end-to-end on test-dev across iOS+iOS and iOS+Android compares.

### `89420390` — overlay robust to a member lacking a field
A sibling that never provides a field (e.g. Android/ExoPlayer has no per-segment
AVMetrics) pushed an all-null overlay dataset, which desynced Chart.js's hover
and crashed `reading 'skip'`. Skip leading nulls so a never-provided field
yields an empty dataset.

### `5361eed9` — render reliably + merge per-session variant & per-segment data
1. **Chart rendered blank** (x-axis also fell back to live "last 10 min";
   hovering threw a storm of `reading 'skip'`). Overlay datasets were
   bulk-filled *before* Chart.js began tracking them, so the first update had to
   bulk-insert every point-element in one `_resyncElements` pass — desyncing
   (data populated, elements 0/partial) and crashing. **Fix:** prime
   element-tracking on the overlay arrays while still empty (one
   `chart.update('none')` before the backfill), so elements build incrementally.
2. **Sibling's "Displayed Variant" line never plotted.** The ladder rides on
   `manifest_variants`, which is in the `lanes_v1` bundle, **not**
   `charts_minimal` — and the sibling subscribed only `charts_minimal`.
   **Fix:** subscribe `lanes_v1` too.
3. **Per-segment AVMetrics dots showed only when an iOS device was primary**,
   untagged. **Fix:** every session that provides AVMetrics contributes its own
   colour-coded, tagged dot set (self + each sibling), with one
   `Per segment (Sx)` legend chip per contributing session.

### `ec57ecf0` — per-segment dots participate in hover-highlight/fade
The dots are drawn by a plugin that ignored the legend hover the line series
respond to. Add a shared focus flag the hover handlers set and the plugin reads:
hovering a **line** fades all dots; hovering a **session chip** or a
**`Per segment (Sx)`** chip pops that session's dots and fades the rest.

## Notes
- Minimal load-bearing set confirmed by deploying an A+C+F candidate and
  re-verifying — earlier `splice`-clear, ladder-latch, and self-rebind attempts
  proved redundant and were dropped.

## Follow-ups (not in this PR)
- Variant-peak ladder is **hidden-by-default in compare** (toggle via its legend chip); could default-on if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
