### PR TITLE
chore(make): deploy branch-guard becomes a warning (freshness check kept)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,11 +470,9 @@ DEPLOY_BRANCH ?= dev
 _ff-guard:
 	@cur=$$(git symbolic-ref --short -q HEAD || echo DETACHED); \
 	if [ "$$cur" != "$(DEPLOY_BRANCH)" ] && [ -z "$(ALLOW_BRANCH_DEPLOY)" ]; then \
-		echo "✗ deploy expects branch '$(DEPLOY_BRANCH)' but HEAD is '$$cur'."; \
-		echo "  A deploy from a stale feature branch silently reverted test-dev on 2026-06-08"; \
-		echo "  (forwarder + dashboard + harness all served pre-merge code)."; \
-		echo "  → 'git switch $(DEPLOY_BRANCH)' to ship $(DEPLOY_BRANCH), or set ALLOW_BRANCH_DEPLOY=1 to deploy '$$cur' on purpose."; \
-		exit 1; \
+		echo "⚠ deploying branch '$$cur' (not '$(DEPLOY_BRANCH)') — test-dev will serve THIS working tree, not $(DEPLOY_BRANCH)."; \
+		echo "  Deliberate? Fine, carrying on. (A SILENT stale-branch deploy reverted test-dev on 2026-06-08 — hence this loud notice.)"; \
+		echo "  Set ALLOW_BRANCH_DEPLOY=1 to silence, or 'git switch $(DEPLOY_BRANCH)' to ship $(DEPLOY_BRANCH)."; \
 	fi
 	@git fetch origin --quiet
 	@behind=$$(git rev-list --count HEAD..@{u} 2>/dev/null || echo 0); \


### PR DESCRIPTION
## What

`make deploy` (and `deploy-frontend` / `analytics-rebuild-forwarder`) no longer **block** when you're not on `dev`. The branch check becomes a loud, non-blocking warning showing which branch's working tree is being deployed; the command then proceeds.

## Why

These targets rsync the **local working tree** to test-dev (:21000), so deploying a feature branch to your iteration box is legitimate and common. The 2026-06-08 incident that motivated the guard was about a stale-branch deploy reverting test-dev *silently* — the fix is to surface it loudly, not to forbid it.

## Kept intact

The **freshness check** is unchanged: `_ff-guard` still `git fetch`es origin, auto-fast-forwards a clean branch that's behind its upstream, and aborts only when the tree is behind-and-diverged or dirty-and-behind. `ALLOW_BRANCH_DEPLOY=1` still silences the warning entirely.

```
- exit 1 on wrong branch
+ ⚠ warn which branch is shipping, then continue
```

Verified the guard returns exit 0 on a feature branch and the Makefile parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
