### PR TITLE
feat(783): population-aware triage tooling on the sessions dashboard

### DIFF
--- a/analytics/go-forwarder/label_associate.go
+++ b/analytics/go-forwarder/label_associate.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Label↔dimension association (#783): Splunk-`associate`-style conditional
+// probability lift. For a target label L, measure how disproportionately it
+// occurs given each dimension value — answering "is this aberrant because of
+// the content / app_version / device?" from the data alone (the observational
+// complement to the sweep's experimental isolation).
+//
+//	GET /api/v2/label_associate?label=<L>&days=N&exclude_faulted=1
+//	  → { label, baseline_pct, total, items: [ {dim,value,n,with_l,pct,lift,significant}, … ] }
+//
+// lift = P(L|dim=value) / P(L). A session = one play_id; a play "has L" if any
+// of its rows (session_events + network_requests + control_events) carries L.
+// Dimension values come from session_events columns (constant per play).
+
+// associateDims are the per-play dimensions we associate against — all derived
+// from session_events columns + the testing=test_* control-event tag (no
+// `platform` column; device_class / device_model proxy it, #783).
+var associateDims = []struct{ label, col string }{
+	{"test", "test"}, // characterization mode (pyramid/rampup/…) from the testing=test_* tag on control_events
+	{"content", "content_name"},
+	{"app_version", "app_version"},
+	{"platform", "platform"}, // derived: iphone / iphone-sim / ipad / ipad-sim / androidtv
+	{"device_model", "device_model"},
+	{"device_kind", "device_kind"}, // simulator vs real (derived from device_model)
+}
+
+func registerLabelAssociateHandler(mux *http.ServeMux, cfg config) {
+	mux.HandleFunc("/api/v2/label_associate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleLabelAssociate(w, r, cfg)
+	})
+}
+
+func handleLabelAssociate(w http.ResponseWriter, r *http.Request, cfg config) {
+	label := strings.TrimSpace(r.URL.Query().Get("label"))
+	if label == "" {
+		http.Error(w, "label param is required", http.StatusBadRequest)
+		return
+	}
+	days := 7
+	if v := strings.TrimSpace(r.URL.Query().Get("days")); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 90 {
+			days = n
+		}
+	}
+	params := map[string]string{"days": fmt.Sprintf("%d", days), "label": label}
+
+	excludeFaulted := false
+	if v := strings.TrimSpace(r.URL.Query().Get("exclude_faulted")); v == "1" || v == "true" {
+		excludeFaulted = true
+	}
+
+	// within=<dim>:<value> stratifies the population to one dimension value, so
+	// the lift of the OTHER dimensions is computed WITHIN that stratum —
+	// holding e.g. recipe=pyramid fixed removes the test-mix confound when
+	// comparing platforms (#783). The held dimension is dropped from the output.
+	withinDim, withinVal, withinCol := "", "", ""
+	if v := strings.TrimSpace(r.URL.Query().Get("within")); v != "" {
+		if i := strings.Index(v, ":"); i > 0 {
+			d, val := v[:i], v[i+1:]
+			for _, dim := range associateDims {
+				if dim.label == d {
+					withinDim, withinVal, withinCol = d, val, dim.col
+					break
+				}
+			}
+			if withinCol == "" {
+				http.Error(w, "within: unknown dimension "+d, http.StatusBadRequest)
+				return
+			}
+		}
+	}
+
+	// Per-play CTE: dimension values (constant per play) + whether the play
+	// carries the target label. `labeled` and `faulted` are play-id sets built
+	// by unioning labels across all three source tables (like label_frequency).
+	win := "ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''"
+	unionLabels := fmt.Sprintf(`
+		SELECT play_id, labels FROM infinite_streaming.session_events WHERE %[1]s
+		UNION ALL SELECT play_id, labels FROM infinite_streaming.network_requests WHERE %[1]s
+		UNION ALL SELECT play_id, labels FROM infinite_streaming.control_events WHERE %[1]s`, win)
+
+	faultFilter := ""
+	faultedCTE := ""
+	if excludeFaulted {
+		faultedCTE = fmt.Sprintf(`, faulted AS (
+			SELECT DISTINCT play_id FROM (%s) ARRAY JOIN labels AS lab WHERE position(lab, 'fault') > 0
+		)`, unionLabels)
+		faultFilter = "AND se.play_id NOT IN faulted"
+	}
+
+	// One UNION-ALL arm per dimension over the shared per_play set. The held
+	// (within) dimension is dropped — associating against a fixed value is moot.
+	var arms []string
+	for _, d := range associateDims {
+		if d.label == withinDim {
+			continue
+		}
+		arms = append(arms, fmt.Sprintf(
+			"SELECT '%s' AS dim, toString(%s) AS value, is_labeled FROM per_play", d.label, d.col))
+	}
+
+	// HAVING on the per_play group restricts to the within stratum.
+	having := ""
+	if withinCol != "" {
+		having = "HAVING " + withinCol + " = {within_val:String}"
+		params["within_val"] = withinVal
+	}
+
+	query := fmt.Sprintf(`
+		WITH labeled AS (
+		    SELECT DISTINCT play_id FROM (%s) ARRAY JOIN labels AS lab WHERE lab = {label:String}
+		)%s,
+		tests AS (
+		    SELECT play_id, replaceOne(arrayFirst(x -> startsWith(x, 'testing=test_'), labs), 'testing=test_', '') AS test
+		    FROM (
+		        SELECT play_id, groupUniqArrayArray(labels) AS labs
+		        FROM infinite_streaming.control_events
+		        WHERE ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''
+		        GROUP BY play_id
+		    )
+		),
+		per_play AS (
+		    SELECT se.play_id AS play_id,
+		        any(t.test) AS test,
+		        any(se.content_name) AS content_name,
+		        any(se.app_version)  AS app_version,
+		        any(se.device_model) AS device_model,
+		        any(se.device_class) AS device_class,
+		        -- iOS/tvOS simulators report the host CPU arch (arm64/x86_64) as
+		        -- device_model instead of a real hardware id (iPhone15,4 etc.) (#783).
+		        any(if(se.device_model IN ('arm64','x86_64','i386'), 'simulator', 'real')) AS device_kind,
+		        -- Derived platform: device_class (phone/tablet/tv) × sim-vs-real.
+		        -- iPhone-sim=phone+arm64, iPad-sim=tablet+arm64, real iPhone=phone+iPhone*,
+		        -- real iPad=tablet+iPad, Android TV=tv+Google TV Streamer.
+		        any(multiIf(
+		            se.device_model IN ('arm64','x86_64','i386') AND se.device_class = 'tablet', 'ipad-sim',
+		            se.device_model IN ('arm64','x86_64','i386') AND se.device_class = 'phone',  'iphone-sim',
+		            se.device_model IN ('arm64','x86_64','i386'), 'sim-other',
+		            se.device_class = 'tv',     'androidtv',
+		            se.device_class = 'tablet', 'ipad',
+		            se.device_class = 'phone',  'iphone',
+		            se.device_class)) AS platform,
+		        (se.play_id IN labeled) AS is_labeled
+		    FROM infinite_streaming.session_events se
+		    LEFT JOIN tests t ON t.play_id = se.play_id
+		    WHERE se.ts >= now() - INTERVAL {days:UInt32} DAY AND se.play_id != '' %s
+		    GROUP BY se.play_id
+		    %s
+		)
+		SELECT dim, value, count() AS n, countIf(is_labeled) AS with_l
+		FROM (%s)
+		WHERE value != ''
+		GROUP BY dim, value
+		HAVING n > 0
+		ORDER BY dim, n DESC
+	`, unionLabels, faultedCTE, faultFilter, having, strings.Join(arms, " UNION ALL "))
+
+	body, err := chQueryBytes(r.Context(), cfg, query, params)
+	if err != nil {
+		http.Error(w, "clickhouse query: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	rawItems, err := parseJSONEachRowItems(body)
+	if err != nil {
+		http.Error(w, "decode rows: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	// Baseline P(L) = total labeled plays / total plays. Each dimension's rows
+	// sum to the same totals (every play has one value per dim), so derive from
+	// the first dimension we see.
+	type rawRow struct {
+		Dim   string      `json:"dim"`
+		Value string      `json:"value"`
+		N     json.Number `json:"n"`
+		WithL json.Number `json:"with_l"`
+	}
+	rows := make([]rawRow, 0, len(rawItems))
+	dimTotN := map[string]int{}
+	dimTotL := map[string]int{}
+	for _, it := range rawItems {
+		var rr rawRow
+		if json.Unmarshal(it, &rr) != nil {
+			continue
+		}
+		rows = append(rows, rr)
+		n, _ := strconv.Atoi(rr.N.String())
+		l, _ := strconv.Atoi(rr.WithL.String())
+		dimTotN[rr.Dim] += n
+		dimTotL[rr.Dim] += l
+	}
+	totalPlays, totalLabeled := 0, 0
+	for d, n := range dimTotN {
+		totalPlays, totalLabeled = n, dimTotL[d] // any dimension's totals
+		break
+	}
+	baseline := 0.0
+	if totalPlays > 0 {
+		baseline = float64(totalLabeled) / float64(totalPlays)
+	}
+
+	type item struct {
+		Dim         string  `json:"dim"`
+		Value       string  `json:"value"`
+		N           int     `json:"n"`
+		WithL       int     `json:"with_l"`
+		Pct         float64 `json:"pct"`
+		Lift        float64 `json:"lift"`
+		Significant bool    `json:"significant"`
+	}
+	out := make([]item, 0, len(rows))
+	for _, rr := range rows {
+		n, _ := strconv.Atoi(rr.N.String())
+		l, _ := strconv.Atoi(rr.WithL.String())
+		pCond := 0.0
+		if n > 0 {
+			pCond = float64(l) / float64(n)
+		}
+		lift := 0.0
+		if baseline > 0 {
+			lift = pCond / baseline
+		}
+		out = append(out, item{
+			Dim: rr.Dim, Value: rr.Value, N: n, WithL: l,
+			Pct:  math.Round(pCond*1000) / 10,
+			Lift: math.Round(lift*100) / 100,
+			// Significance gate: enough sessions + enough label hits + a real
+			// effect, so we never surface 10× lift off a handful of plays.
+			Significant: n >= 20 && l >= 5 && (lift >= 1.5 || lift <= 0.67),
+		})
+	}
+
+	resp := map[string]any{
+		"label":        label,
+		"days":         days,
+		"total":        totalPlays,
+		"baseline_pct": math.Round(baseline*1000) / 10,
+		"items":        out,
+	}
+	if withinDim != "" {
+		resp["within"] = withinDim + "=" + withinVal
+	}
+	writeJSON(w, resp)
+}

--- a/analytics/go-forwarder/label_divergence.go
+++ b/analytics/go-forwarder/label_divergence.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Label divergence / "skew" (#783): for EVERY label, the magnitude of its
+// strongest disproportion across dimensions — max significant lift over
+// platform / content / app_version. A label uniform across dimensions scores
+// ~1; one that spikes 4× on some platform scores ~4. Surfaced as a top-level
+// column next to impact/anomaly so a strongly dimension-driven label is
+// obvious at a glance (without opening each drill-down).
+//
+//	GET /api/v2/label_divergence?days=N&exclude_faulted=1
+//	  → { items: [ {label, skew, top}, … ] }   (top = "dim=value" driving the skew)
+//
+// Everything runs on per-play CTEs (collapsed to ~one row per play), so the
+// label×dimension cross-tab is cheap despite the raw row count.
+
+func registerLabelDivergenceHandler(mux *http.ServeMux, cfg config) {
+	mux.HandleFunc("/api/v2/label_divergence", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleLabelDivergence(w, r, cfg)
+	})
+}
+
+func handleLabelDivergence(w http.ResponseWriter, r *http.Request, cfg config) {
+	days := 7
+	if v := strings.TrimSpace(r.URL.Query().Get("days")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 90 {
+			days = n
+		}
+	}
+	params := map[string]string{"days": strconv.Itoa(days)}
+
+	win := "ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''"
+	unionLabels := "SELECT play_id, labels FROM infinite_streaming.session_events WHERE " + win +
+		" UNION ALL SELECT play_id, labels FROM infinite_streaming.network_requests WHERE " + win +
+		" UNION ALL SELECT play_id, labels FROM infinite_streaming.control_events WHERE " + win
+
+	faultFilterSE := ""
+	faultedCTE := ""
+	if v := strings.TrimSpace(r.URL.Query().Get("exclude_faulted")); v == "1" || v == "true" {
+		// drop plays carrying any fault marker (consistent with label_frequency)
+		faultedCTE = "faulted AS (SELECT DISTINCT play_id FROM (" + unionLabels +
+			") ARRAY JOIN labels AS lab WHERE position(lab,'fault')>0),"
+		faultFilterSE = "AND se.play_id NOT IN faulted"
+	}
+
+	// pl: per-play dimensions (collapsed). labset: per-play distinct labels
+	// across all three tables. tests: the characterization mode (pyramid/ramp/…)
+	// per play, from the testing=test_* tag on control_events — so a label's
+	// skew can be driven by WHICH TEST ran, not only platform/content (#783).
+	// Explode label × dimension and cross-tab into a significant lift per
+	// (label,dim,value); take the max per label.
+	query := `WITH ` + faultedCTE + `
+		tests AS (
+		    SELECT play_id, replaceOne(arrayFirst(x -> startsWith(x, 'testing=test_'), labs), 'testing=test_', '') AS test
+		    FROM (
+		        SELECT play_id, groupUniqArrayArray(labels) AS labs
+		        FROM infinite_streaming.control_events
+		        WHERE ` + win + `
+		        GROUP BY play_id
+		    )
+		),
+		pl AS (
+		    SELECT se.play_id AS play_id,
+		        any(multiIf(
+		            se.device_model IN ('arm64','x86_64','i386') AND se.device_class='tablet','ipad-sim',
+		            se.device_model IN ('arm64','x86_64','i386') AND se.device_class='phone','iphone-sim',
+		            se.device_model IN ('arm64','x86_64','i386'),'sim-other',
+		            se.device_class='tv','androidtv', se.device_class='tablet','ipad', se.device_class='phone','iphone',
+		            se.device_class)) AS platform,
+		        any(se.content_name) AS content,
+		        any(se.app_version)  AS app_version,
+		        any(t.test)          AS test
+		    FROM infinite_streaming.session_events se
+		    LEFT JOIN tests t ON t.play_id = se.play_id
+		    WHERE se.ts >= now() - INTERVAL {days:UInt32} DAY AND se.play_id != '' ` + faultFilterSE + `
+		    GROUP BY se.play_id
+		),
+		labset AS (
+		    SELECT play_id, groupUniqArrayArray(labels) AS labs
+		    FROM (` + unionLabels + `) GROUP BY play_id
+		),
+		total AS (SELECT count() AS t FROM pl),
+		withl AS (
+		    SELECT label, count() AS wl FROM (
+		        SELECT pl.play_id AS pid, arrayJoin(ls.labs) AS label
+		        FROM pl LEFT JOIN labset ls ON ls.play_id = pl.play_id
+		    ) GROUP BY label
+		),
+		nv AS (
+		    SELECT dim, value, count() AS n FROM (
+		        SELECT play_id, dv.1 AS dim, dv.2 AS value
+		        FROM pl ARRAY JOIN [('test',test),('platform',platform),('content',content),('app_version',app_version)] AS dv
+		        WHERE dv.2 != ''
+		    ) GROUP BY dim, value
+		),
+		cond AS (
+		    SELECT label, dim, value, count() AS cnt FROM (
+		        SELECT arrayJoin(ls.labs) AS label, dv.1 AS dim, dv.2 AS value
+		        FROM pl LEFT JOIN labset ls ON ls.play_id = pl.play_id
+		        ARRAY JOIN [('test',pl.test),('platform',pl.platform),('content',pl.content),('app_version',pl.app_version)] AS dv
+		        WHERE dv.2 != ''
+		    ) GROUP BY label, dim, value
+		)
+		SELECT
+		    c.label AS label,
+		    round(max(if(c.cnt >= 5 AND nv.n >= 20,
+		        (c.cnt * (SELECT t FROM total)) / (nv.n * wl.wl), 1.0)), 2) AS skew,
+		    argMax(concat(c.dim,'=',c.value), if(c.cnt >= 5 AND nv.n >= 20,
+		        (c.cnt * (SELECT t FROM total)) / (nv.n * wl.wl), 1.0)) AS top
+		FROM cond c
+		INNER JOIN nv ON nv.dim = c.dim AND nv.value = c.value
+		INNER JOIN withl wl ON wl.label = c.label
+		GROUP BY c.label
+	`
+
+	body, err := chQueryBytes(r.Context(), cfg, query, params)
+	if err != nil {
+		http.Error(w, "clickhouse query: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	raw, err := parseJSONEachRowItems(body)
+	if err != nil {
+		http.Error(w, "decode rows: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	type item struct {
+		Label string  `json:"label"`
+		Skew  float64 `json:"skew"`
+		Top   string  `json:"top"`
+	}
+	out := make([]item, 0, len(raw))
+	for _, it := range raw {
+		var rr struct {
+			Label string      `json:"label"`
+			Skew  json.Number `json:"skew"`
+			Top   string      `json:"top"`
+		}
+		if json.Unmarshal(it, &rr) != nil {
+			continue
+		}
+		sk, _ := rr.Skew.Float64()
+		out = append(out, item{Label: rr.Label, Skew: math.Round(sk*100) / 100, Top: rr.Top})
+	}
+	writeJSON(w, map[string]any{"items": out})
+}

--- a/analytics/go-forwarder/label_frequency.go
+++ b/analytics/go-forwarder/label_frequency.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Label-frequency baseline (#772): how often each severity-tagged label appears
+// across recent sessions, so triage can distinguish ambient labels (fire on
+// most streams → likely threshold noise OR high-impact) from rare ones (a
+// specific stream is broken). The dashboard derives an "anomaly" score
+// (severity×rarity — what the sweep should chase) and an "impact" score
+// (severity×frequency — what product should fix) from this.
+//
+//	GET /api/v2/label_frequency?days=7&exclude_faulted=1
+//	  → { total, days, items: [ {label, severity, sessions, pct}, … ] }
+//
+// A "session" is one play_id. A label counts once per play (distinct), unioned
+// across session_events + network_requests + control_events. exclude_faulted
+// drops plays that had a fault rule armed, for a clean (non-injected) baseline.
+
+func registerLabelFrequencyHandler(mux *http.ServeMux, cfg config) {
+	mux.HandleFunc("/api/v2/label_frequency", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		handleLabelFrequency(w, r, cfg)
+	})
+}
+
+func handleLabelFrequency(w http.ResponseWriter, r *http.Request, cfg config) {
+	days := 7
+	if v := strings.TrimSpace(r.URL.Query().Get("days")); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 90 {
+			days = n
+		}
+	}
+	params := map[string]string{"days": fmt.Sprintf("%d", days)}
+
+	// Filter applied to the per-play CTE so both the per-label count and the
+	// total use the same denominator. A faulted play is one whose label set
+	// contains the fault-rule marker.
+	faultFilter := ""
+	if v := strings.TrimSpace(r.URL.Query().Get("exclude_faulted")); v == "1" || v == "true" {
+		// A session is "faulted" if it carries ANY fault marker — not just the
+		// *fault_rule_enabled control event (which only fires for faults armed
+		// via the live PATCH API). config-on-connect-armed faults (the sweep's
+		// bootstrap path) emit the per-request fault_* labels (fault_timeout /
+		// fault_incomplete / fault_other, set when the proxy flags faulted=1)
+		// but NO rule-armed marker, so match the whole `fault` family.
+		faultFilter = "WHERE NOT arrayExists(x -> position(x, 'fault') > 0, labs)"
+	}
+
+	query := fmt.Sprintf(`
+		WITH play_labels AS (
+		    SELECT play_id, groupUniqArrayArray(labels) AS labs
+		    FROM (
+		        SELECT play_id, labels FROM infinite_streaming.session_events
+		            WHERE ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''
+		        UNION ALL
+		        SELECT play_id, labels FROM infinite_streaming.network_requests
+		            WHERE ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''
+		        UNION ALL
+		        SELECT play_id, labels FROM infinite_streaming.control_events
+		            WHERE ts >= now() - INTERVAL {days:UInt32} DAY AND play_id != ''
+		    )
+		    GROUP BY play_id
+		),
+		filtered AS ( SELECT * FROM play_labels %s )
+		SELECT
+		    label,
+		    splitByChar('=', label)[1] AS severity,
+		    count() AS sessions,
+		    (SELECT count() FROM filtered) AS total,
+		    round(count() / (SELECT count() FROM filtered) * 100, 1) AS pct
+		FROM filtered
+		ARRAY JOIN labs AS label
+		GROUP BY label
+		ORDER BY sessions DESC
+		LIMIT 500
+	`, faultFilter)
+
+	body, err := chQueryBytes(r.Context(), cfg, query, params)
+	if err != nil {
+		http.Error(w, "clickhouse query: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	items, err := parseJSONEachRowItems(body)
+	if err != nil {
+		http.Error(w, "decode rows: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	total := 0
+	if len(items) > 0 {
+		// Every row carries the same total; pull it off the first. ClickHouse
+		// renders UInt64 as a quoted string in JSON, so strip quotes then parse.
+		var first map[string]json.RawMessage
+		if json.Unmarshal(items[0], &first) == nil {
+			if n, err := strconv.Atoi(strings.Trim(string(first["total"]), `"`)); err == nil {
+				total = n
+			}
+		}
+	}
+	writeJSON(w, map[string]any{"total": total, "days": days, "items": items})
+}

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -1453,6 +1453,18 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	// in characterization.go.
 	registerCharacterizationHandlers(mux, cfg)
 
+	// Label-frequency baseline (#772) — % of sessions per label, for
+	// population-aware triage. Defined in label_frequency.go.
+	registerLabelFrequencyHandler(mux, cfg)
+
+	// Label↔dimension association (#783) — conditional-probability lift, for
+	// "is this aberrant because of X?" attribution. Defined in label_associate.go.
+	registerLabelAssociateHandler(mux, cfg)
+
+	// Label divergence / skew (#783) — per-label max lift across dimensions,
+	// for the frequency-table skew column. Defined in label_divergence.go.
+	registerLabelDivergenceHandler(mux, cfg)
+
 	srv := &http.Server{
 		Addr:              cfg.httpListen,
 		Handler:           mux,

--- a/analytics/go-forwarder/p90_threshold.json
+++ b/analytics/go-forwarder/p90_threshold.json
@@ -1,0 +1,47 @@
+{
+  "version": "p90-2026-06-14",
+  "_comment": "QoE thresholds set to the p90 of each observed metric across all sessions in ClickHouse (129 sessions, computed 2026-06-14). Load via FORWARDER_QOE_THRESHOLDS_PATH. Intent: each magnitude label fires on ~the worst 10% of sessions instead of 70-90%.",
+  "_warning": "NOT DEPLOYABLE AS-IS. The test-dev session population is fault/stress-dominated (fault-injection tests + config-sweep stress runs), so these p90s reflect deliberately-broken playback, not real-world QoE — they are far too lenient (e.g. cirr p90=0.74 vs Conviva-good 0.004; vst p90=4.0s). Regenerate from a clean/production baseline (real plays, no fault injection, no sweep stress) before using. Only the magnitude thresholds below were p90-derived; ratios/factors/counts/windows/grace keep the compiled defaults (count thresholds like stall_burst p90=1 would go the WRONG way — noisier — on this data).",
+  "_p90_derived": ["startup.vst_concerning_ms", "startup.vst_breach_ms", "continuity.cirr_concerning", "continuity.cirr_breach", "continuity.cirt_concerning_ms", "continuity.cirt_breach_ms"],
+  "refire_cooldown_s": 30,
+  "outcomes": {
+    "ebvs_threshold_ms": 10000,
+    "user_stopped_after_threshold_ms": 5000
+  },
+  "startup": {
+    "vst_concerning_ms": 4019,
+    "vst_breach_ms": 5320,
+    "drm_dominant_ratio": 0.5
+  },
+  "continuity": {
+    "cirr_concerning": 0.74,
+    "cirr_breach": 0.9,
+    "cirt_concerning_ms": 76140,
+    "cirt_breach_ms": 90000,
+    "stall_burst_threshold": 3,
+    "stall_burst_window_s": 60
+  },
+  "network": {
+    "ttfb_breach_ms": 500,
+    "transfer_stall_ms": 5000,
+    "rate_cap_breach_factor": 1.10,
+    "cmcd_mtp_drift_ratio": 0.5
+  },
+  "abr": {
+    "bitrate_underutilized_ratio": 0.5,
+    "abr_headroom_margin": 0.85,
+    "throughput_divergence_factor": 0.15,
+    "throughput_peak_window_s": 30,
+    "downshift_storm_threshold": 3,
+    "downshift_storm_window_s": 30,
+    "min_variant_stuck_s": 30,
+    "fps_dip_ratio": 0.2,
+    "startup_grace_ms": 10000,
+    "downshift_overshoot_rungs": 2
+  },
+  "live": {
+    "offset_concerning_margin_s": 3,
+    "offset_breach_margin_s": 10,
+    "holdback_deviation_s": 5
+  }
+}

--- a/content/dashboard-v3/src/components/LabelFrequencyTable.vue
+++ b/content/dashboard-v3/src/components/LabelFrequencyTable.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+/**
+ * LabelFrequencyTable — population-aware triage baseline (#772).
+ *
+ * Shows how often each severity-tagged label fires across recent sessions
+ * (% of plays), so triage can tell ambient labels (fire on most streams →
+ * likely threshold noise, or high-impact-if-real) from rare ones (a specific
+ * stream is broken). Two derived scores resolve the "common cuts both ways"
+ * tension:
+ *   - Anomaly = severity × rarity (1 − freq)  → what the SWEEP should chase
+ *   - Impact  = severity × frequency          → what PRODUCT should fix first
+ * Sort toggles between them. Reads GET /analytics/api/v2/label_frequency.
+ */
+import { computed, onMounted, ref, watch } from 'vue';
+import { labelTooltip, hasGlossary } from '@/lib/labelGlossary';
+
+interface Row { label: string; severity: string; sessions: number | string; pct: number | string; }
+
+const SEV_WEIGHT: Record<string, number> = { error: 4, critical: 3, warning: 2, info: 1, testing: 0 };
+
+const items = ref<Row[]>([]);
+const divMap = ref<Record<string, { skew: number; top: string }>>({});
+const total = ref(0);
+const loading = ref(false);
+const error = ref('');
+const days = ref(7);
+const excludeFaulted = ref(true);
+
+type SortKey = 'label' | 'severity' | 'pct' | 'impact' | 'anomaly' | 'skew';
+const sortKey = ref<SortKey>('impact');
+const sortDir = ref<'asc' | 'desc'>('desc');
+function setSort(k: SortKey) {
+  if (sortKey.value === k) sortDir.value = sortDir.value === 'desc' ? 'asc' : 'desc';
+  else { sortKey.value = k; sortDir.value = k === 'label' ? 'asc' : 'desc'; }
+}
+function arrow(k: SortKey): string {
+  return sortKey.value === k ? (sortDir.value === 'desc' ? ' ▼' : ' ▲') : '';
+}
+
+async function load() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const u = `/analytics/api/v2/label_frequency?days=${days.value}&exclude_faulted=${excludeFaulted.value ? 1 : 0}`;
+    const resp = await fetch(u);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = (await resp.json()) as { total: number; items: Row[] | null };
+    total.value = data.total ?? 0;
+    items.value = data.items ?? [];
+    // Divergence / skew per label (max lift across dimensions) — parallel fetch.
+    const du = `/analytics/api/v2/label_divergence?days=${days.value}&exclude_faulted=${excludeFaulted.value ? 1 : 0}`;
+    const dresp = await fetch(du);
+    const m: Record<string, { skew: number; top: string }> = {};
+    if (dresp.ok) {
+      const dd = (await dresp.json()) as { items: Array<{ label: string; skew: number; top: string }> | null };
+      for (const d of dd.items ?? []) m[d.label] = { skew: d.skew, top: d.top };
+    }
+    divMap.value = m;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+watch([days, excludeFaulted], load);
+
+// ── label↔dimension association drill-down (#783) ──
+interface AssocItem { dim: string; value: string; n: number; with_l: number; pct: number; lift: number; significant: boolean; }
+const expanded = ref<string | null>(null);
+const assocItems = ref<AssocItem[]>([]);
+const assocBaseline = ref(0);
+const assocLoading = ref(false);
+const assocWithin = ref<string | null>(null); // "dim:value" held fixed (stratify)
+
+async function fetchAssoc(label: string, within: string | null) {
+  assocItems.value = [];
+  assocLoading.value = true;
+  try {
+    let u = `/analytics/api/v2/label_associate?label=${encodeURIComponent(label)}&days=${days.value}&exclude_faulted=${excludeFaulted.value ? 1 : 0}`;
+    if (within) u += `&within=${encodeURIComponent(within)}`;
+    const resp = await fetch(u);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = (await resp.json()) as { baseline_pct: number; items: AssocItem[] | null };
+    assocBaseline.value = data.baseline_pct ?? 0;
+    assocItems.value = (data.items ?? []).filter((i) => i.n >= 5).sort((a, b) => b.lift - a.lift);
+  } catch {
+    assocItems.value = [];
+  } finally {
+    assocLoading.value = false;
+  }
+}
+
+function toggleAssoc(label: string) {
+  if (expanded.value === label) { expanded.value = null; return; }
+  expanded.value = label;
+  assocWithin.value = null;
+  fetchAssoc(label, null);
+}
+function drillWithin(dim: string, value: string) {
+  if (!expanded.value) return;
+  assocWithin.value = `${dim}:${value}`;
+  fetchAssoc(expanded.value, assocWithin.value);
+}
+function clearWithin() {
+  if (!expanded.value) return;
+  assocWithin.value = null;
+  fetchAssoc(expanded.value, null);
+}
+
+function pctOf(r: Row): number { return typeof r.pct === 'string' ? parseFloat(r.pct) : r.pct; }
+function sevWeight(r: Row): number { return SEV_WEIGHT[r.severity] ?? 0; }
+function anomaly(r: Row): number { return sevWeight(r) * (1 - pctOf(r) / 100); }
+function impact(r: Row): number { return sevWeight(r) * (pctOf(r) / 100); }
+
+const rows = computed(() => {
+  const scored = items.value
+    // Triage cares about problems: drop testing= (operator metadata) and info= (informational, not defects).
+    .filter((r) => r.severity !== 'testing' && r.severity !== 'info')
+    .map((r) => ({
+      ...r, _pct: pctOf(r), _anomaly: anomaly(r), _impact: impact(r), _sev: sevWeight(r),
+      _skew: divMap.value[r.label]?.skew ?? 1, _top: divMap.value[r.label]?.top ?? '',
+    }));
+  const dir = sortDir.value === 'asc' ? 1 : -1;
+  const k = sortKey.value;
+  return scored.sort((a, b) => {
+    if (k === 'label') return a.label.localeCompare(b.label) * dir;
+    const pick = (x: typeof a) => k === 'severity' ? x._sev : k === 'pct' ? x._pct : k === 'anomaly' ? x._anomaly : k === 'skew' ? x._skew : x._impact;
+    return (pick(a) - pick(b)) * dir;
+  });
+});
+</script>
+
+<template>
+  <section class="lft">
+    <header class="lft-head">
+      <h2>Label frequency <span class="sub">across {{ total }} sessions / {{ days }}d</span></h2>
+      <div class="ctl">
+        <label class="chk"><input type="checkbox" v-model="excludeFaulted" /> exclude faulted</label>
+        <select v-model.number="days" class="sel">
+          <option :value="1">24h</option><option :value="7">7d</option><option :value="30">30d</option>
+        </select>
+      </div>
+    </header>
+    <p v-if="error" class="err">label frequency unavailable: {{ error }}</p>
+    <table v-else class="tbl">
+      <thead><tr>
+        <th class="srt" @click="setSort('label')">label{{ arrow('label') }}</th>
+        <th class="srt" @click="setSort('severity')">sev{{ arrow('severity') }}</th>
+        <th class="srt num" @click="setSort('pct')" title="% of sessions with this label">% sessions{{ arrow('pct') }}</th>
+        <th class="srt num" @click="setSort('impact')" title="severity × frequency — fix-first for product">impact{{ arrow('impact') }}</th>
+        <th class="srt num" @click="setSort('anomaly')" title="severity × rarity — chase-first for the sweep">anomaly{{ arrow('anomaly') }}</th>
+        <th class="srt num" @click="setSort('skew')" title="max lift across dimensions — how dimension-driven this label is (click the label for the breakdown)">skew{{ arrow('skew') }}</th>
+      </tr></thead>
+      <tbody>
+        <template v-for="r in rows" :key="r.label">
+          <tr :class="{ open: expanded === r.label }">
+            <td class="lab assoc-toggle" :title="labelTooltip(r.label) || r.label" @click="toggleAssoc(r.label)">
+              <span class="caret">{{ expanded === r.label ? '▾' : '▸' }}</span>
+              <span :class="{ defd: hasGlossary(r.label) }">{{ r.label }}</span>
+            </td>
+            <td><span class="sev" :class="'sv-' + r.severity">{{ r.severity }}</span></td>
+            <td class="num"><span class="bar" :style="{ width: r._pct + '%' }"></span>{{ r._pct }}%</td>
+            <td class="num">{{ r._impact.toFixed(1) }}</td>
+            <td class="num">{{ r._anomaly.toFixed(1) }}</td>
+            <td class="num skew" :class="{ hot: r._skew >= 3 }" :title="r._top ? 'driven by ' + r._top : ''">{{ r._skew >= 1.05 ? r._skew.toFixed(1) + '×' : '—' }}</td>
+          </tr>
+          <tr v-if="expanded === r.label" class="assoc">
+            <td colspan="6">
+              <div v-if="assocLoading" class="assoc-note">loading associations…</div>
+              <div v-else-if="!assocItems.length" class="assoc-note">no dimension associations (not enough sessions)</div>
+              <template v-else>
+                <div class="assoc-head">
+                  Which platforms / content does this label hit most? · normally {{ assocBaseline }}% of sessions · ratio = how much more (or less) likely than that — 1× is average
+                  <span v-if="assocWithin" class="within-chip">held fixed: {{ assocWithin.replace(':', '=') }} <button @click="clearWithin" title="show all again">✕</button></span>
+                </div>
+                <table class="assoc-tbl">
+                  <thead><tr><th>dimension = value <span class="hint-h">(click to hold fixed →)</span></th><th class="num">sessions</th><th class="num">% with label</th><th class="num">lift</th></tr></thead>
+                  <tbody>
+                    <tr v-for="a in assocItems" :key="a.dim + a.value" :class="{ sig: a.significant }">
+                      <td class="adv" @click="drillWithin(a.dim, a.value)" title="hold this value fixed and compare the other dimensions only within it — a fair, like-for-like comparison">
+                        <span class="adim">{{ a.dim }}</span> = {{ a.value }}
+                      </td>
+                      <td class="num">{{ a.n }}</td>
+                      <td class="num">{{ a.pct }}%</td>
+                      <td class="num lift" :class="{ up: a.lift >= 1.5, down: a.lift <= 0.67 }">{{ a.lift }}×<span v-if="a.significant" class="star" title="significant (enough sessions + effect)"> ✦</span></td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p class="assoc-caveat" v-if="!assocWithin">⚠ A high ratio can mislead — each platform / content was tested differently, so it may reflect <em>what we ran there</em>, not the dimension itself. Click a row to hold that value fixed and compare the rest on equal footing.</p>
+              </template>
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+    <p class="note">
+      Ambient labels (high %) are likely threshold noise — relax via
+      <code>FORWARDER_QOE_THRESHOLDS_PATH</code> — or high-impact if real.
+      Rare + severe (high anomaly) = a specific stream is broken.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.lft { background: var(--surface, #f8f9fa); border: 1px solid var(--border, #dadce0); border-radius: 8px; padding: .75rem 1rem; color: var(--text-primary, #202124); }
+.lft-head { display: flex; justify-content: space-between; align-items: center; gap: 1rem; flex-wrap: wrap; }
+.lft-head h2 { font-size: 1rem; margin: 0; }
+.sub { color: var(--text-secondary, #5f6368); font-weight: 400; font-size: .8rem; }
+.ctl { display: flex; gap: .6rem; align-items: center; }
+.chk { color: var(--text-secondary, #5f6368); font-size: .8rem; }
+.sel { background: var(--background, #fff); color: var(--text-primary, #202124); border: 1px solid var(--border, #dadce0); border-radius: 6px; padding: .25rem .4rem; }
+.err { color: var(--error, #d93025); }
+.tbl { width: 100%; border-collapse: collapse; margin-top: .6rem; font-size: .82rem; background: var(--background, #fff); }
+.tbl th { text-align: left; color: var(--text-secondary, #5f6368); font-weight: 600; border-bottom: 1px solid var(--border, #dadce0); padding: .3rem .5rem; }
+.tbl th.srt { cursor: pointer; user-select: none; }
+.tbl th.srt:hover { color: var(--primary-blue, #1a73e8); }
+.tbl th.num, .tbl td.num { text-align: right; font-variant-numeric: tabular-nums; }
+.tbl td { padding: .25rem .5rem; border-bottom: 1px solid var(--border-light, #e8eaed); }
+.lab { font-family: ui-monospace, monospace; color: var(--text-primary, #202124); }
+.lab.defd { text-decoration: underline dotted var(--text-disabled, #9aa0a6); text-underline-offset: 2px; cursor: help; }
+.sev { font-size: .68rem; text-transform: uppercase; padding: 0 .4rem; border-radius: 8px; }
+.sv-error, .sv-critical { background: var(--error-light, #fce8e6); color: var(--error, #d93025); }
+.sv-warning { background: var(--warning-light, #fef7e0); color: #a86a00; }
+.sv-info { background: var(--info-light, #e8f0fe); color: var(--info, #1a73e8); }
+.sv-testing { background: var(--surface-hover, #f1f3f4); color: var(--text-disabled, #9aa0a6); }
+.skew.hot { color: var(--error, #d93025); font-weight: 600; }
+.num .bar { display: inline-block; height: .55em; background: var(--primary-blue, #1a73e8); border-radius: 2px; margin-right: .4rem; vertical-align: middle; opacity: .35; }
+.assoc-toggle { cursor: pointer; }
+.assoc-toggle .caret { color: var(--text-disabled, #9aa0a6); margin-right: .3rem; }
+tr.open { background: var(--surface-hover, #f1f3f4); }
+tr.assoc > td { background: var(--surface, #f8f9fa); padding: .5rem .75rem; }
+.assoc-note { color: var(--text-secondary, #5f6368); font-size: .8rem; }
+.assoc-head { color: var(--text-secondary, #5f6368); font-size: .76rem; margin-bottom: .35rem; }
+.assoc-tbl { width: 100%; border-collapse: collapse; font-size: .8rem; }
+.assoc-tbl th { text-align: left; color: var(--text-disabled, #9aa0a6); font-weight: 600; padding: .15rem .4rem; }
+.assoc-tbl td { padding: .15rem .4rem; border-top: 1px solid var(--border-light, #e8eaed); }
+.assoc-tbl .num { text-align: right; font-variant-numeric: tabular-nums; }
+.assoc-tbl tr.sig { font-weight: 600; }
+.adim { color: var(--primary-blue, #1a73e8); font-family: ui-monospace, monospace; }
+.within-chip { margin-left: .5rem; background: var(--primary-blue-light, #e8f0fe); color: var(--primary-blue, #1a73e8); border-radius: 8px; padding: .05rem .4rem; font-size: .72rem; }
+.within-chip button { background: none; border: none; color: var(--primary-blue, #1a73e8); cursor: pointer; font-size: .72rem; padding: 0 0 0 .2rem; }
+.adv { cursor: pointer; }
+.adv:hover { background: var(--primary-blue-light, #e8f0fe); }
+.hint-h { color: var(--text-disabled, #9aa0a6); font-weight: 400; font-size: .7rem; }
+.assoc-caveat { color: #a86a00; font-size: .72rem; margin: .4rem 0 0; }
+.lift.up { color: var(--error, #d93025); }
+.lift.down { color: var(--success, #1e8e3e); }
+.star { color: var(--warning, #f9ab00); }
+.note { color: var(--text-secondary, #5f6368); font-size: .75rem; margin: .6rem 0 0; }
+.note code { background: var(--surface-hover, #f1f3f4); padding: .05rem .3rem; border-radius: 4px; }
+</style>

--- a/content/dashboard-v3/src/lib/labelGlossary.ts
+++ b/content/dashboard-v3/src/lib/labelGlossary.ts
@@ -1,0 +1,113 @@
+/**
+ * labelGlossary — single source of truth for what each severity-tagged QoE /
+ * lifecycle label means and how it's flagged (#772). Keyed by the *event* (the
+ * part after `severity=`, with any leading `*` synthesized-marker stripped), so
+ * `error=*qoe_vsf` and `warning=*qoe_vsf` resolve to the same entry.
+ *
+ * Defaults in the "how" text are the compiled-in Conviva thresholds
+ * (qoe_thresholds.go); they move if a FORWARDER_QOE_THRESHOLDS_PATH overlay is
+ * loaded. Use `labelTooltip(label)` for a hover string anywhere a label chip is
+ * rendered.
+ */
+
+interface Entry {
+  what: string;
+  how?: string;
+}
+
+const GLOSSARY: Record<string, Entry> = {
+  // ── terminal / player failures ───────────────────────────────────────────
+  qoe_vsf: { what: 'Video Start Failure — playback never produced a first frame', how: 'startup ended in error before any frame' },
+  qoe_msf: { what: 'Mid-Stream Failure — playback started then died and did not recover', how: 'fatal error after first frame' },
+  qoe_ebvs: { what: 'Exit Before Video Start — abandoned during startup', how: 'session ended while still buffering, > ebvs_threshold_ms (10s)' },
+  player_error: { what: 'The player reported a hard error', how: 'client-emitted error event' },
+  restart_auto_recovery: { what: 'The player auto-restarted to recover from a wedge', how: 'a new attempt_id appeared without user action' },
+  restart_user_retry: { what: 'The user manually retried playback', how: 'restart attributed to a user action' },
+
+  // ── startup ──────────────────────────────────────────────────────────────
+  qoe_vst_concerning: { what: 'Video Start Time slow', how: 'time-to-first-frame > vst_concerning_ms (5s)' },
+  qoe_vst_breach: { what: 'Video Start Time very slow', how: 'time-to-first-frame > vst_breach_ms (10s)' },
+  qoe_buffering_long_startup: { what: 'Long buffering during startup', how: 'pre-first-frame buffering over the long threshold' },
+  qoe_buffering_severe_startup: { what: 'Severe buffering during startup', how: 'pre-first-frame buffering over the severe threshold' },
+  qoe_stall_long_startup: { what: 'Long stall during startup' },
+  qoe_stall_severe_startup: { what: 'Severe stall during startup' },
+
+  // ── continuity / rebuffering ─────────────────────────────────────────────
+  qoe_cirr_concerning: { what: 'Rebuffer ratio elevated (Connection-Induced Rebuffer Ratio)', how: 'rebuffer_time / playing_time > cirr_concerning (0.002)' },
+  qoe_cirr_breach: { what: 'Rebuffer ratio high', how: 'rebuffer_time / playing_time > cirr_breach (0.004)' },
+  qoe_cirt_concerning: { what: 'Long individual rebuffers (Connection-Induced Rebuffer Time)', how: 'mean rebuffer-event duration > cirt_concerning_ms (1s)' },
+  qoe_cirt_breach: { what: 'Very long individual rebuffers', how: 'mean rebuffer-event duration > cirt_breach_ms (2s)' },
+  qoe_stall_long_midplay: { what: 'Long stall during mid-play' },
+  qoe_stall_severe_midplay: { what: 'Severe stall during mid-play', how: '≥ stall_burst_threshold (3) stalls in stall_burst_window_s (60s)' },
+  qoe_buffering_severe_scrub: { what: 'Severe buffering after a seek/scrub' },
+  stall_frozen: { what: 'The playhead froze — no progress while not paused', how: 'position stopped advancing (wall-clock confirmed)' },
+  timejump: { what: 'The playhead jumped discontinuously', how: 'position moved more than wall-clock elapsed' },
+
+  // ── tiers (composite QoE verdict) ────────────────────────────────────────
+  qoe_tier_unacceptable: { what: 'Overall QoE tier: unacceptable', how: 'composite of startup + rebuffer + quality signals' },
+  qoe_tier_acceptable: { what: 'Overall QoE tier: acceptable (below premium)' },
+
+  // ── ABR / quality ────────────────────────────────────────────────────────
+  qoe_downshift_storm: { what: 'ABR thrashing down', how: '> downshift_storm_threshold (3) downshifts in downshift_storm_window_s (30s)' },
+  qoe_downshift_overshoot: { what: 'ABR over-corrected downward', how: 'settled ≥ downshift_overshoot_rungs (2) below the rung the cap supports' },
+  qoe_min_variant_stuck: { what: 'Pinned at the lowest rung', how: 'dwelled at the floor variant > min_variant_stuck_s (30s)' },
+  qoe_abr_conservative: { what: 'ABR under-using the link', how: 'selected variant < bitrate_underutilized_ratio (50%) of available throughput' },
+  qoe_ladder_gap: { what: 'No ladder rung fits the available throughput', how: 'next rung needs more than abr_headroom_margin (85%) of throughput' },
+  qoe_throughput_divergence: { what: 'Client vs server throughput disagree', how: 'network_bitrate diverges > throughput_divergence_factor (15%) from server throughput' },
+  qoe_fps_dip: { what: 'Displayed frame rate dipped', how: 'displayed fps < fps_dip_ratio (80%) of nominal' },
+  shift_up: { what: 'ABR shifted up a rung (informational)' },
+  shift_down: { what: 'ABR shifted down a rung (informational)' },
+
+  // ── network / transport ──────────────────────────────────────────────────
+  qoe_rate_cap_breach: { what: 'Measured bitrate exceeded the applied cap', how: 'network bitrate > cap × rate_cap_breach_factor (1.10) — often an AVPlayer burst over-read' },
+  qoe_transfer_stall: { what: 'A segment transfer stalled mid-flight', how: 'no bytes received for transfer_stall_ms (5s)' },
+  master_manifest_failure: { what: 'The master playlist request failed' },
+  manifest_failure: { what: 'A media playlist request failed' },
+  segment_failure: { what: 'A media segment request failed' },
+  http_4xx: { what: 'An HTTP 4xx response on a request' },
+  http_5xx: { what: 'An HTTP 5xx response on a request' },
+  slow_segment: { what: 'A segment fetch was slow (but completed)' },
+  stall_segment: { what: 'A segment fetch stalled' },
+  transport_disconnect: { what: 'The connection dropped at the transport layer', how: 'client/socket disconnect mid-request' },
+  transfer_active_timeout: { what: 'Server closed a transfer for exceeding the active (total) timeout' },
+  transfer_idle_timeout: { what: 'Server closed a transfer for exceeding the idle (no-bytes) timeout' },
+
+  // ── live edge ────────────────────────────────────────────────────────────
+  qoe_live_offset_concerning: { what: 'Playhead drifting behind the live edge', how: '> offset_concerning_margin_s (3s) beyond the recommended live offset' },
+  qoe_live_offset_breach: { what: 'Playhead well behind the live edge', how: '> offset_breach_margin_s (10s) beyond the recommended live offset' },
+
+  // ── injected-fault markers (from fault-injection tests, not real defects) ─
+  fault_timeout: { what: 'INJECTED fault: a timeout was applied (fault test, expected)' },
+  fault_other: { what: 'INJECTED fault: a non-categorised fault was applied (fault test, expected)' },
+  fault_incomplete: { what: 'INJECTED fault: a transfer was cut off by an injected fault (fault test)' },
+  fault_rule_enabled: { what: 'A fault rule was armed on the session (test metadata)' },
+  fault_rule_disabled: { what: 'A fault rule was cleared (test metadata)' },
+
+  // ── lifecycle / info ─────────────────────────────────────────────────────
+  first_frame: { what: 'First decoded frame rendered (startup succeeded)' },
+  play_start: { what: 'Playback started' },
+  play_end: { what: 'Playback ended' },
+  loop_server: { what: 'The origin is looping VOD-as-live (test content marker)' },
+  unexpected_startup: { what: 'Startup behaved outside the expected envelope' },
+  unexpected_fault: { what: 'A fault produced an outcome outside its recovery-expected envelope' },
+  unexpected_end: { what: 'Playback ended unexpectedly (not a clean user stop)' },
+};
+
+/** eventOf strips the `<severity>=` prefix and any leading `*` marker. */
+export function eventOf(label: string): string {
+  const eq = label.indexOf('=');
+  const ev = eq >= 0 ? label.slice(eq + 1) : label;
+  return ev.replace(/^\*/, '');
+}
+
+/** labelTooltip returns a hover string ("what · how") for a label, or '' if unknown. */
+export function labelTooltip(label: string): string {
+  const e = GLOSSARY[eventOf(label)];
+  if (!e) return '';
+  return e.how ? `${e.what} · ${e.how}` : e.what;
+}
+
+/** hasGlossary reports whether a label has a definition (to style it as hoverable). */
+export function hasGlossary(label: string): boolean {
+  return GLOSSARY[eventOf(label)] !== undefined;
+}

--- a/content/dashboard-v3/src/pages/Sessions.vue
+++ b/content/dashboard-v3/src/pages/Sessions.vue
@@ -10,6 +10,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
+import LabelFrequencyTable from '@/components/LabelFrequencyTable.vue';
 import ChatPanel from '@/components/chat/ChatPanel.vue';
 import { sessionViewerURL, type CompareMember } from '@/composables/urlTimeFormat';
 import { listPlays, patchPlayClassification, type PlaySummary, type Scenario } from '@/repo/v2-repo';
@@ -1375,6 +1376,8 @@ const showCustomInputs = computed(() => activeRangeId.value === 'custom');
         <div class="page-title">Sessions</div>
         <div class="page-subtitle">Browse archived streaming sessions. Click one to open it in the Session Viewer.</div>
       </div>
+
+      <LabelFrequencyTable style="margin-bottom: 1rem;" />
 
       <div class="panel">
         <div class="panel-header">


### PR DESCRIPTION
Label-level triage analytics on the **sessions dashboard** — the observational half of the triage stack (the experimental half, the fault sweep, is the stacked PR that follows).

## What's here
- **`label_frequency`** — % of sessions carrying each label, with **Impact** (severity×frequency) and **Anomaly** (severity×rarity) scores; `exclude_faulted`; hides `testing=`/`info=` labels.
- **`label_associate`** — Splunk-`associate`-style conditional-probability **lift**: "is this label aberrant because of platform / app_version / device / which characterization test ran?" Dimensions derived from `session_events` + the `testing=test_*` control-event tag. `within=` stratification to kill the test-mix confound.
- **`label_divergence`** — per-label **skew** (max lift across dimensions, incl. the `test` dim) so a test-driven label (e.g. `stall_frozen` 3.5× on pyramid) is obvious at a glance.
- **`labelGlossary`** — hover tooltips explaining every label + how it's computed.
- **`p90_threshold.json`** — p90 values computed from the ClickHouse corpus (carries a `_warning` that test-dev data is fault-dominated, so not production-ready).

Surfaced via `LabelFrequencyTable.vue`, mounted on `Sessions.vue`.

## Scope / split
This is **Bucket A** of a sweep/sessions split. The fault-injection **sweep** (engine + dashboard tab) is a separate, **stacked** PR that depends on this one (its Sweep tab reuses `LabelFrequencyTable`, and `harness sweep seed-from-triage` reads `label_divergence`). Merge this first.

Forwarder + dashboard build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
