### PR TITLE
test(go-proxy): allowed_variants resolution-match + per-mutation broadcast override coverage (#766)

### DIFF
--- a/go-proxy/cmd/server/content_manipulation_test.go
+++ b/go-proxy/cmd/server/content_manipulation_test.go
@@ -177,10 +177,17 @@ func TestManipulateHLSMaster(t *testing.T) {
 			check: func(t *testing.T, out []byte) { wantURIOrder(t, out, "v1080.m3u8") },
 		},
 		{
-			// mixed match keys, authored ascending order preserved among survivors.
+			// mixed match keys (URI + bare height), authored ascending order
+			// preserved among survivors.
 			name:  "allowed/mixed_keys",
 			cm:    ContentManipulation{AllowedVariants: []string{"v240.m3u8", "720"}},
 			check: func(t *testing.T, out []byte) { wantURIOrder(t, out, "v240.m3u8 v720.m3u8") },
+		},
+		{
+			// two full-resolution keys keep both ends of the ladder (#766).
+			name:  "allowed/multi_resolution",
+			cm:    ContentManipulation{AllowedVariants: []string{"426x240", "1920x1080"}},
+			check: func(t *testing.T, out []byte) { wantURIOrder(t, out, "v240.m3u8 v1080.m3u8") },
 		},
 		{
 			// no whitelist entry matches → every variant is filtered out,

--- a/go-proxy/internal/v2/server/handlers_integration_test.go
+++ b/go-proxy/internal/v2/server/handlers_integration_test.go
@@ -179,16 +179,16 @@ func TestGet_PlayersByID_Projections_Telemetry(t *testing.T) {
 	pid := uuid.New().String()
 	a.addPlayer(pid, "rev1", map[string]any{
 		// Player metrics
-		"player_metrics_video_resolution":     "1920x1080",
-		"player_metrics_video_bitrate_mbps":   5.5,
-		"player_metrics_video_quality_pct":    72.5,
-		"player_metrics_buffer_depth_s":       12.3,
-		"player_metrics_stalls":               2,
-		"player_metrics_loop_count_player":    7,
-		"player_metrics_loop_count_delta": 1,
-		"player_metrics_profile_shift_count":  4,
-		"player_metrics_last_event":           "playing",
-		"player_metrics_source":               "avplayer-ios",
+		"player_metrics_video_resolution":    "1920x1080",
+		"player_metrics_video_bitrate_mbps":  5.5,
+		"player_metrics_video_quality_pct":   72.5,
+		"player_metrics_buffer_depth_s":      12.3,
+		"player_metrics_stalls":              2,
+		"player_metrics_loop_count_player":   7,
+		"player_metrics_loop_count_delta":    1,
+		"player_metrics_profile_shift_count": 4,
+		"player_metrics_last_event":          "playing",
+		"player_metrics_source":              "avplayer-ios",
 		// Server metrics (TCP_INFO + ICMP + bytes)
 		"client_rtt_ms":           42.0,
 		"client_rtt_min_ms":       12.0,
@@ -295,9 +295,9 @@ func TestGet_PlayersByID_Projections_TransferTimeouts(t *testing.T) {
 	a, _, ts := newTestServer(t)
 	pid := uuid.New().String()
 	a.addPlayer(pid, "rev1", map[string]any{
-		"transfer_active_timeout_seconds":   12,
-		"transfer_idle_timeout_seconds":     5,
-		"transfer_timeout_applies_segments": true,
+		"transfer_active_timeout_seconds":    12,
+		"transfer_idle_timeout_seconds":      5,
+		"transfer_timeout_applies_segments":  true,
 		"transfer_timeout_applies_manifests": true,
 	})
 	_, body, _ := mustGet(t, ts, "/api/v2/players/"+pid)
@@ -345,10 +345,10 @@ func TestGet_PlayersByID_Projections_Content(t *testing.T) {
 	a, _, ts := newTestServer(t)
 	pid := uuid.New().String()
 	a.addPlayer(pid, "rev1", map[string]any{
-		"content_strip_codecs":     true,
+		"content_strip_codecs":        true,
 		"content_overstate_bandwidth": true,
-		"content_live_offset":      18,
-		"content_allowed_variants": []any{"720p", "1080p"},
+		"content_live_offset":         18,
+		"content_allowed_variants":    []any{"720p", "1080p"},
 	})
 	_, body, _ := mustGet(t, ts, "/api/v2/players/"+pid)
 	var rec map[string]any
@@ -980,6 +980,94 @@ func TestPatch_DisplayOnlyGroup_NoBroadcast(t *testing.T) {
 	if l2["only"] == "p1" {
 		t.Errorf("p2 received p1's label — display-only group still broadcast: %v", l2)
 	}
+}
+
+// TestPatch_BroadcastOverride covers the per-mutation ?broadcast=true|false
+// query param (#766). The override wins over the group's connect-time default
+// for a single PATCH: it can suppress fan-out on a broadcast=true group, and it
+// can force fan-out on a display-only (group_broadcast=false) group. Drives both
+// directions; mirrors TestPatch_GroupedMember_Broadcasts' labels-based assert.
+func TestPatch_BroadcastOverride(t *testing.T) {
+	// labelOf reads a member's stored _v2_labels[key].
+	labelOf := func(a *fakeAdapter, pid, key string) any {
+		stored, _ := a.SessionByPlayerID(pid)
+		l, _ := stored["_v2_labels"].(map[string]any)
+		return l[key]
+	}
+
+	// newBroadcastGroup wires p1+p2 into a real broadcast=true group (the POST
+	// path) and returns p1's post-grouping control_revision for the If-Match.
+	newBroadcastGroup := func(t *testing.T, a *fakeAdapter, ts *httptest.Server) (p1, p2, rev1 string) {
+		p1, p2 = uuid.New().String(), uuid.New().String()
+		a.addPlayer(p1, "rev1", nil)
+		a.addPlayer(p2, "rev2", nil)
+		body, _ := json.Marshal(map[string]any{"member_player_ids": []string{p1, p2}})
+		mustDo(t, ts, "POST", "/api/v2/player-groups", string(body), nil)
+		stored1, _ := a.SessionByPlayerID(p1)
+		return p1, p2, asString(stored1["control_revision"])
+	}
+
+	t.Run("broadcast_group/override_false_isolates", func(t *testing.T) {
+		a, _, ts := newTestServer(t)
+		p1, p2, rev1 := newBroadcastGroup(t, a, ts)
+
+		// ?broadcast=false on a broadcast=true group → THIS patch must not fan out.
+		status, respBody, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+p1+"?broadcast=false",
+			`{"labels":{"only":"p1"}}`,
+			map[string]string{"If-Match": `"` + rev1 + `"`})
+		if status != http.StatusOK {
+			t.Fatalf("PATCH p1 %d body=%s", status, respBody)
+		}
+		if got := labelOf(a, p1, "only"); got != "p1" {
+			t.Errorf("p1 label = %v, want only=p1", got)
+		}
+		if got := labelOf(a, p2, "only"); got == "p1" {
+			t.Errorf("p2 received p1's label despite ?broadcast=false: %v", got)
+		}
+	})
+
+	t.Run("broadcast_group/override_true_fans_out", func(t *testing.T) {
+		a, _, ts := newTestServer(t)
+		p1, p2, rev1 := newBroadcastGroup(t, a, ts)
+
+		// ?broadcast=true matches the group default → still fans out (override
+		// is a no-op relative to the connect-time mode here).
+		status, respBody, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+p1+"?broadcast=true",
+			`{"labels":{"only":"p1"}}`,
+			map[string]string{"If-Match": `"` + rev1 + `"`})
+		if status != http.StatusOK {
+			t.Fatalf("PATCH p1 %d body=%s", status, respBody)
+		}
+		if got := labelOf(a, p2, "only"); got != "p1" {
+			t.Errorf("p2 label = %v, want only=p1 (override-true should broadcast)", got)
+		}
+	})
+
+	t.Run("display_only_group/override_true_forces_broadcast", func(t *testing.T) {
+		a, _, ts := newTestServer(t)
+		p1, p2 := uuid.New().String(), uuid.New().String()
+		rev := "2020-01-01T00:00:00.000000000Z"
+		// Born display-only (group_broadcast=false) — the startup-fleet path.
+		a.addSession(map[string]any{
+			"player_id": p1, "session_id": "s1", "control_revision": rev,
+			"group_id": "G1", "group_broadcast": false,
+		})
+		a.addSession(map[string]any{
+			"player_id": p2, "session_id": "s2", "control_revision": rev,
+			"group_id": "G1", "group_broadcast": false,
+		})
+
+		// ?broadcast=true overrides the display-only default → forces fan-out to p2.
+		status, respBody, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+p1+"?broadcast=true",
+			`{"labels":{"only":"p1"}}`,
+			map[string]string{"If-Match": `"` + rev + `"`})
+		if status != http.StatusOK {
+			t.Fatalf("PATCH p1 %d body=%s", status, respBody)
+		}
+		if got := labelOf(a, p2, "only"); got != "p1" {
+			t.Errorf("p2 label = %v, want only=p1 (?broadcast=true should force fan-out)", got)
+		}
+	})
 }
 
 // ----- Plays --------------------------------------------------------------


### PR DESCRIPTION
Closes #766. Sequenced onto the unified `ContentManipulation` table from #767 (PR #775).

Two additive control-API surfaces from the catalogue-variants / per-member A/B work that previously had **no test coverage**. Test-only — no production changes.

## 1. `allowed_variants` resolution-match (the important gap)
The `variantAllowed` helper matches a variant by served URI **OR** resolution (`640x360`) **OR** height (`360`/`360p`) — and no test ever exercised the filtering path before (the only `manipulateHLSMaster` test passed `nil`).

Folded onto the `TestManipulateHLSMaster` table (`content_manipulation_test.go`). #767 already landed URI / single-resolution / height / `Np`-suffix / mixed / no-match rows; this adds the **two-full-resolution** case `["426x240","1920x1080"] → [v240, v1080]` to complete #766's matrix.

## 2. Per-mutation `broadcast` override
`TestPatch_BroadcastOverride` (`handlers_integration_test.go`) covers `PATCH /api/v2/players/{id}?broadcast=true|false`, which overrides the group's connect-time default for a single PATCH:

- **`?broadcast=false` on a broadcast=true group → suppresses fan-out** (p2 unchanged) — the genuinely new isolation path.
- **`?broadcast=true` matching the group default → still fans out** (override is a no-op relative to connect mode).
- **`?broadcast=true` on a display-only (`group_broadcast=false`) group → forces fan-out** to the sibling.

Mirrors `TestPatch_GroupedMember_Broadcasts`' scaffolding (`newTestServer` / `addPlayer` / `addSession` / `mustDo` / `SessionByPlayerID`).

I confirmed via the fake adapter's `BroadcastPatch` that the override flag gates the entire fan-out at the handler level, so the labels-based asserts from #766's spec are correct (labels reach members only when broadcast actually fires).

The optional `/api/content variants[]` regression test (#766 item 3) is skipped per the issue ("skip unless wanted") — the parse is already unit-tested in `go-upload`.

## Verification
- `go test ./cmd/server/ -run 'AllowedVariants|ManipulateHLSMaster' -v` — green
- `go test ./internal/v2/server/ -run BroadcastOverride -count=20` — green (stable)
- full `go test ./...` green, **except** the pre-existing `TestConfigOnConnect_ParseErrors/type_conflict` flake (reproduces ~1/8 on clean `dev`, not introduced here)
- `gofmt -l` clean, `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
