### PR TITLE
feat(793): live-offset coverage — window set, variant rewrite, app lever, UI + docs

### DIFF
--- a/.claude/skills/sweep/SKILL.md
+++ b/.claude/skills/sweep/SKILL.md
@@ -104,6 +104,7 @@ When `harness sweep status` shows no `backlog`/`running`, summarize what was fou
 
 ## See also
 - `docs/sweep-design.md` — the full design (oracle trichotomy §3, store §4, scheduler §5, A/B isolation §6, the loop §7, robustness/prereqs §11).
+- `docs/live-offset-testing.md` — how to configure live_offset (manifest/proxy vs app override), the 3×-max-segment floor, which fields each lever moves, how to drive + measure it on the probe, and per-platform coverage (Android `master_2s` drivable via `is.segment`, #798; both Android levers track the value once the persisted `advanced_live_offset_s` confound is reset to 0).
 - `forensics` / `investigate` / `finding` / `triage` — the reasoning + capture skills this loop reuses on a hit.
 - `shape` / `fault` — the underlying control surfaces `sweep apply` wraps.
 - `harness sweep help` — the subcommand surface.

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1541,9 +1541,9 @@ components:
           description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
-          enum: [0, 2, 4, 6, 12, 18, 24, 36, 42]
+          enum: [0, 2, 4, 6, 12, 18, 24, 30, 36, 42]
           default: 0
-          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.'
+          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1541,9 +1541,9 @@ components:
           description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
-          enum: [0, 6, 18, 24]
+          enum: [0, 2, 4, 6, 12, 18, 24, 36, 42]
           default: 0
-          description: 'Live edge offset window in seconds. 0 = no offset.'
+          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1925,8 +1925,14 @@ final class PlayerViewModel: ObservableObject {
         goLive           = d.bool(forKey: Self.flagGoLive)
         skipHomeOnLaunch = d.bool(forKey: Self.flagSkipHome)
         isMuted = d.bool(forKey: Self.flagMuted)
-        liveOffsetSeconds = d.object(forKey: Self.flagLiveOffset) as? Double ?? 0
-        playIdRotationSeconds = max(0, d.object(forKey: Self.flagPlayIdRotation) as? Int ?? 0)
+        // #793 — a launch-arg (`-is.flag.live_offset_s 12`, the test rack) lands
+        // in NSArgumentDomain as the STRING "12"; `object(forKey:) as? Double`
+        // fails that cast and silently reads 0 ("Off"), so the rack-set offset
+        // never engaged (the seek in scheduleLiveOffsetSeek is guarded > 0).
+        // doubleFlag coerces both the launch-arg string and the UI-persisted
+        // NSNumber. Same latent bug fixed on play_id_rotation just below.
+        liveOffsetSeconds = Self.doubleFlag(d, Self.flagLiveOffset) ?? 0
+        playIdRotationSeconds = max(0, d.integer(forKey: Self.flagPlayIdRotation))
         // integer(forKey:) — NOT object(forKey:) as? Int — because a launch-arg
         // override (-is.flag.peak_bitrate_mbps 1, the characterization harness)
         // lands in NSArgumentDomain as the STRING "1"; `as? Int` fails that cast

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -211,9 +211,12 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
       </label>
     </div>
     <p class="note">
-      HLS-only. Forces the player to fall back further from the live edge by
-      stripping the most-recent N seconds of segments from the manifest.
-      Pairs well with `delay_ms` to surface live-offset-driven stalls.
+      HLS-only. Rewrites the manifest's <code>EXT-X-START:TIME-OFFSET</code>
+      (join point) and <code>EXT-X-SERVER-CONTROL:HOLD-BACK</code> (target
+      offset) to N seconds. These are <em>advisory</em>: web (hls.js) honours
+      them, but iOS AVPlayer recomputes its own 3×-max-segment floor and largely
+      ignores a rewritten value — so this does not reliably move the iOS offset
+      (use the app's Live-offset setting for that). It does NOT strip segments.
     </p>
 
     <div class="order-row" data-testid="content-variant-order">

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -213,10 +213,11 @@ function variantLabel(v: { url: string; resolution?: string; bandwidth?: number 
     <p class="note">
       HLS-only. Rewrites the manifest's <code>EXT-X-START:TIME-OFFSET</code>
       (join point) and <code>EXT-X-SERVER-CONTROL:HOLD-BACK</code> (target
-      offset) to N seconds. These are <em>advisory</em>: web (hls.js) honours
-      them, but iOS AVPlayer recomputes its own 3×-max-segment floor and largely
-      ignores a rewritten value — so this does not reliably move the iOS offset
-      (use the app's Live-offset setting for that). It does NOT strip segments.
+      offset) to N seconds, on both the master <em>and</em> the variant
+      playlists. Players honour the variant <code>HOLD-BACK</code> for their
+      join offset (iOS / Android / web). Note the HLS spec requires
+      <code>HOLD-BACK ≥ 3× the max segment duration</code> — below that AVPlayer
+      rejects the playlist (<code>-12646</code>). It does NOT strip segments.
     </p>
 
     <div class="order-row" data-testid="content-variant-order">

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -20,7 +20,7 @@ const variants = computed(() => {
   return rawVariants.value.slice().sort((a, b) => (b.bandwidth ?? 0) - (a.bandwidth ?? 0));
 });
 
-const LIVE_OFFSET_CHOICES = [0, 2, 4, 6, 12, 18, 24, 36, 42] as const;
+const LIVE_OFFSET_CHOICES = [0, 2, 4, 6, 12, 18, 24, 30, 36, 42] as const;
 type LiveOffset = (typeof LIVE_OFFSET_CHOICES)[number];
 
 const VARIANT_ORDER_CHOICES = [

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -20,7 +20,7 @@ const variants = computed(() => {
   return rawVariants.value.slice().sort((a, b) => (b.bandwidth ?? 0) - (a.bandwidth ?? 0));
 });
 
-const LIVE_OFFSET_CHOICES = [0, 6, 18, 24] as const;
+const LIVE_OFFSET_CHOICES = [0, 6, 12, 18, 24, 36] as const;
 type LiveOffset = (typeof LIVE_OFFSET_CHOICES)[number];
 
 const VARIANT_ORDER_CHOICES = [

--- a/content/dashboard-v3/src/components/ContentManipulation.vue
+++ b/content/dashboard-v3/src/components/ContentManipulation.vue
@@ -20,7 +20,7 @@ const variants = computed(() => {
   return rawVariants.value.slice().sort((a, b) => (b.bandwidth ?? 0) - (a.bandwidth ?? 0));
 });
 
-const LIVE_OFFSET_CHOICES = [0, 6, 12, 18, 24, 36] as const;
+const LIVE_OFFSET_CHOICES = [0, 2, 4, 6, 12, 18, 24, 36, 42] as const;
 type LiveOffset = (typeof LIVE_OFFSET_CHOICES)[number];
 
 const VARIANT_ORDER_CHOICES = [

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1907,13 +1907,13 @@ export interface components {
              * @default default
              * @enum {string}
              */
-            variant_order?: "default" | "ascending" | "descending" | "first_4mbps";
+            variant_order: "default" | "ascending" | "descending" | "first_4mbps";
             /**
-             * @description Live edge offset window in seconds. 0 = no offset.
+             * @description Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
              * @default 0
              * @enum {integer}
              */
-            live_offset: 0 | 6 | 18 | 24;
+            live_offset: 0 | 2 | 4 | 6 | 12 | 18 | 24 | 36 | 42;
         };
         Manifest: {
             /** Format: uri */
@@ -1991,6 +1991,16 @@ export interface components {
              * @description Player-reported offset behind live edge (seconds).
              */
             live_offset_s?: number | null;
+            /**
+             * Format: float
+             * @description Manifest-recommended target offset from live (iOS recommendedTimeOffsetFromLive / ExoPlayer liveConfiguration.targetOffsetMs). Gates the qoe_live_offset_* labels.
+             */
+            recommended_offset_s?: number | null;
+            /**
+             * Format: float
+             * @description Configured target offset from live (iOS configuredTimeOffsetFromLive; on Android equals recommended_offset_s).
+             */
+            configured_offset_s?: number | null;
             /**
              * Format: float
              * @description Wall-clock offset between player position and real time (seconds).

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1909,11 +1909,11 @@ export interface components {
              */
             variant_order: "default" | "ascending" | "descending" | "first_4mbps";
             /**
-             * @description Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
+             * @description Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.
              * @default 0
              * @enum {integer}
              */
-            live_offset: 0 | 2 | 4 | 6 | 12 | 18 | 24 | 36 | 42;
+            live_offset: 0 | 2 | 4 | 6 | 12 | 18 | 24 | 30 | 36 | 42;
         };
         Manifest: {
             /** Format: uri */

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1541,9 +1541,9 @@ components:
           description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
-          enum: [0, 2, 4, 6, 12, 18, 24, 36, 42]
+          enum: [0, 2, 4, 6, 12, 18, 24, 30, 36, 42]
           default: 0
-          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.'
+          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1541,9 +1541,9 @@ components:
           description: 'Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer''s initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.'
         live_offset:
           type: integer
-          enum: [0, 6, 18, 24]
+          enum: [0, 2, 4, 6, 12, 18, 24, 36, 42]
           default: 0
-          description: 'Live edge offset window in seconds. 0 = no offset.'
+          description: 'Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/docs/live-offset-testing.md
+++ b/docs/live-offset-testing.md
@@ -1,0 +1,142 @@
+# Live-offset — how to configure it and how to test it
+
+Operator + sweep-skill reference for the **distance-from-live-edge** controls. There are
+**two independent levers** (manifest/proxy vs app override) that move **different fields**;
+mixing them up is the usual source of confusion. This doc is the source of truth for both.
+See also `docs/sweep-design.md §3.1` (the manipulation-check validity gate) and #793 / #797.
+
+## TL;DR
+
+| Lever | Set it with | Rewrites / sets | Moves which field | Floor? |
+|---|---|---|---|---|
+| **Manifest (proxy)** | `harness content <player> --live-offset N`, or the dashboard ContentManipulation radio | `EXT-X-START:TIME-OFFSET=-N` (master) **+** `EXT-X-SERVER-CONTROL:HOLD-BACK=N` (variant) | `configured_offset_s` / `recommended_offset_s` | **Yes** — must be ≥ 3× max-segment or it's rejected/degraded |
+| **App override** | `-is.flag.live_offset_s N` (iOS) / `--es is.flag.live_offset_s N` (Android) | `configuredTimeOffsetFromLive` / `LiveConfiguration` **+ absolute seek to liveEdge−N** | `wall_offset` (= `seekable_end_s − position_s`) | **No** — it's a client seek; works below the floor |
+
+The app override is **absolute, not additive**: when it's > 0 it overrides the manifest target; `configured` stays at the manifest value while `wall_offset` tracks the override.
+
+## Lever 1 — manifest / proxy live_offset
+
+The proxy rewrites the manifest per session so the player joins further back and targets a
+larger hold-back.
+
+- **CLI:** `harness content <player_id> --live-offset N` (patches `content_live_offset`).
+  Note: this does **not** validate against the supported enum — it stores any int, so
+  deliberately sub-spec values (to test rejection) pass through.
+- **Dashboard:** ContentManipulation → Live offset radio. Supported set:
+  `{0, 2, 4, 6, 12, 18, 24, 30, 36, 42}` (0 = no rewrite / native manifest).
+- **What it rewrites** (both, since the #793 fix — the gate used to be master-only, so the
+  variant `HOLD-BACK` was never rewritten and the lever had *no effect on any player*):
+  - master playlist: `EXT-X-START:TIME-OFFSET=-N` (the join point)
+  - each variant playlist: `EXT-X-SERVER-CONTROL:HOLD-BACK=N` (the target offset). HOLD-BACK
+    is a **media-playlist-only** tag — it lives on the variant, never the master.
+- **Fields it moves:** `configured_offset_s` and `recommended_offset_s` (the manifest target
+  the player parsed).
+
+### The 3×-max-segment floor (the headline gotcha)
+
+HLS requires `HOLD-BACK ≥ 3 × target segment duration`. Segment durations round up, so:
+
+| Master | Max segment | Floor (~3×) | A `live_offset=12` here is… |
+|---|---|---|---|
+| `master_6s` | ~7 s (6 s rounds up) | **~21 s** | sub-spec → rejected |
+| `master_2s` | ~3 s | **~9 s** | legal → honoured |
+
+**Below the floor:** iOS AVPlayer goes **degraded** — all offset/buffer/seekable telemetry
+comes back null and `error_code = -12646` fires. **At/above the floor:** honoured exactly
+(`configured`/`recommended` = N, linear). The same offset is therefore sub-spec on s6 but
+legal on s2 — that's the load-bearing segment×offset contrast in the #793 matrix.
+
+## Lever 2 — app override (`is.flag.live_offset_s`)
+
+A client-side launch flag that seeks to `liveEdge − N` and pins the player's target offset.
+Overrides the manifest when > 0.
+
+- **iOS:** `-is.flag.live_offset_s N` (NSArgumentDomain launch arg) →
+  `AVPlayerItem.configuredTimeOffsetFromLive` + an absolute seek (`PlayerViewModel.swift`).
+- **Android:** `--es is.flag.live_offset_s N` (intent extra, added in #796 / PR for #266) →
+  `LiveConfiguration.setTargetOffsetMs` + a seek to `liveEdge − N` (the 0.97–1.03 speed
+  window converges too slowly on its own, so it seeks). `MainActivity.kt` reads the extra.
+- **Works below the floor** (it's a seek, not a manifest constraint), so it's the only way to
+  drive a *tight* offset on s6.
+- **Field it moves:** `wall_offset` (derived = `seekable_end_s − position_s`). `configured`
+  stays at the manifest's value.
+
+## The fields (what to read, what to trust)
+
+| Field | Meaning | Trust |
+|---|---|---|
+| `configured_offset_s` / `recommended_offset_s` | manifest target the player parsed | **the proxy-lever ground truth** |
+| `wall_offset` (= `seekable_end_s − position_s`) | physical playhead-behind-edge | **the app-override ground truth** |
+| `buffer_depth_s` | forward loaded range; ≈ `wall_offset + hold-back` | use for buffer questions |
+| `live_offset_s` / `true_offset_s` | player-reported achieved offset | **over-reads ~1.3–2×** — don't use as the headline |
+
+## How to test it
+
+### Per-run probe (sweep / characterization)
+
+```
+# manifest lever: app pinned to 0 (avoid confounding), proxy sets the offset
+harness content <player_id> --live-offset 24
+CHAR_PLAYER_ID=<player_id> LAUNCH_MODE=appium \
+  CHAR_SWEEP_PLATFORM=ipad-sim CHAR_SWEEP_SEGMENT=s6 CHAR_SWEEP_LIVE_OFFSET=0 \
+  CHAR_CONTENT=insane_new_p200_h264 CHAR_SWEEP_DURATION_S=65 \
+  CHARACTERIZATION_DEVICE_UDID=<udid> \
+  go test ./tests/characterization/modes -run TestSweepProbe -count=1 -v -timeout 8m
+
+# app-override lever: manifest neutral (0), app flag sets the offset
+harness content <player_id> --live-offset 0
+CHAR_SWEEP_LIVE_OFFSET=24   # (same probe; → -is.flag.live_offset_s 24)
+```
+
+- `CHAR_SWEEP_LIVE_OFFSET` maps to the app flag; the probe **always pins it** (default 0) so
+  no run silently inherits the persisted app value — a real confound we hit (a manifest-only
+  sweep showed the app's base offset leaking in).
+- `CHAR_SWEEP_SEGMENT=s6|s2` picks the master (the floor scales with it).
+- Measure from CH after a short flush delay (the forwarder batches): query
+  `/analytics/api/v2/events?play_id=<play>` and take the median of the fields above. The play
+  archive persists, so capture the `play_id` and re-measure if a read comes back empty.
+
+### Server-behavior test (the proxy rewrite itself)
+
+```
+env THROUGHPUT_HOST=dev.jeoliver.com THROUGHPUT_API_PORT=21000 THROUGHPUT_INSECURE=1 \
+  go test ./tests/server_behavior -run 'TestServerContent/master_live_offset' -v
+```
+
+Asserts the proxy rewrites `EXT-X-START:TIME-OFFSET=-N` on the master **and** `HOLD-BACK=N`
+on the variant — the regression test for the master-only-gate bug.
+
+### The manipulation-check gate (validity, #793)
+
+`harness sweep analyze … --confirm-reps 3` marks a live_offset run **`inconclusive`** (not a
+finding) if the *achieved* offset doesn't reach the *intended* value (segment-slack-aware). A
+run that never moved the IV says nothing about any live_offset→QoE hypothesis. See
+`docs/sweep-design.md §3.1`.
+
+## Platform coverage (what's testable where)
+
+| | iOS (sim / device) | Android TV |
+|---|---|---|
+| Manifest live_offset | ✅ | ✅ |
+| App override (`is.flag.live_offset_s`) | ✅ | ✅ (#796) |
+| Segment select (`s2` / LL, to move the floor) | ✅ (`-is.segment`) | ✅ (`--es is.segment`, #798) |
+
+Android `is.segment` landed in **#798** (closing the #797 parity gap), so the
+**`master_2s` / LL live-offset quadrants are now drivable on Android** — provided the device runs
+a #798-or-later build (rebuild + `adb install`). On a pre-#798 build Android is locked to
+`master_6s` (floor ~21 s), where anything below the floor degrades and can't be distinguished
+from the lever simply not landing.
+
+> **Android behaviour (measured, clean #793 matrix on a #798 build):** **both levers work and
+> track the set value.** Manifest/proxy: configured tracks with a slight ~1-segment over-read
+> (s6 12→13, 24→27, 30→36; s2 4→5 … 12→12.5). App override (`is.flag.live_offset_s`, #796):
+> `configured` tracks the value *exactly* (s6 12→12 … 30→30; s2 4→4 … 12→12). Two platform
+> differences vs iOS: (1) Android does **not** enforce the 3×-segment floor — sub-spec offsets
+> play at the requested value instead of refusing to start; (2) on Android `configured_offset_s`
+> reflects the **effective player target** (manifest *or* override), whereas on iOS it reflects the
+> **manifest target** and the override shows only in the achieved offset (`wall`).
+>
+> **Gotcha that confounds Android runs:** the in-app **`advanced_live_offset_s`** setting persists
+> in `shared_prefs/servers.xml` and pins the offset across launches; the launch arg does **not**
+> reliably override it (unlike iOS, where NSArgumentDomain outranks UserDefaults — see #800). Reset
+> it to 0 (or via the Settings UI) before a clean run, or every cell reads the saved value.

--- a/docs/sweep-design.md
+++ b/docs/sweep-design.md
@@ -139,6 +139,10 @@ surprise — exactly how we'd chase whether the over-downshift is iOS-specific, 
 
 ### 3.1 Manipulation check — the independent-variable must actually move (the validity gate, #793)
 
+> For the live_offset IV specifically — the two levers (manifest/proxy vs app override), the
+> 3×-max-segment floor, which fields each moves, how to drive + measure it, and per-platform
+> coverage — see **`docs/live-offset-testing.md`**.
+
 The oracle classifies QoE *outcomes*. But a recipe that varies a manifest **input** (a config-class IV like
 `content_manipulation.live_offset`) is only interpretable if that input demonstrably *took effect*. Otherwise a
 run is attributing an outcome to a cause that never varied. This is a **manipulation check**, and it runs

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6320,11 +6320,16 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	var bytesOut int64
 
-	// Apply content manipulation for master playlists
-	if isMasterManifest && shouldApplyContentManipulation(sessionData) {
+	// Apply content manipulation. Master playlists get the full set (strip /
+	// overstate / live-offset EXT-X-START). Media (VARIANT) playlists get the
+	// live-offset rewrite too — HOLD-BACK + EXT-X-START live in the variant and
+	// are what players actually key off, so a master-only rewrite has no effect
+	// (#793, regression caught by server_content_test master_live_offset).
+	liveOffsetOnVariant := isManifest && !isMasterManifest && getInt(sessionData, "content_live_offset") > 0
+	if (isMasterManifest && shouldApplyContentManipulation(sessionData)) || liveOffsetOnVariant {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Printf("ERROR: Failed to read master playlist body: %v", err)
+			log.Printf("ERROR: Failed to read playlist body for manipulation: %v", err)
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(proxyCtx.Err(), context.DeadlineExceeded) {
 				bumpFaultCounter(sessionData, "transfer_active_timeout")
 				logFaultEvent(sessionData, externalPort, "transfer_active_timeout", requestKind, "transfer_active_timeout_mid_body")
@@ -6333,11 +6338,17 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		modifiedBody, err := a.applyContentManipulation(bodyBytes, sessionData, contentType)
-		if err != nil {
-			log.Printf("ERROR: Failed to manipulate master playlist: %v", err)
-			// Fall back to original content
-			modifiedBody = bodyBytes
+		var modifiedBody []byte
+		if isMasterManifest {
+			modifiedBody, err = a.applyContentManipulation(bodyBytes, sessionData, contentType)
+			if err != nil {
+				log.Printf("ERROR: Failed to manipulate master playlist: %v", err)
+				modifiedBody = bodyBytes // fall back to original
+			}
+		} else {
+			// Media (variant) playlist: live-offset only — rewrite HOLD-BACK +
+			// EXT-X-START to the requested value.
+			modifiedBody = rewriteVariantLiveOffsetTags(bodyBytes, getInt(sessionData, "content_live_offset"))
 		}
 
 		w.Header().Set("Content-Length", strconv.Itoa(len(modifiedBody)))

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -25,8 +25,13 @@ const (
 // Defines values for ContentManipulationLiveOffset.
 const (
 	ContentManipulationLiveOffsetN0  ContentManipulationLiveOffset = 0
+	ContentManipulationLiveOffsetN12 ContentManipulationLiveOffset = 12
 	ContentManipulationLiveOffsetN18 ContentManipulationLiveOffset = 18
+	ContentManipulationLiveOffsetN2  ContentManipulationLiveOffset = 2
 	ContentManipulationLiveOffsetN24 ContentManipulationLiveOffset = 24
+	ContentManipulationLiveOffsetN36 ContentManipulationLiveOffset = 36
+	ContentManipulationLiveOffsetN4  ContentManipulationLiveOffset = 4
+	ContentManipulationLiveOffsetN42 ContentManipulationLiveOffset = 42
 	ContentManipulationLiveOffsetN6  ContentManipulationLiveOffset = 6
 )
 
@@ -35,9 +40,19 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	switch e {
 	case ContentManipulationLiveOffsetN0:
 		return true
+	case ContentManipulationLiveOffsetN12:
+		return true
 	case ContentManipulationLiveOffsetN18:
 		return true
+	case ContentManipulationLiveOffsetN2:
+		return true
 	case ContentManipulationLiveOffsetN24:
+		return true
+	case ContentManipulationLiveOffsetN36:
+		return true
+	case ContentManipulationLiveOffsetN4:
+		return true
+	case ContentManipulationLiveOffsetN42:
 		return true
 	case ContentManipulationLiveOffsetN6:
 		return true
@@ -665,7 +680,7 @@ type ContentManipulation struct {
 	// AllowedVariants When non-empty, only the listed variant URIs are kept in the master playlist.
 	AllowedVariants *[]string `json:"allowed_variants,omitempty"`
 
-	// LiveOffset Live edge offset window in seconds. 0 = no offset.
+	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
 	LiveOffset *ContentManipulationLiveOffset `json:"live_offset,omitempty"`
 
 	// OverstateBandwidth Inflate BANDWIDTH attribute by 10%.
@@ -684,7 +699,7 @@ type ContentManipulation struct {
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
-// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
+// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
 type ContentManipulationLiveOffset int
 
 // ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -29,6 +29,7 @@ const (
 	ContentManipulationLiveOffsetN18 ContentManipulationLiveOffset = 18
 	ContentManipulationLiveOffsetN2  ContentManipulationLiveOffset = 2
 	ContentManipulationLiveOffsetN24 ContentManipulationLiveOffset = 24
+	ContentManipulationLiveOffsetN30 ContentManipulationLiveOffset = 30
 	ContentManipulationLiveOffsetN36 ContentManipulationLiveOffset = 36
 	ContentManipulationLiveOffsetN4  ContentManipulationLiveOffset = 4
 	ContentManipulationLiveOffsetN42 ContentManipulationLiveOffset = 42
@@ -47,6 +48,8 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	case ContentManipulationLiveOffsetN2:
 		return true
 	case ContentManipulationLiveOffsetN24:
+		return true
+	case ContentManipulationLiveOffsetN30:
 		return true
 	case ContentManipulationLiveOffsetN36:
 		return true
@@ -680,7 +683,7 @@ type ContentManipulation struct {
 	// AllowedVariants When non-empty, only the listed variant URIs are kept in the master playlist.
 	AllowedVariants *[]string `json:"allowed_variants,omitempty"`
 
-	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
+	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.
 	LiveOffset *ContentManipulationLiveOffset `json:"live_offset,omitempty"`
 
 	// OverstateBandwidth Inflate BANDWIDTH attribute by 10%.
@@ -699,7 +702,7 @@ type ContentManipulation struct {
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
-// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
+// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.
 type ContentManipulationLiveOffset int
 
 // ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.

--- a/tests/characterization/modes/sweep_probe_test.go
+++ b/tests/characterization/modes/sweep_probe_test.go
@@ -103,6 +103,14 @@ func TestSweepProbe(t *testing.T) {
 	if seg := strings.TrimSpace(os.Getenv("CHAR_SWEEP_SEGMENT")); seg != "" {
 		args = append(args, "-is.segment", seg)
 	}
+	// App-side live-offset override (#793): is.flag.live_offset_s sets the
+	// player's own target — it seeks to liveEdge−N and OVERRIDES the manifest
+	// HOLD-BACK when >0. Lets the sweep exercise the manifest × app-override
+	// combination matrix (the manifest offset comes from the bootstrapped
+	// session; this is the app lever on top).
+	if lo := strings.TrimSpace(os.Getenv("CHAR_SWEEP_LIVE_OFFSET")); lo != "" {
+		args = append(args, "-is.flag.live_offset_s", lo)
+	}
 	appium.SetLaunchArgs(args)
 
 	sess, err := appium.LaunchToHome(setupCtx, *picked)

--- a/tests/characterization/modes/sweep_probe_test.go
+++ b/tests/characterization/modes/sweep_probe_test.go
@@ -105,12 +105,16 @@ func TestSweepProbe(t *testing.T) {
 	}
 	// App-side live-offset override (#793): is.flag.live_offset_s sets the
 	// player's own target — it seeks to liveEdge−N and OVERRIDES the manifest
-	// HOLD-BACK when >0. Lets the sweep exercise the manifest × app-override
-	// combination matrix (the manifest offset comes from the bootstrapped
-	// session; this is the app lever on top).
-	if lo := strings.TrimSpace(os.Getenv("CHAR_SWEEP_LIVE_OFFSET")); lo != "" {
-		args = append(args, "-is.flag.live_offset_s", lo)
+	// HOLD-BACK when >0. ALWAYS pin it (default "0") so a run never inherits the
+	// app's persisted/stepper value, which would silently confound a
+	// manifest-only test (the launch-arg domain wins over the saved default).
+	// CHAR_SWEEP_LIVE_OFFSET sets a non-zero value to exercise the app lever /
+	// the manifest × app-override combination matrix.
+	lo := strings.TrimSpace(os.Getenv("CHAR_SWEEP_LIVE_OFFSET"))
+	if lo == "" {
+		lo = "0"
 	}
+	args = append(args, "-is.flag.live_offset_s", lo)
 	appium.SetLaunchArgs(args)
 
 	sess, err := appium.LaunchToHome(setupCtx, *picked)

--- a/tests/server_behavior/server_content_test.go
+++ b/tests/server_behavior/server_content_test.go
@@ -135,6 +135,56 @@ func TestServerContent(t *testing.T) {
 		})
 	}
 
+	// --- live_offset: EXT-X-START injected on the served master (#793). This
+	// is the wire check the suite was missing — the unit test only covers the
+	// rewrite FUNCTION, so a delivery regression (manipulation not reaching the
+	// served master) would go unnoticed. Fetch the master with live_offset set
+	// and assert the tag actually carries the value. ---
+	t.Run("master_live_offset", func(t *testing.T) {
+		if err := patchSession(p.c, p.apiBase, p.sess.SessionID, map[string]any{"content_live_offset": 24}); err != nil {
+			t.Fatalf("set live_offset: %v", err)
+		}
+		defer patchSession(p.c, p.apiBase, p.sess.SessionID, map[string]any{"content_live_offset": 0})
+		time.Sleep(500 * time.Millisecond)
+
+		got, _, err := getBytes(p.c, p.masterURL)
+		if err != nil {
+			t.Fatalf("manipulated master fetch: %v", err)
+		}
+		const want = "#EXT-X-START:TIME-OFFSET=-24"
+		present := bytes.Contains(got, []byte(want))
+		if !present {
+			n := len(got)
+			if n > 500 {
+				n = 500
+			}
+			t.Errorf("live_offset=24: served master is MISSING %q — manipulation not reaching the wire.\n--- served master (first %d bytes) ---\n%s", want, n, got[:n])
+		}
+		assertParseableMaster(t, "master/live_offset", got, p.masterURL, len(p.variants))
+		rows = append(rows, []string{"master/live_offset", want + " present=" + boolStr(present), boolStr(!bytes.Equal(base, got))})
+
+		// HOLD-BACK is a media-playlist-only tag and is what players actually
+		// key off for the join (#262: hls.js joins at HOLD-BACK; iOS uses
+		// recommendedTimeOffsetFromLive derived from it). EXT-X-START on the
+		// master alone is largely advisory. Verify the VARIANT HOLD-BACK is
+		// rewritten too — the content-manipulation gate is master-only, so this
+		// is expected to expose that the variant is never manipulated (#793).
+		vbody, _, err := getBytes(p.c, p.top.URL)
+		if err != nil {
+			t.Fatalf("variant playlist fetch: %v", err)
+		}
+		const wantHB = "HOLD-BACK=24"
+		hbPresent := bytes.Contains(vbody, []byte(wantHB))
+		if !hbPresent {
+			n := len(vbody)
+			if n > 500 {
+				n = 500
+			}
+			t.Errorf("live_offset=24: variant playlist HOLD-BACK NOT rewritten to 24 — players key off HOLD-BACK, so the live-offset has no effect even though the master EXT-X-START is set. The manipulation gate is master-only (main.go isMasterManifest).\n--- served variant (first %d bytes) ---\n%s", n, vbody[:n])
+		}
+		rows = append(rows, []string{"variant/live_offset", wantHB + " present=" + boolStr(hbPresent), "-"})
+	})
+
 	// --- segment corruption: fetch real, then corrupted (zero-filled) ---
 	t.Run("segment_corrupted", func(t *testing.T) {
 		segs := p.pullOnce(t)

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -632,7 +632,7 @@ func toProxyContent(cm *sweep.ContentManipulation, allowedVariants []string) (*p
 	if cm.LiveOffset != nil {
 		off := proxy.ContentManipulationLiveOffset(int(*cm.LiveOffset))
 		if !off.Valid() {
-			return nil, fmt.Errorf("live_offset %g is not a supported window (0|2|4|6|12|18|24|36|42)", *cm.LiveOffset)
+			return nil, fmt.Errorf("live_offset %g is not a supported window (0|2|4|6|12|18|24|30|36|42)", *cm.LiveOffset)
 		}
 		out.LiveOffset = &off
 	}

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -632,7 +632,7 @@ func toProxyContent(cm *sweep.ContentManipulation, allowedVariants []string) (*p
 	if cm.LiveOffset != nil {
 		off := proxy.ContentManipulationLiveOffset(int(*cm.LiveOffset))
 		if !off.Valid() {
-			return nil, fmt.Errorf("live_offset %g is not a supported window (0|6|18|24)", *cm.LiveOffset)
+			return nil, fmt.Errorf("live_offset %g is not a supported window (0|2|4|6|12|18|24|36|42)", *cm.LiveOffset)
 		}
 		out.LiveOffset = &off
 	}

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -26,8 +26,13 @@ const (
 // Defines values for ContentManipulationLiveOffset.
 const (
 	ContentManipulationLiveOffsetN0  ContentManipulationLiveOffset = 0
+	ContentManipulationLiveOffsetN12 ContentManipulationLiveOffset = 12
 	ContentManipulationLiveOffsetN18 ContentManipulationLiveOffset = 18
+	ContentManipulationLiveOffsetN2  ContentManipulationLiveOffset = 2
 	ContentManipulationLiveOffsetN24 ContentManipulationLiveOffset = 24
+	ContentManipulationLiveOffsetN36 ContentManipulationLiveOffset = 36
+	ContentManipulationLiveOffsetN4  ContentManipulationLiveOffset = 4
+	ContentManipulationLiveOffsetN42 ContentManipulationLiveOffset = 42
 	ContentManipulationLiveOffsetN6  ContentManipulationLiveOffset = 6
 )
 
@@ -36,9 +41,19 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	switch e {
 	case ContentManipulationLiveOffsetN0:
 		return true
+	case ContentManipulationLiveOffsetN12:
+		return true
 	case ContentManipulationLiveOffsetN18:
 		return true
+	case ContentManipulationLiveOffsetN2:
+		return true
 	case ContentManipulationLiveOffsetN24:
+		return true
+	case ContentManipulationLiveOffsetN36:
+		return true
+	case ContentManipulationLiveOffsetN4:
+		return true
+	case ContentManipulationLiveOffsetN42:
 		return true
 	case ContentManipulationLiveOffsetN6:
 		return true
@@ -666,7 +681,7 @@ type ContentManipulation struct {
 	// AllowedVariants When non-empty, only the listed variant URIs are kept in the master playlist.
 	AllowedVariants *[]string `json:"allowed_variants,omitempty"`
 
-	// LiveOffset Live edge offset window in seconds. 0 = no offset.
+	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
 	LiveOffset *ContentManipulationLiveOffset `json:"live_offset,omitempty"`
 
 	// OverstateBandwidth Inflate BANDWIDTH attribute by 10%.
@@ -685,7 +700,7 @@ type ContentManipulation struct {
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
-// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset.
+// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
 type ContentManipulationLiveOffset int
 
 // ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -30,6 +30,7 @@ const (
 	ContentManipulationLiveOffsetN18 ContentManipulationLiveOffset = 18
 	ContentManipulationLiveOffsetN2  ContentManipulationLiveOffset = 2
 	ContentManipulationLiveOffsetN24 ContentManipulationLiveOffset = 24
+	ContentManipulationLiveOffsetN30 ContentManipulationLiveOffset = 30
 	ContentManipulationLiveOffsetN36 ContentManipulationLiveOffset = 36
 	ContentManipulationLiveOffsetN4  ContentManipulationLiveOffset = 4
 	ContentManipulationLiveOffsetN42 ContentManipulationLiveOffset = 42
@@ -48,6 +49,8 @@ func (e ContentManipulationLiveOffset) Valid() bool {
 	case ContentManipulationLiveOffsetN2:
 		return true
 	case ContentManipulationLiveOffsetN24:
+		return true
+	case ContentManipulationLiveOffsetN30:
 		return true
 	case ContentManipulationLiveOffsetN36:
 		return true
@@ -681,7 +684,7 @@ type ContentManipulation struct {
 	// AllowedVariants When non-empty, only the listed variant URIs are kept in the master playlist.
 	AllowedVariants *[]string `json:"allowed_variants,omitempty"`
 
-	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
+	// LiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.
 	LiveOffset *ContentManipulationLiveOffset `json:"live_offset,omitempty"`
 
 	// OverstateBandwidth Inflate BANDWIDTH attribute by 10%.
@@ -700,7 +703,7 @@ type ContentManipulation struct {
 	VariantOrder *ContentManipulationVariantOrder `json:"variant_order,omitempty"`
 }
 
-// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/36/42 added (#793) for the segment×live-offset matrix.
+// ContentManipulationLiveOffset Live edge offset window in seconds. 0 = no offset. Values 2/4/12/30/36/42 added (#793) for the segment×live-offset matrix.
 type ContentManipulationLiveOffset int
 
 // ContentManipulationVariantOrder Re-sort the video EXT-X-STREAM-INF entries by BANDWIDTH to probe whether master-playlist order biases AVPlayer's initial-variant pick (#682). ascending = lowest first (our authoring); descending = highest first; first_4mbps = promote the variant nearest 4 Mbps to first-listed, rest ascending (initial-variant probe); default = passthrough. EXT-X-MEDIA audio/subtitle renditions are left untouched.


### PR DESCRIPTION
## Summary

Live-offset (#793) feature + test coverage:

- **Supported window set** expanded (2, 4, 12, 30, 36, 42) across the proxy schema (`api/openapi/v2/proxy.yaml`, dashboard api-docs, both generated `proxy.gen.go`/`oapigen.gen.go`).
- **Proxy fix:** apply the live-offset rewrite to **variant** playlists, not just the master (`go-proxy/cmd/server/main.go`).
- **iOS:** the app `live_offset` launch flag now parses (was stuck "Off") — `apple/.../PlayerViewModel.swift`.
- **Dashboard:** expose 12s/36s + all supported values in the content UI (`ContentManipulation.vue`, `types/v2.ts`).
- **Tests:** sweep probe pins the app live-offset (default 0) — `sweep_probe_test.go`; server-behavior coverage in `server_content_test.go`.
- **Docs:** `docs/live-offset-testing.md` (operator + sweep-skill reference for the two independent levers), `docs/sweep-design.md`, sweep `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
