### PR TITLE
feat(android): emit recommended_offset_s + configured_offset_s for live-offset QoE parity (#782)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/PlaybackMetrics.java
@@ -893,6 +893,26 @@ public final class PlaybackMetrics {
                 if (windowIndex >= 0 && windowIndex < tl.getWindowCount()) {
                     Timeline.Window window = new Timeline.Window();
                     tl.getWindow(windowIndex, window);
+                    // #782 — live-offset QoE parity with iOS. The forwarder gates
+                    // qoe_live_offset_concerning/_breach/holdback_deviation on a
+                    // recommended offset > 0; Android never reported one, so those
+                    // labels could never fire here (Android live-edge drift was
+                    // invisible). ExoPlayer resolves the manifest HOLD-BACK
+                    // (#EXT-X-SERVER-CONTROL) + any app LiveConfiguration into a
+                    // single targetOffsetMs — emit it as BOTH recommended and
+                    // configured (there is no separate "configured" property, so
+                    // qoe_holdback_deviation reads ~0 on Android by construction).
+                    // recommended ~= getCurrentLiveOffset() for a healthy player,
+                    // so excess = live_offset_s - recommended_offset_s ~= 0, matching
+                    // the iOS semantics the thresholds were tuned against.
+                    if (window.liveConfiguration != null
+                            && window.liveConfiguration.targetOffsetMs != C.TIME_UNSET
+                            && window.liveConfiguration.targetOffsetMs > 0) {
+                        double targetOffsetS =
+                            roundSeconds(window.liveConfiguration.targetOffsetMs / 1000.0);
+                        p.put("player_metrics_recommended_offset_s", targetOffsetS);
+                        p.put("player_metrics_configured_offset_s", targetOffsetS);
+                    }
                     if (window.windowStartTimeMs != C.TIME_UNSET) {
                         long pdtMs = window.windowStartTimeMs + currentPositionMs;
                         p.put("player_metrics_playhead_wallclock_ms", pdtMs);


### PR DESCRIPTION
## Problem
The QoE live-edge labels (`qoe_live_offset_concerning` / `_breach` / `qoe_holdback_deviation`) are structurally iOS-only: the forwarder's `liveOffsetLabels()` returns early when `recommended_offset_s <= 0`, and the Android client never reported it. So Android live-edge drift is invisible to the label system (zero Android rows when filtering those labels — a coverage gap, not healthy play).

## Change (client-only, `PlaybackMetrics.java`)
Emit both offsets from the `Timeline.Window` the metrics block already fetches:
- `recommended_offset_s` ← `window.liveConfiguration.targetOffsetMs / 1000`
- `configured_offset_s` ← same value (ExoPlayer collapses app-configured + manifest `HOLD-BACK` into one `targetOffsetMs`; no separate "configured" property)

Guarded on `targetOffsetMs != C.TIME_UNSET && > 0`.

## Server side: nothing to do (confirmed)
The pipeline is field-name-driven and already exists for the iOS path:
- CH columns `recommended_offset_s` / `configured_offset_s` — `01-schema.sql:529-530`
- forwarder ingest `getF32(s, "player_metrics_recommended_offset_s")` — `main.go:885/886`
- label logic `liveOffsetLabels()` keyed on `recommended_offset_s`

No CH migration, forwarder, or dashboard change needed. ClickHouse supports it directly.

## Notes
- `qoe_holdback_deviation` will read ~0 on Android by construction (configured == recommended) — expected, not a bug.
- Compiles against media3 1.2.1 (`:app:compileDebugJavaWithJavac` clean).

## ⚠️ Gating acceptance check — NOT yet done (needs a real device)
AC #3 requires verifying on a **live Android session** that `live_offset_s − recommended_offset_s ≈ 0` for a healthy player and grows with deliberate drift — i.e. that ExoPlayer's `getCurrentLiveOffset()` reference edge aligns with iOS's "true playlist end", or the forwarder thresholds (3s concerning / 10s breach) will fire at the wrong rate cross-platform. **This can't be done from the build host** — hold merge until it's confirmed on hardware.

## Acceptance criteria
- [x] Android emits `recommended_offset_s > 0` (+ `configured_offset_s`) — code in, compiles
- [ ] `qoe_live_offset_concerning` / `_breach` appear for Android sessions in the label-frequency table (verify post-deploy on a real run)
- [ ] Verified on a real Android live session: `live_offset_s − recommended_offset_s ≈ 0` healthy, grows with drift

Refs #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
