### PR TITLE
feat(800): probe — harness app-config command + Session.ApplyAppConfig (reconfigure without relaunch)

### DIFF
--- a/tests/characterization/README.md
+++ b/tests/characterization/README.md
@@ -117,6 +117,26 @@ Each mode test skips with `t.Skip` if no device of its platform is reachable, so
 | `hysteresis-gap` | stairs up 0.5 → 6, then down, find gap per variant | ~6 min |
 | `emergency-downshift` | drop to 0.05 Mbps briefly, measure recovery | ~2.5 min |
 
+## Per-play client reconfig without relaunch (#800)
+
+Client-side config (segment / live_offset / protocol / peak_bitrate) is normally
+forced via a cold-start launch arg (`-is.segment` etc., #797) — one cold launch
+(~25–30 s) per matrix cell. The server-side half (cap, faults, content) already
+reconfigures per-play with no restart; #800 brings the client half in line.
+
+`runner.Session.ApplyAppConfig(ctx, runner.AppConfig{Segment: "s2", ...})` PATCHes
+the bound player's `app_config` (via `harness app-config <pid> --segment s2 …`);
+the app overlays it at its **next play boundary** with no relaunch. Use it to vary
+a client-side axis between plays of a long-running app instead of relaunching per
+cell.
+
+> **Timing.** The proxy has no session to hold `app_config` until the player's
+> first bootstrap request, so this targets *subsequent* plays of a running app —
+> the very first play still uses config-on-connect (`app.<field>` bootstrap args)
+> or the launch arg. A multi-play sweep driver that loops cells on ONE launch
+> (PATCH → fresh play → repeat) is the natural consumer; the single-play modes
+> below still cold-launch per run.
+
 ## Launch modes
 
 The framework supports three launch modes, picked by `$LAUNCH_MODE`:

--- a/tests/characterization/runner/appconfig.go
+++ b/tests/characterization/runner/appconfig.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// AppConfig is the client-side, per-play behaviour config the harness can push
+// to a RUNNING player (#800): the player applies it at its NEXT play boundary
+// with no cold relaunch — the per-play counterpart to the is.* launch args
+// (#797). Empty strings / nil pointers are omitted from the patch (JSON Merge
+// Patch), so a partial AppConfig leaves the player's other values untouched.
+type AppConfig struct {
+	Segment         string   // "" | ll | s2 | s6
+	Protocol        string   // "" | hls | dash
+	LiveOffsetS     *float64 // seconds behind live; nil = leave unchanged
+	PeakBitrateMbps *int     // ABR ceiling Mbps; nil = leave unchanged
+}
+
+// ApplyAppConfig PATCHes the bound player's app_config via the harness CLI, so
+// the next play this app opens picks up the new client-side config WITHOUT a
+// cold relaunch. The session must already exist (player bound + first play
+// made) — the proxy has no session to carry app_config before the player's
+// first bootstrap request, so this targets reconfiguration of a running app
+// between plays, not the very first play (use config-on-connect for that).
+func (s *Session) ApplyAppConfig(ctx context.Context, cfg AppConfig) error {
+	if s == nil || s.PlayerID == "" {
+		return fmt.Errorf("apply app-config: no player bound")
+	}
+	args := []string{"app-config", s.PlayerID}
+	if cfg.Segment != "" {
+		args = append(args, "--segment", cfg.Segment)
+	}
+	if cfg.Protocol != "" {
+		args = append(args, "--protocol", cfg.Protocol)
+	}
+	if cfg.LiveOffsetS != nil {
+		args = append(args, "--live-offset", strconv.FormatFloat(*cfg.LiveOffsetS, 'f', -1, 64))
+	}
+	if cfg.PeakBitrateMbps != nil {
+		args = append(args, "--peak-bitrate", strconv.Itoa(*cfg.PeakBitrateMbps))
+	}
+	if len(args) == 2 { // only "app-config <pid>" — nothing to set
+		return fmt.Errorf("apply app-config: empty AppConfig")
+	}
+	_, err := runHarness(ctx, args...)
+	return err
+}
+
+// ClearAppConfig wipes all client-side app_config on the bound player, so the
+// next play falls back to the app's own (launch-arg / Settings) values.
+func (s *Session) ClearAppConfig(ctx context.Context) error {
+	if s == nil || s.PlayerID == "" {
+		return fmt.Errorf("clear app-config: no player bound")
+	}
+	_, err := runHarness(ctx, "app-config", s.PlayerID, "--clear")
+	return err
+}

--- a/tools/harness-cli/README.md
+++ b/tools/harness-cli/README.md
@@ -26,6 +26,7 @@ harness --insecure info       # smoke check
 | **`labels`** | Operator KV labels on player | `show`, `set`, `rm`, `clear` |
 | **`timeouts`** | Transfer timeouts | `<target> --active --idle [--applies-* / --show / --clear]` |
 | **`content`** | Master playlist mutators | `<target> --strip-* --overstate-* --live-offset` |
+| **`app-config`** | Client-side per-play config (#800) the player applies at its next play boundary, no relaunch | `<target> --segment --protocol --live-offset --peak-bitrate [--clear]` |
 | **`play`** | Inspect live play | `show`, `patch` |
 | **`groups`** | Player groups | `list`, `show`, `create`, `patch`, `add`, `remove`, `rm` |
 | **`tail`**, **`ts`**, **`events`** | Live SSE streams | `tail` (network), `ts` (combined), `events` (lifecycle) |

--- a/tools/harness-cli/cmd/harness/appconfig.go
+++ b/tools/harness-cli/cmd/harness/appconfig.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/format"
+)
+
+const appConfigUsage = `harness app-config <target> [flags]
+
+PATCH the player's client-side app_config (#800). These are behaviour knobs
+the PLAYER applies at its next play boundary — the per-play, no-restart
+counterpart to the cold-start launch args (is.segment etc., #797). The proxy
+stores them on the session and surfaces them on GET /api/sessions; the player
+overlays any set field onto its own state when it opens the next play.
+
+Use this to reconfigure a RUNNING app between plays without a cold relaunch.
+(The first play of a fresh launch has no session yet — use config-on-connect
+'app.<field>' bootstrap args for that; this command targets subsequent plays.)
+
+Flags:
+  --segment LADDER     ll | s2 | s6
+  --protocol PROTO     hls | dash
+  --live-offset SEC    seconds behind live edge (>=0; 0 = manifest/Go-Live decides)
+  --peak-bitrate MBPS  ABR ceiling in Mbps (>=0; 0 = no cap)
+  --clear              send {"app_config": null} (wipe all client config)
+
+Only the flags you pass are written (JSON Merge Patch); omit a field to leave
+the player's current value untouched.
+`
+
+func cmdAppConfig(client *api.Client, args []string, asJSON bool) error {
+	if len(args) < 1 {
+		return errors.New(appConfigUsage)
+	}
+	fs := flag.NewFlagSet("app-config", flag.ContinueOnError)
+	segment := fs.String("segment", "", "")
+	protocol := fs.String("protocol", "", "")
+	liveOffset := fs.Float64("live-offset", 0, "")
+	peakBitrate := fs.Int("peak-bitrate", 0, "")
+	clear := fs.Bool("clear", false, "")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	// fs.Visit reports only flags actually passed, so a 0 the user typed is
+	// distinguishable from an unset field (which must stay absent from the
+	// merge patch, per JSON Merge Patch semantics).
+	set := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { set[f.Name] = true })
+
+	body, err := buildAppConfigBody(*segment, *protocol, *liveOffset, *peakBitrate, set, *clear)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	pid, err := client.Resolve(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	newETag, err := client.PatchRawWithSnapshot(ctx, pid, "app-config", body)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return format.JSON(os.Stdout, map[string]any{
+			"player_id": pid, "app_config": json.RawMessage(body), "etag": newETag,
+		})
+	}
+	if *clear {
+		fmt.Printf("cleared app_config on %s (etag %s)\n", pid, shortRev(newETag))
+	} else {
+		fmt.Printf("patched app_config on %s: %s (etag %s)\n", pid, string(body), shortRev(newETag))
+	}
+	return nil
+}
+
+// buildAppConfigBody turns the parsed flags into the PATCH body. Pure (no
+// network) so it's unit-testable. `set` marks which numeric/string flags were
+// actually passed (via flag.FlagSet.Visit) so an explicit 0 is written while an
+// omitted field stays absent. --clear wins and emits {"app_config": null}.
+// Enum values are validated here so a bad arg fails fast rather than 400ing.
+func buildAppConfigBody(segment, protocol string, liveOffset float64, peakBitrate int, set map[string]bool, clear bool) ([]byte, error) {
+	if clear {
+		return []byte(`{"app_config": null}`), nil
+	}
+	ac := map[string]any{}
+	if set["segment"] {
+		switch segment {
+		case "ll", "s2", "s6":
+			ac["segment"] = segment
+		default:
+			return nil, fmt.Errorf("invalid --segment %q (want ll|s2|s6)", segment)
+		}
+	}
+	if set["protocol"] {
+		switch protocol {
+		case "hls", "dash":
+			ac["protocol"] = protocol
+		default:
+			return nil, fmt.Errorf("invalid --protocol %q (want hls|dash)", protocol)
+		}
+	}
+	if set["live-offset"] {
+		if liveOffset < 0 {
+			return nil, fmt.Errorf("--live-offset must be >= 0 (got %v)", liveOffset)
+		}
+		ac["live_offset_s"] = liveOffset
+	}
+	if set["peak-bitrate"] {
+		if peakBitrate < 0 {
+			return nil, fmt.Errorf("--peak-bitrate must be >= 0 (got %d)", peakBitrate)
+		}
+		ac["peak_bitrate_mbps"] = peakBitrate
+	}
+	if len(ac) == 0 {
+		return nil, errors.New("nothing to do — pass --segment / --protocol / --live-offset / --peak-bitrate, or --clear")
+	}
+	return json.Marshal(map[string]any{"app_config": ac})
+}

--- a/tools/harness-cli/cmd/harness/appconfig_test.go
+++ b/tools/harness-cli/cmd/harness/appconfig_test.go
@@ -1,0 +1,78 @@
+package main
+
+import "testing"
+
+func TestBuildAppConfigBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		segment string
+		proto   string
+		offset  float64
+		peak    int
+		set     map[string]bool
+		clear   bool
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "clear wins",
+			set:   map[string]bool{"segment": true},
+			clear: true,
+			want:  `{"app_config": null}`,
+		},
+		{
+			name:    "segment only",
+			segment: "s2",
+			set:     map[string]bool{"segment": true},
+			want:    `{"app_config":{"segment":"s2"}}`,
+		},
+		{
+			name:    "all fields (keys sort alpha)",
+			segment: "ll", proto: "dash", offset: 12, peak: 4,
+			set:  map[string]bool{"segment": true, "protocol": true, "live-offset": true, "peak-bitrate": true},
+			want: `{"app_config":{"live_offset_s":12,"peak_bitrate_mbps":4,"protocol":"dash","segment":"ll"}}`,
+		},
+		{
+			name:   "explicit zeros are written when set",
+			offset: 0, peak: 0,
+			set:  map[string]bool{"live-offset": true, "peak-bitrate": true},
+			want: `{"app_config":{"live_offset_s":0,"peak_bitrate_mbps":0}}`,
+		},
+		{
+			name:    "bad segment errors",
+			segment: "nope", set: map[string]bool{"segment": true}, wantErr: true,
+		},
+		{
+			name:  "bad protocol errors",
+			proto: "quic", set: map[string]bool{"protocol": true}, wantErr: true,
+		},
+		{
+			name:   "negative offset errors",
+			offset: -1, set: map[string]bool{"live-offset": true}, wantErr: true,
+		},
+		{
+			name: "negative peak errors",
+			peak: -1, set: map[string]bool{"peak-bitrate": true}, wantErr: true,
+		},
+		{
+			name: "nothing set errors", set: map[string]bool{}, wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildAppConfigBody(tt.segment, tt.proto, tt.offset, tt.peak, tt.set, tt.clear)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got body %s", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("body = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/harness-cli/cmd/harness/main.go
+++ b/tools/harness-cli/cmd/harness/main.go
@@ -142,6 +142,8 @@ func main() {
 		exit(cmdTimeouts(client, args[1:], g.asJSON))
 	case "content":
 		exit(cmdContent(client, args[1:], g.asJSON))
+	case "app-config", "appconfig":
+		exit(cmdAppConfig(client, args[1:], g.asJSON))
 	case "play":
 		exit(cmdPlay(client, args[1:], g.asJSON))
 	case "network":


### PR DESCRIPTION
## Summary

**PR 4 of #800** — the opt-in "reconfigure without relaunch" primitive. Adds the operator + probe surface to push a player's client-side `app_config` (`segment` / `live_offset_s` / `protocol` / `peak_bitrate_mbps`) to a **running** app, applied at its next play boundary with **no cold relaunch** (the client-side counterpart to how server-side cap/fault/content already reconfigure per-play).

## What's here
- **harness CLI `app-config`** (`cmd/harness/appconfig.go`):
  ```
  harness app-config <target> --segment s2 --live-offset 12 --protocol dash --peak-bitrate 4
  harness app-config <target> --clear
  ```
  Builds a JSON Merge Patch from only the flags passed (explicit `0` written, omitted field absent), PATCHes via the existing `PatchRawWithSnapshot` raw-body path. Enum-validated.
- **probe `runner.Session.ApplyAppConfig` / `ClearAppConfig`** (`runner/appconfig.go`) — shells the CLI (same pattern as `ApplyRate`); the building block a sweep loop calls to vary a client-side axis between plays.
- **Unit test** for the body builder (clear / partial / explicit-zero / enum-reject / nothing-set).
- **Docs** — harness-cli README command table + a characterization README section.

`go build` + `go test` green for harness-cli and characterization; `go vet` clean.

## Dependency note
Deliberately **compile-independent of the other #800 PRs**: the raw-JSON PATCH path means it builds against `dev` with no dependency on #801's regenerated typed `AppConfig`. At **runtime** the push takes effect once the server (#801) and a client (#802 Android / #803 iOS) are deployed.

## Timing / scope (why this is the primitive, not a full sweep-loop rewrite)
The proxy holds no session until the player's first bootstrap request, and the single-play characterization modes start their one play at `ResumePlayback` before any post-bind PATCH. So:
- **First play** of a fresh launch → config-on-connect (`app.<field>` bootstrap args, #801) or the launch arg (#797).
- **Subsequent plays** of a running app → this `app-config` PATCH, no relaunch.

The natural consumer is a **multi-play sweep driver** that loops cells on ONE launch (PATCH → fresh play → repeat) — that loop is the documented follow-up; this PR lands the correct, tested primitive it builds on. Cold-launch-per-cell remains the fallback for the existing modes.

## #800 — complete set
| PR | Slice | State |
|---|---|---|
| #801 | Server (`app_config` store/expose/parse) | open |
| #802 | Android client (overlay at play boundary) | open |
| #803 | iOS client (overlay at play boundary) | open |
| #804 | **Probe primitive (this PR)** | this PR |

Refs #800. Refs #801/#802/#803, #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
