### PR TITLE
feat(703a/778): live-aware iOS auto-recovery + fault-recovery characterization

### DIFF
--- a/analytics/go-forwarder/streambundles.go
+++ b/analytics/go-forwarder/streambundles.go
@@ -237,7 +237,21 @@ var bundleRegistry = map[string]bundleDef{
 			"stall_count",
 			"frames_dropped",
 			"player_error",
+			// #703a — error_code/_domain so the IMPAIRMENT ERROR marker can show
+			// the actual NSError code/domain (e.g. -1008 / NSURLErrorDomain), not
+			// just the message string.
+			"error_code",
+			"error_domain",
 			"last_event",
+			// #703a — player_restarts revives the PLAYBACK-lane RESTART marker
+			// (counter-diff; the column IS persisted — it's in panel_v1 too),
+			// and last_event above carries the new `live_resync` nudge event.
+			"player_restarts",
+			// #703a — playback_rate drives the PLAYBACK-lane RATE→0 / RATE→1
+			// markers (rate 0 == AVPlayer paused/stuck; distinguishes a stuck
+			// stall from a transient one, which `player_state` masks). In
+			// panel_v1 too; added here so EventsTimeline gets it per-tick.
+			"playback_rate",
 			"manifest_variants",
 			"master_manifest_consecutive_failures",
 			"manifest_consecutive_failures",

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlaybackDiagnostics.swift
@@ -197,6 +197,20 @@ final class PlaybackDiagnostics: ObservableObject {
 
     @Published var frozenDetected: Bool = false
     @Published var segmentStallDetected: Bool = false
+    /// #778 — live-resync recovery trigger. Flips true when playback has not
+    /// advanced for `liveResyncStallSeconds`, INDEPENDENT of `player.rate` and of
+    /// any -12880. This catches the silent-stall gap the #703a sweep found: a
+    /// bandwidth-starvation stall (rate_choke / segment-timeout) leaves the player
+    /// `state=stalled, rate=1` with a FROZEN playhead — it never flips to `.failed`
+    /// (no terminal path) and never auto-pauses to `rate=0` (no `stallStuck` path),
+    /// so nothing else triggers recovery and it hangs forever. The threshold is
+    /// deliberately HIGH (default 45s) so the faster detectors (`.failed`,
+    /// `stallStuck`) fire first for the faults that DO reach them — this is the
+    /// last-resort catch-all, not a front-line nudge.
+    @Published var liveResyncDue: Bool = false
+    /// Continuous no-progress (seconds) before the live-resync restart. Settable
+    /// via the `is.flag.live_resync_stall_s` launch arg.
+    var liveResyncStallSeconds: Double = 45
     /// #703 — application wedge detector. Flips true when a CoreMedia
     /// -12880 "Can not proceed after removing variants" was seen AND
     /// playback then failed to advance for `wedgeConfirmSeconds`. That's
@@ -771,6 +785,7 @@ final class PlaybackDiagnostics: ObservableObject {
         lastVariantSummaryAt = nil
         lastAccessLogEventCount = 0
         segmentStallDetected = false
+        liveResyncDue = false // #778
         wedgeDetected = false
         wedgeArmedAt = nil
         lastVariantDwellTotal = priorVariantDwellSeconds.values.reduce(0, +)
@@ -1200,6 +1215,8 @@ final class PlaybackDiagnostics: ObservableObject {
             // disarm the wedge watch and clear a prior detection.
             wedgeArmedAt = nil
             if wedgeDetected { wedgeDetected = false }
+            // #778 — any advance disarms the live-resync watch (and clears a prior fire).
+            if liveResyncDue { liveResyncDue = false }
             return
         }
         // States are lowercase ("idle"/"paused"/"stalled"/"buffering"/
@@ -1235,6 +1252,14 @@ final class PlaybackDiagnostics: ObservableObject {
                 frozenLoggedAt = now
                 print("[FROZEN] still frozen at time=\(String(format: "%.2f", time)) for \(String(format: "%.0fs", stalledFor)) state=\(state) rate=\(player?.rate ?? 0)")
             }
+        }
+        // #778 — live-resync restart trigger. Last-resort: only fires after the
+        // faster detectors (frozen 3s observability, stallStuck, .failed) have had
+        // their chance (default 45s no-progress). The binding additionally no-ops if
+        // a restart is already pending, so this only acts on the silent-stall gap.
+        if stalledFor >= liveResyncStallSeconds && !liveResyncDue {
+            liveResyncDue = true
+            print("[LIVE_RESYNC] no progress for \(String(format: "%.0fs", stalledFor)) — live-resync restart (state=\(state) rate=\(player?.rate ?? 0))")
         }
         // #703 — hard wedge: armed by a -12880 AND no progress for
         // wedgeConfirmSeconds. Distinct from frozenDetected (3s) — this is

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -357,12 +357,22 @@ final class PlayerViewModel: ObservableObject {
     private var avMetricsSubscriber: Any?
     private let metricsSessionLookupSeconds: TimeInterval = 30
     private let autoRecoveryThresholdSeconds: TimeInterval = 60
-    private let autoRecoveryBaseDelaySeconds: TimeInterval = 2
+    /// #703a — first auto-recovery backoff delay (then ×2 per attempt: 2/4/8s by
+    /// default). Settable via the `is.flag.auto_recovery_base_delay_s` launch arg
+    /// so characterization can make the restart fire late (deterministic
+    /// clear-before-restart timing) while production tunes it for UX.
+    private var autoRecoveryBaseDelaySeconds: TimeInterval = 2
     private let autoRecoveryMaxAttempts: Int = 3
     private let autoRecoveryVerifyDelaySeconds: TimeInterval = 10
     private var autoRecoveryAttempts: Int = 0
     private var autoRecoveryRestartTimer: Timer?
     private var autoRecoveryVerifyTimer: Timer?
+    /// #703a — the reason that drove the most recent recovery attempt, so the
+    /// exhaustion close-out can stamp a `<reason>_exhausted` terminal message.
+    private var lastRecoveryReason: String?
+    /// #778 — a jump-to-live seek nudge is in flight; suppresses re-entry and the
+    /// straight-to-restart path until the verify timer resolves seek vs escalate.
+    private var liveResyncInFlight = false
     private var zeroBufferStartedAt: Date?
     @Published private(set) var profileShiftCount: Int = 0
     @Published private(set) var playerRestarts: Int = 0
@@ -1077,6 +1087,19 @@ final class PlayerViewModel: ObservableObject {
         player.play()
         if goLive {
             seekToLiveEdge(item: item)
+        } else if resumingFromRestart {
+            // #703a — a restart (retry / auto-recovery) rebuilds the item AFTER
+            // the player has been stuck failing for a while, during which the
+            // live window kept advancing. Resume at the DEFAULT live offset, not
+            // the stale position the player drifted to before it failed —
+            // otherwise the rebuilt item comes back behind the (now-moved) window
+            // and wedges in buffering (fault-recovery probe Test 2). Use the
+            // configured offset when set, else snap to the live edge.
+            if liveOffsetSeconds > 0 {
+                scheduleLiveOffsetSeek(reason: "restart re-sync to live")
+            } else {
+                seekToLiveEdge(item: item)
+            }
         } else if liveOffsetSeconds > 0 {
             // User-configured custom offset — overrides the manifest's
             // HOLD-BACK on first ready-to-play. Mirrors testing-session.html.
@@ -1324,7 +1347,12 @@ final class PlayerViewModel: ObservableObject {
     /// Manual trigger for the auto-recovery path. Same call the
     /// codec-error handler and the auto-recovery branch make: replace
     /// the *same* URL on the *same* AVPlayer.
-    func retry() {
+    ///
+    /// `reason` tags the emitted `restart` event (#703a). The UI Retry button
+    /// uses the default "user_retry"; auto-recovery passes its driving reason so
+    /// the restart row carries the real cause — and emits exactly ONCE here, not
+    /// a "user_retry" from retry() plus a second row from the caller.
+    func retry(reason: String = "user_retry") {
         // Replay the REATTACH URL (proxy.* stripped), not currentURL — a
         // recovery restart must re-attach to the live shaping session, never
         // re-materialize it. If the session was reaped it comes back honestly
@@ -1349,18 +1377,74 @@ final class PlayerViewModel: ObservableObject {
         refreshed = appendStartTime(to: refreshed)
         self.currentURL = refreshed
         Task { [weak self] in
-            await self?.requestHARSnapshot(reason: "user_retry", force: true)
+            await self?.requestHARSnapshot(reason: reason, force: true)
         }
         // #603 — emit a `restart` event so the mid-play recovery is observable
         // (it wasn't before; manual retries left no mark on the events lane).
         // Same play_id, bumped attempt_id; play boundaries are play_start/play_end.
         let restartPayload = buildMetricsPayload(event: "restart", at: Date(), extra: [
-            "player_metrics_restart_reason": "user_retry",
+            "player_metrics_restart_reason": reason,
             "player_restarts": playerRestarts,
         ])
         Task { [weak self] in await self?.sendPlayerMetrics(payload: restartPayload) }
         resumingFromRestart = true
         loadStream(url: refreshed)
+    }
+
+    /// #778 — METHOD 3 of 4: cheap-first jump-to-live recovery, tried BEFORE a
+    /// restart. On a sustained live stall (`liveResyncDue`) seek toward the live
+    /// edge — the recovery AVPlayer won't do itself when the wanted segment has
+    /// rolled off the sliding window. Unlike `retry()` it KEEPS the AVPlayerItem
+    /// (no `playerRestarts`/`attempt_id` bump) — a within-item nudge, emitted as a
+    /// distinct `live_resync` event (reason `live_resync_seek`). Verify-then-
+    /// escalate: if the seek restores progress it's a method-3 recovery; if not,
+    /// escalate to METHOD 4 — `scheduleAutoRecoveryRestart(auto_recovery_live_resync)`,
+    /// a full rebuild. Gated on `autoRecovery` by the caller.
+    private func attemptLiveResyncSeek() {
+        // Don't act on a play we've already terminally closed (sticky terminal).
+        guard diagnostics.terminalStatus == nil else { return }
+        // A rebuild is already scheduled, or a prior nudge is still pending —
+        // don't pile on.
+        guard autoRecoveryRestartTimer == nil, !liveResyncInFlight else { return }
+        guard let item = player.currentItem else { return }
+        // Anti-fight guard: if AVPlayer is about to resume on its own
+        // (automaticallyWaitsToMinimizeStalling), a forced live-edge seek would
+        // needlessly drop buffered content and cause a visible jump. Let it.
+        if item.isPlaybackLikelyToKeepUp {
+            log("LIVE_RESYNC: skipped — likelyToKeepUp, AVPlayer self-recovering")
+            return
+        }
+
+        liveResyncInFlight = true
+        log("LIVE_RESYNC: nudging toward live edge (stall recovery)")
+        // Within-item observability event — distinct name so dashboards don't
+        // count it as a restart; reason matches the escalation reason below.
+        let payload = buildMetricsPayload(event: "live_resync", at: Date(), extra: [
+            "player_metrics_restart_reason": "live_resync_seek",
+        ])
+        Task { [weak self] in await self?.sendPlayerMetrics(payload: payload) }
+        // `automaticallyPreservesTimeOffsetFromLive` keeps this at the server
+        // HOLD-BACK margin, not the bleeding edge — reduces immediate re-stall.
+        seekToLiveEdge(item: item)
+
+        // Verify-then-escalate: if the nudge restored progress, treat it as a
+        // natural recovery; otherwise fall through to the rebuild ladder.
+        let scheduledAtTime = diagnostics.currentTime
+        Timer.scheduledTimer(withTimeInterval: 5, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.liveResyncInFlight = false
+                guard self.diagnostics.terminalStatus == nil else { return }
+                let advanced = self.diagnostics.currentTime > scheduledAtTime + 0.5
+                if self.diagnostics.state == "playing" && advanced {
+                    self.log("LIVE_RESYNC: recovered via seek nudge")
+                    self.autoRecoveryAttempts = 0
+                    return
+                }
+                self.log("LIVE_RESYNC: seek did not restore progress — escalating to restart")
+                self.scheduleAutoRecoveryRestart(reason: "auto_recovery_live_resync")
+            }
+        }
     }
 
     /// Full tear-down + recreate. Replaces the AVPlayer instance,
@@ -1690,14 +1774,18 @@ final class PlayerViewModel: ObservableObject {
         // auto-recovery flag. AndroidView counterpart's NO_MEMORY path
         // doesn't apply here.
         statusText = "Error: \(message)"
-        // Auto-recovery is a reattach, not a fresh bootstrap: replay the
-        // proxy.*-stripped reattach URL so a reaped session comes back
-        // unconfigured rather than re-materialized at pattern step 0 (#719).
-        if autoRecovery, let url = reattachURL ?? currentURL {
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 500_000_000)
-                self?.loadStream(url: url)
-            }
+        // #703a pure-.failed model: a failed item drives the EXPONENTIAL-BACKOFF
+        // restart loop (scheduleAutoRecoveryRestart → retry replays the #719
+        // proxy.*-stripped reattach URL, 2/4/8s backoff, max 3 attempts, then a
+        // clean play_end close on exhaustion) — NOT an immediate, uncapped
+        // reattach. This is the single recovery path now that the time-based
+        // detectors (frozen/segment/zero-buffer/wedge) are observability-only.
+        // The per-item `itemFatalHandled` latch (set above) resets in
+        // startPlayback when the loop's retry() builds the new item, so a
+        // .failed on the rebuilt item re-enters the loop; the loop's attempt
+        // counter bounds it and closes the play after autoRecoveryMaxAttempts.
+        if autoRecovery, reattachURL ?? currentURL != nil {
+            scheduleAutoRecoveryRestart(reason: "auto_recovery_failure")
             return
         }
         // No auto-recovery → this error is terminal. start_failure if
@@ -1751,6 +1839,16 @@ final class PlayerViewModel: ObservableObject {
                 domain: nsErr.domain,
                 details: nsErr.localizedDescription
             )
+        } else if diagnostics.lastErrorCode != 0 || !diagnostics.lastErrorDomain.isEmpty {
+            // #703a — no NSError in hand (e.g. retry-exhaustion close). Fall
+            // back to the last AVPlayerItemErrorLog entry so the terminal row
+            // still carries the classifying CoreMedia/HTTP code that drove the
+            // failure, rather than a blank terminal_error_*.
+            diagnostics.markTerminalError(
+                code: diagnostics.lastErrorCode,
+                domain: diagnostics.lastErrorDomain,
+                details: diagnostics.lastErrorLog.isEmpty ? message : diagnostics.lastErrorLog
+            )
         }
         endSession(status: status, reason: "unknown")
         NSLog("[endSession] fatal status=\(status) message=\(message) err=\((error as NSError?).map { "\($0.domain)#\($0.code)" } ?? "none")")
@@ -1771,6 +1869,11 @@ final class PlayerViewModel: ObservableObject {
     private static let flagPlayIdRotation = "is.flag.play_id_rotation_s"
     private static let flagPreviewVideoSlots = "is.flag.preview_video_slots"
     private static let flagPeakBitrate = "is.flag.peak_bitrate_mbps"
+    // #703a — characterization knobs to shorten the recovery thresholds so the
+    // detectors trip inside a test window (defaults live on PlaybackDiagnostics).
+    private static let flagLiveResyncStallS = "is.flag.live_resync_stall_s" // #778
+    private static let flagWedgeConfirmS = "is.flag.wedge_confirm_s"
+    private static let flagAutoRecoveryBaseDelayS = "is.flag.auto_recovery_base_delay_s"
     private static let flagStartsFirstVariant = "is.flag.starts_first_variant"
     private static let lastPlayedKey = "is.lastPlayed"
     private static let viewCountsKey = "is.viewCounts"
@@ -1804,6 +1907,15 @@ final class PlayerViewModel: ObservableObject {
         }
     }
 
+    /// Read a Double flag that may have been set as an NSNumber (UI/persisted)
+    /// OR a String (NSArgumentDomain launch-arg, e.g. `-is.flag.x 4`). Returns
+    /// nil when the key is absent or unparseable.
+    private static func doubleFlag(_ d: UserDefaults, _ key: String) -> Double? {
+        if let n = d.object(forKey: key) as? NSNumber { return n.doubleValue }
+        if let s = d.string(forKey: key), let v = Double(s) { return v }
+        return nil
+    }
+
     private func loadAdvancedFlags() {
         let d = UserDefaults.standard
         developerMode    = d.bool(forKey: Self.flagDevMode)
@@ -1822,6 +1934,19 @@ final class PlayerViewModel: ObservableObject {
         // and still reads the UI-persisted NSNumber correctly. Was the reason
         // the cold-start clamp never engaged on fleet sims.
         preferredPeakBitRateMbps = max(0, d.integer(forKey: Self.flagPeakBitrate))
+        // #703a — recovery-threshold overrides. NSArgumentDomain delivers a
+        // launch-arg value as a STRING, so coerce both the NSNumber (UI-set) and
+        // the string (launch-arg) forms; only apply when > 0 so an absent flag
+        // leaves the PlaybackDiagnostics defaults (6s / 120s) intact.
+        if let v = Self.doubleFlag(d, Self.flagLiveResyncStallS), v > 0 { // #778
+            diagnostics.liveResyncStallSeconds = v
+        }
+        if let v = Self.doubleFlag(d, Self.flagWedgeConfirmS), v > 0 {
+            diagnostics.wedgeConfirmSeconds = v
+        }
+        if let v = Self.doubleFlag(d, Self.flagAutoRecoveryBaseDelayS), v > 0 {
+            autoRecoveryBaseDelaySeconds = v
+        }
         startsOnFirstEligibleVariant = d.bool(forKey: Self.flagStartsFirstVariant)
         // First launch: no key yet → use the device's hardware cap so
         // the user starts with the richest preview their hardware can
@@ -1976,13 +2101,14 @@ extension PlayerViewModel {
                 guard let self, frozen else { return }
                 let payload = self.buildMetricsPayload(event: "frozen", at: Date())
                 Task { await self.sendPlayerMetrics(payload: payload) }
-                if self.autoRecovery {
-                    // The recovery timer's per-attempt HAR (force=true)
-                    // captures the same incident a moment later.
-                    self.scheduleAutoRecoveryRestart(reason: "auto_recovery_frozen")
-                } else {
-                    Task { await self.requestHARSnapshot(reason: "frozen") }
-                }
+                // #703a — pure-.failed recovery model: the time-based detectors
+                // (frozen/segment-stall/zero-buffer/wedge) are observability-only.
+                // ONLY AVPlayerItem.status==.failed (+ the failure binding) drives
+                // the exponential-backoff restart loop — so the player reaches a
+                // real failed state before we rebuild, instead of being yanked at
+                // 3s. To restore frozen→rebuild, re-add scheduleAutoRecoveryRestart
+                // ("auto_recovery_frozen") here behind `self.autoRecovery`.
+                Task { await self.requestHARSnapshot(reason: "frozen") }
             }
             .store(in: &cancellables)
 
@@ -1993,10 +2119,40 @@ extension PlayerViewModel {
                 guard let self, stalled else { return }
                 let payload = self.buildMetricsPayload(event: "segment_stall", at: Date())
                 Task { await self.sendPlayerMetrics(payload: payload) }
+                // #703a pure-.failed model: observability-only (no rebuild here).
+                Task { await self.requestHARSnapshot(reason: "segment_stall") }
+            }
+            .store(in: &cancellables)
+
+        // #778 — live-resync LADDER. `liveResyncDue` flips after a long no-progress
+        // stall (default 45s) that NEITHER the `.failed` terminal path NOR the
+        // `stallStuck` auto-pause path caught — the silent bandwidth-starvation hang
+        // (`state=stalled, rate=1`, frozen playhead) the #703a sweep surfaced for
+        // rate_choke / segment-timeout. Recovery is a two-rung ladder, both rungs
+        // tagged so the recovery METHOD is attributable:
+        //   • METHOD 3 — `attemptLiveResyncSeek()`: cheap jump-to-live seek, keeps
+        //     the item, emits `live_resync` (reason `live_resync_seek`). Tried FIRST.
+        //   • METHOD 4 — if the seek doesn't restore progress, it escalates to
+        //     `scheduleAutoRecoveryRestart(auto_recovery_live_resync)`, a full rebuild.
+        // (METHOD 1 = `.failed`→`auto_recovery_failure`, METHOD 2 = `stallStuck`→
+        // `auto_recovery_stuck`; both go straight to restart — a dead/auto-paused
+        // item can't be seek-rescued.)
+        //
+        // Guards: skip if the play is already terminal, OR if a restart is already
+        // pending (`autoRecoveryRestartTimer != nil`) — so for faults that DO reach
+        // `.failed`/`stuck`, those faster paths fire first and this never piles on.
+        // It only acts on the gap they miss.
+        diagnostics.$liveResyncDue
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] due in
+                guard let self, due else { return }
+                guard self.diagnostics.terminalStatus == nil,
+                      self.autoRecoveryRestartTimer == nil else { return }
                 if self.autoRecovery {
-                    self.scheduleAutoRecoveryRestart(reason: "auto_recovery_segment_stall")
+                    self.attemptLiveResyncSeek()
                 } else {
-                    Task { await self.requestHARSnapshot(reason: "segment_stall") }
+                    Task { await self.requestHARSnapshot(reason: "live_resync") }
                 }
             }
             .store(in: &cancellables)
@@ -2014,10 +2170,34 @@ extension PlayerViewModel {
                 guard let self, wedged else { return }
                 let payload = self.buildMetricsPayload(event: "wedge_detected", at: Date())
                 Task { await self.sendPlayerMetrics(payload: payload) }
+                // #703a pure-.failed model: the 120s wedge is observability-only.
+                // It's also largely shadowed now — without the time-based rebuilds
+                // a wedged player surfaces as .failed and the failure binding (not
+                // this) drives the restart loop. Re-add scheduleAutoRecoveryRestart
+                // ("wedge_auto_recovery") behind `self.autoRecovery` to restore.
+                Task { await self.requestHARSnapshot(reason: "wedge_detected") }
+            }
+            .store(in: &cancellables)
+
+        // #703a — player-STUCK recovery. `stallStuck` flips true when AVPlayer
+        // auto-pauses mid-stall (timeControlStatus → .paused, player.rate → 0):
+        // the buffer drained, the player gave up, and it will NOT self-recover —
+        // yet it also does NOT transition to .failed, so the pure-.failed path
+        // never fires. So this needs its own trigger into the SAME restart loop,
+        // tagged with a stuck-specific reason (distinct from the failed path's
+        // `auto_recovery_failure`). The restart's retry() rebuilds the item and
+        // re-syncs to the live offset, which is what actually un-sticks it.
+        diagnostics.$stallStuck
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] stuck in
+                guard let self, stuck else { return }
+                let payload = self.buildMetricsPayload(event: "player_stuck", at: Date())
+                Task { await self.sendPlayerMetrics(payload: payload) }
                 if self.autoRecovery {
-                    self.scheduleAutoRecoveryRestart(reason: "wedge_auto_recovery")
+                    self.scheduleAutoRecoveryRestart(reason: "auto_recovery_stuck")
                 } else {
-                    Task { await self.requestHARSnapshot(reason: "wedge_detected") }
+                    Task { await self.requestHARSnapshot(reason: "player_stuck") }
                 }
             }
             .store(in: &cancellables)
@@ -2163,9 +2343,21 @@ extension PlayerViewModel {
     }
 
     fileprivate func scheduleAutoRecoveryRestart(reason: String) {
+        // #703a — sticky terminal: once the play is closed out, never schedule
+        // more recovery work for it.
+        if diagnostics.terminalStatus != nil { return }
         if autoRecoveryRestartTimer != nil { return }
         if autoRecoveryAttempts >= autoRecoveryMaxAttempts {
-            log("Auto-recovery: exhausted after \(autoRecoveryAttempts) consecutive attempts — giving up")
+            // #703a — give-up no longer dangles the play `in_progress` until the
+            // proxy's 5-min reaper (#692). Close the play_id cleanly: emit a
+            // single terminal play_end tagged `<reason>_exhausted`, with
+            // terminal_error_* stamped from the last error-log entry (the nil
+            // error path in markFatalTerminal). Terminal is sticky (guard above
+            // + first-call-wins in markTerminalError), so a late natural
+            // recovery can't revive a play we've already closed.
+            let drivingReason = lastRecoveryReason ?? reason
+            log("Auto-recovery: exhausted after \(autoRecoveryAttempts) attempts — closing play (\(drivingReason)_exhausted)")
+            markFatalTerminal(error: nil, message: "\(drivingReason)_exhausted")
             return
         }
         let attempt = autoRecoveryAttempts + 1
@@ -2187,19 +2379,14 @@ extension PlayerViewModel {
                     return
                 }
                 self.autoRecoveryAttempts = attempt
+                self.lastRecoveryReason = reason
                 self.log("Auto-recovery: attempt \(attempt)/\(self.autoRecoveryMaxAttempts) restarting (\(reason))")
-                self.retry()
-                let restartPayload = self.buildMetricsPayload(event: "restart", at: Date(), extra: [
-                    "player_metrics_restart_reason": reason,
-                    "player_restarts": self.playerRestarts
-                ])
-                Task { [weak self] in await self?.sendPlayerMetrics(payload: restartPayload) }
-                // Each auto-recovery attempt deserves its own HAR — bypass
-                // the per-player debounce so back-to-back attempts inside
-                // the 30s window each produce a snapshot.
-                Task { [weak self] in
-                    await self?.requestHARSnapshot(reason: reason, attempt: attempt, force: true)
-                }
+                // #703a — retry(reason:) emits the single `restart` event tagged
+                // with the real reason AND its own forced HAR. No second emit
+                // here: previously every auto-recovery attempt produced BOTH a
+                // "user_retry" row (from retry()) and a real-reason row, doubling
+                // the restart count on the dashboard.
+                self.retry(reason: reason)
                 self.scheduleAutoRecoverySuccessCheck()
             }
         }
@@ -2212,6 +2399,8 @@ extension PlayerViewModel {
                 guard let self else { return }
                 self.autoRecoveryVerifyTimer = nil
                 if self.autoRecoveryRestartTimer != nil { return }
+                // #703a — don't revive a play we've already terminally closed.
+                guard self.diagnostics.terminalStatus == nil else { return }
                 let playingCleanly = self.diagnostics.state == "playing"
                     && !self.diagnostics.frozenDetected
                     && !self.diagnostics.segmentStallDetected
@@ -2238,7 +2427,11 @@ extension PlayerViewModel {
             return
         }
         if now.timeIntervalSince(zeroBufferStartedAt ?? now) >= autoRecoveryThresholdSeconds {
-            scheduleAutoRecoveryRestart(reason: "auto_recovery_zero_buffer")
+            // #703a pure-.failed model: zero-buffer is observability-only (no
+            // time-based rebuild). The restart loop is driven only by the
+            // failure/.failed path. Re-add scheduleAutoRecoveryRestart(reason:
+            // "auto_recovery_zero_buffer") here to restore the 60s watchdog.
+            log("Auto-recovery: zero-buffer \(Int(autoRecoveryThresholdSeconds))s — observability-only (pure-.failed model)")
         }
     }
 

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -7,8 +7,8 @@
  *     - VARIANT     (per (resolution, bitrate) sub-lane)
  *     - DISPLAY RES
  *     - PLAYERSTATE
- *     - PLAYBACK    (FIRST_FRAME / RESTART / TIMEJUMP / SHIFT_UP /
- *                    SHIFT_DOWN / PLAYBACK_START)
+ *     - PLAYBACK    (FIRST_FRAME / NEW_PLAY / RESTART / LIVE_RESYNC / RATE→N /
+ *                    TIMEJUMP / SHIFT_UP / SHIFT_DOWN / PLAYBACK_START)
  *     - IMPAIRMENT  (STALL / FROZEN / SEGMENT_STALL / ERROR)
  *   CONTROL section
  *     - CONTROL     (CONTROL_CHANGE, USER_MARKED — operator + control
@@ -211,6 +211,11 @@ const props = defineProps<{
    *  consumers (live testing.html) can skip wiring it without
    *  breaking the component. */
   avmetricsStream?: Stream<Record<string, unknown>>;
+  /** control_events stream (proxy/harness/auto action log). Each row carries
+   *  `source` / `event` / `info` — what control mutation happened — which
+   *  drives the CONTROL lane markers. Optional; without it the CONTROL lane
+   *  has no points (control_revision alone only says "something changed"). */
+  controlStream?: Stream<Record<string, unknown>>;
 }>();
 const coord = useChartCoordination(toRef(props, 'playerId'));
 
@@ -228,12 +233,17 @@ interface IngestRow {
   stalls: number | null;
   droppedFrames: number | null;
   error: string;
+  errorCode: number | null;
+  errorDomain: string;
   firstFrameTimeS: number | null;
   videoStartTimeS: number | null;
   loopCountServer: number | null;
   controlRevision: string | null;
   playId: string | null;
   manifestVariants: { bandwidth?: number; resolution?: string }[] | null;
+  playerRestarts: number | null;
+  lastEvent: string;
+  playbackRate: number | null;
 }
 
 function tsOfRow(row: Record<string, unknown>): number {
@@ -284,6 +294,8 @@ function chRowToIngest(row: Record<string, unknown>): IngestRow | null {
     stalls: num(row.stalling_count) ?? num(row.stall_count),
     droppedFrames: num(row.frames_dropped),
     error: String(row.player_error ?? ''),
+    errorCode: num(row.error_code),
+    errorDomain: String(row.error_domain ?? '').trim(),
     firstFrameTimeS: num(row.video_first_frame_time_ms) != null
       ? (num(row.video_first_frame_time_ms) as number) / 1000
       : num(row.video_first_frame_time_s),
@@ -294,6 +306,9 @@ function chRowToIngest(row: Record<string, unknown>): IngestRow | null {
     controlRevision,
     playId: typeof row.play_id === 'string' ? row.play_id : null,
     manifestVariants: variants,
+    playerRestarts: num(row.player_restarts),
+    lastEvent: String(row.last_event ?? '').trim(),
+    playbackRate: num(row.playback_rate),
   };
 }
 
@@ -395,9 +410,21 @@ let prevLoopServer: number | null = null;
 let prevControlRev: string | null = null;
 let prevError: string | null = null;
 let prevPlayId: string | null = null;
+// #703a — play_ids already marked NEW PLAY, so the synthetic-play_id flicker
+// (manifest-URL churn between ticks) doesn't re-mark a play we've already seen.
+const seenPlayIds = new Set<string>();
 let prevFirstFrame: number | null = null;
 let prevVideoStart: number | null = null;
 let prevVariantMbps: number | null = null;
+// #703a — PLAYBACK-lane RESTART (player_restarts counter-diff) + LIVE RESYNC
+// (last_event transition). prevRestarts seeds on the first row so we mark only
+// increments, not the play's starting count.
+let prevRestarts: number | null = null;
+let prevLastEvent: string | null = null;
+// #703a — last playback_rate seen (rounded), so a PLAYBACK-lane "RATE → N"
+// marker drops on ANY rate change. rate 0 = AVPlayer paused/stuck; 1 = play;
+// other = trick/slow. Generic — copes with any rate, not just 0/1.
+let prevRate: number | null = null;
 // Watermark of the latest CH row already fed through `ingest()`. The
 // markers-stream watcher uses this to consume only NEW rows on each
 // version bump (the stream cache holds the full backfill + live tail).
@@ -715,6 +742,16 @@ function ingest(r: IngestRow) {
     prevLoopServer = null;
     prevError = null;
     prevFirstFrame = prevVideoStart = null;
+    prevRestarts = null;
+    prevLastEvent = null;
+    prevRate = null;
+    // #703a — PLAYBACK-lane NEW PLAY marker the first time a play_id appears
+    // (Set-deduped vs the synthetic-id flicker). Marks genuine new-play
+    // boundaries — e.g. each stop/restart-playback case in a sweep session.
+    if (r.playId && !seenPlayIds.has(r.playId)) {
+      seenPlayIds.add(r.playId);
+      pushPoint('PLAYBACK', t, 'NEW PLAY', '#0891b2', `\nplay_id ${r.playId.slice(0, 8)}…`);
+    }
   }
 
   // STATEFUL LANES — push every heartbeat as an event into a flat
@@ -791,15 +828,18 @@ function ingest(r: IngestRow) {
     pushPoint('IMPAIRMENT', t, 'FROZEN', '#4c1d95', `\n+${r.droppedFrames - prevDropped} dropped`);
   }
   if (r.error && r.error !== prevError) {
-    pushPoint('IMPAIRMENT', t, 'ERROR', '#e11d48', `\n${r.error}`);
+    // Include the NSError domain/code when present (e.g. "NSURLErrorDomain
+    // #-1008") — the message string alone rarely identifies the failure.
+    const code = (r.errorCode != null && r.errorCode !== 0)
+      ? `${r.errorDomain || 'error'} #${r.errorCode}` : '';
+    const detail = code ? `\n${r.error}\n${code}` : `\n${r.error}`;
+    pushPoint('IMPAIRMENT', t, 'ERROR', '#e11d48', detail);
     prevError = r.error;
   }
   if (r.stalls != null) prevStalls = r.stalls;
   if (r.droppedFrames != null) prevDropped = r.droppedFrames;
 
   // PLAYBACK — FIRST_FRAME + START TIME on first observation per play.
-  // (Legacy RESTART event was driven by `player_restarts`, which isn't
-  // persisted in CH; drop until the schema gains it.)
   if (r.firstFrameTimeS != null && r.firstFrameTimeS > 0 && prevFirstFrame !== r.firstFrameTimeS) {
     pushPoint('PLAYBACK', t, 'FIRST FRAME', '#14b8a6', `\n${r.firstFrameTimeS.toFixed(3)}s`);
     prevFirstFrame = r.firstFrameTimeS;
@@ -808,6 +848,37 @@ function ingest(r: IngestRow) {
     pushPoint('PLAYBACK', t, 'START TIME', '#15803d', `\n${r.videoStartTimeS.toFixed(3)}s`);
     prevVideoStart = r.videoStartTimeS;
   }
+  // PLAYBACK — RESTART on each player_restarts increment (#703a; the column is
+  // persisted via the lanes_v1 bundle). Seed silently on the first row so we
+  // mark only mid-play recoveries, not the play's starting count.
+  if (r.playerRestarts != null) {
+    if (prevRestarts != null && r.playerRestarts > prevRestarts) {
+      pushPoint('PLAYBACK', t, 'RESTART', '#f59e0b', `\n+${r.playerRestarts - prevRestarts} (total ${r.playerRestarts})`);
+    }
+    prevRestarts = r.playerRestarts;
+  }
+  // PLAYBACK — LIVE RESYNC: the #703a cheap seek-to-live nudge. It keeps the
+  // item (no player_restarts bump), so it's surfaced off the last_event
+  // transition rather than the counter.
+  if (r.lastEvent === 'live_resync' && prevLastEvent !== 'live_resync') {
+    pushPoint('PLAYBACK', t, 'LIVE RESYNC', '#0ea5e9', '\nseek toward live edge');
+  }
+  if (r.lastEvent) prevLastEvent = r.lastEvent;
+
+  // PLAYBACK — playback_rate transitions (#703a). Drop a "RATE → N" marker on
+  // ANY rate change (rounded to ignore float noise), labelled with the actual
+  // rate so it copes with anything: 0 = paused/stuck (the stuck signal that the
+  // state lane masks), 1 = play, 2 = ff, 0.5 = slow, etc. Colour: 0 red, 1
+  // green, anything else amber (trick/slow).
+  if (r.playbackRate != null) {
+    const rate = Math.round(r.playbackRate * 100) / 100;
+    if (prevRate != null && rate !== prevRate) {
+      const color = rate === 0 ? '#dc2626' : (rate === 1 ? '#16a34a' : '#f59e0b');
+      // Label IS the A→B transition (e.g. "RATE 0 → 1"); no redundant detail.
+      pushPoint('PLAYBACK', t, `RATE ${prevRate} → ${rate}`, color, '');
+    }
+    prevRate = rate;
+  }
 
   // SERVER — LOOP increments.
   if (r.loopCountServer != null && prevLoopServer != null && r.loopCountServer > prevLoopServer) {
@@ -815,10 +886,13 @@ function ingest(r: IngestRow) {
   }
   if (r.loopCountServer != null) prevLoopServer = r.loopCountServer;
 
-  // CONTROL — record any control_revision change.
-  if (r.controlRevision && r.controlRevision !== '0' && r.controlRevision !== prevControlRev) {
+  // CONTROL — fallback only. control_revision is an opaque revision stamp, so
+  // this just says "something changed". When a control_events stream is wired
+  // (SessionDisplay), the richer drainControlRows() drives the lane with the
+  // actual action (event/info/source) instead — see below.
+  if (!props.controlStream && r.controlRevision && r.controlRevision !== '0' && r.controlRevision !== prevControlRev) {
     if (prevControlRev != null && prevControlRev !== '0') {
-      pushPoint('CONTROL', t, 'CONTROL CHANGE', '#7c3aed', `\n${prevControlRev} → ${r.controlRevision}`);
+      pushPoint('CONTROL', t, 'CONTROL CHANGE', '#7c3aed', '\nrevision changed');
     }
     prevControlRev = r.controlRevision;
   }
@@ -1223,6 +1297,42 @@ watch(
   { immediate: true },
 );
 
+/* ─── control_events drain (#474) — drives the CONTROL lane with the actual
+ * action (event/info/source) instead of the opaque control_revision. Low
+ * volume, so one pushPoint per row (no AVMetrics-style sizing/reflow). */
+let lastControlIngestedMs = -Infinity;
+async function drainControlRows() {
+  const stream = props.controlStream;
+  if (!stream) return;
+  const raw = stream.inRange(
+    lastControlIngestedMs === -Infinity ? 0 : lastControlIngestedMs + 1,
+    Number.MAX_SAFE_INTEGER,
+  );
+  if (!raw.length) return;
+  await ensureTimeline();
+  let highWater = lastControlIngestedMs;
+  for (const row of raw) {
+    const t = tsOfRow(row);
+    if (!Number.isFinite(t) || t <= lastControlIngestedMs) continue;
+    const event = String(row.event ?? '').trim();
+    const source = String(row.source ?? '').trim();
+    const info = String(row.info ?? '').trim();
+    if (event) {
+      // Label = what + who (e.g. "shape · harness"); tooltip detail = the
+      // info payload (rate, fault kind, pattern step, labels, …).
+      const label = source ? `${event} · ${source}` : event;
+      pushPoint('CONTROL', t, label, EVENT_LANES.CONTROL.color, info ? `\n${info}` : '');
+    }
+    if (t > highWater) highWater = t;
+  }
+  lastControlIngestedMs = highWater;
+}
+watch(
+  () => props.controlStream?.version.value ?? 0,
+  () => { void drainControlRows(); },
+  { immediate: true },
+);
+
 // Toggle the AVMETRICS lane's visibility when activity appears or
 // disappears (issue #486). Single boolean memo so we only call
 // rebuildGroups on the actual transition — every other version
@@ -1275,11 +1385,13 @@ function resetIngest() {
   pendingLiveAV.length = 0;
   lastIngestedMs = -Infinity;
   lastAVIngestedMs = -Infinity;
+  lastControlIngestedMs = -Infinity;
   prevStalls = prevDropped = null;
   prevLoopServer = null;
   prevControlRev = null;
   prevError = null;
   prevPlayId = null;
+  seenPlayIds.clear();
   prevFirstFrame = prevVideoStart = null;
   prevVariantMbps = null;
   if (itemsDS) {

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1784,7 +1784,7 @@ function skipToEnd() {
         :from-ms="cycleBandsDomain.fromMs"
         :to-ms="cycleBandsDomain.toMs"
       />
-      <EventsTimeline :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
+      <EventsTimeline :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" />
     </CollapsibleSection>
 
     <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">

--- a/go.work.sum
+++ b/go.work.sum
@@ -126,6 +126,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
 golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/tests/characterization/modes/fault_recovery_test.go
+++ b/tests/characterization/modes/fault_recovery_test.go
@@ -1,0 +1,612 @@
+package modes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
+)
+
+// Fault-recovery probe — a DEDICATED investigative mode (not a characterization
+// of normal playback). It warms a player to a steady playing state, arms a
+// fault, and classifies the outcome — does AVPlayer go `.failed`, go STUCK
+// (auto-paused mid-stall, rate 0), or ride it out — with time + faulted-request
+// thresholds, then whether it recovers on clear.
+//
+// Two modes:
+//   - FAULT_PROBE_ALL=1   sweep the full fault × kind matrix, one case after
+//                         another (stop+restart playback between — NO sim
+//                         reboot), and print a summary matrix at the end.
+//   - FAULT_PROBE=<fault> run a SINGLE fault (default) for focused drilling.
+//
+// Env axes:
+//
+//	FAULT_PROBE              single-mode fault (default "corrupted"):
+//	                           rate_choke / timeout / 404 / 500 / corrupted /
+//	                           request_{connect,first_byte,body}_{hang,reset,delayed}
+//	FAULT_PROBE_KIND         request kind (default "segment"); also manifest / master_manifest
+//	FAULT_PROBE_ALL          =1 → sweep the whole matrix (ignores FAULT_PROBE/_KIND)
+//	FAULT_PROBE_WARMUP_S     steady-play warmup before arming (default 20)
+//	FAULT_PROBE_HOLD_S       max hold under the fault (default 60; breaks early once a state is reached)
+//	FAULT_PROBE_RECOVER_S    observe window after clearing (default 20)
+//	FAULT_PROBE_AUTORECOVERY auto-recovery flag (default "false" — observe the RAW state)
+//	FAULT_PROBE_RESTART_DELAY_S  auto-recovery backoff (default 60)
+//	FAULT_PROBE_CLEAR_ON_FAILED  =1 → clear the fault the moment a state is reached
+//	                              (restart-into-clean-network testing; single mode)
+//
+// Appium launch mode only (skips otherwise). Honors CHARACTERIZATION_DEVICE_UDID.
+
+func TestFaultRecoveryIPadSim(t *testing.T) { runFaultRecovery(t, runner.PlatformIPadSim) }
+func TestFaultRecoveryIPhone(t *testing.T)  { runFaultRecovery(t, runner.PlatformIPhone) }
+
+func runFaultRecovery(t *testing.T, p runner.Platform) {
+	runFleet(t, p, runFaultRecoveryOnDevice)
+}
+
+type faultCase struct{ fault, kind string }
+
+type caseResult struct {
+	fault, kind  string
+	playID       string // for post-hoc CH recovery-method attribution
+	outcome      string // failed / stuck / rode_it_out / launch_failed
+	timeToStateS int    // seconds to reach failed/stuck (-1 if never)
+	faultedReqs  int    // proxy-applied faults at that point (-1 if unknown)
+	termErr      int    // terminal_error_code if failed
+	// Per-play residency at case end (cumulative): how much it stalled vs how
+	// much it actually played before the fault killed (or it rode out) the play.
+	stallCount uint32
+	stallMs    uint32
+	playCount  uint32
+	playMs     uint32
+	everStuck  bool // stall_stuck / rate-0-while-stalled seen at any point
+	recovered  bool // returned to playing (sustained video) within the window
+	// Aggregated AVPlayer errors over the whole play, pulled from the durable CH
+	// event rows. errInfo = transient error_* (domain+code, e.g. "CoreMedia -16172");
+	// termInfo = terminal_error_* (stamped only on a real terminal close). "" = none.
+	errInfo  string
+	termInfo string
+	// recoveredVia names WHICH of the 4 recovery methods restored playback:
+	//   failure      — METHOD 1: .failed → auto_recovery_failure restart
+	//   stuck        — METHOD 2: stallStuck → auto_recovery_stuck restart
+	//   live_seek    — METHOD 3: live-stall → jump-to-live seek (no restart)
+	//   live_restart — METHOD 4: live-stall seek failed → auto_recovery_live_resync restart
+	//   natural      — rode it out, resumed on clear with no intervention
+	//   "-"          — did not recover
+	recoveredVia string
+}
+
+// buildFaultCases returns the sweep matrix (FAULT_PROBE_ALL) or a single case.
+func buildFaultCases() []faultCase {
+	if envOr("FAULT_PROBE_ALL", "") != "" {
+		faults := []string{
+			"corrupted", "404", "500",
+			"request_first_byte_reset", "request_connect_reset", "request_body_reset",
+			"request_first_byte_hang", "request_body_hang",
+			"rate_choke", "timeout",
+		}
+		cs := make([]faultCase, 0, len(faults)+1)
+		for _, f := range faults {
+			cs = append(cs, faultCase{f, "segment"})
+		}
+		// Also fault the media-playlist refresh — it IS re-fetched continuously on a
+		// live stream, so the fault bites mid-stream. (No master_manifest case: the
+		// multivariant playlist is fetched once at startup and never re-requested in
+		// steady state, so arming it after warmup is a no-op — it's a startup-failure
+		// concern, out of scope for this mid-stream recovery probe.)
+		cs = append(cs, faultCase{"404", "manifest"})
+		return cs
+	}
+	return []faultCase{{envOr("FAULT_PROBE", "corrupted"), envOr("FAULT_PROBE_KIND", "segment")}}
+}
+
+func runFaultRecoveryOnDevice(t *testing.T, p runner.Platform, dev runner.Device, _ *fleetBarriers) {
+	mode, launcher, err := runner.PickMode()
+	if err != nil {
+		t.Skipf("PickMode: %v", err)
+	}
+	appium, isAppium := launcher.(*runner.AppiumLauncher)
+	if !isAppium {
+		t.Skipf("fault-recovery probe requires LAUNCH_MODE=appium (got %s)", mode)
+	}
+	picked := &dev
+	t.Logf("device: %s", picked)
+
+	warmup := time.Duration(envInt("FAULT_PROBE_WARMUP_S", 20)) * time.Second
+	hold := time.Duration(envInt("FAULT_PROBE_HOLD_S", 60)) * time.Second
+	recover := time.Duration(envInt("FAULT_PROBE_RECOVER_S", 20)) * time.Second
+	autoRec := envOr("FAULT_PROBE_AUTORECOVERY", "false")
+	restartDelay := envOr("FAULT_PROBE_RESTART_DELAY_S", "60")
+	restartBackoff := time.Duration(envInt("FAULT_PROBE_RESTART_DELAY_S", 60)) * time.Second
+
+	cases := buildFaultCases()
+
+	// Overall budget: per-case (warmup+hold + wait-for-restart + grace) + restart-playback
+	// overhead. The dynamic recovery window can wait up to restartBackoff+margin for the
+	// scheduled restart, then `recover` (grace) more after it fires.
+	per := warmup + hold + restartBackoff + recover + 50*time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(len(cases))*per+4*time.Minute)
+	defer cancel()
+
+	// --- launch ONCE to a steady playing state ---
+	pid := runner.NewPlayerID()
+	launchArgs := []string{
+		"-is.player_id", pid,
+		"-is.flag.auto_recovery", autoRec,
+		"-is.flag.auto_recovery_base_delay_s", restartDelay,
+		"-is.flag.skip_home", "false",
+		"-is.flag.dev_mode", "true",
+	}
+	// CHAR_CONTENT pins the clip every case plays (e.g. insane_new_p200_h264) via
+	// the is.lastPlayed NSArgumentDomain key — identical content + variant ladder
+	// across cases, same as the other modes (sweep.go). Set once at launch;
+	// persists across the stop/restart-playback cycles.
+	if clip := envOr("CHAR_CONTENT", ""); clip != "" {
+		launchArgs = append(launchArgs, "-is.lastPlayed", clip)
+		t.Logf("content pinned: %s", clip)
+	}
+	appium.SetLaunchArgs(launchArgs)
+	t.Logf("fault-recovery: %d case(s), autoRecovery=%s, restart_backoff=%ss, warmup/hold/recover=%s/%s/%s",
+		len(cases), autoRec, restartDelay, warmup, hold, recover)
+	launchCtx, lc := context.WithTimeout(ctx, 4*time.Minute)
+	sess, lerr := appium.LaunchToHome(launchCtx, *picked)
+	lc()
+	if lerr != nil {
+		t.Fatalf("LaunchToHome: %v", lerr)
+	}
+	sess.PlayerID = pid
+	if err := resumeUntilHeartbeat(ctx, t, appium, sess, picked); err != nil {
+		t.Fatalf("no heartbeat after resume: %v", err)
+	}
+	defer func() {
+		_ = sess.ClearFaults(context.Background())
+		_ = sess.ClearShape(context.Background())
+		_ = sess.CloseViaUI(context.Background())
+	}()
+
+	results := make([]caseResult, 0, len(cases))
+	for i, c := range cases {
+		if i > 0 {
+			// Stop + restart playback → fresh play_id, clean per-play state. The
+			// app and simulator stay up — NO reboot, NO app relaunch.
+			t.Logf("──── restart playback for next case: %s/%s ────", c.fault, c.kind)
+			_ = sess.ClearFaults(ctx)
+			_ = sess.ClearShape(ctx)
+			_ = sess.CloseViaUI(ctx)
+			if err := resumeUntilHeartbeat(ctx, t, appium, sess, picked); err != nil {
+				t.Logf("case %s/%s: restart playback failed: %v — skipping", c.fault, c.kind, err)
+				results = append(results, caseResult{fault: c.fault, kind: c.kind, outcome: "launch_failed", timeToStateS: -1, faultedReqs: -1})
+				continue
+			}
+		}
+		results = append(results, runOneCase(ctx, t, sess, c, warmup, hold, recover, restartBackoff))
+	}
+
+	if len(cases) > 1 {
+		// Let the forwarder flush the last case's events to ClickHouse, then
+		// attribute each recovery from the durable event rows (overrides the
+		// lossy live hint) before rendering the table.
+		_ = holdContext(ctx, 10*time.Second)
+		attributeRecoveries(ctx, t, results)
+		printSweepSummary(t, results, recover)
+	}
+}
+
+// resumeUntilHeartbeat starts playback and waits for the player to report,
+// retrying through the transient empty-catalogue window after a (re)launch.
+func resumeUntilHeartbeat(ctx context.Context, t *testing.T, appium *runner.AppiumLauncher, sess *runner.Session, picked *runner.Device) error {
+	t.Helper()
+	var herr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if rerr := appium.ResumePlayback(ctx, *picked); rerr != nil {
+			t.Logf("resume attempt %d: %v", attempt, rerr)
+		}
+		if herr = sess.WaitForHeartbeat(ctx, 50*time.Second); herr == nil {
+			return nil
+		}
+	}
+	return herr
+}
+
+// runOneCase warms up, arms one fault, classifies the outcome (failed / stuck /
+// rode_it_out) with time + faulted-request thresholds, then checks whether it
+// recovers on clear. Logs per-tick; returns the case summary.
+func runOneCase(ctx context.Context, t *testing.T, sess *runner.Session, c faultCase, warmup, hold, recover, restartBackoff time.Duration) caseResult {
+	res := caseResult{fault: c.fault, kind: c.kind, outcome: "rode_it_out", timeToStateS: -1, faultedReqs: -1}
+	clearOnFailed := envOr("FAULT_PROBE_CLEAR_ON_FAILED", "") != ""
+	tag := fmt.Sprintf("[%s/%s]", c.fault, c.kind)
+
+	if err := holdContext(ctx, warmup); err != nil {
+		return res
+	}
+	sampleProbe(ctx, t, sess, tag+" baseline")
+	playID, _ := sess.CurrentPlayID(ctx)
+	res.playID = playID
+	probeStart := time.Now()
+	t.Logf("%s play_id: %s", tag, playID)
+
+	// Recovery-method attribution. Track which trigger events the player emits
+	// (error / player_stuck / live_resync) and whether a restart fired vs the
+	// baseline — together these name which of the 4 methods restored playback.
+	caseBaseRestarts := 0
+	if rec, err := sess.PlayerState(ctx); err == nil && rec != nil && rec.PlayerMetrics != nil {
+		caseBaseRestarts = rec.PlayerMetrics.PlayerRestarts
+	}
+	var sawError, sawStuck, sawLiveSeek bool
+	noteEvent := func(ev string) {
+		switch ev {
+		case "error":
+			sawError = true
+		case "player_stuck":
+			sawStuck = true
+		case "live_resync":
+			sawLiveSeek = true
+		}
+	}
+
+	clear, desc := armProbeFault(ctx, t, sess, c.fault, c.kind)
+	t.Logf("%s ARMED: %s", tag, desc)
+
+	// --- observe under the fault ---
+	deadline := time.Now().Add(hold)
+	tick := 0
+	prevReqs := -1
+	cleared := false
+	for time.Now().Before(deadline) {
+		if err := holdContext(ctx, 2*time.Second); err != nil {
+			break
+		}
+		tick += 2
+		rec, err := sess.PlayerState(ctx)
+		if err != nil || rec == nil || rec.PlayerMetrics == nil {
+			t.Logf("  +%2ds (no state: %v)", tick, err)
+			continue
+		}
+		m := rec.PlayerMetrics
+		noteEvent(m.LastEvent)
+		faulted, reqInfo := reqCadence(ctx, sess, playID, probeStart, &prevReqs)
+		res.stallCount, res.stallMs = m.StallingCount, m.StallingTimeMs
+		res.playCount, res.playMs = m.PlayingCount, m.PlayingTimeMs
+		failed := m.TerminalErrorCode != 0 || m.ErrorCount > 0 || m.LastEvent == "error" ||
+			m.PlaybackStatus == "mid_stream_failure" || m.PlaybackStatus == "start_failure"
+		stuck := m.StallStuck || (m.PlaybackRate == 0 && m.State == "stalled")
+		if stuck {
+			res.everStuck = true
+		}
+		if res.timeToStateS < 0 && (failed || stuck) {
+			res.timeToStateS = tick
+			res.faultedReqs = faulted
+			if failed {
+				res.outcome = "failed"
+				res.termErr = int(m.TerminalErrorCode)
+			} else {
+				res.outcome = "stuck"
+			}
+			if clearOnFailed && !cleared && clear != nil {
+				clear()
+				cleared = true
+				t.Logf("  >>> CLEARED %s on %s", desc, res.outcome)
+			}
+		}
+		t.Logf("  +%2ds state=%-9s rate=%.0f stuck=%t last_event=%-13s term_err=%d status=%-17s restarts=%d bufEnd=%.1f%s",
+			tick, m.State, m.PlaybackRate, m.StallStuck, m.LastEvent, m.TerminalErrorCode, m.PlaybackStatus, m.PlayerRestarts, m.BufferEndS, reqInfo)
+		// Once a terminal state is confirmed, no need to keep holding.
+		if res.timeToStateS >= 0 && tick >= res.timeToStateS+6 {
+			break
+		}
+	}
+
+	// --- clear + observe recovery (does it come back without a restart?) ---
+	if clear != nil {
+		clear()
+	}
+	// Dynamic recovery window. Under auto-recovery the restart fires ~restartBackoff
+	// after .failed (which happened mid-hold), so a fixed wall-clock window races a
+	// moving target — it can close before the (variable-latency) restart even fires.
+	// Instead: wait up to restartBackoff+margin for a restart to fire, then watch
+	// `recover` (grace, e.g. 60s) from THAT restart. Each new restart in the backoff
+	// chain re-arms the grace; we give up if no video by then.
+	//
+	// "Recovered" is NOT the first non-paused tick — a restart goes buffering→playing
+	// and can re-stall. We require the video to play CONTINUOUSLY for playConfirm (10s)
+	// with the playhead (position_s) actually advancing, so a rate=1-but-frozen blip
+	// doesn't count. Once confirmed → recovered; if the grace expires first → gave up.
+	grace := recover
+	playConfirm := time.Duration(envInt("FAULT_PROBE_PLAY_CONFIRM_S", 10)) * time.Second
+	waitForRestart := restartBackoff + 30*time.Second
+	baseRestarts := -1
+	if rec, err := sess.PlayerState(ctx); err == nil && rec != nil && rec.PlayerMetrics != nil {
+		baseRestarts = rec.PlayerMetrics.PlayerRestarts
+	}
+	t.Logf("%s CLEARED — dynamic recovery window (wait ≤%s for restart, then %s grace; confirm=%s sustained video; base_restarts=%d)",
+		tag, waitForRestart, grace, playConfirm, baseRestarts)
+	deadline = time.Now().Add(waitForRestart)
+	restartSeen := false
+	playingSinceTick := -1 // start of the current uninterrupted playing+advancing streak
+	lastPos := -1.0
+	rtick := 0
+	for time.Now().Before(deadline) {
+		if err := holdContext(ctx, 2*time.Second); err != nil {
+			break
+		}
+		rtick += 2
+		rec, err := sess.PlayerState(ctx)
+		if err != nil || rec == nil || rec.PlayerMetrics == nil {
+			continue
+		}
+		m := rec.PlayerMetrics
+		noteEvent(m.LastEvent)
+		res.stallCount, res.stallMs = m.StallingCount, m.StallingTimeMs
+		res.playCount, res.playMs = m.PlayingCount, m.PlayingTimeMs
+		// A NEW restart fired → (re)arm the grace window from now and reset the
+		// play-confirm streak (the rebuilt item must earn its 10s afresh).
+		if baseRestarts >= 0 && m.PlayerRestarts > baseRestarts {
+			restartSeen = true
+			baseRestarts = m.PlayerRestarts
+			deadline = time.Now().Add(grace)
+			playingSinceTick = -1
+			t.Logf("%s restart #%d fired at R+%ds — watching %s for %s of sustained video", tag, m.PlayerRestarts, rtick, grace, playConfirm)
+		}
+		// Real video = playing + rate + the playhead advancing since the last sample.
+		advancing := lastPos >= 0 && m.PositionS > lastPos+0.1
+		lastPos = m.PositionS
+		if m.State == "playing" && m.PlaybackRate > 0.5 && advancing {
+			if playingSinceTick < 0 {
+				playingSinceTick = rtick
+			}
+		} else {
+			playingSinceTick = -1 // streak broken — buffering, paused, or frozen
+		}
+		playingForS := 0
+		if playingSinceTick >= 0 {
+			playingForS = rtick - playingSinceTick
+		}
+		t.Logf("  R+%2ds state=%-9s rate=%.0f pos=%.1f adv=%-5t playing_for=%2ds last_event=%-13s restarts=%d",
+			rtick, m.State, m.PlaybackRate, m.PositionS, advancing, playingForS, m.LastEvent, m.PlayerRestarts)
+		// Recovered only once the video has played continuously for playConfirm.
+		if playingSinceTick >= 0 && playingForS >= int(playConfirm/time.Second) {
+			res.recovered = true
+			res.recoveredVia = classifyRecovery(m.PlayerRestarts > caseBaseRestarts, sawLiveSeek, sawStuck, sawError)
+			t.Logf("%s recovered at R+%ds via %s — video played %ds continuously (restarts=%d, restart_fired=%t)",
+				tag, rtick, res.recoveredVia, playingForS, m.PlayerRestarts, restartSeen)
+			break
+		}
+		// Sticky terminal: the app exhausted its retries and closed the play.
+		if m.LastEvent == "play_end" {
+			t.Logf("%s gave up (terminal) at R+%ds: status=%s term_err=%d", tag, rtick, m.PlaybackStatus, m.TerminalErrorCode)
+			break
+		}
+	}
+	t.Logf("%s => outcome=%s time=%ds faulted=%d term_err=%d recovered_on_clear=%t",
+		tag, res.outcome, res.timeToStateS, res.faultedReqs, res.termErr, res.recovered)
+	return res
+}
+
+// reqCadence reads the play's network rows: returns the faulted-request count
+// and a log fragment with the cumulative total + per-tick delta (flat = silent).
+func reqCadence(ctx context.Context, sess *runner.Session, playID string, probeStart time.Time, prevReqs *int) (int, string) {
+	if playID == "" {
+		return -1, ""
+	}
+	rows, ferr := runner.FetchNetworkRows(ctx, sess.PlayerID, playID, probeStart, time.Now(), 5000)
+	if ferr != nil {
+		return -1, ""
+	}
+	faulted := 0
+	for _, r := range rows {
+		if r.FaultAction != "" || r.FaultType != "" {
+			faulted++
+		}
+	}
+	delta := 0
+	silent := ""
+	if *prevReqs >= 0 {
+		delta = len(rows) - *prevReqs
+		if delta == 0 {
+			silent = " SILENT"
+		}
+	}
+	*prevReqs = len(rows)
+	return faulted, fmt.Sprintf(" reqs=%d(+%d) faulted=%d%s", len(rows), delta, faulted, silent)
+}
+
+// armProbeFault applies one fault and returns a clear func + human description.
+func armProbeFault(ctx context.Context, t *testing.T, sess *runner.Session, probe, kind string) (func(), string) {
+	t.Helper()
+	switch probe {
+	case "rate_choke":
+		if err := sess.ApplyRate(ctx, 0.01); err != nil {
+			t.Fatalf("rate_choke: %v", err)
+		}
+		return func() { _ = sess.ApplyRate(context.Background(), 0) }, "rate cap 0.01 Mbps"
+	case "timeout":
+		if err := sess.SetSegmentTimeout(ctx, 3*time.Second); err != nil {
+			t.Fatalf("timeout arm: %v", err)
+		}
+		_ = sess.ApplyRate(ctx, 0.1)
+		return func() {
+			_ = sess.SetSegmentTimeout(context.Background(), 0)
+			_ = sess.ApplyRate(context.Background(), 0)
+		}, "segment timeout 3s + 0.1 Mbps"
+	default:
+		// Any HTTP/socket fault shape, applied continuously to `kind` requests.
+		if err := sess.ArmFaultRepeating(ctx, probe, kind, 100000, 1); err != nil {
+			t.Fatalf("arm fault %s/%s: %v", probe, kind, err)
+		}
+		return func() { _ = sess.ClearFaults(context.Background()) }, fmt.Sprintf("%s on %s", probe, kind)
+	}
+}
+
+// sampleProbe logs a single state snapshot with a label.
+func sampleProbe(ctx context.Context, t *testing.T, sess *runner.Session, label string) {
+	t.Helper()
+	rec, err := sess.PlayerState(ctx)
+	if err != nil || rec == nil || rec.PlayerMetrics == nil {
+		t.Logf("%s: (no state: %v)", label, err)
+		return
+	}
+	m := rec.PlayerMetrics
+	t.Logf("%s: state=%s rate=%.0f bufEnd=%.1fs vbr=%.1f restarts=%d", label, m.State, m.PlaybackRate, m.BufferEndS, m.VideoBitrateMbps, m.PlayerRestarts)
+}
+
+// printSweepSummary renders the full fault → outcome matrix.
+func printSweepSummary(t *testing.T, results []caseResult, recover time.Duration) {
+	t.Logf("════════════════════════════ FAULT-RECOVERY SWEEP SUMMARY ════════════════════════════")
+	hdr := "%-24s %-15s %-11s %6s %7s %6s %7s %5s %6s %6s %9s %-12s %-20s %-20s"
+	t.Logf(hdr, "FAULT", "KIND", "OUTCOME", "TIME_S", "FAULTED", "STALLS", "STALL_S", "PLAYS", "PLAY_S", "STUCK", "RECOVERED", "RECOVERED_VIA", "ERROR", "TERM_ERROR")
+	t.Logf(hdr, "─────", "────", "───────", "──────", "───────", "──────", "───────", "─────", "──────", "─────", "─────────", "─────────────", "─────", "──────────")
+	for _, r := range results {
+		ts, fa, via := "-", "-", r.recoveredVia
+		errInfo, termInfo := r.errInfo, r.termInfo
+		if r.timeToStateS >= 0 {
+			ts = fmt.Sprintf("%d", r.timeToStateS)
+		}
+		if r.faultedReqs >= 0 {
+			fa = fmt.Sprintf("%d", r.faultedReqs)
+		}
+		if via == "" {
+			via = "-"
+		}
+		if errInfo == "" {
+			errInfo = "-"
+		}
+		if termInfo == "" {
+			termInfo = "-"
+		}
+		t.Logf("%-24s %-15s %-11s %6s %7s %6d %7.1f %5d %6.1f %6t %9t %-12s %-20s %-20s",
+			r.fault, r.kind, r.outcome, ts, fa,
+			r.stallCount, float64(r.stallMs)/1000, r.playCount, float64(r.playMs)/1000, r.everStuck, r.recovered, via, errInfo, termInfo)
+	}
+	t.Logf("──────────────────────────────────────────────────────────────────────")
+	t.Logf("outcome: failed = AVPlayer terminal (.failed); stuck = auto-paused mid-stall")
+	t.Logf("         (rate 0, needs restart); rode_it_out = stalled but recovered on clear.")
+	t.Logf("recovered = video played continuously (playhead advancing) for the confirm")
+	t.Logf("           window within the grace (grace = %s after each restart).", recover)
+	t.Logf("recovered_via = which of the 4 methods restored playback:")
+	t.Logf("           failure      = METHOD 1  .failed → auto_recovery_failure restart")
+	t.Logf("           stuck        = METHOD 2  stallStuck → auto_recovery_stuck restart")
+	t.Logf("           live_seek    = METHOD 3  live-stall → jump-to-live seek (no restart)")
+	t.Logf("           live_restart = METHOD 4  seek failed → auto_recovery_live_resync restart")
+	t.Logf("           natural      = rode it out, resumed on clear; '-' = did not recover")
+	t.Logf("ERROR = transient AVPlayer error_* (domain+code) seen at any point — sticky")
+	t.Logf("        last_player_error; TERM_ERROR = terminal_error_* (stamped only on a")
+	t.Logf("        real terminal close — empty under auto-recovery). Both from CH rows.")
+	t.Logf("══════════════════════════════════════════════════════════════════════")
+}
+
+// classifyRecovery names which of the 4 recovery methods restored playback, from
+// whether a restart fired (vs the case baseline) and which trigger events the
+// player emitted. `live_resync` is the most specific marker (only the live-stall
+// ladder emits it) so it wins: seen WITHOUT a restart means the cheap jump-to-live
+// seek did it (method 3); WITH a restart means the seek failed and escalated to the
+// rebuild (method 4). Otherwise a restart preceded by player_stuck/error attributes
+// to the stuck/failure paths; a recovery with no restart at all is natural.
+func classifyRecovery(restarted, sawLiveSeek, sawStuck, sawError bool) string {
+	switch {
+	case sawLiveSeek && !restarted:
+		return "live_seek"
+	case sawLiveSeek && restarted:
+		return "live_restart"
+	case restarted && sawStuck:
+		return "stuck"
+	case restarted && sawError:
+		return "failure"
+	case restarted:
+		return "restart"
+	default:
+		return "natural"
+	}
+}
+
+// chEventsResp is the minimal shape of `harness query events <play_id>` — one
+// item per metrics POST, each carrying the player_metrics.last_event for that row.
+type chEventsResp struct {
+	Items []struct {
+		PlayerMetrics struct {
+			LastEvent           string `json:"last_event"`
+			Error               string `json:"error"`
+			ErrorCode           int    `json:"error_code"`
+			ErrorDomain         string `json:"error_domain"`
+			TerminalErrorCode   int    `json:"terminal_error_code"`
+			TerminalErrorDomain string `json:"terminal_error_domain"`
+		} `json:"player_metrics"`
+	} `json:"items"`
+}
+
+// errStrRe pulls "<Foo>ErrorDomain error -16172" out of the player-reported
+// error string — the numeric error_code field is usually 0 even when the string
+// carries the code, so the string is the reliable source.
+var errStrRe = regexp.MustCompile(`([A-Za-z]+ErrorDomain) error (-?\d+)`)
+
+// shortDomain trims the verbose "...ErrorDomain" suffix for table width
+// (CoreMediaErrorDomain → CoreMedia, NSURLErrorDomain → NSURL).
+func shortDomain(d string) string { return strings.TrimSuffix(d, "ErrorDomain") }
+
+// attributeRecoveries overwrites recoveredVia from the DURABLE ClickHouse event
+// rows (every POST is a row) rather than the 2s-sampled live state, which drops
+// the brief error/player_stuck/live_resync trigger events. Authoritative for the
+// summary table. Run AFTER a short flush delay so the last case's rows have landed.
+func attributeRecoveries(ctx context.Context, t *testing.T, results []caseResult) {
+	for i := range results {
+		r := &results[i]
+		if r.playID == "" {
+			continue
+		}
+		raw, err := runner.RunHarnessCLI(ctx, "query", "events", r.playID, "--limit", "1000")
+		if err != nil {
+			t.Logf("attribution: %s/%s events query failed: %v", r.fault, r.kind, err)
+			continue
+		}
+		var resp chEventsResp
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			t.Logf("attribution: %s/%s decode failed: %v", r.fault, r.kind, err)
+			continue
+		}
+		var sawSeek, sawStuck, sawError, sawRestart bool
+		var errDom, termDom string
+		var errCode, termCode int
+		for _, it := range resp.Items {
+			pm := it.PlayerMetrics
+			switch pm.LastEvent {
+			case "live_resync":
+				sawSeek = true
+			case "player_stuck":
+				sawStuck = true
+			case "error":
+				sawError = true
+			case "restart":
+				sawRestart = true
+			}
+			// Aggregate the last non-empty transient error: prefer the numeric
+			// fields, else parse the (sticky) error string.
+			if pm.ErrorCode != 0 {
+				errCode, errDom = pm.ErrorCode, pm.ErrorDomain
+			} else if errCode == 0 && pm.Error != "" {
+				if m := errStrRe.FindStringSubmatch(pm.Error); m != nil {
+					fmt.Sscanf(m[2], "%d", &errCode)
+					errDom = m[1]
+				}
+			}
+			if pm.TerminalErrorCode != 0 {
+				termCode, termDom = pm.TerminalErrorCode, pm.TerminalErrorDomain
+			}
+		}
+		if errCode != 0 {
+			r.errInfo = fmt.Sprintf("%s %d", shortDomain(errDom), errCode)
+		}
+		if termCode != 0 {
+			r.termInfo = fmt.Sprintf("%s %d", shortDomain(termDom), termCode)
+		}
+		if r.recovered {
+			via := classifyRecovery(sawRestart, sawSeek, sawStuck, sawError)
+			if via != r.recoveredVia {
+				t.Logf("attribution: %s/%s via %s (CH) — live hint was %q", r.fault, r.kind, via, r.recoveredVia)
+			}
+			r.recoveredVia = via
+		}
+	}
+}

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -168,7 +168,54 @@ func withBaselineTestFlags(args []string) []string {
 			out = append(out, kv[0], kv[1])
 		}
 	}
+	// Pin the played clip (is.lastPlayed) unless the mode already set one, so
+	// every test streams identical content by default. The clip name is config,
+	// not source: CHAR_CONTENT (shell) overrides, else it's read from .env. No
+	// hardcoded clip — if neither is set, leave the app's own lastPlayed alone.
+	if !present["-is.lastPlayed"] {
+		if clip := defaultContentClip(); clip != "" {
+			out = append(out, "-is.lastPlayed", clip)
+		}
+	}
 	return out
+}
+
+// defaultContentClip resolves the clip every appium test plays: CHAR_CONTENT
+// from the shell environment, else the CHAR_CONTENT key from the nearest .env.
+func defaultContentClip() string {
+	if v := os.Getenv("CHAR_CONTENT"); v != "" {
+		return v
+	}
+	return dotenvValue("CHAR_CONTENT")
+}
+
+// dotenvValue reads a single KEY=value from the nearest .env file found by
+// walking up from the working directory. Returns "" if not found — lets config
+// (the default content clip) live in .env rather than the source.
+func dotenvValue(key string) string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if data, err := os.ReadFile(filepath.Join(dir, ".env")); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" || strings.HasPrefix(line, "#") {
+					continue
+				}
+				if eq := strings.IndexByte(line, '='); eq >= 0 && strings.TrimSpace(line[:eq]) == key {
+					return strings.Trim(strings.TrimSpace(line[eq+1:]), `"'`)
+				}
+			}
+			return "" // found .env, no key
+		}
+		if parent := filepath.Dir(dir); parent != dir {
+			dir = parent
+		} else {
+			return "" // reached fs root
+		}
+	}
 }
 
 // intentExtrasFromLaunchArgs converts `-is.X Y` launch-arg pairs into the

--- a/tests/characterization/runner/harness.go
+++ b/tests/characterization/runner/harness.go
@@ -28,10 +28,10 @@ var HarnessInsecure = os.Getenv("HARNESS_INSECURE") != "0"
 // The harness JSON is the source of truth — extend this struct as new
 // fields are needed rather than parsing into map[string]any everywhere.
 type PlayerRecord struct {
-	ID         string     `json:"id"`
-	LastSeenAt *time.Time `json:"last_seen_at"`
-	UserAgent  string     `json:"user_agent"`
-	Labels     map[string]string `json:"labels"`
+	ID          string            `json:"id"`
+	LastSeenAt  *time.Time        `json:"last_seen_at"`
+	UserAgent   string            `json:"user_agent"`
+	Labels      map[string]string `json:"labels"`
 	CurrentPlay *struct {
 		ID        string `json:"id"`
 		AttemptID int    `json:"attempt_id"`
@@ -46,54 +46,59 @@ type PlayerRecord struct {
 		} `json:"manifest"`
 	} `json:"current_play"`
 	PlayerMetrics *struct {
-		State                  string  `json:"state"`
-		LastEvent              string  `json:"last_event"`
-		EventTime              string  `json:"event_time"`
-		BufferDepthS           float64 `json:"buffer_depth_s"`
+		State        string  `json:"state"`
+		LastEvent    string  `json:"last_event"`
+		EventTime    string  `json:"event_time"`
+		BufferDepthS float64 `json:"buffer_depth_s"`
 		// BufferEndS is the most-distant loaded segment position, in
 		// seconds from the playhead. More reliable than BufferDepthS
 		// on AVPlayer (iOS), which often reports 0 even during normal
 		// playback — see .claude/standards/avplayer-quirks.md.
-		BufferEndS             float64 `json:"buffer_end_s"`
-		Stalls                 int     `json:"stalls"`
-		StallTimeS             float64 `json:"stall_time_s"`
-		ProfileShiftCount      int     `json:"profile_shift_count"`
-		PlayerRestarts         int     `json:"player_restarts"`
-		VideoBitrateMbps       float64 `json:"video_bitrate_mbps"`
-		VideoQualityPct        float64 `json:"video_quality_pct"`
-		VideoResolution        string  `json:"video_resolution"`
+		BufferEndS        float64 `json:"buffer_end_s"`
+		Stalls            int     `json:"stalls"`
+		StallTimeS        float64 `json:"stall_time_s"`
+		ProfileShiftCount int     `json:"profile_shift_count"`
+		PlayerRestarts    int     `json:"player_restarts"`
+		// #703a — PlaybackRate (player.rate; 0 == paused/stuck) and StallStuck
+		// (AVPlayer auto-paused mid-stall, needs intervention) let the
+		// fault-recovery sweep classify a STUCK outcome distinct from .failed.
+		PlaybackRate     float64 `json:"playback_rate"`
+		StallStuck       bool    `json:"stall_stuck"`
+		VideoBitrateMbps float64 `json:"video_bitrate_mbps"`
+		VideoQualityPct  float64 `json:"video_quality_pct"`
+		VideoResolution  string  `json:"video_resolution"`
 		// VideoFirstFrameTimeS is the player's own measurement of time
 		// from play-start to first decoded frame. Per-play (reset on
 		// new play_id). Authoritative for TTFF, vs deriving it from
 		// "first sample with bitrate > 0" which can be polluted by a
 		// previous play's residual metrics.
-		VideoFirstFrameTimeS   float64 `json:"first_frame_time_s"`
-		NetworkBitrateMbps     float64 `json:"network_bitrate_mbps"`
-		AvgNetworkBitrateMbps  float64 `json:"avg_network_bitrate_mbps"`
-		FramesDropped          int     `json:"frames_dropped"`
-		PositionS              float64 `json:"position_s"`
-		LiveEdgeS              float64 `json:"live_edge_s"`
-		LiveOffsetS            float64 `json:"live_offset_s"`
+		VideoFirstFrameTimeS  float64 `json:"first_frame_time_s"`
+		NetworkBitrateMbps    float64 `json:"network_bitrate_mbps"`
+		AvgNetworkBitrateMbps float64 `json:"avg_network_bitrate_mbps"`
+		FramesDropped         int     `json:"frames_dropped"`
+		PositionS             float64 `json:"position_s"`
+		LiveEdgeS             float64 `json:"live_edge_s"`
+		LiveOffsetS           float64 `json:"live_offset_s"`
 
 		// #550 Phase 1 residency accumulators — cumulative ms in each
 		// player state since the current play started. Phase 1
 		// columns in CH (see analytics/clickhouse/init.d/01-schema.sql).
 		// The state_residency characterization test asserts these
 		// after driving the iPad sim through targeted scenarios.
-		PlayingTimeMs       uint32 `json:"playing_time_ms"`
-		PausingTimeMs       uint32 `json:"pausing_time_ms"`
-		BufferingTimeMs     uint32 `json:"buffering_time_ms"`
-		StallingTimeMs      uint32 `json:"stalling_time_ms"`
-		IdlingTimeMs        uint32 `json:"idling_time_ms"`
-		SeekingTimeMs       uint32 `json:"seeking_time_ms"`
-		TrickplayingTimeMs  uint32 `json:"trickplaying_time_ms"`
-		PlayingCount        uint32 `json:"playing_count"`
-		PausingCount        uint32 `json:"pausing_count"`
-		BufferingCount      uint32 `json:"buffering_count"`
-		StallingCount       uint32 `json:"stalling_count"`
-		IdlingCount         uint32 `json:"idling_count"`
-		SeekingCount        uint32 `json:"seeking_count"`
-		TrickplayingCount   uint32 `json:"trickplaying_count"`
+		PlayingTimeMs      uint32 `json:"playing_time_ms"`
+		PausingTimeMs      uint32 `json:"pausing_time_ms"`
+		BufferingTimeMs    uint32 `json:"buffering_time_ms"`
+		StallingTimeMs     uint32 `json:"stalling_time_ms"`
+		IdlingTimeMs       uint32 `json:"idling_time_ms"`
+		SeekingTimeMs      uint32 `json:"seeking_time_ms"`
+		TrickplayingTimeMs uint32 `json:"trickplaying_time_ms"`
+		PlayingCount       uint32 `json:"playing_count"`
+		PausingCount       uint32 `json:"pausing_count"`
+		BufferingCount     uint32 `json:"buffering_count"`
+		StallingCount      uint32 `json:"stalling_count"`
+		IdlingCount        uint32 `json:"idling_count"`
+		SeekingCount       uint32 `json:"seeking_count"`
+		TrickplayingCount  uint32 `json:"trickplaying_count"`
 
 		// #550 Phase 2 outcome — final classification (in_progress,
 		// completed, user_stopped, start_failure, mid_stream_failure,

--- a/tests/characterization/runner/shape.go
+++ b/tests/characterization/runner/shape.go
@@ -103,6 +103,34 @@ func (s *Session) ArmFault(ctx context.Context, shape, kind string, urlPatterns 
 	return err
 }
 
+// ArmFaultRepeating posts a SUSTAINED fault rule on the bound player: the
+// `shape` (e.g. "404", "corrupted", "request_first_byte_reset") fires on
+// `consecutive` matching `kind` requests in a row and re-arms for `frequency`
+// cycles, so every request in the window is affected — unlike ArmFault's
+// one-shot. Used by the fault-recovery probe to keep a fault on long enough to
+// drive AVPlayer toward a .failed state, then ClearFaults.
+func (s *Session) ArmFaultRepeating(ctx context.Context, shape, kind string, consecutive, frequency int, urlPatterns ...string) error {
+	if s == nil || s.PlayerID == "" {
+		return fmt.Errorf("arm fault: no player bound")
+	}
+	if shape == "" || kind == "" {
+		return fmt.Errorf("arm fault: shape and kind required")
+	}
+	args := []string{
+		"fault", "add", s.PlayerID,
+		"--type", shape,
+		"--kind", kind,
+		"--frequency", strconv.Itoa(frequency),
+		"--consecutive", strconv.Itoa(consecutive),
+		"--mode", "requests",
+	}
+	if len(urlPatterns) > 0 {
+		args = append(args, "--url-substr", strings.Join(urlPatterns, ","))
+	}
+	_, err := runHarness(ctx, args...)
+	return err
+}
+
 // ClearFaults wipes all fault rules from the bound player. The
 // abort test calls this between cycles so each cycle starts from
 // a known clean state.


### PR DESCRIPTION
## What

Live-aware iOS auto-recovery (#703a) plus the #778 live-resync recovery path, with a dedicated fault-recovery characterization probe and the dashboard/forwarder wiring to observe it.

### iOS (`apple/`)
- **Recovery model**: terminal `.failed` → restart (`auto_recovery_failure`); AVPlayer auto-pause `stallStuck` → restart (`auto_recovery_stuck`). Each path has a distinct reason; the restart re-syncs to the live edge.
- **#778 live-resync ladder** for the *silent* bandwidth-starvation stall that reaches neither `.failed` nor `stallStuck` (frozen playhead, `rate=1`): jump-to-live **seek first** (`live_resync_seek`, no restart) → **escalate to a rebuild** (`auto_recovery_live_resync`) if the seek doesn't restore progress. Detector defaults to 45s no-progress so the faster paths fire first; guarded so it can't pre-empt a pending restart. Tunable via `is.flag.live_resync_stall_s`.
- Clean terminal close on retry-exhaustion (`<reason>_exhausted` `play_end`), sticky terminal, terminal-error fallback stamped from the error log.

### Characterization (`tests/characterization/`)
- New **`fault_recovery`** probe: single-launch sweep over 11 fault types (corrupted / 404 / 500 / resets / hangs / rate_choke / timeout segment + 404 media-manifest), auto-recovery on/off, content-pinned via `CHAR_CONTENT`/`.env`. (master_manifest dropped — it's fetched once at startup, so a mid-stream fault is a no-op.)
- **Dynamic recovery window**: waits for the backoff-delayed restart, then a grace, and requires **10s of sustained advancing video** to confirm recovery (not a single buffering tick).
- **`RECOVERED_VIA` / `ERROR` / `TERM_ERROR`** columns — recovery method and error codes attributed from the durable ClickHouse event rows (live 2s polling drops the transient trigger events).
- runner: `PlaybackRate`/`StallStuck` metrics, `ArmFaultRepeating`, content pinning.

### Dashboard (`content/dashboard-v3/`)
- EventsTimeline PLAYBACK-lane markers (RESTART, RATE→N, NEW PLAY) + CONTROL lane; IMPAIRMENT ERROR tooltip shows error domain+code.

### Forwarder (`analytics/go-forwarder/`)
- `lanes_v1` bundle adds `error_code`, `error_domain`, `player_restarts`, `playback_rate`.

## Validation
Latest ON sweep on `insane_new` (auto-recovery, 4-method ladder): **all 11 fault types recover**. Methods: 1× `failure`, 8× `stuck`, 2× `live_restart`. Only the decode-class faults (`corrupted`, `404/segment`) surfaced a code (`CoreMediaErrorDomain -16172`); the rest recovered with no AVPlayer error. `go vet` clean across the characterization + forwarder modules; iOS sim build succeeds.

## Follow-ups
- #778: the jump-to-live seek always escalated in this run (rolled-off window needs a rebuild) — consider lengthening its 5s verify window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
