### PR TITLE
feat(shape): add `valley` pattern (high→low→high, inverse of pyramid)

### DIFF
--- a/.claude/skills/CONVENTIONS.md
+++ b/.claude/skills/CONVENTIONS.md
@@ -94,6 +94,6 @@ The harness CLI surface has been refreshed:
 - `harness checkpoint list|show` — pre-mutation state captures (formerly `harness snapshot`).
 - `harness undo` — rolls back the last checkpoint.
 - `harness ts <target> --streams events,network,control` — live SSE multiplex (replaces the old per-stream subcommands).
-- `harness shape <target> --pattern pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders [--step-seconds N]` — pattern shaping (newer than the `--rate / --delay / --loss` static form, which still works for one-shot caps).
+- `harness shape <target> --pattern pyramid|valley|ramp_up|ramp_down|square_wave|transient_shock|sliders [--step-seconds N]` — pattern shaping (newer than the `--rate / --delay / --loss` static form, which still works for one-shot caps).
 
 If a skill snippet still references `archive` or `snapshot`, it's stale.

--- a/.claude/skills/test-author/SKILL.md
+++ b/.claude/skills/test-author/SKILL.md
@@ -33,7 +33,7 @@ Operationalises the **test contract** in [`.claude/standards/characterization-pr
 | **reps** | `3` | n=1 rule (principles §2). "smoke"/"quick"→1. |
 | **segment** | `is.segment: s6` | s2 / ll only if stated. |
 | **forced flags** | LocalProxy OFF, auto-recovery OFF | The fleet forces these (override via `CHAR_LOCAL_PROXY` / `CHAR_AUTO_RECOVERY`). |
-| **mode → shape** | — | `pyramid`→`proxy.shape: {pattern: pyramid, step_seconds: 12, rate_mbps: 1.5}`; `ramp_up`/`ramp_down`/`square_wave`/`transient_shock`→`{pattern: <m>, step_seconds: 12}`; "const N Mbps cap"→`{rate_mbps: N}`; "uncapped"→`{rate_mbps: 0}` (0 = no cap). |
+| **mode → shape** | — | `pyramid`→`proxy.shape: {pattern: pyramid, step_seconds: 12, rate_mbps: 1.5}`; `valley`→`{pattern: valley, step_seconds: 12}` (high→low→high, the inverse of pyramid — starts high so NO startup cap / initial rate is needed); `ramp_up`/`ramp_down`/`square_wave`/`transient_shock`→`{pattern: <m>, step_seconds: 12}`; "const N Mbps cap"→`{rate_mbps: N}`; "uncapped"→`{rate_mbps: 0}` (0 = no cap). |
 
 ## Procedure
 1. **Parse** the one-liner → mode/class, platform(s), duration, any named knob.

--- a/.claude/standards/server-behavior.md
+++ b/.claude/standards/server-behavior.md
@@ -137,7 +137,7 @@ expected for loss-driven congestion-window collapse.
 **Test:** `tests/server_behavior/server_pattern_test.go::TestServerPattern`
 
 **Methodology:** Install a built-in pattern **template** (square_wave /
-ramp_up / ramp_down / pyramid / transient_shock) via `POST /api/nftables/pattern/{port}`, sweep
+ramp_up / ramp_down / pyramid / valley / transient_shock) via `POST /api/nftables/pattern/{port}`, sweep
 the per-step duration (6s / 12s / 24s), pull segments continuously, and bucket
 each segment by the engine's **live** step (`nftables_pattern_step` /
 `nftables_pattern_rate_runtime_mbps`) — bucketing by the engine's own step

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Linux-only (macOS Docker Desktop can't do this).
 ### Network Shaping (per session)
 
 - **Delay / Loss / Throughput** sliders — steady-state shaping (0–250 ms, 0–10%, 0–50 Mbps). Throughput is disabled when a pattern is active.
-- **Pattern mode**: `sliders` (static), `square_wave`, `ramp_up`, `ramp_down`, `pyramid`, `transient_shock` (hold the top cap, dip to each lower rung in turn — deepening — recovering to top between dips). Non-`sliders` modes drive throughput through a scripted sequence of steps.
+- **Pattern mode**: `sliders` (static), `square_wave`, `ramp_up`, `ramp_down`, `pyramid`, `valley` (high → low → high — the inverse of pyramid; starts at the top so the player cold-starts cleanly, no startup cap needed), `transient_shock` (hold the top cap, dip to each lower rung in turn — deepening — recovering to top between dips). Non-`sliders` modes drive throughput through a scripted sequence of steps.
 - **Step duration**: `6s` / `12s` / `18s` / `24s` / `60s` / `120s` — how long each pattern step holds (`60s` / `120s` give buffer-draining holds for `transient_shock`-style probes).
 - **Margin**: `Exact` / `+10%` / `+25%` / `+50%` — headroom added on top of each ladder bitrate when picking preset rates.
 - **Throughput presets** are generated from the current manifest's variants (video + audio, deduped). Effective rate:

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1477,7 +1477,7 @@ components:
       properties:
         template:
           type: string
-          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, transient_shock]
+          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, valley, transient_shock]
           description: |
             Template that drove step-list generation. Stored verbatim
             so the dashboard can repaint the template radios. The kernel

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -27,7 +27,7 @@ import { usePlayer } from '@/composables/usePlayer';
 import { useManifestVariants } from '@/composables/useManifestVariants';
 import type { Pattern } from '@/repo/v2-repo';
 
-const TEMPLATES = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid', 'transient_shock'] as const;
+const TEMPLATES = ['sliders', 'square_wave', 'ramp_up', 'ramp_down', 'pyramid', 'valley', 'transient_shock'] as const;
 type Template = (typeof TEMPLATES)[number];
 
 const TEMPLATE_LABELS: Record<Template, string> = {

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -36,6 +36,7 @@ const TEMPLATE_LABELS: Record<Template, string> = {
   ramp_up:         '↗ Ramp up',
   ramp_down:       '↘ Ramp down',
   pyramid:         '⛰ Pyramid',
+  valley:          '🏞 Valley',
   transient_shock: '⤓ Transient shock',
 };
 

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1430,6 +1430,13 @@ export interface components {
              */
             shape?: components["schemas"]["Shape"];
             /**
+             * @description Client-side config the player applies at its next play boundary
+             *     (#800). Stored server-side; the player reads it from
+             *     `GET /api/sessions` and overlays it on the next play.
+             *     *Broadcasts to group on PATCH.*
+             */
+            app_config?: components["schemas"]["AppConfig"];
+            /**
              * @description Per-device fault hit counters.
              *     *Per-device runtime state — does not broadcast to group.*
              */
@@ -1525,6 +1532,7 @@ export interface components {
             shape?: components["schemas"]["Shape"];
             transfer_timeouts?: components["schemas"]["TransferTimeouts"];
             content?: components["schemas"]["ContentManipulation"];
+            app_config?: components["schemas"]["AppConfig"];
         };
         /**
          * @description Live play state. The same `PlayRecord` schema is also used in the
@@ -1830,7 +1838,7 @@ export interface components {
              *     characterization mode.
              * @enum {string}
              */
-            template?: "sliders" | "square" | "square_wave" | "ramp_up" | "ramp_down" | "pyramid" | "transient_shock";
+            template?: "sliders" | "square" | "square_wave" | "ramp_up" | "ramp_down" | "pyramid" | "valley" | "transient_shock";
             steps: components["schemas"]["PatternStep"][];
             /**
              * @description Default per-step duration the dashboard chose when generating the step list. 60 / 120 give buffer-draining holds for transient_shock-style probes.
@@ -1914,6 +1922,42 @@ export interface components {
              * @enum {integer}
              */
             live_offset: 0 | 2 | 4 | 6 | 12 | 18 | 24 | 30 | 36 | 42;
+        };
+        /**
+         * @description Client-side ("app behaviour") config the player applies at its next
+         *     play boundary — the per-play, no-restart counterpart to the cold-start
+         *     launch args (`is.segment` etc., #797). The proxy stores these per
+         *     session and surfaces them on `GET /api/sessions`; the player overlays
+         *     any non-null field onto its own state when it opens the next play
+         *     (segment/protocol drive the manifest URL; live_offset_s and
+         *     peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+         *     null/omitted field leaves the player's own value untouched.
+         *
+         *     Server-side (`proxy.*` / ContentManipulation) config already
+         *     reconfigures per-play with no restart; this brings the client-side
+         *     half in line. Settable via `PATCH /api/session/{id}` or the
+         *     `app.<field>` config-on-connect URL args. Issue #800.
+         */
+        AppConfig: {
+            /**
+             * @description Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+             * @enum {string|null}
+             */
+            segment?: "ll" | "s2" | "s6" | null;
+            /**
+             * @description Streaming protocol for the next play (maps to `is.protocol`).
+             * @enum {string|null}
+             */
+            protocol?: "hls" | "dash" | null;
+            /**
+             * Format: float
+             * @description Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.
+             */
+            live_offset_s?: number | null;
+            /** @description ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap. */
+            peak_bitrate_mbps?: number | null;
+            /** @description Mute audio for the next play (maps to `is.flag.muted`). Defaults muted; false = audible. Issue #838. */
+            muted?: boolean | null;
         };
         Manifest: {
             /** Format: uri */

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1477,7 +1477,7 @@ components:
       properties:
         template:
           type: string
-          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, transient_shock]
+          enum: [sliders, square, square_wave, ramp_up, ramp_down, pyramid, valley, transient_shock]
           description: |
             Template that drove step-list generation. Stored verbatim
             so the dashboard can repaint the template radios. The kernel
@@ -1591,6 +1591,10 @@ components:
           type: integer
           nullable: true
           description: 'ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap.'
+        muted:
+          type: boolean
+          nullable: true
+          description: 'Mute audio for the next play (maps to `is.flag.muted`). Defaults muted; false = audible. Issue #838.'
 
     # ----- Manifest / metrics --------------------------------------------
 

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -4686,7 +4686,7 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	switch payload.TemplateMode {
-	case "sliders", "square_wave", "ramp_up", "ramp_down", "pyramid", "transient_shock":
+	case "sliders", "square_wave", "ramp_up", "ramp_down", "pyramid", "valley", "transient_shock":
 	default:
 		payload.TemplateMode = "sliders"
 	}

--- a/go-proxy/pkg/ladder/ladder_test.go
+++ b/go-proxy/pkg/ladder/ladder_test.go
@@ -184,6 +184,28 @@ func TestBuildPattern(t *testing.T) {
 			t.Errorf("pyramid not symmetric at %d: %.3f vs %.3f", i, pyr[i].RateMbps, pyr[len(pyr)-1-i].RateMbps)
 		}
 	}
+	// valley: the inverse of pyramid — high → low → high, floored at the same
+	// over-selection midpoint. Same length + symmetry, but starts/ends at the TOP
+	// cap and bottoms out at the floor in the middle.
+	val := BuildPattern(Valley, rungs, 12)
+	valTop := pyr[(len(pyr)-1)/2].RateMbps // pyramid's apex = the top cap
+	if val[0].RateMbps != valTop || val[len(val)-1].RateMbps != valTop {
+		t.Errorf("valley should start+end at top %.3f, got ends %.3f..%.3f", valTop, val[0].RateMbps, val[len(val)-1].RateMbps)
+	}
+	if val[(len(val)-1)/2].RateMbps != fl {
+		t.Errorf("valley should bottom at floor %.3f in the middle, got %.3f", fl, val[(len(val)-1)/2].RateMbps)
+	}
+	if len(val) != wantLen {
+		t.Errorf("valley len %d, want %d (same as pyramid)", len(val), wantLen)
+	}
+	for i := range val {
+		if val[i].RateMbps < fl {
+			t.Errorf("valley cap %.3f below floor %.3f at %d", val[i].RateMbps, fl, i)
+		}
+		if val[i].RateMbps != val[len(val)-1-i].RateMbps {
+			t.Errorf("valley not symmetric at %d: %.3f vs %.3f", i, val[i].RateMbps, val[len(val)-1-i].RateMbps)
+		}
+	}
 	sq := BuildPattern(SquareWave, rungs, 12)
 	if len(sq) != 2 || sq[0].RateMbps != 1.085 || sq[1].RateMbps != 31.064 {
 		t.Errorf("square_wave = %v, want [1.085, 31.064]", sq)

--- a/go-proxy/pkg/ladder/pattern.go
+++ b/go-proxy/pkg/ladder/pattern.go
@@ -9,6 +9,7 @@ const (
 	RampUp         = "ramp_up"
 	RampDown       = "ramp_down"
 	Pyramid        = "pyramid"
+	Valley         = "valley"
 	SquareWave     = "square_wave"
 	TransientShock = "transient_shock"
 )
@@ -24,6 +25,10 @@ type Step struct {
 //   - ramp_up         ascending caps (lowest → highest)
 //   - ramp_down       descending caps (highest → lowest)
 //   - pyramid         ascending then descending, without duplicating the apex
+//   - valley          descending then ascending (high → low → high), the
+//     inverse of pyramid — starts at the top cap so the player cold-starts
+//     cleanly (no startup over-selection wedge → no startup cap needed); the
+//     floored trough is the rate-limiting stress, then it climbs back.
 //   - square_wave     just the lowest and highest cap, alternating
 //   - transient_shock hold the top cap, then dip to each lower rung in turn
 //     (deepening), returning to the top between dips so the buffer refills —
@@ -59,6 +64,16 @@ func BuildPattern(template string, rungs []Rung, stepSecs int) []Step {
 		}
 		down := reversedFloat(asc[:len(asc)-1]) // drop the apex so it isn't held twice
 		seq = append(append([]float64{}, asc...), down...)
+	case Valley:
+		// The inverse of Pyramid: high → low → high. Start at the top cap so the
+		// player cold-starts at full bandwidth (no over-selection wedge, so no
+		// startup cap is needed); dip to the floored bottom, then climb back. The
+		// trough drops the duplicate so it isn't held twice. Shares the pyramid
+		// over-selection floor so the trough stays sustainable, not starving.
+		if fl := pyramidFloor(rungs); fl > 0 {
+			asc = floorAsc(asc, fl)
+		}
+		seq = append(reversedFloat(asc), asc[1:]...) // high→low, then low+1→high
 	case SquareWave:
 		seq = []float64{asc[0], asc[len(asc)-1]}
 	case TransientShock:

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -331,6 +331,7 @@ const (
 	Square         PatternTemplate = "square"
 	SquareWave     PatternTemplate = "square_wave"
 	TransientShock PatternTemplate = "transient_shock"
+	Valley         PatternTemplate = "valley"
 )
 
 // Valid indicates whether the value is a known member of the PatternTemplate enum.
@@ -349,6 +350,8 @@ func (e PatternTemplate) Valid() bool {
 	case SquareWave:
 		return true
 	case TransientShock:
+		return true
+	case Valley:
 		return true
 	default:
 		return false

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -21,7 +21,7 @@ Slider mode (any subset; omitted fields are not modified):
   --loss FLOAT       packet loss %% (e.g. 0.5, range 0–100)
 
 Pattern mode (generates a step list from the player's current variants):
-  --pattern NAME     pyramid | ramp_up | ramp_down | square_wave | transient_shock | sliders
+  --pattern NAME     pyramid | valley | ramp_up | ramp_down | square_wave | transient_shock | sliders
   --step-seconds N   per-step duration: 6 | 12 | 18 | 24 | 60 | 120 (default 12;
                      60/120 give buffer-draining holds for transient_shock)
   --margin PCT       flat headroom above each variant rate: 0|5|10|25|50
@@ -53,6 +53,8 @@ Examples:
 
 Pattern semantics:
   pyramid          ascending variant rates, then descending (without apex dupe)
+  valley           descending then ascending (high->low->high) — inverse of pyramid;
+                   starts at the top so the player cold-starts cleanly (no startup cap)
   ramp_up          ascending rates, single sweep
   ramp_down        descending rates, single sweep
   square_wave      alternate lowest + highest variant
@@ -72,7 +74,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	rate := fs.Float64("rate", -1, "rate cap Mbps")
 	delay := fs.Float64("delay", -1, "delay ms")
 	loss := fs.Float64("loss", -1, "loss %")
-	pattern := fs.String("pattern", "", "pattern template (pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders)")
+	pattern := fs.String("pattern", "", "pattern template (pyramid|valley|ramp_up|ramp_down|square_wave|transient_shock|sliders)")
 	stepSeconds := fs.Int("step-seconds", 12, "per-step duration: 6|12|18|24|60|120")
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
@@ -420,6 +422,8 @@ func parseTemplate(s string) (proxy.PatternTemplate, error) {
 	switch s {
 	case "pyramid":
 		return proxy.Pyramid, nil
+	case "valley":
+		return proxy.Valley, nil
 	case "ramp_up":
 		return proxy.RampUp, nil
 	case "ramp_down":
@@ -431,7 +435,7 @@ func parseTemplate(s string) (proxy.PatternTemplate, error) {
 	case "sliders":
 		return proxy.Sliders, nil
 	}
-	return "", fmt.Errorf("invalid --pattern %q: pyramid|ramp_up|ramp_down|square_wave|transient_shock|sliders", s)
+	return "", fmt.Errorf("invalid --pattern %q: pyramid|valley|ramp_up|ramp_down|square_wave|transient_shock|sliders", s)
 }
 
 func parseStepSeconds(n int) (proxy.PatternDefaultStepSeconds, error) {

--- a/tools/harness-cli/internal/sweep/experiment.go
+++ b/tools/harness-cli/internal/sweep/experiment.go
@@ -126,7 +126,7 @@ type Fault struct {
 // degradation is out of scope for both classes. Nil means "no shaping".
 type Shape struct {
 	RateMbps    *float64 `json:"rate_mbps,omitempty"`
-	Pattern     string   `json:"pattern,omitempty"`      // pyramid | ramp_up | ramp_down | square_wave | transient_shock
+	Pattern     string   `json:"pattern,omitempty"`      // pyramid | valley | ramp_up | ramp_down | square_wave | transient_shock
 	StepSeconds int      `json:"step_seconds,omitempty"` // 6|12|18|24|60|120
 	MarginPct   int      `json:"margin_pct,omitempty"`   // 0|5|10|25|50
 }

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -332,6 +332,7 @@ const (
 	Square         PatternTemplate = "square"
 	SquareWave     PatternTemplate = "square_wave"
 	TransientShock PatternTemplate = "transient_shock"
+	Valley         PatternTemplate = "valley"
 )
 
 // Valid indicates whether the value is a known member of the PatternTemplate enum.
@@ -350,6 +351,8 @@ func (e PatternTemplate) Valid() bool {
 	case SquareWave:
 		return true
 	case TransientShock:
+		return true
+	case Valley:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## What

A new bandwidth-shaping pattern, **`valley`** — the inverse of `pyramid`. Starts at the **top** cap, dips to the floored trough, climbs back: **high → low → high**.

## Why

`pyramid` starts *low*, so the player cold-starts by over-selecting a high rung it can't load under the cap → **startup wedge** (you have to add `is.peak_bitrate_mbps` to avoid it). `valley` starts **high**, so the player cold-starts at full bandwidth cleanly — **no startup cap needed**. The trough is the rate-limiting stress; the climb-back tests recovery. (Surfaced while trying to run a group rate-limit test and repeatedly hitting the documented cold-start over-selection wedge.)

## Changes

- **`go-proxy/pkg/ladder/pattern.go`** — `BuildPattern` `valley` case: `reversedFloat(asc)` then `asc[1:]` (descend, then ascend dropping the trough dupe), sharing the pyramid over-selection floor so the trough stays sustainable. + a mirrored `TestBuildPattern` assertion (high→low→high, floored, symmetric, same length as pyramid).
- Wiring: proxy `TemplateMode` gate (`main.go`), OpenAPI v2 enum (`proxy.yaml`), **regenerated** harness client (`proxy.Valley`) + dashboard types (`v2.ts`), harness `--pattern valley` (`shape.go`), `Pattern` field doc (`experiment.go`), dashboard pattern picker (`NetworkShapingPattern.vue`).
- Docs: `README.md`, `.claude/standards/server-behavior.md`, `.claude/skills/CONVENTIONS.md`, and the `test-author` skill's mode→shape registry.

## Verified

`go-proxy` + `harness-cli` build; `TestBuildPattern` passes. Generated files regenerated via `make gen-harness-cli-client` + `npm run gen-types` (not hand-edited).

## Usage

```yaml
proxy.shape: { pattern: valley, step_seconds: 12 }   # no startup cap needed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
