### PR TITLE
fix(dashboard): persist bitrate Y-max per player across plays

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -34,6 +34,10 @@ import type { PlayerRecord } from '@/repo/v2-repo';
 
 const props = defineProps<{
   playerId: string;
+  /** Coordination scope key (per-player, stable across plays). Drives
+   *  useChartCoordination only; data still keys off playerId. Falls back to
+   *  playerId when absent. */
+  coordId?: string;
   eventsStream: Stream<Record<string, unknown>>;
   /** AVMetrics stream — used to overlay per-segment throughput dots
    *  on the bandwidth chart (issue #486). Optional so existing
@@ -41,7 +45,8 @@ const props = defineProps<{
    *  pre-spike) can still mount the chart. */
   avmetricsStream?: Stream<Record<string, unknown>>;
 }>();
-const coord = useChartCoordination(toRef(props, 'playerId'));
+const coordId = computed(() => props.coordId ?? props.playerId);
+const coord = useChartCoordination(coordId);
 const yMax = computed(() => coord.state.bandwidthYMax);
 const { variants: usePlayerVariants } = useManifestVariants(toRef(props, 'playerId'));
 const { player } = usePlayer(toRef(props, 'playerId'));
@@ -480,6 +485,7 @@ const compareOverlays = useCompareOverlays((sib) => {
 <template>
   <MetricsLineChart
     :player-id="playerId"
+    :coord-id="coordId"
     title="Bandwidth"
     unit="Mbps"
     :series="series"

--- a/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
+++ b/content/dashboard-v3/src/components/BitrateChartPanelToolbar.vue
@@ -14,11 +14,16 @@
  * redundant and confusing when one of three "Live" buttons fell out
  * of sync visually with the other two.
  */
-import { computed, toRef } from 'vue';
+import { computed } from 'vue';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 
-const props = defineProps<{ playerId: string }>();
-const coord = useChartCoordination(toRef(props, 'playerId'));
+const props = defineProps<{
+  playerId: string;
+  /** Coordination scope key (per-player, stable across plays). Falls back to
+   *  playerId when absent so standalone callers keep their old behavior. */
+  coordId?: string;
+}>();
+const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 
 type YMaxMode = 'auto' | '5' | '10' | '20' | '30' | '40' | '50' | '100';
 const modes: YMaxMode[] = ['auto', '5', '10', '20', '30', '40', '50', '100'];

--- a/content/dashboard-v3/src/components/BufferChart.vue
+++ b/content/dashboard-v3/src/components/BufferChart.vue
@@ -15,6 +15,9 @@ import type { PlayerRecord } from '@/repo/v2-repo';
 
 defineProps<{
   playerId: string;
+  /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
+   *  across plays). Falls back to playerId there when absent. */
+  coordId?: string;
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -54,6 +57,7 @@ const series = computed<SeriesSpec[]>(() =>
 <template>
   <MetricsLineChart
     :player-id="playerId"
+    :coord-id="coordId"
     title="Buffer & live offset"
     unit="buffer (s)"
     :series="series"

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -229,6 +229,10 @@ function colorForResolution(res: string | null | undefined): string {
 
 const props = defineProps<{
   playerId: string;
+  /** Coordination scope key (per-player, stable across plays). Drives
+   *  useChartCoordination only; data still keys off playerId. Falls back to
+   *  playerId when absent. */
+  coordId?: string;
   /** Samples stream from SessionDisplay's useSessionTimeSeries model.
    *  Each row is a CH session_snapshots projection (lanes_v1 bundle).
    *  EventsTimeline derives swim-lane segments from successive rows. */
@@ -244,7 +248,7 @@ const props = defineProps<{
    *  has no points (control_revision alone only says "something changed"). */
   controlStream?: Stream<Record<string, unknown>>;
 }>();
-const coord = useChartCoordination(toRef(props, 'playerId'));
+const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 
 /** Adapter — map a CH session_snapshots row (wire shape from the v3
  *  /api/v2/timeseries endpoint) to the small subset of fields ingest()

--- a/content/dashboard-v3/src/components/FPSChart.vue
+++ b/content/dashboard-v3/src/components/FPSChart.vue
@@ -23,6 +23,9 @@ import { compareFpsSeries } from '@/composables/compareSeries';
 
 const props = defineProps<{
   playerId: string;
+  /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
+   *  across plays). Falls back to playerId there when absent. */
+  coordId?: string;
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -134,6 +137,7 @@ const series = computed<SeriesSpec[]>(() => {
 <template>
   <MetricsLineChart
     :player-id="playerId"
+    :coord-id="coordId"
     title="Frame rate (derived)"
     unit="fps"
     :series="series"

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -16,7 +16,7 @@
  * to `windowMs * 2` ms on the older side so a zoom-out / pan-back still
  * has data to show. The chart never holds more than ~2× window worth.
  */
-import { computed, inject, onBeforeUnmount, ref, toRef, watch, type PropType } from 'vue';
+import { computed, inject, onBeforeUnmount, ref, watch, type PropType } from 'vue';
 import { ensureChartJs } from '@/composables/useChartJs';
 import { CompareContextKey } from '@/composables/useCompareContext';
 import { useChartCoordination, fmtTickHMSms, DEFAULT_FOCUS_MS, type ChartViewport } from '@/composables/useChartCoordination';
@@ -80,6 +80,10 @@ export interface ChartOverlaySource {
 
 const props = defineProps({
   playerId: { type: String, required: true },
+  /** Coordination scope key (per-player, stable across plays). Drives
+   *  useChartCoordination only; data still keys off playerId. Falls back to
+   *  playerId when absent. */
+  coordId: { type: String, default: undefined },
   title: { type: String, default: '' },
   unit: { type: String, default: '' },
   series: { type: Array as PropType<SeriesSpec[]>, required: true },
@@ -135,7 +139,7 @@ const emit = defineEmits<{
 const canvas = ref<HTMLCanvasElement | null>(null);
 const wrap = ref<HTMLDivElement | null>(null);
 const canvasWrap = ref<HTMLDivElement | null>(null);
-const coord = useChartCoordination(toRef(props, 'playerId'));
+const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 
 // Compare-mode session legend (issue #579). When mounted inside a
 // SessionDisplay that's in compare mode, the S1/S2 chips drive this

--- a/content/dashboard-v3/src/components/NetworkLog.vue
+++ b/content/dashboard-v3/src/components/NetworkLog.vue
@@ -23,6 +23,10 @@ import type { Stream } from '@/composables/useSessionTimeSeries';
 
 const props = defineProps<{
   playerId: string;
+  /** Coordination scope key (per-player, stable across plays). Drives
+   *  useChartCoordination only; data still keys off playerId. Falls back to
+   *  playerId when absent. */
+  coordId?: string;
   /** Network stream from the parent SessionDisplay's
    *  useSessionTimeSeries model. Supplies every per-request row for
    *  this (player, play), server-filtered to the current play_id,
@@ -31,7 +35,7 @@ const props = defineProps<{
 }>();
 const playerIdRef = toRef(props, 'playerId');
 usePlayer(playerIdRef); // keep the SSE subscription warm; live state is read off `coord` below
-const coord = useChartCoordination(playerIdRef);
+const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 
 /** Rows to highlight for the synchronized "selected event" cursor.
  *

--- a/content/dashboard-v3/src/components/RTTChart.vue
+++ b/content/dashboard-v3/src/components/RTTChart.vue
@@ -16,6 +16,9 @@ import { compareRttSeries } from '@/composables/compareSeries';
 
 const props = defineProps<{
   playerId: string;
+  /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
+   *  across plays). Falls back to playerId there when absent. */
+  coordId?: string;
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -87,6 +90,7 @@ const series = computed<SeriesSpec[]>(() => {
 <template>
   <MetricsLineChart
     :player-id="playerId"
+    :coord-id="coordId"
     title="Round-trip time"
     unit="ms"
     :series="series"

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -298,6 +298,16 @@ const archivePlayerId = computed(() =>
   `archive:${props.playerId}:${props.playId ?? 'all'}`,
 );
 
+// Coordination scope for the chart VIEW state (Bitrate Y-max, zoom width,
+// cursor, expanded) — deliberately play-INDEPENDENT, so a new play on the same
+// player doesn't reset the operator's chosen axis/zoom. Data stays keyed by
+// `archivePlayerId` (with play_id). `compareKey` already resolves to a stable
+// per-player id normally and a stable group id in archive-compare (#736), so it
+// is exactly the right scope (per-player live; per-group + stable across
+// member-tab switches in compare). The position fields are reset per play via
+// coord.resetForNewPlay() in the play_id watcher below.
+const coordId = computed(() => `view:${compareKey.value}`);
+
 // Event accordion source. The events stream isn't on the v3 timeseries
 // endpoint yet (out of scope for TS6); kept here so the brush-rail
 // tick markers, the priority/tier filter UI, and the prev/next nav
@@ -584,7 +594,16 @@ watch(
 // `coord.state.lastSampleMs` (live edge) without a temporal dead zone
 // — and so any earlier reactive code (window watcher, brush clamps)
 // sees a coord instance even though it gets consumed mostly later.
-const coord = useChartCoordination(archivePlayerId);
+const coord = useChartCoordination(coordId);
+
+// A new play (new play_id) on the same player keeps the chosen Bitrate Y-max +
+// zoom width (the view scope is play-independent), but the absolute-position
+// state (live edge, pinned range, cursor) belongs to the OLD play's time
+// domain — reset it so the fresh play follows live instead of showing a stale
+// pinned window. Skipped in archive mode (playId is fixed there).
+watch(() => props.playId, (next, prev) => {
+  if (next !== prev) coord.resetForNewPlay();
+});
 
 /* Refetch-on-pan driver (#587). Watches the committed focus range (the
  * #590 brush debounce means this fires once per gesture, not per
@@ -1784,11 +1803,11 @@ function skipToEnd() {
         :from-ms="cycleBandsDomain.fromMs"
         :to-ms="cycleBandsDomain.toMs"
       />
-      <EventsTimeline :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" />
+      <EventsTimeline :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" />
     </CollapsibleSection>
 
     <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">
-      <BitrateChartPanelToolbar :player-id="archivePlayerId" />
+      <BitrateChartPanelToolbar :player-id="archivePlayerId" :coord-id="coordId" />
       <!-- Compare mode: S1/S2 session chips — hover to highlight a whole
            session across all charts, click to show/hide it (#579). -->
       <CompareSessionLegend
@@ -1797,10 +1816,10 @@ function skipToEnd() {
         :view="compareView"
       />
       <div class="chart-stack">
-        <BandwidthChart :player-id="archivePlayerId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
-        <BufferChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
-        <RTTChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
-        <FPSChart :player-id="archivePlayerId" :events-stream="timeseries.events" />
+        <BandwidthChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
+        <BufferChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
+        <RTTChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
+        <FPSChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
       </div>
     </CollapsibleSection>
 
@@ -1810,7 +1829,7 @@ function skipToEnd() {
            paused. NetworkLog's own in-panel brush would duplicate it
            (or worse, show a brush in live-not-paused when nothing
            else does), so always opt out of it here. -->
-      <NetworkLog :player-id="archivePlayerId" :network-stream="timeseries.network" />
+      <NetworkLog :player-id="archivePlayerId" :coord-id="coordId" :network-stream="timeseries.network" />
     </CollapsibleSection>
 
     <CollapsibleSection title="Play Log" persist-key="play-log" :force-collapsed="compareEnabled">

--- a/content/dashboard-v3/src/composables/useChartCoordination.ts
+++ b/content/dashboard-v3/src/composables/useChartCoordination.ts
@@ -82,11 +82,32 @@ function writeExpandedStored(v: boolean) {
   try { localStorage.setItem(EXPANDED_STORAGE_KEY, v ? 'true' : 'false'); } catch { /* ignore */ }
 }
 
-function freshState(): ChartCoordinationState {
+// Bitrate-chart Y-axis max, persisted PER SCOPE (the coordination key —
+// per-player, not per-play; see SessionDisplay's coordId). Survives both a new
+// play (state is re-seeded from here) and a browser reload. Auto = key absent.
+const YMAX_STORAGE_PREFIX = 'dashboard_v3_bandwidth_ymax:';
+function readYMaxStored(pid: string): number | undefined {
+  try {
+    const raw = localStorage.getItem(YMAX_STORAGE_PREFIX + pid);
+    if (!raw) return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  } catch { return undefined; }
+}
+function writeYMaxStored(pid: string, v: number | undefined) {
+  try {
+    if (v == null) localStorage.removeItem(YMAX_STORAGE_PREFIX + pid);
+    else localStorage.setItem(YMAX_STORAGE_PREFIX + pid, String(v));
+  } catch { /* ignore */ }
+}
+
+function freshState(pid: string): ChartCoordinationState {
   return reactive<ChartCoordinationState>({
     expanded: readExpandedStored(),
     lastSampleMs: 0,
-    bandwidthYMax: undefined,
+    // Seed from the per-scope store so the operator's chosen ceiling survives a
+    // new play (fresh state) and a browser reload, instead of resetting to Auto.
+    bandwidthYMax: readYMaxStored(pid),
     cursorMs: null,
     cursorLabel: null,
     range: null,
@@ -97,7 +118,7 @@ function freshState(): ChartCoordinationState {
 function ensureState(pid: string): ChartCoordinationState {
   let s = states.get(pid);
   if (!s) {
-    s = freshState();
+    s = freshState(pid);
     states.set(pid, s);
   }
   return s;
@@ -202,6 +223,22 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
 
   function setBandwidthYMax(v: number | undefined) {
     cur().bandwidthYMax = v;
+    // Persist per scope so it survives a new play + a browser reload.
+    writeYMaxStored(playerIdRef.value, v);
+  }
+
+  /** Reset only the position / data-edge fields for a fresh play, KEEPING the
+   *  scale + display prefs (bandwidthYMax, liveSpan, expanded). The coordination
+   *  state is now keyed per-player (stable across plays), so without this a
+   *  pinned absolute zoom window from the prior play would carry into the new
+   *  play (wrong time domain) instead of following live. Called from
+   *  SessionDisplay on a play_id change. */
+  function resetForNewPlay() {
+    const s = cur();
+    s.lastSampleMs = 0;
+    s.range = null;
+    s.cursorMs = null;
+    s.cursorLabel = null;
   }
 
   /** Move the synchronized "selected event" cursor. Pass null to
@@ -244,6 +281,7 @@ export function useChartCoordination(playerIdInput: string | Ref<string>) {
     toggleLive,
     toggleExpanded,
     setBandwidthYMax,
+    resetForNewPlay,
     setCursorMs,
     setCursor,
   };


### PR DESCRIPTION
The bandwidth chart's "Bitrate Y Max" control reset to Auto on every new playback because the chart coordination state was keyed by `archive:{playerId}:{playId}` — a new `play_id` minted a fresh state.

Decouple the chart **view** state from the play while keeping **data** keyed per-play:

- `useChartCoordination`: persist `bandwidthYMax` per scope to `localStorage` (`dashboard_v3_bandwidth_ymax:<scope>`), seeding `freshState` from it and writing on set — survives a new play and a browser reload. New `resetForNewPlay()` clears only the position fields (`lastSampleMs`/`range`/`cursor`) so a fresh play follows live, keeping the scale/pref fields.
- `SessionDisplay`: a play-independent `coordId` (`view:` + `compareKey`) drives chart coordination (per-player live; stable group key in archive-compare); `archivePlayerId` still keys per-play data. Resets position state on `play_id` change.
- The seven coordination consumers + `MetricsLineChart` take an optional `coordId` prop (falls back to `playerId`), used only for `useChartCoordination`.

Fully independent of the other open #811 PRs (no shared files). `vue-tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
