### PR TITLE
fix(849): driven-slave shape surfaces on the v2 player record

### DIFF
--- a/go-proxy/pkg/v2translate/shape_driven_test.go
+++ b/go-proxy/pkg/v2translate/shape_driven_test.go
@@ -1,0 +1,41 @@
+package v2translate
+
+import "testing"
+
+// A single-owner group SLAVE carries only the driven markers — no local
+// rate / delay / loss / fault / pattern of its own (the master drives its
+// kernel cap via the fan-out). shapeFromSession must still build a Shape so
+// the "driven by master" badge + the runtime cap reach the v2 player record
+// the shaping panel reads.
+//
+// Regression for the #849 follow-up: the early nil-guard fired on a driven
+// slave (rate==0 && … && pattern==nil), dropping the whole shape — so the
+// panel showed an empty 0-Mbps session even while the cap was being applied.
+func TestShapeFromSession_DrivenSlaveSurfacesMarkers(t *testing.T) {
+	s := map[string]any{
+		"nftables_pattern_driven_by":         "19f66fd3",
+		"nftables_pattern_driven_template":   "valley",
+		"nftables_pattern_rate_runtime_mbps": 12.5,
+	}
+	shape := shapeFromSession(s)
+	if shape == nil {
+		t.Fatal("driven slave: shapeFromSession returned nil — driven markers dropped")
+	}
+	if shape.GroupDrivenBy == nil || *shape.GroupDrivenBy != "19f66fd3" {
+		t.Errorf("GroupDrivenBy = %v, want 19f66fd3", shape.GroupDrivenBy)
+	}
+	if shape.GroupDrivenTemplate == nil || *shape.GroupDrivenTemplate != "valley" {
+		t.Errorf("GroupDrivenTemplate = %v, want valley", shape.GroupDrivenTemplate)
+	}
+	if shape.PatternRateRuntimeMbps == nil || *shape.PatternRateRuntimeMbps != 12.5 {
+		t.Errorf("PatternRateRuntimeMbps = %v, want 12.5", shape.PatternRateRuntimeMbps)
+	}
+}
+
+// A session with no shaping at all still returns nil — the early-out we keep
+// so unshaped sessions don't carry an empty Shape object.
+func TestShapeFromSession_EmptyReturnsNil(t *testing.T) {
+	if shape := shapeFromSession(map[string]any{}); shape != nil {
+		t.Errorf("empty session: shapeFromSession = %+v, want nil", shape)
+	}
+}

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -733,14 +733,23 @@ func faultRuleFromMap(rule map[string]any) oapigen.FaultRule {
 // fields + `_v2_shape_pattern` stash back into a v2 Shape. Returns nil
 // when no shape is configured (rate=0, delay=0, loss=0, no transport
 // fault, no pattern).
+//
+// A single-owner group SLAVE is the exception: it has no LOCAL rate/pattern
+// of its own — the master drives its kernel cap via the fan-out, identified
+// only by `nftables_pattern_driven_by`. Without treating that as a
+// shape-bearing condition, the slave's shape returns nil and the
+// "driven by master" badge + `pattern_rate_runtime_mbps` never reach the v2
+// record the shaping panel reads (#849 follow-up: the cap is applied, but the
+// UI showed an empty 0-Mbps panel).
 func shapeFromSession(s map[string]any) *oapigen.Shape {
 	rate, _ := numericFloatTranslate(s["nftables_bandwidth_mbps"])
 	delay, _ := numericFloatTranslate(s["nftables_delay_ms"])
 	loss, _ := numericFloatTranslate(s["nftables_packet_loss"])
 	tfType, _ := s["transport_failure_type"].(string)
 	pattern, _ := s["_v2_shape_pattern"].(map[string]any)
+	drivenBy, _ := s["nftables_pattern_driven_by"].(string)
 
-	if rate == 0 && delay == 0 && loss == 0 && (tfType == "" || tfType == "none") && pattern == nil {
+	if rate == 0 && delay == 0 && loss == 0 && (tfType == "" || tfType == "none") && pattern == nil && drivenBy == "" {
 		return nil
 	}
 	out := &oapigen.Shape{}


### PR DESCRIPTION
## Symptom
On a grouped master/slave shaping run, the **slave's NETWORK SHAPING panel** showed an empty session — Throughput **0.0 Mbps**, no pattern selected, **no "driven by master" badge** — even though the slave's kernel cap *was* being driven correctly (the bandwidth chart's limit line tracked the valley; the raw `/api/sessions` carried `nftables_pattern_driven_by` / `_rate_runtime_mbps`). So: shaping works, the **UI surfacing** was broken.

## Root cause
`shapeFromSession` (v2translate) early-returns `nil` when a session has no **local** rate/delay/loss/fault/pattern. A single-owner group **slave** is exactly that case — it has no pattern of its own; the master drives its cap via the #849 fan-out and the slave carries only the *driven markers*. With the shape nil'd, `GroupDrivenBy` + `PatternRateRuntimeMbps` never reached the v2 player record the shaping panel reads (`/api/v2/players` → `PlayerFromSession` → `shapeFromSession`).

The bandwidth chart still worked because its limit line reads the **time-series**, not the current player record — which is why the chart showed the rate but the panel didn't.

## Fix
Treat `nftables_pattern_driven_by` as a shape-bearing condition, so a driven slave builds a `Shape` and its markers surface. One-line guard change + doc comment.

## Test
`shape_driven_test.go`:
- driven-slave session (only the driven markers) → `Shape` non-nil with `GroupDrivenBy` / `GroupDrivenTemplate` / `PatternRateRuntimeMbps` set
- empty session → still `nil` (regression guard for the early-out we keep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
