### PR TITLE
fix(800): allowlist app_config in the v2 PATCH unsupportedPaths guard

### DIFF
--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -365,6 +365,9 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 //	endpoints have their own paths and don't run through here).
 //
 // Phase K: + shape.pattern (drives v1's pattern step-engine).
+// #800: + app_config (client-side per-play config; applyAppConfigPatch stores
+//
+//	it nested on the session for the player to read back — no kernel side).
 func unsupportedPaths(paths []string) []string {
 	var bad []string
 	for _, p := range paths {
@@ -379,6 +382,7 @@ func unsupportedPaths(paths []string) []string {
 		case p == "fault_rules":
 		case p == "transfer_timeouts", strings.HasPrefix(p, "transfer_timeouts."):
 		case p == "content", strings.HasPrefix(p, "content."):
+		case p == "app_config", strings.HasPrefix(p, "app_config."):
 		default:
 			bad = append(bad, p)
 		}

--- a/go-proxy/internal/v2/server/mergepatch_test.go
+++ b/go-proxy/internal/v2/server/mergepatch_test.go
@@ -187,3 +187,26 @@ func TestApplyAppConfigPatch(t *testing.T) {
 		}
 	})
 }
+
+// TestUnsupportedPaths_AppConfig — #800: app_config (and its sub-fields) must
+// be admitted by the v2 PATCH guard so harness/probe PATCHes reach
+// applyAppConfigPatch instead of 501ing. Regression for the guard gap where
+// the translator branch existed but the path wasn't allowlisted.
+func TestUnsupportedPaths_AppConfig(t *testing.T) {
+	ok := []string{
+		"app_config",
+		"app_config.segment",
+		"app_config.protocol",
+		"app_config.live_offset_s",
+		"app_config.peak_bitrate_mbps",
+	}
+	if bad := unsupportedPaths(ok); len(bad) != 0 {
+		t.Fatalf("app_config paths wrongly rejected: %v", bad)
+	}
+	// A genuinely unknown top-level path is still rejected (guard didn't go
+	// permissive). Unknown app_config.* sub-keys ride the prefix match like
+	// content.*/shape.* do — applyAppConfigPatch ignores keys it doesn't know.
+	if bad := unsupportedPaths([]string{"totally_unknown"}); len(bad) != 1 {
+		t.Fatalf("expected unknown top-level path rejected, got %v", bad)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up fix to #800 (#801). The v2 `PATCH /api/v2/players/{id}` handler checks an `unsupportedPaths` **allowlist** *before* running the patch translator and 501s anything not listed. #801 added the `app_config` branch to `applyPatchToSession` (`applyAppConfigPatch`) + the config-on-connect parse, but **didn't add `app_config` to that allowlist** — so:

- ✅ config-on-connect (`app.*` bootstrap args) worked (calls `applyPatchToSession` directly, bypassing the guard)
- ❌ the v2 HTTP PATCH 501'd → **`harness app-config` (#804) and the probe `Session.ApplyAppConfig` were dead**, i.e. the whole per-play push path.

**Caught verifying #800 end-to-end on the emulator** — the freshly-deployed `dev` proxy returned `501 v2-to-v1 translation not yet wired` on `harness app-config <pid> --segment s2`.

## Fix
Add `app_config` / `app_config.*` to `unsupportedPaths` (prefix match, same as `content.*` / `shape.*`). One-line guard fix + a regression test (`TestUnsupportedPaths_AppConfig`) asserting the app_config leaf paths are admitted while an unknown top-level path is still rejected.

`go test ./...` green for go-proxy.

Refs #800. Fixes the #801 guard gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
