### PR TITLE
feat(skills): add test-author skill (walks the test-contract gate)

### DIFF
--- a/.claude/skills/test-author/SKILL.md
+++ b/.claude/skills/test-author/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: test-author
+description: Author a new characterization test (a `tests/characterization/matrix/*.yaml` arm spec or a `tests/server_behavior/server_*_test.go` case) by walking the test-contract gate with the real knob vocabulary. Invoke when the user says "write/add a characterization test for…", "new matrix for…", "add a server-behavior case for…", "set up an A/B comparing X vs Y", or otherwise wants a NEW test spec authored. This skill owns the intent-quiz + resolved-config echo + dry-run verify BEFORE any run. NOT for running an existing test (→ `make characterize-*` / `harness char matrix`), the unattended fault loop (→ `sweep`), or analysing results (→ `forensics`).
+last_reviewed: 2026-06-23
+---
+
+# Test-author — walk the test-contract gate when writing a new test
+
+This skill operationalises the **test contract** in [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) ("state this first"). The standard says *confirm intent + echo the resolved config before any run*; this skill carries the **authoritative knob vocabulary** so the quiz is concrete and the echo-back is a filled spec, not prose. The config surface churns constantly — one wrong assumption silently builds a test that measures the wrong thing or passes for the wrong reason.
+
+**Conventions:** follows [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md). Most load-bearing here:
+- **No guessing (§2)** — quiz the operator on every blank in the contract; never fill one with an assumption.
+- **Pass signal is DATA, not a screenshot (§5 / the don't-over-read-screenshots rule)** — the contract's pass/fail line must name a `player_metric` / label / histogram + threshold.
+- **Bash discipline (§1)** — lead verify commands with `harness` / `go` / `make`.
+
+**This skill authors specs; it does not run them.** Running is `make characterize-<platform>` / `harness char matrix <file>` / `make characterize-server`; analysis is `forensics` / `characterize-report`.
+
+## Procedure
+
+### 1. Classify — family + class (pick one, never mix)
+- **char-matrix YAML** → `tests/characterization/matrix/<name>.yaml`, run by `harness char matrix` / the fleet drivers. Class:
+  - `class: config` — benign network/manifest variation (content manipulation, rate caps, pattern ladders, transfer-timeouts). Oracle: any bad QoE label. Targets ABR decision quality.
+  - `class: fault` — injected errors (`4xx/5xx`, `corrupted`, transport `drop`/`reject`, `request_*_hang`). Oracle: the recovery-expected envelope.
+- **server-behavior** → `tests/server_behavior/server_*_test.go`, run by `make characterize-server`. A control-surface **contract** (delay / loss / rate / fault / pattern / limit / transfer), measured as *baseline + configured-effect within tolerance*.
+
+### 2. Run the contract quiz (from the standard, made concrete — quiz every blank)
+- **Behavior under test** — the one thing this run measures.
+- **Platform** — `ipad-sim | iphone | appletv | androidtv | web`. (`parallel: true` ⟹ **single-platform** — the fleet boots N sims of ONE platform.)
+- **Target held constant** — `content` clip + `duration_s` + `reps` (≥3 before generalizing — principles §2). The clip/endpoint is pinned in `defaults:`, never varied across arms (principles §1).
+- **What varies** — the swept knob(s): `axes:` for a cartesian product, or `groups:` / `compare:` / `control:` for an A/B pairing.
+- **Pass/fail signal** — the **data** that confirms it (a `player_metric`, a label, a settled-variant histogram) + threshold. Not a green test process.
+
+### 3. Draft the spec (knob reference below), then 4. ECHO the resolved config
+Spell out every knob with its namespace, e.g.:
+> "config class, ipad-sim, content=insane_new_p200_h264 held constant, 3 reps, 90 s. Varying `axes: proxy.live_offset:[0,24] × is.live_offset:[0,18]` (4 cells). Pass = achieved offset matches the honoured side. `proxy.*` = server, config-on-connect; `is.*` = client, cold relaunch."
+
+Never summarise as "the usual pyramid test".
+
+### 5. Verify before any run
+- Matrix: `harness char matrix tests/characterization/matrix/<name>.yaml --dry-run` — prints the expanded arm cartesian; confirm the cell count + per-arm knobs match the contract.
+- Server-behavior: name the exact run — `go test ./tests/server_behavior -run TestServer<X> -timeout 10m` (or `make characterize-server`).
+
+## char-matrix knob reference (authoritative — from `internal/charmatrix/spec.go`)
+
+**Top-level / run-level:** `name`, `class` (config|fault), `platform`, `content`, `duration_s`, `reps`, `parallel`, `defaults:` (per-arm baseline), and either `axes:` (cartesian sweep) or `groups:`/`control:`/`compare:` (A/B).
+
+**Client knobs `is.*`** — launch arg, **cold relaunch** on change:
+`is.segment` (s2|s6|ll) · `is.protocol` (hls|dash) · `is.codec` (h264|hevc|av1) · `is.live_offset` (client target-latency) · `is.peak_bitrate_mbps` (startup clamp; 0=off) · `is.starts_first_variant` (join first rung vs ABR pick).
+
+**Server knobs `proxy.*`** — config-on-connect, **no relaunch**:
+`proxy.live_offset` (manifest hold-back) · `proxy.shape` · `proxy.fault` · `proxy.transfer_timeouts` · `proxy.content_manipulation` (nested), with flat conveniences `proxy.strip_codecs` / `proxy.strip_avg_bandwidth` / `proxy.strip_resolution` / `proxy.allowed_variants` (`drop-top-rung`|`drop-top-<N>`|`keep-bottom-<N>`) / `proxy.variant_order` (default|ascending|descending) / `proxy.overstate_bandwidth`.
+
+**Worked examples (the living templates — read, don't duplicate):** `matrix/precedence.yaml` (axes cartesian + precedence), `matrix/shape-patterns.yaml` (shape), `matrix/pyramid-1-s2-firstvar-cap.yaml` (client caps). `0 means "unset"` for the numeric knobs.
+
+## server-behavior skeleton (from `sb_common_test.go`)
+
+A `TestServer<X>(t)` that: builds a `newProbe(t)`; sweeps the control surface via `setShapeFull(...)` / `patchSession(...)`; measures baseline at the zero/identity setting, then reports each setting's delta over baseline within a stated tolerance; emits `postServerReport(...)`. The contract is a comment at the top ("path-ping RTT ≈ baseline + configured_delay within a few ms"). Mirror the closest existing `server_*_test.go`.
+
+## Out of scope
+Running tests, aggregation (`cmd/characterize-report`), result analysis (→ `forensics`/`investigate`), and **Roku**.
+
+## See also
+- [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) — the correctness rules a confirmed contract must satisfy (constant-target, n=1, kill/relaunch, cycle labels). Per-mode docs: `abort-`, `startup-`, `retry-backoff-characterization-test.md`.
+- [`.claude/standards/server-behavior.md`](../../standards/server-behavior.md) — the control-surface catalogue + calibration baselines.
+- `sweep` — once a test class is authored, the unattended loop explores it. `forensics` — analyse a run's results.

--- a/.claude/skills/test-author/SKILL.md
+++ b/.claude/skills/test-author/SKILL.md
@@ -1,65 +1,60 @@
 ---
 name: test-author
-description: Author a new characterization test (a `tests/characterization/matrix/*.yaml` arm spec or a `tests/server_behavior/server_*_test.go` case) by walking the test-contract gate with the real knob vocabulary. Invoke when the user says "write/add a characterization test for…", "new matrix for…", "add a server-behavior case for…", "set up an A/B comparing X vs Y", or otherwise wants a NEW test spec authored. This skill owns the intent-quiz + resolved-config echo + dry-run verify BEFORE any run. NOT for running an existing test (→ `make characterize-*` / `harness char matrix`), the unattended fault loop (→ `sweep`), or analysing results (→ `forensics`).
+description: Turn a free-form test request into a ready-to-run characterization spec (a `tests/characterization/matrix/*.yaml` arm spec or a `tests/server_behavior/server_*_test.go` case). Say it in one line — "run a pyramid test on 1 isim and jonathan's iphone for 10min", "startup under a 2Mbps cap on ipad-sim" — and this skill FILLS THE BLANKS from the verified defaults + aliases registry below, echoes the resolved spec, and only asks when a blank both changes what's measured AND has no safe default. Invoke on "write/add/run a characterization test", "new matrix for…", "add a server-behavior case", "A/B comparing X vs Y". NOT for running an existing named test (→ `make characterize-*`), the unattended loop (→ `sweep`), or analysing results (→ `forensics`).
 last_reviewed: 2026-06-23
 ---
 
-# Test-author — walk the test-contract gate when writing a new test
+# Test-author — fill the blanks for a new test, ask only when it matters
 
-This skill operationalises the **test contract** in [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) ("state this first"). The standard says *confirm intent + echo the resolved config before any run*; this skill carries the **authoritative knob vocabulary** so the quiz is concrete and the echo-back is a filled spec, not prose. The config surface churns constantly — one wrong assumption silently builds a test that measures the wrong thing or passes for the wrong reason.
+Operationalises the **test contract** in [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) — but as a *fill-the-blanks* helper, not an interrogation. Parse the request, resolve every blank from the registry below, **echo the resolved spec so the operator sees what was assumed**, and dry-run verify. The echo-back is the safety net; questions are the exception.
 
-**Conventions:** follows [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md). Most load-bearing here:
-- **No guessing (§2)** — quiz the operator on every blank in the contract; never fill one with an assumption.
-- **Pass signal is DATA, not a screenshot (§5 / the don't-over-read-screenshots rule)** — the contract's pass/fail line must name a `player_metric` / label / histogram + threshold.
-- **Bash discipline (§1)** — lead verify commands with `harness` / `go` / `make`.
+**Conventions:** follows [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md) — no-guessing (§2), pass-signal-is-DATA (§5), Bash-first (§1). **This skill authors specs; it does not run them** (running is `make characterize-*` / `harness char matrix`).
 
-**This skill authors specs; it does not run them.** Running is `make characterize-<platform>` / `harness char matrix <file>` / `make characterize-server`; analysis is `forensics` / `characterize-report`.
+## The rule: assume-and-surface, ask-only-on-consequential-ambiguity
+
+1. **Resolve every blank** from the registry. Don't ask for anything that has a safe default.
+2. **Surface — always — in the echo** (even when not asked): the resolved **content**, the **platform/device** targets, **parallel vs sequential**, and the **cost** (arms × reps × duration). These are the error-prone fields.
+3. **Ask only when** a blank *changes what's measured* and has *no safe default*. The usual triggers:
+   - The request names an effect with two distinct mechanisms — e.g. "under a cap" = **network** rate cap (`proxy.shape`, tests bw-estimation) **vs** **client** clamp (`is.peak_bitrate_mbps`, tests config-honoring). Different tests → ask.
+   - A real-device target is ambiguous or its `.env` alias doesn't resolve.
+   - The run is long/expensive and scope is unclear (e.g. no platform given at all).
+   - The pass criterion isn't implied by a known mode.
+   When you do ask, ask the ONE consequential question — don't re-quiz the whole contract.
+
+## Defaults & aliases registry (preferred values — VERIFY content live)
+
+| Blank | Default | Notes |
+|---|---|---|
+| **content** | `insane_newer_p200_h264` | **Always confirm against the live catalogue** (`curl -sk $BASE/api/content`). The example matrices say `insane_new_p200_h264` — that's **STALE / invalid**; never copy content from them. Surface the resolved content every time. |
+| **class** | `config` | → `fault` only if the ask mentions errors / 4xx-5xx / corrupt / drop / recovery. |
+| **platform aliases** | — | "isim"/"ipad sim"→`ipad-sim`; "N isim"→ipad-sim × N; "jonathan's iphone"/"the iphone"→`platform: iphone` (real device, resolved from `.env IPHONE_XCODE_ID` via the fleet roster, `-launch-mode=appium`); "appletv"→`appletv` (`.env APPLETV_XCODE_ID`); "androidtv"/"google tv"→`androidtv`; "web"→`web`. |
+| **multi-platform** | `parallel: false` | A `parallel` matrix MUST be single-platform. Two+ platforms ⟹ sequential legs — surface it. |
+| **duration** | `90` s | Parse "Nmin"→N×60, "Ns"→N. |
+| **reps** | `3` | n=1 rule (principles §2). "smoke"/"quick"→1. |
+| **segment** | `is.segment: s6` | s2 / ll only if stated. |
+| **forced flags** | LocalProxy OFF, auto-recovery OFF | The fleet forces these (override via `CHAR_LOCAL_PROXY` / `CHAR_AUTO_RECOVERY`). |
+| **mode → shape** | — | `pyramid`→`proxy.shape: {pattern: pyramid, step_seconds: 12, rate_mbps: 1.5}`; `ramp_up`/`ramp_down`/`square_wave`/`transient_shock`→`{pattern: <m>, step_seconds: 12}`; "const N Mbps cap"→`{rate_mbps: N}`; "uncapped"→`{rate_mbps: 0}` (0 = no cap). |
 
 ## Procedure
+1. **Parse** the one-liner → mode/class, platform(s), duration, any named knob.
+2. **Resolve** every blank from the registry; verify content against `/api/content`.
+3. **Echo the resolved spec** — a short table: behavior, class, platform(s), content (confirmed), held-constant, what-varies (namespaced knobs), pass signal, cost. Mark anything assumed.
+4. **Ask** only the consequential blank(s), if any (per the rule).
+5. **Verify** — write the YAML and `harness char matrix <file> --dry-run` (shows the expanded arms); for server-behavior, name the exact `go test … -run TestServer<X>`.
 
-### 1. Classify — family + class (pick one, never mix)
-- **char-matrix YAML** → `tests/characterization/matrix/<name>.yaml`, run by `harness char matrix` / the fleet drivers. Class:
-  - `class: config` — benign network/manifest variation (content manipulation, rate caps, pattern ladders, transfer-timeouts). Oracle: any bad QoE label. Targets ABR decision quality.
-  - `class: fault` — injected errors (`4xx/5xx`, `corrupted`, transport `drop`/`reject`, `request_*_hang`). Oracle: the recovery-expected envelope.
-- **server-behavior** → `tests/server_behavior/server_*_test.go`, run by `make characterize-server`. A control-surface **contract** (delay / loss / rate / fault / pattern / limit / transfer), measured as *baseline + configured-effect within tolerance*.
+## char-matrix knob reference (authoritative — `internal/charmatrix/spec.go`)
+Run-level: `name`, `class`, `platform`, `content`, `duration_s`, `reps`, `parallel`, `defaults:`, `axes:` (cartesian) | `groups:`/`compare:`/`control:` (A/B).
+Client `is.*` (launch arg, **cold relaunch**): `is.segment` · `is.protocol` (hls|dash) · `is.codec` (h264|hevc|av1) · `is.live_offset` · `is.peak_bitrate_mbps` (0=off) · `is.starts_first_variant`.
+Server `proxy.*` (config-on-connect, **no relaunch**): `proxy.live_offset` · `proxy.shape` (object-axis: a whole shape block, optional `label:`) · `proxy.fault` · `proxy.transfer_timeouts` · `proxy.allowed_variants` (drop-top-N|keep-bottom-N) · `proxy.variant_order` · `proxy.strip_*` · `proxy.overstate_bandwidth`. `0 = unset` for numeric knobs.
+**Living examples:** `matrix/precedence.yaml`, `matrix/shape-patterns.yaml`, `matrix/startup-cap.yaml` (copy structure, NOT their stale `content:`).
 
-### 2. Run the contract quiz (from the standard, made concrete — quiz every blank)
-- **Behavior under test** — the one thing this run measures.
-- **Platform** — `ipad-sim | iphone | appletv | androidtv | web`. (`parallel: true` ⟹ **single-platform** — the fleet boots N sims of ONE platform.)
-- **Target held constant** — `content` clip + `duration_s` + `reps` (≥3 before generalizing — principles §2). The clip/endpoint is pinned in `defaults:`, never varied across arms (principles §1).
-- **What varies** — the swept knob(s): `axes:` for a cartesian product, or `groups:` / `compare:` / `control:` for an A/B pairing.
-- **Pass/fail signal** — the **data** that confirms it (a `player_metric`, a label, a settled-variant histogram) + threshold. Not a green test process.
-
-### 3. Draft the spec (knob reference below), then 4. ECHO the resolved config
-Spell out every knob with its namespace, e.g.:
-> "config class, ipad-sim, content=insane_new_p200_h264 held constant, 3 reps, 90 s. Varying `axes: proxy.live_offset:[0,24] × is.live_offset:[0,18]` (4 cells). Pass = achieved offset matches the honoured side. `proxy.*` = server, config-on-connect; `is.*` = client, cold relaunch."
-
-Never summarise as "the usual pyramid test".
-
-### 5. Verify before any run
-- Matrix: `harness char matrix tests/characterization/matrix/<name>.yaml --dry-run` — prints the expanded arm cartesian; confirm the cell count + per-arm knobs match the contract.
-- Server-behavior: name the exact run — `go test ./tests/server_behavior -run TestServer<X> -timeout 10m` (or `make characterize-server`).
-
-## char-matrix knob reference (authoritative — from `internal/charmatrix/spec.go`)
-
-**Top-level / run-level:** `name`, `class` (config|fault), `platform`, `content`, `duration_s`, `reps`, `parallel`, `defaults:` (per-arm baseline), and either `axes:` (cartesian sweep) or `groups:`/`control:`/`compare:` (A/B).
-
-**Client knobs `is.*`** — launch arg, **cold relaunch** on change:
-`is.segment` (s2|s6|ll) · `is.protocol` (hls|dash) · `is.codec` (h264|hevc|av1) · `is.live_offset` (client target-latency) · `is.peak_bitrate_mbps` (startup clamp; 0=off) · `is.starts_first_variant` (join first rung vs ABR pick).
-
-**Server knobs `proxy.*`** — config-on-connect, **no relaunch**:
-`proxy.live_offset` (manifest hold-back) · `proxy.shape` · `proxy.fault` · `proxy.transfer_timeouts` · `proxy.content_manipulation` (nested), with flat conveniences `proxy.strip_codecs` / `proxy.strip_avg_bandwidth` / `proxy.strip_resolution` / `proxy.allowed_variants` (`drop-top-rung`|`drop-top-<N>`|`keep-bottom-<N>`) / `proxy.variant_order` (default|ascending|descending) / `proxy.overstate_bandwidth`.
-
-**Worked examples (the living templates — read, don't duplicate):** `matrix/precedence.yaml` (axes cartesian + precedence), `matrix/shape-patterns.yaml` (shape), `matrix/pyramid-1-s2-firstvar-cap.yaml` (client caps). `0 means "unset"` for the numeric knobs.
-
-## server-behavior skeleton (from `sb_common_test.go`)
-
-A `TestServer<X>(t)` that: builds a `newProbe(t)`; sweeps the control surface via `setShapeFull(...)` / `patchSession(...)`; measures baseline at the zero/identity setting, then reports each setting's delta over baseline within a stated tolerance; emits `postServerReport(...)`. The contract is a comment at the top ("path-ping RTT ≈ baseline + configured_delay within a few ms"). Mirror the closest existing `server_*_test.go`.
+## server-behavior skeleton (`sb_common_test.go`)
+`TestServer<X>(t)`: `newProbe(t)`; sweep the control surface via `setShapeFull`/`patchSession`; measure baseline at the identity setting, report each setting's delta within a stated tolerance; `postServerReport`. Contract as a top comment ("RTT ≈ baseline + configured_delay within a few ms"). Mirror the closest `server_*_test.go`.
 
 ## Out of scope
-Running tests, aggregation (`cmd/characterize-report`), result analysis (→ `forensics`/`investigate`), and **Roku**.
+Running tests, aggregation (`characterize-report`), analysis (→ `forensics`/`investigate`), and **Roku**.
 
 ## See also
-- [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) — the correctness rules a confirmed contract must satisfy (constant-target, n=1, kill/relaunch, cycle labels). Per-mode docs: `abort-`, `startup-`, `retry-backoff-characterization-test.md`.
-- [`.claude/standards/server-behavior.md`](../../standards/server-behavior.md) — the control-surface catalogue + calibration baselines.
-- `sweep` — once a test class is authored, the unattended loop explores it. `forensics` — analyse a run's results.
+- [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) — correctness rules a resolved spec must satisfy (constant-target, n=1, kill/relaunch). Per-mode: `abort-`, `startup-`, `retry-backoff-characterization-test.md`.
+- [`.claude/standards/server-behavior.md`](../../standards/server-behavior.md) — control-surface catalogue + baselines.
+- `sweep` (explore an authored class) · `forensics` (analyse a run).


### PR DESCRIPTION
## What

Adds `.claude/skills/test-author/SKILL.md` — turns the just-merged test-contract gate (#840) into a walked authoring procedure.

## Why

The gate (in `characterization-principles.md` + an always-on memory) says *confirm intent + echo resolved config before any run*. This skill carries the **authoritative knob vocabulary** so the quiz is concrete and the echo-back is a filled spec, not prose — which matters because the matrix-YAML / server_behavior config surface churns constantly.

## Covers

- **char-matrix YAML** — class config|fault; the `is.*` (client, cold-relaunch) / `proxy.*` (server, config-on-connect) knob reference from `internal/charmatrix/spec.go`; `axes:` cartesian vs `groups/compare` A/B; points at the worked-example YAMLs as living templates.
- **server-behavior** — the baseline-plus-tolerance contract shape + `sb_common_test.go` helpers.

Procedure: classify family/class → contract quiz → draft → **echo resolved config** → `--dry-run` / `-run` verify, before any run.

## Boundaries

Defers correctness to `characterization-principles.md`, follows `CONVENTIONS.md`, and is explicitly **not** for running tests (`make characterize-*` / `harness char matrix`), the unattended loop (`sweep`), analysis (`forensics`), or Roku.

Closes #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
