### PR TITLE
fix(843): config-on-connect app_config no longer gated on LocalProxy

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -873,10 +873,15 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
 
     /** Overlay the latest server-pushed app_config onto the play-affecting
      *  state, so the next play composed by [composeUrlAndLoad] honours it.
-     *  Best-effort and only while routing through the proxy (localProxy) — the
-     *  app_config lives on the proxy session. A fetch miss is a no-op. #800. */
+     *  Best-effort: a fetch miss is a no-op. #800.
+     *
+     *  NOT gated on localProxy (#843). localProxy toggles routing through the
+     *  per-session go-proxy PORT for media; it does NOT control whether the
+     *  session's app_config exists. fetchServerAppConfig reads /api/sessions off
+     *  activeServer.apiUrl (the API port), reachable regardless. Gating the
+     *  overlay on localProxy silently dropped config-on-connect on every
+     *  localProxy-off run (the characterization default). */
     private suspend fun applyServerAppConfig() {
-        if (!_state.value.localProxy) return
         val cfg = fetchServerAppConfig() ?: return
         _state.update { st ->
             st.copy(

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -1081,10 +1081,17 @@ final class PlayerViewModel: ObservableObject {
 
     /// Overlay the latest server-pushed app_config onto the play-affecting
     /// state so the next play composed by `composeURLAndLoad` honours it.
-    /// Best-effort and only while routing through the proxy (`localProxy`) —
-    /// the app_config lives on the proxy session. A fetch miss is a no-op. #800.
+    /// Best-effort: a fetch miss is a no-op. #800.
+    ///
+    /// NOT gated on `localProxy` (#843). `localProxy` toggles the ON-DEVICE
+    /// LocalHTTPProxy (127.0.0.1 rewrite) — it does NOT control whether we use
+    /// the go-proxy session. Session playback ALWAYS routes through the go-proxy
+    /// port (see `composeURLAndLoad`), so the session's app_config exists and is
+    /// readable from `/api/sessions` (via `metricsBaseURL` → playbackURL)
+    /// regardless of the LocalHTTPProxy. Gating the overlay on `localProxy`
+    /// silently dropped config-on-connect on every LocalProxy-off run (the
+    /// characterization default).
     private func applyServerAppConfig() async {
-        guard localProxy else { return }
         guard let cfg = await fetchServerAppConfig() else { return }
         // segment/protocol/live_offset ride the manifest URL + the live-offset
         // seek; the peak cap is read off this property when the next

--- a/tests/characterization/matrix/mute-both-off.yaml
+++ b/tests/characterization/matrix/mute-both-off.yaml
@@ -1,9 +1,10 @@
 # #838 — BOTH sims UNMUTED (audible) via config-on-connect. Mirror of
 # mute-both.yaml but is.muted: false, so both sessions store app_config.muted=false
-# and both players apply muted=false (overlay needs LocalProxy ON →
-# CHAR_LOCAL_PROXY=true). Two distinct arms via a benign server hold-back.
+# and both players apply muted=false. As of #843 the read-back is no longer gated
+# on LocalProxy (applies under the char default, LocalProxy OFF). Two distinct
+# arms via a benign server hold-back.
 #
-#   CHAR_DEVICE_FARM=1 CHAR_LOCAL_PROXY=true \
+#   CHAR_DEVICE_FARM=1 \
 #     harness char matrix tests/characterization/matrix/mute-both-off.yaml
 #
 # PASS signal (from data): GET /api/sessions shows app_config.muted=false for BOTH

--- a/tests/characterization/matrix/mute-both.yaml
+++ b/tests/characterization/matrix/mute-both.yaml
@@ -1,10 +1,11 @@
 # #838 — BOTH sims muted via config-on-connect. Two arms differ only on a benign
 # server hold-back (proxy.live_offset) so they're distinct fleet arms; both carry
 # is.muted: true from defaults, delivered over config-on-connect (bootstrap
-# app_config.muted) and read back by the player (applyServerAppConfig → needs
-# LocalProxy ON, so run with CHAR_LOCAL_PROXY=true).
+# app_config.muted) and read back by the player (applyServerAppConfig). As of
+# #843 that read-back is no longer gated on LocalProxy (applies under the char
+# default, LocalProxy OFF).
 #
-#   CHAR_DEVICE_FARM=1 CHAR_LOCAL_PROXY=true \
+#   CHAR_DEVICE_FARM=1 \
 #     harness char matrix tests/characterization/matrix/mute-both.yaml
 #
 # PASS signal (from data): GET /api/sessions shows app_config.muted=true for BOTH

--- a/tests/characterization/matrix/mute-config-on-connect.yaml
+++ b/tests/characterization/matrix/mute-config-on-connect.yaml
@@ -1,10 +1,10 @@
 # #838 — verify mute reaches the client via CONFIG-ON-CONNECT across a 2-sim DF
 # fleet. Two arms differ ONLY on `is.muted`; the value rides the config-on-connect
 # bootstrap (PlayerPatch.app_config.muted), so the player reads it back off
-# GET /api/sessions (applyServerAppConfig). That overlay needs LocalProxy ON, so
-# run with CHAR_LOCAL_PROXY=true (overriding the char default of OFF):
+# GET /api/sessions (applyServerAppConfig). As of #843 the overlay is no longer
+# gated on LocalProxy, so it applies under the char default (LocalProxy OFF):
 #
-#   CHAR_DEVICE_FARM=1 CHAR_LOCAL_PROXY=true \
+#   CHAR_DEVICE_FARM=1 \
 #     harness char matrix tests/characterization/matrix/mute-config-on-connect.yaml
 #
 # Needs >=2 booted iOS sims (single-platform requirement); DF allocates them.


### PR DESCRIPTION
Fixes #843.

`applyServerAppConfig()` early-returned when `localProxy` was false, so **all** #800 config-on-connect `app_config` (segment / protocol / live_offset / peak / `muted` from #838) was **silently dropped on every LocalProxy-OFF run** — which is the characterization default.

## Root cause
The guard gated on the wrong flag. `localProxy` (`is.flag.local_proxy`) toggles the **on-device LocalHTTPProxy** (iOS `127.0.0.1` rewrite) / the **media port** (Android) — it does **not** control whether the session's `app_config` exists or is readable. The lookup reads `/api/sessions` off the API port (iOS `metricsBaseURL`→`playbackURL`, Android `activeServer.apiUrl`), reachable regardless. The fetch is already best-effort (null on miss), so removing the guard is a no-op for normal user plays.

## Change
- iOS: drop `guard localProxy else { return }` (`PlayerViewModel.swift`).
- Android: drop `if (!_state.value.localProxy) return` (`PlayerViewModel.kt`).
- Update the #838 mute matrix specs — `CHAR_LOCAL_PROXY=true` is no longer required.

## Verification (2-sim Device Farm fleet, LocalProxy OFF)
Clean before/after, controlled on the fix only:

| | overlay log | `[localproxy]` NET logs | meaning |
|---|---|---|---|
| **before** (pre-fix, OFF) | absent | absent | guard blocked the read-back |
| **after** (post-fix, OFF) | present (`muted=true` / `muted=false` per arm) | absent | read-back applies without the on-device proxy |

`[localproxy]` NET logs absent in both confirms LocalProxy was genuinely OFF (positive control). Both fleet subtests PASS. Server `/api/sessions` stored `app_config.muted` in both (it always did — localProxy-independent).

iOS `** BUILD SUCCEEDED **`; Android `compileDebugKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
