### PR TITLE
docs(claude): knowledge-layout map + routing rule + standards catalogue refresh

### DIFF
--- a/.claude/memory
+++ b/.claude/memory
@@ -1,1 +1,0 @@
-/Users/jonathanoliver/Projects/infinite-stream-private/claude/memory

--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -37,9 +37,12 @@ One-sentence framing.
 - Other standards / findings to read alongside.
 ```
 
-Length: one page rendered. If it grows past that, split.
+Length: one page rendered. If it grows past that, split — **unless**
+it's a reference catalogue (see below), which is exempt by design.
 
 ## Current entries
+
+**Cheat sheets** (the one-page bar applies):
 
 - `hls-taxonomy.md` — m3u8 tags, what each means, what the proxy
   emits/strips
@@ -57,6 +60,27 @@ Length: one page rendered. If it grows past that, split.
 - `invariants.md` — operating manual for the aberration-crawl rule
   catalogue (`tests/aberration_crawl/invariants.yaml`): validity
   windows, census-before-assert, documented NON-rules
+- `avmetrics-forensics.md` — reading AVMetrics events client-side
+  (exact-type subscription, byteRange gotchas, derived_* fields)
+- `harness-cli.md` — harness flag-name traps, `--json`
+  stdout-vs-stderr contract, label round-trip
+- `timestamp-display.md` — the local-AND-UTC display rule, edge
+  cases, macOS conversion command (shared with the dashboard bot)
+
+**Reference catalogues** (exempt from the one-page bar — intentionally
+long, dual-consumed by the dashboard bot via `read_standard()`):
+
+- `data-fields.md` — canonical field semantics for `session_events` /
+  `network_requests` + nested player/server metrics blobs
+- `server-behavior.md` — control-surface contract catalogue +
+  calibration baselines (the `tests/server_behavior/` companion)
+- `fault-injection-wire-contract.md` — per-fault-type wire shapes the
+  proxy emits; read before editing `applySocketFault`
+
+**Test-procedure docs** (how a characterization mode is run + read):
+
+- `characterization-principles.md`, `startup-characterization-test.md`,
+  `abort-characterization-test.md`
 
 ## When to add a new one
 

--- a/.claude/standards/data-fields.md
+++ b/.claude/standards/data-fields.md
@@ -2,6 +2,8 @@
 
 What each field in the analytics tables (and the nested player-side blobs they carry) actually means, what units it's in, who populates it, and what gotchas to watch for when reasoning from it. Canonical for **both** the dashboard chat bot (via `read_standard("data-fields")`) and Claude Code.
 
+> **Reference catalogue — exempt from the standards library's "one page" bar.** This file is intentionally long and is consumed by lookup (grep / `read_standard`), not read end-to-end. Don't split it to satisfy the length rule; grep for the specific field you need.
+
 **Scope of this version (Phase 1, issue #512):** the two most-queried tables — `session_events` and `network_requests` — plus the nested `player_metrics` / `server_metrics` blobs you'll see in their JSON responses. Other sources are covered in Phase 2 (`control_events`, plays summary, label vocabulary) and Phase 3 (characterization report shapes); until those land, this doc has a stub pointer at the bottom for each so you know where the gap is.
 
 **How to use this doc:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Before making UI or product-behavior changes, read `PRD.md` and align implementation to it.
 
+## Knowledge layout
+
+Operational knowledge is split across stores — read and route by kind:
+
+| Store | What lives here | Tracked |
+|---|---|---|
+| `CLAUDE.md` (this file) | Durable architecture, build/run, repo-wide rules true for all contributors | public |
+| `.claude/standards/` | Platform/protocol cheat sheets that bit us once (AVPlayer quirks, ABR model, codec strings, data-field semantics). Read mid-investigation; the `forensics` subagent reads them before hypothesising. | public |
+| `.claude/findings/` | Per-investigation narratives — one observed behaviour: timeline, evidence, tagged hypothesis. | public |
+| `.claude/skills/CONVENTIONS.md` | Cross-skill operating rules (Bash discipline, no-guessing, local-vs-UTC). Read at skill invocation. | public |
+| `.claude/memory/` (symlink → private repo) | Cross-session prefs, working-style corrections, how this maintainer works. Greppable by skills/forensics; `MEMORY.md` is its always-loaded index. | private |
+
+**Routing a new learning:**
+- Durable product/architecture truth for all contributors → `CLAUDE.md`
+- Platform/protocol fact that cost >10 min to confirm → `.claude/standards/`
+- One investigation's cause + evidence → `.claude/findings/`
+- A cross-skill operating rule → `CONVENTIONS.md`
+- How the maintainer works/prefers, or an always-on rule that must survive into every session → `.claude/memory/`
+
+**One fact, one source of truth.** If a rule must also be always-on in memory, keep the memory copy terse and link the canonical store above — don't duplicate the detail.
+
 ## Build & Run Commands
 
 ```bash


### PR DESCRIPTION
## What

Audit-driven cleanup of the `.md` knowledge infrastructure (CLAUDE.md, standards library, the memory symlink). No behavior/code changes — docs + one git-hygiene fix.

## Changes

- **CLAUDE.md** — new **Knowledge layout** table (CLAUDE.md / `.claude/standards/` / `.claude/findings/` / `CONVENTIONS.md` / `.claude/memory/`) and a **Routing a new learning** guide. Previously a fresh session was never told these libraries exist unless it triggered a skill. Adds the "one fact, one source of truth" rule to curb cross-store duplication.
- **`.claude/standards/README.md`** — the "Current entries" list documented only 7 of 17 files. Adds the missing ~10, and splits entries into **cheat sheets** (one-page bar applies), **reference catalogues** (exempt), and **test-procedure docs**.
- **`.claude/standards/data-fields.md`** — inline note marking it an exempt reference catalogue (~105 KB, grep-not-read), so its size is understood as intentional rather than a violation of the library's one-page rule.
- **Untrack `.claude/memory`** — the symlink was committed pointing at a machine-specific absolute path inside a private repo: dangling on any other clone and leaking the private path. `.gitignore` already intends it per-machine (line 92); this makes that effective. Local working symlink is unchanged.

## Not included

Memory-store content edits (dedupe, sectioning, profile) live in the private memory repo and are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
