### PR TITLE
feat(player): default autoRecovery ON + CHAR_AUTO_RECOVERY harness toggle

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -82,8 +82,10 @@ final class PlayerViewModel: ObservableObject {
     @Published var startsOnFirstEligibleVariant: Bool = false
     /// Stream URL goes through the per-session go-proxy port. Off → API port.
     @Published var localProxy: Bool = true
-    /// Auto-retry the current stream on non-codec player errors.
-    @Published var autoRecovery: Bool = false
+    /// Auto-retry the current stream on non-codec player errors. Defaults ON —
+    /// the recovery ladder (live-resync seek → rebuild, stuck/failed restart) is
+    /// the standard playback-resilience path; opt out via `is.flag.auto_recovery`.
+    @Published var autoRecovery: Bool = true
     /// Seek to the live edge on every (re)load.
     @Published var goLive: Bool = false
     /// Skip Home on cold launch when a saved server + lastPlayed both exist.
@@ -2001,7 +2003,11 @@ final class PlayerViewModel: ObservableObject {
         developerMode    = d.bool(forKey: Self.flagDevMode)
         allow4K          = d.object(forKey: Self.flag4K) as? Bool ?? true
         localProxy       = d.object(forKey: Self.flagLocalProxy) as? Bool ?? true
-        autoRecovery     = d.bool(forKey: Self.flagAutoRecovery)
+        // Default ON when unset; honor an explicit persisted bool OR an
+        // NSArgumentDomain launch-arg string (`-is.flag.auto_recovery false`).
+        // `object(forKey:)==nil` ⇒ absent in every domain ⇒ default true;
+        // otherwise d.bool parses both the NSNumber and the launch-arg string.
+        autoRecovery     = d.object(forKey: Self.flagAutoRecovery) == nil ? true : d.bool(forKey: Self.flagAutoRecovery)
         goLive           = d.bool(forKey: Self.flagGoLive)
         skipHomeOnLaunch = d.bool(forKey: Self.flagSkipHome)
         isMuted = d.bool(forKey: Self.flagMuted)

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -180,6 +180,14 @@ func withBaselineTestFlags(args []string) []string {
 			out = append(out, kv[0], kv[1])
 		}
 	}
+	// Pin auto-recovery to a deterministic value every launch (the app defaults
+	// it ON) so a sim's stale persisted toggle can't leak in. CHAR_AUTO_RECOVERY=0
+	// (false/off) turns it OFF for modes that want the player's RAW, unmasked stall
+	// behavior — otherwise the recovery ladder (live-resync seek → rebuild) self-
+	// heals stalls a mode may be trying to measure. A mode that set it explicitly wins.
+	if !present["-is.flag.auto_recovery"] {
+		out = append(out, "-is.flag.auto_recovery", charAutoRecovery())
+	}
 	// Pin the played clip (is.lastPlayed) unless the mode already set one, so
 	// every test streams identical content by default. The clip name is config,
 	// not source: CHAR_CONTENT (shell) overrides, else it's read from .env. No
@@ -190,6 +198,20 @@ func withBaselineTestFlags(args []string) []string {
 		}
 	}
 	return out
+}
+
+// charAutoRecovery resolves CHAR_AUTO_RECOVERY to the value forced onto
+// -is.flag.auto_recovery on every characterization launch. Default "true"
+// (matches the app's own default); "0" / "false" / "off" / "no" force it OFF —
+// for modes that need to observe the player's raw, unmasked stall behavior
+// rather than have the recovery ladder self-heal it.
+func charAutoRecovery() string {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CHAR_AUTO_RECOVERY"))) {
+	case "0", "false", "off", "no":
+		return "false"
+	default:
+		return "true"
+	}
 }
 
 // defaultContentClip resolves the clip every appium test plays: CHAR_CONTENT


### PR DESCRIPTION
## What
- **iOS app:** `autoRecovery` now defaults **ON** (`PlayerViewModel`). The flag-load defaults true only when `is.flag.auto_recovery` is absent in every domain, still honoring an explicit persisted bool **or** a launch-arg string (`-is.flag.auto_recovery false`).
- **Harness:** every appium characterization launch forces `-is.flag.auto_recovery` to a deterministic value (NSArgumentDomain → overrides a sim's stale toggle, and the old app's default). **`CHAR_AUTO_RECOVERY=0/false/off`** turns it OFF; default on.

## Why
The recovery ladder (live-resync seek → rebuild, stuck/failed restart) is the standard resilience path, but it was gated behind `autoRecovery`, which defaulted **off**. A characterization run caught the consequence: an every-other arm hit a routine CoreMedia `-12880` ("can not proceed after removing variants") on a steep downshift, AVPlayer parked in `.waitingToPlayAtSpecifiedRate` at the live edge, `liveResyncDue` fired — but with recovery off the handler only took a HAR snapshot, so it never seeked/rebuilt. Result: `player_restarts=0`, frozen ~15 min, ended via `inactive_timeout`.

With this, that stall self-heals via the live-resync ladder. The harness toggle lets raw-stall-measurement modes opt out.

## Notes
- Go side build/vet clean. The Swift change is a default flip + ternary; **please kick an Xcode build before merge** — I couldn't compile-verify the iOS target in this flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
