### PR TITLE
feat(forwarder): project recommended_offset_s + configured_offset_s in events bundle (#786)

### DIFF
--- a/analytics/go-forwarder/streambundles.go
+++ b/analytics/go-forwarder/streambundles.go
@@ -108,6 +108,11 @@ var bundleRegistry = map[string]bundleDef{
 			"buffer_depth_s",
 			"buffer_end_s",
 			"live_offset_s",
+			// #786 — the live-offset trio so events read-API consumers can compute
+			// excess = live_offset_s - recommended_offset_s without a raw CH query
+			// (the columns are ingested for iOS + Android #782 but were panel_v1-only).
+			"recommended_offset_s",
+			"configured_offset_s",
 			"true_offset_s",
 			// FPS-derived counters
 			"frames_displayed",


### PR DESCRIPTION
Fixes the read-API projection gap found while verifying #782.

## Change
Add `recommended_offset_s` + `configured_offset_s` to the `charts_minimal` bundle (`streambundles.go`, next to `live_offset_s`). These columns are already ingested (iOS + Android #782) and stored in CH, and `panel_v1` already projects them — they were just missing from the events/snapshots read path, so `harness query events/play` returned `None` even when CH had the data.

## Why
During #782 verification the read-API showed `None` while a direct CH query proved the column was populated (`excess ≈ -0.09s` healthy). This surfaces the live-offset trio so `excess = live_offset_s − recommended_offset_s` is computable without a raw CH query.

## Validation
`go build` + `go test` green. No schema/ingest change. Deployed to test-dev.

Closes #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
