### PR TITLE
fix(816): delete per-session tc u32 filter by exact handle (stop cross-session shaping clobber)

### DIFF
--- a/go-proxy/cmd/server/filter_handle_test.go
+++ b/go-proxy/cmd/server/filter_handle_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+// Realistic `tc filter show dev eth0 parent 1:0` output: a u32 hashtable line
+// (fh 800:) plus three leaf filters, one per session port, each a sport match
+// at offset 20. Ports: 30181=0x75e5→1:181, 30381=0x76ad→1:381, 30481=0x7711→1:481.
+const sampleFilterShow = `filter parent 1: protocol ip pref 1 u32 chain 0
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800: ht divisor 1
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:181 not_in_hw
+  match 75e50000/ffff0000 at 20
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::801 order 2049 key ht 800 bkt 0 flowid 1:381 not_in_hw
+  match 76ad0000/ffff0000 at 20
+filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::802 order 2050 key ht 800 bkt 0 flowid 1:481 not_in_hw
+  match 77110000/ffff0000 at 20
+`
+
+func TestU32HandleForPort_resolvesExactHandle(t *testing.T) {
+	cases := map[int]string{
+		30181: "800::800", // 0x75e5
+		30381: "800::801", // 0x76ad
+		30481: "800::802", // 0x7711
+	}
+	for port, want := range cases {
+		if got := u32HandleForPort(sampleFilterShow, port); got != want {
+			t.Errorf("u32HandleForPort(port=%d) = %q, want %q", port, got, want)
+		}
+	}
+}
+
+func TestU32HandleForPort_absentPortReturnsEmpty(t *testing.T) {
+	// 30581=0x7775 has no filter — must return "" so RemoveFilter no-ops rather
+	// than falling back to a match-spec delete (the #816 over-deletion).
+	if got := u32HandleForPort(sampleFilterShow, 30581); got != "" {
+		t.Errorf("absent port: got %q, want empty", got)
+	}
+}
+
+func TestU32HandleForPort_emptyInput(t *testing.T) {
+	if got := u32HandleForPort("", 30181); got != "" {
+		t.Errorf("empty input: got %q, want empty", got)
+	}
+}
+
+func TestU32HandleForPort_dportFallback(t *testing.T) {
+	// The dport fallback form: 0000<port>/0000ffff at offset 20. 30181=0x75e5.
+	show := "filter parent 1: protocol ip pref 1 u32 chain 0 fh 800::805 order 2053 key ht 800 bkt 0 flowid 1:181\n  match 000075e5/0000ffff at 20\n"
+	if got := u32HandleForPort(show, 30181); got != "800::805" {
+		t.Errorf("dport fallback: got %q, want 800::805", got)
+	}
+}
+
+func TestU32HandleForPort_skipsHashtableHandle(t *testing.T) {
+	// A match must never bind to the `fh 800:` hashtable handle (no `::`).
+	show := "filter parent 1: protocol ip pref 1 u32 chain 0 fh 800: ht divisor 1\n  match 75e50000/ffff0000 at 20\n"
+	if got := u32HandleForPort(show, 30181); got != "" {
+		t.Errorf("hashtable-only: got %q, want empty (no leaf handle)", got)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1442,9 +1442,14 @@ func (t *TcTrafficManager) ClearPortShaping(port int) {
 		return
 	}
 	log.Printf("NETSHAPE port_shaping_clear port=%d classid=%s reason=session_start", port, classid)
-	_ = exec.Command("tc", "filter", "del", "dev", t.interfaceName, "protocol", "ip",
-		"parent", "1:0", "prio", "1", "u32",
-		"match", "ip", "sport", fmt.Sprintf("%d", port), "0xffff").Run()
+	// Delete THIS port's u32 filter by its exact handle (#816). This previously
+	// inlined `tc filter del … prio 1 u32 match ip sport <port>`, which at the
+	// shared prio 1 collaterally removed OTHER live sessions' filters — and since
+	// ClearPortShaping is the config-on-start sweep, it was the production
+	// trigger of the cross-session uncap. RemoveFilter resolves the exact handle
+	// (no-op when absent). Safe under the tcMu we already hold — RemoveFilter
+	// takes no lock.
+	_ = t.RemoveFilter(port)
 	// Also clear the per-port ICMP-to-player_ip filter installed for
 	// the path-ping prio routing (issue #404). Per-port pref makes
 	// this a single by-attribute delete; the tracking map is then
@@ -1541,13 +1546,62 @@ func (t *TcTrafficManager) ReadActualRateMbps(port int) float64 {
 	return -1
 }
 
+// RemoveFilter deletes ONLY this port's u32 classifier filter, resolved to its
+// exact kernel handle first. The previous implementation deleted by match-spec
+// at the shared `prio 1` (`tc filter del … prio 1 u32 match ip sport <port>`),
+// which the kernel/iproute2 can apply to the WRONG filter at that prio —
+// collaterally removing ANOTHER live session's filter. The victim's traffic
+// then fell through to the 10 Gbps HTB `default 999` class (uncapped) until its
+// next rate-set re-added its filter. This surfaced when a concurrent session's
+// config-on-start clear sweep (ClearPortShaping) ran while peers were streaming
+// (#816). Deleting by the resolved handle touches exactly one filter — or
+// nothing, when this port has no filter (a fresh session's sweep), which must
+// NOT fall back to a match-spec delete (that is the over-deletion being fixed).
 func (t *TcTrafficManager) RemoveFilter(port int) error {
+	show := exec.Command("tc", "filter", "show", "dev", t.interfaceName, "parent", "1:0")
+	out, _ := show.CombinedOutput()
+	handle := u32HandleForPort(string(out), port)
+	if handle == "" {
+		return nil // no filter classifies this port — nothing to remove
+	}
 	cmd := exec.Command(
-		"tc", "filter", "del", "dev", t.interfaceName, "protocol", "ip", "parent", "1:0", "prio", "1", "u32",
-		"match", "ip", "sport", fmt.Sprintf("%d", port), "0xffff",
+		"tc", "filter", "del", "dev", t.interfaceName, "parent", "1:0", "prio", "1",
+		"handle", handle, "u32",
 	)
-	_ = cmd.Run()
+	if outDel, err := cmd.CombinedOutput(); err != nil {
+		log.Printf("NETSHAPE tc filter del failed port=%d handle=%s: %s", port, handle, strings.TrimSpace(string(outDel)))
+	}
 	return nil
+}
+
+// u32HandleForPort scans `tc filter show … parent 1:0` output and returns the
+// handle (e.g. "800::800") of the u32 filter whose selector matches the given
+// port — as a source port (the primary form ensurePortFilter installs) or a
+// destination port (the dport fallback). Returns "" when no filter classifies
+// the port. Pure/string-only so it is unit-testable off-box.
+//
+// iproute2 prints each u32 leaf filter as a header line carrying
+// `fh <handle> … flowid 1:<minor>` followed by one or more
+// `  match <hex>/<mask> at <off>` lines. ensurePortFilter encodes sport at
+// offset 20 as `<port>0000/ffff0000` and the dport fallback as
+// `0000<port>/0000ffff`, so each match is associated with the most recent leaf
+// handle line (the `fh 800:` hashtable line is skipped — only `::` leaf handles
+// classify traffic).
+func u32HandleForPort(filterShow string, port int) string {
+	sportHex := "match " + fmt.Sprintf("%04x0000/ffff0000", port) // sport at offset 20
+	dportHex := "match " + fmt.Sprintf("0000%04x/0000ffff", port) // dport at offset 20
+	handle := ""
+	for _, line := range strings.Split(filterShow, "\n") {
+		if i := strings.Index(line, "fh "); i >= 0 {
+			if tok := strings.Fields(line[i+3:]); len(tok) > 0 && strings.Contains(tok[0], "::") {
+				handle = tok[0]
+			}
+		}
+		if handle != "" && (strings.Contains(line, sportHex) || strings.Contains(line, dportHex)) {
+			return handle
+		}
+	}
+	return ""
 }
 
 func (t *TcTrafficManager) ensurePortFilter(port int, classid string) error {


### PR DESCRIPTION
## What

Fixes a cross-session traffic-shaping bug in go-proxy: concurrent sessions
clobbered each other's `tc` caps. The per-session u32 classifier filters all
share `prio 1` on `parent 1:0`, and deleting one with
`tc filter del … prio 1 u32 match ip sport <port>` can hit the WRONG filter at
that prio — collaterally removing another live session's filter. The victim's
traffic then fell through to the 10 Gbps HTB `default 999` (uncapped) until its
next rate-set re-added the filter.

The match-spec delete existed in **two** places, both fixed to resolve the
port's exact u32 leaf handle and delete by `handle <fh>` (no-op when absent):
- `RemoveFilter` (the rate=0 / clear path), and
- `ClearPortShaping` (the config-on-start sweep run on every session
  allocation) — the actual **production trigger**; it now delegates to
  `RemoveFilter`.

New pure helper `u32HandleForPort` + unit tests (sport / dport / absent /
hashtable-skip / empty).

## Why now

Surfaced by the higher session/restart churn from fleet group mode (#750),
Appium Device Farm default-on (#809), config-on-connect-default, per-play
app_config (#800), and autoRecovery restart default-on (#810).

## Evidence (test-dev)

- **Bug**, pre-fix: a foreign session's `session_start` dropped two live pyramid
  arms' filters (`1:381`, `1:481`) from `tc filter show`; their server-side
  `mbps_out` burst to 70–770 Mbps under ~7 Mbps caps, recovering on the next
  rate-set.
- **Fix verified live**, deployed: the session-start sweep ran its delete
  (`NETSHAPE port_shaping_clear … reason=session_start`) and removed only the
  target filter — the two live peers (`1:181`, `1:281`) survived. Also confirmed
  the rate=0 path removes exactly its own filter.

## Tests

- `go test ./go-proxy/cmd/server/ -run TestU32HandleForPort` (darwin) — green.
- `GOOS=linux go build ./go-proxy/cmd/server/` — green.

## Follow-up (not in this PR)

Latent: classids / prio+netem handles / ICMP pref are all derived from
`port % 1000` — safe today under per-proxy netns isolation, but a
shared-interface multi-stack deploy would collide. Worth keying on a
globally-unique id (tracked separately).

Fixes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
