### PR TITLE
chore(make): `deploy` = test-dev; k3d moves to deploy-k3d-{dev,release}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,11 +44,14 @@ make shell
 # `dev` and `release` clusters with their host port mappings.
 make k3d-bootstrap
 
+# Everyday deploy: local working tree → test-dev (Docker Compose, :21000)
+make deploy            # alias for test-deploy-dev; frontend-only: make deploy-frontend
+
 # Deploy to k3d (dev cluster — host ports 40000/40081/40181-40881)
-make deploy
+make deploy-k3d-dev
 
 # Deploy to k3d (release cluster — host ports 30000/30081/30181-30881)
-make deploy-release
+make deploy-k3d-release
 
 # Wipe a single cluster (k3d cluster delete) for clean reinstall
 make teardown-dev

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ K3D_RELEASE_KUBECONFIG ?= ~/.config/k3d/smashing-release-kubeconfig.yaml
 # ~/.local/bin to PATH so the install location doesn't have to be
 # in the noninteractive shell's default PATH.
 # Writes per-cluster kubeconfigs to ~/.kube/smashing-{dev,release}.yaml
-# so subsequent `make deploy` / `make deploy-release` targets can pick
+# so subsequent `make deploy-k3d-dev` / `make deploy-k3d-release` targets can pick
 # the right context with KUBECONFIG=… without depending on whichever
 # kubeconfig happens to be active in the user's shell.
 
@@ -284,14 +284,14 @@ k3d-bootstrap:
 		--kubeconfig-update-default=false \
 		--kubeconfig-switch-context=false'
 	ssh $(K3S_SSH_HOST) '$(K3D_REMOTE_SHELL); mkdir -p ~/.config/k3d && k3d kubeconfig get release > $(K3D_RELEASE_KUBECONFIG)'
-	@echo "Both clusters ready. Run \`make deploy\` for dev / \`make deploy-release\` for release."
+	@echo "Both clusters ready. Run \`make deploy-k3d-dev\` for dev / \`make deploy-k3d-release\` for release."
 
 status-k3s:
 	ssh $(K3S_SSH_HOST) '$(K3D_REMOTE_SHELL); k3d cluster list; \
 		echo; echo "--- dev ---"; export KUBECONFIG=$(K3D_DEV_KUBECONFIG); kubectl get pods -A; \
 		echo; echo "--- release ---"; export KUBECONFIG=$(K3D_RELEASE_KUBECONFIG); kubectl get pods -A'
 
-# `make deploy` and `make deploy-release` are end-to-end — they build +
+# `make deploy-k3d-dev` and `make deploy-k3d-release` are end-to-end — they build +
 # push the main image, apply the consolidated `k8s-infinite-streaming.yaml.tmpl`
 # AND the analytics tier (ClickHouse + forwarder + Grafana) into the
 # stack's k3d cluster. Each cluster has exactly one set of resources —
@@ -299,12 +299,12 @@ status-k3s:
 
 # Each target binds its KUBECONFIG_FILE, SERVER_ID, ANNOUNCE_URL/LABEL,
 # and EXTERNAL_PORT_BASE so the same template renders cleanly per stack.
-deploy: KUBECONFIG_FILE=$(K3D_DEV_KUBECONFIG)
-deploy: SERVER_ID=infinite-streaming-dev
-deploy: ANNOUNCE_URL=$(INFINITE_STREAM_ANNOUNCE_URL_K3S_DEV)
-deploy: ANNOUNCE_LABEL=$(INFINITE_STREAM_ANNOUNCE_LABEL_K3S_DEV)
-deploy: EXTERNAL_PORT_BASE=40081
-deploy: analytics-deploy-k3s
+deploy-k3d-dev: KUBECONFIG_FILE=$(K3D_DEV_KUBECONFIG)
+deploy-k3d-dev: SERVER_ID=infinite-streaming-dev
+deploy-k3d-dev: ANNOUNCE_URL=$(INFINITE_STREAM_ANNOUNCE_URL_K3S_DEV)
+deploy-k3d-dev: ANNOUNCE_LABEL=$(INFINITE_STREAM_ANNOUNCE_LABEL_K3S_DEV)
+deploy-k3d-dev: EXTERNAL_PORT_BASE=40081
+deploy-k3d-dev: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 --build-arg VERSION=$(shell cat VERSION) -t $(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev --push .
 	$(MAKE) deploy-k3d K3S_SERVER_IMAGE=$(K3S_REGISTRY)/$(K3S_SERVER_REPO):dev \
 		KUBECONFIG_FILE=$(KUBECONFIG_FILE) \
@@ -313,12 +313,12 @@ deploy: analytics-deploy-k3s
 		ANNOUNCE_LABEL=$(ANNOUNCE_LABEL) \
 		EXTERNAL_PORT_BASE=$(EXTERNAL_PORT_BASE)
 
-deploy-release: KUBECONFIG_FILE=$(K3D_RELEASE_KUBECONFIG)
-deploy-release: SERVER_ID=infinite-streaming-release
-deploy-release: ANNOUNCE_URL=$(INFINITE_STREAM_ANNOUNCE_URL_K3S_RELEASE)
-deploy-release: ANNOUNCE_LABEL=$(INFINITE_STREAM_ANNOUNCE_LABEL_K3S_RELEASE)
-deploy-release: EXTERNAL_PORT_BASE=30081
-deploy-release: analytics-deploy-k3s
+deploy-k3d-release: KUBECONFIG_FILE=$(K3D_RELEASE_KUBECONFIG)
+deploy-k3d-release: SERVER_ID=infinite-streaming-release
+deploy-k3d-release: ANNOUNCE_URL=$(INFINITE_STREAM_ANNOUNCE_URL_K3S_RELEASE)
+deploy-k3d-release: ANNOUNCE_LABEL=$(INFINITE_STREAM_ANNOUNCE_LABEL_K3S_RELEASE)
+deploy-k3d-release: EXTERNAL_PORT_BASE=30081
+deploy-k3d-release: analytics-deploy-k3s
 	docker buildx build --platform linux/amd64 \
 		--build-arg VERSION=$(shell cat VERSION) \
 		-t $(K3S_SERVER_IMAGE) \
@@ -333,7 +333,7 @@ deploy-release: analytics-deploy-k3s
 
 # Inner worker — applies the consolidated main-app template against
 # whichever k3d cluster's kubeconfig was passed in. Used by both
-# `deploy` and `deploy-release`.
+# `deploy-k3d-dev` and `deploy-k3d-release`.
 deploy-k3d:
 	@if [ -z "$(KUBECONFIG_FILE)" ]; then echo "KUBECONFIG_FILE required"; exit 1; fi
 	@echo "=== Applying main app to k3d cluster ($(KUBECONFIG_FILE)) ==="
@@ -396,11 +396,11 @@ analytics-deploy-k3s: analytics-build-forwarder-k3s
 # so each can be exercised in isolation.
 teardown-dev:
 	ssh $(K3S_SSH_HOST) '$(K3D_REMOTE_SHELL); k3d cluster delete dev'
-	@echo "Cluster `dev` deleted. Re-run \`make k3d-bootstrap\` then \`make deploy\` to bring it back."
+	@echo "Cluster `dev` deleted. Re-run \`make k3d-bootstrap\` then \`make deploy-k3d-dev\` to bring it back."
 
 teardown-release:
 	ssh $(K3S_SSH_HOST) '$(K3D_REMOTE_SHELL); k3d cluster delete release'
-	@echo "Cluster `release` deleted. Re-run \`make k3d-bootstrap\` then \`make deploy-release\` to bring it back."
+	@echo "Cluster `release` deleted. Re-run \`make k3d-bootstrap\` then \`make deploy-k3d-release\` to bring it back."
 
 # ── Remote deployment testing ──────────────────────────────────────────
 # Deploy all 4 installation methods to a remote Docker host for parallel testing.
@@ -490,7 +490,7 @@ _ff-guard:
 	fi
 
 # Short alias: rebuild + hot-deploy only the dashboard bundle to test-dev
-# (:21000), no container recreate. Sibling to deploy-dev.
+# (:21000), no container recreate. Sibling to deploy.
 deploy-frontend: test-deploy-frontend
 
 test-deploy-frontend: _ff-guard
@@ -509,10 +509,10 @@ test-deploy-frontend: _ff-guard
 	rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev/content/dashboard/v3/
 	@echo "✓ test-dev frontend updated; sessions untouched."
 
-# Short alias for the everyday workflow: deploy the local working tree to
-# test-dev (:21000). Sibling to deploy-release; distinct from bare `deploy`
-# (which targets the k3d dev cluster, not test-dev).
-deploy-dev: test-deploy-dev
+# Everyday deploy: build + push the local working tree to test-dev (:21000).
+# This is the common case, so it gets the bare `deploy` name. The k3d
+# cluster deploys live under deploy-k3d-dev / deploy-k3d-release.
+deploy: test-deploy-dev
 
 test-deploy-dev: _ff-guard
 	@echo "=== Dev: local working tree (port 21000) ==="

--- a/Makefile
+++ b/Makefile
@@ -505,6 +505,11 @@ test-deploy-frontend: _ff-guard
 	rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev/content/dashboard/v3/
 	@echo "✓ test-dev frontend updated; sessions untouched."
 
+# Short alias for the everyday workflow: deploy the local working tree to
+# test-dev (:21000). Sibling to deploy-release; distinct from bare `deploy`
+# (which targets the k3d dev cluster, not test-dev).
+deploy-dev: test-deploy-dev
+
 test-deploy-dev: _ff-guard
 	@echo "=== Dev: local working tree (port 21000) ==="
 	@# Build the Vue dashboard FIRST, before any rsync --delete touches the

--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,10 @@ _ff-guard:
 		echo "✓ up to date with origin"; \
 	fi
 
+# Short alias: rebuild + hot-deploy only the dashboard bundle to test-dev
+# (:21000), no container recreate. Sibling to deploy-dev.
+deploy-frontend: test-deploy-frontend
+
 test-deploy-frontend: _ff-guard
 	@echo "=== Frontend-only hot deploy (no container recreate) ==="
 	@if [ ! -f content/dashboard-v3/package.json ]; then \

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -46,7 +46,7 @@ Then:
 
 ## k3d
 
-`make deploy` and `make deploy-release` apply `k8s-analytics.yaml`
+`make deploy-k3d-dev` and `make deploy-k3d-release` apply `k8s-analytics.yaml`
 into the matching k3d cluster automatically — one analytics tier per
 cluster (each cluster has its own ClickHouse PVC, forwarder, and
 Grafana). The forwarder's SSE source is the same in-cluster URL in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,8 +134,8 @@ Global selection (content, URL, protocol, codec, segment) is kept in `localStora
 | Mode | How | UI | Notes |
 |---|---|---|---|
 | Docker Compose | `make run` or `docker compose up -d` | `localhost:30000` | Simplest, single-host |
-| k3d release | `make deploy-release` | `$K3S_HOST:30000` | Independent k3d cluster, api `:6544`, 30x port range |
-| k3d dev | `make deploy` | `$K3S_HOST:40000` | Independent k3d cluster, api `:6543`, 40x port range — coexists with release |
+| k3d release | `make deploy-k3d-release` | `$K3S_HOST:30000` | Independent k3d cluster, api `:6544`, 30x port range |
+| k3d dev | `make deploy-k3d-dev` | `$K3S_HOST:40000` | Independent k3d cluster, api `:6543`, 40x port range — coexists with release |
 | GHCR compose | Pull `ghcr.io/jonathaneoliver/infinite-streaming:<tag>` | `localhost:30000` | No local build |
 
 All modes mount the same content layout. See [`README.md`](../README.md#quick-start) for commands and [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) for common operational issues.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,8 +8,8 @@ Two independent k3d clusters on the same host — separate kubeconfigs, separate
 
 | Stack | UI | Session ports | API | Image tag | Cluster | `make` target |
 |---|---|---|---|---|---|---|
-| Release | `$K3S_HOST:30000` | 30081 + 30181–30881 | `:6544` | `:latest` or pinned | `release` | `make deploy-release` |
-| Dev | `$K3S_HOST:40000` | 40081 + 40181–40881 | `:6543` | `:dev` | `dev` | `make deploy` |
+| Release | `$K3S_HOST:30000` | 30081 + 30181–30881 | `:6544` | `:latest` or pinned | `release` | `make deploy-k3d-release` |
+| Dev | `$K3S_HOST:40000` | 40081 + 40181–40881 | `:6543` | `:dev` | `dev` | `make deploy-k3d-dev` |
 
 Both clusters share the host's local Docker registry (`$K3S_REGISTRY`, HTTP-only — wired via `--registry-config`), and mount the host's `$K3S_MEDIA_DIR` and `$K3S_CERTS_DIR` paths via `--volume`. Per-cluster kubeconfigs are written to `~/.config/k3d/smashing-{dev,release}-kubeconfig.yaml` on the remote host.
 
@@ -35,13 +35,13 @@ This installs k3d into `~/.local/bin` on `$K3S_SSH_HOST` (no sudo), writes `~/.c
 
 ```bash
 # dev cluster: builds + pushes :dev, applies main app + analytics tier
-make deploy
+make deploy-k3d-dev
 
 # release cluster: builds + pushes the release tag, applies main app + analytics tier
-make deploy-release
+make deploy-k3d-release
 ```
 
-Each `make deploy[-release]` invocation also builds and pushes the analytics forwarder image, applies `k8s-analytics.yaml` (ClickHouse + forwarder + Grafana with inlined schema and Grafana provisioning), and waits for rollout. The single `k8s-infinite-streaming.yaml.tmpl` template renders identically into both clusters; per-stack identity comes from envsubst placeholders (`SERVER_ID`, `ANNOUNCE_URL`, `EXTERNAL_PORT_BASE`) bound by the `make` target.
+Each `make deploy-k3d-dev` / `deploy-k3d-release` invocation also builds and pushes the analytics forwarder image, applies `k8s-analytics.yaml` (ClickHouse + forwarder + Grafana with inlined schema and Grafana provisioning), and waits for rollout. The single `k8s-infinite-streaming.yaml.tmpl` template renders identically into both clusters; per-stack identity comes from envsubst placeholders (`SERVER_ID`, `ANNOUNCE_URL`, `EXTERNAL_PORT_BASE`) bound by the `make` target.
 
 ### Tear down a single cluster
 
@@ -50,7 +50,7 @@ make teardown-dev       # k3d cluster delete dev
 make teardown-release   # k3d cluster delete release
 ```
 
-Wipes the cluster entirely (analytics + main app + PVC + node containers) so a subsequent `make deploy[-release]` starts clean. The other cluster is untouched.
+Wipes the cluster entirely (analytics + main app + PVC + node containers) so a subsequent `make deploy-k3d-dev` / `deploy-k3d-release` starts clean. The other cluster is untouched.
 
 ## Release tagging
 
@@ -67,7 +67,7 @@ Suggested flow:
    - `ghcr.io/<owner>/infinite-streaming-forwarder:v1.2.3`
 3. Deploy the release cluster pinned to that tag:
    ```bash
-   make deploy-release K3S_SERVER_IMAGE=$K3S_REGISTRY/infinite-streaming:v1.2.3
+   make deploy-k3d-release K3S_SERVER_IMAGE=$K3S_REGISTRY/infinite-streaming:v1.2.3
    ```
 
 `:latest` continues to point at the most recent `main` build; `:v1.2.3` is immutable.


### PR DESCRIPTION
## What

Repoint the deploy verbs so the everyday case gets the short name.

| Command | Now means | Was |
|---|---|---|
| `make deploy` | **test-dev** full stack (:21000) | k3d dev cluster |
| `make deploy-frontend` | **test-dev** dashboard-only hot deploy | *(new)* |
| `make deploy-k3d-dev` | k3d dev cluster | `make deploy` |
| `make deploy-k3d-release` | k3d release cluster | `make deploy-release` |

## Why

The deploy run ~daily (local working tree → test-dev) had the verbose name `test-deploy-dev`, while the short `deploy` name belonged to the rarely-used k3d dev cluster. This swaps them: the common case wins `make deploy`, and the k3d pair is grouped under `deploy-k3d-*`.

## Scope

- `Makefile`: `deploy` → alias for `test-deploy-dev`; new `deploy-frontend`; k3d `deploy`/`deploy-release` targets renamed to `deploy-k3d-dev`/`deploy-k3d-release`; all internal comments + bootstrap/teardown echo messages updated.
- Docs updated to match: `CLAUDE.md`, `docs/ARCHITECTURE.md`, `docs/DEPLOYMENT.md`, `analytics/README.md`.

Verified: `make -n deploy` is identical to `make -n test-deploy-dev`, `make -n deploy-frontend` identical to `test-deploy-frontend`, both renamed k3d targets parse, no make warnings, no stale `make deploy`/`deploy-release` references remain.

## Note

Breaking for anyone with `make deploy`/`make deploy-release` k3d muscle memory or scripts — those become `make deploy-k3d-dev`/`make deploy-k3d-release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
