### PR TITLE
feat(800): server — per-play app_config (config-on-connect + PATCH, /api/sessions expose)

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -962,6 +962,14 @@ components:
           description: |
             Network shaping (rate / delay / loss / transport_fault).
             *Broadcasts to group on PATCH.*
+        app_config:
+          allOf:
+            - $ref: '#/components/schemas/AppConfig'
+          description: |
+            Client-side config the player applies at its next play boundary
+            (#800). Stored server-side; the player reads it from
+            `GET /api/sessions` and overlays it on the next play.
+            *Broadcasts to group on PATCH.*
         fault_counters:
           allOf:
             - $ref: '#/components/schemas/FaultCounters'
@@ -1078,6 +1086,7 @@ components:
         shape:             { $ref: '#/components/schemas/Shape' }
         transfer_timeouts: { $ref: '#/components/schemas/TransferTimeouts' }
         content:           { $ref: '#/components/schemas/ContentManipulation' }
+        app_config:        { $ref: '#/components/schemas/AppConfig' }
 
     PlayRecord:
       description: |
@@ -1544,6 +1553,44 @@ components:
           enum: [0, 6, 18, 24]
           default: 0
           description: 'Live edge offset window in seconds. 0 = no offset.'
+
+    AppConfig:
+      description: |
+        Client-side ("app behaviour") config the player applies at its next
+        play boundary — the per-play, no-restart counterpart to the cold-start
+        launch args (`is.segment` etc., #797). The proxy stores these per
+        session and surfaces them on `GET /api/sessions`; the player overlays
+        any non-null field onto its own state when it opens the next play
+        (segment/protocol drive the manifest URL; live_offset_s and
+        peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+        null/omitted field leaves the player's own value untouched.
+
+        Server-side (`proxy.*` / ContentManipulation) config already
+        reconfigures per-play with no restart; this brings the client-side
+        half in line. Settable via `PATCH /api/session/{id}` or the
+        `app.<field>` config-on-connect URL args. Issue #800.
+      type: object
+      additionalProperties: false
+      properties:
+        segment:
+          type: string
+          enum: [ll, s2, s6]
+          nullable: true
+          description: 'Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.'
+        protocol:
+          type: string
+          enum: [hls, dash]
+          nullable: true
+          description: 'Streaming protocol for the next play (maps to `is.protocol`).'
+        live_offset_s:
+          type: number
+          format: float
+          nullable: true
+          description: 'Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.'
+        peak_bitrate_mbps:
+          type: integer
+          nullable: true
+          description: 'ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -962,6 +962,14 @@ components:
           description: |
             Network shaping (rate / delay / loss / transport_fault).
             *Broadcasts to group on PATCH.*
+        app_config:
+          allOf:
+            - $ref: '#/components/schemas/AppConfig'
+          description: |
+            Client-side config the player applies at its next play boundary
+            (#800). Stored server-side; the player reads it from
+            `GET /api/sessions` and overlays it on the next play.
+            *Broadcasts to group on PATCH.*
         fault_counters:
           allOf:
             - $ref: '#/components/schemas/FaultCounters'
@@ -1078,6 +1086,7 @@ components:
         shape:             { $ref: '#/components/schemas/Shape' }
         transfer_timeouts: { $ref: '#/components/schemas/TransferTimeouts' }
         content:           { $ref: '#/components/schemas/ContentManipulation' }
+        app_config:        { $ref: '#/components/schemas/AppConfig' }
 
     PlayRecord:
       description: |
@@ -1545,6 +1554,44 @@ components:
           default: 0
           description: 'Live edge offset window in seconds. 0 = no offset.'
 
+    AppConfig:
+      description: |
+        Client-side ("app behaviour") config the player applies at its next
+        play boundary — the per-play, no-restart counterpart to the cold-start
+        launch args (`is.segment` etc., #797). The proxy stores these per
+        session and surfaces them on `GET /api/sessions`; the player overlays
+        any non-null field onto its own state when it opens the next play
+        (segment/protocol drive the manifest URL; live_offset_s and
+        peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+        null/omitted field leaves the player's own value untouched.
+
+        Server-side (`proxy.*` / ContentManipulation) config already
+        reconfigures per-play with no restart; this brings the client-side
+        half in line. Settable via `PATCH /api/session/{id}` or the
+        `app.<field>` config-on-connect URL args. Issue #800.
+      type: object
+      additionalProperties: false
+      properties:
+        segment:
+          type: string
+          enum: [ll, s2, s6]
+          nullable: true
+          description: 'Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.'
+        protocol:
+          type: string
+          enum: [hls, dash]
+          nullable: true
+          description: 'Streaming protocol for the next play (maps to `is.protocol`).'
+        live_offset_s:
+          type: number
+          format: float
+          nullable: true
+          description: 'Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.'
+        peak_bitrate_mbps:
+          type: integer
+          nullable: true
+          description: 'ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap.'
+
     # ----- Manifest / metrics --------------------------------------------
 
     Manifest:
@@ -1590,6 +1637,8 @@ components:
         seekable_end_s:      { type: number, format: float, nullable: true, description: 'Player-reported end of seekable range (seconds).' }
         live_edge_s:         { type: number, format: float, nullable: true, description: 'Player-reported live edge timestamp (seconds).' }
         live_offset_s:       { type: number, format: float, nullable: true, description: 'Player-reported offset behind live edge (seconds).' }
+        recommended_offset_s: { type: number, format: float, nullable: true, description: 'Manifest-recommended target offset from live (iOS recommendedTimeOffsetFromLive / ExoPlayer liveConfiguration.targetOffsetMs). Gates the qoe_live_offset_* labels.' }
+        configured_offset_s: { type: number, format: float, nullable: true, description: 'Configured target offset from live (iOS configuredTimeOffsetFromLive; on Android equals recommended_offset_s).' }
         true_offset_s:       { type: number, format: float, nullable: true, description: 'Wall-clock offset between player position and real time (seconds).' }
         position_s:          { type: number, format: float, nullable: true, description: 'Player current position (seconds).' }
         playback_rate:       { type: number, format: float, nullable: true, description: 'Player playback rate (1.0 = normal).' }

--- a/go-proxy/cmd/server/configconnect.go
+++ b/go-proxy/cmd/server/configconnect.go
@@ -32,6 +32,14 @@ import (
 // proxyArgPrefix is the namespace every config-on-connect URL arg lives under.
 const proxyArgPrefix = "proxy."
 
+// appArgPrefix is the client-side config-on-connect namespace (#800). An
+// `app.<field>` arg is sugar for `proxy.app_config.<field>` — it rides the same
+// merge-patch tree and translator as proxy.*, but lands under the PlayerPatch
+// `app_config` object the player reads back at its next play boundary. Kept as a
+// distinct top-level prefix (not literal `proxy.app_config.`) so client vs
+// server config stay visually separate on the bootstrap URL.
+const appArgPrefix = "app."
+
 // proxyCfgKey is the base64url(JSON) escape-hatch key (full PlayerPatch body).
 const proxyCfgKey = "proxy.cfg"
 
@@ -74,19 +82,29 @@ func parseProxyArgs(q url.Values) (patch map[string]any, hasProxy bool, err erro
 		}
 	}
 
-	// Tier 2 (overrides): individual proxy.<path> args, per-field overlaying cfg.
+	// Tier 2 (overrides): individual proxy.<path> args (per-field overlaying
+	// cfg) plus app.<field> client-config args (#800), both projected onto the
+	// same merge-patch tree.
 	for key, vals := range q {
-		if key == proxyCfgKey || !strings.HasPrefix(key, proxyArgPrefix) {
-			continue
-		}
 		if len(vals) == 0 {
 			continue
 		}
+		var path string
+		switch {
+		case key == proxyCfgKey:
+			continue
+		case strings.HasPrefix(key, proxyArgPrefix):
+			path = strings.TrimPrefix(key, proxyArgPrefix)
+		case strings.HasPrefix(key, appArgPrefix):
+			// app.<field> → app_config.<field> in the PlayerPatch tree (#800).
+			path = "app_config." + strings.TrimPrefix(key, appArgPrefix)
+		default:
+			continue
+		}
 		hasProxy = true
-		path := strings.TrimPrefix(key, proxyArgPrefix)
 		steps, perr := parseArgPath(path)
 		if perr != nil {
-			return nil, false, fmt.Errorf("proxy arg %q: %w", key, perr)
+			return nil, false, fmt.Errorf("config arg %q: %w", key, perr)
 		}
 		// Last value wins for a repeated key (arrays are expressed via [i],
 		// not repetition, so this only matters for accidental duplicates).
@@ -203,8 +221,8 @@ func decodeBase64URL(s string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(s)
 }
 
-// stripProxyArgs rebuilds a raw query string with every proxy.* arg removed,
-// preserving the original order and verbatim encoding of the kept pairs
+// stripProxyArgs rebuilds a raw query string with every proxy.* and app.* arg
+// removed, preserving the original order and verbatim encoding of the kept pairs
 // (player_id, play_id, any passthrough). Used so the 302 redirect to the
 // session port carries no config args — config has already been materialized,
 // and a clean redirect URL keeps proxy.* off the session port and out of the
@@ -226,7 +244,7 @@ func stripProxyArgs(rawQuery string) string {
 		if decoded, err := url.QueryUnescape(name); err == nil {
 			name = decoded
 		}
-		if strings.HasPrefix(name, proxyArgPrefix) {
+		if strings.HasPrefix(name, proxyArgPrefix) || strings.HasPrefix(name, appArgPrefix) {
 			continue
 		}
 		kept = append(kept, p)

--- a/go-proxy/cmd/server/configconnect_test.go
+++ b/go-proxy/cmd/server/configconnect_test.go
@@ -173,6 +173,8 @@ func TestConfigOnConnect_StripProxyArgs(t *testing.T) {
 		{"drops cfg too", "proxy.cfg=ABC&player_id=x", "player_id=x"},
 		{"preserves order", "a=1&proxy.x=2&b=3&proxy.y=4&c=5", "a=1&b=3&c=5"},
 		{"all proxy", "proxy.a=1&proxy.b=2", ""},
+		{"drops app.* too (#800)", "player_id=abc&app.segment=s2&play_id=def", "player_id=abc&play_id=def"},
+		{"mixed proxy + app", "a=1&proxy.x=2&app.protocol=dash&b=3", "a=1&b=3"},
 		{"empty", "", ""},
 		{"nothing to strip", "player_id=abc", "player_id=abc"},
 	}
@@ -182,6 +184,74 @@ func TestConfigOnConnect_StripProxyArgs(t *testing.T) {
 				t.Errorf("stripProxyArgs(%q) = %q, want %q", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+// TestConfigOnConnect_ParseAppConfig — `app.<field>` args (#800) project onto
+// the same merge-patch tree as proxy.*, nested under `app_config`.
+func TestConfigOnConnect_ParseAppConfig(t *testing.T) {
+	patch, has, err := parseProxyArgs(mustQuery(t,
+		"player_id=abc&app.segment=s2&app.protocol=dash&app.live_offset_s=12&app.peak_bitrate_mbps=4"))
+	if err != nil || !has {
+		t.Fatalf("parse: has=%v err=%v", has, err)
+	}
+	want := map[string]any{
+		"app_config": map[string]any{
+			"segment":           "s2",
+			"protocol":          "dash",
+			"live_offset_s":     12.0,
+			"peak_bitrate_mbps": 4.0,
+		},
+	}
+	if !reflect.DeepEqual(patch, want) {
+		t.Fatalf("patch mismatch\n got: %#v\nwant: %#v", patch, want)
+	}
+}
+
+// TestConfigOnConnect_AppConfigRoundTrip — parse → translate stores app_config
+// as a nested object on the session map (what GET /api/sessions exposes).
+func TestConfigOnConnect_AppConfigRoundTrip(t *testing.T) {
+	patch, _, err := parseProxyArgs(mustQuery(t, "app.segment=ll&app.peak_bitrate_mbps=8"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sess := SessionData{}
+	if aerr := v2server.ApplyConfigPatch(sess, patch); aerr != nil {
+		t.Fatalf("ApplyConfigPatch: %v", aerr)
+	}
+	ac, ok := sess["app_config"].(map[string]any)
+	if !ok {
+		t.Fatalf("session app_config not a map: %#v", sess["app_config"])
+	}
+	if ac["segment"] != "ll" {
+		t.Errorf("app_config.segment = %#v, want ll", ac["segment"])
+	}
+	if ac["peak_bitrate_mbps"] != 8 {
+		t.Errorf("app_config.peak_bitrate_mbps = %#v, want 8 (int)", ac["peak_bitrate_mbps"])
+	}
+}
+
+// TestConfigOnConnect_AppConfigRejectsBadEnum — an out-of-vocab segment is
+// dropped at translation (the object the client reads stays trustworthy)
+// rather than poisoning app_config.
+func TestConfigOnConnect_AppConfigRejectsBadEnum(t *testing.T) {
+	patch, _, err := parseProxyArgs(mustQuery(t, "app.segment=nope&app.protocol=dash"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	sess := SessionData{}
+	if aerr := v2server.ApplyConfigPatch(sess, patch); aerr != nil {
+		t.Fatalf("ApplyConfigPatch: %v", aerr)
+	}
+	ac, _ := sess["app_config"].(map[string]any)
+	if ac == nil {
+		t.Fatalf("app_config missing; want protocol kept")
+	}
+	if _, present := ac["segment"]; present {
+		t.Errorf("bad enum segment was kept: %#v", ac["segment"])
+	}
+	if ac["protocol"] != "dash" {
+		t.Errorf("app_config.protocol = %#v, want dash", ac["protocol"])
 	}
 }
 

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -464,6 +464,9 @@ func applyPatchToSession(srv *Server, s map[string]any, patch map[string]any) er
 	if c, hasC := patch["content"]; hasC {
 		applyContentPatch(s, c)
 	}
+	if ac, hasAC := patch["app_config"]; hasAC {
+		applyAppConfigPatch(s, ac)
+	}
 	return nil
 }
 
@@ -548,6 +551,88 @@ func applyContentPatch(s map[string]any, c any) {
 			s["content_variant_order"] = str
 		}
 	}
+}
+
+// applyAppConfigPatch — projects the v2 app_config patch (#800: client-side
+// behaviour the player applies at its NEXT play boundary) onto the session map
+// as a nested "app_config" object. Unlike the flat content_*/shape_* fields,
+// app_config is stored nested because it is read back verbatim by the player
+// off GET /api/sessions (the proxy never acts on it server-side — it's a
+// pass-through the client overlays onto its own segment/protocol/offset/peak
+// state). JSON Merge Patch semantics: app_config:null clears the whole object;
+// a field set to null drops just that field; an omitted field is untouched, so
+// a partial patch (e.g. only segment) preserves the rest. Enum fields keep only
+// valid values so a malformed arg can't poison the object the client trusts.
+func applyAppConfigPatch(s map[string]any, c any) {
+	if c == nil {
+		delete(s, "app_config")
+		return
+	}
+	m, ok := c.(map[string]any)
+	if !ok {
+		return
+	}
+	out, _ := s["app_config"].(map[string]any)
+	if out == nil {
+		out = map[string]any{}
+	}
+	setEnum := func(key string, v any, allowed ...string) {
+		if v == nil {
+			delete(out, key)
+			return
+		}
+		str, ok := v.(string)
+		if !ok {
+			return
+		}
+		for _, a := range allowed {
+			if str == a {
+				out[key] = str
+				return
+			}
+		}
+	}
+	if v, present := m["segment"]; present {
+		setEnum("segment", v, "ll", "s2", "s6")
+	}
+	if v, present := m["protocol"]; present {
+		setEnum("protocol", v, "hls", "dash")
+	}
+	if v, present := m["live_offset_s"]; present {
+		if v == nil {
+			delete(out, "live_offset_s")
+		} else {
+			out["live_offset_s"] = toFloatZero(v)
+		}
+	}
+	if v, present := m["peak_bitrate_mbps"]; present {
+		if v == nil {
+			delete(out, "peak_bitrate_mbps")
+		} else {
+			out["peak_bitrate_mbps"] = toIntZero(v)
+		}
+	}
+	if len(out) == 0 {
+		delete(s, "app_config")
+		return
+	}
+	s["app_config"] = out
+}
+
+// toFloatZero coerces a JSON-decoded numeric (float64 from encoding/json, or an
+// int form) to float64, defaulting to 0 for anything else.
+func toFloatZero(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case float32:
+		return float64(n)
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	}
+	return 0
 }
 
 func toIntZero(v any) int {

--- a/go-proxy/internal/v2/server/mergepatch_test.go
+++ b/go-proxy/internal/v2/server/mergepatch_test.go
@@ -124,3 +124,66 @@ func TestDecodePatch_RejectsNonObject(t *testing.T) {
 		}
 	}
 }
+
+// TestApplyAppConfigPatch covers the #800 app_config translation: store nested,
+// merge partials, drop a field via null, clear the object via null, and reject
+// out-of-vocab enum values.
+func TestApplyAppConfigPatch(t *testing.T) {
+	t.Run("stores nested", func(t *testing.T) {
+		s := map[string]any{}
+		applyAppConfigPatch(s, map[string]any{
+			"segment": "s2", "protocol": "dash",
+			"live_offset_s": 12.0, "peak_bitrate_mbps": 4.0,
+		})
+		want := map[string]any{
+			"segment": "s2", "protocol": "dash",
+			"live_offset_s": 12.0, "peak_bitrate_mbps": 4,
+		}
+		if !reflect.DeepEqual(s["app_config"], want) {
+			t.Fatalf("app_config = %#v, want %#v", s["app_config"], want)
+		}
+	})
+
+	t.Run("partial patch merges (preserves untouched)", func(t *testing.T) {
+		s := map[string]any{"app_config": map[string]any{"segment": "s2", "protocol": "hls"}}
+		applyAppConfigPatch(s, map[string]any{"segment": "ll"})
+		want := map[string]any{"segment": "ll", "protocol": "hls"}
+		if !reflect.DeepEqual(s["app_config"], want) {
+			t.Fatalf("merge = %#v, want %#v", s["app_config"], want)
+		}
+	})
+
+	t.Run("field null drops just that field", func(t *testing.T) {
+		s := map[string]any{"app_config": map[string]any{"segment": "s2", "protocol": "hls"}}
+		applyAppConfigPatch(s, map[string]any{"segment": nil})
+		want := map[string]any{"protocol": "hls"}
+		if !reflect.DeepEqual(s["app_config"], want) {
+			t.Fatalf("field-null = %#v, want %#v", s["app_config"], want)
+		}
+	})
+
+	t.Run("whole null clears object", func(t *testing.T) {
+		s := map[string]any{"app_config": map[string]any{"segment": "s2"}}
+		applyAppConfigPatch(s, nil)
+		if _, present := s["app_config"]; present {
+			t.Fatalf("app_config still present after null: %#v", s["app_config"])
+		}
+	})
+
+	t.Run("last field nulled clears object", func(t *testing.T) {
+		s := map[string]any{"app_config": map[string]any{"segment": "s2"}}
+		applyAppConfigPatch(s, map[string]any{"segment": nil})
+		if _, present := s["app_config"]; present {
+			t.Fatalf("empty app_config should be removed, got %#v", s["app_config"])
+		}
+	})
+
+	t.Run("rejects bad enum, keeps valid sibling", func(t *testing.T) {
+		s := map[string]any{}
+		applyAppConfigPatch(s, map[string]any{"segment": "nope", "protocol": "dash"})
+		want := map[string]any{"protocol": "dash"}
+		if !reflect.DeepEqual(s["app_config"], want) {
+			t.Fatalf("bad-enum = %#v, want %#v", s["app_config"], want)
+		}
+	})
+}

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -22,6 +22,45 @@ const (
 	BasicAuthScopes basicAuthContextKey = "basicAuth.Scopes"
 )
 
+// Defines values for AppConfigProtocol.
+const (
+	Dash AppConfigProtocol = "dash"
+	Hls  AppConfigProtocol = "hls"
+)
+
+// Valid indicates whether the value is a known member of the AppConfigProtocol enum.
+func (e AppConfigProtocol) Valid() bool {
+	switch e {
+	case Dash:
+		return true
+	case Hls:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AppConfigSegment.
+const (
+	Ll AppConfigSegment = "ll"
+	S2 AppConfigSegment = "s2"
+	S6 AppConfigSegment = "s6"
+)
+
+// Valid indicates whether the value is a known member of the AppConfigSegment enum.
+func (e AppConfigSegment) Valid() bool {
+	switch e {
+	case Ll:
+		return true
+	case S2:
+		return true
+	case S6:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ContentManipulationLiveOffset.
 const (
 	ContentManipulationLiveOffsetN0  ContentManipulationLiveOffset = 0
@@ -657,6 +696,39 @@ func (e GetApiV2PlayersParamsState) Valid() bool {
 		return false
 	}
 }
+
+// AppConfig Client-side ("app behaviour") config the player applies at its next
+// play boundary — the per-play, no-restart counterpart to the cold-start
+// launch args (`is.segment` etc., #797). The proxy stores these per
+// session and surfaces them on `GET /api/sessions`; the player overlays
+// any non-null field onto its own state when it opens the next play
+// (segment/protocol drive the manifest URL; live_offset_s and
+// peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+// null/omitted field leaves the player's own value untouched.
+//
+// Server-side (`proxy.*` / ContentManipulation) config already
+// reconfigures per-play with no restart; this brings the client-side
+// half in line. Settable via `PATCH /api/session/{id}` or the
+// `app.<field>` config-on-connect URL args. Issue #800.
+type AppConfig struct {
+	// LiveOffsetS Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.
+	LiveOffsetS *float32 `json:"live_offset_s,omitempty"`
+
+	// PeakBitrateMbps ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap.
+	PeakBitrateMbps *int `json:"peak_bitrate_mbps,omitempty"`
+
+	// Protocol Streaming protocol for the next play (maps to `is.protocol`).
+	Protocol *AppConfigProtocol `json:"protocol,omitempty"`
+
+	// Segment Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+	Segment *AppConfigSegment `json:"segment,omitempty"`
+}
+
+// AppConfigProtocol Streaming protocol for the next play (maps to `is.protocol`).
+type AppConfigProtocol string
+
+// AppConfigSegment Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+type AppConfigSegment string
 
 // ContentManipulation Master playlist mutations applied at manifest serve time. Takes
 // effect on the next master manifest fetch. Used to test player
@@ -1500,6 +1572,21 @@ type PlayerMetrics struct {
 // (`POST/PATCH/DELETE /api/v2/players/{id}/fault-rules/{rule_id}`)
 // are a planned addition; not in this initial spec.
 type PlayerPatch struct {
+	// AppConfig Client-side ("app behaviour") config the player applies at its next
+	// play boundary — the per-play, no-restart counterpart to the cold-start
+	// launch args (`is.segment` etc., #797). The proxy stores these per
+	// session and surfaces them on `GET /api/sessions`; the player overlays
+	// any non-null field onto its own state when it opens the next play
+	// (segment/protocol drive the manifest URL; live_offset_s and
+	// peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+	// null/omitted field leaves the player's own value untouched.
+	//
+	// Server-side (`proxy.*` / ContentManipulation) config already
+	// reconfigures per-play with no restart; this brings the client-side
+	// half in line. Settable via `PATCH /api/session/{id}` or the
+	// `app.<field>` config-on-connect URL args. Issue #800.
+	AppConfig *AppConfig `json:"app_config,omitempty"`
+
 	// Content Master playlist mutations applied at manifest serve time. Takes
 	// effect on the next master manifest fetch. Used to test player
 	// robustness against malformed / restricted / shifted manifests.
@@ -1551,6 +1638,12 @@ type PlayerPatch struct {
 // per-device and do not broadcast. Each property's description
 // notes which side it falls on.
 type PlayerRecord struct {
+	// AppConfig Client-side config the player applies at its next play boundary
+	// (#800). Stored server-side; the player reads it from
+	// `GET /api/sessions` and overlays it on the next play.
+	// *Broadcasts to group on PATCH.*
+	AppConfig *AppConfig `json:"app_config,omitempty"`
+
 	// Content Master playlist mutations applied at manifest serve time:
 	// strip CODECS, strip AVERAGE-BANDWIDTH, overstate bandwidth,
 	// allowed-variants whitelist, live-offset window. Takes effect

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -23,6 +23,45 @@ const (
 	BasicAuthScopes basicAuthContextKey = "basicAuth.Scopes"
 )
 
+// Defines values for AppConfigProtocol.
+const (
+	Dash AppConfigProtocol = "dash"
+	Hls  AppConfigProtocol = "hls"
+)
+
+// Valid indicates whether the value is a known member of the AppConfigProtocol enum.
+func (e AppConfigProtocol) Valid() bool {
+	switch e {
+	case Dash:
+		return true
+	case Hls:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AppConfigSegment.
+const (
+	Ll AppConfigSegment = "ll"
+	S2 AppConfigSegment = "s2"
+	S6 AppConfigSegment = "s6"
+)
+
+// Valid indicates whether the value is a known member of the AppConfigSegment enum.
+func (e AppConfigSegment) Valid() bool {
+	switch e {
+	case Ll:
+		return true
+	case S2:
+		return true
+	case S6:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ContentManipulationLiveOffset.
 const (
 	ContentManipulationLiveOffsetN0  ContentManipulationLiveOffset = 0
@@ -658,6 +697,39 @@ func (e GetApiV2PlayersParamsState) Valid() bool {
 		return false
 	}
 }
+
+// AppConfig Client-side ("app behaviour") config the player applies at its next
+// play boundary — the per-play, no-restart counterpart to the cold-start
+// launch args (`is.segment` etc., #797). The proxy stores these per
+// session and surfaces them on `GET /api/sessions`; the player overlays
+// any non-null field onto its own state when it opens the next play
+// (segment/protocol drive the manifest URL; live_offset_s and
+// peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+// null/omitted field leaves the player's own value untouched.
+//
+// Server-side (`proxy.*` / ContentManipulation) config already
+// reconfigures per-play with no restart; this brings the client-side
+// half in line. Settable via `PATCH /api/session/{id}` or the
+// `app.<field>` config-on-connect URL args. Issue #800.
+type AppConfig struct {
+	// LiveOffsetS Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.
+	LiveOffsetS *float32 `json:"live_offset_s,omitempty"`
+
+	// PeakBitrateMbps ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap.
+	PeakBitrateMbps *int `json:"peak_bitrate_mbps,omitempty"`
+
+	// Protocol Streaming protocol for the next play (maps to `is.protocol`).
+	Protocol *AppConfigProtocol `json:"protocol,omitempty"`
+
+	// Segment Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+	Segment *AppConfigSegment `json:"segment,omitempty"`
+}
+
+// AppConfigProtocol Streaming protocol for the next play (maps to `is.protocol`).
+type AppConfigProtocol string
+
+// AppConfigSegment Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+type AppConfigSegment string
 
 // ContentManipulation Master playlist mutations applied at manifest serve time. Takes
 // effect on the next master manifest fetch. Used to test player
@@ -1501,6 +1573,21 @@ type PlayerMetrics struct {
 // (`POST/PATCH/DELETE /api/v2/players/{id}/fault-rules/{rule_id}`)
 // are a planned addition; not in this initial spec.
 type PlayerPatch struct {
+	// AppConfig Client-side ("app behaviour") config the player applies at its next
+	// play boundary — the per-play, no-restart counterpart to the cold-start
+	// launch args (`is.segment` etc., #797). The proxy stores these per
+	// session and surfaces them on `GET /api/sessions`; the player overlays
+	// any non-null field onto its own state when it opens the next play
+	// (segment/protocol drive the manifest URL; live_offset_s and
+	// peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+	// null/omitted field leaves the player's own value untouched.
+	//
+	// Server-side (`proxy.*` / ContentManipulation) config already
+	// reconfigures per-play with no restart; this brings the client-side
+	// half in line. Settable via `PATCH /api/session/{id}` or the
+	// `app.<field>` config-on-connect URL args. Issue #800.
+	AppConfig *AppConfig `json:"app_config,omitempty"`
+
 	// Content Master playlist mutations applied at manifest serve time. Takes
 	// effect on the next master manifest fetch. Used to test player
 	// robustness against malformed / restricted / shifted manifests.
@@ -1552,6 +1639,12 @@ type PlayerPatch struct {
 // per-device and do not broadcast. Each property's description
 // notes which side it falls on.
 type PlayerRecord struct {
+	// AppConfig Client-side config the player applies at its next play boundary
+	// (#800). Stored server-side; the player reads it from
+	// `GET /api/sessions` and overlays it on the next play.
+	// *Broadcasts to group on PATCH.*
+	AppConfig *AppConfig `json:"app_config,omitempty"`
+
 	// Content Master playlist mutations applied at manifest serve time:
 	// strip CODECS, strip AVERAGE-BANDWIDTH, overstate bandwidth,
 	// allowed-variants whitelist, live-offset window. Takes effect


### PR DESCRIPTION
## Summary

**PR 1 of #800** (per-play app-config push, mechanism 2 — config-on-connect). Lets the proxy carry **client-side** behaviour config per session — `segment` / `live_offset_s` / `protocol` / `peak_bitrate_mbps` — so the player can reconfigure at its **next play boundary with no cold restart**. This is the client-side counterpart to server-side config (faults/shape/`ContentManipulation`), which already reconfigures per-play via #714.

**Server half only.** The clients reading + applying `app_config` (Android `buildUrlAndLoad`, iOS `buildURLAndLoad`) and the sweep-probe opt-in land in follow-up PRs.

## Data flow
```
harness ─PATCH /api/v2/players/{id} {app_config}─▶ proxy stores nested app_config on session
  (or bootstrap: app.segment=s2 … ─▶ parseProxyArgs ─▶ ApplyConfigPatch ─▶ same store)
client at next play boundary ─GET /api/sessions─▶ reads app_config ─▶ overlays for next play
```

## What changed
| Area | Change |
|---|---|
| **Spec** (`api/openapi/v2/proxy.yaml`) | new `AppConfig` schema (segment `ll/s2/s6`, protocol `hls/dash`, `live_offset_s`, `peak_bitrate_mbps`, all nullable); referenced from `PlayerPatch` + `PlayerRecord`. Regenerated proxy stubs + harness CLI client; synced api-docs copy. |
| **Translator** (`handlers_mutate.go`) | `applyAppConfigPatch` + branch in `applyPatchToSession`. Stored **nested** (the player reads it verbatim off `/api/sessions`; proxy never acts on it). Merge-patch semantics: whole-null clears, field-null drops, partial merges; enums keep only valid values. |
| **Config-on-connect** (`configconnect.go`) | `app.<field>` URL args → same merge tree under `app_config` (distinct prefix from `proxy.*` so client vs server config read separately); strip covers `app.*`. |
| **Read path** | none — `normalizeSessionsForResponse` returns the raw session map, so nested `app_config` surfaces on `GET /api/sessions` automatically. |

Both write paths covered: config-on-connect bootstrap (`ApplyConfigPatch`) and the v2 `/api/v2/players/{id}` PATCH (`MutatePlayer` → `applyPatchToSession`).

## Tests
`app.*` parse, parse→translate round-trip, bad-enum rejection, strip cases, and the translator's merge / field-null / whole-null / enum semantics. `go test ./...` green for go-proxy; harness CLI builds against the regenerated client.

## Try it (once a player has a session)
```
# bootstrap form
…/master.m3u8?player_id=<uuid>&app.segment=s2&app.live_offset_s=12
# per-play PATCH form
PATCH /api/v2/players/<uuid>  {"app_config": {"segment": "s2", "live_offset_s": 12}}
# read back
GET /api/sessions  → entry.app_config = {segment: s2, live_offset_s: 12}
```

## Follow-up (out of scope here)
- **Android client** — overlay `app_config` at `buildUrlAndLoad` (reuses #797 fields).
- **iOS client** — overlay at `buildURLAndLoad` (`:836`); refresh on the existing session-resolve poll.
- **Probe** — opt-in "reconfigure without relaunch" (PATCH-per-play vs cold launch).
- A dedicated **control-event** classification for `app_config` changes belongs on the v2 mutate path (not v1-flat `emitHarnessSettingsChange`) — best added with the probe push path.

Refs #800. Refs #714 (config-on-connect precedent), #797 (the launch levers this makes per-play).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
