### PR TITLE
feat(v2): surface recommended_offset_s + configured_offset_s in the events archive (#786)

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1590,6 +1590,8 @@ components:
         seekable_end_s:      { type: number, format: float, nullable: true, description: 'Player-reported end of seekable range (seconds).' }
         live_edge_s:         { type: number, format: float, nullable: true, description: 'Player-reported live edge timestamp (seconds).' }
         live_offset_s:       { type: number, format: float, nullable: true, description: 'Player-reported offset behind live edge (seconds).' }
+        recommended_offset_s: { type: number, format: float, nullable: true, description: 'Manifest-recommended target offset from live (iOS recommendedTimeOffsetFromLive / ExoPlayer liveConfiguration.targetOffsetMs). Gates the qoe_live_offset_* labels.' }
+        configured_offset_s: { type: number, format: float, nullable: true, description: 'Configured target offset from live (iOS configuredTimeOffsetFromLive; on Android equals recommended_offset_s).' }
         true_offset_s:       { type: number, format: float, nullable: true, description: 'Wall-clock offset between player position and real time (seconds).' }
         position_s:          { type: number, format: float, nullable: true, description: 'Player current position (seconds).' }
         playback_rate:       { type: number, format: float, nullable: true, description: 'Player playback rate (1.0 = normal).' }

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -46,6 +46,30 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	}
 }
 
+// Defines values for ContentManipulationVariantOrder.
+const (
+	Ascending  ContentManipulationVariantOrder = "ascending"
+	Default    ContentManipulationVariantOrder = "default"
+	Descending ContentManipulationVariantOrder = "descending"
+	First4mbps ContentManipulationVariantOrder = "first_4mbps"
+)
+
+// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
+func (e ContentManipulationVariantOrder) Valid() bool {
+	switch e {
+	case Ascending:
+		return true
+	case Default:
+		return true
+	case Descending:
+		return true
+	case First4mbps:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FaultFilterRequestKind.
 const (
 	FaultFilterRequestKindAudioManifest  FaultFilterRequestKind = "audio_manifest"
@@ -187,17 +211,19 @@ func (e HeartbeatEventType) Valid() bool {
 // Defines values for PatternDefaultStepSeconds.
 const (
 	PatternDefaultStepSecondsN12  PatternDefaultStepSeconds = 12
+	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 	PatternDefaultStepSecondsN18  PatternDefaultStepSeconds = 18
 	PatternDefaultStepSecondsN24  PatternDefaultStepSeconds = 24
 	PatternDefaultStepSecondsN6   PatternDefaultStepSeconds = 6
 	PatternDefaultStepSecondsN60  PatternDefaultStepSeconds = 60
-	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 )
 
 // Valid indicates whether the value is a known member of the PatternDefaultStepSeconds enum.
 func (e PatternDefaultStepSeconds) Valid() bool {
 	switch e {
 	case PatternDefaultStepSecondsN12:
+		return true
+	case PatternDefaultStepSecondsN120:
 		return true
 	case PatternDefaultStepSecondsN18:
 		return true
@@ -206,8 +232,6 @@ func (e PatternDefaultStepSeconds) Valid() bool {
 	case PatternDefaultStepSecondsN6:
 		return true
 	case PatternDefaultStepSecondsN60:
-		return true
-	case PatternDefaultStepSecondsN120:
 		return true
 	default:
 		return false
@@ -656,38 +680,15 @@ type ContentManipulation struct {
 	// StripResolution Remove RESOLUTION attribute from EXT-X-STREAM-INF lines. Apple HLS validator rejects this; AVPlayer plays but variant.video.size becomes empty (issue #486).
 	StripResolution *bool `json:"strip_resolution,omitempty"`
 
-	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
 // ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
 type ContentManipulationLiveOffset int
 
-// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.
 type ContentManipulationVariantOrder string
-
-// Defines values for ContentManipulationVariantOrder.
-const (
-	ContentManipulationVariantOrderAscending  ContentManipulationVariantOrder = "ascending"
-	ContentManipulationVariantOrderDefault    ContentManipulationVariantOrder = "default"
-	ContentManipulationVariantOrderDescending ContentManipulationVariantOrder = "descending"
-	ContentManipulationVariantOrderFirst4mbps ContentManipulationVariantOrder = "first_4mbps"
-)
-
-// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
-func (e ContentManipulationVariantOrder) Valid() bool {
-	switch e {
-	case ContentManipulationVariantOrderAscending:
-		return true
-	case ContentManipulationVariantOrderDefault:
-		return true
-	case ContentManipulationVariantOrderDescending:
-		return true
-	case ContentManipulationVariantOrderFirst4mbps:
-		return true
-	}
-	return false
-}
 
 // FaultCounters Read-only. Server-maintained; never appears in PATCH bodies.
 type FaultCounters map[string]int
@@ -902,7 +903,7 @@ type NetworkLogEntry struct {
 
 // Pattern defines model for Pattern.
 type Pattern struct {
-	// DefaultStepSeconds Default per-step duration the dashboard chose when generating the step list.
+	// DefaultStepSeconds Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
 	DefaultStepSeconds *PatternDefaultStepSeconds `json:"default_step_seconds,omitempty"`
 
 	// MarginPct Headroom percent above the variant rate used when sizing template steps. 0 = exact (deliberate-stall footgun). 5 = default — covers TCP/IP + TLS 1.3 + HTTP/2 framing overhead on a LAN. 10 = real WiFi with retransmits. 25 / 50 = stress-test over-headroom.
@@ -912,11 +913,14 @@ type Pattern struct {
 	// Template Template that drove step-list generation. Stored verbatim
 	// so the dashboard can repaint the template radios. The kernel
 	// cycles through `steps` regardless of template; this field is
-	// metadata, not a recompute trigger.
+	// metadata, not a recompute trigger. `transient_shock` is the
+	// deepening-drop staircase (hold top, dip to each lower rung in
+	// turn, recover to top between dips) mirroring the transient_shock
+	// characterization mode.
 	Template *PatternTemplate `json:"template,omitempty"`
 }
 
-// PatternDefaultStepSeconds Default per-step duration the dashboard chose when generating the step list.
+// PatternDefaultStepSeconds Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
 type PatternDefaultStepSeconds int
 
 // PatternMarginPct Headroom percent above the variant rate used when sizing template steps. 0 = exact (deliberate-stall footgun). 5 = default — covers TCP/IP + TLS 1.3 + HTTP/2 framing overhead on a LAN. 10 = real WiFi with retransmits. 25 / 50 = stress-test over-headroom.
@@ -925,7 +929,10 @@ type PatternMarginPct int
 // PatternTemplate Template that drove step-list generation. Stored verbatim
 // so the dashboard can repaint the template radios. The kernel
 // cycles through `steps` regardless of template; this field is
-// metadata, not a recompute trigger.
+// metadata, not a recompute trigger. `transient_shock` is the
+// deepening-drop staircase (hold top, dip to each lower rung in
+// turn, recover to top between dips) mirroring the transient_shock
+// characterization mode.
 type PatternTemplate string
 
 // PatternStep defines model for PatternStep.
@@ -1269,6 +1276,9 @@ type PlayerMetrics struct {
 	// BufferingTimeMs #550 Phase 1: cumulative buffering time (ms).
 	BufferingTimeMs *int `json:"buffering_time_ms,omitempty"`
 
+	// ConfiguredOffsetS Configured target offset from live (iOS configuredTimeOffsetFromLive; on Android equals recommended_offset_s).
+	ConfiguredOffsetS *float32 `json:"configured_offset_s,omitempty"`
+
 	// ContentName Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue.
 	ContentName *string `json:"content_name,omitempty"`
 
@@ -1388,6 +1398,9 @@ type PlayerMetrics struct {
 
 	// ProfileShiftCount Number of ABR rendition shifts the player has reported.
 	ProfileShiftCount *int `json:"profile_shift_count,omitempty"`
+
+	// RecommendedOffsetS Manifest-recommended target offset from live (iOS recommendedTimeOffsetFromLive / ExoPlayer liveConfiguration.targetOffsetMs). Gates the qoe_live_offset_* labels.
+	RecommendedOffsetS *float32 `json:"recommended_offset_s,omitempty"`
 
 	// SeekableEndS Player-reported end of seekable range (seconds).
 	SeekableEndS *float32 `json:"seekable_end_s,omitempty"`

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -288,6 +288,8 @@ func playerMetricsFromSession(s map[string]any) *oapigen.PlayerMetrics {
 		{"player_metrics_seekable_end_s", &pm.SeekableEndS},
 		{"player_metrics_live_edge_s", &pm.LiveEdgeS},
 		{"player_metrics_live_offset_s", &pm.LiveOffsetS},
+		{"player_metrics_recommended_offset_s", &pm.RecommendedOffsetS}, // #786
+		{"player_metrics_configured_offset_s", &pm.ConfiguredOffsetS},   // #786
 		{"player_metrics_true_offset_s", &pm.TrueOffsetS},
 		{"player_metrics_position_s", &pm.PositionS},
 		{"player_metrics_playback_rate", &pm.PlaybackRate},
@@ -436,17 +438,17 @@ func serverMetricsFromSession(s map[string]any) *oapigen.ServerMetrics {
 		"client_rto_ms":              func(f float32) { sm.RtoMs = &f },
 		"client_path_ping_rtt_ms":    func(f float32) { sm.PathPingRttMs = &f },
 		// Shaper / transfer measurements (developer-mode in v1).
-		"mbps_shaper_avg":            func(f float32) { sm.MbpsShaperAvg = &f },
-		"mbps_shaper_rate":           func(f float32) { sm.MbpsShaperRate = &f },
-		"mbps_transfer_rate":         func(f float32) { sm.MbpsTransferRate = &f },
-		"mbps_transfer_complete":     func(f float32) { sm.MbpsTransferComplete = &f },
-		"mbps_in":                    func(f float32) { sm.MbpsIn = &f },
-		"mbps_out":                   func(f float32) { sm.MbpsOut = &f },
-		"mbps_in_avg":                func(f float32) { sm.MbpsInAvg = &f },
-		"mbps_in_active":             func(f float32) { sm.MbpsInActive = &f },
-		"measured_mbps":              func(f float32) { sm.MeasuredMbps = &f },
-		"measurement_window_io":      func(f float32) { sm.MeasurementWindowIo = &f },
-		"measurement_window_active":  func(f float32) { sm.MeasurementWindowActive = &f },
+		"mbps_shaper_avg":           func(f float32) { sm.MbpsShaperAvg = &f },
+		"mbps_shaper_rate":          func(f float32) { sm.MbpsShaperRate = &f },
+		"mbps_transfer_rate":        func(f float32) { sm.MbpsTransferRate = &f },
+		"mbps_transfer_complete":    func(f float32) { sm.MbpsTransferComplete = &f },
+		"mbps_in":                   func(f float32) { sm.MbpsIn = &f },
+		"mbps_out":                  func(f float32) { sm.MbpsOut = &f },
+		"mbps_in_avg":               func(f float32) { sm.MbpsInAvg = &f },
+		"mbps_in_active":            func(f float32) { sm.MbpsInActive = &f },
+		"measured_mbps":             func(f float32) { sm.MeasuredMbps = &f },
+		"measurement_window_io":     func(f float32) { sm.MeasurementWindowIo = &f },
+		"measurement_window_active": func(f float32) { sm.MeasurementWindowActive = &f },
 	} {
 		if v, ok := numericFloatTranslate(s[key]); ok {
 			set(float32(v))

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -47,6 +47,30 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	}
 }
 
+// Defines values for ContentManipulationVariantOrder.
+const (
+	Ascending  ContentManipulationVariantOrder = "ascending"
+	Default    ContentManipulationVariantOrder = "default"
+	Descending ContentManipulationVariantOrder = "descending"
+	First4mbps ContentManipulationVariantOrder = "first_4mbps"
+)
+
+// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
+func (e ContentManipulationVariantOrder) Valid() bool {
+	switch e {
+	case Ascending:
+		return true
+	case Default:
+		return true
+	case Descending:
+		return true
+	case First4mbps:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FaultFilterRequestKind.
 const (
 	FaultFilterRequestKindAudioManifest  FaultFilterRequestKind = "audio_manifest"
@@ -188,17 +212,19 @@ func (e HeartbeatEventType) Valid() bool {
 // Defines values for PatternDefaultStepSeconds.
 const (
 	PatternDefaultStepSecondsN12  PatternDefaultStepSeconds = 12
+	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 	PatternDefaultStepSecondsN18  PatternDefaultStepSeconds = 18
 	PatternDefaultStepSecondsN24  PatternDefaultStepSeconds = 24
 	PatternDefaultStepSecondsN6   PatternDefaultStepSeconds = 6
 	PatternDefaultStepSecondsN60  PatternDefaultStepSeconds = 60
-	PatternDefaultStepSecondsN120 PatternDefaultStepSeconds = 120
 )
 
 // Valid indicates whether the value is a known member of the PatternDefaultStepSeconds enum.
 func (e PatternDefaultStepSeconds) Valid() bool {
 	switch e {
 	case PatternDefaultStepSecondsN12:
+		return true
+	case PatternDefaultStepSecondsN120:
 		return true
 	case PatternDefaultStepSecondsN18:
 		return true
@@ -207,8 +233,6 @@ func (e PatternDefaultStepSeconds) Valid() bool {
 	case PatternDefaultStepSecondsN6:
 		return true
 	case PatternDefaultStepSecondsN60:
-		return true
-	case PatternDefaultStepSecondsN120:
 		return true
 	default:
 		return false
@@ -657,38 +681,15 @@ type ContentManipulation struct {
 	// StripResolution Remove RESOLUTION attribute from EXT-X-STREAM-INF lines. Apple HLS validator rejects this; AVPlayer plays but variant.video.size becomes empty (issue #486).
 	StripResolution *bool `json:"strip_resolution,omitempty"`
 
-	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+	// VariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
 // ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
 type ContentManipulationLiveOffset int
 
-// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682).
+// ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.
 type ContentManipulationVariantOrder string
-
-// Defines values for ContentManipulationVariantOrder.
-const (
-	ContentManipulationVariantOrderAscending  ContentManipulationVariantOrder = "ascending"
-	ContentManipulationVariantOrderDefault    ContentManipulationVariantOrder = "default"
-	ContentManipulationVariantOrderDescending ContentManipulationVariantOrder = "descending"
-	ContentManipulationVariantOrderFirst4mbps ContentManipulationVariantOrder = "first_4mbps"
-)
-
-// Valid indicates whether the value is a known member of the ContentManipulationVariantOrder enum.
-func (e ContentManipulationVariantOrder) Valid() bool {
-	switch e {
-	case ContentManipulationVariantOrderAscending:
-		return true
-	case ContentManipulationVariantOrderDefault:
-		return true
-	case ContentManipulationVariantOrderDescending:
-		return true
-	case ContentManipulationVariantOrderFirst4mbps:
-		return true
-	}
-	return false
-}
 
 // FaultCounters Read-only. Server-maintained; never appears in PATCH bodies.
 type FaultCounters map[string]int
@@ -903,7 +904,7 @@ type NetworkLogEntry struct {
 
 // Pattern defines model for Pattern.
 type Pattern struct {
-	// DefaultStepSeconds Default per-step duration the dashboard chose when generating the step list.
+	// DefaultStepSeconds Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
 	DefaultStepSeconds *PatternDefaultStepSeconds `json:"default_step_seconds,omitempty"`
 
 	// MarginPct Headroom percent above the variant rate used when sizing template steps. 0 = exact (deliberate-stall footgun). 5 = default — covers TCP/IP + TLS 1.3 + HTTP/2 framing overhead on a LAN. 10 = real WiFi with retransmits. 25 / 50 = stress-test over-headroom.
@@ -913,11 +914,14 @@ type Pattern struct {
 	// Template Template that drove step-list generation. Stored verbatim
 	// so the dashboard can repaint the template radios. The kernel
 	// cycles through `steps` regardless of template; this field is
-	// metadata, not a recompute trigger.
+	// metadata, not a recompute trigger. `transient_shock` is the
+	// deepening-drop staircase (hold top, dip to each lower rung in
+	// turn, recover to top between dips) mirroring the transient_shock
+	// characterization mode.
 	Template *PatternTemplate `json:"template,omitempty"`
 }
 
-// PatternDefaultStepSeconds Default per-step duration the dashboard chose when generating the step list.
+// PatternDefaultStepSeconds Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
 type PatternDefaultStepSeconds int
 
 // PatternMarginPct Headroom percent above the variant rate used when sizing template steps. 0 = exact (deliberate-stall footgun). 5 = default — covers TCP/IP + TLS 1.3 + HTTP/2 framing overhead on a LAN. 10 = real WiFi with retransmits. 25 / 50 = stress-test over-headroom.
@@ -926,7 +930,10 @@ type PatternMarginPct int
 // PatternTemplate Template that drove step-list generation. Stored verbatim
 // so the dashboard can repaint the template radios. The kernel
 // cycles through `steps` regardless of template; this field is
-// metadata, not a recompute trigger.
+// metadata, not a recompute trigger. `transient_shock` is the
+// deepening-drop staircase (hold top, dip to each lower rung in
+// turn, recover to top between dips) mirroring the transient_shock
+// characterization mode.
 type PatternTemplate string
 
 // PatternStep defines model for PatternStep.
@@ -1270,6 +1277,9 @@ type PlayerMetrics struct {
 	// BufferingTimeMs #550 Phase 1: cumulative buffering time (ms).
 	BufferingTimeMs *int `json:"buffering_time_ms,omitempty"`
 
+	// ConfiguredOffsetS Configured target offset from live (iOS configuredTimeOffsetFromLive; on Android equals recommended_offset_s).
+	ConfiguredOffsetS *float32 `json:"configured_offset_s,omitempty"`
+
 	// ContentName Content title bound at metrics-start. Stamped on every payload so dashboards see "which content was playing" without joining against the upload catalogue.
 	ContentName *string `json:"content_name,omitempty"`
 
@@ -1389,6 +1399,9 @@ type PlayerMetrics struct {
 
 	// ProfileShiftCount Number of ABR rendition shifts the player has reported.
 	ProfileShiftCount *int `json:"profile_shift_count,omitempty"`
+
+	// RecommendedOffsetS Manifest-recommended target offset from live (iOS recommendedTimeOffsetFromLive / ExoPlayer liveConfiguration.targetOffsetMs). Gates the qoe_live_offset_* labels.
+	RecommendedOffsetS *float32 `json:"recommended_offset_s,omitempty"`
 
 	// SeekableEndS Player-reported end of seekable range (seconds).
 	SeekableEndS *float32 `json:"seekable_end_s,omitempty"`


### PR DESCRIPTION
Completes #786 — the part #787 missed.

## Problem
`harness query events` (→ `/api/v2/events`) returned `None` for `recommended_offset_s`/`configured_offset_s` even though the data is fully present (CH column + flat keys in `session_json`, 113/113 rows). That endpoint reshapes `session_json` into **nested** `player_metrics` via `v2translate.PlayerFromSession`, which had no mapping for these fields (only `live_offset_s`), and the oapigen `PlayerMetrics` struct lacked them. (#787 fixed the separate `/api/v2/timeseries` flat-projection path — not this one.)

## Change (#550-style plumb, presentation only)
- `proxy.yaml`: add `recommended_offset_s` + `configured_offset_s` to `PlayerMetrics`.
- Regenerate go-proxy oapigen + harness-cli proxy client.
- `translate.go`: map the two flat keys → `pm.RecommendedOffsetS`/`ConfiguredOffsetS` (next to `live_offset_s`).

CH schema + forwarder ingest already had the columns; no schema/ingest change.

## Verified (Google TV play, post-deploy)
`harness query events <play_id>` now returns nested:
```
last_event    state      rec     cfg    live  excess
state_change  playing  22.462  22.462  23.58   1.12
heartbeat     playing  22.462  22.462  25.02   2.56
```
113/114 rows carry `recommended_offset_s`; `excess = live − recommended` is computable straight from the events query. Deployed to test-dev.

Closes #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
