### PR TITLE
fix(820): manifest_variants reflects the manipulated master (bandwidth chart shows thinned ladder)

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6028,6 +6028,14 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 		sessionData["manifest_url"] = filename
 	}
 	if playlistInfo != nil {
+		// getContentType parsed the UNMANIPULATED upstream master, so playlistInfo
+		// is the full ladder. Thin it to the session's allowed_variants so
+		// manifest_variants matches the MANIPULATED master the player receives —
+		// otherwise the bandwidth chart (#815) draws every rung for a thinned
+		// session and the per-session compare is meaningless (#820).
+		if allowed := getStringSlice(sessionData, "content_allowed_variants"); len(allowed) > 0 {
+			playlistInfo = filterPlaylistInfoByAllowed(playlistInfo, allowed)
+		}
 		sessionData["manifest_variants"] = playlistInfo
 	}
 	inferServerVideoRendition(sessionData, filename, isManifest, isSegment)
@@ -6631,23 +6639,53 @@ func (a *App) applyContentManipulation(body []byte, session SessionData, content
 // durations whose served URIs differ — the harness/dashboard need not know the
 // per-segment URI scheme.
 func variantAllowed(v *m3u8.Variant, allowed map[string]bool) bool {
-	if allowed[v.URI] {
+	return variantSelectorAllowed(v.URI, v.Resolution, allowed)
+}
+
+// variantSelectorAllowed is the shared allowed_variants matcher: an entry is
+// kept if the allow-set contains its served URI, its full resolution
+// ("640x360"), its bare height ("360"), or "360p". Both the master rewrite
+// (variantAllowed) and the manifest_variants metric (filterPlaylistInfoByAllowed)
+// route through it so they agree on exactly which rungs the player ends up with.
+func variantSelectorAllowed(uri, resolution string, allowed map[string]bool) bool {
+	if uri != "" && allowed[uri] {
 		return true
 	}
-	res := v.Resolution // "640x360"
-	if res == "" {
+	if resolution == "" || resolution == "unknown" {
 		return false
 	}
-	if allowed[res] {
+	if allowed[resolution] {
 		return true
 	}
-	if i := strings.LastIndex(res, "x"); i >= 0 {
-		h := res[i+1:] // "360"
+	if i := strings.LastIndex(resolution, "x"); i >= 0 {
+		h := resolution[i+1:] // "360"
 		if allowed[h] || allowed[h+"p"] {
 			return true
 		}
 	}
 	return false
+}
+
+// filterPlaylistInfoByAllowed thins a parsed master variant list to the
+// allowed_variants keep-set, so the `manifest_variants` metric reflects the
+// MANIPULATED master the player actually receives — not the unmanipulated
+// upstream getContentType parsed (#820). Returns the input unchanged when no
+// allow-set is configured.
+func filterPlaylistInfoByAllowed(infos []PlaylistInfo, allowed []string) []PlaylistInfo {
+	if len(allowed) == 0 || len(infos) == 0 {
+		return infos
+	}
+	allowedMap := make(map[string]bool, len(allowed))
+	for _, a := range allowed {
+		allowedMap[a] = true
+	}
+	out := make([]PlaylistInfo, 0, len(infos))
+	for _, p := range infos {
+		if variantSelectorAllowed(p.URL, p.Resolution, allowedMap) {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func manipulateHLSMaster(body []byte, cm ContentManipulation) ([]byte, error) {

--- a/go-proxy/cmd/server/manifest_variants_test.go
+++ b/go-proxy/cmd/server/manifest_variants_test.go
@@ -1,0 +1,71 @@
+package main
+
+import "testing"
+
+// full2sLadder mirrors the real insane_new master_2s.m3u8 (11 rungs).
+func full2sLadder() []PlaylistInfo {
+	return []PlaylistInfo{
+		{URL: "playlist_2s_360p.m3u8", Bandwidth: 1063012, Resolution: "640x360"},
+		{URL: "playlist_2s_432p.m3u8", Bandwidth: 1420320, Resolution: "768x432"},
+		{URL: "playlist_2s_540p.m3u8", Bandwidth: 1893473, Resolution: "960x540"},
+		{URL: "playlist_2s_648p.m3u8", Bandwidth: 2571743, Resolution: "1152x648"},
+		{URL: "playlist_2s_720p.m3u8", Bandwidth: 3552350, Resolution: "1280x720"},
+		{URL: "playlist_2s_900p.m3u8", Bandwidth: 5034445, Resolution: "1600x900"},
+		{URL: "playlist_2s_1080p.m3u8", Bandwidth: 7182067, Resolution: "1920x1080"},
+		{URL: "playlist_2s_1296p.m3u8", Bandwidth: 10530479, Resolution: "2304x1296"},
+		{URL: "playlist_2s_1440p.m3u8", Bandwidth: 15484068, Resolution: "2560x1440"},
+		{URL: "playlist_2s_1800p.m3u8", Bandwidth: 21525717, Resolution: "3200x1800"},
+		{URL: "playlist_2s_2160p.m3u8", Bandwidth: 30333359, Resolution: "3840x2160"},
+	}
+}
+
+func resOf(infos []PlaylistInfo) []string {
+	out := make([]string, len(infos))
+	for i, p := range infos {
+		out[i] = p.Resolution
+	}
+	return out
+}
+
+func TestFilterPlaylistInfoByAllowed_everyOther(t *testing.T) {
+	// The #820 case: every-other keep-set (resolution-keyed) must thin 11 → 6.
+	allowed := []string{"640x360", "960x540", "1280x720", "1920x1080", "2560x1440", "3840x2160"}
+	got := filterPlaylistInfoByAllowed(full2sLadder(), allowed)
+	if len(got) != 6 {
+		t.Fatalf("got %d variants, want 6: %v", len(got), resOf(got))
+	}
+	want := []string{"640x360", "960x540", "1280x720", "1920x1080", "2560x1440", "3840x2160"}
+	for i, w := range want {
+		if got[i].Resolution != w {
+			t.Errorf("variant[%d] = %s, want %s", i, got[i].Resolution, w)
+		}
+	}
+}
+
+func TestFilterPlaylistInfoByAllowed_emptyAllowReturnsAll(t *testing.T) {
+	got := filterPlaylistInfoByAllowed(full2sLadder(), nil)
+	if len(got) != 11 {
+		t.Fatalf("no allow-set should pass all 11 through, got %d", len(got))
+	}
+}
+
+func TestFilterPlaylistInfoByAllowed_bareHeightAndURI(t *testing.T) {
+	// Bare-height keep-set ("360"/"720") and exact-URI back-compat both match.
+	got := filterPlaylistInfoByAllowed(full2sLadder(), []string{"360", "720p", "playlist_2s_2160p.m3u8"})
+	if r := resOf(got); len(got) != 3 || r[0] != "640x360" || r[1] != "1280x720" || r[2] != "3840x2160" {
+		t.Fatalf("bare-height/URI match: got %v, want [640x360 1280x720 3840x2160]", resOf(got))
+	}
+}
+
+func TestVariantSelectorAllowed_unknownResolutionExcluded(t *testing.T) {
+	m := map[string]bool{"640x360": true}
+	if variantSelectorAllowed("", "unknown", m) {
+		t.Error("unknown resolution with no URI match must be excluded")
+	}
+	if variantSelectorAllowed("", "", m) {
+		t.Error("empty resolution with no URI match must be excluded")
+	}
+	if !variantSelectorAllowed("", "640x360", m) {
+		t.Error("matching full resolution must be allowed")
+	}
+}


### PR DESCRIPTION
## What

Fixes #820: in compare mode the bandwidth chart (#815) showed **all** variant
peaks even for a session thinned via `allowed_variants` — because the
`manifest_variants` metric it reads was captured from the **unmanipulated
upstream** master, before the per-session thinning was applied.

`getContentType` parses go-live's master (full ladder) and `main.go:6031`
stored that as `manifest_variants` **before** `applyContentManipulation` thinned
the served master. The player received the thinned (e.g. 6-rung) master; the
metric kept all 11; the chart drew 11.

## Fix

Thin `playlistInfo` by the session's `content_allowed_variants` before storing
`manifest_variants`, so the metric matches the master the player receives.
Extracted a shared matcher `variantSelectorAllowed` (URI / full resolution /
bare height / `<h>p`) so the master rewrite (`variantAllowed`) and the metric
(`filterPlaylistInfoByAllowed`) agree on the kept set.

## Tests

- `go test ./go-proxy/cmd/server/ -run 'TestFilterPlaylistInfoByAllowed|TestVariantSelectorAllowed'` — every-other thinning (11→6), empty-allow passthrough, bare-height/URI matching, unknown-resolution exclusion. Green.
- `GOOS=linux go build ./go-proxy/cmd/server/` — green.

## Evidence (test-dev)

Player `86c00262` fetched `master_2s.m3u8` through its session port and got the
6-variant master (`[GO-PROXY][CONTENT] Applied content manipulation`), while
`manifest_variants` reported all 11. This change aligns the metric so the
thinned arm's chart ladder shows its 6 rungs.

Fixes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
