### PR TITLE
feat(dashboard): lifecycle vertical lines on charts + events timeline

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -30,6 +30,7 @@ import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf, useCompareSiblings, sessionMarkerColor, SELF_MARKER_COLOR } from '@/composables/useCompareContext';
 import { compareBandwidthSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 const props = defineProps<{
@@ -38,6 +39,8 @@ const props = defineProps<{
    *  useChartCoordination only; data still keys off playerId. Falls back to
    *  playerId when absent. */
   coordId?: string;
+  /** Shared player-lifecycle vertical lines, passed straight to MetricsLineChart. */
+  lifecycleMarkers?: LifecycleMarker[];
   eventsStream: Stream<Record<string, unknown>>;
   /** AVMetrics stream — used to overlay per-segment throughput dots
    *  on the bandwidth chart (issue #486). Optional so existing
@@ -486,6 +489,7 @@ const compareOverlays = useCompareOverlays((sib) => {
   <MetricsLineChart
     :player-id="playerId"
     :coord-id="coordId"
+    :lifecycle-markers="lifecycleMarkers"
     title="Bandwidth"
     unit="Mbps"
     :series="series"

--- a/content/dashboard-v3/src/components/BufferChart.vue
+++ b/content/dashboard-v3/src/components/BufferChart.vue
@@ -11,6 +11,7 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
 import { compareBufferSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 defineProps<{
@@ -18,6 +19,8 @@ defineProps<{
   /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
    *  across plays). Falls back to playerId there when absent. */
   coordId?: string;
+  /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
+  lifecycleMarkers?: LifecycleMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -58,6 +61,7 @@ const series = computed<SeriesSpec[]>(() =>
   <MetricsLineChart
     :player-id="playerId"
     :coord-id="coordId"
+    :lifecycle-markers="lifecycleMarkers"
     title="Buffer & live offset"
     unit="buffer (s)"
     :series="series"

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -31,6 +31,7 @@ import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import { ensureVisTimeline } from '@/composables/useChartJs';
 import { useChartCoordination, DEFAULT_FOCUS_MS } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import { useLifecycleLineVisibility, type LifecycleMarker } from '@/composables/useLifecycleMarkers';
 import { nearestVariantByBitrate } from '@/composables/useManifestVariants';
 
 interface LaneCfg { label: string; color: string }
@@ -247,8 +248,15 @@ const props = defineProps<{
    *  drives the CONTROL lane markers. Optional; without it the CONTROL lane
    *  has no points (control_revision alone only says "something changed"). */
   controlStream?: Stream<Record<string, unknown>>;
+  /** Player-lifecycle vertical lines (restart / play_start / play_end),
+   *  computed once in SessionDisplay. Rendered as full-height vis-timeline
+   *  custom-times so they cross every lane (incl. Player State) and align
+   *  with the same lines on the value charts. Per-type visibility comes from
+   *  the shared toggle (useLifecycleLineVisibility). */
+  lifecycleMarkers?: LifecycleMarker[];
 }>();
 const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
+const { lineVisibility } = useLifecycleLineVisibility();
 
 /** Adapter — map a CH session_snapshots row (wire shape from the v3
  *  /api/v2/timeseries endpoint) to the small subset of fields ingest()
@@ -745,6 +753,10 @@ async function ensureTimeline(): Promise<void> {
       });
       installLiveWheelAnchor();
       installCursorHoverTooltip();
+      installLifecycleHoverTooltip();
+      // Draw any lifecycle lines that were ready before the timeline existed
+      // (the reactive watcher only re-fires on subsequent marker changes).
+      void syncLifecycleLines();
     } finally {
       // Hold the resolved promise around so subsequent calls short-circuit
       // via the `if (timeline) return` check at the top.
@@ -1569,7 +1581,10 @@ function installCursorHoverTooltip() {
       if (cursorTooltipVisible.value) cursorTooltipVisible.value = false;
       return;
     }
-    const lineEl = c.querySelector('.vis-custom-time') as HTMLElement | null;
+    // Target the nav-cursor line specifically — there are now several
+    // `.vis-custom-time` elements (the lifecycle lines share the class), and
+    // a bare querySelector would grab whichever renders first.
+    const lineEl = c.querySelector('.vis-custom-time.nav-cursor') as HTMLElement | null;
     if (!lineEl) {
       if (cursorTooltipVisible.value) cursorTooltipVisible.value = false;
       return;
@@ -1616,11 +1631,114 @@ watch(
   { immediate: true },
 );
 
+/*
+ * Player-lifecycle vertical lines (restart / play_start / play_end).
+ *
+ * Each visible marker is a vis-timeline custom-time keyed `lc-<kind>-<ms>`,
+ * so the rendered <div> carries that id as a CSS class — the per-kind colour
+ * comes from CSS that matches the class substring. The id encodes the
+ * position, so a marker never needs repositioning: we only add ids that
+ * appeared and remove ids that vanished (markers recomputed, or a kind
+ * toggled off). `lcLines` doubles as the id→detail lookup the hover uses.
+ */
+const lcLines = new Map<string, string>();
+
+function lcIdFor(m: LifecycleMarker): string {
+  return `lc-${m.kind}-${Math.round(m.ms)}`;
+}
+
+async function syncLifecycleLines(): Promise<void> {
+  await ensureTimeline();
+  if (!timeline) return;
+  const desired = new Map<string, { ms: number; detail: string }>();
+  for (const m of props.lifecycleMarkers ?? []) {
+    if (!lineVisibility[m.kind]) continue;
+    if (!Number.isFinite(m.ms)) continue;
+    desired.set(lcIdFor(m), { ms: m.ms, detail: m.detail });
+  }
+  // Remove lines no longer wanted.
+  for (const id of [...lcLines.keys()]) {
+    if (!desired.has(id)) {
+      try { timeline.removeCustomTime(id); } catch { /* ignore */ }
+      lcLines.delete(id);
+    }
+  }
+  // Add newly-wanted lines.
+  for (const [id, { ms, detail }] of desired) {
+    if (!lcLines.has(id)) {
+      try {
+        timeline.addCustomTime(new Date(ms), id);
+        lcLines.set(id, detail);
+      } catch { /* duplicate id / pre-mount — ignore */ }
+    }
+  }
+}
+
+watch(
+  [
+    () => props.lifecycleMarkers,
+    () => lineVisibility.restart,
+    () => lineVisibility.play_start,
+    () => lineVisibility.play_end,
+    () => lineVisibility.user_marked,
+  ],
+  () => { void syncLifecycleLines(); },
+  { immediate: true },
+);
+
+/* Lifecycle-line hover tooltip — same custom-DOM approach as the cursor
+ * tooltip, but hit-tests EVERY lifecycle custom-time element and shows the
+ * nearest one's detail (restart reason / play_id / terminal status). */
+const lcTooltipVisible = ref(false);
+const lcTooltipX = ref(0);
+const lcTooltipY = ref(0);
+const lcTooltipText = ref('');
+
+function installLifecycleHoverTooltip() {
+  const c = container.value;
+  if (!c) return;
+  c.addEventListener('mousemove', (e) => {
+    if (lcLines.size === 0) {
+      if (lcTooltipVisible.value) lcTooltipVisible.value = false;
+      return;
+    }
+    const cRect = c.getBoundingClientRect();
+    const mx = e.clientX - cRect.left;
+    const my = e.clientY - cRect.top;
+    let bestDist = 6; // px tolerance
+    let bestText = '';
+    const els = c.querySelectorAll('.vis-custom-time[class*="lc-"]');
+    els.forEach((el) => {
+      const lineX = el.getBoundingClientRect().left - cRect.left;
+      const d = Math.abs(mx - lineX);
+      if (d >= bestDist) return;
+      // Recover the id (and its detail) from the element's class list.
+      let detail = '';
+      el.classList.forEach((cls) => {
+        if (cls.startsWith('lc-') && lcLines.has(cls)) detail = lcLines.get(cls) as string;
+      });
+      if (detail) { bestDist = d; bestText = detail; }
+    });
+    if (!bestText) {
+      if (lcTooltipVisible.value) lcTooltipVisible.value = false;
+      return;
+    }
+    lcTooltipText.value = bestText;
+    lcTooltipX.value = Math.min(mx + 8, c.clientWidth - 220);
+    lcTooltipY.value = Math.max(4, my - 52);
+    lcTooltipVisible.value = true;
+  });
+  c.addEventListener('mouseleave', () => {
+    lcTooltipVisible.value = false;
+  });
+}
+
 onBeforeUnmount(() => {
   try { timeline?.destroy(); } catch { /* ignore */ }
   timeline = null;
   itemsDS = null;
   groupsDS = null;
+  lcLines.clear();
 });
 </script>
 
@@ -1659,6 +1777,13 @@ onBeforeUnmount(() => {
         class="cursor-tooltip"
         :style="{ left: cursorTooltipX + 'px', top: cursorTooltipY + 'px' }"
       >{{ coord.state.cursorLabel }}</div>
+      <!-- Lifecycle-line hover tooltip — restart reason / play_id /
+           terminal status for the nearest lifecycle line. Multi-line. -->
+      <div
+        v-if="lcTooltipVisible"
+        class="cursor-tooltip lc-tooltip"
+        :style="{ left: lcTooltipX + 'px', top: lcTooltipY + 'px' }"
+      >{{ lcTooltipText }}</div>
     </div>
 
     <!-- Colour key — placed BELOW the chart so the eye reads the
@@ -1816,6 +1941,16 @@ onBeforeUnmount(() => {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+/* Lifecycle tooltip is multi-line (reason / play_id / status / time) and
+ * slate (matches the line charts' marker tooltip) rather than the cursor's
+ * blue, so the two never read as the same thing. */
+.lc-tooltip {
+  background: rgba(15, 23, 42, 0.94);
+  white-space: pre-line;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.4;
+}
 /* "Selected event" custom-time line — full visual parity with the
  * line-chart cursor: 1.5 px dashed blue line + a small filled
  * triangle at the top. vis-timeline renders <div class="vis-custom-time">
@@ -1841,6 +1976,32 @@ onBeforeUnmount(() => {
   border-right: 5px solid transparent;
   border-top: 6px solid #1d4ed8;
 }
+
+/* Per-kind lifecycle custom-time lines — restart (amber dashed),
+ * play_start (green solid), play_end (slate dashed). The id (`lc-<kind>-<ms>`)
+ * lands on the element as a CSS class, so a class-substring match recolours
+ * the shared `.vis-custom-time` line + its top arrow. z-index 4 keeps these
+ * just under the user-selected cursor (5). */
+.events-timeline :deep(.vis-custom-time[class*='lc-restart-']) {
+  border-left: 1.5px dashed #f59e0b !important;
+  z-index: 4;
+}
+.events-timeline :deep(.vis-custom-time[class*='lc-restart-']::before) { border-top-color: #f59e0b; }
+.events-timeline :deep(.vis-custom-time[class*='lc-play_start-']) {
+  border-left: 1.5px solid #15803d !important;
+  z-index: 4;
+}
+.events-timeline :deep(.vis-custom-time[class*='lc-play_start-']::before) { border-top-color: #15803d; }
+.events-timeline :deep(.vis-custom-time[class*='lc-play_end-']) {
+  border-left: 1.5px dashed #475569 !important;
+  z-index: 4;
+}
+.events-timeline :deep(.vis-custom-time[class*='lc-play_end-']::before) { border-top-color: #475569; }
+.events-timeline :deep(.vis-custom-time[class*='lc-user_marked-']) {
+  border-left: 1.5px solid #db2777 !important;
+  z-index: 4;
+}
+.events-timeline :deep(.vis-custom-time[class*='lc-user_marked-']::before) { border-top-color: #db2777; }
 
 /* vis-timeline label panel + labelset pinned to the SAME 60px width
  * as the Chart.js charts' left y-axis (see MetricsLineChart.Y_WIDTH)

--- a/content/dashboard-v3/src/components/FPSChart.vue
+++ b/content/dashboard-v3/src/components/FPSChart.vue
@@ -17,6 +17,7 @@ import { computed, ref, watch } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow } from '@/composables/chRowAdapter';
+import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
 import { compareFpsSeries } from '@/composables/compareSeries';
@@ -26,6 +27,8 @@ const props = defineProps<{
   /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
    *  across plays). Falls back to playerId there when absent. */
   coordId?: string;
+  /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
+  lifecycleMarkers?: LifecycleMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -138,6 +141,7 @@ const series = computed<SeriesSpec[]>(() => {
   <MetricsLineChart
     :player-id="playerId"
     :coord-id="coordId"
+    :lifecycle-markers="lifecycleMarkers"
     title="Frame rate (derived)"
     unit="fps"
     :series="series"

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -22,6 +22,10 @@ import { CompareContextKey } from '@/composables/useCompareContext';
 import { useChartCoordination, fmtTickHMSms, DEFAULT_FOCUS_MS, type ChartViewport } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow, chRowToPlayerRecord } from '@/composables/chRowAdapter';
+import {
+  useLifecycleLineVisibility,
+  type LifecycleMarker,
+} from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 export type SeriesAccessor = (p: PlayerRecord) => number | null | undefined;
@@ -122,6 +126,14 @@ const props = defineProps({
   },
   /** Marker visibility (v-model). Default true. */
   markersVisible: { type: Boolean, default: true },
+  /** Player-lifecycle vertical lines (restart / play_start / play_end),
+   *  computed once in SessionDisplay and shared across every chart so the
+   *  lines align. Each kind's visibility is governed by the shared
+   *  per-type toggle (useLifecycleLineVisibility), not a prop. */
+  lifecycleMarkers: {
+    type: Array as PropType<LifecycleMarker[]>,
+    default: () => [],
+  },
   /** Grouped-sibling overlays (issue #579 compare mode). Each entry is
    *  one sibling's stream + tagged series; drained independently and
    *  rendered alongside the primary `series` on shared axes. Empty in
@@ -140,6 +152,16 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 const wrap = ref<HTMLDivElement | null>(null);
 const canvasWrap = ref<HTMLDivElement | null>(null);
 const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
+const { lineVisibility } = useLifecycleLineVisibility();
+
+/** Lifecycle markers whose kind is currently toggled visible. Reads the
+ *  shared reactive `lineVisibility` so the draw plugin + hover hit-test
+ *  both react to a toggle without prop churn. */
+function visibleLifecycleMarkers(): LifecycleMarker[] {
+  const list = props.lifecycleMarkers;
+  if (!Array.isArray(list) || list.length === 0) return [];
+  return list.filter((m) => lineVisibility[m.kind]);
+}
 
 // Compare-mode session legend (issue #579). When mounted inside a
 // SessionDisplay that's in compare mode, the S1/S2 chips drive this
@@ -611,6 +633,44 @@ function createChartInstance(Chart: any): any {
         ctx.fill();
         ctx.restore();
       },
+    }, {
+      /*
+       * Inline plugin: player-lifecycle vertical lines.
+       * Draws one coloured vertical line per visible lifecycle marker
+       * (restart = amber, play_start = green, play_end = slate) so the
+       * operator can correlate restarts / play boundaries across every
+       * chart. Reason / play_id / status surface in the hover tooltip
+       * (installLifecycleHoverTooltip). Drawn below navCursorLine so the
+       * user-selected cursor still reads on top.
+       */
+      id: 'lifecycleLines',
+      afterDatasetsDraw(c: any) {
+        const list = visibleLifecycleMarkers();
+        if (list.length === 0) return;
+        const sx = c.scales?.x;
+        const sy = c.scales?.y;
+        if (!sx || !sy) return;
+        const ctx = c.ctx;
+        ctx.save();
+        for (const m of list) {
+          if (!Number.isFinite(m.ms) || m.ms < sx.min || m.ms > sx.max) continue;
+          const x = sx.getPixelForValue(m.ms);
+          ctx.beginPath();
+          ctx.moveTo(x, sy.top);
+          ctx.lineTo(x, sy.bottom);
+          ctx.lineWidth = 1.5;
+          ctx.strokeStyle = m.color;
+          ctx.setLineDash(m.dash);
+          ctx.stroke();
+          // Solid cap at the top so the line is findable on a dense chart
+          // and its colour reads even where it overlaps a same-coloured
+          // series.
+          ctx.setLineDash([]);
+          ctx.fillStyle = m.color;
+          ctx.fillRect(x - 2, sy.top, 4, 4);
+        }
+        ctx.restore();
+      },
     }],
     options: {
       responsive: true,
@@ -947,6 +1007,7 @@ function createChartInstance(Chart: any): any {
   installLeftClickLiveToggle();
   installCursorHoverTooltip();
   installMarkerHoverTooltip();
+  installLifecycleHoverTooltip();
   // If compare overlays were already present at mount, compose + drain
   // them now (the overlays watcher's immediate run may have fired before
   // the chart existed). Issue #579.
@@ -1073,6 +1134,62 @@ function installCursorHoverTooltip() {
   });
   c.addEventListener('mouseleave', () => {
     cursorTooltipVisible.value = false;
+  });
+}
+
+/* Lifecycle-line hover tooltip.
+ *
+ * Mousemove hit-tests the horizontal distance to each visible lifecycle
+ * line (restart / play_start / play_end); within ~6 px of one, pop a
+ * multi-line tooltip with that marker's `detail` (reason / play_id /
+ * status). Mirrors the cursor tooltip, but hit-tests a SET of lines and
+ * picks the nearest. */
+const lcTooltipVisible = ref(false);
+const lcTooltipX = ref(0);
+const lcTooltipY = ref(0);
+const lcTooltipText = ref('');
+
+function installLifecycleHoverTooltip() {
+  const c = canvas.value;
+  if (!c) return;
+  c.addEventListener('mousemove', (e) => {
+    const list = visibleLifecycleMarkers();
+    if (list.length === 0 || !chart) {
+      if (lcTooltipVisible.value) lcTooltipVisible.value = false;
+      return;
+    }
+    const sx = chart.scales?.x;
+    const area = chart.chartArea;
+    if (!sx || !area) return;
+    const rect = c.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+    if (my < area.top || my > area.bottom) {
+      if (lcTooltipVisible.value) lcTooltipVisible.value = false;
+      return;
+    }
+    let bestDist = 6; // px tolerance
+    let bestText = '';
+    for (const m of list) {
+      if (!Number.isFinite(m.ms) || m.ms < sx.min || m.ms > sx.max) continue;
+      const px = sx.getPixelForValue(m.ms);
+      const d = Math.abs(mx - px);
+      if (d < bestDist) {
+        bestDist = d;
+        bestText = m.detail;
+      }
+    }
+    if (!bestText) {
+      if (lcTooltipVisible.value) lcTooltipVisible.value = false;
+      return;
+    }
+    lcTooltipText.value = bestText;
+    lcTooltipX.value = Math.min(mx + 10, c.clientWidth - 220);
+    lcTooltipY.value = Math.max(4, my - 56);
+    lcTooltipVisible.value = true;
+  });
+  c.addEventListener('mouseleave', () => {
+    lcTooltipVisible.value = false;
   });
 }
 
@@ -1839,6 +1956,13 @@ onBeforeUnmount(() => {
         class="marker-tooltip"
         :style="{ left: markerTooltipX + 'px', top: markerTooltipY + 'px' }"
       >{{ markerTooltipText }}</div>
+      <!-- Lifecycle-line hover tooltip — restart reason / play_id /
+           terminal status, multi-line. -->
+      <div
+        v-if="lcTooltipVisible"
+        class="marker-tooltip"
+        :style="{ left: lcTooltipX + 'px', top: lcTooltipY + 'px' }"
+      >{{ lcTooltipText }}</div>
     </div>
   </div>
 </template>

--- a/content/dashboard-v3/src/components/RTTChart.vue
+++ b/content/dashboard-v3/src/components/RTTChart.vue
@@ -9,6 +9,7 @@
 import { computed, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
@@ -19,6 +20,8 @@ const props = defineProps<{
   /** Coordination scope key forwarded to MetricsLineChart (per-player, stable
    *  across plays). Falls back to playerId there when absent. */
   coordId?: string;
+  /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
+  lifecycleMarkers?: LifecycleMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -91,6 +94,7 @@ const series = computed<SeriesSpec[]>(() => {
   <MetricsLineChart
     :player-id="playerId"
     :coord-id="coordId"
+    :lifecycle-markers="lifecycleMarkers"
     title="Round-trip time"
     unit="ms"
     :series="series"

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -62,6 +62,13 @@ interface SessionEvent {
 }
 import { usePlayer } from '@/composables/usePlayer';
 import { useSessionTimeSeries, type Stream } from '@/composables/useSessionTimeSeries';
+import {
+  useLifecycleMarkers,
+  useLifecycleLineVisibility,
+  LIFECYCLE_STYLE,
+  LIFECYCLE_KINDS,
+  type LifecycleKind,
+} from '@/composables/useLifecycleMarkers';
 import { useCompareMode } from '@/composables/useCompareMode';
 import { useGroupSiblings } from '@/composables/useGroupSiblings';
 import { CompareContextKey, sessionDash, type CompareSibling, type CompareSeriesIdentity } from '@/composables/useCompareContext';
@@ -571,6 +578,16 @@ const timeseries = useSessionTimeSeries(
     toMs: tsToMs,
   },
 );
+
+// Player-lifecycle vertical lines (restart / play_start / play_end) — derived
+// ONCE here from the shared events stream and passed to every chart + the
+// events timeline so the lines align across panels. Per-type visibility is a
+// shared, persisted toggle surfaced by the legend above the chart stack.
+const { markers: lifecycleMarkers } = useLifecycleMarkers(timeseries.events);
+const { lineVisibility, setLineVisibility } = useLifecycleLineVisibility();
+function onLifecycleToggle(kind: LifecycleKind, e: Event) {
+  setLineVisibility(kind, (e.target as HTMLInputElement).checked);
+}
 
 // Fallback: when the URL didn't carry start_time/end_time, capture
 // the play's bounds the first time samples arrive in archive mode
@@ -1803,7 +1820,7 @@ function skipToEnd() {
         :from-ms="cycleBandsDomain.fromMs"
         :to-ms="cycleBandsDomain.toMs"
       />
-      <EventsTimeline :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" />
+      <EventsTimeline :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" :lifecycle-markers="lifecycleMarkers" />
     </CollapsibleSection>
 
     <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">
@@ -1815,11 +1832,22 @@ function skipToEnd() {
         :sessions="compareSessions"
         :view="compareView"
       />
+      <!-- Lifecycle vertical-line toggles — govern the restart / play-start /
+           play-end lines drawn across every chart AND the events timeline.
+           Per-type, persisted; reason / play_id / status show on line hover. -->
+      <div class="lifecycle-toggles">
+        <span class="lt-label">Lifecycle lines:</span>
+        <label v-for="k in LIFECYCLE_KINDS" :key="k" class="lt-item">
+          <input type="checkbox" :checked="lineVisibility[k]" @change="onLifecycleToggle(k, $event)" />
+          <span class="lt-sw" :style="{ background: LIFECYCLE_STYLE[k].color }" />
+          {{ LIFECYCLE_STYLE[k].label }}
+        </label>
+      </div>
       <div class="chart-stack">
-        <BandwidthChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" />
-        <BufferChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
-        <RTTChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
-        <FPSChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" />
+        <BandwidthChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :lifecycle-markers="lifecycleMarkers" />
+        <BufferChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
+        <RTTChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
+        <FPSChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
       </div>
     </CollapsibleSection>
 
@@ -2456,4 +2484,30 @@ function skipToEnd() {
 }
 
 .chart-stack { display: grid; gap: 12px; }
+
+/* Lifecycle-line toggles — a compact legend/control row above the charts. */
+.lifecycle-toggles {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 4px 0 8px;
+  font-size: 11px;
+  color: #4b5563;
+}
+.lifecycle-toggles .lt-label { font-weight: 600; color: #374151; }
+.lifecycle-toggles .lt-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  user-select: none;
+}
+.lifecycle-toggles .lt-item input { margin: 0; cursor: pointer; }
+.lifecycle-toggles .lt-sw {
+  display: inline-block;
+  width: 14px;
+  height: 3px;
+  border-radius: 1px;
+}
 </style>

--- a/content/dashboard-v3/src/composables/useLifecycleMarkers.ts
+++ b/content/dashboard-v3/src/composables/useLifecycleMarkers.ts
@@ -1,0 +1,253 @@
+/**
+ * useLifecycleMarkers(eventsStream) — derive the player-lifecycle
+ * vertical-line markers (restart / play_start / play_end) once from the
+ * shared session events stream, so every chart + the events timeline can
+ * draw the SAME aligned lines from a single source of truth.
+ *
+ * The markers are recomputed whenever the events cache changes shape
+ * (`version`) or resets (`epoch`). The marker list is tiny relative to the
+ * row count (a handful per play), so a full re-scan of the cached rows on
+ * each bump is cheap and keeps the logic stateless — resets and pan-back
+ * backfills are handled for free.
+ *
+ * Rows here are the RAW snake_case CH projections (same objects the charts
+ * and EventsTimeline ingest), NOT the camelCased adapter shape.
+ *
+ * Per-type visibility (restart / play_start / play_end) is a module-level
+ * reactive object persisted to localStorage, so the toggle legend and every
+ * chart share one switch and it survives a reload.
+ */
+import { computed, reactive, type ComputedRef } from 'vue';
+import type { Stream } from './useSessionTimeSeries';
+
+export type LifecycleKind = 'restart' | 'play_start' | 'play_end' | 'user_marked';
+
+export interface LifecycleMarker {
+  /** ms-since-epoch x-position of the line. */
+  ms: number;
+  kind: LifecycleKind;
+  /** Line colour. */
+  color: string;
+  /** Chart.js / canvas dash pattern ([] = solid). */
+  dash: number[];
+  /** Multi-line hover tooltip text. */
+  detail: string;
+}
+
+/** Per-kind visual style + legend label. Restart is a single fixed colour
+ *  (amber, matching the existing PLAYBACK-lane RESTART dot) regardless of
+ *  reason — the reason shows on hover. */
+export const LIFECYCLE_STYLE: Record<LifecycleKind, { color: string; dash: number[]; label: string }> = {
+  restart:     { color: '#f59e0b', dash: [4, 3], label: 'Restart' },
+  play_start:  { color: '#15803d', dash: [],     label: 'Play start' },
+  play_end:    { color: '#475569', dash: [2, 3], label: 'Play end' },
+  // The operator "911" forensic mark (mark911() → last_event=user_marked,
+  // label critical=user_marked_911). Magenta solid so it stands out from the
+  // amber/green/slate lifecycle lines and the blue user cursor.
+  user_marked: { color: '#db2777', dash: [],     label: 'User mark (911)' },
+};
+
+export const LIFECYCLE_KINDS: LifecycleKind[] = ['restart', 'play_start', 'play_end', 'user_marked'];
+
+// ---- per-type visibility (module-level, persisted) -------------------------
+
+const VIS_STORAGE_KEY = 'dashboard_v3_lifecycle_lines';
+
+function readVisStored(): Record<LifecycleKind, boolean> {
+  const def: Record<LifecycleKind, boolean> = {
+    restart: true, play_start: true, play_end: true, user_marked: true,
+  };
+  try {
+    const raw = localStorage.getItem(VIS_STORAGE_KEY);
+    if (!raw) return def;
+    const o = JSON.parse(raw) as Partial<Record<LifecycleKind, boolean>>;
+    // Default-ON: only an explicit `false` hides a kind, so a partial /
+    // older stored object still shows everything it doesn't mention.
+    return {
+      restart: o.restart !== false,
+      play_start: o.play_start !== false,
+      play_end: o.play_end !== false,
+      user_marked: o.user_marked !== false,
+    };
+  } catch {
+    return def;
+  }
+}
+
+const lineVisibility = reactive<Record<LifecycleKind, boolean>>(readVisStored());
+
+function setLineVisibility(kind: LifecycleKind, visible: boolean) {
+  lineVisibility[kind] = visible;
+  try {
+    localStorage.setItem(VIS_STORAGE_KEY, JSON.stringify({ ...lineVisibility }));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Shared reactive per-kind line visibility + its persisting setter.
+ *  Used by the toggle legend (writes) and every chart (reads). */
+export function useLifecycleLineVisibility() {
+  return { lineVisibility, setLineVisibility };
+}
+
+// ---- row helpers (mirror EventsTimeline's parsing) -------------------------
+
+function tsOfRow(row: Record<string, unknown>): number {
+  const v = row.ts;
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string' || !v) return NaN;
+  // CH DateTime64 comes back as "YYYY-MM-DD HH:MM:SS.mmm" (UTC, no zone).
+  if (v.length > 10 && v.charAt(10) === ' ') return Date.parse(v.replace(' ', 'T') + 'Z');
+  return Date.parse(v);
+}
+
+function numOf(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function strOf(row: Record<string, unknown>, key: string): string {
+  const v = row[key];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+/** Row labels[] as a string array (top-level field; `<sev>=<event>` entries). */
+function labelsOf(row: Record<string, unknown>): string[] {
+  const v = row.labels;
+  if (Array.isArray(v)) return v.map((x) => String(x));
+  // Defensive: some transports stringify the array.
+  if (typeof v === 'string' && v) return v.split(',').map((s) => s.trim());
+  return [];
+}
+
+/** The client's restart reason, recovered from labels[] (restart_reason is
+ *  NOT a stored CH column — the forwarder folds it into `<sev>=restart_<reason>`
+ *  in labels.go). Returns e.g. "auto_recovery_stuck" / "user_retry", or '' . */
+function restartReasonFromLabels(row: Record<string, unknown>): string {
+  for (const l of labelsOf(row)) {
+    const val = l.includes('=') ? l.slice(l.indexOf('=') + 1) : l;
+    if (val.startsWith('restart_')) return val.slice('restart_'.length);
+  }
+  return '';
+}
+
+/** Local HH:MM:SS — dashboard timestamps are shown in local time. */
+function fmtClock(ms: number): string {
+  const d = new Date(ms);
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+export function useLifecycleMarkers(
+  stream: Stream<Record<string, unknown>>,
+): { markers: ComputedRef<LifecycleMarker[]> } {
+  const markers = computed<LifecycleMarker[]>(() => {
+    // Subscribe to cache mutations + resets.
+    void stream.version.value;
+    void stream.epoch.value;
+
+    const rows = stream.inRange(0, Number.MAX_SAFE_INTEGER);
+    const out: LifecycleMarker[] = [];
+
+    const seenPlay = new Set<string>();
+    const playStartMs = new Map<string, number>();
+    let prevPlayId: string | null = null;
+    // Restart count is cumulative per play; seed silently on the first row of
+    // each play so only mid-play increments mark (mirrors EventsTimeline).
+    let prevRestarts: number | null = null;
+
+    for (const r of rows) {
+      const ms = tsOfRow(r);
+      if (!Number.isFinite(ms)) continue;
+
+      const playId = strOf(r, 'play_id');
+      const lastEvent = strOf(r, 'last_event');
+      const restarts = numOf(r.player_restarts);
+
+      if (playId !== prevPlayId) {
+        prevRestarts = null;
+        prevPlayId = playId;
+      }
+
+      // PLAY START — first time a play_id is seen (covers the first play too).
+      // Robust against the synthetic-id flicker via the seen-set, same as the
+      // timeline's NEW PLAY marker.
+      if (playId && !seenPlay.has(playId)) {
+        seenPlay.add(playId);
+        playStartMs.set(playId, ms);
+        const content = strOf(r, 'content_name');
+        const st = LIFECYCLE_STYLE.play_start;
+        out.push({
+          ms,
+          kind: 'play_start',
+          color: st.color,
+          dash: st.dash,
+          detail:
+            `Play start\nplay_id ${playId.slice(0, 8)}…` +
+            (content ? `\n${content}` : '') +
+            `\n${fmtClock(ms)}`,
+        });
+      }
+
+      // PLAY END — explicit terminal event from the client.
+      if (lastEvent === 'play_end') {
+        const status = strOf(r, 'playback_status');
+        const reason = strOf(r, 'playback_reason');
+        const startedAt = playId ? playStartMs.get(playId) : undefined;
+        const durS = startedAt != null ? (ms - startedAt) / 1000 : null;
+        const st = LIFECYCLE_STYLE.play_end;
+        out.push({
+          ms,
+          kind: 'play_end',
+          color: st.color,
+          dash: st.dash,
+          detail:
+            `Play end${status ? `: ${status}` : ''}` +
+            (reason ? `\n${reason}` : '') +
+            (playId ? `\nplay_id ${playId.slice(0, 8)}…` : '') +
+            (durS != null ? `\nduration ${durS.toFixed(1)}s` : '') +
+            `\n${fmtClock(ms)}`,
+        });
+      }
+
+      // RESTART — player_restarts counter increment. Reason from labels[]
+      // (restart_reason is not a stored column).
+      if (restarts != null) {
+        if (prevRestarts != null && restarts > prevRestarts) {
+          const reason = restartReasonFromLabels(r) || 'reason n/a';
+          const st = LIFECYCLE_STYLE.restart;
+          out.push({
+            ms,
+            kind: 'restart',
+            color: st.color,
+            dash: st.dash,
+            detail: `Restart: ${reason}\n+${restarts - prevRestarts} (total ${restarts})\n${fmtClock(ms)}`,
+          });
+        }
+        prevRestarts = restarts;
+      }
+
+      // USER MARK (911) — operator forensic mark (mark911()).
+      if (lastEvent === 'user_marked') {
+        const st = LIFECYCLE_STYLE.user_marked;
+        out.push({
+          ms,
+          kind: 'user_marked',
+          color: st.color,
+          dash: st.dash,
+          detail: `User mark (911)${playId ? `\nplay_id ${playId.slice(0, 8)}…` : ''}\n${fmtClock(ms)}`,
+        });
+      }
+    }
+
+    return out;
+  });
+
+  return { markers };
+}


### PR DESCRIPTION
## What

Adds shared **vertical lines** for player-lifecycle events across every value chart (Bandwidth / Buffer / RTT / FPS) **and** the events timeline (including the Player State lane), aligned with the existing user-selected-event cursor.

| Line | Style | Hover |
|---|---|---|
| **restart** | amber dashed | `Restart: <reason>` (+ count) — reason read from `labels[]` |
| **play_start** | green solid | `play_id` (+ content name) |
| **play_end** | slate dashed | terminal status / reason + computed duration |
| **user_marked (911)** | magenta solid | `User mark (911)` + play_id — the `mark911()` operator forensic mark |

Per-type visibility toggles (a "Lifecycle lines:" checkbox row above the chart stack), all on by default, persisted to `localStorage`.

## How

- New `useLifecycleMarkers` composable derives the markers **once** from the shared events stream and `SessionDisplay` threads them to every chart + the timeline (same pattern as the `coordId` scope work).
- Charts: a `lifecycleLines` Chart.js plugin draws the lines + a hover tooltip. Timeline: one vis-timeline custom-time per marker (per-kind CSS color), with a generalized strip hover.

## Scope

**Dashboard-only — no forwarder or schema change.** The reason comes from `labels[]` (`<sev>=restart_<reason>`), not a stored column; `last_event`, `play_id`, `playback_status/reason`, and `content_name` are already on the events rows.

Built clean (`vue-tsc` + Vite). Part of #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
