### PR TITLE
feat(772): automated fault-injection sweep — engine, probe, dashboard tab

### DIFF
--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: sweep
+description: Drive the automated fault-injection sweep (issue #772, docs/sweep-design.md) — the unattended claim→apply→probe→analyze→isolate→promote loop over the local .sweep/ queue. Invoke under /goal ("drive the sweep until backlog is empty"), or for a single hand-run iteration. Each clean run is a mechanical oracle check (no model call); the LLM only reasons on a notable/aberration hit — picking which axes to flip for isolation and writing the finding. Runs on the Mac with the sims (drives appium/adb), against the test-dev deploy.
+last_reviewed: 2026-06-13
+---
+
+# Sweep — drive the automated fault-injection loop
+
+This skill is the **driver** for the sweep designed in `docs/sweep-design.md` (issue #772). The queue lives in `.sweep/` (gitignored); the `harness sweep` subcommands are the mechanics. **You** (the LLM, under `/goal`) are the investigator — but only on a hit: a clean run is a pure oracle check with no reasoning, so cost scales with *findings*, not the (vast) experiment count.
+
+**Conventions:** follows `.claude/skills/CONVENTIONS.md`. Most load-bearing here:
+- **Bash discipline** — lead every command with `harness`, `go`, `gh`, or `jq` (first token matches the allowlist). Never `cd …`/`VAR=…`/`export …` prefixes; pass values inline.
+- **No guessing during triage** (§2) — tag every causal claim `confirmed`/`refuted`/`needs-test`; the `n=1 is not a pattern` rule is enforced mechanically by the confirm-reps step below.
+- **Recall before investigate** — grep `.claude/findings/` + `.claude/memory/` before reasoning about a hit (the `forensics`/`finding` skills).
+
+## Where this runs
+
+On the **Mac with the sims + attached devices** (the probe drives appium/adb/WDA — cloud CI can't). Target is the **test-dev deploy** (`HARNESS_BASE_URL=https://dev.jeoliver.com:21000`, per `.env`). Single content (`insane_new`) for now. Depth-first: a narrow seed, isolation/bisect dominate, so you can *watch the investigate→insert→re-run chain work* before widening.
+
+## Two classes — pick one, don't mix (§0 of the design)
+
+- **`config`** (default) — realistic stream + benign-network variation: content manipulation, rate caps (floor-guarded — never starve below the lowest sustainable rung), pattern ladders, server transfer-timeouts. **No** injected errors, **no** delay/loss. Oracle: any bad QoE label is the signal. Targets ABR decision quality / over-downshift / manifest-config robustness.
+- **`fault`** — explicit error-recovery: `4xx/5xx`, `corrupted`, `connection_refused`, `dns_failure`, `rate_limiting`, transport `drop`/`reject`, `request_*_hang`. Oracle: the recovery-expected envelope (a fault the player should survive isn't a finding; failing to recover is).
+
+Seed one class at a time: `harness sweep seed --class config` (default) or `--class fault`. Findings are namespaced `sig:<class>-…` so they never dedup-collide. Default to `config` unless explicitly chasing error-recovery.
+
+## The loop (one iteration)
+
+Run these in order. Under `/goal`, repeat until `harness sweep status` shows `backlog 0` (and any in-flight `running` drained), then stop — the sweep is state-driven, not clocked.
+
+### 0. Reap + health-check
+```
+harness sweep reap --max-age-min 60
+```
+Returns claims orphaned by a dead runner. Then confirm the deploy + a sim are healthy; if not, don't blame the player — skip this tick.
+
+### 1. Claim the top-scored experiment
+```
+harness sweep next --claim --owner <runner-id> --json
+```
+Atomic-rename claim (parallel-safe across worktrees). `null` ⇒ backlog empty ⇒ you're done. The `--json` gives you the full recipe (platform/protocol/mode/fault/shape/content_manipulation/why).
+
+### 2. Materialise the recipe, then drive the probe (config-on-connect)
+The probe is the **characterization harness**. The robust path for ANY recipe — including arbitrary fault + content_manipulation, not just shape — is **config-on-connect**: configure the session BEFORE the app launches, then launch the app bound to that same `player_id`. The cap/fault/content is live from the player's first byte, no PATCH race.
+
+```
+harness sweep bootstrap <exp-id> --player <uuid>     # mints uuid if omitted; --group G for A/B
+```
+This GETs the bootstrap master URL on the shaper port carrying a full-fidelity `proxy.cfg` patch built from the recipe — slider shape, HTTP fault, `content_manipulation`, and the `sweep=1`/`exp_id`/`kind`/`arm`/`group`/`why=…` labels (slug-safe; `testing=` tier, no good/bad tint). Verified to materialise all four onto a live test-dev session. It prints the `player_id` to launch with.
+
+Then drive the probe bound to that id. The sweep's generic probe is **`TestSweepProbe`** — it reattaches to the bootstrapped session (no re-config), optionally arms the recipe's **pattern** (the bandwidth motion), plays for a window, and logs the play_id + a session-viewer URL:
+```
+CHAR_PLAYER_ID=<from bootstrap> HARNESS_BASE_URL=… LAUNCH_MODE=appium \
+CHAR_CONTENT=insane_new_p200_h264 CHAR_SWEEP_DURATION_S=90 \
+CHARACTERIZATION_DEVICE_UDID=<booted sim> \
+CHAR_SWEEP_PATTERN=pyramid CHAR_SWEEP_STEP_S=12 CHAR_SWEEP_MARGIN=5 \
+go test ./tests/characterization/modes -run TestSweepProbe -count=1 -v -timeout 8m
+```
+(`LAUNCH_MODE`: `appium` for iOS-sim + Apple TV; `cli`/`adb` for Android TV.) For a **pattern recipe** (`shape.pattern` set), pass `CHAR_SWEEP_PATTERN` (+ `_STEP_S` / `_MARGIN` from the recipe's `shape`); the probe waits for the manifest then arms the pattern via `harness shape --pattern` — the same path the characterization modes use, so the cap actually sweeps. Omit `CHAR_SWEEP_PATTERN` for a plain-play recipe (rate-cap / content-only). **Verified end-to-end** against test-dev + a booted iOS sim, both plain-play and a pyramid that drove real downshifts → `analyze` → verdict.
+
+> Pattern shapes still apply post-launch via `harness shape --pattern` (they need the fetched manifest's ladder). For an ALREADY-live player, `harness sweep apply <id> --target <player>` does the reset-then-apply variant.
+
+**Capture the `play_id`** (the *play*, distinct from the bootstrapped `player_id`) from the Report JSON (`tests/characterization/modes/artifacts/<mode>-<platform>-<short>-<runid>-cyc1.json`, field `play_ids[0]`) or the test log line `play_id: <uuid>`. No `play_id` / probe crash ⇒ **`inconclusive`** (infra, not the player): return the file to backlog for a bounded retry, then `review/`. Don't analyze.
+
+### 3. Analyze — the oracle verdict (mechanical, no reasoning)
+```
+harness sweep analyze <exp-id> --play <play_id> --confirm-reps 3
+```
+Pulls the play's QoE labels, classifies the trichotomy (`clean`→`done/`, `notable`/`aberration`→`found/`), and — on a *first* single-rep hit — enqueues 3 confirmation reps to `backlog/` (the n=1 guard, sharing a `rep_group`; reps don't recurse). A `clean` verdict ends the iteration here. **This step needs no LLM judgment.**
+
+### 4. On a confirmed hit — investigate + insert (this is where you reason)
+A hit is *confirmed* only once the rep batch agrees (don't act on n=1). Then:
+
+1. **Recall** — grep `.claude/findings/` + `.claude/memory/` for the signature/symptom (`forensics` skill). If a prior finding explains it, say so and skip to promote.
+2. **Reason about the cause** from the evidence — *which* labels fired, *when* in the play, on *which* request kind — and pick the most-informative axes to flip. This is the OFAT isolation fan; it is **LLM-reasoned, not a fixed checklist** (a startup VSF on a 4K ladder → flip `platform` + `ladder` first; a mid-play freeze after a drop → vary drop duration + `liveoffset`, not codecs). Cheap/likely-first: Tier 1 = `platform`/`protocol` (different devices → simultaneous), Tier 2 = manifest knobs.
+   ```
+   harness sweep isolate <exp-id> --flip platform=androidtv --flip ladder=drop-top-rung --flip protocol=dash
+   ```
+   This materializes a `control` + one one-axis-flip `variant` per flip into `backlog/` (each enforced to differ from control in exactly one axis; capped at 8). The scheduler will pick them up *next* (they outrank seeds), so the chain runs itself.
+3. **Promote** to a deduped Issue:
+   ```
+   harness sweep promote <exp-id> --dry-run        # inspect signature + body first
+   harness sweep promote <exp-id> --axis platform  # append the attributed axis once isolation confirms it
+   ```
+   Comments on the open Issue carrying the signature label if one exists, else creates one (`sweep` + `sig:…` + `bug`/`notable`). Uses `--body-file` (heredoc rule honored internally).
+
+### 5. Drain
+When `harness sweep status` shows no `backlog`/`running`, summarize what was found and **stop** (don't reschedule — that's `/loop`'s job as an outer cadence, not this inner loop).
+
+## What you do NOT do
+- Don't FIFO — always `sweep next` (discovery-first scoring).
+- Don't promote on n=1 — wait for the confirm-reps batch.
+- Don't run an unfaulted play and call it a fault test (the integration-seam note above).
+- Don't hand-pick a fixed isolation checklist — reason from the specific failure.
+
+## See also
+- `docs/sweep-design.md` — the full design (oracle trichotomy §3, store §4, scheduler §5, A/B isolation §6, the loop §7, robustness/prereqs §11).
+- `forensics` / `investigate` / `finding` / `triage` — the reasoning + capture skills this loop reuses on a hit.
+- `shape` / `fault` — the underlying control surfaces `sweep apply` wraps.
+- `harness sweep help` — the subcommand surface.

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ content/dashboard-v3/node_modules/
 .claude/screenshots/
 .claude/settings.json
 .claude/worktrees/
+
+# fault-sweep local queue (#772) — ephemeral working state
+.sweep/

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -879,3 +879,40 @@ ORDER BY (started_at, test_name, platform)
 TTL toDateTime(started_at) + INTERVAL 90 DAY DELETE WHERE classification = 'other',
     toDateTime(started_at) + INTERVAL 180 DAY DELETE WHERE classification = 'interesting'
 SETTINGS index_granularity = 8192;
+
+-- ── sweep_experiments ─────────────────────────────────────────────────────
+-- The automated fault-sweep's orchestration queue (issue #772), published from
+-- the local .sweep/ store via `harness sweep publish` so the dashboard's Sweep
+-- tab can show pending / running / done / found experiments with their reasons
+-- (why) and results (verdict) and lineage (parent → isolation fan). One
+-- upsertable row per experiment: ReplacingMergeTree(updated_at) ORDER BY exp_id
+-- collapses repeated publishes to the latest state. Query with FINAL (the table
+-- is small — one row per live experiment).
+CREATE TABLE IF NOT EXISTS infinite_streaming.sweep_experiments
+(
+    exp_id      String                  CODEC(ZSTD(1)),
+    class       LowCardinality(String)  CODEC(ZSTD(1)),   -- config | fault
+    status      LowCardinality(String)  CODEC(ZSTD(1)),   -- backlog|running|done|found|review|feedback
+    kind        LowCardinality(String)  CODEC(ZSTD(1)),   -- seed|isolation|hypothesis|bisect
+    platform    LowCardinality(String)  CODEC(ZSTD(1)),
+    protocol    LowCardinality(String)  CODEC(ZSTD(1)),
+    mode        LowCardinality(String)  CODEC(ZSTD(1)),
+    recipe      LowCardinality(String)  CODEC(ZSTD(1)),   -- dominant knob (recipeSlug)
+    arm         LowCardinality(String)  CODEC(ZSTD(1)),   -- control|variant|''
+    group_id    String                  CODEC(ZSTD(1)),   -- A/B group
+    parent      String                  CODEC(ZSTD(1)),   -- lineage to the originating hit
+    depth       UInt8                   DEFAULT 0,
+    why         String                  CODEC(ZSTD(1)),   -- the reason slug
+    why_text    String                  CODEC(ZSTD(3)),   -- full rationale
+    verdict     LowCardinality(String)  CODEC(ZSTD(1)),   -- clean|notable|aberration|inconclusive|''
+    player_id   String                  CODEC(ZSTD(1)),
+    play_id     String                  CODEC(ZSTD(1)),
+    score       Float64                 DEFAULT 0,
+    created_at  DateTime64(3, 'UTC')    CODEC(Delta, ZSTD(1)),
+    updated_at  DateTime64(3, 'UTC')    CODEC(Delta, ZSTD(1)),
+    INDEX idx_exp exp_id TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY exp_id
+TTL toDateTime(updated_at) + INTERVAL 30 DAY
+SETTINGS index_granularity = 8192;

--- a/analytics/go-forwarder/label_associate.go
+++ b/analytics/go-forwarder/label_associate.go
@@ -22,9 +22,13 @@ import (
 // of its rows (session_events + network_requests + control_events) carries L.
 // Dimension values come from session_events columns (constant per play).
 
-// associateDims are the per-play dimensions we associate against — all derived
-// from session_events columns + the testing=test_* control-event tag (no
-// `platform` column; device_class / device_model proxy it, #783).
+// associateDims are the per-play dimensions we associate against. The first
+// group are session_events columns (no `platform` column — device_class /
+// device_model proxy it, #783). The sweep_* group is joined from
+// sweep_experiments (keyed by play_id) so labels can be associated against the
+// KNOWN experiment parameters — pattern/recipe, mode, class. Because the sweep
+// SET those, that association is near-causal, not just observational (the
+// pattern idea). They're empty (→ filtered) for non-sweep plays.
 var associateDims = []struct{ label, col string }{
 	{"test", "test"}, // characterization mode (pyramid/rampup/…) from the testing=test_* tag on control_events
 	{"content", "content_name"},
@@ -32,6 +36,9 @@ var associateDims = []struct{ label, col string }{
 	{"platform", "platform"}, // derived: iphone / iphone-sim / ipad / ipad-sim / androidtv
 	{"device_model", "device_model"},
 	{"device_kind", "device_kind"}, // simulator vs real (derived from device_model)
+	{"sweep_recipe", "sweep_recipe"},
+	{"sweep_mode", "sweep_mode"},
+	{"sweep_class", "sweep_class"},
 }
 
 func registerLabelAssociateHandler(mux *http.ServeMux, cfg config) {
@@ -156,8 +163,13 @@ func handleLabelAssociate(w http.ResponseWriter, r *http.Request, cfg config) {
 		            se.device_class = 'tablet', 'ipad',
 		            se.device_class = 'phone',  'iphone',
 		            se.device_class)) AS platform,
+		        any(sx.recipe) AS sweep_recipe,
+		        any(sx.mode)   AS sweep_mode,
+		        any(sx.class)  AS sweep_class,
 		        (se.play_id IN labeled) AS is_labeled
 		    FROM infinite_streaming.session_events se
+		    LEFT JOIN (SELECT play_id, recipe, mode, class FROM infinite_streaming.sweep_experiments FINAL) sx
+		      ON sx.play_id = se.play_id
 		    LEFT JOIN tests t ON t.play_id = se.play_id
 		    WHERE se.ts >= now() - INTERVAL {days:UInt32} DAY AND se.play_id != '' %s
 		    GROUP BY se.play_id

--- a/analytics/go-forwarder/main.go
+++ b/analytics/go-forwarder/main.go
@@ -1453,6 +1453,10 @@ func serveHTTP(ctx context.Context, cfg config, ring *Ring) {
 	// in characterization.go.
 	registerCharacterizationHandlers(mux, cfg)
 
+	// Sweep-experiment queue (issue #772) — POST snapshot from `harness sweep
+	// publish`, GET for the dashboard's Sweep tab. Defined in sweep_experiments.go.
+	registerSweepHandlers(mux, cfg)
+
 	// Label-frequency baseline (#772) — % of sessions per label, for
 	// population-aware triage. Defined in label_frequency.go.
 	registerLabelFrequencyHandler(mux, cfg)

--- a/analytics/go-forwarder/sweep_experiments.go
+++ b/analytics/go-forwarder/sweep_experiments.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Sweep-experiment queue ingestion + retrieval (issue #772). The local .sweep/
+// store lives on the runner, not the deploy, so `harness sweep publish` POSTs a
+// snapshot of every experiment here; this stores them in
+// infinite_streaming.sweep_experiments (ReplacingMergeTree by exp_id, so each
+// publish upserts the latest state) and serves them back to the dashboard's
+// Sweep tab.
+//
+//	POST /api/v2/sweep/experiments   bulk upsert ({"experiments":[…]})
+//	GET  /api/v2/sweep/experiments   list latest state (optional ?class= ?status= ?limit=)
+
+// sweepExperimentRow is the wire + storage shape (one experiment's current state).
+type sweepExperimentRow struct {
+	ExpID     string  `json:"exp_id"`
+	Class     string  `json:"class"`
+	Status    string  `json:"status"`
+	Kind      string  `json:"kind"`
+	Platform  string  `json:"platform"`
+	Protocol  string  `json:"protocol"`
+	Mode      string  `json:"mode"`
+	Recipe    string  `json:"recipe"`
+	Arm       string  `json:"arm"`
+	GroupID   string  `json:"group_id"`
+	Parent    string  `json:"parent"`
+	Depth     int     `json:"depth"`
+	Why       string  `json:"why"`
+	WhyText   string  `json:"why_text"`
+	Verdict   string  `json:"verdict"`
+	PlayerID  string  `json:"player_id"`
+	PlayID    string  `json:"play_id"`
+	Score     float64 `json:"score"`
+	CreatedAt string  `json:"created_at"` // RFC3339; "" → now
+}
+
+type sweepPublishPost struct {
+	Experiments []sweepExperimentRow `json:"experiments"`
+}
+
+func registerSweepHandlers(mux *http.ServeMux, cfg config) {
+	mux.HandleFunc("/api/v2/sweep/experiments", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			handleSweepPublish(w, r, cfg)
+		case http.MethodGet:
+			handleSweepList(w, r, cfg)
+		default:
+			w.Header().Set("Allow", "POST, GET")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func handleSweepPublish(w http.ResponseWriter, r *http.Request, cfg config) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 8<<20))
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var post sweepPublishPost
+	if err := json.Unmarshal(body, &post); err != nil {
+		http.Error(w, "decode body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(post.Experiments) == 0 {
+		writeJSON(w, map[string]any{"stored": 0})
+		return
+	}
+	now := time.Now().UTC().Format("2006-01-02 15:04:05.000")
+	var lines strings.Builder
+	for _, e := range post.Experiments {
+		if e.ExpID == "" {
+			continue
+		}
+		created := now
+		if e.CreatedAt != "" {
+			if ts, perr := time.Parse(time.RFC3339, e.CreatedAt); perr == nil {
+				created = ts.UTC().Format("2006-01-02 15:04:05.000")
+			}
+		}
+		line, merr := json.Marshal(map[string]any{
+			"exp_id":     e.ExpID,
+			"class":      strOrDefault(e.Class, "config"),
+			"status":     e.Status,
+			"kind":       e.Kind,
+			"platform":   e.Platform,
+			"protocol":   e.Protocol,
+			"mode":       e.Mode,
+			"recipe":     e.Recipe,
+			"arm":        e.Arm,
+			"group_id":   e.GroupID,
+			"parent":     e.Parent,
+			"depth":      e.Depth,
+			"why":        e.Why,
+			"why_text":   e.WhyText,
+			"verdict":    e.Verdict,
+			"player_id":  canonicalV2ID(e.PlayerID),
+			"play_id":    canonicalV2ID(e.PlayID),
+			"score":      e.Score,
+			"created_at": created,
+			"updated_at": now,
+		})
+		if merr != nil {
+			http.Error(w, "marshal row: "+merr.Error(), http.StatusBadRequest)
+			return
+		}
+		lines.Write(line)
+		lines.WriteByte('\n')
+	}
+
+	if err := chInsertJSONEachRow(r.Context(), cfg, "infinite_streaming.sweep_experiments", lines.String()); err != nil {
+		http.Error(w, "clickhouse insert: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, map[string]any{"stored": len(post.Experiments)})
+}
+
+func handleSweepList(w http.ResponseWriter, r *http.Request, cfg config) {
+	q := r.URL.Query()
+	conditions := []string{"1=1"}
+	params := map[string]string{}
+	if v := strings.TrimSpace(q.Get("class")); v != "" {
+		conditions = append(conditions, "class = {class:String}")
+		params["class"] = v
+	}
+	if v := strings.TrimSpace(q.Get("status")); v != "" {
+		conditions = append(conditions, "status = {status:String}")
+		params["status"] = v
+	}
+	limit := 500
+	if v := strings.TrimSpace(q.Get("limit")); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil && n > 0 && n <= 2000 {
+			limit = n
+		}
+	}
+	params["limit"] = fmt.Sprintf("%d", limit)
+
+	// FINAL collapses the ReplacingMergeTree to the latest row per exp_id.
+	query := fmt.Sprintf(`
+		SELECT
+		    exp_id, class, status, kind, platform, protocol, mode, recipe,
+		    arm, group_id, parent, depth, why, why_text, verdict,
+		    player_id, play_id, score,
+		    toString(created_at) AS created_at,
+		    toString(updated_at) AS updated_at
+		FROM infinite_streaming.sweep_experiments FINAL
+		WHERE %s
+		ORDER BY updated_at DESC
+		LIMIT {limit:UInt32}
+	`, strings.Join(conditions, " AND "))
+
+	body, err := chQueryBytes(r.Context(), cfg, query, params)
+	if err != nil {
+		http.Error(w, "clickhouse query: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	items, err := parseJSONEachRowItems(body)
+	if err != nil {
+		http.Error(w, "decode rows: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, map[string]any{"items": items})
+}
+
+// chInsertJSONEachRow POSTs newline-delimited JSON rows into a CH table.
+func chInsertJSONEachRow(ctx context.Context, cfg config, table, rows string) error {
+	if strings.TrimSpace(rows) == "" {
+		return nil
+	}
+	u, err := url.Parse(cfg.clickhouseURL)
+	if err != nil {
+		return err
+	}
+	qs := u.Query()
+	qs.Set("query", "INSERT INTO "+table+" FORMAT JSONEachRow")
+	u.RawQuery = qs.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), strings.NewReader(rows))
+	if err != nil {
+		return err
+	}
+	if cfg.chUser != "" {
+		req.SetBasicAuth(cfg.chUser, cfg.chPassword)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("clickhouse %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+func strOrDefault(v, d string) string {
+	if v == "" {
+		return d
+	}
+	return v
+}

--- a/content/dashboard-v3/src/components/ShellLayout.vue
+++ b/content/dashboard-v3/src/components/ShellLayout.vue
@@ -54,7 +54,7 @@ const DEV_BACKEND = 'https://jonathanoliver-ubuntu.local:21000';
 // /v3/ in dev so links stay on the Vite dev server (HMR); legacy/unmigrated
 // pages are served by the real backend.
 const V3_PAGES =
-  /^\/dashboard\/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|ask|hello)\.html/;
+  /^\/dashboard\/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|sweep|ask|hello)\.html/;
 function rewriteHrefForDev(href: string): string {
   if (typeof window === 'undefined') return href;
   if (window.location.port !== DEV_PORT) return href;
@@ -188,6 +188,7 @@ const sections: NavSection[] = [
       { id: 'testing',       icon: '🧪', text: 'Testing Monitor', href: '/dashboard/testing.html' },
       { id: 'sessions',      icon: '⏪', text: 'Sessions',         href: '/dashboard/sessions.html' },
       { id: 'characterization', icon: '📈', text: 'Automated Testing', href: '/dashboard/characterization.html' },
+      { id: 'sweep',         icon: '🧹', text: 'Fault Sweep',      href: '/dashboard/sweep.html' },
       { id: 'quartet',       icon: '🎬', text: 'Quartet',          href: '/dashboard/quartet.html', alpha: true },
       { id: 'segment-duration', icon: '⏱️', text: 'Live Offset',   href: '/dashboard/segment-duration-comparison.html', alpha: true },
     ],

--- a/content/dashboard-v3/src/entry-sweep.ts
+++ b/content/dashboard-v3/src/entry-sweep.ts
@@ -1,0 +1,4 @@
+import { mountPage } from './main';
+import Sweep from './pages/Sweep.vue';
+
+mountPage(Sweep);

--- a/content/dashboard-v3/src/pages/Sweep.vue
+++ b/content/dashboard-v3/src/pages/Sweep.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+/**
+ * Sweep.vue — live monitor for the automated fault-injection sweep (#772).
+ *
+ * The sweep's queue lives as local .sweep/ JSON files on the runner; the loop
+ * publishes a snapshot via `harness sweep publish` → forwarder
+ * /api/v2/sweep/experiments (ReplacingMergeTree by exp_id). This page polls that
+ * endpoint and shows the queue as status columns — pending (backlog) → running →
+ * done / found — with each experiment's recipe, the WHY (reason it ran), the
+ * VERDICT (result), its lineage (parent → isolation fan), and a session-viewer
+ * link when it produced a play. View filters scope by class / search.
+ */
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import ShellLayout from '@/components/ShellLayout.vue';
+import LabelFrequencyTable from '@/components/LabelFrequencyTable.vue';
+
+interface Experiment {
+  exp_id: string;
+  class: string;
+  status: string;
+  kind: string;
+  platform: string;
+  protocol: string;
+  mode: string;
+  recipe: string;
+  arm: string;
+  group_id: string;
+  parent: string;
+  depth: number;
+  why: string;
+  why_text: string;
+  verdict: string;
+  player_id: string;
+  play_id: string;
+  score: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// Column order = the lifecycle flow.
+const STATUSES = ['backlog', 'running', 'found', 'done', 'review', 'feedback'] as const;
+const STATUS_LABEL: Record<string, string> = {
+  backlog: 'Pending', running: 'Running', found: 'Found', done: 'Done',
+  review: 'Review', feedback: 'Feedback',
+};
+
+const experiments = ref<Experiment[]>([]);
+const loading = ref(false);
+const error = ref('');
+const lastUpdated = ref('');
+const classFilter = ref<'all' | 'config' | 'fault'>('all');
+const search = ref('');
+let timer: number | undefined;
+
+async function load() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const resp = await fetch('/analytics/api/v2/sweep/experiments?limit=2000');
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = (await resp.json()) as { items: Experiment[] | null };
+    experiments.value = data.items ?? [];
+    lastUpdated.value = new Date().toLocaleTimeString();
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  load();
+  timer = window.setInterval(load, 5000); // the loop is slow (~100s/play); 5s is plenty
+});
+onUnmounted(() => {
+  if (timer) window.clearInterval(timer);
+});
+
+const filtered = computed(() =>
+  experiments.value.filter((e) => {
+    if (classFilter.value !== 'all' && (e.class || 'config') !== classFilter.value) return false;
+    const q = search.value.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      e.exp_id.toLowerCase().includes(q) ||
+      (e.recipe || '').toLowerCase().includes(q) ||
+      (e.why || '').toLowerCase().includes(q) ||
+      (e.mode || '').toLowerCase().includes(q)
+    );
+  }),
+);
+
+const byStatus = computed(() => {
+  const m: Record<string, Experiment[]> = {};
+  for (const s of STATUSES) m[s] = [];
+  for (const e of filtered.value) (m[e.status] ??= []).push(e);
+  for (const s of Object.keys(m)) {
+    m[s].sort((a, b) => (b.score || 0) - (a.score || 0) || a.exp_id.localeCompare(b.exp_id));
+  }
+  return m;
+});
+
+const totals = computed(() => {
+  const t = { config: 0, fault: 0 };
+  for (const e of filtered.value) {
+    if ((e.class || 'config') === 'fault') t.fault++;
+    else t.config++;
+  }
+  return t;
+});
+
+function verdictClass(v: string): string {
+  switch (v) {
+    case 'aberration': return 'v-aberration';
+    case 'notable': return 'v-notable';
+    case 'clean': return 'v-clean';
+    case 'inconclusive': return 'v-inconclusive';
+    default: return 'v-none';
+  }
+}
+
+function viewerURL(e: Experiment): string | null {
+  if (!e.player_id) return null;
+  let u = `/dashboard/session-viewer.html?player_id=${encodeURIComponent(e.player_id)}`;
+  if (e.play_id) u += `&play_id=${encodeURIComponent(e.play_id)}`;
+  return u;
+}
+</script>
+
+<template>
+  <ShellLayout activePage="sweep">
+    <div class="sweep-page">
+      <header class="head">
+        <div>
+          <h1>Fault Sweep</h1>
+          <p class="sub">
+            Automated stream-config / fault-recovery sweep (#772). Live queue —
+            pending experiments, results, and the reasons each ran.
+          </p>
+        </div>
+        <div class="meta">
+          <span v-if="lastUpdated">updated {{ lastUpdated }}</span>
+          <span v-if="loading" class="dot">●</span>
+        </div>
+      </header>
+
+      <div class="controls">
+        <div class="seg">
+          <button :class="{ on: classFilter === 'all' }" @click="classFilter = 'all'">All</button>
+          <button :class="{ on: classFilter === 'config' }" @click="classFilter = 'config'">
+            config ({{ totals.config }})
+          </button>
+          <button :class="{ on: classFilter === 'fault' }" @click="classFilter = 'fault'">
+            fault ({{ totals.fault }})
+          </button>
+        </div>
+        <input v-model="search" class="search" placeholder="filter by id / recipe / why / mode…" />
+        <button class="refresh" @click="load">↻</button>
+      </div>
+
+      <p v-if="error" class="err">Couldn't load sweep queue: {{ error }}</p>
+      <p v-else-if="!experiments.length && !loading" class="empty">
+        No experiments published yet. Run <code>harness sweep publish</code> from the runner.
+      </p>
+
+      <LabelFrequencyTable class="lft-block" />
+
+      <div class="board">
+        <section v-for="s in STATUSES" :key="s" class="col">
+          <h2>
+            {{ STATUS_LABEL[s] }}
+            <span class="count">{{ byStatus[s].length }}</span>
+          </h2>
+          <div class="cards">
+            <article v-for="(e, i) in byStatus[s]" :key="e.exp_id" class="card" :class="'cls-' + (e.class || 'config')">
+              <div class="row1">
+                <span class="kind" :class="'k-' + e.kind">{{ e.kind }}</span>
+                <span v-if="s === 'backlog' && i === 0" class="next" title="highest scheduler score — claimed next">next →</span>
+                <span v-if="e.verdict" class="verdict" :class="verdictClass(e.verdict)">{{ e.verdict }}</span>
+                <span class="score" :title="'scheduler score ' + e.score">{{ Math.round(e.score) }}</span>
+              </div>
+              <div class="recipe">{{ e.recipe }}</div>
+              <div class="axes">{{ e.platform }} · {{ e.protocol }} · {{ e.mode }}</div>
+              <div v-if="e.why" class="why" :title="e.why_text">💡 {{ e.why }}</div>
+              <div v-if="e.parent" class="parent">↳ from {{ e.parent }}<span v-if="e.depth"> · d{{ e.depth }}</span></div>
+              <div class="foot">
+                <code class="id">{{ e.exp_id }}</code>
+                <a
+                  v-if="viewerURL(e)"
+                  :href="viewerURL(e)!"
+                  class="viewer"
+                  :class="{ live: s === 'running' }"
+                  target="_blank"
+                  rel="noopener"
+                >{{ s === 'running' ? '▶ watch live' : '↗ viewer' }}</a>
+                <span v-else-if="s === 'running'" class="starting" title="session not bootstrapped yet">⏳ starting…</span>
+              </div>
+            </article>
+          </div>
+        </section>
+      </div>
+    </div>
+  </ShellLayout>
+</template>
+
+<style scoped>
+.sweep-page { padding: 1rem 1.25rem; color: var(--text-primary, #202124); }
+.head { display: flex; justify-content: space-between; align-items: flex-start; gap: 1rem; }
+.head h1 { margin: 0; font-size: 1.4rem; }
+.sub { margin: .2rem 0 0; color: var(--text-secondary, #5f6368); font-size: .85rem; max-width: 60ch; }
+.meta { color: var(--text-secondary, #5f6368); font-size: .8rem; white-space: nowrap; }
+.meta .dot { color: var(--success, #1e8e3e); margin-left: .4rem; animation: pulse 1s infinite; }
+@keyframes pulse { 50% { opacity: .3; } }
+.controls { display: flex; gap: .6rem; align-items: center; margin: 1rem 0; flex-wrap: wrap; }
+.seg { display: inline-flex; border: 1px solid var(--border, #dadce0); border-radius: 6px; overflow: hidden; }
+.seg button { background: var(--background, #fff); color: var(--text-secondary, #5f6368); border: none; padding: .35rem .7rem; cursor: pointer; font-size: .82rem; }
+.seg button.on { background: var(--primary-blue, #1a73e8); color: #fff; }
+.search { flex: 1; min-width: 200px; background: var(--background, #fff); border: 1px solid var(--border, #dadce0); border-radius: 6px; color: var(--text-primary, #202124); padding: .4rem .6rem; }
+.refresh { background: var(--background, #fff); border: 1px solid var(--border, #dadce0); border-radius: 6px; color: var(--text-secondary, #5f6368); padding: .4rem .6rem; cursor: pointer; }
+.err { color: var(--error, #d93025); }
+.empty { color: var(--text-secondary, #5f6368); }
+.empty code { background: var(--surface-hover, #f1f3f4); padding: .1rem .35rem; border-radius: 4px; }
+.lft-block { margin: 0 0 1rem; }
+.board { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .8rem; align-items: start; }
+.col { background: var(--surface, #f8f9fa); border: 1px solid var(--border, #dadce0); border-radius: 8px; padding: .5rem; }
+.col h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-secondary, #5f6368); margin: .2rem .2rem .6rem; display: flex; justify-content: space-between; }
+.count { background: var(--primary-blue-light, #e8f0fe); color: var(--primary-blue, #1a73e8); border-radius: 10px; padding: 0 .5rem; font-size: .75rem; }
+.cards { display: flex; flex-direction: column; gap: .5rem; }
+.card { background: var(--background, #fff); border: 1px solid var(--border-light, #e8eaed); border-left: 3px solid var(--primary-blue, #1a73e8); border-radius: 6px; padding: .5rem .6rem; font-size: .82rem; }
+.card.cls-fault { border-left-color: var(--warning, #f9ab00); }
+.row1 { display: flex; justify-content: space-between; align-items: center; gap: .4rem; }
+.kind { font-size: .68rem; text-transform: uppercase; letter-spacing: .03em; color: var(--text-secondary, #5f6368); }
+.next { font-size: .64rem; font-weight: 700; color: var(--success, #1e8e3e); background: var(--success-light, #e6f4ea); border-radius: 8px; padding: 0 .4rem; }
+.score { margin-left: auto; font-size: .68rem; color: var(--text-disabled, #9aa0a6); font-variant-numeric: tabular-nums; }
+.k-isolation { color: #b06a00; }
+.k-bisect { color: #6f42c1; }
+.verdict { font-size: .7rem; font-weight: 600; padding: 0 .4rem; border-radius: 8px; }
+.v-aberration { background: var(--error-light, #fce8e6); color: var(--error, #d93025); }
+.v-notable { background: var(--warning-light, #fef7e0); color: #a86a00; }
+.v-clean { background: var(--success-light, #e6f4ea); color: var(--success, #1e8e3e); }
+.v-inconclusive { background: var(--surface-hover, #f1f3f4); color: var(--text-disabled, #9aa0a6); }
+.recipe { font-weight: 600; margin: .25rem 0 .1rem; color: var(--text-primary, #202124); }
+.axes { color: var(--text-secondary, #5f6368); font-size: .76rem; }
+.why { margin-top: .35rem; color: var(--text-primary, #202124); font-size: .78rem; }
+.parent { margin-top: .25rem; color: var(--text-disabled, #9aa0a6); font-size: .73rem; }
+.foot { display: flex; justify-content: space-between; align-items: center; margin-top: .4rem; gap: .4rem; }
+.id { font-size: .66rem; color: var(--text-disabled, #9aa0a6); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 60%; }
+.viewer { color: var(--primary-blue, #1a73e8); text-decoration: none; font-size: .73rem; white-space: nowrap; }
+.viewer:hover { text-decoration: underline; }
+.viewer.live { color: var(--success, #1e8e3e); font-weight: 700; }
+.starting { color: var(--text-secondary, #5f6368); font-size: .73rem; white-space: nowrap; }
+</style>

--- a/content/dashboard-v3/sweep.html
+++ b/content/dashboard-v3/sweep.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fault Sweep — InfiniteStream v3</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 48 48%22%3E%3Crect width=%2248%22 height=%2248%22 rx=%2210%22 fill=%22%23091929%22/%3E%3Ccircle cx=%2224%22 cy=%2224%22 r=%224%22 fill=%22%230077B6%22/%3E%3C/svg%3E" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/entry-sweep.ts"></script>
+  </body>
+</html>

--- a/content/dashboard-v3/vite.config.ts
+++ b/content/dashboard-v3/vite.config.ts
@@ -47,6 +47,8 @@ export default defineConfig({
         // Stage 7 — characterization-run summary page. Pre-filters
         // /api/v2/plays on info=test_* labels and groups by run_id.
         characterization: resolve(__dirname, 'characterization.html'),
+        // #772 — automated fault-sweep queue monitor.
+        sweep: resolve(__dirname, 'sweep.html'),
         // Stage 8 (#497) — AI chat fleet-mode entry. Lives at
         // /dashboard/v3/ask.html. The side-panel variant of the same
         // chat is also mounted on other v3 pages.

--- a/docker/nginx-content.conf.template
+++ b/docker/nginx-content.conf.template
@@ -156,7 +156,7 @@ server {
     # /dashboard/v3/<page>.html keeps working for old bookmarks. Surviving
     # legacy static pages (upload, jobs, sources, playback, …) also serve
     # from the prefix location.
-    location ~ ^/dashboard/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|ask|hello)\.html$ {
+    location ~ ^/dashboard/(dashboard|testing|testing-session|sessions|session-viewer|grid|characterization|sweep|ask|hello)\.html$ {
         ${INFINITE_STREAM_AUTH_DIRECTIVES}
         alias /content/dashboard/v3/$1.html;
     }

--- a/docs/sweep-design.md
+++ b/docs/sweep-design.md
@@ -1,0 +1,585 @@
+# Automated fault-injection sweep — design (issue #772)
+
+> **Status:** design approved; Phase 2 build in progress on `feat/772-fault-sweep`. The first milestone is the
+> depth-first vertical slice (§10).
+>
+> **Terminology:** the runnable work-unit is an **experiment** (one `{platform × protocol × fault × shape ×
+> content × HLS-config × duration}` recipe, run once and observed). Not a GitHub Actions "job." A confirmed
+> failure becomes a durable **finding** (a deduped GitHub Issue). Experiments are ephemeral; findings are durable.
+
+## Context
+
+Today fault testing is manual: an operator applies one fault via the harness CLI, watches a player, tries a
+variant. The matrix that *should* be swept — `platform × protocol × fault-type × bitrate/shape × content ×
+HLS-config × duration` — is combinatorially huge, and each run is multi-minute (characterization modes ~1.5–6
+min; cold-start/abort cycles longer). Brute force is infeasible, so **experiment ordering is the core
+intelligence**. We want an **unattended, state-driven loop** that claims an experiment, runs it against a
+faulted origin, drives a player headlessly, reads the QoE telemetry, and — on an aberration — **systematically
+attributes the cause via A/B comparison** (platform-specific? content-specific? tied to an alterable HLS aspect
+like live-offset or ladder?) before promoting a confirmed bug to a deduped Issue. The loop drains when the
+queue has no Backlog left.
+
+All the hard primitives already exist (fault injection, headless probe, QoE-label oracle, content-manipulation
+knobs, broadcast groups, compare-mode viewing, capture skills). This system is an **orchestration layer** over
+them — minimal new code.
+
+---
+
+## 0. Two sweep classes (the load-bearing scope decision)
+
+Experiments belong to exactly one **class**. The two never mix — different purpose, different recipe
+vocabulary, different oracle — and are seeded + run one class at a time (`harness sweep seed --class …`). The
+`config` class is the default and primary focus.
+
+| | **`config`** (default) | **`fault`** (separate) |
+|---|---|---|
+| Question | Does the player make **good decisions**? | Does it **recover from errors**, and are there bugs in recovery? |
+| Knobs | content manipulation; rate caps (floor-guarded); pattern ladders (pyramid/ramp/…); server **transfer-timeouts** | explicit HTTP/connection errors: `4xx/5xx`, `corrupted`, `connection_refused`, `dns_failure`, `rate_limiting`, transport `drop`/`reject`, `request_*_hang/reset` |
+| Oracle | **any** envelope-violating QoE label = the signal (§3) | the **recovery-expected envelope** (A.4) — a fault *within* envelope is fine; failing to recover, or a bug in recovery, is the signal |
+| Target class of bug | ABR rung-choice quality, the over-downshift class, manifest-config robustness | resilience + recovery correctness |
+
+**Explicitly out of scope for *both* classes:** packet **loss %** and **delay** (steady network degradation —
+neither a realistic stream config nor an explicit error), and **any cap that totally chokes throughput**. A
+config-class static rate cap is only ever placed **at or above the lowest variant's sustainable rate** (the
+floor guard): the player can always play *something*, so we test decision quality and recovery, never forced
+starvation. Pattern sweeps are built from the actual variant ladder, so they stay within sustainable rungs by
+construction.
+
+Findings are namespaced by class in the signature (`sig:<class>-…`), so a config finding and a fault finding
+never dedup-collide.
+
+---
+
+## 1. How faults are applied, per protocol
+
+Per-session (per proxy port) via the v2 REST API; the **harness CLI** is the programmatic entry point.
+
+- **HTTP faults** — `POST /api/v2/players/{id}/fault_rules` (`go-proxy/internal/v2/server/handlers_fault_rules.go:26`).
+  Types in `translate_faults.go:35-55`: `403/404/500/503`, `timeout`, `corrupted` (segment-only),
+  `connection_refused`, `dns_failure`, `rate_limiting`, `request_{connect,first_byte,body}_{hang,reset,delayed}`.
+  Scope via `filter.request_kind` + `url_match`; cadence via `frequency`/`mode`/`consecutive`.
+  CLI: `harness fault add <target> --type … --kind … --frequency …` (`tools/harness-cli/cmd/harness/fault.go`).
+- **Traffic shaping** — `PATCH /api/v2/players/{id}` `{shape:{rate_mbps,delay_ms,loss_pct,transport_fault,pattern}}`
+  (`handlers_mutate.go:332`). `transport_fault` = nftables `drop|reject`; `pattern` = timed bandwidth-ladder
+  steps. CLI: `harness shape <target> --rate|--delay|--loss` or `--pattern … --step-seconds …` (`shape.go`).
+- **Content / HLS-aspect manipulation** — the proxy rewrites the master manifest per session via
+  `manipulateHLSMaster` / `manipulateDASHManifest` (`go-proxy/cmd/server/main.go:6563/6828`): knobs are
+  `liveOffset`, `allowedVariants` (ladder density), `variantOrder` (HLS-only), `stripCodecs`,
+  `stripAvgBandwidth`, `stripResolution`, `overstateBandwidth`. **These are the levers for HLS-aspect
+  comparison (§6).** (Being folded into a `ContentManipulation` struct under in-flight #767/#766.)
+- **Composed timed profiles** — `harness procedure {soak|abr-sweep|fault-soak}` (`procedure.go`).
+- **Protocol** is selected by manifest URL extension at nginx (`docker/nginx-content.conf.template:110/123`):
+  `master.m3u8` → HLS, `manifest.mpd` → DASH. An experiment carries `protocol` → picks the URL the probe plays.
+- **Concurrency:** every PATCH needs an `If-Match` ETag; `shape`/`fault_rules` edits don't collide.
+  **Group broadcast** (`?broadcast=`, `harness groups create`) fans an identical profile to a fleet — the
+  mechanism that lets an A/B pair run under *identical* shaping simultaneously (§6).
+
+## 2. What plays back / probes it
+
+The **characterization harness** (`tests/characterization/`) is the probe. It mints a fresh `player_id`,
+applies the shape *before* the manifest fetch, runs a **1 Hz sampler** (`runner/sample.go`) capturing
+state/buffer/stalls/bitrate/resolution/TTFF/frames + per-state residency ms, and POSTs a `Report`.
+
+- **Launch mode:** **`appium` for iOS Simulator AND Apple TV**; **`adb`/`cli` for Android TV**.
+  iOS-sim-via-appium uses a WDA against the booted sim (confirmed working). Web has no headless mode →
+  manual-review lane (§7).
+- **An experiment "recipe" = characterization mode** (`steps`, `transient_shock`, `downshift_severity`,
+  `hysteresis_gap`, `emergency_downshift`, `startup`, `abort`, …) **× fault/shape profile × content ×
+  HLS-config × protocol × platform**.
+
+## 3. Telemetry + the aberration oracle
+
+The queryable aberration signals are **synthesized QoE labels** computed at forwarder ingest, stored on
+ClickHouse `session_events` (`analytics/go-forwarder/qoe_labels.go`, thresholds `qoe_thresholds.go`). OTel
+(`runner/otel.go`, opt-in `CHAR_OTEL_ENDPOINT`) is only a cross-cycle trace view for humans, not the oracle.
+
+**Oracle A — absolute (reuse QoE labels).** After a run, `harness query events <play_id> --label-has …`
+(`query.go`). A run is an **aberration** iff it carries an envelope-violation label:
+
+| Aberration kind | Label(s) |
+|---|---|
+| startup failure | `error=*qoe_vsf` |
+| mid-play failure / no-recovery | `error=*qoe_msf`, `error=player_error` |
+| excess rebuffer | `critical=*qoe_cirr_breach`, `critical=*qoe_cirt_breach` |
+| stall burst / frozen | `critical=*qoe_stall_burst`, `critical=stall_frozen` |
+| ladder collapse | `warning=*qoe_min_variant_stuck`, `warning=*qoe_downshift_storm` |
+| auto-recovery restart | `critical=restart_auto_recovery` |
+
+The **kind** seeds the finding signature (§4). `*qoe_tier_premium` = clean. A/V desync, visual crash →
+`needs-human` → manual-review lane. Reuses production semantics.
+
+**The envelope applies to the `fault` class only.** A `config`-class run has no injected error to forgive, so
+**any** envelope-violating label above is the signal directly — and the floor guard (§0) means a config run is
+never starved into a "deserved" stall. A `fault`-class run instead is judged against the per-fault
+recovery-expected envelope (starter table A.4): a fault the player *should* survive isn't a false positive; the
+signal is failure-to-recover (or a bug in recovery).
+
+**Oracle B — differential (for paired A/B experiments, §6).** Some questions have no absolute "bad" — e.g.
+*does ABR behave the same with vs without `AVERAGE-BANDWIDTH`?* Here the signal is **divergence between the two
+arms**, not a QoE breach. The differential oracle compares the two grouped plays' Reports (`runner/report.go`):
+per-step `variant_idx` timeline, `mean_bitrate_mbps`, `profile_shifts`, `total_stalls`, `lowest_sustainable_cap`.
+Divergence beyond a threshold (default in §9, tunable) = a finding ("dropping AVERAGE-BANDWIDTH changes ABR on
+platform X"). This is what makes a clean-vs-clean comparison productive.
+
+**Oracle C — surprise / novelty (highlight unexpected, non-error behaviour).** Not every notable result is an
+error. The classic example is **iOS over-downshift** — the player drops 2160→1080 (skips fine rungs) and then
+over-corrects, all while playback "succeeds." No error, no A/B partner, but it's the kind of thing we want
+flagged. Two cheap signals already exist:
+- **`warning`-tier QoE labels** — `*qoe_downshift_overshoot` (settles ≥N rungs below cap), `*qoe_downshift_storm`
+  (churn), `*qoe_min_variant_stuck`, `*qoe_abr_conservative`, `*qoe_ladder_gap`, `*qoe_throughput_divergence`.
+  These are "unexpected but tolerated." Today they don't fail a run; here they make it **`notable`**.
+- **VOMM surprise scorer** (`analytics/tools/scorer.py`, PPM-C `surprise_rate`/`peak`) — flags runs whose
+  state-transition sequence deviates from a "clean" reference corpus, catching novel patterns no threshold
+  anticipated. Run post-hoc on the experiment's network/event token stream.
+
+So each run resolves to a **trichotomy** (three-way outcome): **`clean`** (only `info`/`*qoe_tier_premium`),
+**`notable`** (a `warning`-tier label *or* a high VOMM surprise score, no error), or **`aberration`** (`error`/
+`critical`). `notable` outcomes are surfaced and can spawn their own A/B isolation fan (§6) to characterize the
+surprise — exactly how we'd chase whether the over-downshift is iOS-specific, ladder-density-driven, etc.
+
+## 4. Experiment record + the local store
+
+Experiments live in a **local directory-of-JSON-files queue** (no GitHub board). All worktree agents share one
+filesystem, so this is parallel-safe via **atomic `rename`** as the claim. Layout under a repo-local `.sweep/`
+(gitignored — ephemeral working state):
+
+```
+.sweep/
+  backlog/   <experiment-id>.json   # awaiting a runner; scheduler sorts these by score
+  running/   <experiment-id>.json   # claimed (the file's presence here + owner field = the lock)
+  done/      <experiment-id>.json   # clean, no aberration
+  found/     <experiment-id>.json   # aberration confirmed → promoted to an Issue
+  review/    <experiment-id>.json   # manual-review lane (Web / un-provisioned ATV / needs-human)
+  feedback/  <experiment-id>.json   # awaiting a human severity rating (§8)
+```
+
+Each `<experiment-id>.json` (the full recipe + bookkeeping):
+
+| Field | Purpose |
+|---|---|
+| `id`, `created_at` | identity |
+| `class` | `config` (default) / `fault` — the sweep tier (§0); never mixed |
+| `platform`, `protocol`, `content`, `mode`, `duration` | the recipe (the matrix axes) |
+| `content_manipulation`, `shape` (rate/pattern), `transfer_timeouts` | config-class knobs |
+| `fault` | fault-class only (nil on a config experiment) |
+| `kind` | `seed` / `isolation` (OFAT probe) / `hypothesis` (proactive A/B) / `bisect` (recursive) |
+| `arm`, `group` | `control`/`variant` + the A/B group id pairing them (§6) |
+| `reps`, `rep_group` | confirmation reps this experiment wants (1 for seed; ≥3 to confirm) + the id tying a rep-batch together (§5) |
+| `depth`, `parent` | recursive bisection depth (0–3 bound) + origin experiment id |
+| `score` | scheduler sort key (§5), recomputed each pass |
+| `owner` | runner/worktree id stamped at claim |
+| `play_id`, `result` | filled after the run (the play + oracle verdict) |
+
+**Findings stay durable on GitHub:** a confirmed aberration is promoted to a deduped **Issue** labeled `sweep` +
+signature `sig:<class>-<protocol>-<recipe>-<kind>[-<attributed_axis>]` (recipe = the fault family for fault-class,
+or the dominant config knob for config-class). Experiments never become Issues; dead-end
+experiments just sit in `done/`. Human-readable, git-diffable, and inspectable with a `harness sweep status`
+summary command (Phase 2).
+
+### 4.1 Dashboard visibility, run labels & post-mortem archive
+
+**Every sweep run is viewable in the sessions dashboard — `done`, `found`, all of it.** Each experiment drives
+the harness, which mints a `player_id` and archives the play to ClickHouse via the forwarder, so it shows in
+`sessions.html` / `session-viewer.html` with the full charts/events/network exactly like any session — **no new
+plumbing**. A/B arms share `group` → `group_id`, so compare-mode overlays control vs variant side-by-side
+(#579/#736).
+
+**Labels — the WHAT.** At run start the loop calls `harness labels set <target> k=v …` (merge-patch); the
+forwarder stamps these as the **`testing=` tier** — test metadata that does *not* tint a row good/bad (#571).
+We tag every run so the dashboard chips + `harness query --label-has` can filter to one sweep / signature / A/B
+group / rep-batch:
+`sweep=1`, `exp_id=<id>`, `kind=<seed|isolation|hypothesis|bisect>`, `mode`, `platform`, `protocol`, `fault`,
+`arm`, `group`, `parent`, `depth`, `rep_group`, `verdict=<clean|notable|aberration|inconclusive>`.
+> **Value-encoding gotcha (load-bearing):** forwarder label *values* must not contain `,` or `=` — the value is
+> silently dropped (no error, no chip). Keep values slug-safe (`_`/`;`/`|` or a hash), never raw prose.
+
+**Labels + control-event — the WHY (why the LLM chose this run).** A rationale is prose, so it can't live in a
+label value. Record it two ways: (1) a short slug label `why=<slug>` (e.g. `why=startup_vsf_on_4k_ladder`) for
+at-a-glance filtering; (2) the **full rationale as a harness `control_event`** (`source=harness`, #474) — which
+already renders in the session-viewer event stream — and in the `.sweep/<id>.json` + the finding. All three are
+linked by `exp_id`.
+
+**Post-mortem archive (`done` is kept):**
+- `.sweep/done/<id>.json` is **retained, never auto-pruned** — recipe + verdict + rationale + `play_id`. Browse
+  with `harness sweep ls done` / `status`. (`.sweep/` stays gitignored — machine-local, large.)
+- The rich detail (charts/events/network) is the ClickHouse play archive, reachable from the dashboard by the
+  `sweep=1` / `exp_id` filter — for `done` runs too, not only `found`.
+- **Retention caveat:** clean `done` plays are `classification=other` → **30-day** TTL. To keep post-mortems
+  longer, the loop marks sweep plays at least **`interesting`** (90-day; `favourite`/★ = forever).
+
+## 5. Scheduler — *discovery-first* ordering
+
+The loop never takes FIFO; it picks the **max-`score` Backlog experiment**, recomputed each pass:
+
+```
+score =  W_kind    * (isolation? > bisect? > hypothesis? > seed)   # attribution + narrowing jump the queue
+       + W_adj     * aberration_adjacency                          # matrix cells neighbouring a confirmed hit
+       - W_cost    * est_runtime_minutes                           # mild tiebreaker only (NOT cost-first)
+       - W_redun   * covered_by_finding                            # suppress cells already explained by an Issue
+```
+
+- **Discovery-first** ⇒ the instant an aberration is confirmed, its A/B isolation probes and bisection
+  follow-ups outrank any untouched far cell. Breadth is sacrificed deliberately.
+- **Depth-first to start — validate the machinery before widening.** The novel, risky part is the **LLM
+  investigation + experiment-insertion chain** (forensics → isolation fan → bisect → re-run). Initially we want
+  to *watch that work*, not cover the matrix. Bootstrap config: seed a **narrow** set (start with `ipad-sim` + a
+  couple of fault families), crank `W_kind`/depth so isolation+bisect dominate hard, and let the loop go **deep**
+  on the first hits. A `--depth-first` flag caps open seed breadth (e.g. ≤N seed cells in flight) so the queue
+  can't widen until the depth machinery is trusted. Flip to full-breadth seeding once proven.
+- **Cost model** = a small `mode × platform → minutes` table; ties break cheap-first (appium ATV is slow).
+- **Redundancy** = skip cells already explained by an open finding (recall `.claude/findings/` +
+  `gh issue list --label sig:…`).
+- **Weights are learned, not fixed.** `W_*` and the kind→priority map start from `triage`'s heuristic defaults
+  but are overridden by human severity feedback (§8) — the loop learns priorities over time.
+- **Seed** = one cheap broad experiment per `platform × protocol × fault-family` cell at `kind=seed`.
+- **Repetition is the sweep's job, not the test's.** Modes run through **once** (they own only their intrinsic
+  cycles — startup_caps' 5 launches, abort's per-cycle faults; pyramid is a single sweep). The sweep owns
+  *statistical* reps: it re-runs an experiment recipe N times as **separate experiments** sharing a `rep_group`,
+  then aggregates. Spend is adaptive — `reps=1` on a seed; on a `notable`/`aberration` first hit, escalate to
+  `reps≥3` and promote only if the verdict is stable across them (the n=1 guard, A.3). `CHAR_*_REPS` stays a
+  manual convenience the loop doesn't depend on.
+
+**Two independent kinds of concurrency:**
+- **Throughput parallelism (ungrouped).** Any N *independent* experiments run concurrently as long as each has
+  its own device/sim + proxy session — grouping is **not** required. Pool = **4 iOS sims + 1 iPhone + 1 Apple
+  TV + 1 Android TV**: up to 4 iOS-sim experiments concurrently; the physical devices one-at-a-time. Worktree
+  agents each claim from `.sweep/backlog/` via atomic rename (§7); a per-platform runner-pool counter stops the
+  scheduler handing two experiments to one device.
+- **Broadcast-group co-execution (grouped).** Only A/B pairs (§6) need a group — purely to guarantee
+  **byte-identical, simultaneous shaping** for control vs variant. A group is scheduled as a unit onto ≥2
+  runners; if only one runner is free, its arms run back-to-back.
+
+## 6. A/B comparisons — isolation + open-ended hypotheses
+
+A/B pairs serve **two** purposes, both on the same machinery (broadcast group → identical shaping → grouped
+compare-mode view). Each pair = a `control` experiment + a `variant` experiment sharing a `group`.
+
+**(a) Reactive isolation** — when the oracle confirms an aberration, attribute its cause via a **one-factor-at-
+a-time (OFAT) ablation**: hold the aberrant config fixed as the **control**, emit `kind=isolation` variants each
+flipping **exactly one axis**:
+
+| Attribution question | Axis flipped (control held) | Lever |
+|---|---|---|
+| Platform-specific? | **different platform** | run on iOS-sim / ATV / AndroidTV |
+| Content-specific? | *(deferred — single content for now)* | `content` field — disabled until >1 clip |
+| Protocol-specific? | **HLS ↔ DASH** | manifest URL extension |
+| Live-offset related? | **live_offset** ± steps | `content_manipulation.liveOffset` |
+| Ladder related? | **ladder density / allowed_variants** | `allowedVariants` |
+| Variant-order related? | **variant_order** reordered (HLS) | `variantOrder` |
+| Manifest-metadata related? | **strip codecs / avg-bandwidth / resolution / overstate** | `strip*` / `overstate` |
+| Fault-parameter related? | bitrate / frequency / duration midpoint | `shape.rate_mbps` / `fault.frequency` |
+
+**The fan is LLM-reasoned, not a fixed checklist.** The table above is a *menu of levers*, not a script. Given
+the **nature of the specific failure**, the loop's analyze step (the `forensics`/`investigate` skills) proposes
+the *most-informative* next experiments — e.g. a startup-only VSF on a 4K-heavy ladder suggests flipping
+ladder-density and the top rung *first*; a mid-play freeze after a transport drop suggests varying drop duration
+and `liveOffset`, not codec strings. The agent reasons from the evidence (which labels fired, when in the play,
+on which request kind) to pick axes and even propose *novel* configs the menu doesn't list. **Ordering =
+cheap/likely-first, escalate:** Tier 1 = platform + protocol (few, high-signal, run simultaneously on different
+devices — *content is fixed to `insane_new` for now, A.2, so the content axis is deferred*); only if Tier 1
+doesn't attribute does it spend Tier 2 on the manifest knobs (ladder, live-offset, variant-order, strip-*) the
+agent judged relevant. Hard cap `MAX_ISOLATION_AXES` (~8) so a single failure can't monopolize the pool.
+
+**(b) Proactive hypotheses** — standalone `kind=hypothesis` pairs that ask a general comparative question with
+no aberration required, e.g. *"does ABR behave the same on a session with `AVERAGE-BANDWIDTH` and without?"*
+(control = unmodified master; variant = `content_manipulation.stripAvgBandwidth=true`). Same one-axis-flip
+structure, judged by **Oracle B** (the differential, §3) — the finding is "the two arms diverge," not "variant
+breached an envelope." Two sources:
+- **Starter library:** **strip-AVERAGE-BANDWIDTH**, **ladder density (sparse 6-rung vs dense 11-rung)**,
+  **variant-order present/absent**. A small file the loop seeds at start.
+- **LLM-generated, failure-aware:** the agent also proposes *new* comparative hypotheses suggested by what it's
+  seeing — it is not limited to the starter list. The library is a seed, not a ceiling.
+
+**Run as A/B broadcast pairs (both kinds).** Each variant is paired with its control under one
+`harness groups create … --broadcast` group so **shaping is byte-identical and simultaneous**; results land
+**grouped**, viewable side-by-side in the existing **compare-mode** session-viewer (#579/#736). Verdict:
+isolation ⇒ "aberration reproduces in variant but not control ⇒ flipped axis implicated"; hypothesis ⇒ "arms
+diverge beyond threshold ⇒ that axis affects behaviour."
+
+**Bound:**
+- `isolation` + `hypothesis` experiments are a **bounded, non-recursive fan** (≤ `MAX_ISOLATION_AXES`, default
+  ~8) — they never spawn children.
+- `bisect` experiments (the continuous axis an isolation probe implicates) keep the bound: **≤2 recursive
+  follow-ups, stop at `depth ≥ 3`.**
+So tree *depth* stays bounded; attribution *breadth* is a finite capped fan.
+
+## 7. The iteration (self-contained; survives `/clear`, `--resume`, restart)
+
+All state is in `.sweep/`, so each iteration is stateless and idempotent:
+
+0. **Reset + health-check** — clear any residual `shape`/`fault_rules` on the target (confirm via `harness shape
+   --show`), force-kill+relaunch the app, and verify the deploy + device/sim are healthy. If unhealthy → mark
+   `inconclusive` and skip (§11), don't blame the player.
+1. **Claim** — pick the top-`score` file in `backlog/`; **atomically `rename` it to `running/`** and stamp
+   `owner`. The atomic rename is the lock — if rename fails (another worktree took it), pick the next.
+2. **Run** — apply the experiment's fault/shape + `content_manipulation` profile, `harness labels set` the
+   what/why labels + emit the rationale `control_event`, mark the play `interesting` for retention (§4.1), then
+   drive the platform's probe (appium/adb) through the chosen mode, capture `play_id`. A/B pairs run as a
+   broadcast group.
+3. **Analyze** — Oracle A (`harness query events <play_id> --label-has`) for single runs; Oracle B (differential
+   over the grouped Reports) for A/B pairs. Clean → move file to `done/`. No `play_id` / probe failure →
+   `inconclusive` (retry-bounded, §11), not an aberration.
+4. **On `notable` / `aberration`** (the trichotomy, §3) — if this was a 1-rep result, first **enqueue `reps≥3`
+   confirmation experiments** sharing a `rep_group`; only act once the verdict is stable across them (n=1 guard).
+   Then reuse **`triage` → `investigate`/`forensics` → `finding`** (recall `.claude/findings/` first). If confirmed:
+   - **Enqueue** the §6 isolation fan + ≤2 bisect follow-ups (`depth=parent.depth+1`, stop at 3) into `backlog/`.
+   - **Promote** to a deduped Issue: signature `sig:…`; if an open Issue with that label exists, comment the new
+     repro; else `gh issue create --label sweep,sig:…`. Move the file to `found/` (a `notable` becomes a
+     lower-priority Issue, not a `bug`).
+5. **Drain** — when `backlog/` is empty, report a summary and **do not reschedule** (state-driven, not clock).
+
+**Manual-review lane:** Web experiments, Apple TV experiments if WDA isn't provisioned, and `needs-human`
+aberrations (A/V desync, visual artifacts) → moved to `review/`, never auto-claimed.
+
+**Drivers — `/goal` inner, `/loop`/cron outer.** The sweep has a finish line (drain + budget), so the **primary
+driver is `/goal`**: `/goal "drive the sweep until .sweep/backlog is empty or --max-experiments/--max-wall-clock
+trips."` **`/loop` (or cron + headless `claude -p`) is only the *outer cadence*** — for a perpetual posture that
+re-seeds and re-runs the goal nightly / per-build. Both trigger the same `.sweep/` mechanics. Local store ⇒ no
+GitHub rate-limit concern for the queue; only Issue creation (findings) touches GitHub — batch those.
+
+## 8. Human severity feedback — learning what matters (active learning)
+
+Early on the loop can't know which signals matter — a `*qoe_downshift_overshoot` might be a real product bug or
+an accepted trade-off. So the sweep treats **severity/importance as learned, not fixed**.
+
+**Reuses existing skills:**
+- **`triage`** is already the severity model — it ranks plays by weighted "badness" (`user_marked×100 >
+  frozen×50 > error×40 > restart×20 > stall`) and invites tuning. The learned priors *are* those weights.
+- **`finding`** is the capture surface — `harness finding add --tag --note` + `interesting`/`favourite` (★)
+  retention tiers. A human rating lands here as a tag/★.
+- **`forensics`** recall-before-investigate + the `.claude/findings/` & `.claude/standards/` libraries give
+  cross-session persistence.
+- Existing **`user_marked` 911** + `favourite`/`interesting` tiers are human-severity signals already in the
+  label vocabulary.
+
+**Net-new (the closed loop no skill does today):**
+- **Ask, especially at first.** A confirmed finding (or `notable`) lands in a `feedback/` queue. You rate
+  `severity ∈ {ignore, minor, major, critical}` + optional "why". Interactive (`/goal`) runs prompt inline;
+  headless runs queue ratings for a later `harness sweep review` pass.
+- **The rating is a durable label** — onto the finding (tag/★), the Issue (`sev:*` label), and a `feedback.jsonl`
+  keyed by `(aberration_kind, signal-labels, platform, axis)`.
+- **Feedback retrains the scorer** — §5 weights start from triage defaults but are overridden by learned priors.
+- **Active-learning cadence:** cold-start asks ~every finding; as priors firm up it shifts to **uncertainty
+  sampling** (ask only when uncertain/novel). Re-openable anytime.
+- **Distinct from the manual-review lane (§7)** — that lane is for runs the oracle *can't judge*; this is for
+  runs it *has* judged, where you calibrate *how much it matters*.
+
+## 9. Decisions
+
+| Decision | Resolution |
+|---|---|
+| Work-item terminology | **experiment** (not "job"/Actions-job) |
+| Queue store | **local `.sweep/` directory of JSON files**, atomic-rename claim (no GitHub board / token) |
+| Findings | **deduped GitHub Issues** (`sweep` + `sig:*` + `sev:*` labels) |
+| Runner pool | **4 iOS sims + 1 each iPhone / Apple TV / Android TV** |
+| Launch mode | **appium for iOS-sim (WDA confirmed) + Apple TV; adb/cli for Android TV; Web → review lane** |
+| Content | **fixed to `insane_new` for now** — content-isolation axis deferred until >1 clip |
+| A/B axis policy | **LLM-reasoned + cheap/likely-first escalation** (Tier 1 platform+protocol → Tier 2 manifest knobs); cap `MAX_ISOLATION_AXES`=8 |
+| Hypothesis library | seeds = **strip-AVERAGE-BANDWIDTH, ladder density, variant-order**; **LLM also generates failure-specific hypotheses** |
+| Severity feedback | **batched `harness sweep review` + inline when interactive**; cold-start asks ~all → uncertainty-sampling; weights seeded from `triage` |
+| Initial strategy | **depth-first** — narrow seed + isolation/bisect dominate to validate the LLM investigate→insert→re-run chain end-to-end; widen later (`--depth-first` flag, §5) |
+
+**Remaining tunables (defaults baked in — adjust during Phase 2):**
+- **Recovery-expected envelope** (§3, Oracle A) — starter table in **A.4**.
+- **Oracle-B divergence threshold** — start at *≥1 rung sustained `variant_idx` difference OR ≥15%
+  `mean_bitrate_mbps` delta*.
+
+## 10. Phase 2 build outline
+
+**First milestone = the depth-first vertical slice:** narrow seed → one real hit → the LLM investigate→isolation-
+fan→bisect→re-run chain runs end-to-end, labeled + archived + dashboard-visible. Prove that thread works before
+building out breadth seeding. The pieces below are ordered to serve that slice first.
+
+- **Local store + `harness sweep` commands** — `seed`, `status`, `next`, `claim`, `ls`, plus the `.sweep/` dir
+  layout. Small Go tool under `tools/harness-cli/cmd/harness`.
+- **Seed generator** — defaults to a **narrow depth-first seed** (`ipad-sim` + a couple of fault families). A
+  `--full` switch (later) populates the broad `kind=seed` matrix once the depth machinery is proven.
+- **Per-iteration command/skill** — the §7 loop (claim→run→analyze→isolate+narrow/promote→done; drain & stop).
+- **A/B experiment generator** — (a) given a confirmed aberrant experiment, emits the §6 OFAT isolation fan; (b)
+  reads the comparative-hypothesis library and seeds `kind=hypothesis` pairs. Both emit control+variant pairs.
+- **Differential evaluator** — compares two grouped Reports and flags divergence beyond the Oracle-B threshold.
+- **Run labeling + visibility (§4.1)** — `harness labels set` the what-labels (slug-safe), emit the why-rationale
+  control_event, mark plays `interesting`, keep `done/` files for post-mortem. Confirm runs surface in `sessions.html`.
+- **Severity-feedback loop (§8)** — `feedback/` queue + `harness sweep review` + `feedback.jsonl`; scorer-prior
+  updater; uncertainty-sampling gate.
+- **Tests** — unit tests for the oracles + isolation-fan generation against **sample telemetry fixtures**:
+  label→kind→signature mapping, one-axis-flip correctness, bounded-fan cap, recursive depth bound, atomic-claim race.
+- **README** — interactive (`/goal`) vs headless (`claude -p`) run instructions.
+
+## 11. Robustness, operational prerequisites & gaps
+
+- **A 4th outcome — `inconclusive` (infra, not player).** appium/WDA hang, sim wedge, deploy down, harness error,
+  "0 players registered" must **not** count as `aberration`. Add `inconclusive` → file returns to `backlog/` for
+  a bounded retry count, then `review/`. Detect via probe/harness exit status + missing `play_id`.
+- **Reset between experiments.** Faults + shaping are per-session kernel state (nftables/tc) that *persists*.
+  Clear `shape` + `fault_rules` (confirm with `harness shape --show`) before applying its own, or state leaks
+  (cf. #738/#739). Force-kill+relaunch to dodge the stale-socket wedge after a proxy restart.
+- **Stale-claim reaper.** A runner that dies mid-run orphans its file in `running/`. A reaper returns `running/`
+  files whose `owner` heartbeat is older than ~`2× max_run_minutes` to `backlog/`.
+- **Sim/device seeding prerequisites (the real unattended blocker).** Fresh/erased sims hit the blocking
+  server-picker, and a sim seeded with the wrong host fetches an **empty catalogue** (TLS hostname mismatch).
+  Unattended iOS-sim runs require seeding `is.servers.v2` to `HARNESS_BASE_URL=https://dev.jeoliver.com:21000`
+  and `.env` copied into each worktree.
+- **Target / environment binding.** Each experiment runs against the **test-dev deploy** (`THROUGHPUT_HOST` /
+  `:21000`, per `.env`); `<target>` = the `player_id`/proxy-port the harness mints per session. Parallel sessions
+  are isolated at the proxy but share the one per-content go-live worker — fine for single-content.
+- **Stop conditions beyond "backlog empty."** Add operator budgets: `--max-wall-clock`, `--max-experiments`, and
+  a per-signature find-cap (stop chasing a signature after K confirmations).
+- **Oracle-C corpus bootstrapping.** The VOMM surprise scorer needs a "clean" reference corpus. Cold-start has
+  none → seed from existing ClickHouse clean-history, or build it from the first clean runs and enable Oracle C
+  only once warm. Until then rely on Oracle A + `warning`-tier labels.
+- **Runner host, not cloud CI.** "headless `claude -p`" must run **on the Mac with the sims + attached devices**
+  (cron or a self-hosted runner) — generic GitHub-hosted Actions can't drive appium/WDA/adb.
+- **Cost property (good news).** The LLM is invoked **per `aberration`/`notable`, not per run** — clean runs are
+  pure mechanical oracle checks. Cost scales with *findings*, not the (vast) experiment count.
+- **Live-origin caveat.** The origin loops VOD-as-live, so the exact segment under a fault depends on wall-clock.
+  A/B broadcast groups stay fair; standalone fault reproducibility should key on segment *kind / position-in-loop*.
+
+## Appendix A — the full test + configuration matrix (what sets the scale)
+
+### A.1 Tests that already exist
+
+**Characterization modes** (`tests/characterization/modes/`, **52 test funcs = modes × platforms**):
+`steps`, `rampup`, `rampdown`, `pyramid`, `transient_shock`, `downshift_severity`, `hysteresis_gap`,
+`emergency_downshift`, `startup`, `startup_caps`, `state_residency`, `playback_end`, `abort` (+ `fleet.go`,
+`sweep.go`/`runconfig.go` infra).
+
+| Platform | Launch | Mode funcs |
+|---|---|---|
+| iPad Sim | appium | 13 |
+| iPhone | appium | 11 |
+| Apple TV | appium | 11 |
+| Android TV | adb/cli | 11 |
+| Web (Chrome) | manual only → review lane | 6 |
+
+**Server-behavior suites** (`tests/server_behavior/`): `content`, `delay`, `fault`, `limit`, `loss`, `pattern`,
+`scope`, `socket`, `transfer`, `transport_fault`, `config_on_connect`. **Aberration crawl**
+(`tests/aberration_crawl/`): `TestAberrationCensus`.
+
+### A.2 Every configuration axis
+
+| Axis | Values | Source |
+|---|---|---|
+| **Platform** | iPad-sim, iPhone, Apple TV, Android TV, Web(manual) | A.1 |
+| **Protocol** | HLS, DASH — each in LL / 2s / 6s segment variants | nginx, go-live |
+| **Mode** | the 13 characterization recipes | A.1 |
+| **Fault type** (~17, **`fault` class only**) | `403/404/500/503`, `timeout`, `corrupted`, `connection_refused`, `dns_failure`, `rate_limiting`, `request_{connect,first_byte,body}_{hang,reset,delayed}`; transport `drop`/`reject` | `translate_faults.go:35-55` |
+| **Fault scope** (fault class) | request_kind ∈ {master_manifest, manifest, segment, partial, init, audio_segment, audio_manifest} + url_match | `fault.go` |
+| **Fault cadence** (fault class) | `frequency` × `mode` {requests, seconds, failures_per_seconds, failures_per_packets} × `consecutive` | FaultRule |
+| **Rate cap** (config class) | `rate_mbps` — **floor-guarded** (never below the lowest sustainable rung, §0). `delay_ms`/`loss_pct` are **excluded** (out of scope for both classes) | `shape.go` |
+| **Shape patterns** (config class) | pyramid, ramp_up, ramp_down, square_wave, transient_shock, sliders; `step-seconds` {6,12,18,24,60,120}; `margin` {0,5,10,25,50}; `max-step`, `top-headroom` — ladder-derived, sustainable by construction | `shape.go`, #733 |
+| **Server transfer-timeouts** (config class) | `active_timeout_seconds`, `idle_timeout_seconds` + `applies_{segments,manifests,master}` — a slow/stalled origin | `transfer_timeouts.*` |
+| **Content manipulation** (config class) | `liveOffset`, `allowedVariants`, `variantOrder` (HLS), `stripCodecs`, `stripAvgBandwidth`, `stripResolution`, `overstateBandwidth` | `manipulate*` |
+| **Content item** | **FIXED to `insane_new` for now**; ladder density still a tested axis via `allowedVariants` | go-upload catalogue |
+| **Reps / duration** | `CHAR_*_REPS` (≥3), `CHAR_STEP_S`, step count, `CHAR_FLEET_COUNT` | env flags |
+
+Multiplied out this is **≫10⁶ cells** — which is why the design is discovery-first + bounded A/B fan +
+finding-dedup + cell-redundancy suppression, never an exhaustive walk.
+
+### A.3 Factors that bound scale / capability
+
+- **Device concurrency is the hard cap. Pool = 4 iOS sims + 1 iPhone + 1 Apple TV + 1 Android TV** (physical
+  devices 1-apiece; iOS sims scale to 4 via `CHAR_FLEET_COUNT`, #734). One device = one play at a time.
+- **Per-run wall-clock is minutes** (~1.5–6 min/mode). Dominant term in `est_runtime_minutes`.
+- **Web is manual-only** → review lane.
+- **iOS-sim runs via a booted-sim WDA** (confirmed working).
+- **Session pool** — proxy port per session (test-dev 21xxx; default ≈700 ports).
+- **ClickHouse retention** — 30/90/forever TTL bounds redundancy + VOMM-corpus lookback.
+- **n=1 is not a pattern** — ABR jitter is real; a verdict from a single rep needs ≥3 reps before promotion.
+
+### A.4 Recovery-expected envelope — starter proposal (**`fault` class only**)
+
+This envelope only applies to the `fault` class — it's how an injected error is forgiven if the player copes.
+The `config` class has no injected error and is floor-guarded (§0), so it has no envelope: any
+envelope-violating QoE label is the signal directly.
+
+| Fault | Tolerated (no aberration) | Aberration if… |
+|---|---|---|
+| single-shot segment `500`/`503` | ≤1 stall, recovery ≤5 s | no recovery, or >1 stall, or VSF |
+| segment `corrupted` (one-shot) | ≤1 stall, recovers next segment | repeated stalls / freeze / give-up |
+| persistent manifest `404`/`5xx` | — (terminal) | always (`*qoe_vsf`/`player_error`) |
+| `timeout` / `request_body_hang` (brief) | ≤1 rebuffer, recovery ≤10 s | freeze, or no recovery |
+| transport `drop`/`reject` (brief burst) | downshift + recover ≤10 s | sustained stall / wedge |
+
+## Appendix B — worked examples
+
+### B.1 A seed experiment file (`.sweep/backlog/seed-ipad-hls-ratecap.json`)
+
+```json
+{
+  "id": "seed-ipad-hls-ratecap",
+  "created_at": "2026-06-13T18:00:00Z",
+  "kind": "seed", "depth": 0, "parent": null, "reps": 1, "score": 12.0,
+  "platform": "ipad-sim", "protocol": "hls", "content": "insane_new", "mode": "pyramid",
+  "shape": { "pattern": "pyramid", "step_seconds": 30, "margin_pct": 5 },
+  "fault": null, "content_manipulation": null, "duration_s": 360
+}
+```
+
+### B.2 An aberration → isolation fan (OFAT: each variant flips exactly ONE axis)
+
+A seed on `ipad-sim / hls / hard 0.4 Mbps cap` returns `aberration` (`error=*qoe_vsf`, startup failure). The loop
+confirms with `reps=3`, then — because the failure is a startup VSF on a 4K-heavy ladder — the agent *reasons*
+that platform and the top-rung ladder are the likely culprits and emits this fan (content stays `insane_new`):
+
+| file | flips | group/arm | tier |
+|---|---|---|---|
+| `iso-<h>-control.json` | — (the reproducing config) | `g1 / control` | — |
+| `iso-<h>-platform.json` | `platform: ‹androidtv›` | `g2 / variant` | 1 |
+| `iso-<h>-protocol.json` | `protocol: ‹dash›` | `g3 / variant` | 1 |
+| `iso-<h>-ladder.json` | `content_manipulation: {‹allowedVariants›: "drop-top-rung"}` | `g4 / variant` | 2 |
+| `iso-<h>-liveoffset.json` | `content_manipulation: {‹liveOffset›: 6}` | `g5 / variant` | 2 |
+
+Verdict: if only `iso-<h>-platform` comes back clean while the rest still fail ⇒ **not** iOS-specific; if
+dropping the top rung clears it ⇒ a 4K-startup bug. Signature gets the attributed axis, e.g.
+`sig:hls-ratecap-vsf-ladder`. (Content-specific attribution returns once a second clip is added.)
+
+### B.3 A proactive hypothesis pair (the `AVERAGE-BANDWIDTH` question)
+
+```json
+// .sweep/backlog/hyp-avgbw-ipad-control.json   (group h-avgbw, arm control)
+{ "kind":"hypothesis","group":"h-avgbw","arm":"control","platform":"ipad-sim",
+  "protocol":"hls","content":"insane_new","mode":"steps","content_manipulation":null }
+
+// .sweep/backlog/hyp-avgbw-ipad-variant.json   (group h-avgbw, arm variant)
+{ "kind":"hypothesis","group":"h-avgbw","arm":"variant","platform":"ipad-sim",
+  "protocol":"hls","content":"insane_new","mode":"steps",
+  "content_manipulation": { "stripAvgBandwidth": true } }
+```
+
+Run as one broadcast group → identical step ladder on both arms. **Oracle B** diffs the two Reports: if the
+stripped arm's `variant_idx` timeline or `mean_bitrate_mbps` diverges past threshold ⇒ finding; if they track
+together ⇒ clean, recorded as "no effect" (still useful).
+
+### B.4 The iOS over-downshift as a `notable` (non-error) flow
+
+1. A `downshift_severity` seed on `ipad-sim` returns no error but carries `warning=*qoe_downshift_overshoot`
+   (settled 3 rungs below cap) ⇒ verdict **`notable`**, not clean.
+2. Loop escalates `reps=3`; overshoot reproduces in 3/3 (not jitter).
+3. Emits an isolation fan flipping platform (iPhone, Apple TV, Android TV) and ladder density (sparse 6-rung vs
+   dense 11-rung) — directly testing whether *density drives over-downshift hunting, not bitrate overage*.
+4. Files a **lower-priority** Issue `sig:hls-ratecut-downshift_overshoot` (labelled `notable`, not `bug`).
+
+### B.5 Commands the loop actually runs (per iteration)
+
+```sh
+# claim (atomic): mv .sweep/backlog/<id>.json .sweep/running/<id>.json   # via rename(2)
+harness groups create --label iso-<h> --broadcast            # only for A/B pairs
+harness shape <target> --pattern pyramid --step-seconds 30 --margin 5
+harness fault add <target> --type 500 --kind segment --frequency 1 --mode requests   # if faulted
+harness labels set <target> sweep=1 exp_id=iso-h7 kind=isolation arm=variant \
+  axis=ladder why=startup_vsf_on_4k_ladder   # what + why (slug-safe: no , or =)  → testing= tier
+# (full prose rationale emitted as a source=harness control_event, linked by exp_id; play marked interesting)
+# (probe drives the platform via appium/adb through the mode, yields <play_id>)
+harness query events <play_id> --label-has 'error=*qoe_vsf' --json       # Oracle A
+harness query events <play_id> --label-has 'warning=*qoe_downshift_overshoot' --json  # notable
+python3 analytics/tools/scorer.py --play <play_id>                       # Oracle C surprise
+gh issue list --label 'sig:hls-ratecap-vsf' --state open                 # dedup check
+gh issue create --label sweep,bug,sig:hls-ratecap-vsf --body-file repro.md   # promote (heredoc body)
+```
+
+### B.6 Throughput parallelism (ungrouped, §5)
+
+4 sims free, 9 independent seeds in `backlog/` → 4 worktree agents each `rename`-claim one and run concurrently;
+as each finishes it claims the next highest-`score`. No groups involved. An A/B group that needs 2 runners waits
+until 2 of the 4 are free.

--- a/tests/characterization/modes/sweep_probe_test.go
+++ b/tests/characterization/modes/sweep_probe_test.go
@@ -1,0 +1,159 @@
+package modes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/tests/characterization/runner"
+)
+
+// TestSweepProbe is the automated fault-sweep's generic probe (issue #772,
+// docs/sweep-design.md §7). Unlike the characterization modes — which mint
+// their own player_id and apply their own shape recipe — this probe REATTACHES
+// to a session the sweep already materialised via `harness sweep bootstrap`
+// (config-on-connect): the full {shape × fault × content_manipulation × labels}
+// recipe is live on the session BEFORE this launches. The probe's only job is
+// to drive playback on that session for a fixed window so the proxy/forwarder
+// records a play the sweep's `analyze` step can classify into a verdict.
+//
+// It is the "mode-reattach glue": the bridge between the sweep's pre-launch
+// bootstrap and the existing appium launch path. No cap matrix, no pattern, no
+// Report JSON — analyze reads QoE labels from ClickHouse, not from a report.
+//
+// Required env:
+//
+//	CHAR_PLAYER_ID       the bootstrapped session id to reattach to (required)
+//	HARNESS_BASE_URL     test-dev origin (also where the viewer link points)
+//	LAUNCH_MODE=appium   (iOS sim / Apple TV)
+//
+// Optional:
+//
+//	CHAR_CONTENT             clip to resume (pins -is.lastPlayed)
+//	CHAR_SWEEP_DURATION_S    seconds to let it play (default 60)
+//	CHAR_SWEEP_PLATFORM      platform enum (default ipad-sim — any booted iOS sim)
+//	CHARACTERIZATION_DEVICE_UDID  pin a specific device
+func TestSweepProbe(t *testing.T) {
+	playerID := strings.TrimSpace(os.Getenv("CHAR_PLAYER_ID"))
+	if playerID == "" {
+		t.Skip("TestSweepProbe needs CHAR_PLAYER_ID (the session id from `harness sweep bootstrap`)")
+	}
+	platform := runner.Platform(envOr("CHAR_SWEEP_PLATFORM", string(runner.PlatformIPadSim)))
+	durationS := envInt("CHAR_SWEEP_DURATION_S", 60)
+	if durationS <= 0 {
+		durationS = 60
+	}
+
+	mode, launcher, err := runner.PickMode()
+	if err != nil {
+		t.Skipf("PickMode: %v", err)
+	}
+	appium, isAppium := launcher.(*runner.AppiumLauncher)
+	if !isAppium {
+		t.Skipf("sweep probe requires -launch-mode=appium (got %s)", mode)
+	}
+
+	setupCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// Pick the booted device for this platform (honouring an explicit UDID).
+	devs, err := appium.Discover(setupCtx)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	wantUDID := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID"))
+	var picked *runner.Device
+	for i := range devs {
+		if devs[i].Platform != platform {
+			continue
+		}
+		if wantUDID != "" && !strings.EqualFold(devs[i].UDID, wantUDID) {
+			continue
+		}
+		picked = &devs[i]
+		break
+	}
+	if picked == nil {
+		t.Skipf("no %s device discovered (udid=%q)", platform, wantUDID)
+	}
+	t.Logf("sweep probe: reattaching player_id=%s on %s for %ds", playerID, picked, durationS)
+
+	// Launch args bind the app to the bootstrapped session and pin the same
+	// launch-state flags the characterization modes force (rotation off so the
+	// run stays one play; land on home so ResumePlayback drives the intended
+	// play; HUD on for live observation). We do NOT call wireConfigOnConnect —
+	// the session is already configured, so re-running ConfigureOnConnect would
+	// overwrite the sweep's shape with a no-op default.
+	args := []string{
+		"-is.player_id", playerID,
+		"-is.flag.play_id_rotation_s", "0",
+		"-is.flag.skip_home", "false",
+		"-is.flag.dev_mode", "true",
+	}
+	if clip := strings.TrimSpace(os.Getenv("CHAR_CONTENT")); clip != "" {
+		args = append(args, "-is.lastPlayed", clip)
+	}
+	appium.SetLaunchArgs(args)
+
+	sess, err := appium.LaunchToHome(setupCtx, *picked)
+	if err != nil {
+		t.Fatalf("LaunchToHome: %v", err)
+	}
+	sess.PlayerID = playerID
+	// Free the session slot at the end (config-on-connect pool is small); the
+	// ClickHouse archive — what the session-viewer reads — persists regardless.
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = sess.CloseViaUI(cleanupCtx) // clean client play_end
+		_ = sess.Release(cleanupCtx)    // delete the proxy session, free the slot
+	})
+	if err := appium.ResumePlayback(setupCtx, *picked); err != nil {
+		t.Fatalf("ResumePlayback: %v", err)
+	}
+
+	// Drive the bandwidth motion for a config-class pattern recipe: once the
+	// master is fetched (variants known), arm the pattern — the same path the
+	// characterization modes use. This is what makes a `mode: pyramid` /
+	// `shape.pattern` experiment actually sweep bandwidth, not just plain-play.
+	if pattern := strings.TrimSpace(os.Getenv("CHAR_SWEEP_PATTERN")); pattern != "" {
+		stepS := envInt("CHAR_SWEEP_STEP_S", 12)
+		margin := envInt("CHAR_SWEEP_MARGIN", 5)
+		if err := sess.WaitForManifest(setupCtx, 45*time.Second); err != nil {
+			t.Fatalf("waiting for manifest before pattern: %v", err)
+		}
+		if err := sess.ApplyPattern(setupCtx, pattern, stepS, margin); err != nil {
+			t.Fatalf("ApplyPattern(%s): %v", pattern, err)
+		}
+		t.Logf("armed %s pattern (step=%ds margin=%d%%)", pattern, stepS, margin)
+	}
+
+	// Let it play. The recipe (content/shape/transfer) is already live, so this
+	// window is what the oracle later reads.
+	t.Logf("playing for %ds…", durationS)
+	time.Sleep(time.Duration(durationS) * time.Second)
+
+	playID, err := sess.CurrentPlayID(context.Background())
+	if err != nil {
+		t.Logf("warning: could not read play_id: %v", err)
+	}
+
+	base := strings.TrimRight(envOr("HARNESS_BASE_URL", "https://dev.jeoliver.com:21000"), "/")
+	viewer := fmt.Sprintf("%s/dashboard/session-viewer.html?player_id=%s", base, playerID)
+	if playID != "" {
+		viewer += "&play_id=" + playID
+	}
+
+	// The headline output the sweep + operator key off (also satisfies the
+	// "always log player_id, play_id, and a viewer URL" requirement).
+	t.Logf("SWEEP PROBE RESULT")
+	t.Logf("  player_id: %s", playerID)
+	t.Logf("  play_id:   %s   (analyze: harness sweep analyze <exp> --play %s)", playID, playID)
+	t.Logf("  session-viewer: %s", viewer)
+	if playID == "" {
+		t.Fatal("no play_id captured — playback never registered a play (inconclusive, not a player fault)")
+	}
+}

--- a/tests/characterization/runner/session.go
+++ b/tests/characterization/runner/session.go
@@ -100,6 +100,28 @@ func (s *Session) ReleaseDevice(ctx context.Context) error {
 	return r.ReleaseDevice(ctx, s.Device)
 }
 
+// WaitForManifest polls the harness until the bound player's current play has
+// fetched its master playlist (variants present), or until the timeout/ctx
+// fires. The pattern builder needs the variant ladder, so the sweep probe waits
+// on this before ApplyPattern.
+func (s *Session) WaitForManifest(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		rec, err := s.PlayerState(ctx)
+		if err == nil && rec.CurrentPlay != nil && len(rec.CurrentPlay.Manifest.Variants) > 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("manifest not ready after %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
 // WaitForHeartbeat polls the harness until the bound player reports
 // last_seen_at within 60s of now, or until ctx fires. Used by every
 // Launch implementation right before it returns the Session.

--- a/tests/characterization/runner/shape.go
+++ b/tests/characterization/runner/shape.go
@@ -28,6 +28,29 @@ func (s *Session) ApplyRate(ctx context.Context, rateMbps float64) error {
 	return nil
 }
 
+// ApplyPattern arms a throughput pattern (pyramid / ramp_up / ramp_down /
+// square_wave / transient_shock) on the bound player. The harness builds the
+// step ladder from the player's CURRENT manifest variants, so the master must
+// already be fetched — call WaitForManifest first. This is the same path the
+// dashboard pattern panel and the characterization modes use; it's how the
+// sweep drives a config-class pattern recipe's bandwidth motion.
+func (s *Session) ApplyPattern(ctx context.Context, pattern string, stepSeconds, marginPct int) error {
+	if s == nil || s.PlayerID == "" {
+		return fmt.Errorf("apply pattern: no player bound")
+	}
+	if pattern == "" {
+		return fmt.Errorf("apply pattern: empty pattern")
+	}
+	args := []string{
+		"shape", s.PlayerID,
+		"--pattern", pattern,
+		"--step-seconds", strconv.Itoa(stepSeconds),
+		"--margin", strconv.Itoa(marginPct),
+	}
+	_, err := runHarness(ctx, args...)
+	return err
+}
+
 // ClearShape removes all shaping (rate cap, delay, loss, pattern). Used
 // at test teardown to leave the proxy in a clean state.
 func (s *Session) ClearShape(ctx context.Context) error {

--- a/tools/harness-cli/cmd/harness/main.go
+++ b/tools/harness-cli/cmd/harness/main.go
@@ -67,6 +67,7 @@ Operator/CLI:
   finding add <target>         capture state+note into .claude/findings/
   procedure soak|abr-sweep|fault-soak <target>
                                multi-step composed test procedures
+  sweep seed|status|ls|next    automated fault-sweep queue (#772)
   post characterization <file> upload a characterization-test report
                                JSON to the forwarder (test framework
                                calls this from WriteReport)
@@ -161,6 +162,8 @@ func main() {
 		exit(cmdFinding(client, args[1:], g.asJSON))
 	case "procedure":
 		exit(cmdProcedure(client, args[1:], g.asJSON))
+	case "sweep":
+		exit(cmdSweep(client, args[1:], g.asJSON))
 	case "post":
 		exit(cmdPost(client, args[1:], g.asJSON))
 	case "help", "--help", "-h":

--- a/tools/harness-cli/cmd/harness/sweep.go
+++ b/tools/harness-cli/cmd/harness/sweep.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+const sweepUsage = `harness sweep <subcommand>
+
+The automated fault-injection sweep queue (issue #772, docs/sweep-design.md).
+Experiments live as JSON files under .sweep/<status>/ (override with --root or
+$SWEEP_ROOT). Findings are promoted to GitHub Issues elsewhere.
+
+Subcommands:
+  seed [--class C][--full] populate backlog/ with the starter set.
+                           --class config (default: realistic stream/network)
+                           or fault (explicit-error recovery). --full widens
+                           past the narrow depth-first ipad-sim set.
+  status                   counts per bucket (backlog/running/done/…)
+  ls <status>              list experiments in a bucket (one line each)
+  next [--claim --owner O] show the highest-score backlog experiment;
+                           with --claim, atomically claim it for owner O
+  bootstrap <id>           config-on-connect: materialise this recipe (shape/
+                           content/labels/fault) onto a fresh proxy session
+                           BEFORE the app launches, via proxy.cfg on the shaper
+                           port. Prints the player_id to launch the app with
+                           (-is.player_id). [--player UUID --group G --content C]
+  apply <id> --target P    materialise a claimed experiment onto an ALREADY-live
+                           player P: reset shape+faults, then apply this recipe's
+                           shape/content/labels/fault (step 0+2 of the loop).
+                           Pattern shapes need a fetched manifest → apply those
+                           post-launch with 'harness shape --pattern'.
+  analyze <id> --play UUID read the play's QoE labels, record the trichotomy
+                           verdict, and move the file: clean→done, notable/
+                           aberration→found. With --confirm-reps N, a first
+                           single-rep hit instead enqueues N confirmation reps.
+  promote <id>             open (or comment on) a deduped GitHub Issue for a
+                           found experiment [--axis A --dry-run --from found].
+  publish                  snapshot the whole queue → the forwarder so the
+                           dashboard Sweep tab can show it. Call after each
+                           iteration to keep the tab live.
+  reap [--max-age-min N]   return running/ files orphaned by a dead runner to
+                           backlog (default 60; ~2× the longest expected run).
+  isolate <id> --flip axis=value [--flip …]
+                           materialise an OFAT isolation fan off a confirmed
+                           hit (control + one variant per flip) into backlog/.
+                           axes: platform protocol liveoffset ladder
+                           variant_order strip_avg_bandwidth strip_codecs
+                           strip_resolution overstate_bandwidth
+  seed-from-triage [--days N] [--top N] [--min-skew X] [--dry-run]
+                           read the observational triage signal (label
+                           divergence) and seed config experiments for the
+                           controllable dimension (test/platform/content) each
+                           severe, dimension-driven label concentrates on;
+                           skips observational/not-runnable dims with reasons.
+
+Common flags:
+  --root DIR               sweep root (default $SWEEP_ROOT or .sweep)
+  --depth-first[=false]    prefer non-seed work in 'next' (default true)
+`
+
+func cmdSweep(client *api.Client, args []string, asJSON bool) error {
+	if len(args) == 0 {
+		return errors.New(sweepUsage)
+	}
+	switch args[0] {
+	case "seed":
+		return cmdSweepSeed(args[1:], asJSON)
+	case "status":
+		return cmdSweepStatus(args[1:], asJSON)
+	case "ls":
+		return cmdSweepLs(args[1:], asJSON)
+	case "next":
+		return cmdSweepNext(args[1:], asJSON)
+	case "bootstrap":
+		return cmdSweepBootstrap(client, args[1:], asJSON)
+	case "apply":
+		return cmdSweepApply(client, args[1:], asJSON)
+	case "analyze", "analyse":
+		return cmdSweepAnalyze(client, args[1:], asJSON)
+	case "promote":
+		return cmdSweepPromote(client, args[1:], asJSON)
+	case "publish":
+		return cmdSweepPublish(client, args[1:], asJSON)
+	case "reap":
+		return cmdSweepReap(args[1:], asJSON)
+	case "isolate":
+		return cmdSweepIsolate(args[1:], asJSON)
+	case "seed-from-triage":
+		return cmdSweepSeedFromTriage(client, args[1:], asJSON)
+	case "help", "--help", "-h":
+		fmt.Fprint(os.Stdout, sweepUsage)
+		return nil
+	default:
+		return fmt.Errorf("unknown sweep subcommand %q\n\n%s", args[0], sweepUsage)
+	}
+}
+
+func openStore(root string) (*sweep.Store, error) {
+	if root == "" {
+		root = sweep.DefaultRoot()
+	}
+	return sweep.Open(root)
+}
+
+func nowUTC() string { return time.Now().UTC().Format(time.RFC3339) }
+
+func cmdSweepSeed(args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep seed", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	full := fs.Bool("full", false, "widen the seed across all platforms (default narrow depth-first)")
+	class := fs.String("class", "config", "sweep class: config (realistic stream/network) | fault (error-recovery)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	c := sweep.Class(*class)
+	if c != sweep.ClassConfig && c != sweep.ClassFault {
+		return fmt.Errorf("invalid --class %q: config|fault", *class)
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	exps := sweep.Seed(c, *full, nowUTC())
+	for _, e := range exps {
+		if err := s.Save(sweep.StatusBacklog, e); err != nil {
+			return err
+		}
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"seeded": len(exps), "full": *full, "class": *class})
+	}
+	mode := "narrow (depth-first, ipad-sim)"
+	if *full {
+		mode = "full (all platforms)"
+	}
+	fmt.Printf("seeded %d %s-class experiments into %s/backlog — %s\n", len(exps), c, s.Root, mode)
+	return nil
+}
+
+func cmdSweepStatus(args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep status", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	counts, err := s.Counts()
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		m := make(map[string]int, len(counts))
+		for k, v := range counts {
+			m[string(k)] = v
+		}
+		return json.NewEncoder(os.Stdout).Encode(m)
+	}
+	for _, st := range sweep.AllStatuses {
+		fmt.Printf("  %-9s %d\n", st, counts[st])
+	}
+	return nil
+}
+
+func cmdSweepLs(args []string, asJSON bool) error {
+	// status is the leading positional; pull it before parsing flags so
+	// `ls found --root X` works (Go's flag package stops at the positional).
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep ls <status> [--root DIR]")
+	}
+	status := args[0]
+	fs := flag.NewFlagSet("sweep ls", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	exps, err := s.List(sweep.Status(status))
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(exps)
+	}
+	for _, e := range exps {
+		verdict := ""
+		if e.Result != nil {
+			verdict = string(e.Result.Verdict)
+		}
+		fmt.Printf("  %-36s %-10s %-9s %-5s %-18s score=%6.1f %s\n",
+			e.ID, e.Kind, e.Platform, e.Protocol, e.Mode, e.Score, verdict)
+	}
+	return nil
+}
+
+// flipList collects repeatable --flip axis=value pairs.
+type flipList []sweep.Flip
+
+func (f *flipList) String() string { return fmt.Sprintf("%d flips", len(*f)) }
+func (f *flipList) Set(v string) error {
+	i := strings.IndexByte(v, '=')
+	if i < 0 {
+		return fmt.Errorf("flip %q must be axis=value", v)
+	}
+	*f = append(*f, sweep.Flip{Axis: sweep.Axis(v[:i]), Value: v[i+1:]})
+	return nil
+}
+
+func cmdSweepIsolate(args []string, asJSON bool) error {
+	// The experiment id is the first positional; Go's flag package stops at
+	// the first non-flag token, so pull it out before parsing the flags.
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep isolate <experiment-id> --flip axis=value …")
+	}
+	id := args[0]
+	fs := flag.NewFlagSet("sweep isolate", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	from := fs.String("from", "found", "bucket holding the parent experiment")
+	var flips flipList
+	fs.Var(&flips, "flip", "axis=value (repeatable)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	parent, err := s.Load(sweep.Status(*from), id)
+	if err != nil {
+		return fmt.Errorf("load parent %s/%s: %w", *from, id, err)
+	}
+	fan, err := sweep.IsolationFan(parent, flips, nowUTC())
+	if err != nil {
+		return err
+	}
+	for _, e := range fan {
+		if err := s.Save(sweep.StatusBacklog, e); err != nil {
+			return err
+		}
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(fan)
+	}
+	fmt.Printf("inserted isolation fan for %s: %d experiments (control + %d variants) → backlog\n",
+		parent.ID, len(fan), len(fan)-1)
+	for _, e := range fan {
+		fmt.Printf("  %-40s arm=%-7s group=%s\n", e.ID, e.Arm, e.Group)
+	}
+	return nil
+}
+
+func cmdSweepNext(args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep next", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	depthFirst := fs.Bool("depth-first", true, "prefer non-seed work")
+	claim := fs.Bool("claim", false, "atomically claim the selected experiment")
+	owner := fs.String("owner", "", "owner id to stamp on claim")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	backlog, err := s.List(sweep.StatusBacklog)
+	if err != nil {
+		return err
+	}
+	w := sweep.DefaultWeights()
+	pick := w.SelectNext(backlog, *depthFirst)
+	if pick == nil {
+		if asJSON {
+			fmt.Println("null")
+		} else {
+			fmt.Println("backlog empty")
+		}
+		return nil
+	}
+	if *claim {
+		if *owner == "" {
+			return errors.New("--claim requires --owner")
+		}
+		claimed, err := s.Claim(pick.ID, *owner, nowUTC())
+		if err != nil {
+			return fmt.Errorf("claim %s: %w", pick.ID, err)
+		}
+		pick = claimed
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(pick)
+	}
+	fmt.Printf("%s  kind=%s platform=%s protocol=%s mode=%s score=%.1f\n",
+		pick.ID, pick.Kind, pick.Platform, pick.Protocol, pick.Mode, pick.Score)
+	if *claim {
+		fmt.Printf("claimed by %s → running/\n", pick.Owner)
+	}
+	return nil
+}

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -1,0 +1,787 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/v2gen/forwarder"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/v2gen/proxy"
+)
+
+// This file is the device-bound half of the §7 run loop (issue #772): the CLI
+// surface a /goal driver calls per iteration — apply a claimed experiment onto
+// a live session, analyse the resulting play into a verdict + bucket move,
+// promote a confirmed hit to a deduped Issue, and reap dead claims. The pure
+// logic lives in internal/sweep (analyze.go / reap.go / promote.go); these
+// wrappers do the I/O.
+
+// --- sweep apply ----------------------------------------------------------
+
+func cmdSweepApply(client *api.Client, args []string, asJSON bool) error {
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep apply <experiment-id> --target <player> [--from running]")
+	}
+	id := args[0]
+	fs := flag.NewFlagSet("sweep apply", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	from := fs.String("from", "running", "bucket holding the experiment")
+	target := fs.String("target", "", "player target (id/label/ip/UA substring) — required")
+	noReset := fs.Bool("no-reset", false, "skip the pre-apply shape/fault reset (step 0)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if *target == "" {
+		return errors.New("--target is required")
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	e, err := s.Load(sweep.Status(*from), id)
+	if err != nil {
+		return fmt.Errorf("load %s/%s: %w", *from, id, err)
+	}
+
+	ctx := context.Background()
+	pid, err := client.Resolve(ctx, *target)
+	if err != nil {
+		return err
+	}
+
+	applied := []string{}
+
+	// Step 0 (§11): start from a clean target — residual shape/faults are
+	// per-session kernel state that leaks across runs otherwise.
+	if !*noReset {
+		if _, err := client.ClearShape(ctx, pid, "sweep reset shape"); err != nil {
+			return fmt.Errorf("reset shape: %w", err)
+		}
+		if _, err := client.ClearFaultRules(ctx, pid, "sweep reset faults"); err != nil {
+			return fmt.Errorf("reset faults: %w", err)
+		}
+		applied = append(applied, "reset(shape+faults)")
+	}
+
+	// Labels (the what + why, §4.1) + content_manipulation in one PATCH.
+	patch := proxy.PlayerPatch{}
+	labelMap := sweep.RunLabels(e)
+	pl := proxy.Labels(labelMap)
+	patch.Labels = &pl
+	if e.ContentManipulation != nil {
+		allowed, err := resolveAllowedVariants(ctx, client, e.Content, e.ContentManipulation.AllowedVariants)
+		if err != nil {
+			return err
+		}
+		cm, err := toProxyContent(e.ContentManipulation, allowed)
+		if err != nil {
+			return fmt.Errorf("content_manipulation: %w", err)
+		}
+		patch.Content = cm
+		applied = append(applied, "content")
+	}
+	if e.TransferTimeouts != nil {
+		patch.TransferTimeouts = toProxyTransferTimeouts(e.TransferTimeouts)
+		applied = append(applied, "transfer_timeouts")
+	}
+	if _, err := client.PatchPlayer(ctx, pid, "sweep apply labels+content", patch); err != nil {
+		return fmt.Errorf("apply labels/content: %w", err)
+	}
+	applied = append(applied, fmt.Sprintf("labels(%d)", len(labelMap)))
+
+	// Slider shaping (rate/delay/loss) — pattern shapes need a fetched
+	// manifest, so they're applied post-launch via `harness shape --pattern`.
+	if sh := e.Shape; sh != nil {
+		if sh.Pattern != "" {
+			applied = append(applied, fmt.Sprintf("pattern=%s(deferred: run `harness shape %s --pattern %s --step-seconds %d --margin %d` after the master fetch)",
+				sh.Pattern, *target, sh.Pattern, nonZero(sh.StepSeconds, 12), sh.MarginPct))
+		}
+		if ps := toProxySliderShape(sh); ps != nil {
+			if _, err := client.PatchShape(ctx, pid, "sweep apply shape", ps); err != nil {
+				return fmt.Errorf("apply shape: %w", err)
+			}
+			applied = append(applied, "shape(sliders)")
+		}
+	}
+
+	// HTTP fault rule.
+	if e.Fault != nil {
+		rule, err := toProxyFaultRule(e.Fault)
+		if err != nil {
+			return fmt.Errorf("fault: %w", err)
+		}
+		if _, err := client.AddFaultRule(ctx, pid, "sweep apply fault", rule); err != nil {
+			return fmt.Errorf("add fault: %w", err)
+		}
+		applied = append(applied, "fault="+sweepFaultDesc(e.Fault))
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"experiment": e.ID, "player_id": pid, "applied": applied, "why": e.Why,
+		})
+	}
+	fmt.Printf("applied %s → %s: %s\n", e.ID, pid, strings.Join(applied, ", "))
+	if e.WhyText != "" {
+		fmt.Printf("  why: %s\n", e.WhyText)
+	}
+	return nil
+}
+
+// --- sweep bootstrap (config-on-connect) ----------------------------------
+
+// cmdSweepBootstrap is the config-on-connect probe hook (§7 step 2, the
+// integration seam): it materialises an experiment's full recipe onto a proxy
+// session BEFORE the app launches, by GETting the bootstrap master URL on the
+// shaper port carrying `player_id` + a full-fidelity `proxy.cfg` patch. The cap
+// /fault/content is then live from the player's first byte. The caller mints
+// (or passes) the player_id and launches the platform app bound to that same id
+// (`-is.player_id <id>`), so the mode plays the already-configured session.
+func cmdSweepBootstrap(client *api.Client, args []string, asJSON bool) error {
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep bootstrap <experiment-id> [--player UUID] [--group G] [--content C] [--from running]")
+	}
+	id := args[0]
+	fs := flag.NewFlagSet("sweep bootstrap", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	from := fs.String("from", "running", "bucket holding the experiment")
+	player := fs.String("player", "", "player_id to configure (default: mint a fresh UUID)")
+	group := fs.String("group", "", "group_id to born-group the session (A/B pairs)")
+	content := fs.String("content", "", "clip to drive allocation (default: the experiment's content)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	e, err := s.Load(sweep.Status(*from), id)
+	if err != nil {
+		return fmt.Errorf("load %s/%s: %w", *from, id, err)
+	}
+
+	playerID := *player
+	if playerID == "" {
+		playerID = uuid.NewString()
+	}
+	clip := *content
+	if clip == "" {
+		clip = e.Content
+	}
+	if clip == "" {
+		return errors.New("no content: pass --content or set the experiment's content")
+	}
+
+	patch, summary, err := experimentPlayerPatch(context.Background(), client, clip, e)
+	if err != nil {
+		return err
+	}
+	cfgJSON, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	cfgB64 := base64.RawURLEncoding.EncodeToString(cfgJSON)
+
+	bootURL, err := shaperBootstrapURL(client.BaseURL, clip, playerID, *group, cfgB64)
+	if err != nil {
+		return err
+	}
+
+	// Reuse the CLI's configured transport (carries the --insecure TLS skip
+	// test-dev's self-signed cert needs), but don't follow the 302 — receiving
+	// it on the shaper port is the success signal, and the per-session port
+	// need not be reachable from this host.
+	hc := &http.Client{
+		Timeout:       30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Transport:     client.HTTP.Transport,
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, bootURL, nil)
+	if err != nil {
+		return err
+	}
+	if client.BasicAuth != "" {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(client.BasicAuth)))
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("bootstrap GET: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	// #712 materialises + applies the kernel rule BEFORE writing the 302, so a
+	// 3xx (which we don't follow) already means "session configured". 4xx/5xx ⇒
+	// the proxy rejected the args.
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("bootstrap: proxy returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	// Persist the player_id back onto the experiment so analyze (and the
+	// post-mortem) can build the session-viewer link even though the play_id
+	// isn't known until the probe runs.
+	e.PlayerID = playerID
+	if err := s.Save(sweep.Status(*from), e); err != nil {
+		return err
+	}
+
+	viewer := viewerURL(client.BaseURL, playerID, "")
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"experiment": e.ID, "player_id": playerID, "group_id": *group,
+			"clip": clip, "applied": summary, "status": resp.StatusCode,
+			"session_viewer": viewer,
+		})
+	}
+	fmt.Printf("configured session for %s → player_id=%s (%s)\n", e.ID, playerID, strings.Join(summary, ", "))
+	fmt.Printf("  launch the app with -is.player_id %s to play the configured session\n", playerID)
+	fmt.Printf("  session-viewer: %s\n", viewer)
+	return nil
+}
+
+// viewerURL builds the dashboard session-viewer link (SessionViewerLink.vue
+// contract: player_id required, play_id optional). baseURL is the API/UI
+// origin. Empty playID ⇒ player-scoped link (works before the play exists).
+func viewerURL(baseURL, playerID, playID string) string {
+	base := strings.TrimRight(baseURL, "/")
+	u := fmt.Sprintf("%s/dashboard/session-viewer.html?player_id=%s", base, url.QueryEscape(playerID))
+	if playID != "" {
+		u += "&play_id=" + url.QueryEscape(playID)
+	}
+	return u
+}
+
+// experimentPlayerPatch builds the combined PlayerPatch (labels + slider shape
+// + content + fault) that both config-on-connect (proxy.cfg) and a live PATCH
+// can carry. Pattern shapes are omitted — they need a fetched manifest's ladder
+// and are applied post-launch via `harness shape --pattern`.
+func experimentPlayerPatch(ctx context.Context, client *api.Client, content string, e *sweep.Experiment) (proxy.PlayerPatch, []string, error) {
+	patch := proxy.PlayerPatch{}
+	var summary []string
+
+	labelMap := sweep.RunLabels(e)
+	pl := proxy.Labels(labelMap)
+	patch.Labels = &pl
+	summary = append(summary, fmt.Sprintf("labels(%d)", len(labelMap)))
+
+	if e.ContentManipulation != nil {
+		allowed, err := resolveAllowedVariants(ctx, client, content, e.ContentManipulation.AllowedVariants)
+		if err != nil {
+			return patch, nil, err
+		}
+		cm, err := toProxyContent(e.ContentManipulation, allowed)
+		if err != nil {
+			return patch, nil, fmt.Errorf("content_manipulation: %w", err)
+		}
+		patch.Content = cm
+		summary = append(summary, "content")
+	}
+	if e.Shape != nil {
+		if ps := toProxySliderShape(e.Shape); ps != nil {
+			patch.Shape = ps
+			summary = append(summary, "shape(sliders)")
+		}
+		if e.Shape.Pattern != "" {
+			summary = append(summary, "pattern(deferred→post-launch)")
+		}
+	}
+	if e.TransferTimeouts != nil {
+		patch.TransferTimeouts = toProxyTransferTimeouts(e.TransferTimeouts)
+		summary = append(summary, "transfer_timeouts")
+	}
+	if e.Fault != nil {
+		rule, err := toProxyFaultRule(e.Fault)
+		if err != nil {
+			return patch, nil, fmt.Errorf("fault: %w", err)
+		}
+		rules := []proxy.FaultRule{rule}
+		patch.FaultRules = &rules
+		summary = append(summary, "fault="+sweepFaultDesc(e.Fault))
+	}
+	return patch, summary, nil
+}
+
+// shaperBootstrapURL builds the config-on-connect GET URL: the master playlist
+// on the shaper port (UI port with the last 3 digits → 081, mirroring the
+// runner's shaperPortFromUIPort), carrying player_id + group_id + proxy.cfg.
+func shaperBootstrapURL(baseURL, clip, playerID, groupID, cfgB64 string) (string, error) {
+	u, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return "", fmt.Errorf("parse base URL %q: %w", baseURL, err)
+	}
+	host, port := splitHostPortSafe(u.Host)
+	if len(port) >= 4 {
+		port = port[:len(port)-3] + "081"
+	}
+	shaperHost := host
+	if port != "" {
+		shaperHost = net.JoinHostPort(host, port)
+	}
+	q := url.Values{}
+	q.Set("player_id", playerID)
+	if groupID != "" {
+		q.Set("group_id", groupID)
+	}
+	q.Set("proxy.cfg", cfgB64)
+	return fmt.Sprintf("%s://%s/go-live/%s/master_6s.m3u8?%s",
+		u.Scheme, shaperHost, url.PathEscape(clip), q.Encode()), nil
+}
+
+func splitHostPortSafe(hostport string) (host, port string) {
+	if h, p, err := net.SplitHostPort(hostport); err == nil {
+		return h, p
+	}
+	return hostport, ""
+}
+
+// --- sweep analyze --------------------------------------------------------
+
+func cmdSweepAnalyze(client *api.Client, args []string, asJSON bool) error {
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep analyze <experiment-id> --play <play_id> [--from running] [--confirm-reps N]")
+	}
+	id := args[0]
+	fs := flag.NewFlagSet("sweep analyze", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	from := fs.String("from", "running", "bucket holding the experiment")
+	play := fs.String("play", "", "play_id the probe produced — required")
+	confirmReps := fs.Int("confirm-reps", 3, "reps to enqueue for a first-pass hit (n=1 guard); 0 disables")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if *play == "" {
+		return errors.New("--play <play_id> is required")
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	e, err := s.Load(sweep.Status(*from), id)
+	if err != nil {
+		return fmt.Errorf("load %s/%s: %w", *from, id, err)
+	}
+
+	// Oracle A: pull the play's severity-tagged labels (the label_histogram on
+	// the plays row, unioned across all three source tables) and classify.
+	pid, err := parsePlayID(*play)
+	if err != nil {
+		return err
+	}
+	limit := 1
+	params := &forwarder.GetApiV2PlaysParams{PlayId: &pid, Limit: &limit}
+	body, err := client.ArchivePlays(context.Background(), params)
+	if err != nil {
+		return fmt.Errorf("query play %s: %w", *play, err)
+	}
+	labels, err := sweep.LabelsFromPlayHistogram(body)
+	if err != nil {
+		return err
+	}
+
+	bucket := sweep.Analyze(e, *play, labels)
+
+	// n=1 guard: a first single-rep hit enqueues confirmation reps instead of
+	// being promoted straight away. The reps land in backlog; this experiment
+	// still records its verdict and moves to its bucket for the post-mortem.
+	var enqueued []string
+	if *confirmReps > 0 && sweep.NeedsConfirmation(e) {
+		for _, rep := range sweep.ConfirmationReps(e, *confirmReps, nowUTC()) {
+			if err := s.Save(sweep.StatusBacklog, rep); err != nil {
+				return err
+			}
+			enqueued = append(enqueued, rep.ID)
+		}
+	}
+
+	if err := s.Move(sweep.Status(*from), bucket, e); err != nil {
+		return err
+	}
+
+	viewer := viewerURL(client.BaseURL, e.PlayerID, *play)
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"experiment": e.ID, "player_id": e.PlayerID, "play_id": *play, "verdict": e.Result.Verdict,
+			"labels": labels, "moved_to": bucket, "confirm_reps": enqueued,
+			"session_viewer": viewer,
+		})
+	}
+	fmt.Printf("%s: verdict=%s → %s/ (%d labels)\n", e.ID, e.Result.Verdict, bucket, len(labels))
+	if k := sweep.PrimaryKind(labels); k != "" {
+		fmt.Printf("  primary: %s\n", k)
+	}
+	fmt.Printf("  player_id=%s play_id=%s\n", e.PlayerID, *play)
+	fmt.Printf("  session-viewer: %s\n", viewer)
+	if len(enqueued) > 0 {
+		fmt.Printf("  n=1 guard: enqueued %d confirmation reps → backlog (%s)\n", len(enqueued), strings.Join(enqueued, ", "))
+	}
+	return nil
+}
+
+// --- sweep promote --------------------------------------------------------
+
+func cmdSweepPromote(_ *api.Client, args []string, asJSON bool) error {
+	if len(args) < 1 || strings.HasPrefix(args[0], "-") {
+		return errors.New("usage: harness sweep promote <experiment-id> [--axis A] [--from found] [--dry-run]")
+	}
+	id := args[0]
+	fs := flag.NewFlagSet("sweep promote", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	from := fs.String("from", "found", "bucket holding the experiment")
+	axis := fs.String("axis", "", "isolation-attributed axis, appended to the signature")
+	dryRun := fs.Bool("dry-run", false, "print the gh command + body, do not create/comment")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	e, err := s.Load(sweep.Status(*from), id)
+	if err != nil {
+		return fmt.Errorf("load %s/%s: %w", *from, id, err)
+	}
+	var labels []string
+	if e.Result != nil {
+		labels = e.Result.Labels
+	}
+	kind := sweep.PrimaryKind(labels)
+	sig := sweep.Signature(e, kind, *axis)
+	issueLabels := sweep.IssueLabels(sig, verdictOf(e))
+	body := sweep.IssueBody(e, sig, *axis)
+	title := sweep.IssueTitle(e, kind)
+
+	if *dryRun {
+		fmt.Printf("# would promote %s\nsignature: %s\nlabels: %s\ntitle: %s\n\n--- body ---\n%s\n",
+			e.ID, sig, strings.Join(issueLabels, ","), title, body)
+		return nil
+	}
+
+	// Dedup: an open Issue carrying this signature label → comment the new
+	// repro instead of opening a duplicate.
+	existing, err := ghFindIssue(sig)
+	if err != nil {
+		return err
+	}
+	bodyFile, err := os.CreateTemp("", "sweep-issue-*.md")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(bodyFile.Name())
+	if _, err := bodyFile.WriteString(body); err != nil {
+		return err
+	}
+	bodyFile.Close()
+
+	var result string
+	if existing != "" {
+		if err := ghRun("issue", "comment", existing, "--body-file", bodyFile.Name()); err != nil {
+			return err
+		}
+		result = "commented on #" + existing
+	} else {
+		out, err := ghOutput("issue", "create", "--title", title, "--body-file", bodyFile.Name(),
+			"--label", strings.Join(issueLabels, ","))
+		if err != nil {
+			return err
+		}
+		result = "created " + strings.TrimSpace(out)
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"experiment": e.ID, "signature": sig, "result": result,
+		})
+	}
+	fmt.Printf("%s → %s (sig %s)\n", e.ID, result, sig)
+	return nil
+}
+
+// --- sweep publish (→ dashboard) ------------------------------------------
+
+// cmdSweepPublish snapshots the whole .sweep/ queue and POSTs it to the
+// forwarder so the dashboard's Sweep tab can show it (the .sweep/ files live on
+// the runner, not the deploy). Idempotent: the forwarder upserts by exp_id, so
+// the loop can call this after every iteration to keep the tab live.
+func cmdSweepPublish(client *api.Client, args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep publish", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	// Recompute the scheduler score at publish time so the dashboard's
+	// pending order matches what actually runs next. Stored scores can be
+	// stale — isolation/bisect experiments are created with score 0 and only
+	// get their true (kind-dominated) score at live selection — so trust the
+	// scheduler, not the file.
+	w := sweep.DefaultWeights()
+	var rows []map[string]any
+	for _, st := range sweep.AllStatuses {
+		exps, err := s.List(st)
+		if err != nil {
+			return err
+		}
+		for _, e := range exps {
+			verdict := ""
+			if e.Result != nil {
+				verdict = string(e.Result.Verdict)
+			}
+			rows = append(rows, map[string]any{
+				"exp_id": e.ID, "class": string(e.ClassOrDefault()), "status": string(st),
+				"kind": string(e.Kind), "platform": e.Platform, "protocol": e.Protocol,
+				"mode": e.Mode, "recipe": sweep.RecipeSlug(e), "arm": string(e.Arm),
+				"group_id": e.Group, "parent": e.Parent, "depth": e.Depth,
+				"why": e.Why, "why_text": e.WhyText, "verdict": verdict,
+				"player_id": e.PlayerID, "play_id": e.PlayID, "score": w.Score(e),
+				"created_at": e.CreatedAt,
+			})
+		}
+	}
+
+	payload, err := json.Marshal(map[string]any{"experiments": rows})
+	if err != nil {
+		return err
+	}
+	url := strings.TrimRight(client.BaseURL, "/") + "/analytics/api/v2/sweep/experiments"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, strings.NewReader(string(payload)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if client.BasicAuth != "" {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(client.BasicAuth)))
+	}
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("publish POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("publish: %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	if asJSON {
+		_, _ = os.Stdout.Write(respBody)
+		return nil
+	}
+	fmt.Printf("published %d experiments → %s\n", len(rows), url)
+	return nil
+}
+
+// --- sweep reap -----------------------------------------------------------
+
+func cmdSweepReap(args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep reap", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	maxAgeMin := fs.Float64("max-age-min", 60, "minutes since claim before a running experiment is reaped")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+	running, err := s.List(sweep.StatusRunning)
+	if err != nil {
+		return err
+	}
+	stale := sweep.ReapStale(running, nowUTC(), time.Duration(*maxAgeMin*float64(time.Minute)))
+	reaped := make([]string, 0, len(stale))
+	for _, e := range stale {
+		sweep.Requeue(e)
+		if err := s.Move(sweep.StatusRunning, sweep.StatusBacklog, e); err != nil {
+			return err
+		}
+		reaped = append(reaped, e.ID)
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"reaped": reaped, "running": len(running)})
+	}
+	if len(reaped) == 0 {
+		fmt.Printf("no stale claims (%d running)\n", len(running))
+		return nil
+	}
+	fmt.Printf("reaped %d stale claim(s) → backlog: %s\n", len(reaped), strings.Join(reaped, ", "))
+	return nil
+}
+
+// --- translators (sweep recipe → proxy types) -----------------------------
+
+func toProxySliderShape(sh *sweep.Shape) *proxy.Shape {
+	// Rate only — delay/loss are out of scope for the sweep (steady network
+	// degradation isn't a realistic stream config nor an explicit error).
+	// Pattern shapes are applied post-launch via `harness shape --pattern`.
+	if sh.RateMbps == nil {
+		return nil
+	}
+	v := float32(*sh.RateMbps)
+	return &proxy.Shape{RateMbps: &v}
+}
+
+func toProxyTransferTimeouts(t *sweep.TransferTimeouts) *proxy.TransferTimeouts {
+	out := &proxy.TransferTimeouts{}
+	if t.ActiveSeconds > 0 {
+		v := t.ActiveSeconds
+		out.ActiveTimeoutSeconds = &v
+	}
+	if t.IdleSeconds > 0 {
+		v := t.IdleSeconds
+		out.IdleTimeoutSeconds = &v
+	}
+	if t.AppliesSegments {
+		b := true
+		out.AppliesSegments = &b
+	}
+	if t.AppliesManifests {
+		b := true
+		out.AppliesManifests = &b
+	}
+	if t.AppliesMaster {
+		b := true
+		out.AppliesMaster = &b
+	}
+	return out
+}
+
+// toProxyContent translates the sweep CM knobs. `allowedVariants` is the
+// already-resolved keep-set (URIs or resolution heights) for the
+// allowed_variants spec — resolved by the caller via resolveAllowedVariants,
+// which needs network access to the master ladder, so it can't live in this
+// pure translator.
+func toProxyContent(cm *sweep.ContentManipulation, allowedVariants []string) (*proxy.ContentManipulation, error) {
+	out := &proxy.ContentManipulation{}
+	if cm.LiveOffset != nil {
+		off := proxy.ContentManipulationLiveOffset(int(*cm.LiveOffset))
+		if !off.Valid() {
+			return nil, fmt.Errorf("live_offset %g is not a supported window (0|6|18|24)", *cm.LiveOffset)
+		}
+		out.LiveOffset = &off
+	}
+	if cm.VariantOrder != "" {
+		vo := proxy.ContentManipulationVariantOrder(cm.VariantOrder)
+		if !vo.Valid() {
+			return nil, fmt.Errorf("variant_order %q invalid (ascending|descending|default|first_4mbps)", cm.VariantOrder)
+		}
+		out.VariantOrder = &vo
+	}
+	if len(allowedVariants) > 0 {
+		vs := allowedVariants
+		out.AllowedVariants = &vs
+	}
+	if cm.StripCodecs {
+		b := true
+		out.StripCodecs = &b
+	}
+	if cm.StripAvgBandwidth {
+		b := true
+		out.StripAverageBandwidth = &b
+	}
+	if cm.StripResolution {
+		b := true
+		out.StripResolution = &b
+	}
+	if cm.OverstateBandwidth != nil {
+		b := true
+		out.OverstateBandwidth = &b
+	}
+	return out, nil
+}
+
+func toProxyFaultRule(f *sweep.Fault) (proxy.FaultRule, error) {
+	freq := nonZero(f.Frequency, 1)
+	cons := nonZero(f.Consecutive, 1)
+	rule := proxy.FaultRule{
+		Type:        proxy.FaultRuleType(f.Type),
+		Frequency:   &freq,
+		Consecutive: &cons,
+	}
+	mode := f.Mode
+	if mode == "" {
+		mode = "requests"
+	}
+	m := proxy.FaultRuleMode(mode)
+	rule.Mode = &m
+	if filter, err := buildFilter(f.RequestKind, f.URLSubstr, ""); err != nil {
+		return rule, err
+	} else if filter != nil {
+		rule.Filter = filter
+	}
+	return rule, nil
+}
+
+func sweepFaultDesc(f *sweep.Fault) string {
+	if f.RequestKind != "" {
+		return f.Type + "/" + f.RequestKind
+	}
+	return f.Type
+}
+
+func nonZero(v, fallback int) int {
+	if v == 0 {
+		return fallback
+	}
+	return v
+}
+
+func verdictOf(e *sweep.Experiment) sweep.Verdict {
+	if e.Result != nil {
+		return e.Result.Verdict
+	}
+	return sweep.VerdictClean
+}
+
+// --- gh helpers -----------------------------------------------------------
+
+// ghFindIssue returns the number of the first OPEN issue carrying the given
+// signature label, or "" if none. Used for finding dedup (§4).
+func ghFindIssue(sig string) (string, error) {
+	out, err := ghOutput("issue", "list", "--label", sig, "--state", "open",
+		"--json", "number", "--limit", "1")
+	if err != nil {
+		return "", err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" || out == "[]" {
+		return "", nil
+	}
+	var rows []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		return "", fmt.Errorf("parse gh issue list: %w", err)
+	}
+	if len(rows) == 0 {
+		return "", nil
+	}
+	return fmt.Sprintf("%d", rows[0].Number), nil
+}
+
+func ghOutput(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("gh %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func ghRun(args ...string) error {
+	_, err := ghOutput(args...)
+	return err
+}

--- a/tools/harness-cli/cmd/harness/sweep_triage.go
+++ b/tools/harness-cli/cmd/harness/sweep_triage.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+// cmdSweepSeedFromTriage closes the loop (#783): it reads the observational
+// triage signal (label divergence — skew + the dominant dimension per label)
+// and generates sweep experiments that reproduce the dimension a severe,
+// dimension-driven label is concentrated on. Only CONTROLLABLE dimensions
+// become experiments (test/pattern, platform, content); observational ones
+// (app_version, device_model, device_kind) and not-yet-runnable targets are
+// skipped with a logged reason. Dedups by deterministic id.
+//
+//	harness sweep seed-from-triage [--days N] [--top N] [--min-skew X] [--dry-run]
+
+// runnablePlatforms are the platforms the probe can actually drive today.
+var runnablePlatforms = map[string]bool{"ipad-sim": true, "iphone-sim": true, "iphone": true}
+
+// testRecipe maps a characterization `test` value to a sweep mode + (for the
+// pattern tests) the shape pattern the probe arms.
+func testRecipe(test string) (mode, pattern string) {
+	switch test {
+	case "pyramid":
+		return "pyramid", "pyramid"
+	case "transient_shock":
+		return "transient_shock", "transient_shock"
+	case "rampup":
+		return "rampup", "ramp_up"
+	case "rampdown":
+		return "rampdown", "ramp_down"
+	default:
+		return test, "" // non-pattern test: probe plays plain (limited fidelity)
+	}
+}
+
+// labelEvent strips the "<severity>=" prefix and any leading * marker.
+func labelEvent(label string) string {
+	ev := label
+	if i := strings.IndexByte(ev, '='); i >= 0 {
+		ev = ev[i+1:]
+	}
+	return strings.TrimPrefix(ev, "*")
+}
+
+func labelSeverity(label string) string {
+	if i := strings.IndexByte(label, '='); i >= 0 {
+		return label[:i]
+	}
+	return ""
+}
+
+func cmdSweepSeedFromTriage(client *api.Client, args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep seed-from-triage", flag.ContinueOnError)
+	root := fs.String("root", "", "sweep root dir")
+	days := fs.Int("days", 7, "lookback window for the triage signal")
+	top := fs.Int("top", 8, "consider the top-N labels by skew")
+	minSkew := fs.Float64("min-skew", 2.0, "only seed labels whose skew (max lift) ≥ this")
+	dryRun := fs.Bool("dry-run", false, "print the plan; don't write experiments")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	s, err := openStore(*root)
+	if err != nil {
+		return err
+	}
+
+	// Pull the divergence signal: per label, its skew + dominant "dim=value".
+	url := fmt.Sprintf("%s/analytics/api/v2/label_divergence?days=%d&exclude_faulted=1",
+		strings.TrimRight(client.BaseURL, "/"), *days)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if client.BasicAuth != "" {
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(client.BasicAuth)))
+	}
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch divergence: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("divergence: %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var div struct {
+		Items []struct {
+			Label string  `json:"label"`
+			Skew  float64 `json:"skew"`
+			Top   string  `json:"top"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &div); err != nil {
+		return fmt.Errorf("parse divergence: %w", err)
+	}
+
+	// Keep severe, dimension-driven labels; rank by skew; take the top N.
+	type cand struct {
+		label, dim, value string
+		skew              float64
+	}
+	var cands []cand
+	for _, it := range div.Items {
+		sev := labelSeverity(it.Label)
+		if sev != "warning" && sev != "critical" && sev != "error" {
+			continue
+		}
+		if it.Skew < *minSkew || it.Top == "" {
+			continue
+		}
+		dim, value := it.Top, ""
+		if i := strings.IndexByte(it.Top, '='); i >= 0 {
+			dim, value = it.Top[:i], it.Top[i+1:]
+		}
+		cands = append(cands, cand{it.Label, dim, value, it.Skew})
+	}
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].skew > cands[j].skew })
+	if len(cands) > *top {
+		cands = cands[:*top]
+	}
+
+	now := nowUTC()
+	type plan struct {
+		Label, Action, ID, Reason string
+	}
+	var plans []plan
+
+	// Several severe labels often concentrate on the SAME controllable
+	// dimension value (e.g. four labels all 15–18× on iphone-sim). They want
+	// ONE experiment, not four — so fold by deterministic id, recording every
+	// contributing label on the one experiment's rationale.
+	type folded struct {
+		exp     *sweep.Experiment
+		labels  []string
+		topSkew float64
+		topWhy  string
+	}
+	byID := map[string]*folded{}
+	var order []string
+	for _, c := range cands {
+		e, skip := experimentFromTriage(c.label, c.dim, c.value, c.skew, now)
+		if e == nil {
+			plans = append(plans, plan{c.label, "skip", "", skip})
+			continue
+		}
+		f, ok := byID[e.ID]
+		if !ok {
+			f = &folded{exp: e}
+			byID[e.ID] = f
+			order = append(order, e.ID)
+		}
+		f.labels = append(f.labels, c.label)
+		if c.skew > f.topSkew {
+			f.topSkew, f.topWhy = c.skew, fmt.Sprintf("%.1f× on %s=%s", c.skew, c.dim, c.value)
+			f.exp.Why = "triage_" + sweep.Slug(labelEvent(c.label))
+		}
+	}
+
+	seeded := 0
+	for _, id := range order {
+		f := byID[id]
+		e := f.exp
+		e.WhyText = fmt.Sprintf("seeded from triage: %s concentrate on %s (top %s)",
+			strings.Join(f.labels, ", "), strings.SplitN(f.topWhy, " on ", 2)[1], f.topWhy)
+		// Dedup against anything already queued for this target.
+		if _, err := s.Load(sweep.StatusBacklog, e.ID); err == nil {
+			plans = append(plans, plan{strings.Join(f.labels, ", "), "skip", e.ID, "already in backlog"})
+			continue
+		}
+		e.Score = sweep.DefaultWeights().Score(e)
+		if !*dryRun {
+			if err := s.Save(sweep.StatusBacklog, e); err != nil {
+				return err
+			}
+		}
+		seeded++
+		plans = append(plans, plan{strings.Join(f.labels, ", "), "seed", e.ID, f.topWhy})
+	}
+
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"seeded": seeded, "dry_run": *dryRun, "plans": plans})
+	}
+	verb := "seeded"
+	if *dryRun {
+		verb = "would seed"
+	}
+	fmt.Printf("%s %d experiment(s) from triage (top %d labels, skew ≥ %.1f):\n", verb, seeded, *top, *minSkew)
+	for _, p := range plans {
+		if p.Action == "seed" {
+			fmt.Printf("  + %-40s %s  (%s)\n", p.ID, p.Label, p.Reason)
+		} else {
+			fmt.Printf("  – skip %-34s %s  (%s)\n", p.Label, "", p.Reason)
+		}
+	}
+	return nil
+}
+
+// experimentFromTriage turns one triage candidate into a sweep experiment, or
+// returns (nil, reason) when the dominant dimension isn't controllable/runnable.
+func experimentFromTriage(label, dim, value string, skew float64, now string) (*sweep.Experiment, string) {
+	whySlug := "triage_" + sweep.Slug(labelEvent(label))
+	whyText := fmt.Sprintf("seeded from triage: %s is %.1f× on %s=%s", label, skew, dim, value)
+
+	switch dim {
+	case "test":
+		mode, pattern := testRecipe(value)
+		e := &sweep.Experiment{
+			ID: "triage-test-" + sweep.Slug(value), CreatedAt: now, Class: sweep.ClassConfig,
+			Platform: "ipad-sim", Protocol: "hls", Content: sweep.SeedContent, Mode: mode,
+			Kind: sweep.KindSeed, Reps: 1, Why: whySlug, WhyText: whyText,
+		}
+		if pattern != "" {
+			e.Shape = &sweep.Shape{Pattern: pattern, StepSeconds: 12, MarginPct: 5}
+		}
+		return e, ""
+	case "platform":
+		if !runnablePlatforms[value] {
+			return nil, "platform " + value + " not runnable by the probe yet (e.g. Android TV) — expand coverage first"
+		}
+		return &sweep.Experiment{
+			ID: "triage-platform-" + sweep.Slug(value), CreatedAt: now, Class: sweep.ClassConfig,
+			Platform: value, Protocol: "hls", Content: sweep.SeedContent, Mode: "steps",
+			Kind: sweep.KindSeed, Reps: 1, Why: whySlug, WhyText: whyText,
+		}, ""
+	case "content":
+		if value != sweep.SeedContent {
+			return nil, "content " + value + " out of scope (single-content sweep) — add it to expand"
+		}
+		return nil, "content matches the current clip — no new test"
+	default:
+		return nil, dim + " is observational (app/device) — can't reproduce it with an experiment, only filter"
+	}
+}

--- a/tools/harness-cli/cmd/harness/sweep_variants.go
+++ b/tools/harness-cli/cmd/harness/sweep_variants.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+)
+
+// allowed_variants spec resolution (#772). A config-class experiment stores a
+// human-meaningful ladder spec like "drop-top-rung"; the proxy's
+// allowed_variants is a concrete keep-set matched by URI OR resolution
+// (variantAllowed in go-proxy). So before applying it we resolve the spec
+// against the content's actual master playlist into resolution heights (e.g.
+// ["1440","1080","720","480","360"]) — height matching is segment-duration
+// agnostic. Without this, an unresolved spec reached the proxy verbatim and
+// filtered the ladder to nothing → a spurious startup failure.
+
+var (
+	reMasterBandwidth  = regexp.MustCompile(`(?:^|,)BANDWIDTH=(\d+)`)
+	reMasterResolution = regexp.MustCompile(`(?:^|,)RESOLUTION=(\d+)x(\d+)`)
+)
+
+type masterRung struct {
+	bandwidth int
+	height    int
+	uri       string
+}
+
+// resolveAllowedVariants turns an allowed_variants spec into a concrete
+// keep-set the proxy understands. An explicit comma-separated list (URIs or
+// resolutions) passes through unchanged. Ladder specs — "drop-top-rung",
+// "drop-top-<N>", "keep-bottom-<N>" — are resolved against the live master
+// ladder and returned as resolution heights. A bare single token (no comma, not
+// a known spec) is returned as-is so callers can pass a one-off resolution.
+func resolveAllowedVariants(ctx context.Context, client *api.Client, content, spec string) ([]string, error) {
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return nil, nil
+	}
+	if strings.Contains(spec, ",") {
+		return splitTrimNonEmpty(spec), nil
+	}
+
+	// A single literal token (e.g. "1080p" or one URI) — pass through.
+	if !isLadderSpec(spec) {
+		return []string{spec}, nil
+	}
+
+	rungs, err := fetchMasterRungs(ctx, client, content)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", spec, err)
+	}
+	return ladderKeepSet(spec, rungs)
+}
+
+// isLadderSpec reports whether a spec needs the master ladder to resolve.
+func isLadderSpec(spec string) bool {
+	return spec == "drop-top-rung" ||
+		strings.HasPrefix(spec, "drop-top-") ||
+		strings.HasPrefix(spec, "keep-bottom-")
+}
+
+// ladderKeepSet resolves a ladder spec against the rungs into a keep-set of
+// resolution heights (matched by the proxy's variantAllowed). Pure — the
+// network fetch is the caller's job — so the drop/keep arithmetic is testable.
+func ladderKeepSet(spec string, rungs []masterRung) ([]string, error) {
+	if len(rungs) == 0 {
+		return nil, fmt.Errorf("resolve %q: no variants in master", spec)
+	}
+	drop, keepBottom := 0, 0
+	switch {
+	case spec == "drop-top-rung":
+		drop = 1
+	case strings.HasPrefix(spec, "drop-top-"):
+		n, err := strconv.Atoi(strings.TrimPrefix(spec, "drop-top-"))
+		if err != nil || n < 1 {
+			return nil, fmt.Errorf("allowed_variants %q: bad drop-top count", spec)
+		}
+		drop = n
+	case strings.HasPrefix(spec, "keep-bottom-"):
+		n, err := strconv.Atoi(strings.TrimPrefix(spec, "keep-bottom-"))
+		if err != nil || n < 1 {
+			return nil, fmt.Errorf("allowed_variants %q: bad keep-bottom count", spec)
+		}
+		keepBottom = n
+	default:
+		return nil, fmt.Errorf("allowed_variants %q: not a ladder spec", spec)
+	}
+
+	// Descending by bandwidth: rungs[0] is the top rung.
+	sort.Slice(rungs, func(i, j int) bool { return rungs[i].bandwidth > rungs[j].bandwidth })
+
+	var kept []masterRung
+	if keepBottom > 0 {
+		if keepBottom >= len(rungs) {
+			kept = rungs
+		} else {
+			kept = rungs[len(rungs)-keepBottom:]
+		}
+	} else {
+		if drop >= len(rungs) {
+			return nil, fmt.Errorf("resolve %q: would drop all %d rungs", spec, len(rungs))
+		}
+		kept = rungs[drop:]
+	}
+
+	// Express the keep-set as resolution heights (matched by variantAllowed),
+	// falling back to the URI for a rung with no RESOLUTION.
+	out := make([]string, 0, len(kept))
+	seen := map[string]bool{}
+	for _, r := range kept {
+		var key string
+		if r.height > 0 {
+			key = strconv.Itoa(r.height)
+		} else if r.uri != "" {
+			key = r.uri
+		} else {
+			continue
+		}
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out, nil
+}
+
+// fetchMasterRungs GETs the content's master playlist directly off the origin
+// (no proxy session needed) and parses each variant's bandwidth + resolution.
+func fetchMasterRungs(ctx context.Context, client *api.Client, content string) ([]masterRung, error) {
+	url := fmt.Sprintf("%s/go-live/%s/master_6s.m3u8", strings.TrimRight(client.BaseURL, "/"), content)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("GET %s: %d", url, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	return parseMasterRungs(string(body)), nil
+}
+
+func parseMasterRungs(body string) []masterRung {
+	var out []masterRung
+	lines := strings.Split(body, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(strings.ToUpper(line), "#EXT-X-STREAM-INF:") {
+			continue
+		}
+		// Match against the attributes only (after the "…STREAM-INF:" prefix), so
+		// the `(?:^|,)BANDWIDTH=` anchor sees BANDWIDTH at the start and doesn't
+		// confuse it with AVERAGE-BANDWIDTH.
+		attrs := line[strings.IndexByte(line, ':')+1:]
+		r := masterRung{}
+		if m := reMasterBandwidth.FindStringSubmatch(attrs); m != nil {
+			r.bandwidth, _ = strconv.Atoi(m[1])
+		}
+		if m := reMasterResolution.FindStringSubmatch(attrs); m != nil {
+			r.height, _ = strconv.Atoi(m[2])
+		}
+		for j := i + 1; j < len(lines); j++ {
+			uri := strings.TrimSpace(lines[j])
+			if uri == "" || strings.HasPrefix(uri, "#") {
+				continue
+			}
+			r.uri = uri
+			i = j
+			break
+		}
+		if r.bandwidth > 0 || r.uri != "" {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/tools/harness-cli/cmd/harness/sweep_variants_test.go
+++ b/tools/harness-cli/cmd/harness/sweep_variants_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+const sampleMaster = `#EXTM3U
+#EXT-X-STREAM-INF:BANDWIDTH=800000,AVERAGE-BANDWIDTH=600000,RESOLUTION=640x360,CODECS="avc1"
+playlist_6s_360p.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=2500000,AVERAGE-BANDWIDTH=1800000,RESOLUTION=1920x1080,CODECS="avc1"
+playlist_6s_1080p.m3u8
+#EXT-X-STREAM-INF:BANDWIDTH=16000000,AVERAGE-BANDWIDTH=12000000,RESOLUTION=3840x2160,CODECS="avc1"
+playlist_6s_2160p.m3u8
+`
+
+func TestParseMasterRungs(t *testing.T) {
+	rungs := parseMasterRungs(sampleMaster)
+	if len(rungs) != 3 {
+		t.Fatalf("want 3 rungs, got %d", len(rungs))
+	}
+	// The bug: matching the whole line made `(?:^|,)BANDWIDTH=` miss the first
+	// attribute (preceded by ':') and pick up nothing → bandwidth 0. Assert the
+	// REAL BANDWIDTH (not AVERAGE-BANDWIDTH) is parsed for each rung.
+	want := map[int]int{360: 800000, 1080: 2500000, 2160: 16000000}
+	for _, r := range rungs {
+		if want[r.height] != r.bandwidth {
+			t.Errorf("height %d: bandwidth=%d want %d", r.height, r.bandwidth, want[r.height])
+		}
+	}
+}
+
+func TestLadderKeepSetDropTopRung(t *testing.T) {
+	rungs := parseMasterRungs(sampleMaster)
+	got, err := ladderKeepSet("drop-top-rung", rungs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Drops the TOP (2160, highest bandwidth), keeps the rest as heights,
+	// descending.
+	want := []string{"1080", "360"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("drop-top-rung = %v, want %v", got, want)
+	}
+}
+
+func TestLadderKeepSetVariants(t *testing.T) {
+	rungs := parseMasterRungs(sampleMaster)
+	// drop-top-2 → only the lowest survives.
+	if got, _ := ladderKeepSet("drop-top-2", rungs); len(got) != 1 || got[0] != "360" {
+		t.Fatalf("drop-top-2 = %v, want [360]", got)
+	}
+	// keep-bottom-1 → only the lowest.
+	if got, _ := ladderKeepSet("keep-bottom-1", rungs); len(got) != 1 || got[0] != "360" {
+		t.Fatalf("keep-bottom-1 = %v, want [360]", got)
+	}
+	// drop-all is an error, not an empty (which would break the player).
+	if _, err := ladderKeepSet("drop-top-9", rungs); err == nil {
+		t.Fatal("dropping all rungs should error")
+	}
+}

--- a/tools/harness-cli/internal/sweep/analyze.go
+++ b/tools/harness-cli/internal/sweep/analyze.go
@@ -1,0 +1,134 @@
+package sweep
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// This file is the device-INDEPENDENT half of the §7 run loop: once a probe
+// has produced a play_id, everything here is pure data → verdict → next-state,
+// so it unit-tests against fixtures without a live deploy or a sim.
+
+// LabelsFromPlayHistogram extracts the distinct severity-tagged labels for one
+// play from a forwarder /api/v2/plays response envelope. The authoritative
+// source is each play row's `label_histogram` — `[[label, count], …]` pairs
+// unioned across session_events + network_requests + control_events (the same
+// vocab the oracle classifies). This is what the dashboard's chip cloud reads;
+// the per-row events `labels` field is the operator k/v MAP, not these. Order
+// is the histogram's (occurrence-descending), deduped. A missing/empty
+// histogram returns nil so a clean play reads `clean`, not an error.
+func LabelsFromPlayHistogram(body []byte) ([]string, error) {
+	var env struct {
+		Items []struct {
+			LabelHistogram [][]any `json:"label_histogram"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("sweep: parse plays envelope: %w", err)
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, it := range env.Items {
+		for _, pair := range it.LabelHistogram {
+			if len(pair) == 0 {
+				continue
+			}
+			label, _ := pair[0].(string)
+			if label == "" || seen[label] {
+				continue
+			}
+			seen[label] = true
+			out = append(out, label)
+		}
+	}
+	return out, nil
+}
+
+// Analyze records the oracle verdict (Oracle A, §3) onto an experiment and
+// reports the bucket it should move to. It does NOT touch the store — the
+// caller owns the Move so a crash can't lose the file. `playID` is stamped so
+// the dashboard/`found` post-mortem can jump straight to the archived play.
+//
+//	clean       → done
+//	notable     → found   (a lower-priority finding, still promoted)
+//	aberration  → found
+//
+// inconclusive is never produced here — it's an infra/probe verdict the runner
+// sets when there's no play_id at all (§11), distinct from "the player coped".
+func Analyze(e *Experiment, playID string, labels []string) Status {
+	v := Classify(labels)
+	e.PlayID = playID
+	e.Result = &Result{
+		Verdict: v,
+		Labels:  labels,
+		Note:    analysisNote(v, labels),
+	}
+	switch v {
+	case VerdictNotable, VerdictAberration:
+		return StatusFound
+	default:
+		return StatusDone
+	}
+}
+
+func analysisNote(v Verdict, labels []string) string {
+	switch v {
+	case VerdictNotable, VerdictAberration:
+		if k := PrimaryKind(labels); k != "" {
+			return fmt.Sprintf("%s: %s", v, k)
+		}
+	}
+	return string(v)
+}
+
+// NeedsConfirmation reports whether a first-pass hit should be re-run before
+// it's trusted — the n=1 guard (§5, A.3). A single-rep seed/isolation that came
+// back notable/aberration needs ≥reps confirmation runs; an experiment that is
+// itself already part of a rep batch (RepGroup set) must NOT spawn another
+// batch, or the queue never converges.
+func NeedsConfirmation(e *Experiment) bool {
+	if e.Result == nil {
+		return false
+	}
+	if e.RepGroup != "" { // already a confirmation rep — don't recurse
+		return false
+	}
+	switch e.Result.Verdict {
+	case VerdictNotable, VerdictAberration:
+		return e.Reps <= 1
+	default:
+		return false
+	}
+}
+
+// ConfirmationReps materialises `n` independent re-runs of a hit's recipe,
+// each a separate experiment sharing one rep_group, so the loop can promote
+// only when the verdict is stable across them (§5: "repetition is the sweep's
+// job, not the test's"). The reps carry RepGroup (so they won't themselves
+// spawn more) and reset runtime/outcome state. `now` is RFC3339 UTC.
+func ConfirmationReps(parent *Experiment, n int, now string) []*Experiment {
+	if n < 1 {
+		n = 1
+	}
+	group := "rep-" + shortHash(parent.ID)
+	out := make([]*Experiment, 0, n)
+	for i := 0; i < n; i++ {
+		c := cloneExperimentRecipe(parent)
+		c.ID = fmt.Sprintf("%s-%d", group, i+1)
+		c.Kind = parent.Kind
+		c.Arm = parent.Arm
+		c.Group = parent.Group
+		c.Parent = parent.ID
+		c.Depth = parent.Depth
+		c.RepGroup = group
+		c.Reps = 1
+		c.CreatedAt = now
+		c.ClaimedAt = ""
+		c.Why = "confirm_" + string(parent.Result.Verdict)
+		c.WhyText = fmt.Sprintf("confirmation rep %d/%d for %s (verdict %s); n=1 guard before promotion",
+			i+1, n, parent.ID, parent.Result.Verdict)
+		c.Score = 0
+		out = append(out, c)
+	}
+	return out
+}

--- a/tools/harness-cli/internal/sweep/analyze_test.go
+++ b/tools/harness-cli/internal/sweep/analyze_test.go
@@ -1,0 +1,182 @@
+package sweep
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLabelsFromPlayHistogram(t *testing.T) {
+	// Mirrors the live /api/v2/plays shape: label_histogram is [[label,count],…]
+	// (count is a string), unioned across the three source tables.
+	body := []byte(`{"items":[{"label_histogram":[
+		["critical=unexpected_startup","1"],
+		["warning=*qoe_live_offset_concerning","1"],
+		["info=first_frame","1"],
+		["warning=*qoe_live_offset_concerning","1"]
+	]}]}`)
+	got, err := LabelsFromPlayHistogram(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// distinct, histogram order; the duplicate collapses
+	want := []string{"critical=unexpected_startup", "warning=*qoe_live_offset_concerning", "info=first_frame"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("at %d got %q want %q (%v)", i, got[i], want[i], got)
+		}
+	}
+	// the critical label drives an aberration verdict
+	if Classify(got) != VerdictAberration {
+		t.Fatalf("critical=unexpected_startup should be an aberration")
+	}
+}
+
+func TestLabelsFromEmptyPlays(t *testing.T) {
+	for _, body := range []string{`{"items":[]}`, `{}`, `{"items":[{"label_histogram":null}]}`} {
+		got, err := LabelsFromPlayHistogram([]byte(body))
+		if err != nil || len(got) != 0 {
+			t.Fatalf("%s: want empty/no-err, got %v err=%v", body, got, err)
+		}
+	}
+}
+
+func TestAnalyzeBucketing(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+		want   Status
+		verd   Verdict
+	}{
+		{"clean→done", []string{"info=first_frame"}, StatusDone, VerdictClean},
+		{"notable→found", []string{"warning=*qoe_downshift_overshoot"}, StatusFound, VerdictNotable},
+		{"aberration→found", []string{"error=*qoe_vsf"}, StatusFound, VerdictAberration},
+		{"empty→done", nil, StatusDone, VerdictClean},
+	}
+	for _, c := range cases {
+		e := &Experiment{ID: "x"}
+		got := Analyze(e, "play-123", c.labels)
+		if got != c.want {
+			t.Errorf("%s: bucket=%s want %s", c.name, got, c.want)
+		}
+		if e.Result == nil || e.Result.Verdict != c.verd {
+			t.Errorf("%s: verdict=%v want %s", c.name, e.Result, c.verd)
+		}
+		if e.PlayID != "play-123" {
+			t.Errorf("%s: play_id not stamped", c.name)
+		}
+	}
+}
+
+func TestNeedsConfirmation(t *testing.T) {
+	mk := func(v Verdict, reps int, repGroup string) *Experiment {
+		return &Experiment{Reps: reps, RepGroup: repGroup, Result: &Result{Verdict: v}}
+	}
+	if !NeedsConfirmation(mk(VerdictAberration, 1, "")) {
+		t.Error("single-rep aberration should need confirmation")
+	}
+	if !NeedsConfirmation(mk(VerdictNotable, 0, "")) {
+		t.Error("single-rep notable should need confirmation")
+	}
+	if NeedsConfirmation(mk(VerdictClean, 1, "")) {
+		t.Error("clean never needs confirmation")
+	}
+	if NeedsConfirmation(mk(VerdictAberration, 1, "rep-abc")) {
+		t.Error("a rep must not spawn another rep batch (no recursion)")
+	}
+	if NeedsConfirmation(mk(VerdictAberration, 3, "")) {
+		t.Error("already multi-rep should not re-confirm")
+	}
+	if NeedsConfirmation(&Experiment{}) {
+		t.Error("unanalysed experiment needs nothing")
+	}
+}
+
+func TestConfirmationReps(t *testing.T) {
+	rate := 0.4
+	parent := &Experiment{
+		ID: "seed-x", Platform: "ipad-sim", Protocol: "hls", Mode: "pyramid",
+		Kind: KindSeed, Shape: &Shape{RateMbps: &rate}, Reps: 1,
+		Result: &Result{Verdict: VerdictAberration},
+	}
+	reps := ConfirmationReps(parent, 3, "2026-06-13T00:00:00Z")
+	if len(reps) != 3 {
+		t.Fatalf("want 3 reps, got %d", len(reps))
+	}
+	group := reps[0].RepGroup
+	if group == "" {
+		t.Fatal("reps must share a rep_group")
+	}
+	for i, r := range reps {
+		if r.RepGroup != group {
+			t.Errorf("rep %d not in shared group", i)
+		}
+		if r.Parent != parent.ID || r.Reps != 1 || r.Result != nil || r.ClaimedAt != "" {
+			t.Errorf("rep %d wiring wrong: %+v", i, r)
+		}
+		if r.Shape == nil || r.Shape.RateMbps == nil || *r.Shape.RateMbps != 0.4 {
+			t.Errorf("rep %d lost recipe shape", i)
+		}
+		// a rep must not itself trigger another confirmation batch
+		r.Result = &Result{Verdict: VerdictAberration}
+		if NeedsConfirmation(r) {
+			t.Errorf("rep %d would recurse", i)
+		}
+	}
+}
+
+func TestReapStale(t *testing.T) {
+	now := "2026-06-13T12:00:00Z"
+	running := []*Experiment{
+		{ID: "fresh", ClaimedAt: "2026-06-13T11:55:00Z"}, // 5 min ago — alive
+		{ID: "stale", ClaimedAt: "2026-06-13T11:00:00Z"}, // 60 min ago — dead
+		{ID: "noclaim"},                                   // missing stamp — reap
+		{ID: "bad", ClaimedAt: "not-a-time"},              // unparseable — reap
+		{ID: "future", ClaimedAt: "2026-06-13T12:30:00Z"}, // clock skew — not stale
+	}
+	stale := ReapStale(running, now, 30*time.Minute)
+	got := map[string]bool{}
+	for _, e := range stale {
+		got[e.ID] = true
+	}
+	if !got["stale"] || !got["noclaim"] || !got["bad"] {
+		t.Fatalf("missing expected stale: %v", got)
+	}
+	if got["fresh"] || got["future"] {
+		t.Fatalf("reaped a live/skewed claim: %v", got)
+	}
+}
+
+func TestRequeueResetsRuntime(t *testing.T) {
+	e := &Experiment{Owner: "r1", ClaimedAt: "t", PlayID: "p", Result: &Result{Verdict: VerdictClean}}
+	Requeue(e)
+	if e.Owner != "" || e.ClaimedAt != "" || e.PlayID != "" || e.Result != nil {
+		t.Fatalf("runtime not cleared: %+v", e)
+	}
+}
+
+func TestIssueArtifacts(t *testing.T) {
+	e := &Experiment{
+		ID: "iso-h-platform", Class: ClassFault, Platform: "androidtv", Protocol: "hls", Content: "insane_new",
+		Mode: "pyramid", Kind: KindIsolation, Fault: &Fault{Type: "500", RequestKind: "segment"},
+		PlayID: "play-abc", WhyText: "startup VSF on 4k ladder",
+		Result: &Result{Verdict: VerdictAberration, Labels: []string{"error=*qoe_vsf"}},
+	}
+	sig := Signature(e, "qoe_vsf", "platform")
+	labels := IssueLabels(sig, VerdictAberration)
+	if labels[0] != "sweep" || labels[1] != sig || labels[2] != "bug" {
+		t.Fatalf("aberration labels wrong: %v", labels)
+	}
+	if nl := IssueLabels(sig, VerdictNotable); nl[2] != "notable" {
+		t.Fatalf("notable should not be a bug: %v", nl)
+	}
+	body := IssueBody(e, sig, "platform")
+	for _, want := range []string{"qoe_vsf", "androidtv", "500_segment", "play-abc", sig, "startup VSF on 4k ladder"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("issue body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/tools/harness-cli/internal/sweep/experiment.go
+++ b/tools/harness-cli/internal/sweep/experiment.go
@@ -1,0 +1,187 @@
+// Package sweep is the local working store + experiment model for the
+// automated fault-injection sweep (issue #772, docs/sweep-design.md).
+//
+// An *experiment* is one runnable recipe (one
+// {platform × protocol × fault × shape × content × HLS-config × mode}
+// combination) — ephemeral working state. A confirmed failure becomes a
+// durable *finding* (a GitHub Issue) elsewhere; this package only owns the
+// experiment queue. Experiments live as one JSON file each under a
+// status-named subdirectory of `.sweep/`; the file's directory IS its status,
+// and an atomic rename between directories is the parallel-safe claim lock
+// (§4, §7 of the design).
+package sweep
+
+// Class is the sweep tier an experiment belongs to. The two tiers never mix —
+// they have different purposes, recipe vocabularies, and oracle semantics, and
+// are seeded + run one class at a time:
+//
+//   - config: realistic stream-config + benign-network variation (content
+//     manipulation, rate shaping never below the sustainable floor, pattern
+//     ladders, server transfer-timeouts). Asks "does the player make GOOD
+//     decisions?" — ABR rung choice, over-downshift, manifest-config robustness.
+//     ANY bad QoE label is the signal; there is no injected error to recover from.
+//   - fault: explicit HTTP/connection error injection (4xx/5xx, corrupted,
+//     connection_refused, dns_failure, rate_limiting, transport drop/reject,
+//     request hangs). Asks "does the player RECOVER from errors, and are there
+//     bugs in recovery?" — judged against the per-fault recovery-expected
+//     envelope, so a fault the player should survive isn't a false positive.
+type Class string
+
+const (
+	ClassConfig Class = "config" // realistic stream-config + network variation (default)
+	ClassFault  Class = "fault"  // explicit error injection → recovery testing
+)
+
+// ClassOrDefault treats an empty Class as config (the default tier).
+func (e *Experiment) ClassOrDefault() Class {
+	if e.Class == "" {
+		return ClassConfig
+	}
+	return e.Class
+}
+
+// Kind is what produced an experiment and how aggressively the scheduler
+// should prioritise it (§5). isolation/bisect/hypothesis come from a hit;
+// seed is the broad starter set.
+type Kind string
+
+const (
+	KindSeed       Kind = "seed"       // broad starter cell
+	KindIsolation  Kind = "isolation"  // one-factor-at-a-time probe off a confirmed hit (non-recursive)
+	KindHypothesis Kind = "hypothesis" // proactive A/B comparison (non-recursive)
+	KindBisect     Kind = "bisect"     // recursive narrowing of a continuous axis (depth-bounded)
+)
+
+// Arm tags one side of an A/B pair (§6). Empty for standalone experiments.
+type Arm string
+
+const (
+	ArmControl Arm = "control"
+	ArmVariant Arm = "variant"
+)
+
+// Verdict is the trichotomy outcome of analysing a run, plus the infra
+// escape hatch `inconclusive` (§3, §11). Empty until the run is analysed.
+type Verdict string
+
+const (
+	VerdictClean        Verdict = "clean"        // only info / *qoe_tier_premium
+	VerdictNotable      Verdict = "notable"      // warning-tier label or high surprise, no error
+	VerdictAberration   Verdict = "aberration"   // error / critical envelope breach
+	VerdictInconclusive Verdict = "inconclusive" // probe/infra failure — NOT the player's fault
+)
+
+// Status is the lifecycle bucket, and also the subdirectory name under
+// `.sweep/` that holds the experiment file (§4).
+type Status string
+
+const (
+	StatusBacklog  Status = "backlog"
+	StatusRunning  Status = "running"
+	StatusDone     Status = "done"
+	StatusFound    Status = "found"
+	StatusReview   Status = "review"
+	StatusFeedback Status = "feedback"
+)
+
+// AllStatuses is the canonical ordered list — used to create the dir layout
+// and to iterate buckets in `sweep status`.
+var AllStatuses = []Status{
+	StatusBacklog, StatusRunning, StatusDone, StatusFound, StatusReview, StatusFeedback,
+}
+
+// Fault mirrors the proxy FaultRule knobs the harness `fault add` exposes
+// (§1). Only ever set on a `fault`-class experiment; nil otherwise (a
+// config-class experiment never injects errors).
+type Fault struct {
+	Type        string `json:"type"`                   // 500, timeout, corrupted, connection_refused, …
+	RequestKind string `json:"request_kind,omitempty"` // segment, manifest, master_manifest, init, audio_segment, …
+	URLSubstr   string `json:"url_substr,omitempty"`   // optional URL scope
+	Frequency   int    `json:"frequency,omitempty"`
+	Mode        string `json:"mode,omitempty"`        // requests | seconds | failures_per_seconds | failures_per_packets
+	Consecutive int    `json:"consecutive,omitempty"` // failure run length
+}
+
+// Shape is the realistic-bandwidth knob (§1). RateMbps is a static cap that
+// must never sit below the lowest variant's sustainable rate (the floor guard —
+// we test ABR decision quality, never forced starvation); Pattern is a
+// ladder-derived sweep (pyramid/ramp/…) which stays within sustainable rungs by
+// construction. delay_ms / loss_pct are deliberately ABSENT — steady network
+// degradation is out of scope for both classes. Nil means "no shaping".
+type Shape struct {
+	RateMbps    *float64 `json:"rate_mbps,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`      // pyramid | ramp_up | ramp_down | square_wave | transient_shock
+	StepSeconds int      `json:"step_seconds,omitempty"` // 6|12|18|24|60|120
+	MarginPct   int      `json:"margin_pct,omitempty"`   // 0|5|10|25|50
+}
+
+// TransferTimeouts mirrors the proxy server-side transfer-timeout knob — a
+// genuinely slow/stalled origin (config-class, §1). Distinct from the
+// request_*_hang fault types (those are fault-class injected errors). 0 ⇒
+// disabled. AppliesSegments defaults true server-side; set the Applies* flags
+// to scope which request kinds the timeout governs.
+type TransferTimeouts struct {
+	ActiveSeconds    int  `json:"active_seconds,omitempty"`
+	IdleSeconds      int  `json:"idle_seconds,omitempty"`
+	AppliesSegments  bool `json:"applies_segments,omitempty"`
+	AppliesManifests bool `json:"applies_manifests,omitempty"`
+	AppliesMaster    bool `json:"applies_master,omitempty"`
+}
+
+// ContentManipulation mirrors the per-session master-manifest rewrite knobs
+// (§1, §6) — the levers for HLS-aspect A/B comparison. Nil means "unmodified
+// master". Pointers/empties distinguish "not set" from "set to zero".
+type ContentManipulation struct {
+	LiveOffset         *float64 `json:"live_offset,omitempty"`
+	AllowedVariants    string   `json:"allowed_variants,omitempty"` // e.g. "drop-top-rung", a rung-set spec
+	VariantOrder       string   `json:"variant_order,omitempty"`    // HLS-only
+	StripCodecs        bool     `json:"strip_codecs,omitempty"`
+	StripAvgBandwidth  bool     `json:"strip_avg_bandwidth,omitempty"`
+	StripResolution    bool     `json:"strip_resolution,omitempty"`
+	OverstateBandwidth *float64 `json:"overstate_bandwidth,omitempty"`
+}
+
+// Result is filled after a run is analysed.
+type Result struct {
+	Verdict Verdict  `json:"verdict"`
+	Labels  []string `json:"labels,omitempty"` // the QoE labels the oracle saw
+	Note    string   `json:"note,omitempty"`   // one-line human/oracle summary
+}
+
+// Experiment is one runnable recipe + its bookkeeping. JSON-serialised one
+// per file under `.sweep/<status>/<id>.json`.
+type Experiment struct {
+	ID        string `json:"id"`
+	CreatedAt string `json:"created_at"` // RFC3339 UTC; stamped by the caller (Date.now is unavailable in some contexts)
+
+	// --- the recipe (matrix axes) ---
+	Class               Class                `json:"class,omitempty"` // config (default) | fault — the sweep tier
+	Platform            string               `json:"platform"`        // ipad-sim | iphone | appletv | androidtv | web
+	Protocol            string               `json:"protocol"`        // hls | dash
+	Content             string               `json:"content"`         // fixed to insane_new for now
+	Mode                string               `json:"mode"`            // steps | pyramid | downshift_severity | …
+	DurationS           int                  `json:"duration_s,omitempty"`
+	Fault               *Fault               `json:"fault,omitempty"` // fault-class only
+	Shape               *Shape               `json:"shape,omitempty"`
+	ContentManipulation *ContentManipulation `json:"content_manipulation,omitempty"`
+	TransferTimeouts    *TransferTimeouts    `json:"transfer_timeouts,omitempty"`
+
+	// --- provenance / scheduling ---
+	Kind     Kind    `json:"kind"`
+	Arm      Arm     `json:"arm,omitempty"`
+	Group    string  `json:"group,omitempty"`     // A/B pairing id
+	Reps     int     `json:"reps,omitempty"`      // confirmation reps requested (1 for seed; ≥3 to confirm)
+	RepGroup string  `json:"rep_group,omitempty"` // ties a rep-batch together
+	Depth    int     `json:"depth"`               // recursive bisection depth (0–3 bound)
+	Parent   string  `json:"parent,omitempty"`    // origin experiment id
+	Score    float64 `json:"score"`               // scheduler sort key (§5)
+	Why      string  `json:"why,omitempty"`       // LLM rationale slug (the why= label seed)
+	WhyText  string  `json:"why_text,omitempty"`  // full prose rationale (also emitted as a control_event)
+
+	// --- runtime / outcome ---
+	Owner     string  `json:"owner,omitempty"`      // runner/worktree id, stamped at claim
+	ClaimedAt string  `json:"claimed_at,omitempty"` // RFC3339 UTC stamped at claim; drives the stale-claim reaper (§11)
+	PlayerID  string  `json:"player_id,omitempty"`  // the proxy session the probe played (stamped at bootstrap)
+	PlayID    string  `json:"play_id,omitempty"`    // the play the run produced
+	Result    *Result `json:"result,omitempty"`     // filled after analysis
+}

--- a/tools/harness-cli/internal/sweep/isolate.go
+++ b/tools/harness-cli/internal/sweep/isolate.go
@@ -1,0 +1,272 @@
+package sweep
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strconv"
+)
+
+// Axis names a single dimension the isolation fan can flip to attribute a
+// confirmed hit (§6). The LLM picks which axes (and values) are most
+// informative for a given failure; this package materialises them as valid
+// one-axis-flip experiments. The content axis is deferred (single content).
+type Axis string
+
+const (
+	AxisPlatform          Axis = "platform"
+	AxisProtocol          Axis = "protocol"
+	AxisLiveOffset        Axis = "liveoffset"
+	AxisLadder            Axis = "ladder"
+	AxisVariantOrder      Axis = "variant_order"
+	AxisStripAvgBandwidth Axis = "strip_avg_bandwidth"
+	AxisStripCodecs       Axis = "strip_codecs"
+	AxisStripResolution   Axis = "strip_resolution"
+	AxisOverstate         Axis = "overstate_bandwidth"
+)
+
+// AxisTier returns the escalation tier (§6): Tier 1 = platform/protocol (cheap,
+// high-signal, different devices → simultaneous); Tier 2 = the manifest knobs.
+func AxisTier(a Axis) int {
+	switch a {
+	case AxisPlatform, AxisProtocol:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// Flip is one axis change the LLM proposes for a variant.
+type Flip struct {
+	Axis  Axis   `json:"axis"`
+	Value string `json:"value"` // parsed per-axis (platform name, "drop-top-rung", a float for offsets, "true" for strips)
+}
+
+// MaxIsolationAxes caps a single failure's fan so it can't monopolise the pool (§6).
+const MaxIsolationAxes = 8
+
+func shortHash(s string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return fmt.Sprintf("%06x", h.Sum32()&0xffffff)
+}
+
+func cloneExperimentRecipe(p *Experiment) *Experiment {
+	e := *p // shallow copy of scalars
+	e.Fault = cloneFault(p.Fault)
+	if p.Shape != nil {
+		sh := *p.Shape
+		e.Shape = &sh
+	}
+	if p.ContentManipulation != nil {
+		cm := *p.ContentManipulation
+		e.ContentManipulation = &cm
+	}
+	if p.TransferTimeouts != nil {
+		tt := *p.TransferTimeouts
+		e.TransferTimeouts = &tt
+	}
+	// clear per-experiment state that must not be inherited
+	e.Owner, e.ClaimedAt, e.PlayerID, e.PlayID, e.Result = "", "", "", "", nil
+	return &e
+}
+
+func (e *Experiment) ensureCM() *ContentManipulation {
+	if e.ContentManipulation == nil {
+		e.ContentManipulation = &ContentManipulation{}
+	}
+	return e.ContentManipulation
+}
+
+// applyFlip mutates exactly one axis on e. Returns an error for an unknown
+// axis or unparseable value, so a bad LLM proposal fails loudly.
+func applyFlip(e *Experiment, f Flip) error {
+	switch f.Axis {
+	case AxisPlatform:
+		e.Platform = f.Value
+	case AxisProtocol:
+		e.Protocol = f.Value
+	case AxisLiveOffset:
+		v, err := strconv.ParseFloat(f.Value, 64)
+		if err != nil {
+			return fmt.Errorf("liveoffset value %q: %w", f.Value, err)
+		}
+		e.ensureCM().LiveOffset = &v
+	case AxisOverstate:
+		v, err := strconv.ParseFloat(f.Value, 64)
+		if err != nil {
+			return fmt.Errorf("overstate value %q: %w", f.Value, err)
+		}
+		e.ensureCM().OverstateBandwidth = &v
+	case AxisLadder:
+		e.ensureCM().AllowedVariants = f.Value
+	case AxisVariantOrder:
+		e.ensureCM().VariantOrder = f.Value
+	case AxisStripAvgBandwidth:
+		e.ensureCM().StripAvgBandwidth = true
+	case AxisStripCodecs:
+		e.ensureCM().StripCodecs = true
+	case AxisStripResolution:
+		e.ensureCM().StripResolution = true
+	default:
+		return fmt.Errorf("unknown isolation axis %q", f.Axis)
+	}
+	return nil
+}
+
+// IsolationFan materialises an OFAT ablation off a confirmed-aberrant parent
+// (§6): a `control` arm (the reproducing config, unchanged) plus one `variant`
+// arm per flip, each differing from the control in EXACTLY one axis. All arms
+// share one isolation `group` so compare-mode overlays them and the
+// differential oracle reads control-vs-variant. Caller supplies `now`
+// (RFC3339). Errors if a flip is invalid or the fan exceeds MaxIsolationAxes.
+func IsolationFan(parent *Experiment, flips []Flip, now string) ([]*Experiment, error) {
+	if len(flips) == 0 {
+		return nil, fmt.Errorf("isolation fan needs at least one axis")
+	}
+	if len(flips) > MaxIsolationAxes {
+		return nil, fmt.Errorf("isolation fan %d exceeds MaxIsolationAxes %d", len(flips), MaxIsolationAxes)
+	}
+	group := "iso-" + shortHash(parent.ID)
+
+	control := cloneExperimentRecipe(parent)
+	control.ID = group + "-control"
+	control.Kind = KindIsolation
+	control.Arm = ArmControl
+	control.Group = group
+	control.Parent = parent.ID
+	control.CreatedAt = now
+	control.Reps = 1
+	control.Score = 0
+
+	out := []*Experiment{control}
+	for _, f := range flips {
+		v := cloneExperimentRecipe(parent)
+		if err := applyFlip(v, f); err != nil {
+			return nil, err
+		}
+		v.ID = fmt.Sprintf("%s-%s", group, f.Axis)
+		v.Kind = KindIsolation
+		v.Arm = ArmVariant
+		v.Group = group
+		v.Parent = parent.ID
+		v.CreatedAt = now
+		v.Reps = 1
+		v.Why = fmt.Sprintf("isolate_%s", f.Axis)
+		// invariant: a variant differs from the control in exactly one axis
+		if diff, ok := OneAxisDiff(control, v); !ok {
+			return nil, fmt.Errorf("variant %s is not a single-axis flip (diff=%v)", v.ID, diff)
+		}
+		v.Score = 0
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// BisectRate emits up to two depth+1 `bisect` children that narrow the rate
+// axis (§6 bound: ≤2 follow-ups, stop at depth 3). Returns nil when the parent
+// is already at the depth cap. Each child sets shape.rate_mbps to one of the
+// provided probe rates.
+func BisectRate(parent *Experiment, rates []float64, now string) []*Experiment {
+	if parent.Depth >= 3 {
+		return nil
+	}
+	if len(rates) > 2 {
+		rates = rates[:2]
+	}
+	var out []*Experiment
+	for _, r := range rates {
+		c := cloneExperimentRecipe(parent)
+		rr := r
+		if c.Shape == nil {
+			c.Shape = &Shape{}
+		}
+		c.Shape.RateMbps = &rr
+		c.ID = fmt.Sprintf("bisect-%s-r%s", shortHash(parent.ID), strconv.FormatFloat(r, 'f', -1, 64))
+		c.Kind = KindBisect
+		c.Arm = ""
+		c.Group = ""
+		c.Depth = parent.Depth + 1
+		c.Parent = parent.ID
+		c.CreatedAt = now
+		c.Reps = 1
+		c.Why = fmt.Sprintf("bisect_rate_%.3g", r)
+		c.Score = 0
+		out = append(out, c)
+	}
+	return out
+}
+
+// OneAxisDiff reports the recipe axis on which a and b differ, and whether they
+// differ in EXACTLY one. Used to enforce the OFAT invariant (verification #3)
+// and is the gate IsolationFan runs on every variant it produces.
+func OneAxisDiff(a, b *Experiment) (axis string, ok bool) {
+	var diffs []string
+	if a.Platform != b.Platform {
+		diffs = append(diffs, "platform")
+	}
+	if a.Protocol != b.Protocol {
+		diffs = append(diffs, "protocol")
+	}
+	if a.Mode != b.Mode {
+		diffs = append(diffs, "mode")
+	}
+	if a.Content != b.Content {
+		diffs = append(diffs, "content")
+	}
+	if faultKey(a.Fault) != faultKey(b.Fault) {
+		diffs = append(diffs, "fault")
+	}
+	if cmKey(a.ContentManipulation) != cmKey(b.ContentManipulation) {
+		diffs = append(diffs, "content_manipulation")
+	}
+	if shapeKey(a.Shape) != shapeKey(b.Shape) {
+		diffs = append(diffs, "shape")
+	}
+	if transferKey(a.TransferTimeouts) != transferKey(b.TransferTimeouts) {
+		diffs = append(diffs, "transfer_timeouts")
+	}
+	if len(diffs) == 1 {
+		return diffs[0], true
+	}
+	return fmt.Sprintf("%v", diffs), false
+}
+
+func faultKey(f *Fault) string {
+	if f == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s|%s|%s|%d|%s|%d", f.Type, f.RequestKind, f.URLSubstr, f.Frequency, f.Mode, f.Consecutive)
+}
+
+func cmKey(c *ContentManipulation) string {
+	if c == nil {
+		return ""
+	}
+	off, over := "nil", "nil"
+	if c.LiveOffset != nil {
+		off = strconv.FormatFloat(*c.LiveOffset, 'f', -1, 64)
+	}
+	if c.OverstateBandwidth != nil {
+		over = strconv.FormatFloat(*c.OverstateBandwidth, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%s|%s|%s|%t|%t|%t|%s", off, c.AllowedVariants, c.VariantOrder,
+		c.StripCodecs, c.StripAvgBandwidth, c.StripResolution, over)
+}
+
+func shapeKey(s *Shape) string {
+	if s == nil {
+		return ""
+	}
+	rate := "nil"
+	if s.RateMbps != nil {
+		rate = strconv.FormatFloat(*s.RateMbps, 'f', -1, 64)
+	}
+	return fmt.Sprintf("%s|%s|%d|%d", rate, s.Pattern, s.StepSeconds, s.MarginPct)
+}
+
+func transferKey(t *TransferTimeouts) string {
+	if t == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d|%d|%t|%t|%t", t.ActiveSeconds, t.IdleSeconds, t.AppliesSegments, t.AppliesManifests, t.AppliesMaster)
+}

--- a/tools/harness-cli/internal/sweep/isolate_test.go
+++ b/tools/harness-cli/internal/sweep/isolate_test.go
@@ -1,0 +1,196 @@
+package sweep
+
+import "testing"
+
+// --- oracle (trichotomy) ---
+
+func TestClassifyTrichotomy(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+		want   Verdict
+	}{
+		{"clean", []string{"info=first_frame", "info=*qoe_tier_premium", "testing=test_pyramid"}, VerdictClean},
+		{"notable-warning", []string{"info=first_frame", "warning=*qoe_downshift_overshoot"}, VerdictNotable},
+		{"aberration-critical", []string{"warning=timejump", "critical=stall_frozen"}, VerdictAberration},
+		{"aberration-error", []string{"error=*qoe_vsf"}, VerdictAberration},
+		{"only-testing-is-clean", []string{"testing=run_id_x", "testing=platform_ipad"}, VerdictClean},
+		{"empty-is-clean", nil, VerdictClean},
+	}
+	for _, c := range cases {
+		if got := Classify(c.labels); got != c.want {
+			t.Errorf("%s: Classify=%s want %s", c.name, got, c.want)
+		}
+	}
+}
+
+func TestPrimaryKind(t *testing.T) {
+	if k := PrimaryKind([]string{"error=*qoe_vsf", "warning=timejump"}); k != "qoe_vsf" {
+		t.Fatalf("want qoe_vsf, got %q", k)
+	}
+	if k := PrimaryKind([]string{"warning=*qoe_downshift_overshoot"}); k != "qoe_downshift_overshoot" {
+		t.Fatalf("want qoe_downshift_overshoot, got %q", k)
+	}
+	if k := PrimaryKind([]string{"info=first_frame"}); k != "" {
+		t.Fatalf("clean run must have empty kind, got %q", k)
+	}
+}
+
+// --- labels + signature ---
+
+func TestSlugEncodesForbiddenChars(t *testing.T) {
+	// , and = would be silently dropped by the forwarder — must be encoded.
+	if got := Slug("a,b=c d"); got != "a_b_c_d" {
+		t.Fatalf("Slug must encode , = space → _, got %q", got)
+	}
+}
+
+func TestRunLabelsWhatAndWhy(t *testing.T) {
+	off := 6.0
+	e := &Experiment{
+		ID: "iso-abc123-platform", Platform: "androidtv", Protocol: "hls", Mode: "startup",
+		Kind: KindIsolation, Arm: ArmVariant, Group: "iso-abc123", Parent: "seed-x", Depth: 0,
+		Why: "startup vsf, 4k ladder", Fault: &Fault{Type: "timeout", RequestKind: "manifest"},
+		ContentManipulation: &ContentManipulation{LiveOffset: &off},
+	}
+	m := RunLabels(e)
+	if m["sweep"] != "1" || m["kind"] != "isolation" || m["arm"] != "variant" {
+		t.Fatalf("missing core labels: %v", m)
+	}
+	if m["fault"] != "timeout_manifest" {
+		t.Fatalf("fault label wrong: %q", m["fault"])
+	}
+	if m["why"] != "startup_vsf__4k_ladder" { // comma+spaces encoded
+		t.Fatalf("why not slugged: %q", m["why"])
+	}
+}
+
+func TestSignature(t *testing.T) {
+	// fault-class: recipe slot is the fault family, class namespaces it
+	e := &Experiment{Class: ClassFault, Protocol: "hls", Fault: &Fault{Type: "500", RequestKind: "segment"}}
+	if s := Signature(e, "qoe_vsf", ""); s != "sig:fault-hls-500_segment-qoe_vsf" {
+		t.Fatalf("sig wrong: %q", s)
+	}
+	if s := Signature(e, "qoe_vsf", "platform"); s != "sig:fault-hls-500_segment-qoe_vsf-platform" {
+		t.Fatalf("sig+axis wrong: %q", s)
+	}
+	// config-class (default): no fault → recipe is the config knob, baseline here
+	base := &Experiment{Protocol: "dash"}
+	if s := Signature(base, "downshift_overshoot", ""); s != "sig:config-dash-baseline-downshift_overshoot" {
+		t.Fatalf("sig baseline wrong: %q", s)
+	}
+	// config-class with a content knob → recipe reflects it
+	strip := &Experiment{Protocol: "hls", ContentManipulation: &ContentManipulation{StripAvgBandwidth: true}}
+	if s := Signature(strip, "downshift_overshoot", "ladder"); s != "sig:config-hls-strip_avgbw-downshift_overshoot-ladder" {
+		t.Fatalf("sig config-knob wrong: %q", s)
+	}
+}
+
+// --- isolation fan (the OFAT job-insertion invariant) ---
+
+func reproParent() *Experiment {
+	rate := 0.4
+	return &Experiment{
+		ID: "seed-ipad-sim-hls-abr-pyramid", Platform: "ipad-sim", Protocol: "hls",
+		Content: "insane_new", Mode: "pyramid", Kind: KindSeed, Depth: 0,
+		Shape: &Shape{RateMbps: &rate}, CreatedAt: "t0",
+	}
+}
+
+func TestIsolationFanEachVariantFlipsExactlyOneAxis(t *testing.T) {
+	parent := reproParent()
+	flips := []Flip{
+		{Axis: AxisPlatform, Value: "androidtv"},
+		{Axis: AxisProtocol, Value: "dash"},
+		{Axis: AxisLadder, Value: "drop-top-rung"},
+		{Axis: AxisLiveOffset, Value: "6"},
+	}
+	fan, err := IsolationFan(parent, flips, "now")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 1 control + 4 variants
+	if len(fan) != 5 {
+		t.Fatalf("want 5 (control+4), got %d", len(fan))
+	}
+	control := fan[0]
+	if control.Arm != ArmControl || control.Kind != KindIsolation {
+		t.Fatalf("first must be control/isolation: %+v", control)
+	}
+	group := control.Group
+	for _, v := range fan[1:] {
+		if v.Arm != ArmVariant || v.Group != group || v.Parent != parent.ID {
+			t.Fatalf("variant wiring wrong: %+v", v)
+		}
+		axis, ok := OneAxisDiff(control, v)
+		if !ok {
+			t.Fatalf("variant %s differs in !=1 axis", v.ID)
+		}
+		_ = axis
+	}
+}
+
+func TestIsolationFanControlMatchesParent(t *testing.T) {
+	parent := reproParent()
+	fan, _ := IsolationFan(parent, []Flip{{Axis: AxisProtocol, Value: "dash"}}, "now")
+	if _, ok := OneAxisDiff(parent, fan[0]); ok {
+		t.Fatal("control should be identical to parent (zero-axis diff), got a 1-axis diff")
+	}
+}
+
+func TestIsolationFanRejectsTooMany(t *testing.T) {
+	parent := reproParent()
+	flips := make([]Flip, MaxIsolationAxes+1)
+	for i := range flips {
+		flips[i] = Flip{Axis: AxisPlatform, Value: "iphone"}
+	}
+	if _, err := IsolationFan(parent, flips, "now"); err == nil {
+		t.Fatal("want error exceeding MaxIsolationAxes")
+	}
+}
+
+func TestIsolationFanRejectsBadAxis(t *testing.T) {
+	parent := reproParent()
+	if _, err := IsolationFan(parent, []Flip{{Axis: "bogus", Value: "x"}}, "now"); err == nil {
+		t.Fatal("want error for unknown axis")
+	}
+	if _, err := IsolationFan(parent, []Flip{{Axis: AxisLiveOffset, Value: "not-a-number"}}, "now"); err == nil {
+		t.Fatal("want error for unparseable liveoffset")
+	}
+}
+
+// --- bisect (recursive depth bound) ---
+
+func TestBisectRateChildren(t *testing.T) {
+	parent := reproParent()
+	parent.Kind = KindIsolation
+	parent.Depth = 0
+	kids := BisectRate(parent, []float64{1.0, 2.0}, "now")
+	if len(kids) != 2 {
+		t.Fatalf("want 2 bisect kids, got %d", len(kids))
+	}
+	for _, k := range kids {
+		if k.Kind != KindBisect || k.Depth != 1 || k.Parent != parent.ID {
+			t.Fatalf("bisect child wiring wrong: %+v", k)
+		}
+		if k.Shape == nil || k.Shape.RateMbps == nil {
+			t.Fatalf("bisect child missing rate: %+v", k.Shape)
+		}
+	}
+}
+
+func TestBisectStopsAtDepthCap(t *testing.T) {
+	parent := reproParent()
+	parent.Depth = 3
+	if kids := BisectRate(parent, []float64{1.0}, "now"); kids != nil {
+		t.Fatalf("depth cap should stop bisection, got %d kids", len(kids))
+	}
+}
+
+func TestBisectCapsAtTwo(t *testing.T) {
+	parent := reproParent()
+	kids := BisectRate(parent, []float64{1, 2, 3, 4}, "now")
+	if len(kids) != 2 {
+		t.Fatalf("bisect must cap at 2, got %d", len(kids))
+	}
+}

--- a/tools/harness-cli/internal/sweep/labels.go
+++ b/tools/harness-cli/internal/sweep/labels.go
@@ -1,0 +1,122 @@
+package sweep
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Slug makes a value safe to use as a forwarder label value. The forwarder
+// silently DROPS any label value containing `,` or `=` (the LabelPlay
+// encoding), so we must never pass raw text — we encode those (and spaces) to
+// `_` instead of losing the value with no error (§4.1). Idempotent.
+func Slug(v string) string {
+	r := strings.NewReplacer(",", "_", "=", "_", " ", "_")
+	return r.Replace(v)
+}
+
+// RunLabels builds the `testing=`-tier metadata for one run — the WHAT (recipe
+// axes + provenance) plus the WHY slug (§4.1). The harness stamps these via
+// `harness labels set <target> k=v …`; the forwarder prefixes them `testing=`
+// so they're metadata, not a good/bad signal. All values are Slug-encoded.
+func RunLabels(e *Experiment) map[string]string {
+	m := map[string]string{
+		"sweep":    "1",
+		"exp_id":   Slug(e.ID),
+		"class":    string(e.ClassOrDefault()),
+		"kind":     string(e.Kind),
+		"platform": e.Platform,
+		"protocol": e.Protocol,
+		"mode":     e.Mode,
+		"recipe":   recipeSlug(e),
+	}
+	if e.Fault != nil {
+		m["fault"] = faultSlug(e.Fault)
+	}
+	if e.Arm != "" {
+		m["arm"] = string(e.Arm)
+	}
+	if e.Group != "" {
+		m["group"] = Slug(e.Group)
+	}
+	if e.Parent != "" {
+		m["parent"] = Slug(e.Parent)
+	}
+	if e.Depth > 0 {
+		m["depth"] = fmt.Sprintf("%d", e.Depth)
+	}
+	if e.RepGroup != "" {
+		m["rep_group"] = Slug(e.RepGroup)
+	}
+	if e.Why != "" {
+		m["why"] = Slug(e.Why)
+	}
+	if e.Result != nil && e.Result.Verdict != "" {
+		m["verdict"] = string(e.Result.Verdict)
+	}
+	return m
+}
+
+// faultSlug is the fault descriptor for the `fault=` label: "none" when there
+// is no HTTP fault, else "<type>_<request_kind>" (e.g. "500_segment").
+func faultSlug(f *Fault) string {
+	if f == nil {
+		return "none"
+	}
+	if f.RequestKind != "" {
+		return Slug(f.Type + "_" + f.RequestKind)
+	}
+	return Slug(f.Type)
+}
+
+// RecipeSlug is the exported form of recipeSlug for callers outside the
+// package (e.g. `harness sweep publish` building the dashboard row).
+func RecipeSlug(e *Experiment) string { return recipeSlug(e) }
+
+// recipeSlug is the single most-distinguishing knob of an experiment — the
+// dedup-relevant "what was applied". For a fault-class experiment that's the
+// fault family; for a config-class experiment it's the dominant config knob
+// (content manipulation > pattern > transfer-timeout > baseline). Used in the
+// `recipe=` label and the finding signature.
+func recipeSlug(e *Experiment) string {
+	if e.Fault != nil {
+		return faultSlug(e.Fault)
+	}
+	if cm := e.ContentManipulation; cm != nil {
+		switch {
+		case cm.StripAvgBandwidth:
+			return "strip_avgbw"
+		case cm.StripCodecs:
+			return "strip_codecs"
+		case cm.StripResolution:
+			return "strip_resolution"
+		case cm.AllowedVariants != "":
+			return Slug("ladder_" + cm.AllowedVariants)
+		case cm.VariantOrder != "":
+			return Slug("variant_order_" + cm.VariantOrder)
+		case cm.LiveOffset != nil:
+			return Slug(fmt.Sprintf("live_offset_%g", *cm.LiveOffset))
+		case cm.OverstateBandwidth != nil:
+			return "overstate_bw"
+		}
+	}
+	if e.Shape != nil && e.Shape.Pattern != "" {
+		return Slug("pattern_" + e.Shape.Pattern)
+	}
+	if e.TransferTimeouts != nil {
+		return "xfer_timeout"
+	}
+	return "baseline"
+}
+
+// Signature is the dedup key for a finding's GitHub Issue (§4):
+// `sig:<class>-<protocol>-<recipe>-<aberrationKind>[-<attributedAxis>]`. The
+// class namespaces config findings from fault findings so they never collide;
+// recipe is the dominant knob; axis is appended once isolation attributes a
+// cause.
+func Signature(e *Experiment, aberrationKind, attributedAxis string) string {
+	parts := []string{"sig:" + string(e.ClassOrDefault()), e.Protocol, recipeSlug(e), Slug(aberrationKind)}
+	if attributedAxis != "" {
+		parts = append(parts, Slug(attributedAxis))
+	}
+	return strings.Join(parts, "-")
+}

--- a/tools/harness-cli/internal/sweep/oracle.go
+++ b/tools/harness-cli/internal/sweep/oracle.go
@@ -1,0 +1,87 @@
+package sweep
+
+import "strings"
+
+// The oracle turns a run's QoE labels into a trichotomy verdict (§3). It does
+// NOT decide infra failures — `inconclusive` is set by the runner when there's
+// no play_id / the probe errored, never from labels.
+//
+// A forwarder label is `"<severity>=<event>"` (synthesized events may carry a
+// leading `*` on the event, e.g. `error=*qoe_vsf`). The verdict is the worst
+// severity present: error/critical → aberration, warning → notable, otherwise
+// clean. This mirrors the forwarder's own worstSeverity (analytics/go-forwarder
+// /labels.go) so the sweep reuses production semantics rather than inventing
+// thresholds.
+
+const (
+	sevError    = "error"
+	sevCritical = "critical"
+	sevWarning  = "warning"
+	sevInfo     = "info"
+	sevTesting  = "testing" // operator/test KV metadata — never tints a verdict
+)
+
+func severityRank(sev string) int {
+	switch sev {
+	case sevError:
+		return 4
+	case sevCritical:
+		return 3
+	case sevWarning:
+		return 2
+	case sevInfo:
+		return 1
+	default: // testing, unknown
+		return 0
+	}
+}
+
+// splitLabel returns (severity, event) for a "<sev>=<event>" label. The event
+// keeps any leading `*` stripped (synthesized marker) for a clean signature.
+func splitLabel(label string) (sev, event string) {
+	i := strings.IndexByte(label, '=')
+	if i < 0 {
+		return "", label
+	}
+	sev = label[:i]
+	event = strings.TrimPrefix(label[i+1:], "*")
+	return sev, event
+}
+
+// worstLabel returns the highest-severity label and its rank. Ties resolve to
+// the first seen (caller passes a stable order).
+func worstLabel(labels []string) (label string, rank int) {
+	for _, l := range labels {
+		sev, _ := splitLabel(l)
+		if r := severityRank(sev); r > rank {
+			rank, label = r, l
+		}
+	}
+	return label, rank
+}
+
+// Classify maps a run's labels to the trichotomy verdict. `testing=` and
+// `info=` labels (incl. *qoe_tier_premium) are clean.
+func Classify(labels []string) Verdict {
+	_, rank := worstLabel(labels)
+	switch {
+	case rank >= severityRank(sevCritical): // error or critical
+		return VerdictAberration
+	case rank == severityRank(sevWarning):
+		return VerdictNotable
+	default:
+		return VerdictClean
+	}
+}
+
+// PrimaryKind returns the event of the worst label — the aberration/notable
+// "kind" slug that seeds a finding signature (§4), e.g. `vsf`, `frozen`,
+// `downshift_overshoot`. Empty when the run is clean.
+func PrimaryKind(labels []string) string {
+	label, rank := worstLabel(labels)
+	if rank <= severityRank(sevInfo) {
+		return ""
+	}
+	_, event := splitLabel(label)
+	return event
+}

--- a/tools/harness-cli/internal/sweep/promote.go
+++ b/tools/harness-cli/internal/sweep/promote.go
@@ -1,0 +1,164 @@
+package sweep
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Promotion turns a confirmed hit into the durable record: a deduped GitHub
+// Issue (§4). The dedup key is the Signature
+// (sig:<class>-<proto>-<recipe>-<kind>[-axis]) — the CLI checks `gh issue list
+// --label <sig>` and either comments the new repro or opens a fresh Issue. This
+// file builds the human-facing title/body; the gh calls live in the cmd layer
+// so this stays pure + testable.
+
+// IssueLabels are the GitHub labels a promoted finding carries. `sweep` scopes
+// the search; the signature is the dedup key; the verdict picks bug-vs-notable
+// priority (a notable is a lower-priority Issue, not a `bug`, per §7.4).
+func IssueLabels(sig string, v Verdict) []string {
+	labels := []string{"sweep", sig}
+	if v == VerdictAberration {
+		labels = append(labels, "bug")
+	} else {
+		labels = append(labels, "notable")
+	}
+	return labels
+}
+
+// IssueTitle is a one-line human summary: the aberration kind + the recipe that
+// triggered it. Stable enough to read in a list, specific enough to tell two
+// signatures apart.
+func IssueTitle(e *Experiment, kind string) string {
+	if kind == "" {
+		kind = "anomaly"
+	}
+	return fmt.Sprintf("[sweep/%s] %s on %s/%s/%s (%s)",
+		e.ClassOrDefault(), kind, e.Platform, e.Protocol, e.Mode, recipeSlug(e))
+}
+
+// IssueBody renders the markdown body for a finding Issue (or a follow-up
+// comment when the signature already has an open Issue). `attributedAxis` is
+// the isolation-confirmed cause if known (else ""). Designed to be written to
+// a --body-file (per the repo's gh heredoc/body-file rule), never inlined.
+func IssueBody(e *Experiment, sig, attributedAxis string) string {
+	var b strings.Builder
+	v, labels := VerdictClean, []string(nil)
+	if e.Result != nil {
+		v, labels = e.Result.Verdict, e.Result.Labels
+	}
+	kind := PrimaryKind(labels)
+
+	fmt.Fprintf(&b, "## %s\n\n", IssueTitle(e, kind))
+	fmt.Fprintf(&b, "Auto-detected by the fault-injection sweep (issue #772, `docs/sweep-design.md`).\n\n")
+
+	fmt.Fprintf(&b, "**Verdict:** `%s`", v)
+	if attributedAxis != "" {
+		fmt.Fprintf(&b, " — attributed to axis `%s`", attributedAxis)
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "**Signature:** `%s`\n\n", sig)
+
+	b.WriteString("### Recipe\n\n")
+	b.WriteString("| field | value |\n|---|---|\n")
+	fmt.Fprintf(&b, "| class | %s |\n", e.ClassOrDefault())
+	fmt.Fprintf(&b, "| platform | %s |\n", e.Platform)
+	fmt.Fprintf(&b, "| protocol | %s |\n", e.Protocol)
+	fmt.Fprintf(&b, "| content | %s |\n", e.Content)
+	fmt.Fprintf(&b, "| mode | %s |\n", e.Mode)
+	if e.Fault != nil {
+		fmt.Fprintf(&b, "| fault | %s |\n", faultSlug(e.Fault))
+	}
+	if e.Shape != nil {
+		fmt.Fprintf(&b, "| shape | %s |\n", shapeSummary(e.Shape))
+	}
+	if e.ContentManipulation != nil {
+		fmt.Fprintf(&b, "| content_manipulation | %s |\n", cmSummary(e.ContentManipulation))
+	}
+	if e.TransferTimeouts != nil {
+		fmt.Fprintf(&b, "| transfer_timeouts | %s |\n", transferSummary(e.TransferTimeouts))
+	}
+	fmt.Fprintf(&b, "| experiment | `%s` (kind=%s, depth=%d) |\n", e.ID, e.Kind, e.Depth)
+
+	if len(labels) > 0 {
+		b.WriteString("\n### QoE labels seen\n\n")
+		for _, l := range labels {
+			fmt.Fprintf(&b, "- `%s`\n", l)
+		}
+	}
+
+	if e.PlayID != "" {
+		b.WriteString("\n### Evidence\n\n")
+		fmt.Fprintf(&b, "- play_id `%s` — `harness query play %s`\n", e.PlayID, e.PlayID)
+		fmt.Fprintf(&b, "- dashboard: filter sessions by `sweep=1` / `exp_id=%s`\n", Slug(e.ID))
+	}
+	if e.WhyText != "" {
+		fmt.Fprintf(&b, "\n### Why this ran\n\n%s\n", e.WhyText)
+	}
+	return b.String()
+}
+
+func shapeSummary(s *Shape) string {
+	var parts []string
+	if s.Pattern != "" {
+		parts = append(parts, fmt.Sprintf("pattern=%s", s.Pattern))
+	}
+	if s.RateMbps != nil {
+		parts = append(parts, fmt.Sprintf("rate=%gMbps", *s.RateMbps))
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " ")
+}
+
+func transferSummary(t *TransferTimeouts) string {
+	var parts []string
+	if t.ActiveSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("active=%ds", t.ActiveSeconds))
+	}
+	if t.IdleSeconds > 0 {
+		parts = append(parts, fmt.Sprintf("idle=%ds", t.IdleSeconds))
+	}
+	if t.AppliesSegments {
+		parts = append(parts, "segments")
+	}
+	if t.AppliesManifests {
+		parts = append(parts, "manifests")
+	}
+	if t.AppliesMaster {
+		parts = append(parts, "master")
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " ")
+}
+
+func cmSummary(c *ContentManipulation) string {
+	var parts []string
+	if c.LiveOffset != nil {
+		parts = append(parts, fmt.Sprintf("live_offset=%g", *c.LiveOffset))
+	}
+	if c.AllowedVariants != "" {
+		parts = append(parts, "allowed_variants="+c.AllowedVariants)
+	}
+	if c.VariantOrder != "" {
+		parts = append(parts, "variant_order="+c.VariantOrder)
+	}
+	if c.StripCodecs {
+		parts = append(parts, "strip_codecs")
+	}
+	if c.StripAvgBandwidth {
+		parts = append(parts, "strip_avg_bandwidth")
+	}
+	if c.StripResolution {
+		parts = append(parts, "strip_resolution")
+	}
+	if c.OverstateBandwidth != nil {
+		parts = append(parts, fmt.Sprintf("overstate=%g", *c.OverstateBandwidth))
+	}
+	if len(parts) == 0 {
+		return "—"
+	}
+	return strings.Join(parts, " ")
+}

--- a/tools/harness-cli/internal/sweep/reap.go
+++ b/tools/harness-cli/internal/sweep/reap.go
@@ -1,0 +1,46 @@
+package sweep
+
+import "time"
+
+// A runner that dies mid-run orphans its file in running/ — without recovery
+// the queue silently shrinks (§11). ReapStale finds the running experiments
+// whose claim is older than maxAge so the caller can return them to backlog.
+//
+// `now` and each ClaimedAt are RFC3339 UTC. An experiment with no ClaimedAt
+// (claimed by an older binary, or a hand-moved file) is treated as stale so it
+// can't wedge the queue forever. A future-dated ClaimedAt (clock skew) is not
+// stale. The threshold should be generous — the design suggests ~2× the
+// longest expected run — so a slow-but-alive run is never yanked out from
+// under itself.
+func ReapStale(running []*Experiment, now string, maxAge time.Duration) []*Experiment {
+	nowT, err := time.Parse(time.RFC3339, now)
+	if err != nil {
+		return nil // can't reason about time → reap nothing, fail safe
+	}
+	var stale []*Experiment
+	for _, e := range running {
+		if e.ClaimedAt == "" {
+			stale = append(stale, e)
+			continue
+		}
+		claimedT, err := time.Parse(time.RFC3339, e.ClaimedAt)
+		if err != nil {
+			stale = append(stale, e) // unparseable → treat as stale
+			continue
+		}
+		if nowT.Sub(claimedT) > maxAge {
+			stale = append(stale, e)
+		}
+	}
+	return stale
+}
+
+// Requeue resets the runtime state a reaped experiment accumulated under its
+// dead owner, so the next claimer starts clean. The recipe + provenance are
+// untouched; only owner/claim/play/result are cleared.
+func Requeue(e *Experiment) {
+	e.Owner = ""
+	e.ClaimedAt = ""
+	e.PlayID = ""
+	e.Result = nil
+}

--- a/tools/harness-cli/internal/sweep/scheduler.go
+++ b/tools/harness-cli/internal/sweep/scheduler.go
@@ -1,0 +1,114 @@
+package sweep
+
+import "sort"
+
+// Weights drive the discovery-first score (§5 of the design). Defaults make
+// the system depth-first by construction: a confirmed hit's isolation/bisect
+// follow-ups always outrank any untouched seed cell, and cost is only a
+// tiebreaker. Human severity feedback (§8) later overrides these.
+type Weights struct {
+	Kind  float64 // weight on kind rank (isolation > bisect > hypothesis > seed)
+	Depth float64 // weight on bisection depth (deeper narrowing rises)
+	Cost  float64 // penalty per estimated runtime-minute (tiebreaker only)
+}
+
+// DefaultWeights: Kind dominates (100) so non-seed work always jumps the
+// queue; Depth (10) lifts deeper bisects; Cost (1) only breaks ties among
+// equals — a 6-minute run loses to a 3-minute one, never to a seed.
+func DefaultWeights() Weights { return Weights{Kind: 100, Depth: 10, Cost: 1} }
+
+// kindRank orders the four kinds for the scheduler. Higher = run sooner.
+func kindRank(k Kind) float64 {
+	switch k {
+	case KindIsolation:
+		return 4
+	case KindBisect:
+		return 3
+	case KindHypothesis:
+		return 2
+	case KindSeed:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// modeMinutes is the per-mode wall-clock estimate (§A.3) — minutes, the
+// dominant cost term. Unknown modes fall back to 3.
+var modeMinutes = map[string]float64{
+	"pyramid":             6,
+	"hysteresis_gap":      6,
+	"startup_caps":        5,
+	"steps":               3,
+	"rampup":              3,
+	"rampdown":            3,
+	"downshift_severity":  3,
+	"transient_shock":     2,
+	"emergency_downshift": 3,
+	"startup":             2,
+	"abort":               3,
+}
+
+// platformCostMul scales runtime by platform (appium Apple TV is the slow end).
+var platformCostMul = map[string]float64{
+	"appletv":   1.5,
+	"androidtv": 1.2,
+	"iphone":    1.1,
+	"ipad-sim":  1.0,
+	"web":       1.0,
+}
+
+// EstRuntimeMinutes is the scheduler's cost estimate for one experiment.
+func EstRuntimeMinutes(e *Experiment) float64 {
+	m, ok := modeMinutes[e.Mode]
+	if !ok {
+		m = 3
+	}
+	if mul, ok := platformCostMul[e.Platform]; ok {
+		m *= mul
+	}
+	return m
+}
+
+// Score computes the scheduler sort key for one experiment (§5). Higher runs
+// first. Adjacency + redundancy terms (which need cross-experiment / findings
+// context) are layered on by the orchestrator; this is the per-experiment core.
+func (w Weights) Score(e *Experiment) float64 {
+	return w.Kind*kindRank(e.Kind) + w.Depth*float64(e.Depth) - w.Cost*EstRuntimeMinutes(e)
+}
+
+// Rank sorts a backlog by descending Score (id breaks ties for determinism),
+// recomputing and stamping each experiment's Score in place.
+func (w Weights) Rank(backlog []*Experiment) {
+	for _, e := range backlog {
+		e.Score = w.Score(e)
+	}
+	sort.SliceStable(backlog, func(i, j int) bool {
+		if backlog[i].Score != backlog[j].Score {
+			return backlog[i].Score > backlog[j].Score
+		}
+		return backlog[i].ID < backlog[j].ID
+	})
+}
+
+// SelectNext returns the highest-priority backlog experiment to run next, or
+// nil if the backlog is empty. depthFirst is the bootstrap guard (§5): while
+// on, if any non-seed (isolation/bisect/hypothesis) work exists it is always
+// chosen over a seed, so the loop drives the LLM investigate→insert→re-run
+// chain deep before widening — even if a seed somehow scored higher.
+func (w Weights) SelectNext(backlog []*Experiment, depthFirst bool) *Experiment {
+	if len(backlog) == 0 {
+		return nil
+	}
+	ranked := make([]*Experiment, len(backlog))
+	copy(ranked, backlog)
+	w.Rank(ranked)
+	if depthFirst {
+		for _, e := range ranked {
+			if e.Kind != KindSeed {
+				return e
+			}
+		}
+	}
+	return ranked[0]
+}

--- a/tools/harness-cli/internal/sweep/scheduler_test.go
+++ b/tools/harness-cli/internal/sweep/scheduler_test.go
@@ -1,0 +1,110 @@
+package sweep
+
+import "testing"
+
+func TestKindRankingDominates(t *testing.T) {
+	w := DefaultWeights()
+	seed := &Experiment{Kind: KindSeed, Mode: "steps", Platform: "ipad-sim"}      // cheap seed
+	iso := &Experiment{Kind: KindIsolation, Mode: "pyramid", Platform: "appletv"} // expensive isolation
+	if w.Score(iso) <= w.Score(seed) {
+		t.Fatalf("isolation must outrank seed regardless of cost: iso=%.1f seed=%.1f",
+			w.Score(iso), w.Score(seed))
+	}
+}
+
+func TestDeeperBisectRanksHigher(t *testing.T) {
+	w := DefaultWeights()
+	shallow := &Experiment{Kind: KindBisect, Depth: 1, Mode: "steps", Platform: "ipad-sim"}
+	deep := &Experiment{Kind: KindBisect, Depth: 3, Mode: "steps", Platform: "ipad-sim"}
+	if w.Score(deep) <= w.Score(shallow) {
+		t.Fatalf("deeper bisect should rank higher: deep=%.1f shallow=%.1f", w.Score(deep), w.Score(shallow))
+	}
+}
+
+func TestCostBreaksTiesCheapFirst(t *testing.T) {
+	w := DefaultWeights()
+	cheap := &Experiment{Kind: KindSeed, Mode: "transient_shock", Platform: "ipad-sim"} // ~2 min
+	dear := &Experiment{Kind: KindSeed, Mode: "pyramid", Platform: "appletv"}           // ~9 min
+	if w.Score(cheap) <= w.Score(dear) {
+		t.Fatalf("cheaper run should win the tie: cheap=%.1f dear=%.1f", w.Score(cheap), w.Score(dear))
+	}
+}
+
+func TestSelectNextDepthFirstPrefersNonSeed(t *testing.T) {
+	w := DefaultWeights()
+	backlog := []*Experiment{
+		{ID: "s1", Kind: KindSeed, Mode: "transient_shock", Platform: "ipad-sim"},
+		{ID: "b1", Kind: KindBisect, Depth: 1, Mode: "pyramid", Platform: "appletv"}, // slower + bisect
+	}
+	got := w.SelectNext(backlog, true)
+	if got == nil || got.ID != "b1" {
+		t.Fatalf("depth-first should pick the bisect, got %+v", got)
+	}
+	// Without depth-first the bisect still wins here (kind dominates), but the
+	// guard guarantees it even if a seed ever scored higher.
+}
+
+func TestSelectNextEmpty(t *testing.T) {
+	if got := DefaultWeights().SelectNext(nil, true); got != nil {
+		t.Fatalf("empty backlog must select nil, got %+v", got)
+	}
+}
+
+func TestSeedNarrowConfigClass(t *testing.T) {
+	es := Seed(ClassConfig, false, "2026-06-13T00:00:00Z")
+	// 1 platform × len(seedProtocols) × len(configRecipes)
+	want := len(seedProtocols) * len(configRecipes)
+	if len(es) != want {
+		t.Fatalf("narrow config seed want %d, got %d", want, len(es))
+	}
+	seen := map[string]bool{}
+	for _, e := range es {
+		if e.Platform != "ipad-sim" {
+			t.Fatalf("narrow seed must be ipad-sim only, got %s", e.Platform)
+		}
+		if e.Class != ClassConfig {
+			t.Fatalf("config seed must be config-class, got %s", e.Class)
+		}
+		if e.Fault != nil {
+			t.Fatalf("config seed must never carry a fault: %+v", e.Fault)
+		}
+		if e.Kind != KindSeed || e.Content != SeedContent {
+			t.Fatalf("bad seed: %+v", e)
+		}
+		if seen[e.ID] {
+			t.Fatalf("duplicate seed id %s", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}
+
+func TestSeedFaultClass(t *testing.T) {
+	es := Seed(ClassFault, false, "2026-06-13T00:00:00Z")
+	want := len(seedProtocols) * len(faultRecipes)
+	if len(es) != want {
+		t.Fatalf("narrow fault seed want %d, got %d", want, len(es))
+	}
+	for _, e := range es {
+		if e.Class != ClassFault || e.Fault == nil {
+			t.Fatalf("fault seed must be fault-class with a fault: %+v", e)
+		}
+	}
+}
+
+func TestSeedFullWidens(t *testing.T) {
+	es := Seed(ClassConfig, true, "2026-06-13T00:00:00Z")
+	want := len(fullPlatforms) * len(seedProtocols) * len(configRecipes)
+	if len(es) != want {
+		t.Fatalf("full seed want %d, got %d", want, len(es))
+	}
+}
+
+func TestSeedDeterministic(t *testing.T) {
+	a := Seed(ClassConfig, false, "t")
+	b := Seed(ClassConfig, false, "t")
+	for i := range a {
+		if a[i].ID != b[i].ID || a[i].Score != b[i].Score {
+			t.Fatalf("seed not deterministic at %d: %s/%s", i, a[i].ID, b[i].ID)
+		}
+	}
+}

--- a/tools/harness-cli/internal/sweep/seed.go
+++ b/tools/harness-cli/internal/sweep/seed.go
@@ -1,0 +1,149 @@
+package sweep
+
+import "fmt"
+
+// A seedRecipe is one starter experiment shape: a mode (the playback motion)
+// plus the class-appropriate overlay. config-class recipes set content/shape/
+// transfer knobs; fault-class recipes set a Fault. Content is fixed to
+// insane_new for now (§9). The characterization mode drives the bandwidth
+// motion itself (pyramid shapes a pyramid, etc.).
+type seedRecipe struct {
+	family   string // recipe-family slug, for the id
+	mode     string
+	cm       *ContentManipulation
+	shape    *Shape
+	transfer *TransferTimeouts
+	fault    *Fault
+}
+
+func floatPtr(v float64) *float64 { return &v }
+
+// configRecipes — the realistic stream-config + benign-network set (§5, §10).
+// No injected errors, no delay/loss, no sub-floor caps: patterns are
+// ladder-derived (sustainable by construction) and the content knobs are
+// legitimate manifest variations. This is the default depth-first set, built to
+// surface ABR decision-quality issues (the over-downshift class) and
+// manifest-config robustness.
+var configRecipes = []seedRecipe{
+	{family: "abr-pyramid", mode: "pyramid", shape: &Shape{Pattern: "pyramid", StepSeconds: 30, MarginPct: 5}},
+	{family: "downshift", mode: "downshift_severity"}, // where over-downshift `notable` surfaces
+	{family: "strip-avgbw", mode: "steps", cm: &ContentManipulation{StripAvgBandwidth: true}},
+	{family: "sparse-ladder", mode: "steps", cm: &ContentManipulation{AllowedVariants: "drop-top-rung"}},
+	{family: "live-offset", mode: "startup", cm: &ContentManipulation{LiveOffset: floatPtr(6)}},
+	{family: "xfer-timeout", mode: "steps", transfer: &TransferTimeouts{ActiveSeconds: 10, AppliesSegments: true}},
+}
+
+// faultRecipes — the explicit-error recovery set (separate class). Each injects
+// one HTTP/connection fault the player is expected to recover from; the oracle
+// judges against the recovery-expected envelope (a fault within envelope is not
+// an aberration). Seeded + run only when `--class fault` is selected.
+var faultRecipes = []seedRecipe{
+	{family: "seg5xx", mode: "steps", fault: &Fault{Type: "500", RequestKind: "segment", Frequency: 1, Mode: "requests"}},
+	{family: "manifest-timeout", mode: "startup", fault: &Fault{Type: "timeout", RequestKind: "manifest", Frequency: 1, Mode: "requests"}},
+	{family: "seg-corrupt", mode: "steps", fault: &Fault{Type: "corrupted", RequestKind: "segment", Frequency: 1, Mode: "requests"}},
+}
+
+// narrowPlatforms / fullPlatforms — the active sweep is **iOS-sim only** for
+// now; --full is reserved for when the other platforms come online.
+var (
+	narrowPlatforms = []string{"ipad-sim"}
+	fullPlatforms   = []string{"ipad-sim", "iphone", "appletv", "androidtv"}
+	// Protocol is **HLS only** for now — the probe plays the app's default
+	// (HLS) and protocol selection isn't wired in yet. DASH returns when it is.
+	seedProtocols = []string{"hls"}
+)
+
+// SeedContent is the single content item the sweep runs against for now: the
+// H264 build of the "insane new" clip (the catalogue `name`).
+const SeedContent = "insane_new_p200_h264"
+
+// recipesFor returns the recipe set for a class (config is the default).
+func recipesFor(class Class) []seedRecipe {
+	if class == ClassFault {
+		return faultRecipes
+	}
+	return configRecipes
+}
+
+// Seed builds the starter backlog for one class. full=false is the narrow
+// depth-first set (iPad-sim only); full=true widens across the physical-device
+// platforms. `now` is the RFC3339 UTC stamp for created_at (passed in so
+// callers control the clock). Scores are stamped with the default weights.
+func Seed(class Class, full bool, now string) []*Experiment {
+	if class == "" {
+		class = ClassConfig
+	}
+	platforms := narrowPlatforms
+	if full {
+		platforms = fullPlatforms
+	}
+	recipes := recipesFor(class)
+	w := DefaultWeights()
+	var out []*Experiment
+	for _, p := range platforms {
+		for _, proto := range seedProtocols {
+			for _, r := range recipes {
+				e := &Experiment{
+					ID:                  fmt.Sprintf("seed-%s-%s-%s-%s-%s", class, p, proto, r.family, r.mode),
+					CreatedAt:           now,
+					Class:               class,
+					Platform:            p,
+					Protocol:            proto,
+					Content:             SeedContent,
+					Mode:                r.mode,
+					ContentManipulation: cloneCM(r.cm),
+					Shape:               cloneShape(r.shape),
+					TransferTimeouts:    cloneTransfer(r.transfer),
+					Fault:               cloneFault(r.fault),
+					Kind:                KindSeed,
+					Reps:                1,
+					Depth:               0,
+				}
+				e.Score = w.Score(e)
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+func cloneFault(f *Fault) *Fault {
+	if f == nil {
+		return nil
+	}
+	c := *f
+	return &c
+}
+
+func cloneShape(s *Shape) *Shape {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	if s.RateMbps != nil {
+		c.RateMbps = floatPtr(*s.RateMbps)
+	}
+	return &c
+}
+
+func cloneCM(cm *ContentManipulation) *ContentManipulation {
+	if cm == nil {
+		return nil
+	}
+	c := *cm
+	if cm.LiveOffset != nil {
+		c.LiveOffset = floatPtr(*cm.LiveOffset)
+	}
+	if cm.OverstateBandwidth != nil {
+		c.OverstateBandwidth = floatPtr(*cm.OverstateBandwidth)
+	}
+	return &c
+}
+
+func cloneTransfer(t *TransferTimeouts) *TransferTimeouts {
+	if t == nil {
+		return nil
+	}
+	c := *t
+	return &c
+}

--- a/tools/harness-cli/internal/sweep/store.go
+++ b/tools/harness-cli/internal/sweep/store.go
@@ -1,0 +1,164 @@
+package sweep
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ErrAlreadyClaimed is returned by Claim when another runner won the race
+// (the atomic rename found no backlog file). The caller should try the next
+// candidate, not retry this one.
+var ErrAlreadyClaimed = errors.New("sweep: experiment already claimed")
+
+// ErrNotFound is returned when an experiment file is absent in the bucket.
+var ErrNotFound = errors.New("sweep: experiment not found")
+
+// Store is the on-disk `.sweep/` queue. All worktree runners share one Store
+// on one filesystem; the atomic rename in Claim is the only synchronisation.
+type Store struct {
+	Root string
+}
+
+// DefaultRoot is `.sweep` in the current directory, overridable via SWEEP_ROOT.
+func DefaultRoot() string {
+	if r := os.Getenv("SWEEP_ROOT"); r != "" {
+		return r
+	}
+	return ".sweep"
+}
+
+// Open returns a Store rooted at root, creating the status subdirectories if
+// they don't exist. Safe to call repeatedly.
+func Open(root string) (*Store, error) {
+	s := &Store{Root: root}
+	for _, st := range AllStatuses {
+		if err := os.MkdirAll(s.dir(st), 0o755); err != nil {
+			return nil, fmt.Errorf("sweep: create %s dir: %w", st, err)
+		}
+	}
+	return s, nil
+}
+
+func (s *Store) dir(st Status) string             { return filepath.Join(s.Root, string(st)) }
+func (s *Store) path(st Status, id string) string { return filepath.Join(s.dir(st), id+".json") }
+
+// Save writes e into the given status bucket atomically (temp file + rename),
+// overwriting any existing file for that id in that bucket.
+func (s *Store) Save(st Status, e *Experiment) error {
+	b, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return fmt.Errorf("sweep: marshal %s: %w", e.ID, err)
+	}
+	b = append(b, '\n')
+	final := s.path(st, e.ID)
+	tmp := filepath.Join(s.dir(st), "."+e.ID+".tmp")
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return fmt.Errorf("sweep: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, final); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("sweep: commit %s: %w", final, err)
+	}
+	return nil
+}
+
+// Load reads one experiment from a bucket.
+func (s *Store) Load(st Status, id string) (*Experiment, error) {
+	b, err := os.ReadFile(s.path(st, id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	var e Experiment
+	if err := json.Unmarshal(b, &e); err != nil {
+		return nil, fmt.Errorf("sweep: parse %s/%s: %w", st, id, err)
+	}
+	return &e, nil
+}
+
+// List returns every experiment in a bucket, sorted by id for determinism.
+// Dotfiles (in-flight temp writes) are skipped.
+func (s *Store) List(st Status) ([]*Experiment, error) {
+	entries, err := os.ReadDir(s.dir(st))
+	if err != nil {
+		return nil, err
+	}
+	var out []*Experiment
+	for _, ent := range entries {
+		name := ent.Name()
+		if ent.IsDir() || strings.HasPrefix(name, ".") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".json")
+		e, err := s.Load(st, id)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// Counts returns the number of experiments in each bucket.
+func (s *Store) Counts() (map[Status]int, error) {
+	counts := make(map[Status]int, len(AllStatuses))
+	for _, st := range AllStatuses {
+		es, err := s.List(st)
+		if err != nil {
+			return nil, err
+		}
+		counts[st] = len(es)
+	}
+	return counts, nil
+}
+
+// Claim atomically moves an experiment from backlog → running and stamps the
+// owner + claim time. The os.Rename is the lock: if two runners race for the
+// same id, only one rename succeeds; the loser gets ErrAlreadyClaimed and
+// should move on. `now` (RFC3339 UTC) is recorded as ClaimedAt so the
+// stale-claim reaper can recover files orphaned by a dead runner (§11); pass
+// "" to skip stamping (e.g. in tests that don't exercise the reaper).
+func (s *Store) Claim(id, owner, now string) (*Experiment, error) {
+	src := s.path(StatusBacklog, id)
+	dst := s.path(StatusRunning, id)
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrAlreadyClaimed
+		}
+		return nil, err
+	}
+	// We now exclusively own the running/ file.
+	e, err := s.Load(StatusRunning, id)
+	if err != nil {
+		return nil, err
+	}
+	e.Owner = owner
+	e.ClaimedAt = now
+	if err := s.Save(StatusRunning, e); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// Move writes e into the `to` bucket and removes its file from the `from`
+// bucket — the post-verdict transition (running → done/found/review/feedback).
+// Unlike Claim this is not a race point: only the owning runner touches a
+// running/ file. The write-then-remove order means a crash mid-Move leaves the
+// experiment in both buckets (recoverable) rather than vanishing.
+func (s *Store) Move(from, to Status, e *Experiment) error {
+	if err := s.Save(to, e); err != nil {
+		return err
+	}
+	if err := os.Remove(s.path(from, e.ID)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("sweep: remove %s/%s: %w", from, e.ID, err)
+	}
+	return nil
+}

--- a/tools/harness-cli/internal/sweep/store_test.go
+++ b/tools/harness-cli/internal/sweep/store_test.go
@@ -1,0 +1,163 @@
+package sweep
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func sampleExp(id string) *Experiment {
+	rate := 0.4
+	return &Experiment{
+		ID:        id,
+		CreatedAt: "2026-06-13T18:00:00Z",
+		Platform:  "ipad-sim",
+		Protocol:  "hls",
+		Content:   "insane_new",
+		Mode:      "pyramid",
+		Kind:      KindSeed,
+		Depth:     0,
+		Reps:      1,
+		Score:     12.0,
+		Shape:     &Shape{RateMbps: &rate, Pattern: "pyramid", StepSeconds: 30, MarginPct: 5},
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	s, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := sampleExp("seed-ipad-hls-ratecap")
+	if err := s.Save(StatusBacklog, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Load(StatusBacklog, want.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != want.ID || got.Platform != "ipad-sim" || got.Kind != KindSeed {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+	if got.Shape == nil || got.Shape.RateMbps == nil || *got.Shape.RateMbps != 0.4 {
+		t.Fatalf("shape not preserved: %+v", got.Shape)
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	if _, err := s.Load(StatusBacklog, "nope"); err != ErrNotFound {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestListSortedSkipsDotfiles(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	for _, id := range []string{"c", "a", "b"} {
+		if err := s.Save(StatusBacklog, sampleExp(id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := s.List(StatusBacklog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 || got[0].ID != "a" || got[2].ID != "c" {
+		t.Fatalf("want sorted [a b c], got %v", ids(got))
+	}
+}
+
+func TestCounts(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Save(StatusBacklog, sampleExp("a"))
+	s.Save(StatusBacklog, sampleExp("b"))
+	s.Save(StatusDone, sampleExp("c"))
+	counts, err := s.Counts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts[StatusBacklog] != 2 || counts[StatusDone] != 1 || counts[StatusFound] != 0 {
+		t.Fatalf("bad counts: %v", counts)
+	}
+}
+
+func TestClaimStampsOwnerAndMovesBucket(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Save(StatusBacklog, sampleExp("x"))
+	e, err := s.Claim("x", "runner-1", "2026-06-13T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Owner != "runner-1" {
+		t.Fatalf("owner not stamped: %q", e.Owner)
+	}
+	if e.ClaimedAt != "2026-06-13T12:00:00Z" {
+		t.Fatalf("claim time not stamped: %q", e.ClaimedAt)
+	}
+	if _, err := s.Load(StatusBacklog, "x"); err != ErrNotFound {
+		t.Fatalf("backlog file should be gone, got %v", err)
+	}
+	running, err := s.Load(StatusRunning, "x")
+	if err != nil || running.Owner != "runner-1" {
+		t.Fatalf("running file missing owner: %+v err=%v", running, err)
+	}
+}
+
+func TestClaimMissingIsAlreadyClaimed(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	if _, err := s.Claim("ghost", "r", ""); err != ErrAlreadyClaimed {
+		t.Fatalf("want ErrAlreadyClaimed, got %v", err)
+	}
+}
+
+// The load-bearing guarantee: N runners racing for one experiment → exactly
+// one wins, the rest get ErrAlreadyClaimed. This is the parallel-safety the
+// whole local-store design rests on (§4, §7).
+func TestConcurrentClaimExactlyOneWinner(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Save(StatusBacklog, sampleExp("contested"))
+
+	const racers = 16
+	var wins int64
+	var wg sync.WaitGroup
+	wg.Add(racers)
+	for i := 0; i < racers; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := s.Claim("contested", "r", ""); err == nil {
+				atomic.AddInt64(&wins, 1)
+			} else if err != ErrAlreadyClaimed {
+				t.Errorf("unexpected claim error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if wins != 1 {
+		t.Fatalf("want exactly 1 winner, got %d", wins)
+	}
+}
+
+func TestMoveToDone(t *testing.T) {
+	s, _ := Open(t.TempDir())
+	s.Save(StatusBacklog, sampleExp("y"))
+	e, _ := s.Claim("y", "r", "")
+	e.Result = &Result{Verdict: VerdictClean}
+	if err := s.Move(StatusRunning, StatusDone, e); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Load(StatusRunning, "y"); err != ErrNotFound {
+		t.Fatalf("running file should be gone, got %v", err)
+	}
+	done, err := s.Load(StatusDone, "y")
+	if err != nil || done.Result == nil || done.Result.Verdict != VerdictClean {
+		t.Fatalf("done file wrong: %+v err=%v", done, err)
+	}
+}
+
+func ids(es []*Experiment) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.ID
+	}
+	return out
+}


### PR DESCRIPTION
The automated fault-injection **sweep** — a state-driven loop that claims an experiment, runs it against a faulted/shaped origin, drives a headless player, reads the QoE-label oracle, and on an aberration attributes the cause via OFAT isolation before promoting a deduped finding.

> ⚠️ **Stacked on #788** (`feat/sessions-triage`). Base is `feat/sessions-triage`, not `dev` — **merge #788 first**, then this retargets to `dev` automatically. The diff shown here is sweep-only; the triage tooling belongs to #788.

## What's here
- **`docs/sweep-design.md`** — the Phase-1 design (discovery-first scheduler, config + fault classes, trichotomy oracle, OFAT isolation fan, A/B hypotheses, severity feedback). Scoped to **HLS + H264 + iOS-sim** for now.
- **`tools/harness-cli/internal/sweep` + `cmd/harness/sweep*.go`** — store, scheduler, seed, oracle, isolate, analyze, promote, reap, labels, variants, and `seed-from-triage`.
- **`tests/characterization`** — the sweep probe + runner `ApplyPattern`/`WaitForManifest`.
- **analytics** — `sweep_experiments` ClickHouse table + read API; `label_associate` gains the `sweep_recipe`/`mode`/`class` dimensions (joined from `sweep_experiments`).
- **dashboard** — the Fault Sweep tab (`Sweep.vue`/`sweep.html`/entry) + nav + nginx allowlist.
- **`.claude/skills/sweep`** — the `/goal`-driven loop skill.

## Why it stacks on the triage PR
- `Sweep.vue` imports `LabelFrequencyTable.vue` (a #788 component).
- `harness sweep seed-from-triage` reads `label_divergence` (#788) to seed experiments for the controllable dimension a severe label concentrates on — closing the **observe → hypothesize → confirm** loop.

Forwarder, harness, characterization, and dashboard all build green.

Related: #783 (associate), #785 (seed-from-triage follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
