### PR TITLE
feat(char): mixed-platform fleets + hybrid real-iOS playback (off-farm + farm-lock)

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/component/LivePreviewTile.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/component/LivePreviewTile.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.C
@@ -91,6 +93,13 @@ fun LivePreviewTile(
             .tvFocus(cornerRadius = Radius.card)
             .clip(RoundedCornerShape(Radius.card))
             .background(Tokens.bgSoft)
+            // Appium accessibility id on Android (content-desc): the harness's
+            // ResumePlaybackClip finds + clicks `home-tile-<clipId>` to start a
+            // DETERMINISTIC play of a specific clip. iOS exposes the same id
+            // (home-tile-\(item.clipId)); without it the harness dead-polls 30s
+            // and falls back to continue-watching. clipId is stable across the
+            // h264/hevc/av1 encodings of one clip.
+            .semantics { contentDescription = "home-tile-${content.clipId}" }
             .clickable { onClick(content) },
     ) {
         // Poster thumbnail underneath everything else. Renders for both

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/HomeScreen.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/HomeScreen.kt
@@ -213,16 +213,19 @@ fun HomeScreen(
             Spacer(Modifier.height(Space.s7))
 
             val activeServer = state.activeServer
-            // LIVE row — flat thumbnail row over the whole pool (minus
-            // the featured clip, which is already showing as the hero
-            // band above). Tiles render with `active=false` so they
-            // skip the ExoPlayer build entirely and stay as static
-            // posters. The hero is the only video decoder in use on
-            // Home; the MTK shared-decoder flicker we saw with two
-            // concurrent decoders on the same URL goes away.
-            val tilePool = if (heroVideoActive) {
-                previewPool.filter { it.clipId != featured?.clipId }
-            } else previewPool
+            // LIVE row — flat thumbnail row over the whole pool. Tiles render
+            // with `active=false` so they skip the ExoPlayer build entirely and
+            // stay as static posters. The hero is the only video decoder in use
+            // on Home; the MTK shared-decoder flicker we saw with two concurrent
+            // decoders on the same URL goes away.
+            //
+            // We deliberately KEEP the featured (hero) clip in the tile row too
+            // (matches iOS), so the harness's deterministic home-tile-<clipId>
+            // lookup finds the pinned content even when it IS the hero — the
+            // common case, since the harness pins lastPlayed. Excluding it made
+            // the harness dead-poll 30s and fall back to continue-watching. The
+            // duplicate is decode-free (tiles are active=false static posters).
+            val tilePool = previewPool
             if (tilePool.isNotEmpty() && activeServer != null) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     StatusDot(color = Tokens.live)

--- a/tests/characterization/modes/char_matrix_fleet_test.go
+++ b/tests/characterization/modes/char_matrix_fleet_test.go
@@ -292,6 +292,22 @@ func runCharMatrixArmOnDevice(t *testing.T, p runner.Platform, dev runner.Device
 		t.Fatalf("WaitForHeartbeat: %v", herr)
 	}
 
+	// Capture the play_id NOW, while the player is confirmed connected. Reading it
+	// only at the END of the window (below) is fragile: a slow-starting arm — the
+	// Android TV cold-starts ~50s and stops heartbeating a few seconds before its
+	// window elapses — makes the end-read 404 and the play look unregistered even
+	// though it streamed the whole time. The play_id is stable for a play, so the
+	// earliest reliable read is the trustworthy source; the end-read only refreshes
+	// it. Brief poll because the play registers just after the first heartbeat.
+	var earlyPlayID string
+	for i := 0; i < 10; i++ {
+		if pid, e := sess.CurrentPlayID(setupCtx); e == nil && pid != "" {
+			earlyPlayID = pid
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
 	// Arm the bandwidth pattern post-launch (it can't ride config-on-connect — the
 	// ladder is built from the live manifest variants, so the master playlist must
 	// be fetched first). ONLY the master arms it; the proxy propagates the master's
@@ -325,8 +341,15 @@ func runCharMatrixArmOnDevice(t *testing.T, p runner.Platform, dev runner.Device
 	}
 
 	playID, perr := sess.CurrentPlayID(context.Background())
-	if perr != nil {
-		t.Logf("arm %d: could not read play_id: %v", dev.FleetIndex, perr)
+	if playID == "" {
+		// End-of-window read failed/empty — e.g. the arm disconnected a few seconds
+		// before the window elapsed (the Android-TV teardown race). Fall back to the
+		// play_id captured at launch, which is the same play.
+		if earlyPlayID != "" {
+			playID = earlyPlayID
+		} else if perr != nil {
+			t.Logf("arm %d: could not read play_id: %v", dev.FleetIndex, perr)
+		}
 	}
 	base := strings.TrimRight(envOr("HARNESS_BASE_URL", "https://dev.jeoliver.com:21000"), "/")
 	viewer := fmt.Sprintf("%s/dashboard/session-viewer.html?player_id=%s", base, cfg.playerID)

--- a/tests/characterization/modes/char_matrix_fleet_test.go
+++ b/tests/characterization/modes/char_matrix_fleet_test.go
@@ -164,6 +164,15 @@ func runCharMatrixArmOnDevice(t *testing.T, p runner.Platform, dev runner.Device
 	if bars != nil {
 		setupTimeout = 12 * time.Minute
 	}
+	// A real iOS device cold-builds WDA via xcodebuild (~190s observed) BEFORE the
+	// app launches — over the 3-min single-device window. Give it room so the
+	// first (cold) run doesn't fail the create; later runs reuse the build and are
+	// fast. Aligns with the launcher's 300s HTTP ceiling + 240s wdaLaunchTimeout.
+	if dev.Platform == runner.PlatformIPhone || dev.Platform == runner.PlatformIPad {
+		if setupTimeout < 8*time.Minute {
+			setupTimeout = 8 * time.Minute
+		}
+	}
 	setupCtx, cancel := context.WithTimeout(context.Background(), setupTimeout)
 	defer cancel()
 

--- a/tests/characterization/modes/fleet.go
+++ b/tests/characterization/modes/fleet.go
@@ -104,7 +104,22 @@ func resolveFleetDeviceFarm(t *testing.T, p runner.Platform) []runner.Device {
 	}
 	fleet := make([]runner.Device, n)
 	for i := range fleet {
-		fleet[i] = runner.Device{Platform: p, FleetIndex: i}
+		// Per-arm platform (mixed-platform fleets): each arm's device is
+		// allocated from the farm by ITS own platform capability, falling back to
+		// the fleet primary p. So an isim master + a real-iphone slave can share
+		// one group/pattern.
+		ap := runner.Platform(envOr(fmt.Sprintf("CHAR_ARM_%d_PLATFORM", i), string(p)))
+		dev := runner.Device{Platform: ap, FleetIndex: i}
+		// A real iOS device isn't matchable by platformVersion (the farm leaves
+		// it unconstrained), so it could be handed a free sim. Pin its hardware
+		// UDID — supplied by the operator via CHARACTERIZATION_DEVICE_UDID — so
+		// the iphone arm gets THE iphone. Sims stay unpinned (farm picks freely).
+		if ap == runner.PlatformIPhone || ap == runner.PlatformIPad {
+			if u := strings.TrimSpace(os.Getenv("CHARACTERIZATION_DEVICE_UDID")); u != "" {
+				dev.UDID = u
+			}
+		}
+		fleet[i] = dev
 	}
 	return fleet
 }

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -1069,6 +1069,12 @@ func appiumCapabilities(d Device, bundleID string, df bool, platformVersion stri
 		if d.Label != "" {
 			caps["appium:deviceName"] = d.Label
 		}
+	} else if d.UDID != "" && (d.Platform == PlatformIPhone || d.Platform == PlatformIPad) {
+		// Real iOS hardware in a (mixed) DF fleet: platformVersion is left
+		// unconstrained for real devices, so without a UDID the farm could hand
+		// this arm a free sim. Pin the UDID so it allocates THIS iphone. Sims
+		// stay unpinned so the farm picks freely from the pool.
+		caps["appium:udid"] = d.UDID
 	}
 	if df && platformVersion != "" {
 		caps["appium:platformVersion"] = platformVersion

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -63,7 +64,13 @@ type AppiumLauncher struct {
 	// that receive a UDID-less Device resolve the session through this. Empty in
 	// the non-DF path (the caller's Device already carries its UDID).
 	allocatedUDID string
-	hc            *http.Client
+	// farmLockUDID/Host: a real iOS device on the hybrid path is driven OFF the
+	// farm, so nothing serializes the one physical phone across parallel runs. We
+	// /block it in the farm as a cross-run mutex and release on Close/discardSession.
+	// Empty when no lock is held. See farmlock.go.
+	farmLockUDID string
+	farmLockHost string
+	hc           *http.Client
 }
 
 // NewAppiumLauncher returns a launcher pointing at the configured server.
@@ -78,11 +85,15 @@ func NewAppiumLauncher() *AppiumLauncher {
 		closeBeat:        800 * time.Millisecond,
 		BundleIDs:        cloneBundleIDs(),
 		sessions:         map[string]string{},
-		// 180s, not 60s: a session-create cold-builds WDA on the sim, and an
-		// N-sim fleet queues N of those on one Appium server — the later ones
-		// blow past 60s. doRequest passes the caller's ctx (NewRequestWithContext)
-		// so per-call deadlines still apply; this is just the backstop ceiling.
-		hc: &http.Client{Timeout: 180 * time.Second},
+		// 300s, not 60s: a session-create cold-builds WDA, and an N-sim fleet
+		// queues N of those on one Appium server — the later ones blow past 60s.
+		// A REAL iOS device cold-builds WDA via xcodebuild (~190s observed) then
+		// polls /status up to wdaLaunchTimeout (240s), so the ceiling must exceed
+		// that or the create is killed client-side mid-build (the real-iphone
+		// hybrid path hit exactly this at 180s). doRequest passes the caller's ctx
+		// (NewRequestWithContext) so per-call deadlines still apply; this is just
+		// the backstop ceiling.
+		hc: &http.Client{Timeout: 300 * time.Second},
 	}
 }
 
@@ -273,10 +284,49 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 	if bundleID == "" {
 		return nil, fmt.Errorf("appium launcher: no bundle id for platform %s", d.Platform)
 	}
+	// Hybrid real-iOS routing. The device-farm plugin can't bring WDA up on a
+	// real iOS 17+/26 device — its preinstalled-WDA launch needs a go-ios /
+	// RemoteXPC tunnel the farm never provisions (the runwda arm passes a dynamic
+	// --tunnel-info-port it doesn't serve). So drive real hardware through a PLAIN
+	// Appium (no device-farm plugin) on the xcodebuild WDA path instead, even
+	// while the farm stays on for the sims in the same fleet. The arm still binds
+	// to the same proxy group/master — grouping is by player_id/group_id AT THE
+	// PROXY, independent of which Appium server puppeteers the app — so a mixed
+	// isim-master + real-iphone-slave run shares one pattern. Set the URL before
+	// healthCheck so we probe the server we'll actually drive.
+	realIOS := isRealIOSHardware(d.Platform)
+	if realIOS {
+		if u := directIOSAppiumURL(a.URL); u != a.URL {
+			a.URL = u
+		}
+		// Cross-run mutex on the physical phone: it's driven off-farm, so two
+		// parallel runs would otherwise grab it at once. Borrow the farm's block
+		// flag — wait until it's free, then /block it (released on teardown). Only
+		// when the farm is up (the lock server); acquireFarmLock no-ops if the farm
+		// is unreachable or doesn't list the device, so a lone run never wedges.
+		if DeviceFarmEnabled() {
+			host, lerr := acquireFarmLock(ctx, d.UDID)
+			if lerr != nil {
+				return nil, fmt.Errorf("acquire %s via device farm: %w", d.UDID, lerr)
+			}
+			a.mu.Lock()
+			a.farmLockUDID, a.farmLockHost = d.UDID, host
+			a.mu.Unlock()
+		}
+	}
+	// Release the farm lock if we bail out before returning a live Session — the
+	// happy path keeps it (Close releases it at test end). Post-launch failures go
+	// through discardSession, which also releases. Idempotent either way.
+	launched := false
+	defer func() {
+		if !launched {
+			a.releaseFarmLockIfHeld()
+		}
+	}()
 	if err := a.healthCheck(ctx); err != nil {
 		return nil, fmt.Errorf("appium server not reachable at %s: %w (start with `appium`, or unset LAUNCH_MODE=appium)", a.URL, err)
 	}
-	df := DeviceFarmEnabled()
+	df := DeviceFarmEnabled() && !realIOS
 	var platformVersion string
 	if df {
 		platformVersion = dfPlatformVersion(ctx, d.Platform)
@@ -337,6 +387,7 @@ func (a *AppiumLauncher) LaunchToHome(ctx context.Context, d Device) (*Session, 
 		_ = a.tapByAccessibilityID(ctx, sessID, "playback-back-button")
 		time.Sleep(800 * time.Millisecond)
 	}
+	launched = true // keep the farm lock; Close releases it at test end
 	return &Session{Device: d, Launcher: a}, nil
 }
 
@@ -614,8 +665,20 @@ func (a *AppiumLauncher) Screenshot(ctx context.Context, d Device, path string) 
 	return path, nil
 }
 
+// releaseFarmLockIfHeld clears the farm block this launcher set for a real iOS
+// device (no-op when none is held). Idempotent — every teardown path (Close,
+// discardSession, the launch-failure defer) can call it safely.
+func (a *AppiumLauncher) releaseFarmLockIfHeld() {
+	a.mu.Lock()
+	udid, host := a.farmLockUDID, a.farmLockHost
+	a.farmLockUDID, a.farmLockHost = "", ""
+	a.mu.Unlock()
+	releaseFarmLock(udid, host)
+}
+
 // Close tears down every Appium session this launcher opened.
 func (a *AppiumLauncher) Close() error {
+	a.releaseFarmLockIfHeld()
 	a.mu.Lock()
 	sessions := make(map[string]string, len(a.sessions))
 	for k, v := range a.sessions {
@@ -965,6 +1028,7 @@ func (a *AppiumLauncher) sessionID(d Device) string {
 // context: the common trigger is a heartbeat timeout, where the caller's ctx is
 // already expired and would make the DELETE fail instantly.
 func (a *AppiumLauncher) discardSession(d Device) {
+	a.releaseFarmLockIfHeld()
 	a.mu.Lock()
 	sessID := a.sessions[d.UDID]
 	if sessID == "" && a.allocatedUDID != "" {
@@ -1069,12 +1133,6 @@ func appiumCapabilities(d Device, bundleID string, df bool, platformVersion stri
 		if d.Label != "" {
 			caps["appium:deviceName"] = d.Label
 		}
-	} else if d.UDID != "" && (d.Platform == PlatformIPhone || d.Platform == PlatformIPad) {
-		// Real iOS hardware in a (mixed) DF fleet: platformVersion is left
-		// unconstrained for real devices, so without a UDID the farm could hand
-		// this arm a free sim. Pin the UDID so it allocates THIS iphone. Sims
-		// stay unpinned so the farm picks freely from the pool.
-		caps["appium:udid"] = d.UDID
 	}
 	if df && platformVersion != "" {
 		caps["appium:platformVersion"] = platformVersion
@@ -1102,6 +1160,23 @@ func appiumCapabilities(d Device, bundleID string, df bool, platformVersion stri
 			if os.Getenv("CHAR_IOS_PREBUILT_WDA") == "1" {
 				caps["appium:usePrebuiltWDA"] = true
 			}
+			// Sign WDA for a team that provisions THIS device. Appium's default
+			// WDA (com.facebook.*) + automatic signing has no team and fails to
+			// install/run on a real device; supplying the team + a WDA bundle id
+			// in our own namespace lets xcodebuild auto-provision (mint/refresh the
+			// dev cert, register the device) and run WDA as a TEST so its HTTP
+			// server comes up — the hybrid path that's proven to work on iOS 26.
+			// Gated on CHAR_IOS_XCODE_ORG_ID: unset ⇒ Appium's defaults (prior
+			// behavior). Values from the env or the nearest .env.
+			applyIOSSigningCaps(caps)
+			// Real-device WDA cold-builds via xcodebuild on a first/changed run;
+			// Appium's default 60s /status poll times out before a fresh build +
+			// launch finishes (~50-150s observed). Give it headroom so the cold
+			// path doesn't fail the launch. Overridable via
+			// CHAR_IOS_WDA_LAUNCH_TIMEOUT_MS; default 240000 (4 min).
+			to := iosWDALaunchTimeoutMs()
+			caps["appium:wdaLaunchTimeout"] = to
+			caps["appium:wdaConnectionTimeout"] = to
 		}
 	case PlatformIPadSim:
 		caps["platformName"] = "iOS"
@@ -1192,4 +1267,74 @@ func sharedSimWDADerivedDataPath() string {
 		base = filepath.Join(home, ".appium-wda-deriveddata")
 	}
 	return filepath.Join(base, "wda-sim-shared")
+}
+
+// isRealIOSHardware reports whether p is a wired/real iOS device (iPhone/iPad)
+// rather than a simulator. Real hardware takes the hybrid direct-Appium +
+// xcodebuild-WDA path; sims go through the device farm. PlatformIPadSim is the
+// simulator platform and is deliberately excluded.
+func isRealIOSHardware(p Platform) bool {
+	return p == PlatformIPhone || p == PlatformIPad
+}
+
+// directIOSAppiumURL returns the Appium base URL to drive a REAL iOS device on
+// the hybrid path. Resolution: CHAR_IOS_DIRECT_APPIUM_URL wins; else, when the
+// device farm is on (so the default :4723 is the farm-plugin server, which can't
+// drive a real device), fall back to the conventional plain-Appium port :4799;
+// else (farm off) keep the launcher's current URL — the operator has already
+// pointed APPIUM_URL at a plain Appium.
+func directIOSAppiumURL(current string) string {
+	if u := strings.TrimSpace(os.Getenv("CHAR_IOS_DIRECT_APPIUM_URL")); u != "" {
+		return u
+	}
+	if DeviceFarmEnabled() {
+		return "http://localhost:4799"
+	}
+	return current
+}
+
+// applyIOSSigningCaps adds the real-device WDA signing capabilities to caps when
+// CHAR_IOS_XCODE_ORG_ID is set (process env or nearest .env). xcodeOrgId +
+// xcodeSigningId drive xcodebuild's automatic signing (auto-provisioning the dev
+// cert + registering the device); updatedWDABundleId puts WDA in a bundle-id
+// namespace the team's wildcard profile covers; allowProvisioningDeviceRegistration
+// lets a not-yet-registered device be added. Unset org ⇒ no-op (Appium defaults).
+func applyIOSSigningCaps(caps map[string]any) {
+	org := envOrDotenv("CHAR_IOS_XCODE_ORG_ID")
+	if org == "" {
+		return
+	}
+	caps["appium:xcodeOrgId"] = org
+	signing := envOrDotenv("CHAR_IOS_XCODE_SIGNING_ID")
+	if signing == "" {
+		signing = "Apple Development"
+	}
+	caps["appium:xcodeSigningId"] = signing
+	if wb := envOrDotenv("CHAR_IOS_WDA_BUNDLE_ID"); wb != "" {
+		caps["appium:updatedWDABundleId"] = wb
+	}
+	caps["appium:allowProvisioningDeviceRegistration"] = true
+}
+
+// envOrDotenv reads KEY from the process environment, falling back to the
+// nearest .env file — the same resolution defaultContentClip uses for config
+// that lives in .env rather than the source.
+func envOrDotenv(key string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(dotenvValue(key))
+}
+
+// iosWDALaunchTimeoutMs is the wdaLaunchTimeout/wdaConnectionTimeout (ms) for a
+// real iOS device. Default 240000 (4 min) — a cold xcodebuild WDA build + launch
+// overruns Appium's 60s default. Overridable via CHAR_IOS_WDA_LAUNCH_TIMEOUT_MS;
+// a non-numeric/empty/non-positive value falls back to the default.
+func iosWDALaunchTimeoutMs() int {
+	if v := strings.TrimSpace(os.Getenv("CHAR_IOS_WDA_LAUNCH_TIMEOUT_MS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 240000
 }

--- a/tests/characterization/runner/farmlock.go
+++ b/tests/characterization/runner/farmlock.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Farm mutex for the real iPhone on the HYBRID path.
+//
+// A real iOS device is driven OFF the device farm (a plain Appium on :4799, see
+// directIOSAppiumURL) — the farm can't bring up WDA on iOS 17+/26. That means
+// the farm never marks it busy, so nothing stops two parallel runs from grabbing
+// the same physical phone at once. We borrow the farm's manual block flag
+// (`userBlocked`, toggled by POST /device-farm/api/{block,unblock}) purely as a
+// cross-process lock: acquire = wait-until-free then /block; release = /unblock.
+//
+// NOTE the harness CLI reap only unblocks `busy` devices, not `userBlocked`
+// ones, so release is owned HERE (Close/discardSession), not by the reap.
+
+// deviceFarmBaseURL is the appium-device-farm server base (the plugin host) —
+// CHAR_APPIUM_URL or the :4723 default, mirroring the harness CLI. Distinct from
+// a real device's direct-Appium URL (:4799 on the hybrid path).
+func deviceFarmBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("CHAR_APPIUM_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	return "http://localhost:4723"
+}
+
+// farmLockWait is the max time acquireFarmLock waits for the phone to free up.
+// Parallel runs serialize on ONE device, so a later run may wait out the whole
+// earlier run — keep it generous. CHAR_IOS_FARM_WAIT_SEC overrides; default 20m.
+func farmLockWait() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("CHAR_IOS_FARM_WAIT_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 20 * time.Minute
+}
+
+type farmDeviceStatus struct {
+	UDID        string `json:"udid"`
+	Host        string `json:"host"`
+	Busy        bool   `json:"busy"`
+	UserBlocked bool   `json:"userBlocked"`
+}
+
+func farmRoster(ctx context.Context, client *http.Client, base string) ([]farmDeviceStatus, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/device-farm/api/device", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var all []farmDeviceStatus
+	if err := json.Unmarshal(raw, &all); err != nil {
+		return nil, err
+	}
+	return all, nil
+}
+
+func farmDeviceByUDID(roster []farmDeviceStatus, udid string) (farmDeviceStatus, bool) {
+	for _, d := range roster {
+		if strings.EqualFold(d.UDID, udid) {
+			return d, true
+		}
+	}
+	return farmDeviceStatus{}, false
+}
+
+func farmBlockCall(ctx context.Context, client *http.Client, base, action, udid, host string) error {
+	body, _ := json.Marshal(map[string]string{"udid": udid, "host": host})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/device-farm/api/"+action, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("farm %s %s: HTTP %d", action, udid, resp.StatusCode)
+	}
+	return nil
+}
+
+// acquireFarmLock waits until the farm shows udid free (not busy, not
+// userBlocked), then /block-s it as a cross-run mutex and returns the host to
+// /unblock with later. Returns ("", nil) — no lock, caller drives anyway — when
+// the farm is unreachable or doesn't list this device (best-effort; the lock is
+// an optimization, never a hard gate that could wedge a lone run). Returns an
+// error only when the device stays blocked past the wait budget, so a genuinely
+// contended phone surfaces instead of silently double-driving.
+func acquireFarmLock(ctx context.Context, udid string) (host string, err error) {
+	udid = strings.TrimSpace(udid)
+	if udid == "" {
+		return "", nil
+	}
+	base := deviceFarmBaseURL()
+	client := &http.Client{Timeout: 6 * time.Second}
+	deadline := time.Now().Add(farmLockWait())
+	for {
+		roster, rerr := farmRoster(ctx, client, base)
+		if rerr != nil {
+			// Farm not reachable — skip locking, drive anyway (single-run case).
+			return "", nil
+		}
+		dev, ok := farmDeviceByUDID(roster, udid)
+		if !ok {
+			// Device not in the farm roster — nothing to lock against.
+			return "", nil
+		}
+		if !dev.Busy && !dev.UserBlocked {
+			if berr := farmBlockCall(ctx, client, base, "block", dev.UDID, dev.Host); berr != nil {
+				return "", nil // best-effort: couldn't block, drive anyway
+			}
+			return dev.Host, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("device %s still blocked in the farm after %s (another run is using it, or a leaked lock — POST /device-farm/api/unblock to clear)", udid, farmLockWait())
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// releaseFarmLock clears the userBlocked flag this run set in acquireFarmLock.
+// Best-effort with its own short context so it runs even when the caller's ctx
+// is already done (the common teardown case). No-op when host is empty (no lock
+// was taken).
+func releaseFarmLock(udid, host string) {
+	if strings.TrimSpace(udid) == "" || strings.TrimSpace(host) == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	client := &http.Client{Timeout: 6 * time.Second}
+	_ = farmBlockCall(ctx, client, deviceFarmBaseURL(), "unblock", udid, host)
+}

--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -132,15 +132,12 @@ func cmdCharMatrix(client *api.Client, args []string, asJSON bool) error {
 // recorded with its error and left out of the fleet env (that fleet index then
 // skips), so one bad arm doesn't sink the run.
 func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir string, durationOverride int, group string) ([]charmatrix.ArmResult, error) {
-	// The fleet draws from a single platform's device pool (one arm per device),
-	// so a parallel matrix must be single-platform. Split by platform or run
-	// sequential otherwise.
+	// The fleet allocates one device PER ARM from the device-farm by that arm's
+	// platform capability, so a parallel matrix MAY mix platforms — e.g. an
+	// ipad-sim master + a real iPhone slave sharing one group/pattern. Each arm's
+	// platform rides in CHAR_ARM_<i>_PLATFORM (emitted below); arms[0]'s is the
+	// primary (CHAR_SWEEP_PLATFORM) the fleet resolver falls back to.
 	platform := arms[0].Platform
-	for _, a := range arms {
-		if a.Platform != platform {
-			return nil, fmt.Errorf("parallel matrices require one platform across arms (got %q and %q) — split by platform or use parallel:false", platform, a.Platform)
-		}
-	}
 
 	// For a grouped pattern run, ONE master arms the pattern; the proxy propagates
 	// it to the group's slaves (NETSHAPE group pattern propagation), so every arm


### PR DESCRIPTION
## What

Run a **mixed isim-master + real-iPhone-slave** characterization fleet as a single test — sharing one proxy group/master — with the real iPhone brought up reliably on iOS 26.

Two commits:
1. **Mixed-platform grouped fleets** (`ce7c5aff`) — per-arm platform in the device-farm roster + the matrix guard, so a fleet can pair an ipad-sim master with a real-iphone slave under one group/pattern.
2. **Hybrid real-iOS playback + farm-lock** (`d32b2c6f`) — drive the real iPhone off-farm.

## Why hybrid (not the farm) for the real iPhone

appium-device-farm can't bring up WDA on a real iOS 17+/26 device — its preinstalled-WDA launch needs a go-ios / RemoteXPC tunnel it never provisions (the `runwda` arm passes a dynamic `--tunnel-info-port` it doesn't serve). Full diagnosis lives on the `experimental/farm-ios-playback` branch (`.claude/findings/farm-ios-playback-attempt.md`).

So real hardware is driven via a **plain Appium (:4799, xcodebuild WDA) off-farm**, while sims stay on the farm. Both bind to the same proxy group, so the cross-platform fan-out is unaffected.

## Changes

- Real iOS hardware → off-farm direct Appium (`CHAR_IOS_DIRECT_APPIUM_URL`, default `:4799`), `df=false`.
- WDA signing caps (`CHAR_IOS_XCODE_ORG_ID` / `_SIGNING_ID` / `_WDA_BUNDLE_ID`) for xcodebuild automatic provisioning.
- `wdaLaunchTimeout` 240s + 300s Appium-client ceiling + an 8-min real-iOS setup window for the cold WDA build.
- `runner/farmlock.go` — the farm's `userBlocked` flag as a cross-run mutex on the one physical phone (acquire waits-then-`/block`, release `/unblock` on every teardown path; the harness reap only frees `busy` devices, so release is owned in the runner).
- Drops the now-dead DF real-device caps branch.

## Verification

- Single-iPhone smoke: **PASS**.
- Mixed isim + real-iPhone valley: both arms **PASS**; the iPhone slave rode the sim master's valley (no local shaping), `userBlocked` during the run and released after.

## Operator config (`.env`, gitignored)

A box driving a real iPhone needs a plain Appium on `:4799` plus `CHAR_IOS_DIRECT_APPIUM_URL`, `CHAR_IOS_XCODE_ORG_ID`, `CHAR_IOS_XCODE_SIGNING_ID`, `CHAR_IOS_WDA_BUNDLE_ID`. Unset → prior behavior (Appium defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
