### PR TITLE
fix(android): main playback always routes through go-proxy (#862)

### DIFF
--- a/android/InfiniteStreamPlayer/BEHAVIOR.md
+++ b/android/InfiniteStreamPlayer/BEHAVIOR.md
@@ -66,7 +66,11 @@ Behavioural rules below are additions.
 Six toggles, all persisted alongside developer mode:
 
 - **4K** — allow renditions above 1080p (off → cap at 1080p, default off).
-- **Local Proxy** — route through per-session go-proxy port (default on).
+- **Local Proxy** — toggles the on-device proxy hop (iOS `LocalHTTPProxy`).
+  Android has no on-device proxy, so this flag is currently inert for routing —
+  main playback ALWAYS routes through the per-session go-proxy port regardless
+  (#862). Retained for harness/iOS parity and reported as `local_proxy` in
+  metrics. Default on.
 - **Auto-Recovery** — single retry on non-codec player errors (default off).
 - **Go Live** — `seekToDefaultPosition` on every load (default off).
 - **Skip Home on launch** — auto-resume to Playback when a saved server and
@@ -129,7 +133,11 @@ so YouTube (or whatever else takes foreground) gets a clean codec budget.
 http://{server.host}:{port}/go-live/{selectedContent}/{manifest}?player_id={playerId}
 ```
 
-- `port` = `server.port` when Local Proxy on, `server.apiPort` when off.
+- `port` = `server.port` (the per-session go-proxy port) **always** — main
+  playback is always shaped/fault-injectable. The Local Proxy flag does NOT
+  switch this to the API port (that bypassed go-proxy entirely, silently
+  unshaping `local_proxy=false` runs and leaving `manifest_variants` empty —
+  #862). Matches iOS, which hardcodes `localProxy:true` in `playbackURL`.
 - `manifest` = `master{segment.suffix}.m3u8` (HLS) or `manifest{segment.suffix}.mpd` (DASH).
 
 **Live preview tile** (always direct to API port, no player_id):

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerViewModel.kt
@@ -834,10 +834,17 @@ class PlayerViewModel(app: Application) : AndroidViewModel(app) {
         if (s.selectedContent.isEmpty()) return
         val manifest = if (s.protocol == Protocol.HLS) "master${s.segment.suffix}.m3u8"
                        else "manifest${s.segment.suffix}.mpd"
-        // Local Proxy ON → playback port (per-session go-proxy with failure
-        // injection). OFF → API/main nginx port (no proxy in front of the
-        // stream). Same /go-live route in both cases.
-        val port = if (s.localProxy) server.port else server.apiPort
+        // Session playback ALWAYS routes through the per-session go-proxy port
+        // (failure injection + traffic shaping live there). The `localProxy`
+        // flag only toggles the ON-DEVICE proxy hop — and Android has no
+        // on-device proxy (the iOS-only LocalHTTPProxy), so the flag is inert
+        // for routing here. It must NOT switch to the API/nginx port: doing so
+        // bypassed go-proxy entirely, so a `local_proxy=false` run (the
+        // characterization default) was silently UNSHAPED and the proxy never
+        // parsed the master playlist — leaving manifest_variants (and the whole
+        // bandwidth-chart variant ladder) empty for Android sessions (#862).
+        // Mirrors the iOS fix in PlayerViewModel.swift (playbackURL localProxy:true).
+        val port = server.port
         // Fresh play_id at every loadStream boundary (issue #280) so
         // go-proxy can scope its network log per play. reload() rotates the
         // id itself (so play_start carries the new id) and passes false here

--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/ui/screen/SettingsOverlay.kt
@@ -387,7 +387,7 @@ private fun PickerList(
                     }
                     item {
                         PickerItem(
-                            label = "Local Proxy (route through go-proxy port)",
+                            label = "Local Proxy (on-device hop; iOS only — Android always routes via go-proxy)",
                             selected = state.localProxy,
                             onClick = { vm.setLocalProxy(!state.localProxy) },
                         )


### PR DESCRIPTION
## Root cause (data-confirmed)

Investigating #862 (active/self session shows no variant ladder / Displayed line in compare mode), the data pointed past the dashboard:

- A live `valley-trio` compare group: the **Android (Google TV / ExoPlayer)** session had **0 requests through the per-session proxy** (iPhone: 229), null `master_manifest_url`, and **0 rows with `manifest_variants`**. iPhone + arm64-sim sessions had the full ladder.
- `manifest_variants` is set **only** by the proxy, from the master playlist the client fetches **through the per-session go-proxy** (`go-proxy/cmd/server/main.go:6247`). There is no client-reported manifest path.

So the Android session was **bypassing go-proxy entirely**. Cause: `composeUrlAndLoad` picked the port as `if (localProxy) server.port else server.apiPort` — so `local_proxy=false` (the characterization default) pointed playback at the nginx API port, skipping go-proxy. That silently **unshaped** every `local_proxy=false` Android run AND left `manifest_variants` (hence the whole bandwidth-chart variant ladder + Displayed/Fetching lines) empty.

## Fix

Main playback ALWAYS routes through `server.port` (the per-session go-proxy). Mirrors iOS, which hardcodes `localProxy:true` in `playbackURL` and lets the `localProxy` flag toggle only the on-device `LocalHTTPProxy` (`PlayerViewModel.swift:1030-1043`). Android has no on-device proxy, so the flag is now inert for routing — kept for harness/iOS parity and still reported as `local_proxy`. SettingsOverlay label + BEHAVIOR.md updated to match.

## Testing

- `./gradlew :app:compileDebugKotlin` clean.
- **Device verification pending:** deploy to a Google TV / emulator, play with Local Proxy OFF, and confirm via `harness q network <play_id>` that requests now hit go-proxy and `manifest_variants` populates (and check whether `video_bitrate_mbps` / `video_resolution` — client-reported, were also null in the captured session — populate once video renders; if not, that's a separate client-instrumentation follow-up).

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
