### PR TITLE
feat(forwarder): label #703a recovery vocab (player_stuck / live_resync / split auto_recovery_*) (#705)

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -300,12 +300,25 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 		out = []string{SevWarning + "=timejump"}
 	case "segment_stall":
 		out = []string{SevWarning + "=stall_segment"}
+	// #703a/#778 — the jump-to-live seek nudge (METHOD 3). A recovery action,
+	// not itself a failure; keeps the item (no restart). Warning so it surfaces.
+	case "live_resync":
+		out = []string{SevWarning + "=live_resync"}
 
-	// critical — user-visible impact
+	// critical / error — user-visible impact
 	case "frozen":
 		out = []string{SevCritical + "=stall_frozen"}
 	case "user_marked":
 		out = []string{SevCritical + "=user_marked_911"}
+	// #703a — AVPlayer auto-paused mid-stall (rate→0, buffer drained): a hard
+	// stall that needs intervention and does NOT reach .failed. Error severity.
+	case "player_stuck":
+		out = []string{SevError + "=player_stuck"}
+	// #703 — confirmed hard wedge (-12880 + sustained no-progress). Observability
+	// only post-#703a (a real wedge surfaces as .failed and recovers there), but
+	// a confirmed wedge is still a play-ending fault signature → error.
+	case "wedge_detected":
+		out = []string{SevError + "=wedge_detected"}
 
 	// restart splits on reason — operator-initiated reload is
 	// informational; everything else is an involuntary recovery
@@ -322,7 +335,16 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 			out = []string{SevWarning + "=restart_user_retry"}
 		case r.RestartReason == "reload" || r.TriggerType == "reload":
 			out = []string{SevInfo + "=restart_reload"}
-		default: // auto_recovery / unknown
+		// #703a — distinguish the auto-recovery methods so the dashboard/harness
+		// can tell which path drove the restart (failure vs stuck vs live-resync),
+		// instead of collapsing all three into one `restart_auto_recovery` chip.
+		case r.RestartReason == "auto_recovery_failure":
+			out = []string{SevCritical + "=restart_auto_recovery_failure"}
+		case r.RestartReason == "auto_recovery_stuck":
+			out = []string{SevCritical + "=restart_auto_recovery_stuck"}
+		case r.RestartReason == "auto_recovery_live_resync":
+			out = []string{SevCritical + "=restart_auto_recovery_live_resync"}
+		default: // legacy auto_recovery / unknown reason
 			out = []string{SevCritical + "=restart_auto_recovery"}
 		}
 


### PR DESCRIPTION
Implements the forwarder/dashboard half of #705 (703b), rescoped to the post-#703a recovery model.

## Problem
After #779 (#703a), iOS emits a richer recovery vocab the forwarder didn't classify: `player_stuck`, `live_resync` (the jump-to-live seek), and three distinct restart reasons (`auto_recovery_failure` / `_stuck` / `_live_resync`). The forwarder collapsed all auto-recovery restarts into one `restart_auto_recovery` label and had no case for the new events — so no dashboard chip and no `harness query --label-has` filter could distinguish the four recovery methods.

## Change (`analytics/go-forwarder/labels.go`)
- New event labels: `error=player_stuck`, `error=wedge_detected`, `warning=live_resync`.
- Split the `restart` reason into the four methods → `critical=restart_auto_recovery_{failure,stuck,live_resync}`; `user_retry`/`reload` unchanged; generic `restart_auto_recovery` kept as the unknown-reason fallback.

## No dashboard change needed
Chips render generically: severity comes from the `<severity>=<event>` prefix (`SEVERITY_META`), all `session_events` rows categorize as `reaction` (SessionDisplay.vue:375), and the event name is the display label. The new labels auto-render across the SessionDisplay triplet + replay rail markers.

## Already covered (dropped from #705)
- **Characterization fire+recover** — delivered by the `fault_recovery` probe (#779) via the CH-sourced `RECOVERED_VIA` column.
- **`wedge_auto_recovery`** — no longer emitted (the 120s wedge is observability-only post-#703a); only `wedge_detected` remains and is now labelled.

## Validation
`go build` + `go test ./...` pass for the forwarder module. Deployed to test-dev (`make analytics-rebuild-forwarder`); forwarder recreated and healthy. Labels are computed at ingest, so they'll appear on new runs — `harness query plays --label-has critical=restart_auto_recovery_stuck` (and the `_failure`/`_live_resync`/`error=player_stuck`/`warning=live_resync` variants) will return matching `fault_recovery` runs.

## Done when (from #705)
- [x] forwarder labels the new vocab + splits the auto_recovery reasons
- [x] chips render across the SessionDisplay triplet (generic — verified)
- [x] characterization fire+recover proof (already via #779)

Closes #705. Refs #703, #778, #779.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
