### PR TITLE
feat(797): Android launch levers P2 — codec / 4k / go_live / play_id_rotation_s / starts_first_variant / content

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/MainActivity.kt
@@ -61,6 +61,33 @@ object LaunchConfig {
     var streamProtocol: com.infinitestream.player.state.Protocol? = null
     @Volatile
     var peakBitrateMbps: Int? = null
+
+    // #797 priority-2 levers, same launch-override semantics as above. codec is
+    // UI-only state (not persisted); 4k / go_live / play_id_rotation_s /
+    // starts_first_variant override their persisted Advanced flags; lastPlayed
+    // pins which clip the Continue-Watching hero / auto-resume targets (the
+    // harness drives this via `is.lastPlayed`, with `is.content` as an alias).
+    @Volatile
+    var codec: com.infinitestream.player.state.Codec? = null
+    @Volatile
+    var allow4K: Boolean? = null
+    @Volatile
+    var goLive: Boolean? = null
+    @Volatile
+    var playIdRotationSeconds: Int? = null
+    @Volatile
+    var startsFirstVariant: Boolean? = null
+    @Volatile
+    var lastPlayed: String? = null
+}
+
+/** Parse a launch-arg boolean intent extra. The harness sends booleans as
+ *  `true`/`false` strings (NSArgumentDomain on iOS); tolerate `1`/`0`/`yes`/`no`
+ *  too. null = unparseable (leave the override unset). #797. */
+private fun boolArg(raw: String): Boolean? = when (raw.trim().lowercase()) {
+    "true", "1", "yes" -> true
+    "false", "0", "no" -> false
+    else -> null
 }
 
 class MainActivity : ComponentActivity() {
@@ -121,6 +148,53 @@ class MainActivity : ComponentActivity() {
         intent?.getStringExtra("is.flag.peak_bitrate_mbps")?.toDoubleOrNull()?.let { raw ->
             LaunchConfig.peakBitrateMbps = raw.toInt().coerceAtLeast(0)
             tag("launch-arg peak_bitrate_mbps=${LaunchConfig.peakBitrateMbps}")
+        }
+        // #797 P2 codec lever — `--es is.codec hevc` (auto / h264 / hevc / av1).
+        intent?.getStringExtra("is.codec")?.let { raw ->
+            com.infinitestream.player.state.Codec.fromArg(raw)?.let { c ->
+                LaunchConfig.codec = c
+                tag("launch-arg codec=${c.label}")
+            }
+        }
+        // #797 P2 4K-ladder lever — `--es is.flag.4k true`. A baseline flag the
+        // harness sets on every launch, so honouring it stops a stale persisted
+        // 4K toggle from leaking into a run (mirrors iOS NSArgumentDomain).
+        intent?.getStringExtra("is.flag.4k")?.let { raw ->
+            boolArg(raw)?.let { on ->
+                LaunchConfig.allow4K = on
+                tag("launch-arg 4k=$on")
+            }
+        }
+        // #797 P2 Go-Live lever — `--es is.flag.go_live true` (snap to live edge).
+        intent?.getStringExtra("is.flag.go_live")?.let { raw ->
+            boolArg(raw)?.let { on ->
+                LaunchConfig.goLive = on
+                tag("launch-arg go_live=$on")
+            }
+        }
+        // #797 P2 play_id rotation lever — `--es is.flag.play_id_rotation_s 0`
+        // (seconds; 0 = one play_id per session). Soak-run knob.
+        intent?.getStringExtra("is.flag.play_id_rotation_s")?.toDoubleOrNull()?.let { raw ->
+            LaunchConfig.playIdRotationSeconds = raw.toInt().coerceAtLeast(0)
+            tag("launch-arg play_id_rotation_s=${LaunchConfig.playIdRotationSeconds}")
+        }
+        // #797 P2 startup-rung lever — `--es is.flag.starts_first_variant true`
+        // (pin the start to the lowest rung, then ABR adapts up at first frame).
+        intent?.getStringExtra("is.flag.starts_first_variant")?.let { raw ->
+            boolArg(raw)?.let { on ->
+                LaunchConfig.startsFirstVariant = on
+                tag("launch-arg starts_first_variant=$on")
+            }
+        }
+        // #797 P2 content selection — the harness pins the played clip with
+        // `--es is.lastPlayed <name>`; accept `is.content` as an alias for the
+        // name the issue uses. Seeds lastPlayed so the hero / auto-resume target
+        // that clip (iOS reads `is.lastPlayed` the same way).
+        (intent?.getStringExtra("is.lastPlayed") ?: intent?.getStringExtra("is.content"))?.let { raw ->
+            if (raw.isNotEmpty()) {
+                LaunchConfig.lastPlayed = raw
+                tag("launch-arg lastPlayed=$raw")
+            }
         }
         // Keep the screen on while playback is active — release in onStop.
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
@@ -77,7 +77,22 @@ enum class Segment(val label: String, val suffix: String) {
         }
     }
 }
-enum class Codec(val label: String) { AUTO("Auto"), H264("H.264"), HEVC("HEVC"), AV1("AV1") }
+enum class Codec(val label: String) {
+    AUTO("Auto"), H264("H.264"), HEVC("HEVC"), AV1("AV1");
+
+    companion object {
+        /** Map an `is.codec` launch-arg / wire value (iOS `CodecFilter`
+         *  rawValue: `auto` / `h264` / `hevc` / `av1`) to the enum.
+         *  null = unrecognised. #797. */
+        fun fromArg(raw: String): Codec? = when (raw.trim().lowercase()) {
+            "auto" -> AUTO
+            "h264" -> H264
+            "hevc" -> HEVC
+            "av1" -> AV1
+            else -> null
+        }
+    }
+}
 
 /** Snapshot of UI state — observed by every screen. */
 data class UiState(
@@ -139,6 +154,14 @@ data class UiState(
      *  alongside the other Advanced flags, and drivable at launch for tests
      *  via the `is.flag.peak_bitrate_mbps` intent extra (issue #797). */
     val peakBitrateMbps: Int = 0,
+    /** Pin the *startup* rendition to the lowest rung, then let ABR adapt
+     *  upward once the first frame is on screen. Off = ABR picks the start
+     *  rung normally (default). The analog of iOS
+     *  `AVPlayerItem.startsOnFirstEligibleVariant`; on Android it's a
+     *  one-shot `setForceLowestBitrate(true)` lock released at first frame.
+     *  Persisted alongside the other Advanced flags, and drivable at launch
+     *  for tests via the `is.flag.starts_first_variant` intent extra (#797). */
+    val startsFirstVariant: Boolean = false,
     /** Skip the Home screen on cold launch when a saved server and a
      *  lastPlayed clip both exist — go straight to Playback so the user
      *  is back inside their stream without waiting for /api/content

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -370,10 +370,14 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         _state.update {
             it.copy(
                 developerMode = p.getBoolean(DEV_MODE_KEY, false),
-                allow4K           = p.getBoolean(FLAG_4K, true),
+                // #797 P2: `is.flag.4k` / `is.flag.go_live` launch overrides
+                // outrank the persisted value for this launch (not written back).
+                allow4K           = com.infinitestream.player.LaunchConfig.allow4K
+                    ?: p.getBoolean(FLAG_4K, true),
                 localProxy        = p.getBoolean(FLAG_LOCAL_PROXY, true),
                 autoRecovery      = p.getBoolean(FLAG_AUTO_RECOVERY, false),
-                goLive            = p.getBoolean(FLAG_GO_LIVE, false),
+                goLive            = com.infinitestream.player.LaunchConfig.goLive
+                    ?: p.getBoolean(FLAG_GO_LIVE, false),
                 skipHomeOnLaunch  = p.getBoolean(FLAG_SKIP_HOME, false),
                 // A launch-provided override (the `is.flag.live_offset_s` intent
                 // extra captured by MainActivity) wins over the persisted value,
@@ -393,6 +397,12 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                 protocol = com.infinitestream.player.LaunchConfig.streamProtocol ?: it.protocol,
                 peakBitrateMbps = (com.infinitestream.player.LaunchConfig.peakBitrateMbps
                     ?: p.getInt(FLAG_PEAK_BITRATE, 0)).coerceAtLeast(0),
+                // #797 P2: codec is UI-only state (not persisted), so a launch
+                // override just seeds it for this launch. starts_first_variant
+                // IS persisted (iOS parity); a launch override outranks it.
+                codec = com.infinitestream.player.LaunchConfig.codec ?: it.codec,
+                startsFirstVariant = com.infinitestream.player.LaunchConfig.startsFirstVariant
+                    ?: p.getBoolean(FLAG_STARTS_FIRST_VARIANT, false),
                 previewVideoSlots = run {
                     // First launch (no key) → hardware default. Otherwise
                     // clamp the stored value to the device's current cap.
@@ -404,9 +414,15 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
                     }
                     stored.coerceIn(0, hwCap)
                 },
-                lastPlayed    = p.getString(LAST_PLAYED_KEY, "") ?: "",
+                // #797 P2: `is.lastPlayed` (the harness's content-selection arg;
+                // `is.content` is an alias) pins which clip the hero / auto-resume
+                // targets. Not persisted from launch — first-frame still writes
+                // the real lastPlayed through normally.
+                lastPlayed    = com.infinitestream.player.LaunchConfig.lastPlayed
+                    ?: (p.getString(LAST_PLAYED_KEY, "") ?: ""),
                 viewCounts    = readViewCounts(p),
-                playIdRotationSeconds = p.getInt(FLAG_PLAY_ID_ROTATION, 0).coerceAtLeast(0),
+                playIdRotationSeconds = (com.infinitestream.player.LaunchConfig.playIdRotationSeconds
+                    ?: p.getInt(FLAG_PLAY_ID_ROTATION, 0)).coerceAtLeast(0),
             )
         }
     }
@@ -469,6 +485,17 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         prefs().edit().putBoolean(FLAG_GO_LIVE, on).apply()
     }
 
+    /** #797 starts_first_variant — pin the startup rung to the lowest variant,
+     *  releasing to free ABR once the first frame renders. The analog of iOS
+     *  `AVPlayerItem.startsOnFirstEligibleVariant`. Takes effect on the next
+     *  (re)load; re-applies the selector now so a toggle while paused-idle is
+     *  consistent. Persisted alongside the other Advanced flags. */
+    fun setStartsFirstVariant(on: Boolean) {
+        _state.update { it.copy(startsFirstVariant = on) }
+        prefs().edit().putBoolean(FLAG_STARTS_FIRST_VARIANT, on).apply()
+        applyTrackSelectionParameters()
+    }
+
     fun setSkipHomeOnLaunch(on: Boolean) {
         _state.update { it.copy(skipHomeOnLaunch = on) }
         prefs().edit().putBoolean(FLAG_SKIP_HOME, on).apply()
@@ -505,21 +532,30 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         applyTrackSelectionParameters()
     }
 
+    /** #797 starts_first_variant: latched false at the start of every play,
+     *  set true once the first frame renders. While the flag is on and this
+     *  is still false, the track selector is pinned to the lowest rung. */
+    private var startupVariantLockReleased = false
+
     /**
      * Push the current flag set into ExoPlayer's track selector. `allow4K`
      * caps the resolution (1080 p when off, so the chip isn't asked to decode
      * 4K). `peakBitrateMbps` caps the bitrate of the rung ABR may select
      * (#797) — the analog of iOS `preferredPeakBitRate`; 0 leaves it
-     * uncapped.
+     * uncapped. `startsFirstVariant` forces the lowest rung until the first
+     * frame is up (the #797 analog of iOS `startsOnFirstEligibleVariant`),
+     * after which [onRenderedFirstFrame] releases the lock and ABR adapts.
      */
     private fun applyTrackSelectionParameters() {
         val cap = if (_state.value.allow4K) Int.MAX_VALUE else 1080
         // Mbps → bps. 0 (or anything that would overflow Int) = no cap.
         val peakMbps = _state.value.peakBitrateMbps
         val peakBps = if (peakMbps in 1..2000) peakMbps * 1_000_000 else Int.MAX_VALUE
+        val forceLowest = _state.value.startsFirstVariant && !startupVariantLockReleased
         player.trackSelectionParameters = player.trackSelectionParameters.buildUpon()
             .setMaxVideoSize(if (_state.value.allow4K) Int.MAX_VALUE else 1920, cap)
             .setMaxVideoBitrate(peakBps)
+            .setForceLowestBitrate(forceLowest)
             .build()
     }
 
@@ -828,6 +864,10 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             player.stop()
             player.clearMediaItems()
         }
+        // #797 starts_first_variant: re-arm the startup low-rung lock for this
+        // play (released again at first frame). No-op when the flag is off.
+        startupVariantLockReleased = false
+        applyTrackSelectionParameters()
         // Live-edge offset policy (issues #266 / #793):
         //  - Go Live ON      → snap to the edge (seekToDefaultPosition below);
         //                      leave the offset UNSET so the manifest decides
@@ -1108,6 +1148,14 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
             override fun onRenderedFirstFrame() {
                 tag("main player: first frame for '${_state.value.selectedContent}'")
                 metrics?.onFirstFrameRendered()
+                // #797 starts_first_variant: first frame is up on the startup
+                // (lowest) rung; release the lock so ABR can adapt upward for
+                // the rest of the play. Mirrors iOS startsOnFirstEligibleVariant.
+                if (_state.value.startsFirstVariant && !startupVariantLockReleased) {
+                    startupVariantLockReleased = true
+                    applyTrackSelectionParameters()
+                    tag("starts_first_variant: released startup low-rung lock")
+                }
                 // Successful frame = the chip allocated decoders for us
                 // and they're functioning, so wipe the codec retry
                 // counter. Next time we hit a decoder fault we get a
@@ -1251,6 +1299,7 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         private const val FLAG_SKIP_HOME = "advanced_skip_home_on_launch"
         private const val FLAG_LIVE_OFFSET = "advanced_live_offset_s"
         private const val FLAG_PEAK_BITRATE = "advanced_peak_bitrate_mbps"
+        private const val FLAG_STARTS_FIRST_VARIANT = "advanced_starts_first_variant"
         private const val FLAG_PREVIEW_VIDEO_SLOTS = "advanced_preview_video_slots"
         private const val FLAG_PLAY_ID_ROTATION = "advanced_play_id_rotation_s"
         private const val LAST_PLAYED_KEY = "last_played_content"

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -434,6 +434,13 @@ private fun PickerList(
                     }
                     item {
                         PickerItem(
+                            label = "Start on lowest rung (ABR adapts up)",
+                            selected = state.startsFirstVariant,
+                            onClick = { vm.setStartsFirstVariant(!state.startsFirstVariant) },
+                        )
+                    }
+                    item {
+                        PickerItem(
                             label = "HUD",
                             selected = state.developerMode,
                             onClick = { vm.setDeveloperMode(!state.developerMode) },


### PR DESCRIPTION
## Summary

Second PR for #797, building on the P1 trio (#798). Adds the **priority-2** launch levers so the characterization probe can drive the rest of the matrix on Android. Each follows the #796 / P1 launch-override pattern (read as `--es is.X Y` intent extras at cold start; a launch override outranks the default/persisted value and is not written back).

| Lever | Wire values | Android wiring |
|---|---|---|
| `is.codec` | `auto`/`h264`/`hevc`/`av1` | `Codec.fromArg` → existing `Codec` enum; UI-only (seeds the launch) |
| `is.flag.4k` | `true`/`false` | `allow4K` — baseline flag set on *every* harness launch; honouring it stops a stale persisted toggle leaking in |
| `is.flag.go_live` | `true`/`false` | `goLive` |
| `is.flag.play_id_rotation_s` | int seconds | `playIdRotationSeconds` (soak knob) |
| `is.flag.starts_first_variant` | `true`/`false` | **new knob** → ExoPlayer `setForceLowestBitrate` at startup, released at first frame (analog of iOS `startsOnFirstEligibleVariant`); persisted + Settings row |
| content | `is.lastPlayed <name>` (`is.content` alias) | seeds `lastPlayed` so the hero / auto-resume targets the clip |

## Notes

- **Boolean extras** parse `true`/`false` (tolerating `1`/`0`/`yes`/`no`) via a shared `boolArg` helper — matches how the harness emits NSArgumentDomain booleans.
- **`starts_first_variant`** is a one-shot lock: `loadStream` re-arms it per play, `onRenderedFirstFrame` releases it so ABR adapts upward. iOS's property is set-once on the item; this is the closest ExoPlayer equivalent.
- **content**: the harness actually emits `is.lastPlayed` (not `is.content`); I wired that and accept `is.content` as an alias for the name the issue uses. Auto-routing to playback still depends on `is.flag.skip_home`, which #797 lists as out of scope for Android — the appium test self-drives playback, so seeding `lastPlayed` (the clip the hero/auto-resume targets) is the useful primitive.

## Out of scope (per #797)

`is.flag.skip_home` / `local_proxy` / `dev_mode` / `muted` — Android uses its own mechanisms. The harness passes some of these to Android as no-op extras, which is fine.

## Verification

- `:app:compileDebugKotlin` → **BUILD SUCCESSFUL**.
- ⚠️ **Not runtime-verified on hardware** — the Google TV Streamer runs a release-signed build, so a debug install needs an uninstall (wipes saved server/settings). The behavioral levers (`starts_first_variant` release, content pinning) want a device pass on a fresh/test device.

With this merged, #797's P1 + P2 lever set is complete and #797 can close.

Refs #797. Refs #796 / #798 (the P1 template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
