### PR TITLE
feat(proxy): single-owner group-pattern fan-out + driven-slave shaping UI

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1469,6 +1469,16 @@ components:
           nullable: true
           readOnly: true
           description: 'Effective rate the kernel is enforcing right now from the active step. Distinct from `rate_mbps` (the static fallback when pattern is off).'
+        group_driven_by:
+          type: string
+          nullable: true
+          readOnly: true
+          description: 'Single-owner group shaping: when non-empty, this session has NO pattern of its own — its kernel cap is fanned per-tick from the group master named here (display label / short player_id). The slave UI shows a "driven by master" badge + a disabled rate slider; `pattern_rate_runtime_mbps` carries the live cap.'
+        group_driven_template:
+          type: string
+          nullable: true
+          readOnly: true
+          description: 'The pattern template (e.g. `pyramid`) the group master is running, surfaced on a driven slave for its "driven by master — <template>" label. Empty unless `group_driven_by` is set.'
 
     Pattern:
       type: object

--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -99,6 +99,40 @@ function appendPeakLadder(
       groupLegend,
       ...(opts.tag ? { sessionTag: opts.tag } : {}),
       hidden: opts.hidden,
+      excludeFromAutoScale: true, // reference ladder — don't let it drive the auto y-axis
+    });
+  }
+}
+
+/** Append the per-variant avg↔peak BAND series for a ladder — a light filled
+ *  region (fillToValue=avg) per variant, drawn behind the rung lines. Mirrors
+ *  appendPeakLadder; tagged in compare mode so the S1/S2 legend toggles each
+ *  session's bands in lockstep. Always excludeFromAutoScale (reference overlay).
+ *  Skips a variant lacking a usable avg < peak. */
+function appendBands(
+  out: SeriesSpec[],
+  ladder: ReadonlyArray<VariantLite>,
+  opts: { hidden: boolean; tag?: string },
+): void {
+  const groupLegend = opts.tag ? `Variant Bands (${opts.tag})` : 'Variant Bands';
+  for (const v of ladder) {
+    const peakBw = Number(v.bandwidth);
+    const avgBw = Number((v as { average_bandwidth?: number }).average_bandwidth);
+    if (!Number.isFinite(peakBw) || peakBw <= 0) continue;
+    if (!Number.isFinite(avgBw) || avgBw <= 0 || avgBw >= peakBw) continue;
+    const peakMbps = peakBw / 1_000_000;
+    const avgMbps = avgBw / 1_000_000;
+    const label = `Variant band ${v.resolution ?? '?'} (${avgMbps.toFixed(2)}–${peakMbps.toFixed(2)} Mbps)`;
+    out.push({
+      label: opts.tag ? `${label} (${opts.tag})` : label,
+      color: '#38bdf8',
+      accessor: () => peakMbps,
+      fillToValue: avgMbps,
+      stepped: false,
+      groupLegend,
+      ...(opts.tag ? { sessionTag: opts.tag } : {}),
+      hidden: opts.hidden,
+      excludeFromAutoScale: true,
     });
   }
 }
@@ -176,6 +210,13 @@ function extractSegmentMarkers(
         if (Number.isFinite(v)) mbps = v;
         const cached = String(parsed.derived_from_cache ?? '0');
         if (cached === '1') continue; // skip cache-served requests
+        // Skip the EXT-X-MAP init segment: AVPlayer reports it as a video
+        // HLSMediaSegmentRequestEvent too, but it's a ~900-byte init/codec header
+        // (no media frames) that transfers in sub-ms — so its derived_mbps is a
+        // meaningless spike at every variant switch. A real media segment (even a
+        // low-bitrate partial) is far larger than this floor. #811.
+        const segBytes = Number(parsed.derived_bytes);
+        if (Number.isFinite(segBytes) && segBytes > 0 && segBytes < 4096) continue;
         // Tooltip body — short event-type label, the path
         // (filename only — full URL is too long for the floating
         // tooltip), and the derived bandwidth / transfer details.
@@ -311,7 +352,13 @@ const baseSeries: SeriesSpec[] = [
       const sh = p.shape;
       if (!sh) return 0;
       const runtime = sh.pattern_rate_runtime_mbps;
-      if (sh.pattern && Number.isFinite(runtime as number) && (runtime as number) >= 0) {
+      // Use the kernel's enforced runtime rate whenever it's set — not only when
+      // THIS session owns a pattern. A group-driven slave (single-owner shaping)
+      // has no local pattern but its port is fanned the master's per-tick rate via
+      // `nftables_pattern_rate_runtime_mbps`, so this lets the slave's Limit line
+      // track the master's pyramid. Safe for normal no-pattern sessions: the proxy
+      // defaults runtime to `bandwidth_mbps` (== rate_mbps), so the line is unchanged.
+      if (Number.isFinite(runtime as number) && (runtime as number) >= 0) {
         return runtime as number;
       }
       const stepIdx = Number(sh.pattern_step_runtime ?? sh.pattern_step ?? 0);
@@ -397,6 +444,7 @@ const series = computed<SeriesSpec[]>(() => {
     // rungs. Each sibling builds its OWN ladder from its OWN manifest in the
     // useCompareOverlays closure below, so manifests that differ across the
     // compared sessions show distinct rung sets (issue #812).
+    appendBands(compareOut, variants.value, { hidden: true, tag: self.tag });
     appendPeakLadder(compareOut, variants.value, { hidden: true, tag: self.tag, dash: self.dash });
     return compareOut;
   }
@@ -446,23 +494,7 @@ const series = computed<SeriesSpec[]>(() => {
   // sitting at/below the rung-below's peak (#811) — or leave GAPS. Fill is
   // semi-transparent, so overlapping bands compound into a darker tint. Built
   // BEFORE the avg/peak ladder lines so the bands draw BEHIND those rung lines.
-  for (const v of ladder) {
-    const peakBw = Number(v.bandwidth);
-    const avgBw = Number((v as { average_bandwidth?: number }).average_bandwidth);
-    if (!Number.isFinite(peakBw) || peakBw <= 0) continue;
-    if (!Number.isFinite(avgBw) || avgBw <= 0 || avgBw >= peakBw) continue;
-    const peakMbps = peakBw / 1_000_000;
-    const avgMbps = avgBw / 1_000_000;
-    out.push({
-      label: `Variant band ${v.resolution ?? '?'} (${avgMbps.toFixed(2)}–${peakMbps.toFixed(2)} Mbps)`,
-      color: '#38bdf8',
-      accessor: () => peakMbps,
-      fillToValue: avgMbps,
-      stepped: false,
-      groupLegend: 'Variant Bands',
-      hidden: true,
-    });
-  }
+  appendBands(out, ladder, { hidden: true });
   // Mute the variant-line color so it doesn't out-shout the live
   // traces. Slate-400 reads at a glance but stays in the background.
   const AVG_COLOR = '#94a3b8';
@@ -479,6 +511,7 @@ const series = computed<SeriesSpec[]>(() => {
         borderDash: [2, 4],
         groupLegend: 'Variant avg bandwidth',
         hidden: true,
+        excludeFromAutoScale: true, // reference ladder — don't let it drive the auto y-axis
       });
     }
   }
@@ -501,6 +534,7 @@ const compareOverlays = useCompareOverlays((sib) => {
   // its events stream — so comparing two sessions whose manifests differ
   // shows each one's distinct rung set. Hidden by default, tagged + dashed
   // per session so the S1/S2 legend toggles it in lockstep (issue #812).
+  appendBands(specs, latestManifestVariants(sib.stream), { hidden: true, tag: sib.tag });
   appendPeakLadder(specs, latestManifestVariants(sib.stream), {
     hidden: true,
     tag: sib.tag,

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -64,6 +64,11 @@ export interface SeriesSpec {
    *  semi-transparent tint of `color`, so overlapping bands compound to a
    *  darker shade. Used for the bandwidth chart's per-variant avg↔peak bands. */
   fillToValue?: number;
+  /** Exclude this series from y-axis AUTO-scaling (when no explicit yMax is set):
+   *  the auto range is computed from the OTHER series only. For static reference
+   *  lines — the variant peak/avg ladder + the avg↔peak bands — which otherwise
+   *  blow the auto-axis up to the top (4K) rung and squash the live traces. */
+  excludeFromAutoScale?: boolean;
 }
 
 /**
@@ -357,6 +362,7 @@ function makeDsObj(
     hidden: !!s.hidden,
     _groupLegend: s.groupLegend ?? null,
     _sessionTag: s.sessionTag ?? null,
+    _excludeFromAutoScale: !!s.excludeFromAutoScale,
     _dsKey: dsKey,
   };
 }
@@ -402,6 +408,7 @@ function buildPrimaryDatasetObjs(): any[] {
       prev.hidden = legendVis.resolveHidden(s); // persisted toggle survives a new play_id
       prev._groupLegend = s.groupLegend ?? null;
       prev._sessionTag = s.sessionTag ?? null;
+      prev._excludeFromAutoScale = !!s.excludeFromAutoScale;
       dataset[i] = prev.data;
       out.push(prev);
     } else {
@@ -452,6 +459,7 @@ function buildOverlayDatasetObjs(): any[] {
         prev.spanGaps = false;
         prev._groupLegend = s.groupLegend ?? null;
         prev._sessionTag = s.sessionTag ?? null;
+        prev._excludeFromAutoScale = !!s.excludeFromAutoScale;
         rt.datasets[i] = prev.data;
         out.push(prev);
       } else {
@@ -1010,6 +1018,31 @@ function createChartInstance(Chart: any): any {
             ? { display: true, text: props.unit, font: { size: 10 } }
             : undefined,
           afterFit: pinYWidth,
+          // Auto-scale (no explicit yMax) ignores reference series flagged
+          // _excludeFromAutoScale — the variant peak/avg ladder + the avg↔peak
+          // bands — which otherwise pin the axis to the top (4K) rung and squash
+          // the live traces. Recompute max over the OTHER visible left-axis
+          // series within the current x-view. An explicit yMax (the Y-axis
+          // selector / persisted bandwidthYMax) is respected (early return).
+          afterDataLimits: (scale: any) => {
+            if (props.yMax != null) return;
+            const ch = scale.chart;
+            const xs = ch.scales?.x;
+            const xmin = xs?.min ?? -Infinity;
+            const xmax = xs?.max ?? Infinity;
+            let max = -Infinity;
+            (ch.data.datasets as any[]).forEach((ds: any, i: number) => {
+              if (ds._excludeFromAutoScale) return;
+              if ((ds.yAxisID ?? 'y') !== 'y') return;
+              if (!ch.isDatasetVisible(i)) return;
+              for (const pt of (ds.data as Array<{ x: number; y: number | null }>)) {
+                if (!pt || pt.y == null) continue;
+                if (pt.x < xmin || pt.x > xmax) continue;
+                if (pt.y > max) max = pt.y;
+              }
+            });
+            if (max > -Infinity && max > 0) scale.max = max * 1.1;
+          },
         },
         ...(usesY2 ? {
           y2: {

--- a/content/dashboard-v3/src/components/NetworkShapingPattern.vue
+++ b/content/dashboard-v3/src/components/NetworkShapingPattern.vue
@@ -139,6 +139,20 @@ const activeTemplate = computed<Template>(() => {
   return 'sliders';
 });
 
+// Single-owner group shaping: a driven SLAVE has no pattern of its own — its
+// kernel cap is fanned per-tick from the group master (`group_driven_by`). When
+// driven we replace the editable template UI with a read-only "driven by master"
+// banner so the operator can't arm a competing pattern on the slave. Guarded on
+// `!pattern` so the MASTER (which carries the pattern) shows the normal editor —
+// the proxy stamps the marker on the master too, but its own pattern wins here.
+const groupDrivenBy = computed<string | null>(() => {
+  const by = player.value?.shape?.group_driven_by;
+  return !pattern.value && by ? by : null;
+});
+const groupDrivenTemplate = computed<string | null>(
+  () => player.value?.shape?.group_driven_template ?? null,
+);
+
 const margin = computed<Margin>(() => {
   const src = editMode.value ? draftPattern.value : pattern.value;
   const m = src?.margin_pct;
@@ -469,7 +483,15 @@ const runtimeStep = computed(() => player.value?.shape?.pattern_step_runtime ?? 
 
 <template>
   <div v-if="player" class="shape-pattern">
-    <div class="row template-row">
+    <!-- Single-owner group shaping: a driven slave has no pattern of its own;
+         show a read-only "driven by master" banner instead of the editable
+         template UI so the operator can't arm a competing pattern on it. -->
+    <div v-if="groupDrivenBy" class="driven-banner">
+      ⛓ Shaping driven by group master <strong>{{ groupDrivenBy }}</strong>
+      <span v-if="groupDrivenTemplate"> — {{ groupDrivenTemplate }}</span>
+      <span v-if="runtimeMbps !== null" class="driven-rate"> · <strong>{{ runtimeMbps.toFixed(2) }} Mbps</strong></span>
+    </div>
+    <div v-if="!groupDrivenBy" class="row template-row">
       <span class="lbl">Template</span>
       <div class="radio-group">
         <label v-for="t in TEMPLATES" :key="t">
@@ -513,7 +535,7 @@ const runtimeStep = computed(() => player.value?.shape?.pattern_step_runtime ?? 
            pattern is yet applied (first run from sliders → template).
            Hidden when a pattern is applied and the user has clicked
            Apply Pattern (collapses the definition panel back). -->
-      <template v-if="editMode || !pattern">
+      <template v-if="(editMode || !pattern) && !groupDrivenBy">
       <div class="row">
         <span class="lbl">Margin</span>
         <div class="radio-group">
@@ -567,7 +589,7 @@ const runtimeStep = computed(() => player.value?.shape?.pattern_step_runtime ?? 
         </div>
       </div>
 
-      <div class="runtime" v-if="runtimeMbps !== null">
+      <div class="runtime" v-if="runtimeMbps !== null && !groupDrivenBy">
         Running step <strong>{{ runtimeStep ?? '?' }}</strong> at
         <strong>{{ runtimeMbps.toFixed(2) }} Mbps</strong>
       </div>
@@ -708,6 +730,25 @@ const runtimeStep = computed(() => player.value?.shape?.pattern_step_runtime ?? 
   padding: 10px 14px;
   font-size: 13px;
   color: #065f46;
+}
+
+/* Single-owner group shaping — a driven slave's read-only banner. Slate/blue so
+ * it reads as "inherited from the group master", distinct from the green
+ * applied-summary (this session's own pattern). */
+.driven-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-size: 13px;
+  color: #1e40af;
+}
+.driven-rate {
+  color: #1d4ed8;
 }
 .applied-chip {
   font-weight: 700;

--- a/content/dashboard-v3/src/components/ShapeSliders.vue
+++ b/content/dashboard-v3/src/components/ShapeSliders.vue
@@ -48,17 +48,26 @@ const patternRunning = computed(() => {
   return !!(p && Array.isArray(p.steps) && p.steps.length);
 });
 
+// Single-owner group shaping: a driven SLAVE has no pattern of its own but its
+// kernel cap is fanned per-tick from the group master (`group_driven_by`). Show
+// the same disabled-slider + runtime-rate treatment as a local pattern, with a
+// "driven by master" annotation. Guarded on `!patternRunning` so the MASTER
+// (which carries the pattern) never reads as driven — the proxy stamps the
+// marker on the master too, but its own pattern takes precedence here.
+const groupDrivenBy = computed<string | null>(() => {
+  const by = player.value?.shape?.group_driven_by;
+  return !patternRunning.value && by ? by : null;
+});
+
 // What the slider displays. Local wins during drag; model wins
-// otherwise. When a pattern is running we display the kernel-
-// enforced runtime rate (`pattern_rate_runtime_mbps`) instead of the
-// static `rate_mbps` so the slider tracks the pattern as it steps,
-// matching the legacy behaviour the operator expects. Slider is
-// disabled in that mode (see `patternRunning`) so the moving handle
-// is read-only.
+// otherwise. When a pattern is running — OR this is a group-driven slave — we
+// display the kernel-enforced runtime rate (`pattern_rate_runtime_mbps`) instead
+// of the static `rate_mbps` so the slider tracks the pattern as it steps. Slider
+// is disabled in those modes (see template) so the moving handle is read-only.
 const dispRate = computed(() => {
   if (localRate.value !== null) return localRate.value;
   const sh = player.value?.shape;
-  if (patternRunning.value) {
+  if (patternRunning.value || groupDrivenBy.value) {
     const rt = sh?.pattern_rate_runtime_mbps;
     if (rt != null && Number.isFinite(rt)) return rt;
   }
@@ -144,10 +153,11 @@ watch(
       <span class="val">{{ dispLoss.toFixed(1) }} %</span>
     </div>
 
-    <div class="row" :class="{ disabled: patternRunning }">
+    <div class="row" :class="{ disabled: patternRunning || !!groupDrivenBy }">
       <label for="ss-rate">
         Throughput
         <span v-if="patternRunning" class="hint">(pattern active)</span>
+        <span v-else-if="groupDrivenBy" class="hint">⛓ driven by group master {{ groupDrivenBy }}</span>
       </label>
       <input
         id="ss-rate"
@@ -156,7 +166,7 @@ watch(
         max="50"
         step="0.1"
         :value="dispRate"
-        :disabled="patternRunning"
+        :disabled="patternRunning || !!groupDrivenBy"
         @input="onRateInput"
       />
       <span class="val">

--- a/content/dashboard-v3/src/composables/compareSeries.ts
+++ b/content/dashboard-v3/src/composables/compareSeries.ts
@@ -83,7 +83,14 @@ function limitAccessor(p: PlayerRecord): number | null {
   } | undefined;
   if (!sh) return 0;
   const runtime = sh.pattern_rate_runtime_mbps;
-  if (sh.pattern && Number.isFinite(runtime as number) && (runtime as number) >= 0) {
+  // Use the kernel's enforced runtime rate whenever it's set — not only when THIS
+  // session owns a pattern. A group-driven slave (single-owner shaping) has no
+  // local pattern but its port is fanned the master's per-tick rate via
+  // pattern_rate_runtime_mbps, so this lets the slave's Limit line track the
+  // master's pyramid. Safe for normal no-pattern sessions: the proxy defaults
+  // runtime to bandwidth_mbps (== rate_mbps), so the line is unchanged. Mirrors
+  // the same fix in BandwidthChart.vue's single-session accessor.
+  if (Number.isFinite(runtime as number) && (runtime as number) >= 0) {
     return runtime as number;
   }
   const stepIdx = Number(sh.pattern_step_runtime ?? sh.pattern_step ?? 0);

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -92,15 +92,10 @@ const chatScope = computed<ChatScope>(() => {
   };
 });
 
-/** "Show before/after" toggle. When ON, SessionDisplay drops the
- *  play_id filter on its SSE subscription and widens the time
- *  window to play_bounds ± 5 min, so rows from neighbouring plays
- *  for the same player become visible in the same panel layout.
- *  Default OFF — the page is locked to this play, matching the
- *  "click a session row, see that session" mental model from
- *  sessions.html. */
-const showContext = ref<boolean>(false);
-function toggleShowContext() { showContext.value = !showContext.value; }
+// Session-viewer is always scoped to this play — play_id is passed straight to
+// the SSE, the same play-scoped view testing.html uses. The old "showing context
+// / this play only" padlock toggle was removed for parity with testing.html (and
+// because it was confusing); the play_id filter is simply always on here.
 
 // Starred state — backed by TanStack so the optimistic flip, the
 // mutation rollback, and any future cache invalidations follow the
@@ -253,32 +248,9 @@ const backHref = '/dashboard/sessions.html';
               <span class="meta-label">player</span>
               <code class="id-pill" :title="playerId">{{ playerId || '(no player)' }}</code>
               <span class="meta-label">play</span>
-              <!-- play_id gets a "disabled" style when showContext is on:
-                   the SSE has dropped the play_id filter so the id shown
-                   here is no longer what's actually being filtered. The
-                   strike + muted colour signals "this label doesn't
-                   reflect what you're currently looking at". -->
-              <code
-                class="id-pill"
-                :class="{ 'id-pill-disabled': showContext }"
-                :title="showContext
-                  ? `${playId ?? '(all plays)'} — filter disabled while showing context`
-                  : (playId ?? '(all plays)')"
-              >{{ playId ?? '(all plays)' }}</code>
+              <code class="id-pill" :title="playId ?? '(all plays)'">{{ playId ?? '(all plays)' }}</code>
             </div>
             <div class="banner-actions">
-              <button
-                type="button"
-                class="banner-btn"
-                :class="{ active: showContext }"
-                @click="toggleShowContext"
-                :disabled="!playId"
-                :title="showContext
-                  ? 'Snap back to this play only'
-                  : 'Show rows from before and after this play (same player, ±5 min)'"
-              >
-                {{ showContext ? '🔓 Showing context' : '🔒 This play only' }}
-              </button>
               <button
                 type="button"
                 class="banner-btn"
@@ -297,7 +269,6 @@ const backHref = '/dashboard/sessions.html';
           <SessionDisplay
             :player-id="playerId"
             :play-id="playId"
-            :show-context="showContext"
             :start-ms="startMs"
             :end-ms="endMs"
             :compare-plays="comparePlays"

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1430,6 +1430,13 @@ export interface components {
              */
             shape?: components["schemas"]["Shape"];
             /**
+             * @description Client-side config the player applies at its next play boundary
+             *     (#800). Stored server-side; the player reads it from
+             *     `GET /api/sessions` and overlays it on the next play.
+             *     *Broadcasts to group on PATCH.*
+             */
+            app_config?: components["schemas"]["AppConfig"];
+            /**
              * @description Per-device fault hit counters.
              *     *Per-device runtime state — does not broadcast to group.*
              */
@@ -1525,6 +1532,7 @@ export interface components {
             shape?: components["schemas"]["Shape"];
             transfer_timeouts?: components["schemas"]["TransferTimeouts"];
             content?: components["schemas"]["ContentManipulation"];
+            app_config?: components["schemas"]["AppConfig"];
         };
         /**
          * @description Live play state. The same `PlayRecord` schema is also used in the
@@ -1818,6 +1826,10 @@ export interface components {
              * @description Effective rate the kernel is enforcing right now from the active step. Distinct from `rate_mbps` (the static fallback when pattern is off).
              */
             readonly pattern_rate_runtime_mbps?: number | null;
+            /** @description Single-owner group shaping: when non-empty, this session has NO pattern of its own — its kernel cap is fanned per-tick from the group master named here (display label / short player_id). The slave UI shows a "driven by master" badge + a disabled rate slider; `pattern_rate_runtime_mbps` carries the live cap. */
+            readonly group_driven_by?: string | null;
+            /** @description The pattern template (e.g. `pyramid`) the group master is running, surfaced on a driven slave for its "driven by master — <template>" label. Empty unless `group_driven_by` is set. */
+            readonly group_driven_template?: string | null;
         };
         Pattern: {
             /**
@@ -1914,6 +1926,40 @@ export interface components {
              * @enum {integer}
              */
             live_offset: 0 | 2 | 4 | 6 | 12 | 18 | 24 | 30 | 36 | 42;
+        };
+        /**
+         * @description Client-side ("app behaviour") config the player applies at its next
+         *     play boundary — the per-play, no-restart counterpart to the cold-start
+         *     launch args (`is.segment` etc., #797). The proxy stores these per
+         *     session and surfaces them on `GET /api/sessions`; the player overlays
+         *     any non-null field onto its own state when it opens the next play
+         *     (segment/protocol drive the manifest URL; live_offset_s and
+         *     peak_bitrate_mbps drive the ExoPlayer/AVPlayer track selector). A
+         *     null/omitted field leaves the player's own value untouched.
+         *
+         *     Server-side (`proxy.*` / ContentManipulation) config already
+         *     reconfigures per-play with no restart; this brings the client-side
+         *     half in line. Settable via `PATCH /api/session/{id}` or the
+         *     `app.<field>` config-on-connect URL args. Issue #800.
+         */
+        AppConfig: {
+            /**
+             * @description Segment ladder for the next play (maps to the client `is.segment` lever). ll / s2 / s6.
+             * @enum {string|null}
+             */
+            segment?: "ll" | "s2" | "s6" | null;
+            /**
+             * @description Streaming protocol for the next play (maps to `is.protocol`).
+             * @enum {string|null}
+             */
+            protocol?: "hls" | "dash" | null;
+            /**
+             * Format: float
+             * @description Live-edge offset in seconds for the next play (maps to `is.flag.live_offset_s`). 0 = let the manifest HOLD-BACK / Go Live decide.
+             */
+            live_offset_s?: number | null;
+            /** @description ABR peak-bitrate ceiling in Mbps for the next play (maps to `is.flag.peak_bitrate_mbps`). 0 = no cap. */
+            peak_bitrate_mbps?: number | null;
         };
         Manifest: {
             /** Format: uri */

--- a/go-proxy/cmd/server/group_pattern_fanout_test.go
+++ b/go-proxy/cmd/server/group_pattern_fanout_test.go
@@ -1,0 +1,121 @@
+package main
+
+import "testing"
+
+// Single-owner group shaping (issue: single-master group shaping). The pattern
+// loop runs on ONE master; each tick fanPatternRateToGroup mirrors the master's
+// cap onto the group's other members and stamps the "driven by master" markers
+// the slave UI reads — without arming a per-member pattern. These tests exercise
+// that fan-out + the owner-label resolution with an in-memory App (no tc): a
+// zero-value portMap makes sessionPortToInternal an identity, and pre-seeding the
+// member's shape-apply state to the fanned rate makes applyShapeIfChanged
+// short-circuit as "unchanged" so it never shells out to the kernel.
+
+func newFanoutTestApp(sessions []SessionData, shapeApply map[int]ShapeApplyState) *App {
+	a := &App{shapeApply: shapeApply}
+	a.sessionsSnap.Store(&sessions)
+	return a
+}
+
+func TestPatternOwnerLabels_PlayerIDFallbackAndTemplate(t *testing.T) {
+	master := SessionData{
+		"player_id":         "abb13111-9e46-4230-bd48-031b92154b63",
+		"group_id":          "pyramid-2sim/pairX",
+		"x_forwarded_port":  "30181",
+		"_v2_shape_pattern": map[string]interface{}{"template": "pyramid"},
+	}
+	slave := SessionData{
+		"player_id":        "c929ba15-a846-4606-84fe-54c33d9e5f48",
+		"group_id":         "pyramid-2sim/pairX",
+		"x_forwarded_port": "30281",
+	}
+	a := newFanoutTestApp([]SessionData{master, slave}, map[int]ShapeApplyState{})
+
+	by, tmpl := a.patternOwnerLabels(30181)
+	// No display_id → short (8-char) player_id.
+	if by != "abb13111" {
+		t.Errorf("drivenBy: want short player_id %q, got %q", "abb13111", by)
+	}
+	// Template read from the master's _v2_shape_pattern.
+	if tmpl != "pyramid" {
+		t.Errorf("drivenTemplate: want %q, got %q", "pyramid", tmpl)
+	}
+}
+
+func TestPatternOwnerLabels_DisplayIDPreferred(t *testing.T) {
+	master := SessionData{
+		"player_id":        "abb13111-9e46-4230-bd48-031b92154b63",
+		"display_id":       "lab-master-7",
+		"group_id":         "G",
+		"x_forwarded_port": "30181",
+	}
+	a := newFanoutTestApp([]SessionData{master}, map[int]ShapeApplyState{})
+	by, _ := a.patternOwnerLabels(30181)
+	if by != "lab-master-7" {
+		t.Errorf("drivenBy: want display_id %q, got %q", "lab-master-7", by)
+	}
+}
+
+func TestFanPatternRateToGroup_StampsSlaveOnly(t *testing.T) {
+	master := SessionData{
+		"player_id":        "abb13111-9e46-4230-bd48-031b92154b63",
+		"group_id":         "G",
+		"x_forwarded_port": "30181",
+	}
+	slave := SessionData{
+		"player_id":        "c929ba15-a846-4606-84fe-54c33d9e5f48",
+		"group_id":         "G",
+		"x_forwarded_port": "30281",
+	}
+	// Pre-seed the slave's apply-state to the rate we'll fan so applyShapeIfChanged
+	// short-circuits ("unchanged") and never touches tc — lets the test run off-Linux.
+	a := newFanoutTestApp(
+		[]SessionData{master, slave},
+		map[int]ShapeApplyState{30281: {rate: 2.5, delay: 0, loss: 0}},
+	)
+
+	a.fanPatternRateToGroup(30181, 2.5, 0, 0, "M1", "pyramid")
+
+	var ms, sv SessionData
+	for _, s := range a.sessionsView() {
+		switch getString(s, "x_forwarded_port") {
+		case "30181":
+			ms = s
+		case "30281":
+			sv = s
+		}
+	}
+	if sv == nil {
+		t.Fatal("slave session missing after fan-out")
+	}
+	// Slave gets the fanned rate + the driven markers.
+	if got := getFloat(sv, "nftables_pattern_rate_runtime_mbps"); got != 2.5 {
+		t.Errorf("slave rate_runtime: want 2.5, got %v", got)
+	}
+	if got := getString(sv, "nftables_pattern_driven_by"); got != "M1" {
+		t.Errorf("slave driven_by: want %q, got %q", "M1", got)
+	}
+	if got := getString(sv, "nftables_pattern_driven_template"); got != "pyramid" {
+		t.Errorf("slave driven_template: want %q, got %q", "pyramid", got)
+	}
+	// Master (the origin) is the single owner — it must NOT be fanned onto as a
+	// driven slave (it carries its own pattern). The UI also guards on this.
+	if got := getString(ms, "nftables_pattern_driven_by"); got != "" {
+		t.Errorf("master should not be stamped driven_by, got %q", got)
+	}
+}
+
+func TestFanPatternRateToGroup_NoGroupIsNoop(t *testing.T) {
+	// A lone (ungrouped) session must not panic or stamp anything.
+	solo := SessionData{
+		"player_id":        "abb13111-9e46-4230-bd48-031b92154b63",
+		"x_forwarded_port": "30181",
+	}
+	a := newFanoutTestApp([]SessionData{solo}, map[int]ShapeApplyState{})
+	a.fanPatternRateToGroup(30181, 2.5, 0, 0, "M1", "pyramid")
+	for _, s := range a.sessionsView() {
+		if got := getString(s, "nftables_pattern_driven_by"); got != "" {
+			t.Errorf("ungrouped session should not be stamped, got %q", got)
+		}
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3886,6 +3886,9 @@ func (a *App) runShapePatternLoop(ctx context.Context, port int, steps []NftShap
 			break
 		}
 	}
+	// Resolve the owner labels once (master identity + template) for the slave
+	// "driven by master" markers fanned out each tick.
+	drivenBy, drivenTemplate := a.patternOwnerLabels(port)
 	stepIndex := 0
 	for {
 		select {
@@ -3950,7 +3953,11 @@ func (a *App) runShapePatternLoop(ctx context.Context, port int, steps []NftShap
 			"nftables_pattern_step":              stepIndex + 1,
 			"nftables_pattern_step_runtime":      stepIndex + 1,
 			"nftables_pattern_rate_runtime_mbps": step.RateMbps,
+			"nftables_pattern_master":            true,
 		})
+		// Single-owner group shaping: mirror this step's cap onto the rest of the
+		// group so every member tracks the master in lock-step (no per-member loop).
+		a.fanPatternRateToGroup(port, step.RateMbps, delayMs, loss, drivenBy, drivenTemplate)
 		// Emit pattern_step as a control_event for every session on
 		// this port (issue #474 Milestone B). Info is a tiny JSON
 		// blob so downstream (graphs, harness archive) can read
@@ -3989,6 +3996,75 @@ func (a *App) disablePatternForPort(port int) {
 	// applySessionSettingsUpdate (e.g. switching to sliders mode,
 	// session release, group reset). Issue #474 follow-up.
 	a.emitControlEventForPort(port, "proxy", "pattern_disabled", "")
+}
+
+// fanPatternRateToGroup applies the master's current pattern rate to every OTHER
+// port in the master's group — the single-owner model. This pattern loop is the
+// only engine; each tick mirrors its cap onto the group's members so they track
+// in lock-step with zero drift. Members get the kernel cap via applyShapeIfChanged
+// (change-detected → an unchanged member is a no-op) plus display markers
+// (rate_runtime + driven_by + driven_template) so the dashboard shows "driven by
+// master" WITHOUT arming a per-member pattern (no steps, no step-clock). The group
+// is re-enumerated every call, so a member that connected/reattached after the
+// master armed is picked up on the next tick (no dependence on instantiation order).
+func (a *App) fanPatternRateToGroup(originPort int, rate float64, delay int, loss float64, drivenBy, drivenTemplate string) {
+	snap := a.sessionsView() // #740 read-only: group/port lookups only
+	gid := a.getGroupIdByPort(originPort, snap)
+	if gid == "" {
+		log.Printf("NETSHAPE group fan-out skipped port=%d reason=no_group_id sessions=%d", originPort, len(snap))
+		return
+	}
+	ports := a.getPortsForGroup(gid, snap)
+	fanned := 0
+	for _, gp := range ports {
+		if gp == originPort {
+			continue
+		}
+		if err := a.applyShapeIfChanged(gp, rate, delay, loss); err != nil {
+			log.Printf("NETSHAPE group pattern fan-out failed port=%d group=%s rate_mbps=%.3f: %v", gp, gid, rate, err)
+			continue
+		}
+		// Display only — the member's chart Limit line + slider track the master's
+		// cap. Deliberately NO setShapeRuntimeStep / nftables_pattern_steps: members
+		// stay template-less and step-clock-less (single owner = the master).
+		a.updateSessionsByPort(gp, map[string]interface{}{
+			"nftables_pattern_rate_runtime_mbps": rate,
+			"nftables_pattern_driven_by":         drivenBy,
+			"nftables_pattern_driven_template":   drivenTemplate,
+		})
+		fanned++
+	}
+	// #single-owner debug: surface what the fan-out resolved each tick so a
+	// non-firing group (slaves stuck at their connect cap) is diagnosable from
+	// the proxy log — origin port, resolved group, ALL member ports the group
+	// enumerated, and how many were actually fanned.
+	log.Printf("NETSHAPE group fan-out port=%d group=%s member_ports=%v fanned=%d rate_mbps=%.3f", originPort, gid, ports, fanned, rate)
+}
+
+// patternOwnerLabels reads the master (origin) session for the labels the slave
+// UI shows: the master's display label and the active template name. Best-effort —
+// empty strings just mean the slave badge omits that detail.
+func (a *App) patternOwnerLabels(originPort int) (drivenBy, drivenTemplate string) {
+	for _, s := range a.sessionsView() { // #740 read-only
+		if !a.sessionMatchesPort(s, originPort) {
+			continue
+		}
+		drivenBy = getString(s, "display_id")
+		if drivenBy == "" {
+			pid := getString(s, "player_id")
+			if len(pid) > 8 {
+				pid = pid[:8]
+			}
+			drivenBy = pid
+		}
+		if raw, ok := s["_v2_shape_pattern"]; ok {
+			if m, ok := raw.(map[string]interface{}); ok {
+				drivenTemplate = getString(m, "template")
+			}
+		}
+		break
+	}
+	return drivenBy, drivenTemplate
 }
 
 // emitControlEventsForDiff inspects a (before, after) session-state
@@ -4730,29 +4806,11 @@ func (a *App) handleNftPattern(w http.ResponseWriter, r *http.Request) {
 		"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
 	}, "")
 
-	// Propagate to group members
-	snap := a.sessionsView() // #740 read-only: group/port lookups only
-	groupID := a.getGroupIdByPort(port, snap)
-	if groupID != "" {
-		groupPorts := a.getPortsForGroup(groupID, snap)
-		for _, groupPort := range groupPorts {
-			if groupPort == port {
-				continue // Skip the original port
-			}
-			if err := a.applyShapePattern(groupPort, cleanSteps, payload.DelayMs, payload.LossPct); err != nil {
-				log.Printf("NETSHAPE group pattern propagation failed port=%d: %v", groupPort, err)
-				continue
-			}
-			a.updateSessionsByPortWithControl(groupPort, map[string]interface{}{
-				"nftables_pattern_segment_duration_seconds": payload.SegmentDurationSeconds,
-				"nftables_pattern_default_segments":         payload.DefaultSegments,
-				"nftables_pattern_default_step_seconds":     payload.DefaultStepSeconds,
-				"nftables_pattern_template_mode":            payload.TemplateMode,
-				"nftables_pattern_margin_pct":               payload.TemplateMarginPct,
-			}, "")
-			log.Printf("NETSHAPE group pattern propagation applied port=%d group=%s", groupPort, groupID)
-		}
-	}
+	// Single-owner group shaping: the origin port's pattern loop fans each tick's
+	// rate to the group's members (see fanPatternRateToGroup in runShapePatternLoop).
+	// We deliberately do NOT arm a second pattern loop on each member here — that was
+	// the double-arm: N independent per-member loops that drift apart and show the
+	// pattern template on every member instead of just the master.
 
 	writeJSON(w, map[string]interface{}{
 		"success":         true,

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -1928,8 +1928,14 @@ type ServerMetrics struct {
 // `DESIGN.md § shape.transport_fault × shape.loss_pct interaction`.
 type Shape struct {
 	DelayMs *float32 `json:"delay_ms,omitempty"`
-	LossPct *float32 `json:"loss_pct,omitempty"`
-	Pattern *Pattern `json:"pattern,omitempty"`
+
+	// GroupDrivenBy Single-owner group shaping: when non-empty, this session has NO pattern of its own — its kernel cap is fanned per-tick from the group master named here (display label / short player_id). The slave UI shows a "driven by master" badge + a disabled rate slider; `pattern_rate_runtime_mbps` carries the live cap.
+	GroupDrivenBy *string `json:"group_driven_by,omitempty"`
+
+	// GroupDrivenTemplate The pattern template (e.g. `pyramid`) the group master is running, surfaced on a driven slave for its "driven by master — <template>" label. Empty unless `group_driven_by` is set.
+	GroupDrivenTemplate *string  `json:"group_driven_template,omitempty"`
+	LossPct             *float32 `json:"loss_pct,omitempty"`
+	Pattern             *Pattern `json:"pattern,omitempty"`
 
 	// PatternRateRuntimeMbps Effective rate the kernel is enforcing right now from the active step. Distinct from `rate_mbps` (the static fallback when pattern is off).
 	PatternRateRuntimeMbps *float32 `json:"pattern_rate_runtime_mbps,omitempty"`

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -823,6 +823,17 @@ func shapeFromSession(s map[string]any) *oapigen.Shape {
 		f := float32(v)
 		out.PatternRateRuntimeMbps = &f
 	}
+	// Single-owner group shaping markers (issue: single-master group shaping).
+	// A driven slave has no pattern of its own; these tell the UI to show the
+	// "driven by master" badge + disabled slider and which template is running.
+	if by, ok := s["nftables_pattern_driven_by"].(string); ok && by != "" {
+		b := by
+		out.GroupDrivenBy = &b
+	}
+	if tmpl, ok := s["nftables_pattern_driven_template"].(string); ok && tmpl != "" {
+		t := tmpl
+		out.GroupDrivenTemplate = &t
+	}
 	return out
 }
 

--- a/tests/characterization/matrix/pyramid-2sim-s2.yaml
+++ b/tests/characterization/matrix/pyramid-2sim-s2.yaml
@@ -13,7 +13,7 @@ defaults:
   is.peak_bitrate_mbps: 1
   proxy.shape:
     pattern: pyramid                # climb the ladder then descend; master arms it, slave follows via group propagation
-    step_seconds: 18
+    step_seconds: 12
     rate_mbps: 1                    # initial network cap (Mbps) applied at config-on-connect, before the pattern arms
 groups:
   - id: pair

--- a/tests/characterization/matrix/pyramid-2sim-s6.yaml
+++ b/tests/characterization/matrix/pyramid-2sim-s6.yaml
@@ -12,7 +12,7 @@ defaults:
   is.peak_bitrate_mbps: 1
   proxy.shape:
     pattern: pyramid                # climb the ladder then descend; master arms it, slave follows via group propagation
-    step_seconds: 18
+    step_seconds: 12
     rate_mbps: 1                    # initial network cap (Mbps) applied at config-on-connect, before the pattern arms
 groups:
   - id: pair

--- a/tests/characterization/matrix/pyramid-4sim-s2.yaml
+++ b/tests/characterization/matrix/pyramid-4sim-s2.yaml
@@ -1,0 +1,26 @@
+# 4-sim group, s2 (2s nominal) segments — 4× iPhone 15 sim version of
+# pyramid-2sim-s2 to exercise single-owner group shaping across MORE members:
+# control=master arms the pyramid, 3 slaves follow via the proxy's per-tick rate
+# fan-out (one engine, no per-member loops, lock-step). pyramid @ 1 Mbps initial
+# cap + 1 Mbps client cap, NO live_offset, NO alternating.
+name: pyramid-4sim-s2
+class: config
+parallel: true
+reps: 1
+duration_s: 300
+defaults:
+  platform: ipad-sim
+  content: insane_newer_p200_h264
+  is.segment: s2
+  is.peak_bitrate_mbps: 1
+  proxy.shape:
+    pattern: pyramid                # climb the ladder then descend; master arms it, slaves follow via the proxy rate fan-out
+    step_seconds: 12
+    rate_mbps: 1                    # initial network cap (Mbps) applied at config-on-connect, before the pattern arms
+groups:
+  - id: quad
+    control: { id: master }
+    variants:
+      - { id: slave1 }
+      - { id: slave2 }
+      - { id: slave3 }

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -1104,6 +1104,20 @@ func appiumCapabilities(d Device, bundleID string, df bool, platformVersion stri
 		// step Appium does by default — WDA only needs (re)deploy on
 		// real devices.
 		caps["appium:useNewWDA"] = false
+		// Shared prebuilt WDA (CHAR_IOS_PREBUILT_WDA=1): every sim in the booted
+		// pool reuses ONE WDA build at a shared derivedDataPath instead of appium's
+		// per-UDID rebuild (which otherwise rebuilds WDA once per sim — the 4x-build
+		// pain on a 4-sim pool). Requires the shared path to be pre-populated by a
+		// one-time prebuild (boot-pool / `xcodebuild build-for-testing` into the
+		// path); appium ERRORS if usePrebuiltWDA is set with nothing built there, so
+		// it stays OFF by default (per-UDID build, always safe). Gating BOTH caps on
+		// the env means a non-prebuilt run never points concurrent first-builds at
+		// one path (which would race). Safe under DF: derivedDataPath is the build
+		// location, not a port (DF still owns port/session allocation).
+		if os.Getenv("CHAR_IOS_PREBUILT_WDA") == "1" {
+			caps["appium:derivedDataPath"] = sharedSimWDADerivedDataPath()
+			caps["appium:usePrebuiltWDA"] = true
+		}
 		if !df {
 			setXCUITestFleetPorts(caps, d.FleetIndex)
 		}
@@ -1154,4 +1168,22 @@ func iosWDADerivedDataPath(fleetIndex int) string {
 		base = filepath.Join(home, ".appium-wda-deriveddata")
 	}
 	return filepath.Join(base, fmt.Sprintf("wda-%d", fleetIndex))
+}
+
+// sharedSimWDADerivedDataPath is the ONE derivedDataPath every iOS simulator
+// session shares when CHAR_IOS_PREBUILT_WDA=1 — so WDA is built once (a prebuild
+// step / boot-pool) and reused across the whole booted pool instead of appium's
+// per-UDID rebuild (the "rebuild WDA N times" pain). Reuse is read-only, so
+// concurrent fleet sessions don't race on it. Distinct from the per-fleet-index
+// real-device path so a sim run never collides with a wired-device build.
+func sharedSimWDADerivedDataPath() string {
+	base := strings.TrimSpace(os.Getenv("CHAR_IOS_WDA_DERIVED_DATA"))
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			home = os.TempDir()
+		}
+		base = filepath.Join(home, ".appium-wda-deriveddata")
+	}
+	return filepath.Join(base, "wda-sim-shared")
 }

--- a/tests/characterization/runner/shape.go
+++ b/tests/characterization/runner/shape.go
@@ -46,6 +46,15 @@ func (s *Session) ApplyPattern(ctx context.Context, pattern string, stepSeconds,
 		"--pattern", pattern,
 		"--step-seconds", strconv.Itoa(stepSeconds),
 		"--margin", strconv.Itoa(marginPct),
+		// Arm the pattern on THIS player only. In a group the master calls
+		// ApplyPattern; without broadcast=false the proxy copies the pattern
+		// onto every member's session, so each fleet arm starts its own
+		// independent pattern engine (the double-arm bug). broadcast=false
+		// keeps a single owner. NOTE (Part 1): a slave then has NO pattern and
+		// will sit at its config-on-connect rate cap unless the proxy fans the
+		// master's per-tick rate to group members — verify whether the slave
+		// still follows the pyramid.
+		"--broadcast", "false",
 	}
 	_, err := runHarness(ctx, args...)
 	return err

--- a/tools/harness-cli/cmd/harness/shape.go
+++ b/tools/harness-cli/cmd/harness/shape.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/ladder"
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
@@ -37,6 +38,11 @@ Pattern mode (generates a step list from the player's current variants):
                      (default 50; adds a headroom start rung above the
                      top anchor so playback settles before constraining;
                      0 disables it)
+  --broadcast BOOL   group fan-out for the pattern arm (only valid with
+                     --pattern): false = arm the pattern on THIS player only
+                     (e.g. the group master) so other members don't each start
+                     their own pattern engine; true = force broadcast; unset =
+                     server default (a normal group broadcasts shape to all)
   --clear-pattern    stop any running pattern (back to slider rate)
   --show-pattern     print current pattern + active step
 
@@ -77,6 +83,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	margin := fs.Int("margin", 5, "headroom %% above variant rate: 0|5|10|25|50 (5 covers protocol overhead)")
 	maxStep := fs.Float64("max-step", ladder.DefaultMaxStep, "max ratio between consecutive caps before a geometric fill is inserted (default 1.15; raise to coarsen + shorten the pattern)")
 	topHeadroom := fs.Float64("top-headroom", ladder.DefaultTopHeadroomPct, "start the ladder this %% over the top variant's peak (default 50; 0 disables the headroom start rung)")
+	broadcast := fs.String("broadcast", "", "group broadcast for the --pattern arm: false|true (unset = server default)")
 	clearPattern := fs.Bool("clear-pattern", false, "stop any running pattern")
 	showPattern := fs.Bool("show-pattern", false, "print current pattern, don't modify")
 	clear := fs.Bool("clear", false, "send {shape:null}")
@@ -90,6 +97,13 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	if err != nil {
 		return err
 	}
+	broadcastPtr, berr := parseBroadcast(*broadcast)
+	if berr != nil {
+		return berr
+	}
+	if broadcastPtr != nil && *pattern == "" {
+		return errors.New("--broadcast is only valid with --pattern (it controls whether the pattern arm broadcasts to the group)")
+	}
 
 	switch {
 	case *show:
@@ -101,7 +115,7 @@ func cmdShape(client *api.Client, args []string, asJSON bool) error {
 	case *clearPattern:
 		return doClearPattern(client, ctx, pid, asJSON)
 	case *pattern != "":
-		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin, *maxStep, *topHeadroom)
+		return doPattern(client, ctx, pid, asJSON, *pattern, *stepSeconds, *margin, *maxStep, *topHeadroom, broadcastPtr)
 	}
 
 	if *rate < 0 && *delay < 0 && *loss < 0 {
@@ -357,7 +371,7 @@ func doClearPattern(client *api.Client, ctx context.Context, pid string, asJSON 
 // anchor per variant, +marginPct flat, with geometric fills to maxStep
 // (#551). Snapshots pre-state for `harness undo` and PATCHes.
 func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
-	tplStr string, stepSecs, marginPct int, maxStep, topHeadroomPct float64) error {
+	tplStr string, stepSecs, marginPct int, maxStep, topHeadroomPct float64, broadcast *bool) error {
 
 	tpl, err := parseTemplate(tplStr)
 	if err != nil {
@@ -402,7 +416,7 @@ func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
 	}
 	action := fmt.Sprintf("shape pattern=%s steps=%d step_s=%d margin=%d%%",
 		tplStr, len(steps), stepSecs, marginPct)
-	newETag, err := client.PatchShape(ctx, pid, action, &shape)
+	newETag, err := client.PatchShapeBroadcast(ctx, pid, action, &shape, broadcast)
 	if err != nil {
 		return err
 	}
@@ -414,6 +428,23 @@ func doPattern(client *api.Client, ctx context.Context, pid string, asJSON bool,
 	fmt.Printf("applied %s pattern to %s — %d steps × %ds = %ds total cycle (etag %s)\n",
 		tplStr, pid, len(steps), stepSecs, len(steps)*stepSecs, shortRev(newETag))
 	return nil
+}
+
+// parseBroadcast turns the tri-state --broadcast flag into a *bool:
+// "" → nil (server default), true|1 → &true, false|0 → &false. Threaded into
+// the PATCH as the ?broadcast= query param (see client.PatchShapeBroadcast).
+func parseBroadcast(s string) (*bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return nil, nil
+	case "true", "1":
+		v := true
+		return &v, nil
+	case "false", "0":
+		v := false
+		return &v, nil
+	}
+	return nil, fmt.Errorf("invalid --broadcast %q: true|false", s)
 }
 
 func parseTemplate(s string) (proxy.PatternTemplate, error) {

--- a/tools/harness-cli/internal/api/client.go
+++ b/tools/harness-cli/internal/api/client.go
@@ -457,6 +457,45 @@ func (c *Client) PatchShape(ctx context.Context, playerID, action string, shape 
 	return c.PatchPlayer(ctx, playerID, action, proxy.PlayerPatch{Shape: shape})
 }
 
+// PatchShapeBroadcast is PatchShape with explicit control over the group
+// broadcast query param (`?broadcast=true|false`, read raw by the proxy —
+// handlers_mutate.go:263-271). broadcast==nil keeps the server default (a
+// normal group broadcasts shape to all members). broadcast=false applies the
+// shape to the TARGET ONLY — used to arm a pattern on the group master without
+// the proxy copying the pattern engine onto every member's session (each member
+// would otherwise start its own per-port pattern loop).
+func (c *Client) PatchShapeBroadcast(ctx context.Context, playerID, action string, shape *proxy.Shape, broadcast *bool) (string, error) {
+	patch := proxy.PlayerPatch{Shape: shape}
+	editor := broadcastQueryEditor(broadcast)
+	return c.patchWithETagRetry(ctx, playerID, action,
+		"PATCH /api/v2/players/"+playerID, patch,
+		func(etag string) (*http.Response, error) {
+			params := &proxy.PatchApiV2PlayersPlayerIdParams{IfMatch: quoteETag(etag)}
+			return c.proxy.PatchApiV2PlayersPlayerIdWithApplicationMergePatchPlusJSONBody(
+				ctx, proxy.PlayerId(playerID), params, patch, editor,
+			)
+		})
+}
+
+// broadcastQueryEditor returns a proxy RequestEditorFn that sets the
+// `?broadcast=true|false` query param on the outgoing PATCH. Returns a no-op
+// editor when b is nil so the call keeps the server's default behaviour.
+func broadcastQueryEditor(b *bool) proxy.RequestEditorFn {
+	if b == nil {
+		return func(context.Context, *http.Request) error { return nil }
+	}
+	val := "false"
+	if *b {
+		val = "true"
+	}
+	return func(_ context.Context, req *http.Request) error {
+		q := req.URL.Query()
+		q.Set("broadcast", val)
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+}
+
 // ClearShape sends `{"shape": null}` — the merge-patch sentinel that
 // removes all kernel shaping in one PATCH. Can't be expressed through
 // the generated typed body (PlayerPatch.Shape is `*Shape`, so nil


### PR DESCRIPTION
Extracted from `feat/811-namespaced-knobs` as a focused branch — the rest of that branch is already on dev via #829 (SFQ) and #834 (namespaced knobs). This is the genuinely-new remainder, verified by **content diff** vs `origin/dev` (not commit count, which is full of duplicate/cherry-picked SHAs).

## What's in it
- **Single-owner group-pattern fan-out** — one owner drives the shape pattern; group slaves are fanned the master's per-tick cap. go-proxy fan-out resolution + `group_pattern_fanout_test`, `v2translate`, openapi `group_driven_by` / `group_driven_template`.
- **Driven-slave dashboard UI** — `NetworkShapingPattern.vue` shows a "⛓ Shaping driven by group master" banner; `ShapeSliders.vue` disables the rate slider for a slave; `compareSeries.ts` tracks the master's Limit line via `pattern_rate_runtime_mbps`.
- **Variant Bands chart** — `BandwidthChart.vue` per-rung avg↔peak bands; `MetricsLineChart.vue` excludes static reference lines from the y auto-range.
- Harness `shape` + `reset` plumbing, `runner/{shape,appium}`, 2sim/4sim matrices.

## Heads-up for review
- **`SessionViewer.vue` removes the "Show before/after context" toggle** (−37 lines), via group-shaping commit `d7593238`. Deliberate, but it deletes an existing dev feature — revert if not intended.
- `types/v2.ts` includes an `AppConfig` regen — this is a **TS-types sync** to dev's *existing* openapi (dev's generated types were stale at 0 refs while `proxy.yaml` has 3), **not** a new feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
