### PR TITLE
feat(proxy): per-flow fairness on throttled media ports (SFQ off by default)

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LocalHTTPProxy.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LocalHTTPProxy.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import os
 
 /// A tiny HTTP/1.1 forward proxy running on 127.0.0.1:<ephemeral>. The app
 /// rewrites the master HLS URL from http://origin/path → http://127.0.0.1:port/proxy/http/origin/path
@@ -13,6 +14,9 @@ import Network
 /// Connection: close (one request per connection). Sufficient for our test
 /// environment where the origin is unencrypted HTTP on a LAN.
 final class LocalHTTPProxy: NSObject {
+    /// os_log mirror (same subsystem as the rest) so [NETBYTES] per-segment
+    /// byte/throughput lines are greppable via `log show` on Appium-launched sims.
+    static let netLog = Logger(subsystem: "com.jeoliver.InfiniteStreamPlayer", category: "localproxy")
     static let shared = LocalHTTPProxy()
 
     private let queue = DispatchQueue(label: "com.jeoliver.LocalHTTPProxy", qos: .userInitiated)
@@ -29,6 +33,21 @@ final class LocalHTTPProxy: NSObject {
     private var originHost: String = ""
     private var originPort: Int?
 
+    // player_id / play_id for the [NET*] log lines so they can be correlated to a
+    // specific harness play (the os_log alone has no play key — different sims /
+    // leftover plays are otherwise indistinguishable). Set from the main thread at
+    // item build; read on the proxy's delegate queue. Own lock (delegate runs on `queue`).
+    private let idLock = NSLock()
+    private var _playerId = ""
+    private var _playId = ""
+    func setIDs(playerId: String, playId: String) {
+        idLock.lock(); _playerId = playerId; _playId = playId; idLock.unlock()
+    }
+    var idsLog: String {
+        idLock.lock(); defer { idLock.unlock() }
+        return "player_id=\(_playerId) play_id=\(_playId)"
+    }
+
     // Map URLSession task id → the connection session that owns it. Serialized
     // on `queue`. URLSession delegate callbacks come in on the session's
     // operation queue (which we back with `queue`).
@@ -41,6 +60,11 @@ final class LocalHTTPProxy: NSObject {
         config.httpAdditionalHeaders = nil
         config.timeoutIntervalForRequest = 60
         config.timeoutIntervalForResource = 300
+        // Allow many concurrent upstream connections so video/audio (and range
+        // fetches) aren't bottlenecked on a small per-host pool. For an HTTP/2
+        // origin URLSession still coalesces to one multiplexed connection, so
+        // this mainly matters if the origin falls back to HTTP/1.1.
+        config.httpMaximumConnectionsPerHost = 50
         let opQueue = OperationQueue()
         opQueue.underlyingQueue = queue
         self.session = URLSession(configuration: config, delegate: self, delegateQueue: opQueue)
@@ -181,6 +205,31 @@ extension LocalHTTPProxy: URLSessionDataDelegate {
                     didCompleteWithError error: Error?) {
         unregisterTask(task.taskIdentifier)?.onUpstreamComplete(error: error)
     }
+
+    /// System-measured per-stream wire timing — independent of our serial
+    /// delegate queue, so [NETWIRE] wireTTFB is the TRUE time-to-first-byte and
+    /// `proto` is the actual negotiated protocol (h2 / h3 / http/1.1). Compare
+    /// against [NETBYTES] ttfb: if they agree, the starvation is real on the wire
+    /// (server scheduler); if [NETWIRE] is early and [NETBYTES] late, it's our
+    /// serial queue. Media segments only.
+    func urlSession(_ session: URLSession, task: URLSessionTask,
+                    didFinishCollecting metrics: URLSessionTaskMetrics) {
+        guard let tm = metrics.transactionMetrics.last,
+              let url = tm.request.url ?? task.originalRequest?.url,
+              !url.lastPathComponent.hasSuffix(".m3u8") else { return }
+        let parent = url.deletingLastPathComponent().lastPathComponent
+        let label = parent.isEmpty ? url.lastPathComponent : "\(parent)/\(url.lastPathComponent)"
+        let proto = tm.networkProtocolName ?? "?"
+        let ttfb: Double = {
+            guard let rs = tm.requestStartDate, let rsp = tm.responseStartDate else { return -1 }
+            return rsp.timeIntervalSince(rs) * 1000
+        }()
+        let total: Double = {
+            guard let fs = tm.fetchStartDate, let re = tm.responseEndDate else { return -1 }
+            return re.timeIntervalSince(fs) * 1000
+        }()
+        LocalHTTPProxy.netLog.notice("[NETWIRE] \(label, privacy: .public) proto=\(proto, privacy: .public) wireTTFB=\(String(format: "%.0fms", ttfb), privacy: .public) total=\(String(format: "%.0fms", total), privacy: .public) bytes=\(tm.countOfResponseBodyBytesReceived, privacy: .public) reusedConn=\(tm.isReusedConnection, privacy: .public) \(LocalHTTPProxy.shared.idsLog, privacy: .public)")
+    }
 }
 
 /// Handles a single inbound HTTP/1.1 connection: reads the request line and
@@ -198,6 +247,12 @@ final class ConnectionSession {
     private var headersSentToClient = false
     private var usingChunkedTE = false
     private var upstreamTask: URLSessionDataTask?
+    // Per-request byte accounting for the [NETBYTES] line — the exact wire view
+    // of one segment/manifest fetch as it streams through the proxy.
+    private var segURL: URL?
+    private var segStartAt: Date?
+    private var segFirstByteAt: Date?
+    private var segBytes: Int64 = 0
     // Queued writes back to the client — we process sequentially to avoid
     // overlapping sends on the same NWConnection.
     private var writeQueue: [Data] = []
@@ -314,8 +369,18 @@ final class ConnectionSession {
         for key in passThrough {
             if let v = clientHeaders[key] { req.setValue(v, forHTTPHeaderField: key.capitalized) }
         }
+        // [NETRANGE] proves the proxy honors ranges: logs the Range header AVPlayer
+        // sent (in=) vs what we forward to go-proxy (out=). They MUST match —
+        // match=false would mean we're rewriting/dropping the range (e.g. turning a
+        // byte-range into a whole-segment GET). `none` = no Range header on that side.
+        let inRange = clientHeaders["range"] ?? "none"
+        let outRange = req.value(forHTTPHeaderField: "Range") ?? "none"
+        let rangeLabel = originURL.pathComponents.suffix(2).joined(separator: "/")
+        LocalHTTPProxy.netLog.notice("[NETRANGE] \(rangeLabel, privacy: .public) in=\(inRange, privacy: .public) out=\(outRange, privacy: .public) match=\(inRange == outRange, privacy: .public) \(LocalHTTPProxy.shared.idsLog, privacy: .public)")
         let task = proxy.session.dataTask(with: req)
         upstreamTask = task
+        segURL = originURL
+        segStartAt = Date()
         proxy.registerTask(task.taskIdentifier, session: self)
         proxy.tracker.requestStarted()
         if let result = proxy.tracker.recordRequestURL(originURL), result.isWrap {
@@ -340,13 +405,43 @@ final class ConnectionSession {
         // If the client has gone away, drop the chunk — enqueueing would
         // produce one ECANCELED-failed send per chunk, flooding logs.
         if finished { return }
+        if segFirstByteAt == nil { segFirstByteAt = Date() }
+        segBytes += Int64(data.count)
+        // Per-chunk wire timeline — shows the byte-arrival pattern within a
+        // segment (steady / bursty / starved). Media segments only.
+        if let start = segStartAt, let url = segURL, !url.lastPathComponent.hasSuffix(".m3u8") {
+            let ms = Date().timeIntervalSince(start) * 1000
+            LocalHTTPProxy.netLog.notice("[NETCHUNK] \(self.segLabel, privacy: .public) +\(data.count, privacy: .public)B cum=\(self.segBytes, privacy: .public) t=\(String(format: "%.0fms", ms), privacy: .public) \(LocalHTTPProxy.shared.idsLog, privacy: .public)")
+        }
         proxy.tracker.chunkReceived(byteCount: data.count)
         if method != "HEAD" {
             enqueueWrite(data)
         }
     }
 
+    /// Parent dir + filename, so video / audio / variant fetches of the same
+    /// segment number are distinguishable (lastPathComponent alone collapses them).
+    private var segLabel: String {
+        guard let url = segURL else { return "?" }
+        let parent = url.deletingLastPathComponent().lastPathComponent
+        return parent.isEmpty ? url.lastPathComponent : "\(parent)/\(url.lastPathComponent)"
+    }
+
+    /// Emit the per-segment wire view: bytes received, wall-clock duration of the
+    /// fetch, the effective throughput, and time-to-first-byte. Manifests (.m3u8)
+    /// are skipped — we care about the media-segment cost that gates startup.
+    private func logNetBytes() {
+        guard let url = segURL, let start = segStartAt, segBytes > 0 else { return }
+        let name = url.lastPathComponent
+        guard !name.hasSuffix(".m3u8") else { return }
+        let dur = Date().timeIntervalSince(start)
+        let mbps = dur > 0 ? Double(segBytes) * 8 / dur / 1_000_000 : 0
+        let ttfbMs = segFirstByteAt.map { $0.timeIntervalSince(start) * 1000 } ?? -1
+        LocalHTTPProxy.netLog.notice("[NETBYTES] \(self.segLabel, privacy: .public) bytes=\(self.segBytes, privacy: .public) dur=\(String(format: "%.2fs", dur), privacy: .public) rate=\(String(format: "%.2fMbps", mbps), privacy: .public) ttfb=\(String(format: "%.0fms", ttfbMs), privacy: .public) \(LocalHTTPProxy.shared.idsLog, privacy: .public)")
+    }
+
     fileprivate func onUpstreamComplete(error: Error?) {
+        logNetBytes()
         if let error = error {
             if !headersSentToClient {
                 writeStatusLineAndClose(status: 502, reason: "Upstream Error")

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1163,6 +1163,7 @@ final class PlayerViewModel: ObservableObject {
         let assetURL: URL
         if localProxy {
             LocalHTTPProxy.shared.startIfNeeded()
+            LocalHTTPProxy.shared.setIDs(playerId: playerId, playId: currentPlayID)
             assetURL = LocalHTTPProxy.shared.rewrite(originURL: url) ?? url
         } else {
             assetURL = url

--- a/generate_abr/create_abr_ladder.sh
+++ b/generate_abr/create_abr_ladder.sh
@@ -449,6 +449,7 @@ SEGMENT_DURATION="${SEGMENT_DURATION:-6}"    # Target segment duration in second
 PARTIAL_DURATION="${PARTIAL_DURATION:-0.2}"  # Partial fragment duration in seconds
 GOP_DURATION="${GOP_DURATION:-1.0}"          # GOP/keyframe duration in seconds
 MAXRATE_PERCENT="${MAXRATE_PERCENT:-124}"    # Peak cap percentage of target bitrate (<125% guidance)
+BUFSIZE_MULT="${BUFSIZE_MULT:-1}"            # VBV bufsize = this × target kbps. 1× ≈ ~1s window → tight per-segment peaks so each 2s chunk hugs target (was 2×, which let 2s chunks burst ~1.5× target).
 MULTI_DURATION_LCM=12           # LCM of 2s/4s/6s for multi-duration support
 PADDING_THRESHOLD=0.1           # Minimum remainder to trigger padding (seconds)
 PADDING_WARNING_RATIO=50        # Warn if padding exceeds this % of total duration
@@ -2055,7 +2056,7 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -allow_sw 1 \
                    -b:v "${bitrate_kbps}k" \
                    -maxrate "$((bitrate_kbps * MAXRATE_PERCENT / 100))k" \
-                   -bufsize "$((bitrate_kbps * 2))k" \
+                   -bufsize "$((bitrate_kbps * BUFSIZE_MULT))k" \
                    -g "$KEYINT" \
                    -force_key_frames "expr:gte(n,n_forced*$KEYINT)" \
                    -tag:v hvc1 \
@@ -2071,7 +2072,7 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -c:v libx265 \
                    -b:v "${bitrate_kbps}k" \
                    -maxrate "$((bitrate_kbps * MAXRATE_PERCENT / 100))k" \
-                   -bufsize "$((bitrate_kbps * 2))k" \
+                   -bufsize "$((bitrate_kbps * BUFSIZE_MULT))k" \
                    -preset "$preset" \
                    -threads 0 \
                    -x265-params "keyint=${KEYINT}:min-keyint=${KEYINT}:scenecut=0:open-gop=0:pools=+:frame-threads=0" \
@@ -2091,7 +2092,7 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -allow_sw 1 \
                    -b:v "${bitrate_kbps}k" \
                    -maxrate "$((bitrate_kbps * MAXRATE_PERCENT / 100))k" \
-                   -bufsize "$((bitrate_kbps * 2))k" \
+                   -bufsize "$((bitrate_kbps * BUFSIZE_MULT))k" \
                    -g "$KEYINT" \
                    -force_key_frames "expr:gte(n,n_forced*$KEYINT)" \
                    -tag:v avc1 \
@@ -2107,7 +2108,7 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -c:v libx264 \
                    -b:v "${bitrate_kbps}k" \
                    -maxrate "$((bitrate_kbps * MAXRATE_PERCENT / 100))k" \
-                   -bufsize "$((bitrate_kbps * 2))k" \
+                   -bufsize "$((bitrate_kbps * BUFSIZE_MULT))k" \
                    -preset "$preset" \
                    -threads 0 \
                    -x264-params "keyint=${KEYINT}:min-keyint=${KEYINT}:scenecut=0:open-gop=0" \
@@ -2126,7 +2127,7 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                -preset 8 \
                -b:v "${bitrate_kbps}k" \
                -maxrate "$((bitrate_kbps * MAXRATE_PERCENT / 100))k" \
-               -bufsize "$((bitrate_kbps * 2))k" \
+               -bufsize "$((bitrate_kbps * BUFSIZE_MULT))k" \
                -g "$KEYINT" \
                -force_key_frames "expr:gte(n,n_forced*$KEYINT)" \
                -svtav1-params "keyint=${KEYINT}:scd=0" \

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -385,6 +385,7 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 	}
 	content := worker.content
 	inputPath := worker.inputPath
+	workerStart := time.Now()
 	logf("[GO-LIVE] HLS worker started: content=%s\n", content)
 	logf("  Input: %s\n", inputPath)
 
@@ -445,6 +446,11 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 	llMasterWritten := false
 	master2sWritten := false
 	master6sWritten := false
+	// One-shot "content fully warm" timing: how long from worker spawn until all
+	// three master playlists (LL + 2s + 6s) are generated — i.e. how long a
+	// pre-warm curl must wait before every variant is discoverable. The per-
+	// variant media-playlist gen times are logged separately below.
+	warmupLogged := false
 	lastLLUpdate := time.Time{}
 	lastSegLL := int64(-1)
 	lastSeg2 := int64(-1)
@@ -531,6 +537,11 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 					logf("ERROR: Failed to write 6s master playlist: %v\n", err)
 				}
 			}
+		}
+		if !warmupLogged && llMasterWritten && master2sWritten && master6sWritten {
+			warmupLogged = true
+			logf("[GO-LIVE][WARMUP] all master playlists ready: content=%s warmup=%.3fs variants=%d\n",
+				content, time.Since(workerStart).Seconds(), len(variantURIs))
 		}
 
 		updatedLL := false

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1694,12 +1694,13 @@ func (t *TcTrafficManager) ensureClassCore(port int, rateMbps float64) error {
 // whenever the band's netem is (re)placed, since replacing a qdisc drops its
 // children. Best-effort: logs on failure.
 func (t *TcTrafficManager) addFairLeaf(port, band int) {
-	// PROXY_DISABLE_SFQ=1 skips the sfq leaf so the prio band falls back to
-	// netem's internal FIFO — the pre-#404 "before SFQ" behaviour, where the
-	// byte-heavy video flow dominates the queue and audio backs up behind it
-	// (no per-flow round-robin). A/B knob for testing whether the SFQ-driven
-	// audio fairness feeds AVPlayer's bandwidth over-read / variant over-selection.
-	if os.Getenv("PROXY_DISABLE_SFQ") == "1" {
+	// SFQ is OFF by default: the prio band falls back to netem's internal FIFO,
+	// where the byte-heavy video flow dominates the queue and audio backs up
+	// behind it (no per-flow round-robin). The A/B test concluded the SFQ-driven
+	// audio fairness was feeding AVPlayer's bandwidth over-read / variant
+	// over-selection, so FIFO is the default. Opt back IN with PROXY_ENABLE_SFQ=1
+	// to restore the per-flow fair-queue leaf.
+	if os.Getenv("PROXY_ENABLE_SFQ") != "1" {
 		return
 	}
 	portSuffix := fmt.Sprintf("%03d", port%1000)

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -1680,6 +1680,45 @@ func (t *TcTrafficManager) ensureClassCore(port int, rateMbps float64) error {
 // UpdateNetem subsequently replaces the per-band netems with user-
 // configured values. Idempotent — exits fast when the prio handle
 // already shows up under `tc qdisc show parent <classid>`.
+// addFairLeaf attaches sfq (Stochastic Fair Queuing) UNDER a prio band's netem
+// qdisc, so that concurrent flows sharing the same rate-capped class — e.g. a
+// player's separate video + audio HTTP/1.1 connections — are dequeued FAIRLY
+// per flow (round-robin over a 5-tuple hash) instead of one starving the other
+// in netem's internal FIFO. sfq is chosen over fq_codel deliberately: fq_codel's
+// CoDel AQM fights the shaper's *intentional* queue (the throttle pushes latency
+// past CoDel's 5ms target, so it ECN-marks/drops aggressively → TCP backs off →
+// throughput falls below the shaped rate). sfq gives the same per-flow fairness
+// with NO latency-based AQM, so it doesn't interfere with the rate shaping.
+// `perturb 10` re-hashes periodically so a hash collision can't persist.
+// netem applies any delay/loss first, then hands off to sfq. Must be re-applied
+// whenever the band's netem is (re)placed, since replacing a qdisc drops its
+// children. Best-effort: logs on failure.
+func (t *TcTrafficManager) addFairLeaf(port, band int) {
+	// PROXY_DISABLE_SFQ=1 skips the sfq leaf so the prio band falls back to
+	// netem's internal FIFO — the pre-#404 "before SFQ" behaviour, where the
+	// byte-heavy video flow dominates the queue and audio backs up behind it
+	// (no per-flow round-robin). A/B knob for testing whether the SFQ-driven
+	// audio fairness feeds AVPlayer's bandwidth over-read / variant over-selection.
+	if os.Getenv("PROXY_DISABLE_SFQ") == "1" {
+		return
+	}
+	portSuffix := fmt.Sprintf("%03d", port%1000)
+	netemHandle := fmt.Sprintf("%s%d:", portSuffix, band)    // e.g. 1811:
+	fairHandle := fmt.Sprintf("%s%d:", portSuffix, band+4)   // PPP5:/6:/7: — distinct from prio (PPP0:) + netem (PPP1-3:)
+	// delete-then-add, NOT replace: `tc qdisc replace` does an in-place CHANGE
+	// when a qdisc already exists at that parent, which tc rejects across a
+	// qdisc-TYPE switch (e.g. a leftover fq_codel from a prior build — host tc
+	// state survives container restarts). del is best-effort (errors harmlessly
+	// when nothing is there).
+	_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName, "parent", netemHandle).Run()
+	if out, err := exec.Command(
+		"tc", "qdisc", "add", "dev", t.interfaceName,
+		"parent", netemHandle, "handle", fairHandle, "sfq", "perturb", "10",
+	).CombinedOutput(); err != nil {
+		log.Printf("NETSHAPE sfq leaf install failed port=%d band=%d: %s", port, band, strings.TrimSpace(string(out)))
+	}
+}
+
 func (t *TcTrafficManager) ensurePrioLeafForPort(port int) error {
 	portSuffix := fmt.Sprintf("%03d", port%1000)
 	classid := fmt.Sprintf("1:%s", portSuffix)
@@ -1708,6 +1747,7 @@ func (t *TcTrafficManager) ensurePrioLeafForPort(port int) error {
 		).CombinedOutput(); err != nil {
 			return fmt.Errorf("tc netem (band %d) replace failed: %s", band, strings.TrimSpace(string(out)))
 		}
+		t.addFairLeaf(port, band)
 	}
 	return nil
 }
@@ -1786,6 +1826,7 @@ func (t *TcTrafficManager) updateNetemCore(port int, delayMs int, lossPct float6
 		if out, err := exec.Command("tc", args...).CombinedOutput(); err != nil {
 			return fmt.Errorf("tc netem band %d failed: %s", band, strings.TrimSpace(string(out)))
 		}
+		t.addFairLeaf(port, band)
 	}
 	if delayMs <= 0 && lossPct <= 0 {
 		t.logTcState("netem_clear", port)
@@ -2247,7 +2288,7 @@ func main() {
 	errorCh := make(chan error, len(ports))
 	for _, port := range ports {
 		addr := fmt.Sprintf(":%d", port)
-		go func(bind string) {
+		go func(bind string, p int) {
 			srv := &http.Server{
 				Addr:    bind,
 				Handler: router,
@@ -2257,6 +2298,17 @@ func main() {
 				// read. Issue #401.
 				ConnContext: withTCPConnContext,
 			}
+			// Disable HTTP/2 on the per-session MEDIA ports so a player's video
+			// and audio fetch over SEPARATE HTTP/1.1 connections rather than
+			// multiplexing on one rate-capped h2 connection — where audio starves
+			// behind video in the kernel/tc FIFO (the origin fetch is instant, but
+			// the audio response queues ~the whole video drain). A non-nil empty
+			// TLSNextProto suppresses the stdlib's automatic h2 ALPN. Keep h2 on
+			// the API port (30081), where the dashboard/forwarder SSE streams rely
+			// on multiplexing many event-streams over one connection.
+			if p != 30081 {
+				srv.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){}
+			}
 			if tlsEnabled {
 				log.Printf("go-proxy listening on %s (TLS)", bind)
 				errorCh <- srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
@@ -2264,7 +2316,7 @@ func main() {
 				log.Printf("go-proxy listening on %s (plain HTTP)", bind)
 				errorCh <- srv.ListenAndServe()
 			}
-		}(addr)
+		}(addr, port)
 	}
 
 	err := <-errorCh
@@ -7702,11 +7754,19 @@ func (a *App) doRequestWithTracing(ctx context.Context, req *http.Request) (*htt
 
 	req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
 
+	// Time the upstream fetch itself: a.client.Do returns once the response
+	// HEADERS arrive, so do_ms is how long the origin (nginx/go-live) took to
+	// start answering. If the audio request's do_ms is ~1.5s while video's is
+	// ~10ms, the stall is the origin fetch — not go-proxy's streaming.
+	doStart := time.Now()
 	resp, err := a.client.Do(req)
+	doMs := float64(time.Since(doStart).Microseconds()) / 1000.0
 	if err != nil {
 		entry.TotalMs = float64(time.Since(start).Microseconds()) / 1000.0
+		log.Printf("[UPSTREAM_DO] url=%s do_ms=%.1f err=%v", req.URL.String(), doMs, err)
 		return nil, entry, err
 	}
+	log.Printf("[UPSTREAM_DO] url=%s do_ms=%.1f upstream_ttfb_ms=%.1f status=%d", req.URL.String(), doMs, entry.TTFBMs, resp.StatusCode)
 
 	// If we got first byte, calculate transfer time after body is read
 	// Note: We'll update TransferMs after body is copied

--- a/tests/deploy/override-dev.yml
+++ b/tests/deploy/override-dev.yml
@@ -22,10 +22,6 @@ services:
       # the issue describes don't recur. Prod-style deployments leave
       # this unset (= 0 = unlimited) to preserve today's behaviour.
       - INFINITE_STREAM_DEFAULT_RATE_MBPS=100
-      # TEMP A/B (revert after SFQ test): disable the sfq fair-queue leaf so
-      # bands fall back to netem FIFO — testing whether SFQ-driven audio
-      # over-banking feeds AVPlayer's bandwidth over-read / 4K over-selection.
-      - PROXY_DISABLE_SFQ=1
     ports:
       !override
       - "21000:30000"

--- a/tests/deploy/override-dev.yml
+++ b/tests/deploy/override-dev.yml
@@ -22,6 +22,10 @@ services:
       # the issue describes don't recur. Prod-style deployments leave
       # this unset (= 0 = unlimited) to preserve today's behaviour.
       - INFINITE_STREAM_DEFAULT_RATE_MBPS=100
+      # TEMP A/B (revert after SFQ test): disable the sfq fair-queue leaf so
+      # bands fall back to netem FIFO — testing whether SFQ-driven audio
+      # over-banking feeds AVPlayer's bandwidth over-read / 4K over-selection.
+      - PROXY_DISABLE_SFQ=1
     ports:
       !override
       - "21000:30000"


### PR DESCRIPTION
Stop a player's audio flow starving behind video under a shared rate cap.

- **go-proxy**: optional `sfq` (Stochastic Fair Queuing) leaf under each prio band's netem so concurrent flows in a rate-capped class dequeue round-robin per 5-tuple instead of FIFO. **Off by default** (the A/B concluded SFQ-driven fairness was feeding AVPlayer's bandwidth over-read / 4K over-selection) — opt in with `PROXY_ENABLE_SFQ=1`.
- **go-proxy**: disable HTTP/2 on the per-session MEDIA ports so video + audio fetch over separate HTTP/1.1 connections instead of multiplexing on one rate-capped h2 connection where audio queues behind the whole video drain. h2 stays on the API port (30081) for the SSE streams.
- **go-proxy**: `[UPSTREAM_DO]` log times the origin fetch to localize stalls.
- **go-live**: `[WARMUP]` one-shot log — time from worker spawn until all three master playlists are ready.
- **create_abr_ladder.sh**: configurable VBV `BUFSIZE_MULT` (default 1×) so 2s chunks hug target instead of bursting ~1.5× under the old 2×.
- **LocalHTTPProxy.swift** (iOS): per-segment `[NETBYTES]`/`[NETWIRE]`/`[NETCHUNK]`/`[NETRANGE]` wire instrumentation + play-id tagging — the client-side view for diagnosing the above.

Self-contained; the one `PlayerViewModel.swift` line (`setIDs`) feeds the LocalHTTPProxy logging. go-proxy + go-live build clean.

Note: shares `PlayerViewModel.swift` (a disjoint hunk) with the #811 epic (#830) — recommend landing #830 first, then rebasing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
