### PR TITLE
feat(266): Android client-side live-offset override + launch config

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
@@ -41,6 +41,13 @@ object LaunchConfig {
     // URL (e.g. "proxy.shape.rate_mbps=2.5"), captured from the launch intent.
     @Volatile
     var proxyQuery: String? = null
+
+    // #266 / #793 live-offset lever: a test-provided override (seconds behind
+    // live) captured from the launch intent so the harness can pin the offset
+    // at startup without driving the Settings UI. Mirrors iOS reading
+    // `-is.flag.live_offset_s` from NSArgumentDomain. null = no override.
+    @Volatile
+    var liveOffsetSeconds: Int? = null
 }
 
 class MainActivity : ComponentActivity() {
@@ -69,6 +76,14 @@ class MainActivity : ComponentActivity() {
                 LaunchConfig.proxyQuery = raw
                 tag("launch-arg proxy_query=$raw")
             }
+        }
+        // #266 / #793 live-offset lever — `--es is.flag.live_offset_s 6`. Parsed
+        // as a number (tolerating "6.0") and rounded to whole seconds; the VM's
+        // loadAdvancedFlags lets this outrank the persisted value for this
+        // launch. Mirrors iOS's `-is.flag.live_offset_s` launch arg.
+        intent?.getStringExtra("is.flag.live_offset_s")?.toDoubleOrNull()?.let { raw ->
+            LaunchConfig.liveOffsetSeconds = raw.toInt().coerceAtLeast(0)
+            tag("launch-arg live_offset_s=${LaunchConfig.liveOffsetSeconds}")
         }
         // Keep the screen on while playback is active — release in onStop.
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
@@ -99,6 +99,16 @@ data class UiState(
     /** Seek to the live edge on every (re)load instead of letting the
      *  manifest's EXT-X-SERVER-CONTROL HOLD-BACK pick the start point. */
     val goLive: Boolean = false,
+    /** User-configurable live-edge offset in seconds. 0 = "use whatever the
+     *  manifest's HOLD-BACK or Go Live setting picks" (default). When > 0
+     *  the player is pinned to that offset behind live via ExoPlayer's
+     *  `LiveConfiguration` target/min/max so ABR rate-adjustment holds it
+     *  rather than drifting away. Go Live takes precedence when both are on
+     *  (snap to edge). Mirrors the Apple `liveOffsetSeconds` flag and the
+     *  `live_offset_s` query param on `testing-session.html` (issues #266 /
+     *  #793). Drivable at launch for tests via the `is.flag.live_offset_s`
+     *  intent extra. */
+    val liveOffsetSeconds: Int = 0,
     /** Skip the Home screen on cold launch when a saved server and a
      *  lastPlayed clip both exist — go straight to Playback so the user
      *  is back inside their stream without waiting for /api/content

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -372,6 +372,14 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                 autoRecovery      = p.getBoolean(FLAG_AUTO_RECOVERY, false),
                 goLive            = p.getBoolean(FLAG_GO_LIVE, false),
                 skipHomeOnLaunch  = p.getBoolean(FLAG_SKIP_HOME, false),
+                // A launch-provided override (the `is.flag.live_offset_s` intent
+                // extra captured by MainActivity) wins over the persisted value,
+                // matching iOS where NSArgumentDomain outranks the saved default.
+                // It is NOT persisted — like an NSArgumentDomain arg it lives
+                // only for this launch, so a manual change in Settings later
+                // still writes through normally.
+                liveOffsetSeconds = (com.infinitestream.player.LaunchConfig.liveOffsetSeconds
+                    ?: p.getInt(FLAG_LIVE_OFFSET, 0)).coerceAtLeast(0),
                 previewVideoSlots = run {
                     // First launch (no key) → hardware default. Otherwise
                     // clamp the stored value to the device's current cap.
@@ -451,6 +459,19 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     fun setSkipHomeOnLaunch(on: Boolean) {
         _state.update { it.copy(skipHomeOnLaunch = on) }
         prefs().edit().putBoolean(FLAG_SKIP_HOME, on).apply()
+    }
+
+    /** User-driven setter for the live-edge offset (seconds). 0 disables
+     *  (manifest HOLD-BACK / Go Live decides). The offset is baked into the
+     *  MediaItem's LiveConfiguration in [loadStream], so apply a change to an
+     *  in-progress play by rebuilding + reloading the stream — mirrors how
+     *  [setLocalProxy] reloads, and gives the same immediate effect as iOS's
+     *  live re-seek. Issue #266 / #793. */
+    fun setLiveOffsetSeconds(seconds: Int) {
+        val clamped = seconds.coerceAtLeast(0)
+        _state.update { it.copy(liveOffsetSeconds = clamped) }
+        prefs().edit().putInt(FLAG_LIVE_OFFSET, clamped).apply()
+        if (_state.value.currentUrl.isNotEmpty()) buildUrlAndLoad()
     }
 
     fun setPreviewVideoSlots(value: Int) {
@@ -777,13 +798,26 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             player.stop()
             player.clearMediaItems()
         }
-        // Match iOS AVPlayer behaviour: let manifest's EXT-X-SERVER-CONTROL pick
-        // the start point, narrow the playback-speed window so ExoPlayer recovers
-        // via rate adjustment (not seeks) after a stall.
+        // Live-edge offset policy (issues #266 / #793):
+        //  - Go Live ON      → snap to the edge (seekToDefaultPosition below);
+        //                      leave the offset UNSET so the manifest decides
+        //                      the window and Go Live takes precedence — same
+        //                      ordering as iOS (goLive beats liveOffsetSeconds).
+        //  - offset > 0       → pin target/min/max to that offset so ABR
+        //                      rate-adjustment holds it rather than drifting,
+        //                      overriding the manifest's HOLD-BACK.
+        //  - otherwise        → UNSET: let manifest's EXT-X-SERVER-CONTROL pick
+        //                      the start point (default behaviour).
+        // The narrow 0.97–1.03 speed window lets ExoPlayer recover toward the
+        // target via rate adjustment (not seeks) after a stall in every case.
+        val offsetMs = if (!_state.value.goLive && _state.value.liveOffsetSeconds > 0)
+            _state.value.liveOffsetSeconds * 1000L
+        else
+            C.TIME_UNSET
         val live = MediaItem.LiveConfiguration.Builder()
-            .setTargetOffsetMs(C.TIME_UNSET)
-            .setMinOffsetMs(C.TIME_UNSET)
-            .setMaxOffsetMs(C.TIME_UNSET)
+            .setTargetOffsetMs(offsetMs)
+            .setMinOffsetMs(offsetMs)
+            .setMaxOffsetMs(offsetMs)
             .setMinPlaybackSpeed(0.97f)
             .setMaxPlaybackSpeed(1.03f)
             .build()
@@ -795,8 +829,54 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             // Snap to live edge after the manifest finishes parsing — ExoPlayer
             // honours seekToDefaultPosition() once the period is known.
             player.seekToDefaultPosition()
+        } else if (_state.value.liveOffsetSeconds > 0) {
+            // Pinning the LiveConfiguration target alone is NOT enough: ExoPlayer
+            // joins at the manifest's EXT-X-START / HOLD-BACK position (~21s for
+            // 6s segments) and then converges to the target ONLY through the
+            // narrow 0.97–1.03 speed window — ~0.03 s/s, so a 40s target takes
+            // ~10 min to reach. Seek straight to liveEdge − offset (iOS parity
+            // with scheduleLiveOffsetSeek); the pinned target/min/max then holds
+            // it there. Issue #266 / #793.
+            scheduleLiveOffsetSeek("playback started")
         }
         metrics?.onPlaybackStarted()
+    }
+
+    /** One-shot job that jumps the playhead to `liveEdge − liveOffsetSeconds`
+     *  once ExoPlayer reports a valid live offset, then lets the pinned
+     *  LiveConfiguration (target=min=max) hold it. Polls every 250 ms for up
+     *  to 20 s while the live window forms. No-op when the offset is 0 or Go
+     *  Live is on. Mirrors iOS `scheduleLiveOffsetSeek`. */
+    private var liveOffsetSeekJob: kotlinx.coroutines.Job? = null
+    private fun scheduleLiveOffsetSeek(reason: String) {
+        liveOffsetSeekJob?.cancel()
+        liveOffsetSeekJob = null
+        val targetSeconds = _state.value.liveOffsetSeconds
+        if (targetSeconds <= 0 || _state.value.goLive) return
+        val targetMs = targetSeconds * 1000L
+        liveOffsetSeekJob = viewModelScope.launch {
+            val deadline = System.currentTimeMillis() + 20_000L
+            while (System.currentTimeMillis() < deadline) {
+                val current = player.currentLiveOffset
+                if (player.isCurrentMediaItemLive && current != C.TIME_UNSET && current > 0) {
+                    // delta > 0 → sit further back (seek earlier); < 0 → closer
+                    // to live (seek later). Only act when we're meaningfully off
+                    // target so we don't fight the speed controller near the mark.
+                    val delta = targetMs - current
+                    if (kotlin.math.abs(delta) > 1000L) {
+                        val seekTo = (player.currentPosition - delta).coerceAtLeast(0L)
+                        player.seekTo(seekTo)
+                        android.util.Log.i("InfiniteStream",
+                            "LIVE OFFSET: seek to ${targetSeconds}s behind live " +
+                                "(was ${current / 1000.0}s, $reason)")
+                    }
+                    return@launch
+                }
+                kotlinx.coroutines.delay(250)
+            }
+            android.util.Log.i("InfiniteStream",
+                "LIVE OFFSET: gave up after 20s (live offset not ready)")
+        }
     }
 
     /** Clear the "currently playing" URL marker. Called by MainActivity on
@@ -1124,6 +1204,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
     override fun onCleared() {
         super.onCleared()
         playIdRotationJob?.cancel()
+        liveOffsetSeekJob?.cancel()
         metrics?.release()
         player.release()
     }
@@ -1138,6 +1219,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         private const val FLAG_AUTO_RECOVERY = "advanced_auto_recovery"
         private const val FLAG_GO_LIVE = "advanced_go_live"
         private const val FLAG_SKIP_HOME = "advanced_skip_home_on_launch"
+        private const val FLAG_LIVE_OFFSET = "advanced_live_offset_s"
         private const val FLAG_PREVIEW_VIDEO_SLOTS = "advanced_preview_video_slots"
         private const val FLAG_PLAY_ID_ROTATION = "advanced_play_id_rotation_s"
         private const val LAST_PLAYED_KEY = "last_played_content"

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -400,6 +400,13 @@ private fun PickerList(
                         )
                     }
                     item {
+                        LiveOffsetRow(
+                            seconds = state.liveOffsetSeconds,
+                            enabled = !state.goLive,
+                            onChange = { vm.setLiveOffsetSeconds(it) },
+                        )
+                    }
+                    item {
                         PickerItem(
                             label = "Skip Home on launch (auto-resume last stream)",
                             selected = state.skipHomeOnLaunch,
@@ -653,6 +660,59 @@ private fun PreviewVideoSlotsRow(
             symbol = "+",
             enabled = slots < hardwareCap,
             onClick = { onChange(slots + 1) },
+        )
+    }
+}
+
+/**
+ * Numeric stepper for the user-configurable live-edge offset (seconds).
+ * 0 = use the manifest's HOLD-BACK / Go Live default; otherwise the player
+ * is pinned that many seconds behind the live edge. Capped at 60 s in 1 s
+ * steps. When Go Live is on it takes precedence, so the row renders disabled
+ * with an explanatory subtitle. Mirrors the Apple `LiveOffsetRow` and the
+ * `live_offset_s` query param on `testing-session.html` (issues #266 / #793).
+ */
+@Composable
+private fun LiveOffsetRow(
+    seconds: Int,
+    enabled: Boolean,
+    onChange: (Int) -> Unit,
+) {
+    val maxOffset = 60
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(60.dp)
+            .clip(RoundedCornerShape(Radius.row))
+            .background(Tokens.bgSoft)
+            .padding(horizontal = Space.s4),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                "Live offset (seconds behind live)",
+                style = AppType.body.copy(color = if (enabled) Tokens.fg else Tokens.fgFaint),
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                when {
+                    !enabled -> "Overridden by Go Live (snaps to edge)"
+                    seconds <= 0 -> "Off — use manifest HOLD-BACK"
+                    else -> "${seconds}s behind live edge"
+                },
+                style = AppType.monoSm.copy(color = Tokens.fgFaint),
+            )
+        }
+        StepperButton(
+            symbol = "−",
+            enabled = enabled && seconds > 0,
+            onClick = { onChange(seconds - 1) },
+        )
+        Spacer(Modifier.width(Space.s2))
+        StepperButton(
+            symbol = "+",
+            enabled = enabled && seconds < maxOffset,
+            onClick = { onChange(seconds + 1) },
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds the **Android client-side live-offset lever**, mirroring iOS — closes the Android gap in #266 and lands #793 sub-task #4/#12 ("Android client lever"). Before this, Android pinned `LiveConfiguration.targetOffsetMs` at `C.TIME_UNSET`, so the manifest's `HOLD-BACK` fully decided the offset and `live_offset` was **untestable** on Android (its sweep arms always came back inconclusive).

Now there's a user setting **and** a test-startup config path, both behaving like their iOS counterparts.

## What changed

- **`PlayerState`** — new `liveOffsetSeconds` on `UiState` (`0` = manifest decides, default).
- **`PlayerViewModel`**
  - `loadStream()` builds `LiveConfiguration` target/min/max from the offset. Go Live keeps precedence (snap to edge); otherwise `C.TIME_UNSET` (manifest default).
  - `scheduleLiveOffsetSeek()` — **seeks straight to `liveEdge − offset`** on load. `LiveConfiguration` alone only converges via the narrow 0.97–1.03 speed window (~0.03 s/s), and ExoPlayer honours the manifest's `EXT-X-START` for the initial join, so a 40s target would take ~10 min to reach. The seek jumps there immediately; the pinned config then holds it. Mirrors iOS `scheduleLiveOffsetSeek`.
  - `setLiveOffsetSeconds()` setter — persists + reloads an in-progress play (same pattern as `setLocalProxy`).
  - `loadAdvancedFlags()` lets a launch override outrank the persisted value (and does **not** persist it), matching iOS NSArgumentDomain.
- **`MainActivity`** — `LaunchConfig` reads the `is.flag.live_offset_s` intent extra at cold start. The appium launcher already maps `-is.X Y` → `--es is.X Y`, so any seeded harness arm passing the flag pins Android with **no further harness wiring**.
- **`SettingsOverlay`** — "Live offset (seconds behind live)" stepper (1–60 s) in Settings → Advanced, placed after Go Live to match iOS ordering; disables with "Overridden by Go Live" when Go Live is on.

## Approach note vs. iOS
iOS seeks to `liveEdge − offset` (AVPlayer has no target-offset API). Android uses ExoPlayer's native `LiveConfiguration` to *hold* the offset **plus** a seek to *reach* it — because neither `targetOffsetMs` nor `min/max` overrides the manifest's `EXT-X-START` for the initial join. User-facing behaviour and the `is.flag.live_offset_s` knob are identical across platforms.

## Verification (Google TV Streamer)
- UI: setting 40s seeks the playhead to ~40s behind live and holds (`bufDepth` settles ~33s — the media-bound ceiling, as expected).
- Launch config: cold launch with `--es is.flag.live_offset_s 40` → `launch-arg live_offset_s=40` captured, **overrides the persisted 28**, seek lands ~40s (joined at 22s), and the override is **not** persisted afterward.

## Out of scope
- Harness `seed.go` arm that emits `-is.flag.live_offset_s` (the delivery path now works end-to-end; only the recipe is missing — separate #793 task).
- Server-side `EXT-X-START` / HOLD-BACK changes (explicitly out of scope per #266/#793).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)
