### PR TITLE
feat(793): live-offset test validity — manipulation-check gate, segment matrix, tight label

### DIFF
--- a/.claude/findings/live-offset-androidtv-untestable-2026-06-15.md
+++ b/.claude/findings/live-offset-androidtv-untestable-2026-06-15.md
@@ -1,0 +1,50 @@
+# Live-offset is currently untestable on Android TV — 2026-06-15
+
+## Summary
+A config-class sweep that sets `content_manipulation.live_offset` does **not** move the achieved
+offset on Android TV (ExoPlayer): the recipe asked for 6 s, the player ran at ~21.5 s the whole play.
+Two reasons stack: (1) the sub-spec hold-back is rejected/clamped to the floor, and (2) Android has
+**no client-side offset lever** at all. So a sub-spec (or any not-honoured) `live_offset` is untestable
+on Android TV until either the manifest path lands a *legal* value or an Android `LiveConfiguration`
+target-offset lever is plumbed. Tag: **confirmed**.
+
+## How we learned this
+Triaging the androidtv finding `seed-config-androidtv-hls-live-offset-startup` (`live_offset=6`,
+`startup`) + its rep batch `rep-8c0d9e-*`. It kept scoring `aberration` (`qoe_cirr_breach`, a
+stall-continuity breach), but the achieved offset never matched the intended 6 s — so the stall was
+being (wrongly) attributed to a live-offset that never took effect.
+
+## Evidence
+Play `b104c934` (rep) and `827b7269` (parent), androidtv / Google TV Streamer / ExoPlayer 1.2.1:
+- `configured_offset_s` and `recommended_offset_s` (the parsed manifest hold-back) ≈ **21.464 s**;
+  `true_offset_s`/`live_offset_s` tracked ~21.5 s. Intended: **6 s**. The IV never moved.
+- The hold-back floor is `3 × max segment duration`. "6 s" segments round up to ~7 s, so the floor is
+  ~21 s (not 18 s) — which is exactly where the player sat. `HOLD-BACK=6` is sub-spec and was
+  rejected/clamped.
+- Android has no client lever: `LiveConfiguration.targetOffsetMs/min/max` are hardcoded `C.TIME_UNSET`
+  (`android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt:783`),
+  so ExoPlayer derives the offset from the manifest alone; `MainActivity.kt` reads only `is.player_id`
+  as an intent extra — there is no `is.flag.live_offset_s` equivalent.
+- iOS DOES have the client lever: `is.flag.live_offset_s` → `AVPlayerItem.configuredTimeOffsetFromLive`
+  + a seek (`PlayerViewModel.swift:1868`), so iOS can be driven independent of the manifest.
+
+## Hypothesis
+**confirmed.** On Android TV the manifest is the only live-offset lever, and a sub-spec value won't
+land; with no client lever, any offset the manifest doesn't honour is untestable there. The
+`qoe_cirr_breach` stall on those plays is **not attributable to live_offset** (the IV didn't vary).
+
+## Where this matters
+- The #793 manipulation-check gate now marks these runs **`inconclusive` → `review`** automatically
+  (achieved offset ≠ intended within a segment-aware tolerance), so they never become false findings.
+- The segment × live-offset matrix runs on **ipad-sim**, where the manifest lever works for legal
+  values (and iOS additionally has the client lever). Android-TV live-offset arms stay inconclusive
+  until the Android client lever (#793 step 4) is plumbed.
+
+## Action items
+- [ ] (Optional, #793 step 4) Wire `is.flag.live_offset_s` → `LiveConfiguration.setTargetOffsetMs` on
+      Android so it can be driven like iOS.
+- [x] Manipulation-check gate gates findings on IV-moved (shipped, #793).
+
+## See also
+- `docs/sweep-design.md` §3.1 (manipulation check / validity gate).
+- `.claude/findings/avplayer-startup-variant-selection-2026-06-07.md` (adjacent startup-behaviour finding).

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -503,6 +503,7 @@ func TestQoELiveOffset(t *testing.T) {
 	}
 	concerning := qoeLabel(SevWarning, "qoe_live_offset_concerning")
 	breach := qoeLabel(SevCritical, "qoe_live_offset_breach")
+	tight := qoeLabel(SevWarning, "qoe_live_offset_tight")
 	holdback := qoeLabel(SevWarning, "qoe_holdback_deviation")
 	// excess 2 < 3 → none; configured == recommended → no holdback.
 	if got := mk(7, 5); hasLabel(got, concerning) || hasLabel(got, breach) || hasLabel(got, holdback) {
@@ -519,6 +520,14 @@ func TestQoELiveOffset(t *testing.T) {
 	// configured 8 vs recommended 5 → dev 3 > 2 → holdback.
 	if got := mk(5, 8); !hasLabel(got, holdback) {
 		t.Fatalf("holdback dev 3 should fire: %v", got)
+	}
+	// #793 tight direction: excess -2 (off 3 < rec 5) → within tight margin, clean.
+	if got := mk(3, 5); hasLabel(got, tight) || hasLabel(got, concerning) || hasLabel(got, breach) {
+		t.Fatalf("excess -2 should not fire any offset label: %v", got)
+	}
+	// excess -3 (off 2 < rec 5) → tight, and NOT concerning/breach.
+	if got := mk(2, 5); !hasLabel(got, tight) || hasLabel(got, concerning) || hasLabel(got, breach) {
+		t.Fatalf("excess -3 should be tight only: %v", got)
 	}
 }
 

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -506,6 +506,11 @@ func liveOffsetLabels(cfg *QoEThresholds, r *row) []string {
 			out = append(out, qoeLabel(SevCritical, "qoe_live_offset_breach"))
 		case excess >= cfg.Live.OffsetConcerningMarginS:
 			out = append(out, qoeLabel(SevWarning, "qoe_live_offset_concerning"))
+		case cfg.Live.OffsetTightMarginS > 0 && excess <= -cfg.Live.OffsetTightMarginS:
+			// Player is running CLOSER to live than the manifest's hold-back
+			// target wants — less buffer than the stream specified, a latency-
+			// for-stability trade the manifest didn't ask for (#793).
+			out = append(out, qoeLabel(SevWarning, "qoe_live_offset_tight"))
 		}
 	}
 	if cfgd := float64(r.ConfiguredOffsetS); cfgd > 0 && math.Abs(cfgd-rec) > cfg.Live.HoldbackDeviationS {

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -115,11 +115,14 @@ type QoEThresholds struct {
 		DownshiftOvershootRungs int `json:"downshift_overshoot_rungs"`
 	} `json:"abr"`
 
-	// Live-edge label thresholds (#553). Margins are seconds BEYOND the
-	// manifest-recommended offset.
+	// Live-edge label thresholds (#553). Concerning/Breach margins are seconds
+	// BEYOND the manifest-recommended offset (player drifting behind live).
+	// TightMargin is seconds BELOW it (player running closer to live than the
+	// manifest's hold-back wants → less buffer; #793).
 	Live struct {
 		OffsetConcerningMarginS float64 `json:"offset_concerning_margin_s"`
 		OffsetBreachMarginS     float64 `json:"offset_breach_margin_s"`
+		OffsetTightMarginS      float64 `json:"offset_tight_margin_s"`
 		HoldbackDeviationS      float64 `json:"holdback_deviation_s"`
 	} `json:"live"`
 }
@@ -156,6 +159,7 @@ func qoeDefaults() *QoEThresholds {
 	t.ABR.DownshiftOvershootRungs = 2 // ≥2 rungs below the cap-supported ceiling ⇒ overshoot (#669)
 	t.Live.OffsetConcerningMarginS = 3
 	t.Live.OffsetBreachMarginS = 10
+	t.Live.OffsetTightMarginS = 3 // ≥3s CLOSER to live than the manifest target ⇒ tight (#793)
 	t.Live.HoldbackDeviationS = 2
 	return t
 }
@@ -271,6 +275,9 @@ func loadQoEThresholds(path string) *QoEThresholds {
 	}
 	if override.Live.OffsetBreachMarginS != 0 {
 		cfg.Live.OffsetBreachMarginS = override.Live.OffsetBreachMarginS
+	}
+	if override.Live.OffsetTightMarginS != 0 {
+		cfg.Live.OffsetTightMarginS = override.Live.OffsetTightMarginS
 	}
 	if override.Live.HoldbackDeviationS != 0 {
 		cfg.Live.HoldbackDeviationS = override.Live.HoldbackDeviationS

--- a/docs/sweep-design.md
+++ b/docs/sweep-design.md
@@ -137,6 +137,42 @@ So each run resolves to a **trichotomy** (three-way outcome): **`clean`** (only 
 `critical`). `notable` outcomes are surfaced and can spawn their own A/B isolation fan (§6) to characterize the
 surprise — exactly how we'd chase whether the over-downshift is iOS-specific, ladder-density-driven, etc.
 
+### 3.1 Manipulation check — the independent-variable must actually move (the validity gate, #793)
+
+The oracle classifies QoE *outcomes*. But a recipe that varies a manifest **input** (a config-class IV like
+`content_manipulation.live_offset`) is only interpretable if that input demonstrably *took effect*. Otherwise a
+run is attributing an outcome to a cause that never varied. This is a **manipulation check**, and it runs
+*before* the verdict counts:
+
+1. **The IV must have moved.** Compare the player's *achieved* value (read from the play's telemetry) to the
+   recipe's *intended* value, within tolerance. If it didn't move, the run is **`inconclusive`** (→ `review`),
+   never `found`/`done` — it says nothing about the hypothesis.
+2. **Only then does the effect comparison mean anything.** Compare outcomes across arms whose *achieved* IVs
+   genuinely differ. Two arms that both land at the default (because neither manipulation took) are not
+   comparable at all.
+
+Corollary: if, on a platform, *no available lever* moves the IV, the hypothesis is **untestable there** until a
+lever lands — and the gate surfaces that automatically (every such arm returns inconclusive) instead of letting
+it masquerade as findings.
+
+**Worked instance — live-offset (the motivating case).** `live_offset` is a load-time/session property
+(`EXT-X-START` + `HOLD-BACK`, read at join), so it can't be swept mid-play like bandwidth — **each value is its
+own little job** (one clean IV per run), and the arms share a per-platform comparison group. The achieved offset
+the gate reads is `recommended_offset_s` / `true_offset_s` (median of steady-state samples). The hold-back floor
+is **3× the MAX segment duration**, and "6 s" segments can round up to 7 s, so the floor sits near **21 s, not
+18 s**; the achieved offset also quantizes to segment boundaries — so the gate's tolerance is **segment-aware**
+(~one max-segment). Consequence: the *same* offset is sub-spec on `s6` (clamped → inconclusive) but legal on `s2`
+(lands) — which is exactly the segment × offset matrix the recipe seeds (`live-offset-s{2,6}-*`).
+
+**Detection economics (label vs LLM post-mortem).** Only two live-offset dimensions carry a deterministic
+forwarder label today — drift *behind* target (`qoe_live_offset_breach`/`_concerning`) and config↔manifest
+mismatch (`qoe_holdback_deviation`). The rest (did-it-land, join accuracy, too-tight, sub-spec handling, segment
+interaction, latency↔stability, post-stall resync, TTFF, cross-platform parity) are **detectable post-mortem by
+the LLM with no new labelling/code**, because the play already emits `configured/recommended/true/live_offset_s`
++ `error_code` + `playback_rate` + `first_frame` + resolution/bitrate. So the rule of thumb: make the
+**manipulation check** deterministic (it gates every finding), and lean on the LLM investigate step for the long
+tail — don't add a label per question.
+
 ## 4. Experiment record + the store
 
 > **⚠️ Superseded — migrated to ClickHouse-master (#772 CH-master).** This section's original design (a local

--- a/docs/sweep-design.md
+++ b/docs/sweep-design.md
@@ -164,11 +164,12 @@ is **3× the MAX segment duration**, and "6 s" segments can round up to 7 s, so 
 (~one max-segment). Consequence: the *same* offset is sub-spec on `s6` (clamped → inconclusive) but legal on `s2`
 (lands) — which is exactly the segment × offset matrix the recipe seeds (`live-offset-s{2,6}-*`).
 
-**Detection economics (label vs LLM post-mortem).** Only two live-offset dimensions carry a deterministic
-forwarder label today — drift *behind* target (`qoe_live_offset_breach`/`_concerning`) and config↔manifest
-mismatch (`qoe_holdback_deviation`). The rest (did-it-land, join accuracy, too-tight, sub-spec handling, segment
-interaction, latency↔stability, post-stall resync, TTFF, cross-platform parity) are **detectable post-mortem by
-the LLM with no new labelling/code**, because the play already emits `configured/recommended/true/live_offset_s`
+**Detection economics (label vs LLM post-mortem).** Three live-offset dimensions carry a deterministic forwarder
+label — drift *behind* target (`qoe_live_offset_breach`/`_concerning`), running *too tight* (`qoe_live_offset_tight`,
+#793 — closer to live than the manifest hold-back wants), and config↔manifest mismatch (`qoe_holdback_deviation`).
+The rest (did-it-land, join accuracy, sub-spec handling, segment interaction, latency↔stability, post-stall
+resync, TTFF, cross-platform parity) are **detectable post-mortem by the LLM with no new labelling/code**, because
+the play already emits `configured/recommended/true/live_offset_s`
 + `error_code` + `playback_rate` + `first_frame` + resolution/bitrate. So the rule of thumb: make the
 **manipulation check** deterministic (it gates every finding), and lean on the LLM investigate step for the long
 tail — don't add a label per question.

--- a/tests/characterization/modes/sweep_probe_test.go
+++ b/tests/characterization/modes/sweep_probe_test.go
@@ -96,6 +96,13 @@ func TestSweepProbe(t *testing.T) {
 	if clip := strings.TrimSpace(os.Getenv("CHAR_CONTENT")); clip != "" {
 		args = append(args, "-is.lastPlayed", clip)
 	}
+	// Segment variant (#793 live-offset matrix): s2|s6|ll selects which
+	// master the app requests (master_2s/master_6s/master). Empty leaves the
+	// app default (s6). The hold-back floor scales with segment duration, so a
+	// given live_offset can be legal on one and sub-spec on another.
+	if seg := strings.TrimSpace(os.Getenv("CHAR_SWEEP_SEGMENT")); seg != "" {
+		args = append(args, "-is.segment", seg)
+	}
 	appium.SetLaunchArgs(args)
 
 	sess, err := appium.LaunchToHome(setupCtx, *picked)

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -390,6 +390,26 @@ func cmdSweepAnalyze(client *api.Client, args []string, asJSON bool) error {
 
 	bucket := sweep.Analyze(e, *play, labels)
 
+	// Manipulation-check gate (epic #793): a live-offset recipe is only
+	// interpretable if changing the knob actually moved the player's ACHIEVED
+	// offset. If it didn't, the independent variable never varied — so no QoE
+	// outcome can be attributed to live_offset — override the label verdict to
+	// inconclusive and route to review instead of letting it become a finding.
+	if intended, ok := sweep.IntendedLiveOffset(e); ok {
+		evBody, evErr := client.ArchiveEvents(context.Background(), &forwarder.GetApiV2EventsParams{PlayId: &pid})
+		if evErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: manipulation check could not read offsets for %s: %v\n", *play, evErr)
+		} else if achieved := sweep.AchievedOffsetFromEvents(evBody); !sweep.ManipulationLanded(intended, achieved) {
+			got := achieved.RecommendedS
+			if got <= 0 {
+				got = achieved.TrueS
+			}
+			bucket = sweep.MarkInconclusive(e, fmt.Sprintf(
+				"manipulation check FAILED: live_offset intended %.1fs but achieved ~%.1fs — IV did not move, result not attributable to live_offset",
+				intended, got))
+		}
+	}
+
 	// n=1 guard: a first single-rep hit enqueues confirmation reps instead of
 	// being promoted straight away. The reps land in backlog; this experiment
 	// still records its verdict and moves to its bucket for the post-mortem.

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -399,7 +399,7 @@ func cmdSweepAnalyze(client *api.Client, args []string, asJSON bool) error {
 		evBody, evErr := client.ArchiveEvents(context.Background(), &forwarder.GetApiV2EventsParams{PlayId: &pid})
 		if evErr != nil {
 			fmt.Fprintf(os.Stderr, "warning: manipulation check could not read offsets for %s: %v\n", *play, evErr)
-		} else if achieved := sweep.AchievedOffsetFromEvents(evBody); !sweep.ManipulationLanded(intended, achieved) {
+		} else if achieved := sweep.AchievedOffsetFromEvents(evBody); !sweep.ManipulationLanded(intended, achieved, sweep.SegmentSlackS(e.Segment)) {
 			got := achieved.RecommendedS
 			if got <= 0 {
 				got = achieved.TrueS

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -404,9 +404,17 @@ func cmdSweepAnalyze(client *api.Client, args []string, asJSON bool) error {
 			if got <= 0 {
 				got = achieved.TrueS
 			}
+			// Name the direction so the review/LLM can promote a systematic cap
+			// to a finding: shallower-than-requested = the player held closer to
+			// live than asked (candidate "won't honor a deeper offset"); deeper =
+			// it lagged behind / didn't tighten to the requested offset.
+			dir := "held deeper than requested (lagged behind / didn't tighten)"
+			if got < intended {
+				dir = "held SHALLOWER than requested — closer to live than asked (candidate: player won't honor a deeper offset)"
+			}
 			bucket = sweep.MarkInconclusive(e, fmt.Sprintf(
-				"manipulation check FAILED: live_offset intended %.1fs but achieved ~%.1fs — IV did not move, result not attributable to live_offset",
-				intended, got))
+				"manipulation check FAILED: live_offset intended %.1fs but achieved ~%.1fs — IV did not move (%s); result not attributable to live_offset",
+				intended, got, dir))
 		}
 	}
 

--- a/tools/harness-cli/internal/sweep/experiment.go
+++ b/tools/harness-cli/internal/sweep/experiment.go
@@ -178,6 +178,7 @@ type Experiment struct {
 	LaunchMode          string               `json:"launch_mode,omitempty"` // how the probe launches the app: appium (the only mode TestSweepProbe supports). Stamped at creation; the runner passes it as LAUNCH_MODE.
 	Protocol            string               `json:"protocol"`              // hls | dash
 	Content             string               `json:"content"`               // fixed to insane_new for now
+	Segment             string               `json:"segment,omitempty"`     // master variant the probe requests via -is.segment: s2 | s6 | ll. Empty = app default (s6). Drives the segment×live-offset matrix (#793).
 	Mode                string               `json:"mode"`                  // steps | pyramid | downshift_severity | …
 	DurationS           int                  `json:"duration_s,omitempty"`
 	Fault               *Fault               `json:"fault,omitempty"` // fault-class only

--- a/tools/harness-cli/internal/sweep/manipulation.go
+++ b/tools/harness-cli/internal/sweep/manipulation.go
@@ -1,0 +1,171 @@
+package sweep
+
+import (
+	"encoding/json"
+	"math"
+	"sort"
+)
+
+// The manipulation check (epic #793) is the foundational gate for the
+// live-offset recipe: a live_offset run is only interpretable if changing the
+// knob actually changed the player's ACHIEVED offset. If the achieved offset
+// never moved to ~the intended value, the independent variable never varied —
+// so no observed QoE/stall outcome can be attributed to live_offset, and the
+// run is `inconclusive`, not a finding. (The androidtv run that motivated this:
+// intended 6 s, achieved ~21.5 s — the manifest HOLD-BACK either didn't reach
+// ExoPlayer or it rejected the sub-spec value; either way the IV didn't move.)
+
+// Offset-match tolerance: achieved counts as "landed" within whichever is
+// larger — a small absolute floor (so tiny intended offsets aren't held to an
+// impossible fraction) or a fraction of the intended value.
+const (
+	OffsetToleranceAbsS = 2.0
+	OffsetToleranceFrac = 0.25
+)
+
+// IntendedLiveOffset returns the offset the recipe meant to impose and whether
+// this is a live-offset experiment at all. Non-live-offset experiments return
+// false and skip the gate entirely.
+func IntendedLiveOffset(e *Experiment) (float64, bool) {
+	if e == nil || e.ContentManipulation == nil || e.ContentManipulation.LiveOffset == nil {
+		return 0, false
+	}
+	v := *e.ContentManipulation.LiveOffset
+	if v <= 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// AchievedOffset is the player-reported live offset for a play, read from the
+// events archive. RecommendedS is the manifest HOLD-BACK the player parsed (the
+// most direct "did the knob land" signal); TrueS is the actual achieved
+// distance from the live edge. HasData is false when no offset sample exists
+// (e.g. a play that never reached steady state).
+type AchievedOffset struct {
+	RecommendedS float64
+	TrueS        float64
+	HasData      bool
+}
+
+// AchievedOffsetFromEvents extracts a representative achieved offset from a
+// forwarder /api/v2/events response body. The offset fields live nested under
+// each row's `player_metrics` (which the archive emits as either a JSON object
+// or a JSON-encoded string). It takes the MEDIAN of the non-null samples so a
+// startup transient or end-of-play drift doesn't skew the steady-state read.
+func AchievedOffsetFromEvents(body []byte) AchievedOffset {
+	var env struct {
+		Items []struct {
+			PlayerMetrics json.RawMessage `json:"player_metrics"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return AchievedOffset{}
+	}
+	var rec, tru []float64
+	for _, it := range env.Items {
+		pm, ok := decodeMaybeStringObject(it.PlayerMetrics)
+		if !ok {
+			continue
+		}
+		if v, ok := numField(pm, "recommended_offset_s"); ok {
+			rec = append(rec, v)
+		}
+		if v, ok := numField(pm, "true_offset_s"); ok {
+			tru = append(tru, v)
+		}
+	}
+	out := AchievedOffset{}
+	if len(rec) > 0 {
+		out.RecommendedS = median(rec)
+		out.HasData = true
+	}
+	if len(tru) > 0 {
+		out.TrueS = median(tru)
+		out.HasData = true
+	}
+	return out
+}
+
+// ManipulationLanded reports whether the achieved offset reflects the intended
+// one within tolerance. It prefers the recommended (parsed manifest target) and
+// falls back to the true offset. With no offset data it returns true — a query
+// gap must not masquerade as "the IV didn't move" (the caller logs the gap).
+func ManipulationLanded(intended float64, a AchievedOffset) bool {
+	if !a.HasData {
+		return true
+	}
+	got := a.RecommendedS
+	if got <= 0 {
+		got = a.TrueS
+	}
+	if got <= 0 {
+		return true
+	}
+	tol := math.Max(OffsetToleranceAbsS, intended*OffsetToleranceFrac)
+	return math.Abs(got-intended) <= tol
+}
+
+// MarkInconclusive overrides a run's verdict to inconclusive and routes it to
+// review — a human/LLM looks, but it never becomes a finding. Used by the
+// manipulation-check gate when the IV demonstrably didn't move.
+func MarkInconclusive(e *Experiment, note string) Status {
+	if e.Result == nil {
+		e.Result = &Result{}
+	}
+	e.Result.Verdict = VerdictInconclusive
+	if e.Result.Note != "" {
+		e.Result.Note += " · "
+	}
+	e.Result.Note += note
+	return StatusReview
+}
+
+// decodeMaybeStringObject unmarshals a RawMessage that is either a JSON object
+// or a JSON-encoded string wrapping an object (the events archive emits
+// player_metrics in both shapes across versions).
+func decodeMaybeStringObject(raw json.RawMessage) (map[string]any, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	if raw[0] == '"' {
+		var s string
+		if json.Unmarshal(raw, &s) != nil {
+			return nil, false
+		}
+		var m map[string]any
+		if json.Unmarshal([]byte(s), &m) != nil {
+			return nil, false
+		}
+		return m, true
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil {
+		return nil, false
+	}
+	return m, true
+}
+
+// numField reads a numeric field from a decoded JSON object. JSON numbers
+// decode to float64; a null/absent/non-numeric field returns ok=false.
+func numField(m map[string]any, key string) (float64, bool) {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return 0, false
+	}
+	f, ok := v.(float64)
+	return f, ok
+}
+
+func median(xs []float64) float64 {
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	n := len(s)
+	if n == 0 {
+		return 0
+	}
+	if n%2 == 1 {
+		return s[n/2]
+	}
+	return (s[n/2-1] + s[n/2]) / 2
+}

--- a/tools/harness-cli/internal/sweep/manipulation.go
+++ b/tools/harness-cli/internal/sweep/manipulation.go
@@ -16,12 +16,34 @@ import (
 // ExoPlayer or it rejected the sub-spec value; either way the IV didn't move.)
 
 // Offset-match tolerance: achieved counts as "landed" within whichever is
-// larger — a small absolute floor (so tiny intended offsets aren't held to an
-// impossible fraction) or a fraction of the intended value.
+// largest of — a small absolute floor (so tiny intended offsets aren't held to
+// an impossible fraction), a fraction of the intended value, and ~one max
+// segment duration (the achieved offset quantizes to segment boundaries, and
+// the hold-back floor is 3× the MAX segment duration — "6s" segments can round
+// up to 7s, so the floor sits near 21s, not 18s). The segment slack keeps a
+// legal arm that the player honours at its rounded floor from being false-
+// flagged as "didn't land".
 const (
-	OffsetToleranceAbsS = 2.0
+	OffsetToleranceAbsS = 3.0
 	OffsetToleranceFrac = 0.25
 )
+
+// SegmentSlackS returns ~one max-segment-duration of tolerance for an arm's
+// segment selection. "6s" segments can round up to 7s; "2s" to ~3s; LL is
+// sub-second but we floor it at 2s. Empty (app default) is treated as the 6s
+// worst case so we never under-tolerate.
+func SegmentSlackS(segment string) float64 {
+	switch segment {
+	case "s2":
+		return 3
+	case "ll":
+		return 2
+	case "s6", "":
+		return 7
+	default:
+		return 7
+	}
+}
 
 // IntendedLiveOffset returns the offset the recipe meant to impose and whether
 // this is a live-offset experiment at all. Non-live-offset experiments return
@@ -89,9 +111,11 @@ func AchievedOffsetFromEvents(body []byte) AchievedOffset {
 
 // ManipulationLanded reports whether the achieved offset reflects the intended
 // one within tolerance. It prefers the recommended (parsed manifest target) and
-// falls back to the true offset. With no offset data it returns true — a query
-// gap must not masquerade as "the IV didn't move" (the caller logs the gap).
-func ManipulationLanded(intended float64, a AchievedOffset) bool {
+// falls back to the true offset. `segmentSlackS` is ~one max-segment-duration
+// (from SegmentSlackS) so the segment-boundary quantization of the achieved
+// offset doesn't false-flag a legal arm. With no offset data it returns true —
+// a query gap must not masquerade as "the IV didn't move" (the caller logs it).
+func ManipulationLanded(intended float64, a AchievedOffset, segmentSlackS float64) bool {
 	if !a.HasData {
 		return true
 	}
@@ -102,7 +126,7 @@ func ManipulationLanded(intended float64, a AchievedOffset) bool {
 	if got <= 0 {
 		return true
 	}
-	tol := math.Max(OffsetToleranceAbsS, intended*OffsetToleranceFrac)
+	tol := math.Max(math.Max(OffsetToleranceAbsS, intended*OffsetToleranceFrac), segmentSlackS)
 	return math.Abs(got-intended) <= tol
 }
 

--- a/tools/harness-cli/internal/sweep/manipulation_test.go
+++ b/tools/harness-cli/internal/sweep/manipulation_test.go
@@ -1,0 +1,93 @@
+package sweep
+
+import "testing"
+
+func TestIntendedLiveOffset(t *testing.T) {
+	if _, ok := IntendedLiveOffset(&Experiment{}); ok {
+		t.Error("no content_manipulation → not a live-offset experiment")
+	}
+	if _, ok := IntendedLiveOffset(&Experiment{ContentManipulation: &ContentManipulation{}}); ok {
+		t.Error("nil LiveOffset → not a live-offset experiment")
+	}
+	zero := 0.0
+	if _, ok := IntendedLiveOffset(&Experiment{ContentManipulation: &ContentManipulation{LiveOffset: &zero}}); ok {
+		t.Error("zero LiveOffset → skip the gate")
+	}
+	v, ok := IntendedLiveOffset(&Experiment{ContentManipulation: &ContentManipulation{LiveOffset: floatPtr(6)}})
+	if !ok || v != 6 {
+		t.Errorf("want (6,true), got (%v,%v)", v, ok)
+	}
+}
+
+func TestAchievedOffsetFromEvents(t *testing.T) {
+	// player_metrics arrives nested (object) on some rows and string-wrapped on
+	// others; the parser must handle both, ignore the null/startup row, and
+	// take the median of the steady-state samples.
+	body := []byte(`{"items":[
+		{"player_metrics":{"recommended_offset_s":null,"true_offset_s":null}},
+		{"player_metrics":{"recommended_offset_s":21.4,"true_offset_s":21.5}},
+		{"player_metrics":"{\"recommended_offset_s\":21.6,\"true_offset_s\":21.7}"},
+		{"player_metrics":{"recommended_offset_s":21.5,"true_offset_s":21.6}}
+	]}`)
+	a := AchievedOffsetFromEvents(body)
+	if !a.HasData {
+		t.Fatal("expected offset data")
+	}
+	if a.RecommendedS != 21.5 { // median of {21.4,21.5,21.6}
+		t.Errorf("recommended median: got %v want 21.5", a.RecommendedS)
+	}
+	if a.TrueS != 21.6 { // median of {21.5,21.6,21.7}
+		t.Errorf("true median: got %v want 21.6", a.TrueS)
+	}
+}
+
+func TestAchievedOffsetEmpty(t *testing.T) {
+	for _, body := range []string{`{"items":[]}`, `{}`, `{"items":[{"player_metrics":{}}]}`, `not json`} {
+		if a := AchievedOffsetFromEvents([]byte(body)); a.HasData {
+			t.Errorf("%s: expected no data", body)
+		}
+	}
+}
+
+func TestManipulationLanded(t *testing.T) {
+	cases := []struct {
+		name     string
+		intended float64
+		achieved AchievedOffset
+		want     bool
+	}{
+		// The androidtv run that motivated the gate: intended 6, achieved ~21.5.
+		{"did not land (6 vs 21.5)", 6, AchievedOffset{RecommendedS: 21.5, HasData: true}, false},
+		{"landed exactly", 6, AchievedOffset{RecommendedS: 6, HasData: true}, true},
+		{"landed within abs tolerance", 6, AchievedOffset{RecommendedS: 7.5, HasData: true}, true},  // tol = max(2, 1.5) = 2
+		{"landed within frac tolerance", 24, AchievedOffset{RecommendedS: 28, HasData: true}, true}, // tol = max(2, 6) = 6
+		{"outside frac tolerance", 24, AchievedOffset{RecommendedS: 33, HasData: true}, false},      // 9 > 6
+		{"falls back to true offset", 6, AchievedOffset{TrueS: 6.5, HasData: true}, true},           // recommended 0 → use true
+		{"no data → don't false-flag", 6, AchievedOffset{HasData: false}, true},
+		{"data present but zero → don't flag", 6, AchievedOffset{HasData: true}, true},
+	}
+	for _, c := range cases {
+		if got := ManipulationLanded(c.intended, c.achieved); got != c.want {
+			t.Errorf("%s: got %v want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestMarkInconclusive(t *testing.T) {
+	e := &Experiment{Result: &Result{Verdict: VerdictAberration, Note: "label says bad"}}
+	bucket := MarkInconclusive(e, "IV did not move: intended 6s, achieved 21.5s")
+	if bucket != StatusReview {
+		t.Errorf("bucket: got %s want %s", bucket, StatusReview)
+	}
+	if e.Result.Verdict != VerdictInconclusive {
+		t.Errorf("verdict: got %s want %s", e.Result.Verdict, VerdictInconclusive)
+	}
+	if e.Result.Note == "label says bad" || e.Result.Note == "IV did not move: intended 6s, achieved 21.5s" {
+		t.Errorf("note should append, not replace: %q", e.Result.Note)
+	}
+	// nil-Result path must not panic.
+	e2 := &Experiment{}
+	if MarkInconclusive(e2, "x") != StatusReview || e2.Result == nil {
+		t.Error("nil-Result path failed")
+	}
+}

--- a/tools/harness-cli/internal/sweep/manipulation_test.go
+++ b/tools/harness-cli/internal/sweep/manipulation_test.go
@@ -50,24 +50,35 @@ func TestAchievedOffsetEmpty(t *testing.T) {
 }
 
 func TestManipulationLanded(t *testing.T) {
+	s6 := SegmentSlackS("s6") // 7
+	s2 := SegmentSlackS("s2") // 3
 	cases := []struct {
 		name     string
 		intended float64
 		achieved AchievedOffset
+		slack    float64
 		want     bool
 	}{
-		// The androidtv run that motivated the gate: intended 6, achieved ~21.5.
-		{"did not land (6 vs 21.5)", 6, AchievedOffset{RecommendedS: 21.5, HasData: true}, false},
-		{"landed exactly", 6, AchievedOffset{RecommendedS: 6, HasData: true}, true},
-		{"landed within abs tolerance", 6, AchievedOffset{RecommendedS: 7.5, HasData: true}, true},  // tol = max(2, 1.5) = 2
-		{"landed within frac tolerance", 24, AchievedOffset{RecommendedS: 28, HasData: true}, true}, // tol = max(2, 6) = 6
-		{"outside frac tolerance", 24, AchievedOffset{RecommendedS: 33, HasData: true}, false},      // 9 > 6
-		{"falls back to true offset", 6, AchievedOffset{TrueS: 6.5, HasData: true}, true},           // recommended 0 → use true
-		{"no data → don't false-flag", 6, AchievedOffset{HasData: false}, true},
-		{"data present but zero → don't flag", 6, AchievedOffset{HasData: true}, true},
+		// The androidtv run that motivated the gate: intended 6 on 6s segments,
+		// achieved ~21.5 (clamped to the 3×7 floor). 15.5 > slack 7 → not landed.
+		{"s6 sub-spec did not land (6 vs 21.5)", 6, AchievedOffset{RecommendedS: 21.5, HasData: true}, s6, false},
+		// s6 cross arm: intended 12, clamped to ~21 → 9 > slack 7 → not landed.
+		{"s6 cross (12 vs 21) not landed", 12, AchievedOffset{RecommendedS: 21, HasData: true}, s6, false},
+		// s6 deep arm honoured: intended 36, achieved ~36 → landed.
+		{"s6 deep honoured (36 vs 36)", 36, AchievedOffset{RecommendedS: 36, HasData: true}, s6, true},
+		// s6 deep NOT honoured: stayed ~21 → 15 > slack 7 → not landed.
+		{"s6 deep ignored (36 vs 21) not landed", 36, AchievedOffset{RecommendedS: 21, HasData: true}, s6, false},
+		// s2 cross arm legal + honoured: intended 12, achieved ~12 → landed.
+		{"s2 cross honoured (12 vs 12)", 12, AchievedOffset{RecommendedS: 12, HasData: true}, s2, true},
+		// Segment slack absorbs boundary quantization: intended 12 on s6, got 18
+		// (one 6-7s segment off) → 6 ≤ slack 7 → still counts as landed.
+		{"s6 segment-boundary slack (12 vs 18)", 12, AchievedOffset{RecommendedS: 18, HasData: true}, s6, true},
+		{"falls back to true offset", 6, AchievedOffset{TrueS: 6.5, HasData: true}, s2, true},
+		{"no data → don't false-flag", 6, AchievedOffset{HasData: false}, s6, true},
+		{"data present but zero → don't flag", 6, AchievedOffset{HasData: true}, s6, true},
 	}
 	for _, c := range cases {
-		if got := ManipulationLanded(c.intended, c.achieved); got != c.want {
+		if got := ManipulationLanded(c.intended, c.achieved, c.slack); got != c.want {
 			t.Errorf("%s: got %v want %v", c.name, got, c.want)
 		}
 	}

--- a/tools/harness-cli/internal/sweep/scheduler_test.go
+++ b/tools/harness-cli/internal/sweep/scheduler_test.go
@@ -52,8 +52,9 @@ func TestSelectNextEmpty(t *testing.T) {
 
 func TestSeedNarrowConfigClass(t *testing.T) {
 	es := Seed(ClassConfig, false, "2026-06-13T00:00:00Z")
-	// 1 platform × len(seedProtocols) × len(configRecipes)
-	want := len(seedProtocols) * len(configRecipes)
+	// 1 platform × len(seedProtocols) × the full config recipe set
+	// (configRecipes + the live-offset matrix, via recipesFor).
+	want := len(seedProtocols) * len(recipesFor(ClassConfig))
 	if len(es) != want {
 		t.Fatalf("narrow config seed want %d, got %d", want, len(es))
 	}
@@ -78,6 +79,43 @@ func TestSeedNarrowConfigClass(t *testing.T) {
 	}
 }
 
+func TestLiveOffsetMatrixArms(t *testing.T) {
+	es := Seed(ClassConfig, false, "2026-06-13T00:00:00Z")
+	var segs, offs int
+	segSeen := map[string]bool{}
+	groupSeen := map[string]bool{}
+	for _, e := range es {
+		if e.Segment == "" {
+			continue // non-matrix config arm
+		}
+		segs++
+		segSeen[e.Segment] = true
+		if e.Group == "" {
+			t.Errorf("live-offset arm %s has a segment but no comparison group", e.ID)
+		}
+		groupSeen[e.Group] = true
+		if e.ContentManipulation == nil || e.ContentManipulation.LiveOffset == nil {
+			t.Errorf("live-offset arm %s missing live_offset", e.ID)
+		} else {
+			offs++
+		}
+		if e.WhyText == "" || e.LaunchMode != LaunchModeAppium {
+			t.Errorf("arm %s: why_text/launch_mode not stamped", e.ID)
+		}
+	}
+	if segs != 4 || offs != 4 {
+		t.Fatalf("want 4 live-offset matrix arms with offsets, got segs=%d offs=%d", segs, offs)
+	}
+	// Both segment sizes present (the cross-segment comparison), one shared
+	// per-platform group (ipad-sim narrow seed).
+	if !segSeen["s2"] || !segSeen["s6"] {
+		t.Fatalf("matrix must cover both s2 and s6: %v", segSeen)
+	}
+	if len(groupSeen) != 1 {
+		t.Fatalf("narrow matrix arms should share ONE per-platform group, got %v", groupSeen)
+	}
+}
+
 func TestSeedFaultClass(t *testing.T) {
 	es := Seed(ClassFault, false, "2026-06-13T00:00:00Z")
 	want := len(seedProtocols) * len(faultRecipes)
@@ -93,7 +131,7 @@ func TestSeedFaultClass(t *testing.T) {
 
 func TestSeedFullWidens(t *testing.T) {
 	es := Seed(ClassConfig, true, "2026-06-13T00:00:00Z")
-	want := len(fullPlatforms) * len(seedProtocols) * len(configRecipes)
+	want := len(fullPlatforms) * len(seedProtocols) * len(recipesFor(ClassConfig))
 	if len(es) != want {
 		t.Fatalf("full seed want %d, got %d", want, len(es))
 	}

--- a/tools/harness-cli/internal/sweep/seed.go
+++ b/tools/harness-cli/internal/sweep/seed.go
@@ -8,12 +8,15 @@ import "fmt"
 // insane_new for now (§9). The characterization mode drives the bandwidth
 // motion itself (pyramid shapes a pyramid, etc.).
 type seedRecipe struct {
-	family   string // recipe-family slug, for the id
-	mode     string
-	cm       *ContentManipulation
-	shape    *Shape
-	transfer *TransferTimeouts
-	fault    *Fault
+	family    string // recipe-family slug, for the id
+	mode      string
+	segment   string // master variant the probe requests (s2|s6|ll); "" = app default (s6)
+	groupSlug string // non-empty → arms sharing it form a per-platform comparison group
+	whyText   string // optional rationale override (else a generic starter-seed line)
+	cm        *ContentManipulation
+	shape     *Shape
+	transfer  *TransferTimeouts
+	fault     *Fault
 }
 
 func floatPtr(v float64) *float64 { return &v }
@@ -29,8 +32,32 @@ var configRecipes = []seedRecipe{
 	{family: "downshift", mode: "downshift_severity"}, // where over-downshift `notable` surfaces
 	{family: "strip-avgbw", mode: "steps", cm: &ContentManipulation{StripAvgBandwidth: true}},
 	{family: "sparse-ladder", mode: "steps", cm: &ContentManipulation{AllowedVariants: "drop-top-rung"}},
-	{family: "live-offset", mode: "startup", cm: &ContentManipulation{LiveOffset: floatPtr(6)}},
 	{family: "xfer-timeout", mode: "steps", transfer: &TransferTimeouts{ActiveSeconds: 10, AppliesSegments: true}},
+}
+
+// liveOffsetRecipes — the segment × live-offset matrix (#793). live_offset is a
+// load-time/session property (read at manifest join), so each value is its OWN
+// little job (one clean IV per run, which is what the manipulation-check gate
+// needs); the arms share a per-platform group so the dashboard + an LLM
+// synthesis compare them as a set. The hold-back FLOOR is 3× the MAX segment
+// duration, and "6s" segments can round up to 7s → floor ~21s (not 18s); "2s"
+// → ~6-9s. So the same offset is sub-spec on s6 but legal on s2 — the headline
+// comparison. The gate marks a run inconclusive when the achieved offset
+// doesn't reach the intended value (segment-slack-aware), so arms expected NOT
+// to land are real "is this even testable here" probes, not false findings.
+var liveOffsetRecipes = []seedRecipe{
+	{family: "live-offset-s6-cross12", mode: "startup", segment: "s6", groupSlug: "live-offset",
+		cm:      &ContentManipulation{LiveOffset: floatPtr(12)},
+		whyText: "live-offset 12s on 6s segments — below the ~21s floor (3×7) → sub-spec; expect inconclusive (IV clamped to the floor, won't land). The out-of-spec half of the segment×offset comparison (pairs with s2-cross12)."},
+	{family: "live-offset-s2-cross12", mode: "startup", segment: "s2", groupSlug: "live-offset",
+		cm:      &ContentManipulation{LiveOffset: floatPtr(12)},
+		whyText: "live-offset 12s on 2s segments — above the ~6-9s floor → legal; expect it to land. The in-spec half of the segment×offset comparison (pairs with s6-cross12): same offset, opposite outcome by segment size."},
+	{family: "live-offset-s6-deep36", mode: "startup", segment: "s6", groupSlug: "live-offset",
+		cm:      &ContentManipulation{LiveOffset: floatPtr(36)},
+		whyText: "live-offset 36s on 6s segments — well above the ~21s floor and far from the ~21s default → legal; expect it to land (shows s6 CAN honour a deliberately-moved offset, so a non-landing elsewhere is meaningful)."},
+	{family: "live-offset-s2-sub2", mode: "startup", segment: "s2", groupSlug: "live-offset",
+		cm:      &ContentManipulation{LiveOffset: floatPtr(2)},
+		whyText: "live-offset 2s on 2s segments — below the ~6-9s floor → sub-spec; expect inconclusive (clamped to the floor)."},
 }
 
 // faultRecipes — the explicit-error recovery set (separate class). Each injects
@@ -57,12 +84,14 @@ var (
 // H264 build of the "insane new" clip (the catalogue `name`).
 const SeedContent = "insane_new_p200_h264"
 
-// recipesFor returns the recipe set for a class (config is the default).
+// recipesFor returns the recipe set for a class (config is the default). The
+// config set includes the live-offset matrix (#793).
 func recipesFor(class Class) []seedRecipe {
 	if class == ClassFault {
 		return faultRecipes
 	}
-	return configRecipes
+	out := append([]seedRecipe{}, configRecipes...)
+	return append(out, liveOffsetRecipes...)
 }
 
 // Seed builds the starter backlog for one class. full=false is the narrow
@@ -96,16 +125,18 @@ func Seed(class Class, full bool, now string, platformsOverride ...string) []*Ex
 					LaunchMode:          LaunchModeAppium, // every item is driven by appium (the only mode the probe supports), incl. the physical Android TV
 					Protocol:            proto,
 					Content:             SeedContent,
+					Segment:             r.segment,
 					Mode:                r.mode,
 					ContentManipulation: cloneCM(r.cm),
 					Shape:               cloneShape(r.shape),
 					TransferTimeouts:    cloneTransfer(r.transfer),
 					Fault:               cloneFault(r.fault),
 					Kind:                KindSeed,
+					Group:               groupID(r.groupSlug, p),
 					Reps:                1,
 					Depth:               0,
 					Why:                 "starter_seed",
-					WhyText:             fmt.Sprintf("starter %s-class seed: %s recipe (%s) on %s/%s", class, r.family, r.mode, p, proto),
+					WhyText:             seedWhyText(r, class, p, proto),
 				}
 				e.Score = w.Score(e)
 				out = append(out, e)
@@ -113,6 +144,25 @@ func Seed(class Class, full bool, now string, platformsOverride ...string) []*Ex
 		}
 	}
 	return out
+}
+
+// groupID expands a recipe's group slug into a per-platform comparison group
+// id (so arms on the same device compare against each other). Empty slug → no
+// group (the standalone-seed default).
+func groupID(slug, platform string) string {
+	if slug == "" {
+		return ""
+	}
+	return fmt.Sprintf("grp-%s-%s", slug, platform)
+}
+
+// seedWhyText prefers a recipe's explicit rationale; otherwise a generic
+// starter-seed line. Provenance is never blank.
+func seedWhyText(r seedRecipe, class Class, platform, proto string) string {
+	if r.whyText != "" {
+		return r.whyText
+	}
+	return fmt.Sprintf("starter %s-class seed: %s recipe (%s) on %s/%s", class, r.family, r.mode, platform, proto)
 }
 
 func cloneFault(f *Fault) *Fault {

--- a/tools/qe-offhours.sh
+++ b/tools/qe-offhours.sh
@@ -131,6 +131,7 @@ while [ "$iters" -lt "$MAX_ITERS" ] && [ "$(time_left)" -gt 360 ]; do  # need >6
   pattern=$(printf '%s' "$recipe_json" | jq -r '.shape.pattern // empty' 2>/dev/null)
   step=$(printf '%s' "$recipe_json" | jq -r '.shape.step_seconds // 12' 2>/dev/null)
   margin=$(printf '%s' "$recipe_json" | jq -r '.shape.margin_pct // 5' 2>/dev/null)
+  segment=$(printf '%s' "$recipe_json" | jq -r '.segment // empty' 2>/dev/null)  # s2|s6|ll → master variant (#793 live-offset matrix)
 
   # Launch mode is an instruction carried on the item (seed/triage stamp
   # launch_mode=appium); appium is the only mode TestSweepProbe supports and it
@@ -169,6 +170,7 @@ while [ "$iters" -lt "$MAX_ITERS" ] && [ "$(time_left)" -gt 360 ]; do  # need >6
   env CHAR_PLAYER_ID="$player_id" HARNESS_BASE_URL="$HARNESS_BASE_URL" LAUNCH_MODE="$launch" \
       CHAR_SWEEP_PLATFORM="$platform" \
       CHAR_CONTENT="$CONTENT" CHAR_SWEEP_DURATION_S="$DURATION" CHARACTERIZATION_DEVICE_UDID="$device" \
+      ${segment:+CHAR_SWEEP_SEGMENT="$segment"} \
       ${pattern:+CHAR_SWEEP_PATTERN="$pattern" CHAR_SWEEP_STEP_S="$step" CHAR_SWEEP_MARGIN="$margin"} \
       go test ./tests/characterization/modes -run TestSweepProbe -count=1 -v -timeout 8m >"$log" 2>&1
   play_id=$(grep -oE 'play_id: +[0-9a-fA-F-]+' "$log" | head -1 | awk '{print $2}')


### PR DESCRIPTION
Epic #793 — makes the live-offset sweep recipe valid and complete. Buildable scope; Android client-lever (step 4) deferred.

**Commits**
- **Manipulation-check gate** — a live-offset run is only interpretable if changing the knob actually moved the player's *achieved* offset. `analyze` reads the play's `recommended/true_offset_s` from the events archive and, when the recipe set `content_manipulation.live_offset`, compares achieved (median of steady-state samples) to intended. If it didn't move → `inconclusive` → review, never a finding. Verified: re-scoring the androidtv `live_offset=6` finding + 3 reps (achieved ~21.5s) flips them `aberration → inconclusive`.
- **Segment dimension + live-offset matrix** — `live_offset` is a load-time property, so each value is its own little job (one clean IV/run), arms sharing a per-platform comparison group. New `Segment` axis (s2|s6|ll) plumbed recipe→runner(`CHAR_SWEEP_SEGMENT`)→probe(`-is.segment`). Matrix: 12s is sub-spec on 6s segments (floor ~3×7=21s) but legal on 2s — same offset, opposite outcome by segment size. Gate tolerance is segment-aware (hold-back floor = 3× MAX seg; "6s" rounds to 7s; achieved quantizes to segment boundaries).
- **Methodology in the durable homes** — `docs/sweep-design.md §3.1` (manipulation check as a general IV-validity gate + the live-offset worked instance + label-vs-LLM economics) and a `.claude/findings/` entry (live-offset untestable on Android TV: no client lever; manifest sub-spec clamps to the floor).
- **`qoe_live_offset_tight` + direction-aware note** — labels the player running *closer to live* than the manifest hold-back wants (the previously-silent tight direction); the gate's inconclusive note now names shallower-vs-behind so a systematic "won't honor a deeper offset" can be promoted.

**Verified:** `go test ./...` (harness + forwarder), `gofmt`, `go vet`, runner `bash -n`. The 4 ipad-sim matrix arms are seeded and run tonight.

**Deploy note:** `qoe_live_offset_tight` is code-only (labels are dynamic strings, no CH migration) — needs `make analytics-rebuild-forwarder` to emit live.

Part of #793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
