### PR TITLE
feat(797): Android launch levers — is.segment / is.protocol / is.flag.peak_bitrate_mbps

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
@@ -48,6 +48,19 @@ object LaunchConfig {
     // `-is.flag.live_offset_s` from NSArgumentDomain. null = no override.
     @Volatile
     var liveOffsetSeconds: Int? = null
+
+    // #797 characterization launch levers, mirroring iOS `-is.segment` /
+    // `-is.protocol` / `-is.flag.peak_bitrate_mbps`. Each captured from the
+    // launch intent so the harness can drive the test matrix without touching
+    // the Settings UI. null = no override; the VM's loadAdvancedFlags lets a
+    // non-null value outrank the default/persisted value for this launch,
+    // matching iOS NSArgumentDomain.
+    @Volatile
+    var segment: com.infinitestream.player.state.Segment? = null
+    @Volatile
+    var streamProtocol: com.infinitestream.player.state.Protocol? = null
+    @Volatile
+    var peakBitrateMbps: Int? = null
 }
 
 class MainActivity : ComponentActivity() {
@@ -84,6 +97,30 @@ class MainActivity : ComponentActivity() {
         intent?.getStringExtra("is.flag.live_offset_s")?.toDoubleOrNull()?.let { raw ->
             LaunchConfig.liveOffsetSeconds = raw.toInt().coerceAtLeast(0)
             tag("launch-arg live_offset_s=${LaunchConfig.liveOffsetSeconds}")
+        }
+        // #797 segment lever — `--es is.segment s2` (iOS rawValues ll / s2 / s6).
+        // Selects the master_2s / master_6s / LL ladder; unblocks the 2s/LL
+        // matrix on Android. Unrecognised values are ignored (no override).
+        intent?.getStringExtra("is.segment")?.let { raw ->
+            com.infinitestream.player.state.Segment.fromArg(raw)?.let { seg ->
+                LaunchConfig.segment = seg
+                tag("launch-arg segment=${seg.label}")
+            }
+        }
+        // #797 protocol lever — `--es is.protocol dash` (hls / dash). Drives
+        // Android to DASH, which the Settings-only Protocol picker couldn't.
+        intent?.getStringExtra("is.protocol")?.let { raw ->
+            com.infinitestream.player.state.Protocol.fromArg(raw)?.let { proto ->
+                LaunchConfig.streamProtocol = proto
+                tag("launch-arg protocol=${proto.label}")
+            }
+        }
+        // #797 ABR peak-bitrate cap — `--es is.flag.peak_bitrate_mbps 4` (Mbps;
+        // 0 = no cap). Parsed as a number (tolerating "4.0"). Mirrors iOS's
+        // `-is.flag.peak_bitrate_mbps` (AVPlayerItem.preferredPeakBitRate).
+        intent?.getStringExtra("is.flag.peak_bitrate_mbps")?.toDoubleOrNull()?.let { raw ->
+            LaunchConfig.peakBitrateMbps = raw.toInt().coerceAtLeast(0)
+            tag("launch-arg peak_bitrate_mbps=${LaunchConfig.peakBitrateMbps}")
         }
         // Keep the screen on while playback is active — release in onStop.
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
@@ -49,9 +49,33 @@ data class ContentItem(
     val thumbnailPathLarge: String? = null,
 )
 
-enum class Protocol(val label: String) { HLS("HLS"), DASH("DASH") }
+enum class Protocol(val label: String) {
+    HLS("HLS"), DASH("DASH");
+
+    companion object {
+        /** Map an `is.protocol` launch-arg / wire value (iOS `StreamProtocol`
+         *  rawValue: `hls` / `dash`) to the enum. null = unrecognised. #797. */
+        fun fromArg(raw: String): Protocol? = when (raw.trim().lowercase()) {
+            "hls" -> HLS
+            "dash" -> DASH
+            else -> null
+        }
+    }
+}
 enum class Segment(val label: String, val suffix: String) {
-    LL("LL", ""), TWO("2s", "_2s"), SIX("6s", "_6s")
+    LL("LL", ""), TWO("2s", "_2s"), SIX("6s", "_6s");
+
+    companion object {
+        /** Map an `is.segment` launch-arg / wire value (iOS `SegmentLength`
+         *  rawValue: `ll` / `s2` / `s6`) to the enum; tolerates the `2s`/`6s`
+         *  label form too. null = unrecognised. #797. */
+        fun fromArg(raw: String): Segment? = when (raw.trim().lowercase()) {
+            "ll" -> LL
+            "s2", "2s" -> TWO
+            "s6", "6s" -> SIX
+            else -> null
+        }
+    }
 }
 enum class Codec(val label: String) { AUTO("Auto"), H264("H.264"), HEVC("HEVC"), AV1("AV1") }
 
@@ -109,6 +133,12 @@ data class UiState(
      *  #793). Drivable at launch for tests via the `is.flag.live_offset_s`
      *  intent extra. */
     val liveOffsetSeconds: Int = 0,
+    /** ABR peak-bitrate ceiling in Mbps. 0 = no cap (default). When > 0 the
+     *  ExoPlayer track selector won't pick a video rung whose bitrate exceeds
+     *  this — the analog of iOS `AVPlayerItem.preferredPeakBitRate`. Persisted
+     *  alongside the other Advanced flags, and drivable at launch for tests
+     *  via the `is.flag.peak_bitrate_mbps` intent extra (issue #797). */
+    val peakBitrateMbps: Int = 0,
     /** Skip the Home screen on cold launch when a saved server and a
      *  lastPlayed clip both exist — go straight to Playback so the user
      *  is back inside their stream without waiting for /api/content

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -324,6 +324,9 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             )
         }
         loadAdvancedFlags()
+        // Re-push the (now-default) flags into the track selector so a cleared
+        // peak-bitrate cap / 4K setting actually takes effect (#797).
+        applyTrackSelectionParameters()
     }
 
     /** Returns the index of the (possibly newly-added) server, or -1. */
@@ -380,6 +383,16 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                 // still writes through normally.
                 liveOffsetSeconds = (com.infinitestream.player.LaunchConfig.liveOffsetSeconds
                     ?: p.getInt(FLAG_LIVE_OFFSET, 0)).coerceAtLeast(0),
+                // #797 characterization launch levers. segment/protocol are not
+                // persisted on Android (UI-only state), so a launch override
+                // just seeds the initial value for this launch; absent one the
+                // current default stands. peak_bitrate_mbps IS persisted (iOS
+                // parity) — a launch override outranks the stored value and is
+                // not written back. 0 Mbps = no ABR ceiling.
+                segment  = com.infinitestream.player.LaunchConfig.segment ?: it.segment,
+                protocol = com.infinitestream.player.LaunchConfig.streamProtocol ?: it.protocol,
+                peakBitrateMbps = (com.infinitestream.player.LaunchConfig.peakBitrateMbps
+                    ?: p.getInt(FLAG_PEAK_BITRATE, 0)).coerceAtLeast(0),
                 previewVideoSlots = run {
                     // First launch (no key) → hardware default. Otherwise
                     // clamp the stored value to the device's current cap.
@@ -480,16 +493,33 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         prefs().edit().putInt(FLAG_PREVIEW_VIDEO_SLOTS, clamped).apply()
     }
 
+    /** #797 ABR peak-bitrate ceiling (Mbps; 0 = no cap). Maps to ExoPlayer's
+     *  track selector `setMaxVideoBitrate` — the analog of iOS
+     *  `AVPlayerItem.preferredPeakBitRate`. The selector parameter is mutable
+     *  mid-play, so re-applying it takes effect on the next ABR decision
+     *  without a reload. Persisted like the other Advanced flags. */
+    fun setPeakBitrateMbps(mbps: Int) {
+        val clamped = mbps.coerceAtLeast(0)
+        _state.update { it.copy(peakBitrateMbps = clamped) }
+        prefs().edit().putInt(FLAG_PEAK_BITRATE, clamped).apply()
+        applyTrackSelectionParameters()
+    }
+
     /**
-     * Push the current flag set into ExoPlayer's track selector. Today only
-     * `allow4K` matters here — when off we cap to 1080 p so the chip's
-     * decoder isn't asked to do 4K H.264 if the network would otherwise
-     * pull the top rung of the ladder.
+     * Push the current flag set into ExoPlayer's track selector. `allow4K`
+     * caps the resolution (1080 p when off, so the chip isn't asked to decode
+     * 4K). `peakBitrateMbps` caps the bitrate of the rung ABR may select
+     * (#797) — the analog of iOS `preferredPeakBitRate`; 0 leaves it
+     * uncapped.
      */
     private fun applyTrackSelectionParameters() {
         val cap = if (_state.value.allow4K) Int.MAX_VALUE else 1080
+        // Mbps → bps. 0 (or anything that would overflow Int) = no cap.
+        val peakMbps = _state.value.peakBitrateMbps
+        val peakBps = if (peakMbps in 1..2000) peakMbps * 1_000_000 else Int.MAX_VALUE
         player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
             .setMaxVideoSize(if (_state.value.allow4K) Int.MAX_VALUE else 1920, cap)
+            .setMaxVideoBitrate(peakBps)
             .build()
     }
 
@@ -1220,6 +1250,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         private const val FLAG_GO_LIVE = "advanced_go_live"
         private const val FLAG_SKIP_HOME = "advanced_skip_home_on_launch"
         private const val FLAG_LIVE_OFFSET = "advanced_live_offset_s"
+        private const val FLAG_PEAK_BITRATE = "advanced_peak_bitrate_mbps"
         private const val FLAG_PREVIEW_VIDEO_SLOTS = "advanced_preview_video_slots"
         private const val FLAG_PLAY_ID_ROTATION = "advanced_play_id_rotation_s"
         private const val LAST_PLAYED_KEY = "last_played_content"

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -427,6 +427,12 @@ private fun PickerList(
                         )
                     }
                     item {
+                        PeakBitrateRow(
+                            mbps = state.peakBitrateMbps,
+                            onChange = { vm.setPeakBitrateMbps(it) },
+                        )
+                    }
+                    item {
                         PickerItem(
                             label = "HUD",
                             selected = state.developerMode,
@@ -750,6 +756,62 @@ private fun PlayIdRotationRow(seconds: Int, onChange: (Int) -> Unit) {
             presets.forEachIndexed { index, (label, value) ->
                 if (index > 0) Spacer(Modifier.width(Space.s2))
                 val active = seconds == value
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(if (active) Tokens.accent else Tokens.bgCard)
+                        .tvFocus(cornerRadius = 8.dp)
+                        .clickable(onClick = { onChange(value) })
+                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        label,
+                        style = AppType.monoSm.copy(
+                            color = if (active) Tokens.bg else Tokens.fg,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Preset selector for the ABR peak-bitrate ceiling (Mbps). 0 = no cap; any
+ * other value pins the ExoPlayer track selector so it won't pick a video rung
+ * above that bitrate. The analog of the Apple peak-bitrate clamp and the
+ * `is.flag.peak_bitrate_mbps` launch lever (issue #797).
+ */
+@Composable
+private fun PeakBitrateRow(mbps: Int, onChange: (Int) -> Unit) {
+    val presets = listOf(
+        "Off" to 0,
+        "2" to 2,
+        "4" to 4,
+        "8" to 8,
+        "16" to 16,
+    )
+    val subtitle = if (mbps <= 0) "Off — ABR may pick any rung"
+                   else "Cap ABR at ${mbps} Mbps"
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(Radius.row))
+            .background(Tokens.bgSoft)
+            .padding(horizontal = Space.s4, vertical = Space.s3),
+    ) {
+        Text(
+            "Peak bitrate cap (ABR ceiling)",
+            style = AppType.body.copy(color = Tokens.fg),
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(subtitle, style = AppType.monoSm.copy(color = Tokens.fgFaint))
+        Spacer(Modifier.height(Space.s2))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            presets.forEachIndexed { index, (label, value) ->
+                if (index > 0) Spacer(Modifier.width(Space.s2))
+                val active = mbps == value
                 Box(
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))


### PR DESCRIPTION
## Summary

Closes the **priority-1 Android-parity gap** from #797. The characterization probe drives client apps via `-is.X` launch args (mapped to `--es is.X` for Android appium), but Android read only 3 (`is.player_id`, `is.proxy_query`, `is.flag.live_offset_s`). This adds the P1 trio that unblocks concrete matrices — the **2s/LL ladder**, **DASH**, and the **ABR-cap** dimension — modelled directly on the #796 `live_offset_s` precedent.

| Lever | Wire values | Android wiring |
|---|---|---|
| `is.segment` | `ll` / `s2` / `s6` | `Segment.fromArg` → existing `Segment` enum; not persisted (seeds the launch) |
| `is.protocol` | `hls` / `dash` | `Protocol.fromArg` → existing `Protocol` enum; not persisted; drives DASH |
| `is.flag.peak_bitrate_mbps` | int Mbps (`0` = no cap) | **new knob** → ExoPlayer `trackSelectionParameters.setMaxVideoBitrate` (the `preferredPeakBitRate` analog); persisted, mutable mid-play |

## What changed

Each lever follows the #796 pattern:

- **`PlayerState`** — new `peakBitrateMbps` field; `Segment.fromArg` / `Protocol.fromArg` companions map iOS wire rawValues to the enums.
- **`MainActivity`** — `LaunchConfig` captures the three intent extras at cold start (with the existing `tag("launch-arg …")` breadcrumbs).
- **`PlayerViewModel`** — `loadAdvancedFlags` lets a launch override outrank the default/persisted value (iOS NSArgumentDomain semantics); `applyTrackSelectionParameters` adds `setMaxVideoBitrate`; new `setPeakBitrateMbps` setter + `FLAG_PEAK_BITRATE`. Also re-applies track-selection params after `resetAllSettings` so a cleared peak cap (and the pre-existing `allow4K`) actually takes effect.
- **`SettingsOverlay`** — peak-bitrate preset row (Off/2/4/8/16 Mbps). Segment/protocol already had Settings pickers.

Semantics note: `segment`/`protocol` are UI-only state on Android (not persisted), so a launch override just seeds the initial value for that launch. `peak_bitrate_mbps` IS persisted (iOS parity); a launch override outranks the stored value and is not written back.

## Verification

- `./gradlew :app:compileDebugKotlin` → **BUILD SUCCESSFUL**.
- ⚠️ **Not yet runtime-verified on hardware** — the Google TV Streamer has a release-signed build, so installing the debug variant needs an uninstall (wipes saved server/settings). Behavioral verification (cold-launch `--es is.segment s2` → fetches `master_2s`; `--es is.flag.peak_bitrate_mbps 4` → ABR ceiling) is a follow-up on a fresh/test device.

## Follow-up

P2 batch (`is.codec`, `is.content`, `is.flag.4k`, `is.flag.starts_first_variant`, `is.flag.go_live`, `is.flag.play_id_rotation_s`) lands in a second PR per the sizing note on #797.

Refs #797. Refs #796 (the `live_offset_s` template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
