### PR TITLE
feat(812): per-session variant-peak ladder in compare mode

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -25,7 +25,7 @@
 import { computed, ref, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
-import { useManifestVariants, nearestVariantByBitrate, displayedVariantPeakMbps } from '@/composables/useManifestVariants';
+import { useManifestVariants, nearestVariantByBitrate, displayedVariantPeakMbps, latestManifestVariants, type VariantLite } from '@/composables/useManifestVariants';
 import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf, useCompareSiblings, sessionMarkerColor, SELF_MARKER_COLOR } from '@/composables/useCompareContext';
 import { compareBandwidthSeries } from '@/composables/compareSeries';
@@ -59,24 +59,38 @@ interface ManifestVariantLite {
 }
 
 /** Append one horizontal reference line per ladder rung at its published PEAK
- *  bandwidth (EXT-X-STREAM-INF BANDWIDTH), all collapsed under the single
- *  "Variant peak bandwidth" legend chip. `hidden` starts the whole group off
- *  (compare mode) or on (single-session, the rate ABR keys on). Shared so the
- *  ladder reads identically in both modes. */
-function appendPeakLadder(out: SeriesSpec[], ladder: ManifestVariantLite[], hidden: boolean): void {
+ *  bandwidth (EXT-X-STREAM-INF BANDWIDTH), all collapsed under a single
+ *  "Variant peak bandwidth" legend chip. `opts.hidden` starts the whole group
+ *  off (compare mode) or on (single-session, the rate ABR keys on).
+ *
+ *  When `opts.tag` is set (compare mode) the chip and each rung label carry
+ *  the session's `(Sx)` so each session gets its OWN ladder built from its OWN
+ *  manifest, and `sessionTag` wires the rungs to the S1/S2 session legend so a
+ *  session's lines hide/highlight in lockstep (issue #812). `opts.dash` styles
+ *  the rungs by the per-session dash convention ([] solid = active session).
+ *  Without a tag the single-session ladder reads exactly as before. */
+function appendPeakLadder(
+  out: SeriesSpec[],
+  ladder: ReadonlyArray<VariantLite>,
+  opts: { hidden: boolean; tag?: string; dash?: number[] },
+): void {
   const PEAK_COLOR = '#cbd5e1';
+  const groupLegend = opts.tag ? `Variant peak bandwidth (${opts.tag})` : 'Variant peak bandwidth';
+  const borderDash = opts.dash ?? [6, 4];
   for (const v of ladder) {
     const peakBw = Number(v.bandwidth);
     if (!Number.isFinite(peakBw) || peakBw <= 0) continue;
     const mbps = peakBw / 1_000_000;
+    const label = `Variant peak ${v.resolution ?? '?'} (${mbps.toFixed(2)} Mbps)`;
     out.push({
-      label: `Variant peak ${v.resolution ?? '?'} (${mbps.toFixed(2)} Mbps)`,
+      label: opts.tag ? `${label} (${opts.tag})` : label,
       color: PEAK_COLOR,
       accessor: () => mbps,
       stepped: false,
-      borderDash: [6, 4],
-      groupLegend: 'Variant peak bandwidth',
-      hidden,
+      borderDash,
+      groupLegend,
+      ...(opts.tag ? { sessionTag: opts.tag } : {}),
+      hidden: opts.hidden,
     });
   }
 }
@@ -88,21 +102,9 @@ function appendPeakLadder(out: SeriesSpec[], ladder: ManifestVariantLite[], hidd
  *  the manifest because the archive record is built without it. The
  *  events stream rows DO carry `manifest_variants` (it's part of the
  *  charts_minimal projection), so read from there. Issue #486. */
-const eventsStreamVariants = computed<ManifestVariantLite[]>(() => {
-  void props.eventsStream.version.value;
-  const rows = props.eventsStream.inRange(0, Number.MAX_SAFE_INTEGER);
-  for (let i = rows.length - 1; i >= 0; i--) {
-    const mv = (rows[i] as Record<string, unknown>).manifest_variants;
-    if (Array.isArray(mv) && mv.length) return mv as ManifestVariantLite[];
-    if (typeof mv === 'string' && mv.length > 0 && mv !== 'null') {
-      try {
-        const parsed = JSON.parse(mv);
-        if (Array.isArray(parsed) && parsed.length) return parsed as ManifestVariantLite[];
-      } catch { /* ignore */ }
-    }
-  }
-  return [];
-});
+const eventsStreamVariants = computed<ManifestVariantLite[]>(
+  () => latestManifestVariants(props.eventsStream) as ManifestVariantLite[],
+);
 
 const variants = computed<ManifestVariantLite[]>(() => {
   const fromPlayer = usePlayerVariants.value;
@@ -380,12 +382,14 @@ const series = computed<SeriesSpec[]>(() => {
   // (solid, `S<id>`) the siblings overlay — not its full single-session
   // series — so every session reads identically (issue #579).
   if (compareSelf.value) {
-    const compareOut = compareBandwidthSeries(compareSelf.value);
-    // Variant peak-bandwidth ladder, also available in compare mode but
-    // hidden by default (toggle via the single "Variant peak bandwidth" legend
-    // chip). The manifest ladder is content-level — the same across the
-    // compared sessions — so it's drawn ONCE here, not tagged per sibling.
-    appendPeakLadder(compareOut, variants.value, true);
+    const self = compareSelf.value;
+    const compareOut = compareBandwidthSeries(self);
+    // Active session's own variant-peak ladder — hidden by default, tagged
+    // `(Sx)` and styled with the session dash so it reads as this session's
+    // rungs. Each sibling builds its OWN ladder from its OWN manifest in the
+    // useCompareOverlays closure below, so manifests that differ across the
+    // compared sessions show distinct rung sets (issue #812).
+    appendPeakLadder(compareOut, variants.value, { hidden: true, tag: self.tag, dash: self.dash });
     return compareOut;
   }
   const out = [...baseSeries];
@@ -446,8 +450,8 @@ const series = computed<SeriesSpec[]>(() => {
     }
   }
   // Variant peak ladder — default ON in single-session (the rung rate ABR
-  // keys on). Same builder feeds the default-OFF compare-mode ladder above.
-  appendPeakLadder(out, ladder, false);
+  // keys on). Same builder feeds the default-OFF compare-mode ladders above.
+  appendPeakLadder(out, ladder, { hidden: false });
   return out;
 });
 
@@ -458,7 +462,19 @@ const series = computed<SeriesSpec[]>(() => {
  *  visible; Player Est / Server Variant / Shaper Avg legend-toggleable).
  *  On the shared 'y' axis so the rate axis sizes across every overlaid
  *  session (the #165 union-sizing fix). */
-const compareOverlays = useCompareOverlays(compareBandwidthSeries);
+const compareOverlays = useCompareOverlays((sib) => {
+  const specs = compareBandwidthSeries(sib);
+  // Each sibling's own variant-peak ladder, read from its OWN manifest via
+  // its events stream — so comparing two sessions whose manifests differ
+  // shows each one's distinct rung set. Hidden by default, tagged + dashed
+  // per session so the S1/S2 legend toggles it in lockstep (issue #812).
+  appendPeakLadder(specs, latestManifestVariants(sib.stream), {
+    hidden: true,
+    tag: sib.tag,
+    dash: sib.dash,
+  });
+  return specs;
+});
 </script>
 
 <template>

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -383,6 +383,7 @@ function buildOverlayDatasetObjs(): any[] {
   for (const d of existing) if (d._dsKey) byKey.set(d._dsKey, d);
   const out: any[] = [];
   for (const src of sources) {
+    const rtExisted = overlayRuntime.has(src.key);
     let rt = overlayRuntime.get(src.key);
     if (!rt) {
       rt = { datasets: [], watermark: -Infinity, epoch: src.eventsStream.epoch.value };
@@ -390,6 +391,7 @@ function buildOverlayDatasetObjs(): any[] {
     }
     while (rt.datasets.length < src.series.length) rt.datasets.push([]);
     while (rt.datasets.length > src.series.length) rt.datasets.pop();
+    let addedSeries = false;
     for (let i = 0; i < src.series.length; i++) {
       const s = src.series[i];
       const dsKey = src.key + '|' + s.label;
@@ -409,7 +411,21 @@ function buildOverlayDatasetObjs(): any[] {
         const data = rt.datasets[i] ?? [];
         rt.datasets[i] = data;
         out.push(makeDsObj(dsKey, s, data, false));
+        if (rtExisted) addedSeries = true;
       }
+    }
+    // A series appearing on an ALREADY-draining overlay (e.g. a sibling's
+    // variant-peak ladder once its manifest_variants row is parsed, #812)
+    // lands after the ingest watermark, so a forward-only drain would never
+    // backfill it — the dataset stays empty on a static/archived view and
+    // only partially fills live. Reset the watermark + clear every array so
+    // the next drainOverlays re-seeds the whole set from the start. Mirrors
+    // the epoch-reset path in drainOverlays; safe because the callers update
+    // once while the arrays are empty before draining (see the structure
+    // watcher's empty-prime note, #579).
+    if (addedSeries) {
+      rt.watermark = -Infinity;
+      for (const arr of rt.datasets) arr.length = 0;
     }
   }
   return out;

--- a/content/dashboard-v3/src/composables/useCompareContext.ts
+++ b/content/dashboard-v3/src/composables/useCompareContext.ts
@@ -111,13 +111,17 @@ export function sessionMarkerColor(index: number): string {
 
 /**
  * useCompareOverlays — turn the provided compare context into a chart's
- * `overlays` prop. `specsFor` maps one session identity to the
- * SeriesSpec[] that chart wants (its own accessors, tagged + styled per
- * session). Returns [] when compare mode is off or no context is
- * provided (so a chart mounted outside SessionDisplay is unaffected).
+ * `overlays` prop. `specsFor` maps one grouped sibling to the SeriesSpec[]
+ * that chart wants (its own accessors, tagged + styled per session).
+ * The callback receives the full `CompareSibling` — most chart builders
+ * only read its `CompareSeriesIdentity` (tag + dash), but a builder can
+ * also reach the sibling's own `stream` to derive per-session series from
+ * its manifest (the bandwidth chart's per-session variant ladder, #812).
+ * Returns [] when compare mode is off or no context is provided (so a
+ * chart mounted outside SessionDisplay is unaffected).
  */
 export function useCompareOverlays(
-  specsFor: (id: CompareSeriesIdentity) => SeriesSpec[],
+  specsFor: (sib: CompareSibling) => SeriesSpec[],
 ): ComputedRef<ChartOverlaySource[]> {
   const ctx = inject(CompareContextKey, null);
   return computed<ChartOverlaySource[]>(() => {

--- a/content/dashboard-v3/src/composables/useManifestVariants.ts
+++ b/content/dashboard-v3/src/composables/useManifestVariants.ts
@@ -13,6 +13,7 @@
  */
 import { computed, type Ref } from 'vue';
 import { usePlayer } from './usePlayer';
+import type { Stream } from './useSessionTimeSeries';
 import type { components } from '@/types/v2';
 
 type ManifestVariant = components['schemas']['ManifestVariant'];
@@ -85,6 +86,32 @@ export function parseManifestVariants(value: unknown): VariantLite[] {
     try { v = JSON.parse(v); } catch { return []; }
   }
   return Array.isArray(v) ? (v as VariantLite[]) : [];
+}
+
+/**
+ * Most-recent non-empty `manifest_variants` value from a charts_minimal
+ * events stream, scanning newest row first. The per-row `manifest_variants`
+ * column is part of the charts_minimal projection both the live/active
+ * stream and each compare-mode sibling stream carry, so reading it here
+ * lets a chart build a per-session variant ladder from whichever stream it
+ * holds — the active session's own (single-session / self) or a sibling's
+ * (compare-mode overlay, issue #812).
+ *
+ * Reads `stream.version.value` so a caller invoking this inside a `computed`
+ * re-derives when the stream ingests new rows. Returns `[]` for a null
+ * stream or one with no usable manifest yet (e.g. pre-manifest heartbeats).
+ */
+export function latestManifestVariants(
+  stream: Stream<Record<string, unknown>> | null | undefined,
+): VariantLite[] {
+  if (!stream) return [];
+  void stream.version.value;
+  const rows = stream.inRange(0, Number.MAX_SAFE_INTEGER);
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const parsed = parseManifestVariants((rows[i] as Record<string, unknown>).manifest_variants);
+    if (parsed.length) return parsed;
+  }
+  return [];
 }
 
 /**


### PR DESCRIPTION
## Summary

In compare mode the bandwidth chart drew exactly **one** variant-peak ladder, read from the active session's manifest only. Comparing two sessions whose manifests differ (e.g. one with half its variants dropped) couldn't show the other session's distinct rung set — which is the whole point of that comparison.

Now each session gets its **own** ladder, read from its own `manifest_variants`:

- **`useManifestVariants.ts`** — factored a reusable `latestManifestVariants(stream)` out of `BandwidthChart`'s inline `eventsStreamVariants` (`manifest_variants` rides in the `lanes_v1` bundle; scanned newest-row-first).
- **`appendPeakLadder`** now takes `{ hidden, tag?, dash? }` → per-session rung labels, a `Variant peak bandwidth (Sx)` group chip, `sessionTag` so the S1/S2 legend toggles it in lockstep, and the per-session dash. Untagged single-session ladder is byte-for-byte unchanged (still default-ON).
- Self ladder gets the active session's tag+dash; each sibling builds its own from `latestManifestVariants(sib.stream)` in the `useCompareOverlays` closure.
- `useCompareOverlays` hands the full `CompareSibling` (incl. its stream) to the series builder.

## Drain-watermark fix (`MetricsLineChart.vue`)

While verifying on test-dev, the sibling ladder rendered for only one session. Root cause was **not** a data gap (the sibling stream delivers `manifest_variants` on ~every row) but the overlay drain: a series that appears on an already-draining overlay (the ladder, once its `manifest_variants` row is parsed) lands *after* the ingest watermark, so a forward-only drain never backfills it — leaving the sibling ladder empty on a static/archived view. Fix: reset the overlay watermark + clear its arrays when a new series appears, so the next drain re-seeds every dataset from the start (mirrors the existing epoch-reset idiom).

## Verification

- `vue-tsc --noEmit` clean + `vite build` succeeds.
- Confirmed live on test-dev that the sibling timeseries carries `manifest_variants` (3180/3181 rows), and that the deployed bundle renders both `Variant peak bandwidth (S1)` / `(S2)` chips after the drain fix.
- No backend / forwarder / schema changes.

Fixes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
