### PR TITLE
chore(char): throwaway test specs default to gitignored matrix/scratch/

### DIFF
--- a/.claude/skills/test-author/SKILL.md
+++ b/.claude/skills/test-author/SKILL.md
@@ -40,13 +40,14 @@ Operationalises the **test contract** in [`.claude/standards/characterization-pr
 2. **Resolve** every blank from the registry; verify content against `/api/content`.
 3. **Echo the resolved spec** — a short table: behavior, class, platform(s), content (confirmed), held-constant, what-varies (namespaced knobs), pass signal, cost. Mark anything assumed.
 4. **Ask** only the consequential blank(s), if any (per the rule).
-5. **Verify** — write the YAML and `harness char matrix <file> --dry-run` (shows the expanded arms); for server-behavior, name the exact `go test … -run TestServer<X>`.
+5. **Verify** — write the YAML to `tests/characterization/matrix/scratch/<name>.yaml` (gitignored — throwaway by default, no `git status` noise) and `harness char matrix <file> --dry-run` (shows the expanded arms); for server-behavior, name the exact `go test … -run TestServer<X>`.
+6. **Promote on request** — specs default to `scratch/`; most are throwaway. After a run the user likes, OFFER to keep it: `git mv tests/characterization/matrix/scratch/<name>.yaml tests/characterization/matrix/ && git add` (now tracked + covered by the `matrix/*.yaml` validation glob). Never promote unasked.
 
 ## char-matrix knob reference (authoritative — `internal/charmatrix/spec.go`)
 Run-level: `name`, `class`, `platform`, `content`, `duration_s`, `reps`, `parallel`, `defaults:`, `axes:` (cartesian) | `groups:`/`compare:`/`control:` (A/B).
 Client `is.*` (launch arg, **cold relaunch**): `is.segment` · `is.protocol` (hls|dash) · `is.codec` (h264|hevc|av1) · `is.live_offset` · `is.peak_bitrate_mbps` (0=off) · `is.starts_first_variant`.
 Server `proxy.*` (config-on-connect, **no relaunch**): `proxy.live_offset` · `proxy.shape` (object-axis: a whole shape block, optional `label:`) · `proxy.fault` · `proxy.transfer_timeouts` · `proxy.allowed_variants` (drop-top-N|keep-bottom-N) · `proxy.variant_order` · `proxy.strip_*` · `proxy.overstate_bandwidth`. `0 = unset` for numeric knobs.
-**Living examples:** `matrix/precedence.yaml`, `matrix/shape-patterns.yaml`, `matrix/startup-cap.yaml` (copy structure, NOT their stale `content:`).
+**Living examples:** `matrix/precedence.yaml`, `matrix/shape-patterns.yaml`, `matrix/pyramid-1-s2-firstvar-cap.yaml` (copy structure, NOT their stale `content:`).
 
 ## server-behavior skeleton (`sb_common_test.go`)
 `TestServer<X>(t)`: `newProbe(t)`; sweep the control surface via `setShapeFull`/`patchSession`; measure baseline at the identity setting, report each setting's delta within a stated tolerance; `postServerReport`. Contract as a top comment ("RTT ≈ baseline + configured_delay within a few ms"). Mirror the closest `server_*_test.go`.

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,11 @@ tests/integration/test_run.log
 tests/characterization/artifacts/
 tests/characterization/modes/artifacts/
 
+# Throwaway char-matrix specs — generate here by default; promote a keeper up
+# to tests/characterization/matrix/ (git add) when it's worth keeping. Subdir,
+# so the matrix/*.yaml validation glob in examples_test.go never sees these.
+tests/characterization/matrix/scratch/
+
 # Xcode user state
 apple/InfiniteStreamPlayer/InfiniteStreamPlayer.xcodeproj/project.xcworkspace/xcuserdata/
 


### PR DESCRIPTION
## What

Generated char-matrix specs were landing **untracked** inside the **tracked** `tests/characterization/matrix/` dir — so they piled up in `git status` indefinitely and risked breaking the `matrix/*.yaml` validation glob in `examples_test.go` the moment one was added with a typo.

## Change

- **`.gitignore`**: add `tests/characterization/matrix/scratch/` — a gitignored home for throwaway specs (subdir, so the non-recursive `matrix/*.yaml` validation glob never sees them).
- **test-author skill**: step 5 now writes generated specs to `matrix/scratch/<name>.yaml` by default; new **step 6** offers to *promote* a keeper up to `matrix/` (`git mv … && git add`) on request — never unasked. Most specs are throwaway, so this is the right default.
- Repairs the skill's dangling `matrix/startup-cap.yaml` example reference → tracked `pyramid-1-s2-firstvar-cap.yaml`.

## Effect

Future generated tests make zero git noise; you opt-in to keep one only after you've run it and want it. No behavior change to the harness — `harness char matrix <path>` already takes any path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
