### PR TITLE
docs(843): drop stale 'needs LocalProxy ON' comment in sweep_run.go

### DIFF
--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -277,8 +277,8 @@ func experimentPlayerPatch(ctx context.Context, client *api.Client, content stri
 
 	// #838 mute rides config-on-connect: stamp app_config.muted onto the
 	// bootstrap patch so the per-arm value is stored on the session and the
-	// player reads it back off GET /api/sessions (applyServerAppConfig, which
-	// needs LocalProxy ON — run with CHAR_LOCAL_PROXY=true).
+	// player reads it back off GET /api/sessions (applyServerAppConfig). As of
+	// #843 that read-back is no longer gated on LocalProxy.
 	if e.Muted != nil {
 		patch.AppConfig = &proxy.AppConfig{Muted: e.Muted}
 		summary = append(summary, fmt.Sprintf("muted=%t", *e.Muted))


### PR DESCRIPTION
Follow-up to #844. The config-on-connect comment in `experimentPlayerPatch` still claimed `app_config.muted` "needs LocalProxy ON — run with `CHAR_LOCAL_PROXY=true`". The guard was removed in #843/#844, so that's no longer true. Comment-only, no behavior change.

Relates to #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
