### PR TITLE
feat(dashboard): bandwidth variant-ladder legend order + default visibility

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -69,7 +69,7 @@ interface ManifestVariantLite {
 /** Append one horizontal reference line per ladder rung at its published PEAK
  *  bandwidth (EXT-X-STREAM-INF BANDWIDTH), all collapsed under a single
  *  "Variant peak bandwidth" legend chip. `opts.hidden` starts the whole group
- *  off (compare mode) or on (single-session, the rate ABR keys on).
+ *  off by default (toggle on for the rung rate the ABR keys on).
  *
  *  When `opts.tag` is set (compare mode) the chip and each rung label carry
  *  the session's `(Sx)` so each session gets its OWN ladder built from its OWN
@@ -430,8 +430,10 @@ const baseSeries: SeriesSpec[] = [
  *  whole X range; sharing a `groupLegend` collapses them all to a
  *  single legend chip that toggles every line at once.
  *
- *  Defaults: peak ON (the rate ABR actually keys on — see abr-ladder
- *  standard), avg OFF (toggle on for the typical-body-bitrate reference). */
+ *  Defaults: bands ON (the avg↔peak shaded region — see appendBands), peak OFF
+ *  and avg OFF (toggle either on for the rung / typical-body-bitrate reference).
+ *  All three families are hoisted to the front of the dataset list by
+ *  MetricsLineChart so they lead the legend and draw behind the live traces. */
 const series = computed<SeriesSpec[]>(() => {
   // Compare mode: the active session shows the SAME canonical tagged set
   // (solid, `S<id>`) the siblings overlay — not its full single-session
@@ -439,12 +441,12 @@ const series = computed<SeriesSpec[]>(() => {
   if (compareSelf.value) {
     const self = compareSelf.value;
     const compareOut = compareBandwidthSeries(self);
-    // Active session's own variant-peak ladder — hidden by default, tagged
-    // `(Sx)` and styled with the session dash so it reads as this session's
-    // rungs. Each sibling builds its OWN ladder from its OWN manifest in the
-    // useCompareOverlays closure below, so manifests that differ across the
-    // compared sessions show distinct rung sets (issue #812).
-    appendBands(compareOut, variants.value, { hidden: true, tag: self.tag });
+    // Active session's own variant bands (ON by default) + peak ladder (OFF),
+    // tagged `(Sx)` and styled with the session dash so they read as this
+    // session's rungs. Each sibling builds its OWN ladder from its OWN manifest
+    // in the useCompareOverlays closure below, so manifests that differ across
+    // the compared sessions show distinct rung sets (issue #812).
+    appendBands(compareOut, variants.value, { hidden: false, tag: self.tag });
     appendPeakLadder(compareOut, variants.value, { hidden: true, tag: self.tag, dash: self.dash });
     return compareOut;
   }
@@ -464,6 +466,10 @@ const series = computed<SeriesSpec[]>(() => {
       return nearestVariantByBitrate(ladder, vb)?.peakMbps ?? vb;
     },
     stepped: true,
+    // Drawn BEFORE (under) "Displayed Variant"; the two coincide whenever ABR is
+    // steady. The wider under-line peeks out as a red halo around the purple
+    // Displayed line so the operator sees both. See SeriesSpec.borderWidth.
+    borderWidth: 4,
   });
   // "Displayed Variant": the same value that drives the player-state
   // "Video Res" line (player_metrics.video_resolution = the DECODED frame
@@ -487,14 +493,16 @@ const series = computed<SeriesSpec[]>(() => {
     stepped: true,
   });
   // Variant Bands — a light shaded region between each variant's
-  // AVERAGE-BANDWIDTH and BANDWIDTH. Default OFF; one "Variant Bands" legend chip
-  // (sitting beside the avg / peak chips) toggles the whole set. Turn it on
-  // (alongside the peak + avg ladders) to SEE, at a glance, where adjacent
-  // variants' [avg,peak] bands OVERLAP — the over-selection trap, a rung's avg
-  // sitting at/below the rung-below's peak (#811) — or leave GAPS. Fill is
-  // semi-transparent, so overlapping bands compound into a darker tint. Built
-  // BEFORE the avg/peak ladder lines so the bands draw BEHIND those rung lines.
-  appendBands(out, ladder, { hidden: true });
+  // AVERAGE-BANDWIDTH and BANDWIDTH. Default ON; one "Variant Bands" legend chip
+  // (sitting beside the avg / peak chips) toggles the whole set. It shows, at a
+  // glance, where adjacent variants' [avg,peak] bands OVERLAP — the
+  // over-selection trap, a rung's avg sitting at/below the rung-below's peak
+  // (#811) — or leave GAPS. Fill is semi-transparent, so overlapping bands
+  // compound into a darker tint. Built BEFORE the avg/peak ladder lines so the
+  // bands draw BEHIND those rung lines; MetricsLineChart hoists the whole
+  // variant family to the front of the dataset list so it also draws behind the
+  // live traces and leads the legend.
+  appendBands(out, ladder, { hidden: false });
   // Mute the variant-line color so it doesn't out-shout the live
   // traces. Slate-400 reads at a glance but stays in the background.
   const AVG_COLOR = '#94a3b8';
@@ -515,9 +523,9 @@ const series = computed<SeriesSpec[]>(() => {
       });
     }
   }
-  // Variant peak ladder — default ON in single-session (the rung rate ABR
-  // keys on). Same builder feeds the default-OFF compare-mode ladders above.
-  appendPeakLadder(out, ladder, { hidden: false });
+  // Variant peak ladder — default OFF (toggle on for the rung rate ABR keys
+  // on). Same builder feeds the compare-mode ladders above.
+  appendPeakLadder(out, ladder, { hidden: true });
   return out;
 });
 
@@ -530,11 +538,11 @@ const series = computed<SeriesSpec[]>(() => {
  *  session (the #165 union-sizing fix). */
 const compareOverlays = useCompareOverlays((sib) => {
   const specs = compareBandwidthSeries(sib);
-  // Each sibling's own variant-peak ladder, read from its OWN manifest via
-  // its events stream — so comparing two sessions whose manifests differ
-  // shows each one's distinct rung set. Hidden by default, tagged + dashed
+  // Each sibling's own variant bands (ON by default) + peak ladder (OFF), read
+  // from its OWN manifest via its events stream — so comparing two sessions
+  // whose manifests differ shows each one's distinct rung set. Tagged + dashed
   // per session so the S1/S2 legend toggles it in lockstep (issue #812).
-  appendBands(specs, latestManifestVariants(sib.stream), { hidden: true, tag: sib.tag });
+  appendBands(specs, latestManifestVariants(sib.stream), { hidden: false, tag: sib.tag });
   appendPeakLadder(specs, latestManifestVariants(sib.stream), {
     hidden: true,
     tag: sib.tag,

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -47,6 +47,13 @@ export interface SeriesSpec {
   hidden?: boolean;
   /** Chart.js `borderDash` — e.g. `[4, 4]` for a dashed line. */
   borderDash?: number[];
+  /** Line thickness in px (default 2). Set wider on a series that tends to be
+   *  COVERED by another line drawn on top of it (e.g. Fetching Variant sitting
+   *  exactly under Displayed Variant when ABR is steady): the wider under-line
+   *  peeks out as a coloured halo on both sides of the narrower top line, so the
+   *  operator can see both are present. Ignored for band (`fillToValue`) series,
+   *  which are borderless fills. */
+  borderWidth?: number;
   /** Collapse this series into a group-shared legend entry. All series
    *  sharing the same `groupLegend` string appear under a single
    *  legend item whose label is the group name; clicking it toggles
@@ -354,12 +361,23 @@ function makeDsObj(
     tension: 0,
     stepped: !!s.stepped,
     pointRadius: 0,
-    borderWidth: band ? 0 : 2,
+    borderWidth: band ? 0 : (s.borderWidth ?? 2),
     borderDash: s.borderDash ?? [],
     fill: band ? { value: s.fillToValue } : false,
     spanGaps,
     yAxisID: s.axis === 'y2' ? 'y2' : 'y',
     hidden: !!s.hidden,
+    // Chart.js draws + legends + tooltips in ASCENDING `order` (NOT raw array
+    // order — the legend reads `_getSortedDatasetMetas()`, which sorts by this).
+    // Grouped "variant ladder" series (Bands / avg / peak — the only grouped
+    // series in the app) get order 0 so they lead the legend AND draw BEHIND the
+    // live traces (order 1), regardless of which session contributed them. #486.
+    order: variantOrder(s),
+    // The series' OWN intended hidden state — overwritten by the resolve-aware
+    // build paths with the persisted-toggle-or-default value. applySessionVisibility
+    // reads it so a VISIBLE compare-mode session no longer force-shows a
+    // hidden-by-default tagged series (e.g. each session's Variant peak ladder). #579.
+    _ownHidden: !!s.hidden,
     _groupLegend: s.groupLegend ?? null,
     _sessionTag: s.sessionTag ?? null,
     _excludeFromAutoScale: !!s.excludeFromAutoScale,
@@ -399,13 +417,18 @@ function buildPrimaryDatasetObjs(): any[] {
       const band = typeof s.fillToValue === 'number' && Number.isFinite(s.fillToValue);
       prev.borderColor = band ? 'transparent' : s.color;
       prev.backgroundColor = s.color + (band ? '33' : '22');
-      prev.borderWidth = band ? 0 : 2;
+      prev.borderWidth = band ? 0 : (s.borderWidth ?? 2);
+      // The hover-highlight base is re-derived from this width on the next
+      // hover; drop the stale stash so a width change here takes effect.
+      prev._origBorderWidth = null;
       prev.fill = band ? { value: s.fillToValue } : false;
       prev.stepped = !!s.stepped;
       prev.borderDash = s.borderDash ?? [];
       prev.yAxisID = s.axis === 'y2' ? 'y2' : 'y';
       prev.spanGaps = true;
+      prev.order = variantOrder(s); // variant ladder behind + first in legend
       prev.hidden = legendVis.resolveHidden(s); // persisted toggle survives a new play_id
+      prev._ownHidden = prev.hidden;
       prev._groupLegend = s.groupLegend ?? null;
       prev._sessionTag = s.sessionTag ?? null;
       prev._excludeFromAutoScale = !!s.excludeFromAutoScale;
@@ -416,6 +439,7 @@ function buildPrimaryDatasetObjs(): any[] {
       dataset[i] = data;
       const obj = makeDsObj(dsKey, s, data, true);
       obj.hidden = legendVis.resolveHidden(s); // persisted toggle survives a new play_id
+      obj._ownHidden = obj.hidden;
       out.push(obj);
     }
   }
@@ -453,10 +477,18 @@ function buildOverlayDatasetObjs(): any[] {
       if (prev) {
         prev.borderColor = s.color;
         prev.backgroundColor = s.color + '22';
+        prev.borderWidth = typeof s.fillToValue === 'number' ? 0 : (s.borderWidth ?? 2);
+        prev._origBorderWidth = null;
         prev.stepped = !!s.stepped;
         prev.borderDash = s.borderDash ?? [];
         prev.yAxisID = s.axis === 'y2' ? 'y2' : 'y';
+        prev.order = variantOrder(s); // variant ladder behind + first in legend
         prev.spanGaps = false;
+        // Sibling series respect their own hidden default (+ persisted toggle) so
+        // e.g. a sibling's Variant peak ladder starts OFF even though its session
+        // is visible. applySessionVisibility reads _ownHidden, not just the tag.
+        prev.hidden = legendVis.resolveHidden(s);
+        prev._ownHidden = prev.hidden;
         prev._groupLegend = s.groupLegend ?? null;
         prev._sessionTag = s.sessionTag ?? null;
         prev._excludeFromAutoScale = !!s.excludeFromAutoScale;
@@ -465,7 +497,10 @@ function buildOverlayDatasetObjs(): any[] {
       } else {
         const data = rt.datasets[i] ?? [];
         rt.datasets[i] = data;
-        out.push(makeDsObj(dsKey, s, data, false));
+        const obj = makeDsObj(dsKey, s, data, false);
+        obj.hidden = legendVis.resolveHidden(s);
+        obj._ownHidden = obj.hidden;
+        out.push(obj);
         if (rtExisted) addedSeries = true;
       }
     }
@@ -486,10 +521,21 @@ function buildOverlayDatasetObjs(): any[] {
   return out;
 }
 
-/** Recompose `chart.data.datasets` = [primary…, overlay…] from the
- *  current `series` + `overlays` props. The single owner of the dataset
- *  list; both the series-prop watcher and the overlays watcher route
- *  through here so the two halves never clobber each other. */
+/** Chart.js draw / legend / tooltip order: grouped "variant ladder" series
+ *  (Bands / avg / peak — the only grouped series in the app) sort to order 0 so
+ *  they lead the legend and draw BEHIND the live traces (order 1), no matter
+ *  which session contributed them. The legend's stock `generateLabels` reads
+ *  `_getSortedDatasetMetas()` (sorted by `order`), so the raw datasets[] array
+ *  order is irrelevant — this property is the only reliable lever. */
+function variantOrder(s: SeriesSpec): number {
+  return s.groupLegend ? 0 : 1;
+}
+
+/** Recompose `chart.data.datasets` = [primary…, overlay…] from the current
+ *  `series` + `overlays` props. The single owner of the dataset list; both the
+ *  series-prop watcher and the overlays watcher route through here so the two
+ *  halves never clobber each other. Draw/legend order is driven by each
+ *  dataset's `order` (variantOrder), not array position. */
 function rebuildAllDatasets() {
   if (!chart || !chart.data) return;
   const primary = buildPrimaryDatasetObjs();
@@ -512,7 +558,10 @@ function applySessionVisibility(doUpdate = true) {
   let changed = false;
   chart.data.datasets.forEach((ds: any, idx: number) => {
     if (!ds._sessionTag) return;
-    const shouldShow = !hidden.has(ds._sessionTag);
+    // Visible iff the session is shown AND the series isn't hidden by its own
+    // default / persisted toggle — so a shown session no longer force-reveals a
+    // hidden-by-default tagged series (the per-session Variant peak ladder).
+    const shouldShow = !hidden.has(ds._sessionTag) && !ds._ownHidden;
     if (chart.isDatasetVisible(idx) !== shouldShow) {
       chart.setDatasetVisibility(idx, shouldShow);
       changed = true;
@@ -808,6 +857,7 @@ function createChartInstance(Chart: any): any {
             if (!grp) {
               const nowVisible = !ci.isDatasetVisible(item.datasetIndex);
               ci.setDatasetVisibility(item.datasetIndex, nowVisible);
+              if (ds) ds._ownHidden = !nowVisible; // keep applySessionVisibility in sync
               // Persist so a new play_id doesn't reset this toggle.
               legendVis.setHidden({ label: ds?.label ?? '', groupLegend: null }, !nowVisible);
               ci.update();
@@ -818,7 +868,10 @@ function createChartInstance(Chart: any): any {
                 d._groupLegend === grp && ci.isDatasetVisible(idx),
             );
             ci.data.datasets.forEach((d: any, idx: number) => {
-              if (d._groupLegend === grp) ci.setDatasetVisibility(idx, !anyVisible);
+              if (d._groupLegend === grp) {
+                ci.setDatasetVisibility(idx, !anyVisible);
+                d._ownHidden = anyVisible; // keep applySessionVisibility in sync
+              }
             });
             // Persist the group's new hidden state (hidden when it was visible).
             legendVis.setHidden({ groupLegend: grp, label: '' }, anyVisible);
@@ -931,6 +984,19 @@ function createChartInstance(Chart: any): any {
           },
         },
         tooltip: {
+          // 'x' (not the interaction-wide 'nearest'): list EVERY visible
+          // series' value at the hovered time, so two lines that sit exactly on
+          // top of each other both appear — equal values reveal the overlap the
+          // eye can't see (e.g. Fetching Variant == Displayed Variant when ABR
+          // is steady). Datasets are heterogeneous in length (variant rungs are
+          // 2-point spans, live traces are thousands), so 'x' — nearest point
+          // per dataset — is correct where 'index' would misalign.
+          mode: 'x',
+          intersect: false,
+          // Drop the band FILL series (borderless avg↔peak shaded regions):
+          // their value is just the band's peak edge, meaningless as a readout
+          // and pure clutter in a now-longer multi-series tooltip.
+          filter: (item: any) => !(item?.dataset && item.dataset.fill),
           callbacks: {
             title: (items: any[]) => fmtTickHMSms(items[0]?.parsed?.x ?? 0),
             label: (ctx: any) => {

--- a/content/dashboard-v3/src/composables/compareSeries.ts
+++ b/content/dashboard-v3/src/composables/compareSeries.ts
@@ -126,6 +126,9 @@ export function compareBandwidthSeries(id: CompareSeriesIdentity): SeriesSpec[] 
       accessor: (p: PlayerRecord) => p.player_metrics?.video_bitrate_mbps ?? null,
       stepped: true,
       borderDash: dash,
+      // Drawn under "Displayed Variant" (next); the wider under-line shows as a
+      // halo when the two coincide. Mirrors the single-session BandwidthChart.
+      borderWidth: 4,
     },
     {
       // Decoded rung's published peak bitrate, matched by frame height —


### PR DESCRIPTION
## What

Improves the bandwidth chart everywhere it renders (live testing-session, testing, session-viewer/replay — all mount the same `BandwidthChart.vue`).

- **Variant ladder leads the legend + draws behind the live traces**, no matter which session contributed it. Grouped series (Bands / avg / peak — the only grouped series in the app) get Chart.js `order: 0`; everything else `order: 1`. The legend's stock `generateLabels` reads `_getSortedDatasetMetas()` (sorted by `order`), so `order` — not raw `datasets[]` position — is the reliable lever for both legend order and draw order.
- **Default visibility:** Variant **Bands ON**, **avg OFF**, **peak OFF**, across all three build paths (single-session, compare-self, sibling overlays).
- **Compare-mode session show/hide respects each series' own hidden default** (`_ownHidden`, persisted-toggle-aware). Previously a *visible* session force-revealed every tagged series, overriding the `hidden: true` default — which is why the per-session peak/avg ladders showed up enabled. Now a shown session only reveals series that aren't hidden by their own default, and a manual per-session toggle persists.
- **Coincident-line visibility:** `Fetching Variant` renders as a wider under-line (`borderWidth: 4`) so its red halo peeks out around `Displayed Variant` when the two coincide (steady ABR); the tooltip switches to `mode: 'x'` (all series at the hovered time, band fills filtered) so overlapping values read as equal numbers.

## Testing

- `vue-tsc --noEmit` clean.
- Deployed to test-dev (`make deploy-frontend`) and verified in session-viewer: variant chips lead the legend across S1/S2/S3, bands on, peak/avg disabled by default.

## Known follow-up (pre-existing, not introduced here)

In compare mode the **active (self) session's `manifest_variants` don't resolve**, so its `Displayed Variant` line and variant ladder are absent (legend chip shows, no line). Same root cause for all three S-self symptoms; turning Bands on by default just surfaced it. Tracked as a separate investigation into the self-vs-sibling manifest sourcing (`variants.value` vs `latestManifestVariants(sib.stream)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
