### PR TITLE
feat(appium-df): Appium Device Farm integration — capability launch, fleet roster, config-on-connect bind, default-on

### DIFF
--- a/tests/characterization/README.md
+++ b/tests/characterization/README.md
@@ -153,6 +153,24 @@ The `-launch-mode` flag is preferred over the env var — keeps `go` as the firs
 
 The CLI launcher expects each player app to be built with `skipHomeOnLaunch=true` so a cold launch picks up `lastPlayed` automatically — that's how it can recover from a wedged player without driving UI.
 
+### Device Farm (`CHAR_DEVICE_FARM=1`)
+
+Layered on top of `appium` mode: instead of the harness hand-picking a UDID and offsetting WDA/MJPEG ports, the [`appium-device-farm`](../../tools/appium-device-farm/) plugin arbitrates devices — capability-based allocation, queuing, and auto port assignment (like Selenium Grid for browsers). Turn it on with `CHAR_DEVICE_FARM=1` alongside `-launch-mode=appium`. The plain-appium path stays the default.
+
+Under the flag the harness requests a device by capability (`platformName` + latest `platformVersion` for sims, overridable via `CHAR_DF_IOS_VERSION` / `CHAR_DF_TVOS_VERSION`; real hardware unconstrained), reads back the allocated UDID, and builds the fleet roster as N **logical** devices (`CHAR_FLEET_COUNT`, default 1) — no UDID pinning, port offsets, `staggerFleetLaunch`, or per-UDID `seedFleetServer` (the server is set by the app's server-picker navigation). `CHAR_FLEET_UDIDS` identities are ignored under DF.
+
+Workflow:
+
+```sh
+tools/appium-device-farm/boot-pool.sh   # boot N latest-OS sims + verify app + warm WDA
+tools/appium-device-farm/run.sh         # start the DF server on :4723
+CHAR_DEVICE_FARM=1 go test -C tests/characterization ./modes/... \
+  -run TestStartupIPadSim -launch-mode=appium -timeout 20m
+# or: CHAR_DEVICE_FARM=1 make characterize-ipad-sim   (overnight.sh boots the pool for you)
+```
+
+DF only allocates among already-booted sims, so `boot-pool.sh` is the required first step for sim pools; it also warms each sim's WebDriverAgent so the first session doesn't cold-build WDA inside a launch timeout. See [`tools/appium-device-farm/README.md`](../../tools/appium-device-farm/README.md).
+
 ### Bundle IDs (overridable via `BundleIDs[platform]`)
 
 | Platform | Bundle ID |
@@ -168,6 +186,10 @@ The CLI launcher expects each player app to be built with `skipHomeOnLaunch=true
 | `HARNESS_BIN` | `harness` | path to the harness CLI binary |
 | `HARNESS_INSECURE` | unset (=on) | disable with `HARNESS_INSECURE=0` against a public-cert deploy |
 | `LAUNCH_MODE` | `cli` | `manual` \| `cli` \| `appium` |
+| `CHAR_DEVICE_FARM` | unset | `1` routes `appium` launches through the device-farm plugin (capability allocation; see **Device Farm** above) |
+| `CHAR_DF_IOS_VERSION` | latest installed | override the iOS `platformVersion` DF pins for sims (major.minor, e.g. `26.4`) |
+| `CHAR_DF_TVOS_VERSION` | unset | pin a tvOS `platformVersion` under DF (sims only) |
+| `CHAR_FLEET_COUNT` | `1` | fleet size — N parallel devices. Under DF these are logical (DF allocates); without DF, the first N booted sims of the platform |
 | `CHARACTERIZATION_OUTDIR` | `t.TempDir()` | persistent artifacts directory (set for CI / aggregator use) |
 | `CHARACTERIZATION_DEVICE_UDID` | unset = first-match | target a specific device by UDID. Use to run parallel tests across multiple sims of the same platform — each terminal exports its own UDID, no race for the same device. |
 | `CHAR_RAMPUP_REPS` | `3` | rampup cycles per run, on ONE live play. Between cycles the cap drops top→floor and the player re-climbs — the inter-cycle transition is the instructive part. |

--- a/tests/characterization/modes/fleet.go
+++ b/tests/characterization/modes/fleet.go
@@ -66,6 +66,15 @@ func fleetSubtestName(dev runner.Device) string {
 // a helper has already issued t.Skip — the caller then returns early.
 func resolveFleet(t *testing.T, p runner.Platform) []runner.Device {
 	t.Helper()
+	// Device Farm path: the plugin owns device allocation, so the roster is just
+	// N LOGICAL devices (no discovery, booting, UDID-pinning, or per-UDID server
+	// seeding). Each LaunchToHome requests a device by capability and DF hands
+	// out a free one + auto-assigns ports; the server is set by LaunchToHome's
+	// navigateServerPickerIfPresent (replacing seedFleetServer). FleetIndex stays
+	// logical (arm assignment + fleet barriers). See HANDOFF.md Stage 2.
+	if runner.DeviceFarmEnabled() {
+		return resolveFleetDeviceFarm(t, p)
+	}
 	if raw := strings.TrimSpace(os.Getenv("CHAR_FLEET_UDIDS")); raw != "" {
 		return resolveFleetFromUDIDs(t, p, splitFleetCSV(raw))
 	}
@@ -73,6 +82,31 @@ func resolveFleet(t *testing.T, p runner.Platform) []runner.Device {
 		return resolveFleetByCount(t, p, n)
 	}
 	return resolveSingleDevice(t, p)
+}
+
+// resolveFleetDeviceFarm builds the Device Farm roster: N logical devices of
+// platform p, FleetIndex by position, no UDID (DF allocates by capability). N is
+// CHAR_FLEET_COUNT (default 1); if CHAR_FLEET_UDIDS is set its identities are
+// ignored under DF — only its length matters, as a fleet-size hint. The
+// operator boots the pool (the latest-OS, app-installed Fleet sims) up front;
+// see tools/appium-device-farm/boot-pool.sh.
+func resolveFleetDeviceFarm(t *testing.T, p runner.Platform) []runner.Device {
+	t.Helper()
+	n := envInt("CHAR_FLEET_COUNT", 1)
+	if raw := strings.TrimSpace(os.Getenv("CHAR_FLEET_UDIDS")); raw != "" {
+		if ids := splitFleetCSV(raw); len(ids) > 0 {
+			t.Logf("CHAR_DEVICE_FARM=1: ignoring CHAR_FLEET_UDIDS device identities (DF allocates by capability); using fleet size %d", len(ids))
+			n = len(ids)
+		}
+	}
+	if n < 1 {
+		n = 1
+	}
+	fleet := make([]runner.Device, n)
+	for i := range fleet {
+		fleet[i] = runner.Device{Platform: p, FleetIndex: i}
+	}
+	return fleet
 }
 
 // resolveSingleDevice reproduces the legacy discover→first-match selection:
@@ -355,6 +389,11 @@ func (b *fleetStartBarrier) giveUp() {
 // so this only affects bring-up order. Index 0 never waits.
 func staggerFleetLaunch(t *testing.T, fleetIndex int) {
 	t.Helper()
+	// Under Device Farm the plugin queues concurrent session-creates internally
+	// (maxSessions), so there's nothing to spread out — the stagger is redundant.
+	if runner.DeviceFarmEnabled() {
+		return
+	}
 	if fleetIndex <= 0 {
 		return
 	}

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -557,10 +557,16 @@ func RunVariantSweep(ctx context.Context, t *testing.T, sess *runner.Session, mo
 			return r
 		}
 		// Wedge detection: if the player's playhead hasn't moved over
-		// the last 10 s, it's given up. Remaining caps are strictly
+		// the last 2 min, it's given up. Remaining caps are strictly
 		// lower (descending sweep) so we'd just stack more stalls onto
 		// a dead player. Mark the rest skipped and exit so the report
 		// reflects "we stopped here because the player wedged."
+		//
+		// 2-min window (was 10 s): a startup-overshoot player can park on a
+		// too-high rung and rebuffer for a while before the ABR recovers down
+		// to the capped rung — a 10 s window declared that a wedge and aborted
+		// a player that was still working through it. 2 min only fires on a
+		// player that's genuinely dead, not one slowly recovering.
 		//
 		// #632: skip this on the FIRST step. The entry step is where the
 		// player resumes (often probing high — e.g. 4K with no
@@ -569,7 +575,7 @@ func RunVariantSweep(ctx context.Context, t *testing.T, sess *runner.Session, mo
 		// during that downshift+rebuffer, which is NOT a wedge — declaring
 		// one here aborts a player that's actively recovering. Later steps
 		// start from a settled buffer, so the check is valid there.
-		if i > 0 && playerWedged(s, 10*time.Second) {
+		if i > 0 && playerWedged(s, 2*time.Minute) {
 			t.Logf("  player wedged (position not advancing) — skipping remaining %d step(s)",
 				len(steps)-i-1)
 			for k := i + 1; k < len(steps); k++ {

--- a/tests/characterization/modes/sweep.go
+++ b/tests/characterization/modes/sweep.go
@@ -347,41 +347,73 @@ func OpenSessionOnDevice(t *testing.T, platform runner.Platform, dev *runner.Dev
 	}
 
 	var sess *runner.Session
-	if appium, isAppium := launcher.(*runner.AppiumLauncher); isAppium && bars != nil {
-		// Fleet path: split the launch so the home barrier can gate the
-		// simultaneous playback start. The launcher already carries any launch
-		// args the caller set (none for the high-start modes). A generous
-		// setup window — an early sim holds at the home barrier until the last
-		// (most-staggered) sim arrives.
-		setupCtx, setupCancel := context.WithTimeout(context.Background(), 12*time.Minute)
-		defer setupCancel()
+	if appium, isAppium := launcher.(*runner.AppiumLauncher); isAppium {
+		// Appium binds via CONFIG-ON-CONNECT (a minted player_id) rather than the
+		// heuristic pickPlayerFor inside launcher.Launch. pickPlayerFor guesses the
+		// player by UDID-prefix / UA-substring / "sole heartbeater" — all of which
+		// fail under Device Farm and on a shared server: the player_id is a random
+		// UUID (not the sim UDID), iPhone sims classify as ipad-sim (UA "iphone" ≠
+		// hint "ipad"), and a fleet/shared box has many heartbeaters. Minting the id
+		// and waiting on THAT (the same path pyramid/rampup already use) makes the
+		// warmup bind deterministic regardless of how many players are live.
+		//
+		// Fleet runs need a generous window (an early sim holds at the home barrier
+		// until the last, most-staggered sim arrives); single runs keep 90 s.
+		bindCtx := ctx
+		if bars != nil {
+			var bindCancel context.CancelFunc
+			bindCtx, bindCancel = context.WithTimeout(context.Background(), 12*time.Minute)
+			defer bindCancel()
+		}
 		// If we die before reaching the home barrier (e.g. LaunchToHome fails),
 		// drop ourselves from its expected set so the survivors still release
-		// together. t.Fatalf runs deferred funcs via runtime.Goexit.
+		// together. t.Fatalf runs deferred funcs via runtime.Goexit. (nil bars =
+		// single-device run, no barrier.)
 		homeArrived := false
-		defer func() {
-			if !homeArrived {
-				bars.home.giveUp()
-			}
-		}()
-		s, lerr := appium.LaunchToHome(setupCtx, *picked)
+		if bars != nil {
+			defer func() {
+				if !homeArrived {
+					bars.home.giveUp()
+				}
+			}()
+		}
+		// Uncapped warmup (cap=0 → no shape): OpenSession just opens + binds; the
+		// mode applies its own rates afterward. groupID="" — grouping for the
+		// measured sweep is the mode's job, not the warmup's.
+		pid := runner.NewPlayerID()
+		wireConfigOnConnect(bindCtx, t, appium, nil, pid, 0, 0, 0, "", false, nil)
+		s, lerr := appium.LaunchToHome(bindCtx, *picked)
 		if lerr != nil {
 			t.Fatalf("LaunchToHome: %v", lerr)
 		}
-		// Fleet sync #1 (home): hold until every sim is at home, then all start
-		// playback at once.
-		homeArrived = true
-		t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
-		bars.home.arriveAndWait(setupCtx)
-		t.Logf("HOME barrier released — starting playback")
-		if rerr := appium.ResumePlayback(setupCtx, *picked); rerr != nil {
+		s.PlayerID = pid
+		if bars != nil {
+			// Fleet sync #1 (home): hold until every sim is at home, then all start
+			// playback at once.
+			homeArrived = true
+			t.Logf("at home — waiting at fleet HOME barrier (playback starts together)")
+			bars.home.arriveAndWait(bindCtx)
+			t.Logf("HOME barrier released — starting playback")
+		}
+		// Tap the pinned clip's tile when CHAR_CONTENT is set (deterministic
+		// content), else the continue-watching hero. Mirrors pyramid.
+		var rerr error
+		if clip := os.Getenv("CHAR_CONTENT"); clip != "" {
+			rerr = appium.ResumePlaybackClip(bindCtx, *picked, clipIDFromContent(clip))
+		} else {
+			rerr = appium.ResumePlayback(bindCtx, *picked)
+		}
+		if rerr != nil {
 			t.Fatalf("ResumePlayback: %v", rerr)
 		}
-		if herr := s.WaitForHeartbeat(setupCtx, 90*time.Second); herr != nil {
+		if herr := s.WaitForHeartbeat(bindCtx, 90*time.Second); herr != nil {
 			t.Fatalf("WaitForHeartbeat: %v", herr)
 		}
 		sess = s
 	} else {
+		// CLI / Manual can't inject a player_id, so they bind heuristically
+		// (the app uses its own persistent id). launcher.Launch = home + resume +
+		// pickPlayerFor heartbeat.
 		s, lerr := launcher.Launch(ctx, *picked)
 		if lerr != nil {
 			t.Fatalf("launch %s: %v", picked, lerr)

--- a/tests/characterization/overnight.sh
+++ b/tests/characterization/overnight.sh
@@ -45,12 +45,28 @@ mkdir -p "$RUN_DIR"
 
 LAUNCH_MODE=${LAUNCH_MODE:-appium}
 PER_TEST_TIMEOUT=${PER_TEST_TIMEOUT:-120m}
-DEVICE_FARM=${CHAR_DEVICE_FARM:-}   # propagates to `go test` via the environment
+# Resolve Device Farm on/off the SAME way the Go harness does (runner.DeviceFarmEnabled):
+# DEFAULT ON — off only when explicitly 0/false/off. The shell env wins, else the
+# nearest .env. Without this, a DIRECT `./overnight.sh` run would allocate via DF
+# (the harness defaults on / reads .env) yet skip booting the pool here. `make
+# characterize-*` already `-include`s + exports .env.
+DEVICE_FARM="${CHAR_DEVICE_FARM:-}"
+if [[ -z "$DEVICE_FARM" && -f "$REPO_ROOT/.env" ]]; then
+    df_line="$(grep -E '^[[:space:]]*CHAR_DEVICE_FARM[[:space:]]*=' "$REPO_ROOT/.env" | tail -1)"
+    DEVICE_FARM="${df_line#*=}"
+    DEVICE_FARM="${DEVICE_FARM//[[:space:]]/}"
+    DEVICE_FARM="${DEVICE_FARM//\"/}"
+    DEVICE_FARM="${DEVICE_FARM//\'/}"
+fi
+DF_ON=1
+case "$(printf '%s' "$DEVICE_FARM" | tr '[:upper:]' '[:lower:]')" in
+    0|false|off) DF_ON=0 ;;
+esac
 
 # Under Device Farm the sim pool must be booted (+ WDA warm) before the run so DF
 # can allocate. boot-pool.sh is iOS-sim specific; real hardware / web don't need
 # it. Best-effort — a warning there shouldn't abort the run.
-if [[ "$DEVICE_FARM" == "1" && "$PLATFORM" == "ipad-sim" ]]; then
+if [[ "$DF_ON" == "1" && "$PLATFORM" == "ipad-sim" ]]; then
     echo "Device Farm on — booting the sim pool (boot-pool.sh)…"
     "$REPO_ROOT/tools/appium-device-farm/boot-pool.sh" || echo "  boot-pool reported an issue (continuing)"
 fi
@@ -60,7 +76,7 @@ SUMMARY=$RUN_DIR/summary.txt
     echo "platform:   $PLATFORM"
     echo "run_id:     $RUN_ID"
     echo "launch:     $LAUNCH_MODE"
-    echo "device_farm: ${DEVICE_FARM:+on}${DEVICE_FARM:-off}"
+    echo "device_farm: $([[ "$DF_ON" == "1" ]] && echo on || echo off)"
     echo "timeout:    $PER_TEST_TIMEOUT (per test)"
     echo "run_dir:    $RUN_DIR"
     echo "started:    $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/tests/characterization/overnight.sh
+++ b/tests/characterization/overnight.sh
@@ -45,12 +45,22 @@ mkdir -p "$RUN_DIR"
 
 LAUNCH_MODE=${LAUNCH_MODE:-appium}
 PER_TEST_TIMEOUT=${PER_TEST_TIMEOUT:-120m}
+DEVICE_FARM=${CHAR_DEVICE_FARM:-}   # propagates to `go test` via the environment
+
+# Under Device Farm the sim pool must be booted (+ WDA warm) before the run so DF
+# can allocate. boot-pool.sh is iOS-sim specific; real hardware / web don't need
+# it. Best-effort — a warning there shouldn't abort the run.
+if [[ "$DEVICE_FARM" == "1" && "$PLATFORM" == "ipad-sim" ]]; then
+    echo "Device Farm on — booting the sim pool (boot-pool.sh)…"
+    "$REPO_ROOT/tools/appium-device-farm/boot-pool.sh" || echo "  boot-pool reported an issue (continuing)"
+fi
 
 SUMMARY=$RUN_DIR/summary.txt
 {
     echo "platform:   $PLATFORM"
     echo "run_id:     $RUN_ID"
     echo "launch:     $LAUNCH_MODE"
+    echo "device_farm: ${DEVICE_FARM:+on}${DEVICE_FARM:-off}"
     echo "timeout:    $PER_TEST_TIMEOUT (per test)"
     echo "run_dir:    $RUN_DIR"
     echo "started:    $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -57,7 +57,13 @@ type AppiumLauncher struct {
 
 	mu       sync.Mutex
 	sessions map[string]string // device UDID → Appium session id
-	hc       *http.Client
+	// allocatedUDID is the UDID Device Farm assigned to this launcher's
+	// session, read back from the create-session response. Under DF the caller
+	// requests a device by capability (no UDID up front), so downstream methods
+	// that receive a UDID-less Device resolve the session through this. Empty in
+	// the non-DF path (the caller's Device already carries its UDID).
+	allocatedUDID string
+	hc            *http.Client
 }
 
 // NewAppiumLauncher returns a launcher pointing at the configured server.
@@ -242,7 +248,12 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 	if err := a.healthCheck(ctx); err != nil {
 		return nil, fmt.Errorf("appium server not reachable at %s: %w (start with `appium`, or unset LAUNCH_MODE=appium)", a.URL, err)
 	}
-	caps := appiumCapabilities(d, bundleID)
+	df := deviceFarmEnabled()
+	var platformVersion string
+	if df {
+		platformVersion = dfPlatformVersion(ctx, d.Platform)
+	}
+	caps := appiumCapabilities(d, bundleID, df, platformVersion)
 	// Always fold in the baseline test flags (4K on, peak clamp off unless the
 	// mode set it) so a sim's stale persisted UserDefaults can't leak in.
 	effectiveArgs := withBaselineTestFlags(a.launchArgs)
@@ -261,12 +272,21 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 			caps["appium:processArguments"] = map[string]any{"args": effectiveArgs}
 		}
 	}
-	sessID, err := a.createSession(ctx, caps)
+	sessID, allocatedUDID, err := a.createSession(ctx, caps)
 	if err != nil {
 		return nil, fmt.Errorf("appium create session: %w", err)
 	}
+	// Under Device Farm the device wasn't pinned — the plugin chose it. Adopt
+	// the allocated UDID so the session map, screenshots, logs, and
+	// ReleaseDevice key off the real device. The returned Session carries the
+	// updated Device so the caller's cleanup (CloseViaUI / ReleaseDevice) sees
+	// it too.
+	if df && allocatedUDID != "" {
+		d.UDID = allocatedUDID
+	}
 	a.mu.Lock()
 	a.sessions[d.UDID] = sessID
+	a.allocatedUDID = d.UDID
 	a.mu.Unlock()
 
 	// A freshly-installed/erased sim can come up on the blocking
@@ -298,9 +318,7 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 // that drive the phases separately call Session.WaitForHeartbeat
 // themselves afterward.
 func (a *AppiumLauncher) ResumePlayback(ctx context.Context, d Device) error {
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return errors.New("ResumePlayback: no active appium session for device")
 	}
@@ -336,9 +354,7 @@ func (a *AppiumLauncher) ResumePlaybackClip(ctx context.Context, d Device, clipI
 	if clipID == "" {
 		return a.ResumePlayback(ctx, d)
 	}
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return errors.New("ResumePlaybackClip: no active appium session for device")
 	}
@@ -394,9 +410,7 @@ func (a *AppiumLauncher) waitForHeartbeat(ctx context.Context, sess *Session) er
 // session entirely if terminate isn't supported on this driver.
 func (a *AppiumLauncher) Kill(ctx context.Context, d Device) error {
 	bundleID := a.BundleIDs[d.Platform]
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return nil // never launched; nothing to kill
 	}
@@ -423,9 +437,7 @@ func (a *AppiumLauncher) SetSegmentLength(ctx context.Context, d Device, value s
 	default:
 		return fmt.Errorf("SetSegmentLength: unsupported platform %s", d.Platform)
 	}
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return errors.New("SetSegmentLength: no active appium session for device")
 	}
@@ -456,9 +468,7 @@ func (a *AppiumLauncher) SetSegmentLength(ctx context.Context, d Device, value s
 // affordance isn't present (already on home / play already ended), it's a
 // no-op rather than an error where possible. Satisfies runner.UICloser.
 func (a *AppiumLauncher) ClosePlaybackViaUI(ctx context.Context, d Device) error {
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return nil // never launched; nothing to close
 	}
@@ -548,9 +558,7 @@ func (a *AppiumLauncher) ReleaseDevice(ctx context.Context, d Device) error {
 // Returns the path on success. Intended to be called from a sweep
 // runner to attach visual context to interesting steps.
 func (a *AppiumLauncher) Screenshot(ctx context.Context, d Device, path string) (string, error) {
-	a.mu.Lock()
-	sessID := a.sessions[d.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(d)
 	if sessID == "" {
 		return "", errors.New("screenshot: no active session for device")
 	}
@@ -661,9 +669,7 @@ func (a *AppiumLauncher) TapByAccessibilityID(ctx context.Context, sess *Session
 	if id == "" {
 		return errors.New("TapByAccessibilityID: empty id")
 	}
-	a.mu.Lock()
-	sessID := a.sessions[sess.Device.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(sess.Device)
 	if sessID == "" {
 		return errors.New("TapByAccessibilityID: no active appium session for device")
 	}
@@ -677,9 +683,7 @@ func (a *AppiumLauncher) TapTileByClipID(ctx context.Context, sess *Session, cli
 	if clipID == "" {
 		return errors.New("TapTileByClipID: empty clip_id")
 	}
-	a.mu.Lock()
-	sessID := a.sessions[sess.Device.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(sess.Device)
 	if sessID == "" {
 		return errors.New("TapTileByClipID: no active appium session for device")
 	}
@@ -700,9 +704,7 @@ func (a *AppiumLauncher) ReadPlayerID(ctx context.Context, sess *Session) (strin
 	if sess == nil {
 		return "", errors.New("ReadPlayerID: nil session")
 	}
-	a.mu.Lock()
-	sessID := a.sessions[sess.Device.UDID]
-	a.mu.Unlock()
+	sessID := a.sessionID(sess.Device)
 	if sessID == "" {
 		return "", errors.New("ReadPlayerID: no active appium session for device")
 	}
@@ -864,7 +866,12 @@ func (a *AppiumLauncher) healthCheck(ctx context.Context) error {
 	return nil
 }
 
-func (a *AppiumLauncher) createSession(ctx context.Context, caps map[string]any) (string, error) {
+// createSession opens a WebDriver session and returns its id plus the UDID of
+// the device Appium actually bound to (read back from the response's negotiated
+// capabilities). Under Device Farm the request carries no UDID, so this is how
+// we learn which device the plugin allocated; in the non-DF path it echoes back
+// the UDID we pinned. Empty allocatedUDID means the driver didn't surface one.
+func (a *AppiumLauncher) createSession(ctx context.Context, caps map[string]any) (sessID, allocatedUDID string, err error) {
 	body := map[string]any{
 		"capabilities": map[string]any{
 			"alwaysMatch": caps,
@@ -873,20 +880,53 @@ func (a *AppiumLauncher) createSession(ctx context.Context, caps map[string]any)
 	}
 	raw, err := a.doRequest(ctx, "POST", "/session", body)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	var resp struct {
 		Value struct {
-			SessionID string `json:"sessionId"`
+			SessionID    string         `json:"sessionId"`
+			Capabilities map[string]any `json:"capabilities"`
 		} `json:"value"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return "", err
+		return "", "", err
 	}
 	if resp.Value.SessionID == "" {
-		return "", fmt.Errorf("appium returned empty sessionId; body: %s", string(raw))
+		return "", "", fmt.Errorf("appium returned empty sessionId; body: %s", string(raw))
 	}
-	return resp.Value.SessionID, nil
+	udid := capString(resp.Value.Capabilities, "udid")
+	if udid == "" {
+		udid = capString(resp.Value.Capabilities, "appium:udid")
+	}
+	return resp.Value.SessionID, udid, nil
+}
+
+// capString reads a string-valued capability from a negotiated-capabilities map,
+// returning "" if absent or non-string.
+func capString(caps map[string]any, key string) string {
+	if caps == nil {
+		return ""
+	}
+	if v, ok := caps[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// sessionID resolves the Appium session id for a device. Normally it's keyed by
+// the device's UDID; under Device Farm the caller may hold a capability-
+// requested Device with no UDID, but this launcher owns exactly one allocated
+// session — so we fall back to the UDID Device Farm assigned (allocatedUDID).
+func (a *AppiumLauncher) sessionID(d Device) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if s, ok := a.sessions[d.UDID]; ok {
+		return s
+	}
+	if a.allocatedUDID != "" {
+		return a.sessions[a.allocatedUDID]
+	}
+	return ""
 }
 
 func (a *AppiumLauncher) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {
@@ -932,11 +972,17 @@ func truncate(s string, n int) string {
 // capabilities object Appium expects in session creation. noReset=true
 // keeps the app's state (so skipHomeOnLaunch + lastPlayed survive across
 // sessions); fullReset=false avoids wiping settings between runs.
-func appiumCapabilities(d Device, bundleID string) map[string]any {
+//
+// When df is true (CHAR_DEVICE_FARM=1) the device-allocation caps are dropped so
+// the appium-device-farm plugin arbitrates instead of us: no appium:udid (DF
+// picks the device), no deviceName (don't over-constrain the match), no
+// hand-offset WDA/MJPEG ports or derivedDataPath (DF auto-assigns ports). For
+// sims we pin appium:platformVersion (passed in by the caller) so DF never
+// allocates an old-OS sim; real hardware is left unconstrained.
+func appiumCapabilities(d Device, bundleID string, df bool, platformVersion string) map[string]any {
 	caps := map[string]any{
 		"appium:noReset":   true,
 		"appium:fullReset": false,
-		"appium:udid":      d.UDID,
 		"appium:bundleId":  bundleID,
 		// newCommandTimeout default is 60 s — Appium auto-terminates the
 		// session (and the app with it) if no WebDriver command lands
@@ -953,29 +999,41 @@ func appiumCapabilities(d Device, bundleID string) map[string]any {
 		// preserved because noReset=true.
 		"appium:forceAppLaunch": true,
 	}
-	if d.Label != "" {
-		caps["appium:deviceName"] = d.Label
+	if !df {
+		// Non-DF: we pin the exact device (and surface its name). Under DF the
+		// plugin chooses the device by capability, so omitting these lets it
+		// allocate freely from the pool.
+		caps["appium:udid"] = d.UDID
+		if d.Label != "" {
+			caps["appium:deviceName"] = d.Label
+		}
+	}
+	if df && platformVersion != "" {
+		caps["appium:platformVersion"] = platformVersion
 	}
 	switch d.Platform {
 	case PlatformIPhone, PlatformIPad:
 		caps["platformName"] = "iOS"
 		caps["appium:automationName"] = "XCUITest"
-		setXCUITestFleetPorts(caps, d.FleetIndex)
-		// Real-device WDA bring-up is the slow part: by default Appium runs
-		// xcodebuild + deploys WebDriverAgent into a throwaway DerivedData dir
-		// every session. Pin a STABLE derivedDataPath so the build persists
-		// across runs — xcodebuild goes incremental and the WDA app stays
-		// installed, cutting per-session bring-up. Always safe (still builds on
-		// first run). Per fleet index so parallel real devices don't share one
-		// build dir. (Sims are fast enough not to need this.)
-		caps["appium:derivedDataPath"] = iosWDADerivedDataPath(d.FleetIndex)
-		// CHAR_IOS_PREBUILT_WDA=1 skips the xcodebuild step entirely and reuses
-		// the WDA already built at derivedDataPath — the big speedup. Off by
-		// default because Appium ERRORS when usePrebuiltWDA is set but nothing
-		// has been built there yet: run once WITHOUT it to populate the path,
-		// then flip it on. (See the run-prebuilt-wda guide.)
-		if os.Getenv("CHAR_IOS_PREBUILT_WDA") == "1" {
-			caps["appium:usePrebuiltWDA"] = true
+		if !df {
+			setXCUITestFleetPorts(caps, d.FleetIndex)
+			// Real-device WDA bring-up is the slow part: by default Appium runs
+			// xcodebuild + deploys WebDriverAgent into a throwaway DerivedData dir
+			// every session. Pin a STABLE derivedDataPath so the build persists
+			// across runs — xcodebuild goes incremental and the WDA app stays
+			// installed, cutting per-session bring-up. Always safe (still builds on
+			// first run). Per fleet index so parallel real devices don't share one
+			// build dir. (Sims are fast enough not to need this.) Under DF the
+			// plugin owns port + session allocation, so we don't hand-pin these.
+			caps["appium:derivedDataPath"] = iosWDADerivedDataPath(d.FleetIndex)
+			// CHAR_IOS_PREBUILT_WDA=1 skips the xcodebuild step entirely and reuses
+			// the WDA already built at derivedDataPath — the big speedup. Off by
+			// default because Appium ERRORS when usePrebuiltWDA is set but nothing
+			// has been built there yet: run once WITHOUT it to populate the path,
+			// then flip it on. (See the run-prebuilt-wda guide.)
+			if os.Getenv("CHAR_IOS_PREBUILT_WDA") == "1" {
+				caps["appium:usePrebuiltWDA"] = true
+			}
 		}
 	case PlatformIPadSim:
 		caps["platformName"] = "iOS"
@@ -984,11 +1042,15 @@ func appiumCapabilities(d Device, bundleID string) map[string]any {
 		// step Appium does by default — WDA only needs (re)deploy on
 		// real devices.
 		caps["appium:useNewWDA"] = false
-		setXCUITestFleetPorts(caps, d.FleetIndex)
+		if !df {
+			setXCUITestFleetPorts(caps, d.FleetIndex)
+		}
 	case PlatformAppleTV:
 		caps["platformName"] = "tvOS"
 		caps["appium:automationName"] = "XCUITest"
-		setXCUITestFleetPorts(caps, d.FleetIndex)
+		if !df {
+			setXCUITestFleetPorts(caps, d.FleetIndex)
+		}
 	case PlatformAndroidTV:
 		caps["platformName"] = "Android"
 		caps["appium:automationName"] = "UiAutomator2"

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -1030,6 +1030,14 @@ func appiumCapabilities(d Device, bundleID string, df bool, platformVersion stri
 		// starting state per run. App data (settings, lastPlayed) is
 		// preserved because noReset=true.
 		"appium:forceAppLaunch": true,
+		// shouldTerminateApp terminates the app when the WebDriver session ends.
+		// Both drivers honour it (XCUITest defaults it OFF, which is why the app
+		// otherwise lingers — streaming + heartbeating a player — after a run;
+		// UiAutomator2 recognises it too). We delete the session in Close()
+		// (test end) and discardSession() (failed launch), so this auto-quiets
+		// the app on every teardown path, cross-platform, with no simctl/adb —
+		// the device is left WDA-warm but app-off when no test is using it.
+		"appium:shouldTerminateApp": true,
 	}
 	if !df {
 		// Non-DF: we pin the exact device (and surface its name). Under DF the

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -122,10 +122,16 @@ func (a *AppiumLauncher) Launch(ctx context.Context, d Device) (*Session, error)
 	if err != nil {
 		return nil, err
 	}
+	// A step that fails AFTER the session is open must tear it down, or the
+	// session lingers until newCommandTimeout (2 h) holding the device busy —
+	// under Device Farm that blocks every later allocation. sess.Device carries
+	// the (DF-allocated) UDID so discardSession finds it.
 	if err := a.ResumePlayback(ctx, d); err != nil {
+		a.discardSession(sess.Device)
 		return nil, err
 	}
 	if err := a.waitForHeartbeat(ctx, sess); err != nil {
+		a.discardSession(sess.Device)
 		return nil, err
 	}
 	return sess, nil
@@ -296,6 +302,7 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 	switch d.Platform {
 	case PlatformIPhone, PlatformIPad, PlatformIPadSim:
 		if err := a.navigateServerPickerIfPresent(ctx, sessID, bootstrapBaseURL()); err != nil {
+			a.discardSession(d) // don't leak the just-opened session on this error path
 			return nil, fmt.Errorf("server picker navigation: %w", err)
 		}
 	}
@@ -927,6 +934,31 @@ func (a *AppiumLauncher) sessionID(d Device) string {
 		return a.sessions[a.allocatedUDID]
 	}
 	return ""
+}
+
+// discardSession deletes the Appium session bound to d (best-effort) and drops
+// it from the launcher's map, so a launch that fails AFTER createSession doesn't
+// leak a session — which would hold the device busy until newCommandTimeout
+// (2 h) and, under Device Farm, block every later allocation. Uses its OWN short
+// context: the common trigger is a heartbeat timeout, where the caller's ctx is
+// already expired and would make the DELETE fail instantly.
+func (a *AppiumLauncher) discardSession(d Device) {
+	a.mu.Lock()
+	sessID := a.sessions[d.UDID]
+	if sessID == "" && a.allocatedUDID != "" {
+		sessID = a.sessions[a.allocatedUDID]
+	}
+	delete(a.sessions, d.UDID)
+	if a.allocatedUDID != "" {
+		delete(a.sessions, a.allocatedUDID)
+	}
+	a.mu.Unlock()
+	if sessID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, _ = a.doRequest(ctx, "DELETE", "/session/"+sessID, nil)
 }
 
 func (a *AppiumLauncher) doRequest(ctx context.Context, method, path string, body any) ([]byte, error) {

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -248,7 +248,7 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 	if err := a.healthCheck(ctx); err != nil {
 		return nil, fmt.Errorf("appium server not reachable at %s: %w (start with `appium`, or unset LAUNCH_MODE=appium)", a.URL, err)
 	}
-	df := deviceFarmEnabled()
+	df := DeviceFarmEnabled()
 	var platformVersion string
 	if df {
 		platformVersion = dfPlatformVersion(ctx, d.Platform)

--- a/tests/characterization/runner/cli.go
+++ b/tests/characterization/runner/cli.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -494,6 +495,68 @@ func mapSimRuntime(rt string) Platform {
 		return PlatformAppleTV
 	}
 	return ""
+}
+
+// LatestSimRuntimeVersion returns the highest installed, available simulator
+// runtime version for the given OS family ("iOS" / "tvOS"), e.g. "26.4". The
+// Device Farm launch path pins this as appium:platformVersion so DF never
+// allocates an old-OS sim. Returns an error if xcrun is unavailable or no
+// matching runtime is installed.
+func LatestSimRuntimeVersion(ctx context.Context, osName string) (string, error) {
+	if _, err := exec.LookPath("xcrun"); err != nil {
+		return "", errors.New("xcrun not on $PATH")
+	}
+	cmd := exec.CommandContext(ctx, "xcrun", "simctl", "list", "runtimes", "--json")
+	raw, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("xcrun simctl list runtimes: %w", err)
+	}
+	var resp struct {
+		Runtimes []struct {
+			Version     string `json:"version"`
+			Platform    string `json:"platform"`
+			IsAvailable bool   `json:"isAvailable"`
+		} `json:"runtimes"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return "", fmt.Errorf("decode runtimes: %w", err)
+	}
+	var best string
+	for _, rt := range resp.Runtimes {
+		if !rt.IsAvailable || !strings.EqualFold(rt.Platform, osName) {
+			continue
+		}
+		if best == "" || compareSemverish(rt.Version, best) > 0 {
+			best = rt.Version
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf("no available %s simulator runtime installed", osName)
+	}
+	return best, nil
+}
+
+// compareSemverish compares dotted numeric version strings ("26.4" vs "26.10")
+// segment-by-segment numerically, so 26.10 > 26.4 (lexical compare would get it
+// wrong). Non-numeric or missing segments sort as 0. Returns -1/0/1.
+func compareSemverish(a, b string) int {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) || i < len(bs); i++ {
+		var ai, bi int
+		if i < len(as) {
+			ai, _ = strconv.Atoi(as[i])
+		}
+		if i < len(bs) {
+			bi, _ = strconv.Atoi(bs[i])
+		}
+		if ai != bi {
+			if ai < bi {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
 }
 
 func simctlTerminate(ctx context.Context, udid, bundleID string) error {

--- a/tests/characterization/runner/devicefarm.go
+++ b/tests/characterization/runner/devicefarm.go
@@ -17,8 +17,19 @@ import (
 
 // DeviceFarmEnabled reports whether the Device Farm allocation path is on.
 // Exported so the modes package (fleet roster) can branch on it too.
+//
+// DEFAULT ON: Device Farm is now the standard appium allocation path. Opt OUT
+// with CHAR_DEVICE_FARM=0 (or false/off) — for CI / machines without the DF
+// server running. Resolution order (mirrors CHAR_CONTENT): the process env
+// wins, else the nearest .env, else the default (on). So a no-DF machine sets
+// CHAR_DEVICE_FARM=0 in its env or .env; everywhere else appium runs go through
+// the farm with no flag at all.
 func DeviceFarmEnabled() bool {
-	return strings.TrimSpace(os.Getenv("CHAR_DEVICE_FARM")) == "1"
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("CHAR_DEVICE_FARM")))
+	if v == "" {
+		v = strings.ToLower(strings.TrimSpace(dotenvValue("CHAR_DEVICE_FARM")))
+	}
+	return v != "0" && v != "false" && v != "off"
 }
 
 // dfPlatformVersion returns the appium:platformVersion to pin for a Device-Farm

--- a/tests/characterization/runner/devicefarm.go
+++ b/tests/characterization/runner/devicefarm.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+// Device Farm launch path (Stage 1, see tools/appium-device-farm/HANDOFF.md).
+//
+// When CHAR_DEVICE_FARM=1, the Appium launcher stops hand-picking a UDID and
+// offsetting WDA/MJPEG ports off FleetIndex. Instead it requests a device by
+// capability (platformName [+ latest platformVersion for sims]) and lets the
+// `appium-device-farm` plugin allocate the device, queue when the pool is busy,
+// and auto-assign the per-session ports. The non-DF path (plain Appium) stays
+// intact as the fallback for CI / no-DF machines.
+
+// deviceFarmEnabled reports whether the Device Farm allocation path is on.
+func deviceFarmEnabled() bool {
+	return strings.TrimSpace(os.Getenv("CHAR_DEVICE_FARM")) == "1"
+}
+
+// dfPlatformVersion returns the appium:platformVersion to pin for a Device-Farm
+// session, or "" to leave it unconstrained. Simulators are pinned to the latest
+// installed runtime so DF never allocates an old-OS sim (HANDOFF §3.1 / §4.1) —
+// overridable via CHAR_DF_IOS_VERSION / CHAR_DF_TVOS_VERSION. Real hardware is
+// left unconstrained: a physical device runs whatever OS it runs. A failure to
+// compute the latest runtime degrades to "" (unconstrained) rather than failing
+// the run — DF then arbitrates among whatever matches the platform.
+func dfPlatformVersion(ctx context.Context, p Platform) string {
+	switch p {
+	case PlatformIPadSim:
+		if v := strings.TrimSpace(os.Getenv("CHAR_DF_IOS_VERSION")); v != "" {
+			return v
+		}
+		v, _ := LatestSimRuntimeVersion(ctx, "iOS")
+		// Device Farm matches appium:platformVersion against its device `sdk`
+		// field, which it reports as the runtime's major.minor (e.g. the
+		// iOS-26-4 runtime — whose simctl `version` is "26.4.1" — surfaces as
+		// sdk "26.4"). Pinning the full "26.4.1" matches no device and DF
+		// queues to a timeout, so we pin major.minor.
+		return majorMinor(v)
+	case PlatformAppleTV:
+		// PlatformAppleTV covers BOTH a real Apple TV and a tvOS sim, and we
+		// can't tell which here — so only pin a version when the operator sets
+		// an explicit tvOS override. (Stage 1 targets iOS sims; the tvOS pool
+		// isn't set up yet — HANDOFF §7.)
+		return strings.TrimSpace(os.Getenv("CHAR_DF_TVOS_VERSION"))
+	default:
+		// Real iOS/iPad hardware, Android — unconstrained.
+		return ""
+	}
+}
+
+// majorMinor truncates a dotted version to its first two segments ("26.4.1" →
+// "26.4", "26.5" → "26.5"), matching the major.minor form Device Farm reports
+// as a device's sdk and matches platformVersion against. A version with fewer
+// than two segments is returned unchanged.
+func majorMinor(v string) string {
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return v
+	}
+	return parts[0] + "." + parts[1]
+}

--- a/tests/characterization/runner/devicefarm.go
+++ b/tests/characterization/runner/devicefarm.go
@@ -15,8 +15,9 @@ import (
 // and auto-assign the per-session ports. The non-DF path (plain Appium) stays
 // intact as the fallback for CI / no-DF machines.
 
-// deviceFarmEnabled reports whether the Device Farm allocation path is on.
-func deviceFarmEnabled() bool {
+// DeviceFarmEnabled reports whether the Device Farm allocation path is on.
+// Exported so the modes package (fleet roster) can branch on it too.
+func DeviceFarmEnabled() bool {
 	return strings.TrimSpace(os.Getenv("CHAR_DEVICE_FARM")) == "1"
 }
 

--- a/tools/appium-device-farm/HANDOFF.md
+++ b/tools/appium-device-farm/HANDOFF.md
@@ -1,9 +1,39 @@
 # Device Farm — harness simplification: handoff & plan
 
-Status as of this handoff: **Device Farm is running and Stage 0 is validated.** The
-next work is **Stage 1+ (simplify the characterization harness to lean on Device
-Farm)**, not yet started. This doc is self-contained so a fresh session can pick
-it up.
+Status as of this handoff: **Stage 1 (capability-based launch path, gated) is
+CODE-COMPLETE and committed.** Stage 0 validated earlier; Device Farm runs on
+:4723. The next work is **Stage 2 (seeding + retire port plumbing)** and **Stage 3
+(migrate callers)**. This doc is self-contained so a fresh session can pick it up.
+
+**Stage 1 done (see §6):** `runner/devicefarm.go` (`deviceFarmEnabled` / `dfPlatformVersion`
++ `majorMinor`), `runner/cli.go` (`LatestSimRuntimeVersion` + version compare), and a
+DF-aware `runner/appium.go` (`appiumCapabilities` omits udid/deviceName/fleet-ports/
+derivedDataPath under DF and pins `platformVersion`; `createSession` reads back the
+allocated UDID; `sessionID()` resolves the sole session for a UDID-less Device).
+Validated: build/vet/`runner` unit green; a standalone `POST /session` proved DF
+accepts the exact capability request the launcher emits and returns the allocated
+udid + auto-assigned ports; DF-driven test launches produced live iPhone players
+streaming to the server.
+
+**Deferred e2e (NOT a Stage 1 defect):** `TestStartupIPadSim` still fails at the
+*initial* manifest-warmup `Launch` (sweep.go `OpenSessionOnDevice`, single-device
+path, 90 s ctx) because `pickPlayerFor` can't bind: the Fleet pool is **iPhone 15**
+sims classified as `ipad-sim` (UA hint `"ipad"` ≠ the sims' `"iphone"` UA), the
+`player_id` is a persistent UUID (not the sim UDID), and the shared dev server has
+other heartbeaters (so "sole heartbeater" fails). This fails identically with and
+without `CHAR_DEVICE_FARM`. The per-cycle path uses config-on-connect (pre-set
+`player_id`) and is unaffected — so the natural fix is **Stage 3**: give the initial
+OpenSession warmup a known `player_id` via config-on-connect too (or run on real
+iPad sims / a non-shared server).
+
+**Two debugging artifacts to remember:**
+- The `Cannot read properties of undefined (reading '0')` 500 was a **malformed
+  curl** (missing `"firstMatch":[{}]`), NOT a DF wedge — DF reads `firstMatch[0]`.
+  The harness always sends it, so it's unaffected. DF is healthy.
+- Under DF the **first** session per cold sim cold-builds WDA into DF's own
+  `DerivedData/WebDriverAgent-<UDID>` (~40 s), which blows the 90 s single-device
+  ctx. Warm the pool first (one allocate+release per sim). Fold WDA-warming into the
+  Stage 2 "boot the pool" helper.
 
 Branch: `feat/appium-device-farm` (off `origin/dev`). Worktree:
 `/Users/jonathanoliver/Projects/smashing-device-farm`.
@@ -133,11 +163,15 @@ first — see §4 decision 3).
 
 ## 6. The staged plan
 
-### Stage 1 — capability-based launch path (gated)
+### Stage 1 — capability-based launch path (gated) ✅ DONE
 - Add `CHAR_DEVICE_FARM=1` detection (helper in `runner`, e.g. `deviceFarmEnabled()`).
-- In `appiumCapabilities()`, when DF mode: **omit** `appium:udid`,
+- In `appiumCapabilities()`, when DF mode: **omit** `appium:udid`, `deviceName`,
   `setXCUITestFleetPorts`, `appium:derivedDataPath`; **set** `platformName` +
   `appium:platformVersion=<latest computed>` (sims) — hardware unconstrained.
+  - **Gotcha (fixed):** DF matches `platformVersion` against its device `sdk`,
+    which is **major.minor** (`iOS-26-4` runtime, simctl `version` "26.4.1",
+    surfaces as sdk "26.4"). Pin **major.minor** (`dfPlatformVersion` →
+    `majorMinor`); the full "26.4.1" matches nothing and DF queues to a timeout.
 - After `createSession`, **read back the allocated UDID** from the returned session
   caps (`value.capabilities.udid` / `appium:udid`) and stash it on the `Session`/
   `Device` so logs, screenshots, and `ReleaseDevice` still work.

--- a/tools/appium-device-farm/HANDOFF.md
+++ b/tools/appium-device-farm/HANDOFF.md
@@ -1,10 +1,12 @@
 # Device Farm — harness simplification: handoff & plan
 
-Status as of this handoff: **Stages 1 & 2 are CODE-COMPLETE and committed.** Stage 0
-validated earlier; Device Farm runs on :4723. Stage 1 = the gated capability-based
-launch path; Stage 2 = DF fleet roster (logical devices), retired seeding/stagger,
-and the `boot-pool.sh` helper. The next work is **Stage 3 (migrate callers + the
-deferred e2e)**. This doc is self-contained so a fresh session can pick it up.
+Status as of this handoff: **Stages 1, 2, and 3 are committed.** Stage 0 validated
+earlier; Device Farm runs on :4723. Stage 1 = the gated capability-based launch
+path; Stage 2 = DF fleet roster (logical devices), retired seeding/stagger, and
+`boot-pool.sh`; Stage 3 = orchestration (`overnight.sh` DF-aware) + docs + the
+failed-launch session-leak fix. The one **remaining** item is the deferred green
+e2e, which needs the warmup-binding → config-on-connect refactor (see Stage 3
+below). This doc is self-contained so a fresh session can pick it up.
 
 **Stage 1 done (see §6):** `runner/devicefarm.go` (`deviceFarmEnabled` / `dfPlatformVersion`
 + `majorMinor`), `runner/cli.go` (`LatestSimRuntimeVersion` + version compare), and a
@@ -199,10 +201,32 @@ no UDID, FleetIndex by position; N = `CHAR_FLEET_COUNT`, default 1). No discover
 booting, UDID-pinning, or seeding — DF allocates per session. `CHAR_FLEET_UDIDS`
 identities are ignored under DF (length used as a size hint only).
 
-### Stage 3 — migrate callers
+### Stage 3 — migrate callers ✅ MOSTLY DONE
 - Point the 7 modes + `overnight.sh` / `Makefile` `characterize-*` at the DF path
   (default when `CHAR_DEVICE_FARM=1`). Keep plain-appium fallback intact.
-- Update `tests/characterization/README.md` (+ this dir's `README.md`).
+  → The modes already inherit DF through the shared launcher + roster (Stages 1–2);
+  no per-mode change needed. `CHAR_DEVICE_FARM` propagates `make characterize-* →
+  overnight.sh → go test` via the environment. `overnight.sh` now logs
+  `device_farm:on` and boots the sim pool (`boot-pool.sh`) for `ipad-sim` under DF.
+- Update `tests/characterization/README.md` (+ this dir's `README.md`). → Done
+  (added a **Device Farm** launch-mode section + `CHAR_DEVICE_FARM` / `CHAR_DF_*` /
+  `CHAR_FLEET_COUNT` env rows).
+- **Session-leak fix** (the Stage 2 finding): `AppiumLauncher.Launch`/`LaunchToHome`
+  now call `discardSession()` on any post-`createSession` failure (uses its own
+  context, so it cleans up even when the trigger is the caller's ctx expiring), so
+  a failed launch no longer holds a sim busy until `newCommandTimeout`.
+
+**Remaining (the deferred e2e):** `TestStartupIPadSim` still can't go green because
+the *initial* manifest-warmup bind is heuristic. `OpenSessionOnDevice` (sweep.go)
+binds the warmup play via `launcher.Launch → waitForHeartbeat → pickPlayerFor`
+(single-device path) — which on a shared server with iPhone-15 sims (classified
+`ipad-sim`, UA `iphone` ≠ hint `ipad`) and a persistent-UUID `player_id` can't
+match. This is **launcher-agnostic** (fails the same in non-DF). The robust fix is
+to give the warmup a known `player_id` via **config-on-connect** (as the per-cycle
+path already does), so binding is by id, not heuristics. NOTE before touching it:
+the fleet path (`bars != nil`) calls `s.WaitForHeartbeat` without setting
+`PlayerID` — reconcile how the fleet warmup binds today before refactoring both
+paths, so committed multi-sim runs don't regress.
 
 ---
 

--- a/tools/appium-device-farm/HANDOFF.md
+++ b/tools/appium-device-farm/HANDOFF.md
@@ -1,0 +1,202 @@
+# Device Farm — harness simplification: handoff & plan
+
+Status as of this handoff: **Device Farm is running and Stage 0 is validated.** The
+next work is **Stage 1+ (simplify the characterization harness to lean on Device
+Farm)**, not yet started. This doc is self-contained so a fresh session can pick
+it up.
+
+Branch: `feat/appium-device-farm` (off `origin/dev`). Worktree:
+`/Users/jonathanoliver/Projects/smashing-device-farm`.
+
+---
+
+## 1. Goal (from the user)
+
+> Auto-allocate devices — stop hand-picking UDIDs and offsetting ports. Two modes:
+> (a) my **attached hardware** (1 iPhone + 1 Apple TV + 1 Android TV), or (b) **fire
+> up multiple sims** (iPhone / iPad / Apple TV). All sims on the **latest** iOS/tvOS
+> — never old runtimes.
+
+Translation: the harness should request a device **by capability**
+(`platformName` [+ latest `platformVersion`]) and let the `appium-device-farm`
+plugin allocate, queue, and assign WDA/MJPEG ports — replacing the manual
+`CHAR_FLEET_UDIDS` / `setXCUITestFleetPorts` plumbing.
+
+---
+
+## 2. What's already done
+
+### Tooling (committed on `feat/appium-device-farm`)
+- `257896b9` — `tools/appium-device-farm/run.sh` + `README.md` (launch wrapper).
+- `537527cb` — `tools/appium-device-farm/appium.config.json` (the `bootedSimulators`
+  allowlist config); `run.sh` launches via `appium --config`.
+- `b48cd2c0` — dropped an `_comment` key (appium's config schema is strict).
+
+### Running state (machine-global, not branch-isolated)
+- Appium **3.4.2** + plugin **`device-farm@11.3.2`** installed into `~/.appium`.
+- Server up on **`:4723`** via `tools/appium-device-farm/run.sh` (nohup; log
+  `/tmp/appium-device-farm.log`). Dashboard: <http://localhost:4723/device-farm/>.
+- Config in effect (`appium.config.json`): `platform/iosDeviceType/androidDeviceType:
+  both`, **`bootedSimulators: true`**.
+- Pool = **4 booted Fleet iPhone 15 sims on iOS 26.4** (the app is installed on all 4):
+  - `#1 4D62CB39-BAB7-4294-99D7-8E28FBCD0FF0`
+  - `#2 0EA208D3-6E04-48BF-8309-F6ACAF383A59`
+  - `#3 7C6110A4-754C-47DA-B225-E95ED11F9F60`
+  - `#4 B3A40CBF-87F4-414C-9C01-6A756060DBDF`
+- Latest installed runtimes: **iOS 26.4, tvOS 26.4** (`xcrun simctl list runtimes`).
+
+To (re)start the server: `tools/appium-device-farm/run.sh` (boot the Fleet sims
+first — see §4 decision 3).
+
+---
+
+## 3. Stage 0 findings (these are the design constraints)
+
+1. ✅ **`platformVersion` filtering works.** Requesting `26.4` only ever selects
+   26.4 devices; the old 26.1 iPad was excluded.
+2. ✅ **DF allocates by capability + arbitrates the pool.** Two `POST /session`
+   with **no UDID** landed on **different** Fleet sims (#2 then #3), each with
+   distinct **auto-assigned** ports (53708/53707, then 54172/54171), each running
+   our actual app. No collisions, no hand-picking.
+3. ✅ **`bootedSimulators: true` is the reliable model.** It restricts DF to
+   already-booted sims (managed pool dropped 35 → 7). The booted Fleet set becomes
+   the de-facto **allowlist**.
+4. ⚠️ **DF's on-demand cold-boot is UNRELIABLE on this box.** Without
+   `bootedSimulators`, DF naively picked a never-booted sim (iPhone 17 Pro 26.4)
+   over free booted ones and the cold boot **timed out (120 s) / failed (code 22)**.
+   → Don't rely on DF cold-booting; pre-boot the pool.
+5. ⚠️ **Every pooled sim must have the app installed.** A booted sim without
+   `com.jeoliver.InfiniteStreamPlayer` would be allocated and then fail at launch.
+   Keep the pool = app-installed sims only.
+6. ✅ **Attached hardware needs no special handling** — real devices are always
+   "booted", so `iosDeviceType/androidDeviceType: both` picks them up.
+
+---
+
+## 4. Design decisions already made (recommendations the user accepted/leaned to)
+
+1. **Latest-OS pinning** — compute the newest installed runtime per platform at
+   runtime (`simctl list runtimes`), pin `appium:platformVersion` for **sims**;
+   leave **hardware** unconstrained (a physical phone runs what it runs). Make it
+   overridable: `CHAR_DF_IOS_VERSION` / `CHAR_DF_TVOS_VERSION`.
+2. **Seeding → UI server-picker fallback.** Drop the per-UDID
+   `seedFleetServer`/`simseed` path entirely; rely on the existing
+   `navigateServerPickerIfPresent` (it needs no UDID up front, fits capability
+   allocation). Seed the picker with **`https://dev.jeoliver.com:21000`**
+   (cert-valid; `.local` gives an empty catalogue on sims — known TLS-hostname trap).
+3. **`bootedSimulators: true` pool model.** The harness/operator boots the
+   latest-OS, app-installed Fleet pool (a small "boot the pool" helper), then DF
+   allocates among them. "Fire up N sims" = boot N Fleet sims.
+4. **Gate behind `CHAR_DEVICE_FARM=1`; keep the plain-appium path as fallback.**
+   Don't delete discovery/fleet/port code — gate it. DF path becomes the default
+   for appium once proven; non-DF stays for CI / no-DF machines. Reversible, low
+   blast radius.
+5. **Keep `FleetIndex` as a *logical* index** (A/B arm assignment + fleet
+   barriers), no longer device/port-bound. Assign arm[i] by session-creation
+   order, not device identity.
+
+---
+
+## 5. Appium inventory — what changes vs stays
+
+(Full map was done; key files below.)
+
+**Becomes redundant under Device Farm (gate/remove in DF mode):**
+- `tests/characterization/runner/appium.go`
+  - `appiumCapabilities()` (~L935): `appium:udid` (L939), `setXCUITestFleetPorts()`
+    (L963/987/991 → def L1012), `iosWDADerivedDataPath()` (L1027) per-index.
+  - `CHAR_FLEET_PORT_OFFSET` (in `setXCUITestFleetPorts`).
+- `tests/characterization/modes/fleet.go` — device discovery + roster:
+  `CHAR_FLEET_UDIDS/COUNT/AUTOBOOT/STAGGER/SEED_SERVER`, sim booting,
+  `seedFleetServer` (L376), `staggerFleetLaunch`.
+- `tests/characterization/runner/simseed.go` — `SeedServerProfile` (replaced by UI
+  picker).
+- `CHARACTERIZATION_DEVICE_UDID` pinning (`fleet.go`).
+
+**Must stay (above the allocation layer):**
+- Config-on-connect / `wireConfigOnConnect` (`sweep.go` L91), `ConfigureOnConnect`
+  (`bootstrap.go`) — mints `player_id`; app launches with `-is.player_id`; device-
+  agnostic.
+- A/B arm treatment — `armContentConfig` (`sweep.go` L221; note: the
+  `CHAR_ARM_<i>_STRIP_AVG_BW` arm lives in the **`feat/char-strip-avgbw-arm`**
+  branch / `smashing-char-avgbw` worktree, `96f96b7e`, not here).
+- Fleet barriers (home/sweep sync), UI driving (`TapByAccessibilityID`,
+  `ResumePlayback(Clip)`, `ReadPlayerID`, `SetSegmentLength`,
+  `navigateServerPickerIfPresent`), `Screenshot`, `CHAR_CONTENT`.
+
+**Callers (all 7 modes type-assert `*AppiumLauncher`, skip otherwise):**
+`startup`, `pyramid`, `rampup`, `rampdown`, `fault_recovery`, `state_residency`,
+`playback_end` `_test.go` + `sweep.go` helpers. Plus `overnight.sh`, `Makefile`
+`characterize-*` targets, `tools/qe-offhours.sh`.
+
+---
+
+## 6. The staged plan
+
+### Stage 1 — capability-based launch path (gated)
+- Add `CHAR_DEVICE_FARM=1` detection (helper in `runner`, e.g. `deviceFarmEnabled()`).
+- In `appiumCapabilities()`, when DF mode: **omit** `appium:udid`,
+  `setXCUITestFleetPorts`, `appium:derivedDataPath`; **set** `platformName` +
+  `appium:platformVersion=<latest computed>` (sims) — hardware unconstrained.
+- After `createSession`, **read back the allocated UDID** from the returned session
+  caps (`value.capabilities.udid` / `appium:udid`) and stash it on the `Session`/
+  `Device` so logs, screenshots, and `ReleaseDevice` still work.
+- `FleetIndex` stays logical (arm + barriers).
+- **Smoke-test after Stage 1** before touching modes: run one mode (e.g.
+  `TestStartupIPadSim`) with `CHAR_DEVICE_FARM=1`, no `CHAR_FLEET_UDIDS`.
+
+### Stage 2 — seeding + retire port plumbing
+- Under DF, seed via `navigateServerPickerIfPresent` (already called in
+  `LaunchToHome`); drop `seedFleetServer`/`CHAR_FLEET_SEED_SERVER` from the DF path.
+- Retire `CHAR_FLEET_PORT_OFFSET` + `staggerFleetLaunch` under DF (DF queues).
+- Add a small **"boot the pool"** helper: boot N latest-OS Fleet sims (+ verify the
+  app is installed) so "fire up N sims" is one command before the run.
+
+### Stage 3 — migrate callers
+- Point the 7 modes + `overnight.sh` / `Makefile` `characterize-*` at the DF path
+  (default when `CHAR_DEVICE_FARM=1`). Keep plain-appium fallback intact.
+- Update `tests/characterization/README.md` (+ this dir's `README.md`).
+
+---
+
+## 7. Open questions / risks
+
+- **App-on-pool invariant:** pool must be app-installed sims only. The "boot the
+  pool" helper should install the app if missing (or fail loudly).
+- **A/B-by-index under capability alloc:** assign arm config by the order sessions
+  are created, since you no longer choose which physical device is "index 1".
+- **DF picking app-less booted sims:** if any non-Fleet sim is booted, DF may grab
+  it. Keep the booted set clean, or use the `simulators` allowlist array in
+  `appium.config.json` (schema confirms the key exists; element shape unverified —
+  `bootedSimulators` was chosen instead because it's unambiguous).
+- **Wedged sim:** `iPhone 17 Pro 26.4` (`BFC34E3A-638C-4921-A94D-CB6A64323829`)
+  failed to boot cleanly; `simctl erase` it if it's ever wanted in the pool.
+- **tvOS / Android TV pools:** only iOS is set up. tvOS sims would need booting too;
+  attached Apple TV / Android TV appear automatically when connected.
+- **Concurrent sessions on this machine** (a `TestSweepProbe` loop has run here):
+  DF arbitration now prevents the 8100 port collisions that previously forced
+  `CHAR_FLEET_PORT_OFFSET` — a bonus of this work.
+
+---
+
+## 8. Quick reference
+
+```sh
+# (re)start Device Farm (boot the Fleet pool first)
+for u in 4D62CB39-BAB7-4294-99D7-8E28FBCD0FF0 0EA208D3-6E04-48BF-8309-F6ACAF383A59 \
+         7C6110A4-754C-47DA-B225-E95ED11F9F60 B3A40CBF-87F4-414C-9C01-6A756060DBDF; do
+  xcrun simctl boot "$u" 2>/dev/null
+done
+tools/appium-device-farm/run.sh        # serves :4723 + /device-farm dashboard
+
+# capability-only allocation smoke test (no UDID, latest OS, our app)
+curl -s -X POST http://localhost:4723/session -H 'Content-Type: application/json' -d '{
+  "capabilities":{"alwaysMatch":{"platformName":"iOS","appium:automationName":"XCUITest",
+  "appium:platformVersion":"26.4","appium:bundleId":"com.jeoliver.InfiniteStreamPlayer",
+  "appium:noReset":true,"appium:forceAppLaunch":true,"appium:newCommandTimeout":300}}}'
+# → allocates a booted Fleet sim, auto-assigns ports, launches the app. DELETE /session/<id> to release.
+```
+
+App bundle ids (`runner/simseed.go`): iOS/iPad `com.jeoliver.InfiniteStreamPlayer`,
+Apple TV `com.jeoliver.InfiniteStreamPlayerTV`, Android TV `com.infinitestream.player`.
+Harness base URL for seeding: `https://dev.jeoliver.com:21000` (`HARNESS_BASE_URL`).

--- a/tools/appium-device-farm/HANDOFF.md
+++ b/tools/appium-device-farm/HANDOFF.md
@@ -1,9 +1,10 @@
 # Device Farm — harness simplification: handoff & plan
 
-Status as of this handoff: **Stage 1 (capability-based launch path, gated) is
-CODE-COMPLETE and committed.** Stage 0 validated earlier; Device Farm runs on
-:4723. The next work is **Stage 2 (seeding + retire port plumbing)** and **Stage 3
-(migrate callers)**. This doc is self-contained so a fresh session can pick it up.
+Status as of this handoff: **Stages 1 & 2 are CODE-COMPLETE and committed.** Stage 0
+validated earlier; Device Farm runs on :4723. Stage 1 = the gated capability-based
+launch path; Stage 2 = DF fleet roster (logical devices), retired seeding/stagger,
+and the `boot-pool.sh` helper. The next work is **Stage 3 (migrate callers + the
+deferred e2e)**. This doc is self-contained so a fresh session can pick it up.
 
 **Stage 1 done (see §6):** `runner/devicefarm.go` (`deviceFarmEnabled` / `dfPlatformVersion`
 + `majorMinor`), `runner/cli.go` (`LatestSimRuntimeVersion` + version compare), and a
@@ -179,12 +180,24 @@ first — see §4 decision 3).
 - **Smoke-test after Stage 1** before touching modes: run one mode (e.g.
   `TestStartupIPadSim`) with `CHAR_DEVICE_FARM=1`, no `CHAR_FLEET_UDIDS`.
 
-### Stage 2 — seeding + retire port plumbing
+### Stage 2 — seeding + retire port plumbing ✅ DONE
 - Under DF, seed via `navigateServerPickerIfPresent` (already called in
   `LaunchToHome`); drop `seedFleetServer`/`CHAR_FLEET_SEED_SERVER` from the DF path.
+  → Done: the DF roster (`resolveFleetDeviceFarm`) never calls `seedFleetServer`;
+  the server is set by the picker nav in `LaunchToHome`.
 - Retire `CHAR_FLEET_PORT_OFFSET` + `staggerFleetLaunch` under DF (DF queues).
+  → `staggerFleetLaunch` is a no-op under DF. `CHAR_FLEET_PORT_OFFSET` was never in
+  code (concept only) — nothing to retire.
 - Add a small **"boot the pool"** helper: boot N latest-OS Fleet sims (+ verify the
   app is installed) so "fire up N sims" is one command before the run.
+  → `tools/appium-device-farm/boot-pool.sh`: boots N latest-OS `Fleet` sims,
+  verifies the app, and warms each sim's WDA via DF (the Stage 1 cold-WDA finding).
+
+**The DF fleet roster** (`modes/fleet.go`): under `CHAR_DEVICE_FARM=1`,
+`resolveFleet` → `resolveFleetDeviceFarm` returns N logical devices (platform p,
+no UDID, FleetIndex by position; N = `CHAR_FLEET_COUNT`, default 1). No discovery,
+booting, UDID-pinning, or seeding — DF allocates per session. `CHAR_FLEET_UDIDS`
+identities are ignored under DF (length used as a size hint only).
 
 ### Stage 3 — migrate callers
 - Point the 7 modes + `overnight.sh` / `Makefile` `characterize-*` at the DF path
@@ -210,18 +223,23 @@ first — see §4 decision 3).
 - **Concurrent sessions on this machine** (a `TestSweepProbe` loop has run here):
   DF arbitration now prevents the 8100 port collisions that previously forced
   `CHAR_FLEET_PORT_OFFSET` — a bonus of this work.
+- **Leaked DF sessions hold sims busy (Stage 3 cleanup).** A test that dies before
+  `AppiumLauncher.Close()` leaves its DF session open; with `newCommandTimeout=7200`
+  the sim stays `busy` for up to 2 h and DF queues new requests against it (this bit
+  the WDA warm). Don't shorten the timeout (long sweeps send no UI commands for
+  30 min legitimately) — instead make `Close()` reliably deferred per run, and/or
+  add a "release all DF sessions" cleanup. Manual unstick: read the busy
+  `sessionId`s from `GET /device-farm/api/device` and `DELETE /session/<id>` each
+  (or restart `run.sh`).
 
 ---
 
 ## 8. Quick reference
 
 ```sh
-# (re)start Device Farm (boot the Fleet pool first)
-for u in 4D62CB39-BAB7-4294-99D7-8E28FBCD0FF0 0EA208D3-6E04-48BF-8309-F6ACAF383A59 \
-         7C6110A4-754C-47DA-B225-E95ED11F9F60 B3A40CBF-87F4-414C-9C01-6A756060DBDF; do
-  xcrun simctl boot "$u" 2>/dev/null
-done
-tools/appium-device-farm/run.sh        # serves :4723 + /device-farm dashboard
+# (re)start Device Farm — boot+warm the pool, then start the server (Stage 2)
+tools/appium-device-farm/run.sh         # serves :4723 + /device-farm dashboard
+tools/appium-device-farm/boot-pool.sh   # boot N Fleet sims + verify app + warm WDA
 
 # capability-only allocation smoke test (no UDID, latest OS, our app)
 curl -s -X POST http://localhost:4723/session -H 'Content-Type: application/json' -d '{

--- a/tools/appium-device-farm/README.md
+++ b/tools/appium-device-farm/README.md
@@ -27,7 +27,8 @@ Grid does for browsers:
 ## Bring it up
 
 ```sh
-tools/appium-device-farm/run.sh
+tools/appium-device-farm/boot-pool.sh   # boot the sim pool (see below) — once per session
+tools/appium-device-farm/run.sh         # start the DF server
 ```
 
 Then open the dashboard: <http://localhost:4723/device-farm/>
@@ -48,18 +49,57 @@ install on first run if missing:
 appium plugin install --source=npm appium-device-farm
 ```
 
+## Boot the pool
+
+`bootedSimulators:true` means DF only allocates among ALREADY-BOOTED sims — the
+booted set is the allowlist. `boot-pool.sh` is the "fire up N sims" step: it boots
+N latest-OS Fleet sims, verifies the app is installed on each, and warms each
+sim's WebDriverAgent via DF so the FIRST real session doesn't cold-build WDA and
+blow a test's launch timeout. Idempotent — re-run anytime.
+
+```sh
+tools/appium-device-farm/boot-pool.sh
+```
+
+Env overrides:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `DF_POOL_COUNT` | `4` | how many sims to boot |
+| `DF_POOL_MATCH` | `Fleet` | sim-name substring to pick from |
+| `DF_POOL_OS` | latest installed | iOS runtime major.minor |
+| `DF_BUNDLE_ID` | `com.jeoliver.InfiniteStreamPlayer` | app to verify |
+| `DF_WARM_WDA` | `1` | warm WDA via DF (needs the server up) or skip |
+
+WDA warming needs the DF server up, so for a cold start either run `run.sh` first
+then `boot-pool.sh`, or run `boot-pool.sh DF_WARM_WDA=0`, start the server, and
+re-run `boot-pool.sh` to warm.
+
 ## Using it from the harness
 
-With Device Farm on `:4723`, a test no longer needs to pin a UDID or a port — it
-requests a platform and lets Device Farm allocate. To let the farm choose, run
-*without* `CHARACTERIZATION_DEVICE_UDID` / `CHAR_FLEET_UDIDS` so the session is
-matched by capability. (The harness's own fleet-port offset becomes redundant
-once Device Farm owns port allocation.)
+With Device Farm on `:4723`, a test no longer pins a UDID or a port — it requests
+a platform (+ latest version for sims) and lets DF allocate. Turn it on with
+`CHAR_DEVICE_FARM=1` (Stage 1). Under that flag the harness:
+
+- requests by capability — drops `appium:udid`, `deviceName`, the FleetIndex
+  WDA/MJPEG port offsets, and `derivedDataPath`; pins `appium:platformVersion` to
+  the latest installed sim runtime (override: `CHAR_DF_IOS_VERSION` /
+  `CHAR_DF_TVOS_VERSION`; hardware unconstrained);
+- builds the fleet roster as N **logical** devices (`CHAR_FLEET_COUNT`, default 1)
+  — no discovery/boot/per-UDID seeding, no `CHAR_FLEET_UDIDS` identities, no
+  `staggerFleetLaunch` (DF queues). The server is set by the app's server-picker
+  navigation in `LaunchToHome`, not the retired `seedFleetServer`.
 
 ## Notes
 
 - Device Farm IS the Appium server — run **one** instance per port. Don't also
   run a plain `appium` on the same port.
 - Real iOS devices need a signed WebDriverAgent (same prerequisite as plain
-  Appium); simulators build WDA on demand.
+  Appium); simulators build WDA on demand. The first session per cold sim
+  cold-builds WDA (~40 s) into DF's own DerivedData — `boot-pool.sh` warms it so a
+  test's launch timeout isn't spent on the build.
+- A test that dies before releasing its session leaves the sim `busy` (up to the
+  2 h `newCommandTimeout`), so DF queues new requests against it. Unstick by
+  reading the busy `sessionId`s from `GET /device-farm/api/device` and
+  `DELETE /session/<id>` each, or just restart `run.sh`.
 - Plugin version pinned at install time; re-run the install command to update.

--- a/tools/appium-device-farm/README.md
+++ b/tools/appium-device-farm/README.md
@@ -1,0 +1,65 @@
+# Appium Device Farm
+
+A thin wrapper for running our Appium server with the
+[`appium-device-farm`](https://github.com/AppiumTestDistribution/appium-device-farm)
+plugin enabled, so Appium **arbitrates devices across independent test clients**
+instead of each client hand-picking a UDID and dodging port collisions.
+
+## Why
+
+The characterization harness today talks to a plain Appium server, which does
+**not** pool or allocate devices — every session must name its `appium:udid` and,
+for parallel iOS, a unique `appium:wdaLocalPort` (else they all default to 8100
+and collide). The harness works around this with `CHAR_FLEET_UDIDS` +
+`CHAR_FLEET_PORT_OFFSET`. Two *independent* runs (e.g. a pyramid + a sweep loop)
+still step on each other.
+
+Device Farm replaces that manual allocation with real arbitration, like Selenium
+Grid does for browsers:
+
+- **Auto-discovery** of booted simulators + connected real devices.
+- **Capability-based assignment**: a client requests `platformName=iOS` (and
+  optionally `platformVersion`), Device Farm hands out a free matching device.
+- **Queuing** when all matching devices are busy (no collision, no failure).
+- **Automatic per-session WDA/MJPEG port allocation**.
+- A **live dashboard** (device grid + session queue) at `/device-farm/`.
+
+## Bring it up
+
+```sh
+tools/appium-device-farm/run.sh
+```
+
+Then open the dashboard: <http://localhost:4723/device-farm/>
+
+Env overrides:
+
+| Var | Default | Meaning |
+|---|---|---|
+| `DF_PORT` | `4723` | Appium port (the port the harness expects). |
+| `DF_PLATFORM` | `both` | `ios` \| `android` \| `both`. |
+| `DF_LOG` | `/tmp/appium-device-farm.log` | server log. |
+
+`run.sh` frees `DF_PORT` first (stops any plain Appium already holding it), then
+starts Appium with the plugin. The plugin is installed globally into the Appium
+install on first run if missing:
+
+```sh
+appium plugin install --source=npm appium-device-farm
+```
+
+## Using it from the harness
+
+With Device Farm on `:4723`, a test no longer needs to pin a UDID or a port — it
+requests a platform and lets Device Farm allocate. To let the farm choose, run
+*without* `CHARACTERIZATION_DEVICE_UDID` / `CHAR_FLEET_UDIDS` so the session is
+matched by capability. (The harness's own fleet-port offset becomes redundant
+once Device Farm owns port allocation.)
+
+## Notes
+
+- Device Farm IS the Appium server — run **one** instance per port. Don't also
+  run a plain `appium` on the same port.
+- Real iOS devices need a signed WebDriverAgent (same prerequisite as plain
+  Appium); simulators build WDA on demand.
+- Plugin version pinned at install time; re-run the install command to update.

--- a/tools/appium-device-farm/appium.config.json
+++ b/tools/appium-device-farm/appium.config.json
@@ -1,10 +1,8 @@
 {
-  "_comment": "Appium server + Device Farm plugin config. Loaded via `appium --config`. The key knob is bootedSimulators:true — Device Farm then ONLY allocates among already-booted simulators and never tries to cold-boot one. On this machine cold-booting an arbitrary sim (e.g. a never-booted iPhone 17 Pro) times out / fails (code 22), and DF's naive selection kept choosing those. Booting ONLY the known-good, app-installed, latest-OS Fleet sims makes the booted set the de-facto allowlist: DF allocates among them, queues when busy, auto-assigns WDA/MJPEG ports. Real iOS/tvOS/Android hardware is always 'booted', so iosDeviceType/androidDeviceType:both still picks attached devices up.",
   "server": {
     "port": 4723,
     "keep-alive-timeout": 800,
     "use-plugins": ["device-farm"],
-    "use-drivers": ["xcuitest", "uiautomator2"],
     "plugin": {
       "device-farm": {
         "platform": "both",

--- a/tools/appium-device-farm/appium.config.json
+++ b/tools/appium-device-farm/appium.config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Appium server + Device Farm plugin config. Loaded via `appium --config`. The key knob is bootedSimulators:true — Device Farm then ONLY allocates among already-booted simulators and never tries to cold-boot one. On this machine cold-booting an arbitrary sim (e.g. a never-booted iPhone 17 Pro) times out / fails (code 22), and DF's naive selection kept choosing those. Booting ONLY the known-good, app-installed, latest-OS Fleet sims makes the booted set the de-facto allowlist: DF allocates among them, queues when busy, auto-assigns WDA/MJPEG ports. Real iOS/tvOS/Android hardware is always 'booted', so iosDeviceType/androidDeviceType:both still picks attached devices up.",
+  "server": {
+    "port": 4723,
+    "keep-alive-timeout": 800,
+    "use-plugins": ["device-farm"],
+    "use-drivers": ["xcuitest", "uiautomator2"],
+    "plugin": {
+      "device-farm": {
+        "platform": "both",
+        "iosDeviceType": "both",
+        "androidDeviceType": "both",
+        "bootedSimulators": true
+      }
+    }
+  }
+}

--- a/tools/appium-device-farm/boot-pool.sh
+++ b/tools/appium-device-farm/boot-pool.sh
@@ -124,5 +124,18 @@ except Exception: print("")' 2>/dev/null)
 	fi
 fi
 
+# Leave the pool quiet: terminate the player app on each sim. Warming (and any
+# prior run) leaves the app foregrounded — streaming + heartbeating a player to
+# the server — which is just noise when no test is using it. WDA is a SEPARATE
+# process and stays resident, so the next session is still fast; and every test
+# does appium:forceAppLaunch anyway, so an off app costs the next run nothing.
+# Opt out with DF_KEEP_APP_RUNNING=1.
+if [ "${DF_KEEP_APP_RUNNING:-0}" != "1" ]; then
+	echo "terminating $DF_BUNDLE_ID on the pool (WDA stays resident; quiet until a test launches it)…"
+	for u in $UDIDS; do
+		xcrun simctl terminate "$u" "$DF_BUNDLE_ID" >/dev/null 2>&1 || true
+	done
+fi
+
 echo "pool ready. start the server with tools/appium-device-farm/run.sh (if not already running)."
 [ "$missing_app" = "0" ] || { echo "WARNING: one or more sims are missing $DF_BUNDLE_ID — install it before running." >&2; exit 2; }

--- a/tools/appium-device-farm/boot-pool.sh
+++ b/tools/appium-device-farm/boot-pool.sh
@@ -104,10 +104,13 @@ if [ "$DF_WARM_WDA" = "1" ]; then
 		echo "warming WebDriverAgent via DF on :$DF_PORT (first build per sim is slow; cached after)…"
 		for u in $UDIDS; do
 			# || true: a slow/failed warm on one sim must not abort the loop (set -e).
+			# shouldTerminateApp:true so releasing this session leaves the app off
+			# (WDA stays resident) — the same native mechanism the harness uses.
 			resp=$(curl -s --max-time 180 -X POST "http://localhost:$DF_PORT/session" -H 'Content-Type: application/json' -d '{
 				"capabilities":{"alwaysMatch":{"platformName":"iOS","appium:automationName":"XCUITest",
 				"appium:udid":"'"$u"'","appium:bundleId":"'"$DF_BUNDLE_ID"'","appium:noReset":true,
-				"appium:forceAppLaunch":false,"appium:useNewWDA":false,"appium:newCommandTimeout":60},
+				"appium:forceAppLaunch":false,"appium:useNewWDA":false,"appium:shouldTerminateApp":true,
+				"appium:newCommandTimeout":60},
 				"firstMatch":[{}]}}' 2>/dev/null || true)
 			sid=$(printf '%s' "$resp" | python3 -c 'import sys,json
 try: print(json.load(sys.stdin)["value"].get("sessionId",""))
@@ -124,18 +127,9 @@ except Exception: print("")' 2>/dev/null)
 	fi
 fi
 
-# Leave the pool quiet: terminate the player app on each sim. Warming (and any
-# prior run) leaves the app foregrounded — streaming + heartbeating a player to
-# the server — which is just noise when no test is using it. WDA is a SEPARATE
-# process and stays resident, so the next session is still fast; and every test
-# does appium:forceAppLaunch anyway, so an off app costs the next run nothing.
-# Opt out with DF_KEEP_APP_RUNNING=1.
-if [ "${DF_KEEP_APP_RUNNING:-0}" != "1" ]; then
-	echo "terminating $DF_BUNDLE_ID on the pool (WDA stays resident; quiet until a test launches it)…"
-	for u in $UDIDS; do
-		xcrun simctl terminate "$u" "$DF_BUNDLE_ID" >/dev/null 2>&1 || true
-	done
-fi
+# The warm sessions above set appium:shouldTerminateApp, so releasing them already
+# leaves the app off (WDA stays resident — it's a separate process). The harness
+# test sessions do the same, so the pool is left quiet without any simctl/adb.
 
 echo "pool ready. start the server with tools/appium-device-farm/run.sh (if not already running)."
 [ "$missing_app" = "0" ] || { echo "WARNING: one or more sims are missing $DF_BUNDLE_ID — install it before running." >&2; exit 2; }

--- a/tools/appium-device-farm/boot-pool.sh
+++ b/tools/appium-device-farm/boot-pool.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Boot the Device Farm simulator pool — the operator-side "fire up N sims" step.
+#
+# Device Farm allocates ONLY among already-booted sims (bootedSimulators:true in
+# appium.config.json), so the booted set IS the allowlist. This script boots N
+# latest-OS, app-installed Fleet sims, verifies the app, and (if the DF server is
+# up) warms each sim's WebDriverAgent so the FIRST real session doesn't cold-build
+# WDA and blow a test's launch timeout. Run this BEFORE run.sh / a characterization
+# run. Idempotent: already-booted sims and already-built WDA are no-ops.
+#
+# Env:
+#   DF_POOL_COUNT     how many sims to boot           (default 4)
+#   DF_POOL_MATCH     sim-name substring to pick from (default "Fleet")
+#   DF_POOL_OS        iOS runtime major.minor         (default: latest installed)
+#   DF_BUNDLE_ID      app to verify on each sim        (default com.jeoliver.InfiniteStreamPlayer)
+#   DF_PORT           DF/Appium port for WDA warming   (default 4723)
+#   DF_WARM_WDA       warm WDA via DF (1) or skip (0)  (default 1)
+set -eu
+
+DF_POOL_COUNT="${DF_POOL_COUNT:-4}"
+DF_POOL_MATCH="${DF_POOL_MATCH:-Fleet}"
+DF_BUNDLE_ID="${DF_BUNDLE_ID:-com.jeoliver.InfiniteStreamPlayer}"
+DF_PORT="${DF_PORT:-4723}"
+DF_WARM_WDA="${DF_WARM_WDA:-1}"
+
+command -v xcrun >/dev/null 2>&1 || { echo "xcrun not on \$PATH" >&2; exit 1; }
+
+# Latest installed iOS runtime major.minor (overridable). DF matches
+# platformVersion against this, and the harness pins it (runner.dfPlatformVersion).
+DF_POOL_OS="${DF_POOL_OS:-$(xcrun simctl list runtimes --json | python3 -c '
+import sys, json
+best = ""
+for rt in json.load(sys.stdin)["runtimes"]:
+    if rt.get("platform") != "iOS" or not rt.get("isAvailable"):
+        continue
+    v = rt.get("version", "")
+    def key(s): return [int(x) for x in s.split(".") if x.isdigit()]
+    if not best or key(v) > key(best):
+        best = v
+print(".".join(best.split(".")[:2]) if best else "")
+')}"
+
+[ -n "$DF_POOL_OS" ] || { echo "no available iOS simulator runtime found" >&2; exit 1; }
+echo "pool target: $DF_POOL_COUNT sim(s) matching \"$DF_POOL_MATCH\" on iOS $DF_POOL_OS"
+
+# UDIDs of available sims on that runtime whose name contains DF_POOL_MATCH.
+UDIDS=$(xcrun simctl list devices available --json | DF_POOL_OS="$DF_POOL_OS" DF_POOL_MATCH="$DF_POOL_MATCH" DF_POOL_COUNT="$DF_POOL_COUNT" python3 -c '
+import sys, json, os
+want_os = os.environ["DF_POOL_OS"].replace(".", "-")
+match = os.environ["DF_POOL_MATCH"].lower()
+count = int(os.environ["DF_POOL_COUNT"])
+out = []
+for rt, devs in json.load(sys.stdin)["devices"].items():
+    if ("iOS-" + want_os) not in rt:
+        continue
+    for d in devs:
+        if match in d.get("name", "").lower():
+            out.append((d["name"], d["udid"]))
+out.sort()
+for name, udid in out[:count]:
+    print(udid)
+')
+
+if [ -z "$UDIDS" ]; then
+	echo "no available sims matching \"$DF_POOL_MATCH\" on iOS $DF_POOL_OS" >&2
+	echo "  (list candidates: xcrun simctl list devices available | grep -i \"$DF_POOL_MATCH\")" >&2
+	exit 1
+fi
+
+n=$(printf '%s\n' "$UDIDS" | grep -c .)
+echo "selected $n sim(s):"
+
+missing_app=0
+for u in $UDIDS; do
+	name=$(xcrun simctl list devices --json | python3 -c "import sys,json
+for rt,devs in json.load(sys.stdin)['devices'].items():
+    for d in devs:
+        if d['udid']=='$u': print(d['name'])" 2>/dev/null || echo "$u")
+	echo "  - $name ($u)"
+
+	# Boot (idempotent — swallow 'current state: Booted').
+	if out=$(xcrun simctl boot "$u" 2>&1); then
+		xcrun simctl bootstatus "$u" >/dev/null 2>&1 || true
+		echo "      booted"
+	elif printf '%s' "$out" | grep -q "current state: Booted"; then
+		echo "      already booted"
+	else
+		echo "      BOOT FAILED: $out" >&2
+		continue
+	fi
+
+	# Verify the app is installed (the app-on-pool invariant — HANDOFF §7).
+	if xcrun simctl listapps "$u" 2>/dev/null | grep -q "$DF_BUNDLE_ID"; then
+		echo "      app $DF_BUNDLE_ID present"
+	else
+		echo "      ⚠️  app $DF_BUNDLE_ID NOT installed — DF would allocate this sim then fail at launch" >&2
+		missing_app=1
+	fi
+done
+
+# Warm WebDriverAgent on each sim via DF so the first real session is fast.
+if [ "$DF_WARM_WDA" = "1" ]; then
+	if curl -s --max-time 3 "http://localhost:$DF_PORT/status" 2>/dev/null | grep -q '"ready":true'; then
+		echo "warming WebDriverAgent via DF on :$DF_PORT (first build per sim is slow; cached after)…"
+		for u in $UDIDS; do
+			# || true: a slow/failed warm on one sim must not abort the loop (set -e).
+			resp=$(curl -s --max-time 180 -X POST "http://localhost:$DF_PORT/session" -H 'Content-Type: application/json' -d '{
+				"capabilities":{"alwaysMatch":{"platformName":"iOS","appium:automationName":"XCUITest",
+				"appium:udid":"'"$u"'","appium:bundleId":"'"$DF_BUNDLE_ID"'","appium:noReset":true,
+				"appium:forceAppLaunch":false,"appium:useNewWDA":false,"appium:newCommandTimeout":60},
+				"firstMatch":[{}]}}' 2>/dev/null || true)
+			sid=$(printf '%s' "$resp" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["value"].get("sessionId",""))
+except Exception: print("")' 2>/dev/null)
+			if [ -n "$sid" ]; then
+				echo "  $u: WDA ready"
+				curl -s --max-time 20 -X DELETE "http://localhost:$DF_PORT/session/$sid" >/dev/null 2>&1 || true
+			else
+				echo "  $u: WDA warm failed (will cold-build on first real session): $(printf '%s' "$resp" | head -c 120)" >&2
+			fi
+		done
+	else
+		echo "DF not up on :$DF_PORT — skipping WDA warm (start it with run.sh, then re-run, or set DF_WARM_WDA=0)"
+	fi
+fi
+
+echo "pool ready. start the server with tools/appium-device-farm/run.sh (if not already running)."
+[ "$missing_app" = "0" ] || { echo "WARNING: one or more sims are missing $DF_BUNDLE_ID — install it before running." >&2; exit 2; }

--- a/tools/appium-device-farm/run.sh
+++ b/tools/appium-device-farm/run.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Bring up an Appium server with the Device Farm plugin enabled.
+#
+# Device Farm turns ONE Appium server into a device-pool manager: it
+# auto-discovers booted simulators + connected real devices, and assigns a
+# free one per `POST /session` BY CAPABILITY (platformName / platformVersion),
+# queuing when none are free and auto-allocating per-session WDA/MJPEG ports.
+# That removes the manual device picking + port-offset dance the
+# characterization harness does today (CHAR_FLEET_UDIDS / CHAR_FLEET_PORT_OFFSET)
+# and lets independent test runs coexist on the same server without colliding on
+# wdaLocalPort 8100.
+#
+# Dashboard (live device grid + session queue): http://<host>:<port>/device-farm/
+#
+# Env:
+#   DF_PORT      Appium port (default 4723 — the port the harness expects).
+#   DF_PLATFORM  ios | android | both (default both — iOS sims + Android TV).
+#   DF_LOG       log file (default /tmp/appium-device-farm.log).
+#
+# The plugin is installed globally into the Appium install (not this repo):
+#   appium plugin install --source=npm appium-device-farm
+# This script installs it on first run if it's missing.
+set -eu
+
+DF_PORT="${DF_PORT:-4723}"
+DF_PLATFORM="${DF_PLATFORM:-both}"
+DF_LOG="${DF_LOG:-/tmp/appium-device-farm.log}"
+
+if ! appium plugin list --installed 2>&1 | grep -q "device-farm"; then
+	echo "device-farm plugin not installed — installing from npm…"
+	appium plugin install --source=npm appium-device-farm
+fi
+
+# Free the port if a plain Appium (or a stale Device Farm) is already holding it.
+if lsof -nP -iTCP:"$DF_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+	echo "port $DF_PORT in use — stopping the listener so Device Farm can take it"
+	lsof -nP -tiTCP:"$DF_PORT" -sTCP:LISTEN | xargs -r kill
+	sleep 2
+fi
+
+echo "starting Appium + Device Farm on :$DF_PORT (platform=$DF_PLATFORM), log -> $DF_LOG"
+echo "dashboard: http://localhost:$DF_PORT/device-farm/"
+exec appium server \
+	--port "$DF_PORT" \
+	--keep-alive-timeout 800 \
+	--use-plugins=device-farm \
+	--plugin-device-farm-platform="$DF_PLATFORM"

--- a/tools/appium-device-farm/run.sh
+++ b/tools/appium-device-farm/run.sh
@@ -1,29 +1,33 @@
 #!/bin/sh
 # Bring up an Appium server with the Device Farm plugin enabled.
 #
-# Device Farm turns ONE Appium server into a device-pool manager: it
-# auto-discovers booted simulators + connected real devices, and assigns a
-# free one per `POST /session` BY CAPABILITY (platformName / platformVersion),
-# queuing when none are free and auto-allocating per-session WDA/MJPEG ports.
-# That removes the manual device picking + port-offset dance the
-# characterization harness does today (CHAR_FLEET_UDIDS / CHAR_FLEET_PORT_OFFSET)
-# and lets independent test runs coexist on the same server without colliding on
-# wdaLocalPort 8100.
+# Device Farm turns ONE Appium server into a device-pool manager: it allocates a
+# free device per `POST /session` BY CAPABILITY (platformName / platformVersion),
+# queues when none are free and auto-allocates per-session WDA/MJPEG ports — so
+# clients stop hand-picking UDIDs and offsetting ports.
+#
+# Config lives in appium.config.json (next to this script). The key setting is
+# bootedSimulators:true — DF only allocates among ALREADY-BOOTED sims and never
+# cold-boots one (cold-booting an arbitrary sim is unreliable on this box). So
+# the workflow is: boot the known-good, app-installed, latest-OS Fleet sims you
+# want in the pool, then start this server — the booted set IS the allowlist.
+# Attached real devices are always "booted", so they're picked up automatically.
 #
 # Dashboard (live device grid + session queue): http://<host>:<port>/device-farm/
 #
 # Env:
-#   DF_PORT      Appium port (default 4723 — the port the harness expects).
-#   DF_PLATFORM  ios | android | both (default both — iOS sims + Android TV).
-#   DF_LOG       log file (default /tmp/appium-device-farm.log).
+#   DF_PORT   Appium port (default 4723 — the port the harness expects).
+#   DF_CONFIG config file (default: appium.config.json beside this script).
+#   DF_LOG    log file (default /tmp/appium-device-farm.log).
 #
-# The plugin is installed globally into the Appium install (not this repo):
+# The plugin + drivers are installed globally into the Appium install (not this
+# repo); this script installs the plugin on first run if it's missing:
 #   appium plugin install --source=npm appium-device-farm
-# This script installs it on first run if it's missing.
 set -eu
 
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 DF_PORT="${DF_PORT:-4723}"
-DF_PLATFORM="${DF_PLATFORM:-both}"
+DF_CONFIG="${DF_CONFIG:-$SCRIPT_DIR/appium.config.json}"
 DF_LOG="${DF_LOG:-/tmp/appium-device-farm.log}"
 
 if ! appium plugin list --installed 2>&1 | grep -q "device-farm"; then
@@ -38,10 +42,11 @@ if lsof -nP -iTCP:"$DF_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
 	sleep 2
 fi
 
-echo "starting Appium + Device Farm on :$DF_PORT (platform=$DF_PLATFORM), log -> $DF_LOG"
+echo "booted simulators currently in the Device Farm pool:"
+xcrun simctl list devices booted 2>/dev/null | grep -iE "iphone|ipad|apple tv" || echo "  (none — boot the Fleet sims you want in the pool)"
+
+echo "starting Appium + Device Farm on :$DF_PORT (config $DF_CONFIG), log -> $DF_LOG"
 echo "dashboard: http://localhost:$DF_PORT/device-farm/"
-exec appium server \
-	--port "$DF_PORT" \
-	--keep-alive-timeout 800 \
-	--use-plugins=device-farm \
-	--plugin-device-farm-platform="$DF_PLATFORM"
+# --config carries the plugin block (bootedSimulators, platforms); --port here
+# overrides the config's port so DF_PORT still wins.
+exec appium --config "$DF_CONFIG" --port "$DF_PORT"


### PR DESCRIPTION
Integrates the [`appium-device-farm`](../tree/dev/tools/appium-device-farm) plugin so the characterization harness allocates devices **by capability** (and queues/auto-assigns ports) instead of hand-picking UDIDs and offsetting WDA/MJPEG ports.

## Stages
- **Stage 1** — gated capability launch path: `appiumCapabilities` omits `udid`/`deviceName`/fleet-ports/`derivedDataPath` and pins `platformVersion` (latest sim runtime, major.minor); `createSession` reads back the allocated UDID; `runner/devicefarm.go` added.
- **Stage 2** — DF fleet roster = N **logical** devices (no discovery/boot/seed); retired `seedFleetServer`/`staggerFleetLaunch` under DF; **`boot-pool.sh`** helper (boot N latest-OS sims, verify the app, warm WDA).
- **Stage 3** — orchestration (`overnight.sh` DF-aware), docs, and a **failed-launch session cleanup** (`discardSession`) so a dead launch doesn't hold a sim busy for 2 h. Plus `appium:shouldTerminateApp` so the app is terminated on session teardown (WDA stays resident).
- **Stage 4** — `OpenSession` binds via **config-on-connect** (minted `player_id`) instead of the heuristic `pickPlayerFor`, which couldn't disambiguate a player under DF / on a shared server. Fixes the OpenSession-bound modes (abort, playback_end, state_residency, startup warmup). **Device Farm is now the default** appium path (`DeviceFarmEnabled()` default-on; opt out `CHAR_DEVICE_FARM=0`); resolution env → `.env` → default.

## Decoupling
The network-shaping / fault-injection sweep and the dashboard's Automated Testing page need **no** DF awareness — they operate by `player_id` through the proxy. DF only affects the *launch* layer.

## Validation
- `TestPyramidIPadSim` fleet groups run end-to-end under DF (A/B content treatments).
- `TestAbortIPadSim` with **no flag** binds via config-on-connect under default-on DF (validates the Stage 4 bind refactor + the default flip together).
- build / vet / `runner` unit / `modes` compile green throughout.

See `tools/appium-device-farm/HANDOFF.md` for the full plan + findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
