### PR TITLE
fix(dashboard): crash-safe single-line chart hover (singleNearest mode)

### DIFF
--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -758,7 +758,11 @@ function createChartInstance(Chart: any): any {
       responsive: true,
       maintainAspectRatio: false,
       animation: false,
-      interaction: { mode: 'nearest', intersect: false },
+      // 'singleNearest' = crash-safe 'nearest' (registered in useChartJs): built
+      // on 'x' so it tolerates the band-fill/spanGaps overlay datasets that make
+      // raw 'nearest' throw, and returns only the ONE non-fill line nearest the
+      // cursor — single-line hover + highlight.
+      interaction: { mode: 'singleNearest', intersect: false },
       layout: {
         padding: {
           // Reserve room on the right edge for the y2 axis. When no y2
@@ -984,9 +988,12 @@ function createChartInstance(Chart: any): any {
           },
         },
         tooltip: {
-          // Single hovered line only — the tooltip inherits the chart's
-          // interaction `mode: 'nearest'` (above), so hovering reads out just the
-          // series under the cursor, not every visible line at that x.
+          // Single hovered line only, via the crash-safe 'singleNearest' mode
+          // (same one the interaction uses) — reads out just the line under the
+          // cursor, not every visible series at that x, and without the
+          // 'nearest'-on-band-fill crash.
+          mode: 'singleNearest',
+          intersect: false,
           callbacks: {
             title: (items: any[]) => fmtTickHMSms(items[0]?.parsed?.x ?? 0),
             label: (ctx: any) => {

--- a/content/dashboard-v3/src/composables/useChartJs.ts
+++ b/content/dashboard-v3/src/composables/useChartJs.ts
@@ -45,6 +45,36 @@ export function ensureChartJs(): Promise<any> {
       Chart.register(zoom);
       Chart.__zoomRegistered = true;
     }
+    // Custom interaction mode: 'singleNearest'. Chart.js's built-in 'nearest'
+    // hit-test throws "Cannot read properties of undefined (reading 'skip')" on
+    // the metrics chart's band-FILL (fillToValue) + spanGaps overlay datasets,
+    // whose elements arrays are intentionally sparse/undefined (compare mode is
+    // the worst case). The 'x' mode tolerates those gaps; we delegate to it and
+    // then return only the ONE non-fill line nearest the cursor's Y — so hover +
+    // tooltip read out a single line (what the operator wants) without crashing.
+    if (Chart?.Interaction?.modes?.x && !Chart.__singleNearestRegistered) {
+      const xMode = Chart.Interaction.modes.x;
+      Chart.Interaction.modes.singleNearest = (chart: any, e: any, options: any, useFinalPosition: any) => {
+        const items = xMode(chart, e, { ...options, intersect: false }, useFinalPosition);
+        if (!items || !items.length) return [];
+        const cy = e && typeof e.y === 'number' ? e.y : null;
+        let best: any = null;
+        let bestD = Infinity;
+        for (const it of items) {
+          const ds = chart.data?.datasets?.[it.datasetIndex];
+          if (ds && ds.fill) continue; // skip borderless avg↔peak band fills
+          const ey = it.element?.y;
+          if (typeof ey !== 'number') continue;
+          const d = cy == null ? 0 : Math.abs(ey - cy);
+          if (d < bestD) {
+            bestD = d;
+            best = it;
+          }
+        }
+        return best ? [best] : [];
+      };
+      Chart.__singleNearestRegistered = true;
+    }
     return Chart;
   })();
   return chartJsPromise;


### PR DESCRIPTION
## Problem

#864 reverted the metrics/bandwidth chart tooltip to single-line by inheriting Chart.js's built-in `'nearest'` interaction. But `'nearest'` throws **`Cannot read properties of undefined (reading 'skip')`** when it hit-tests the **band-fill (`fillToValue`) + `spanGaps` overlay datasets** introduced in #861 — their element arrays are intentionally sparse/undefined. Worst case is **compare mode**, which overlays several sessions' band fills at once.

## Fix

Register a custom `'singleNearest'` interaction mode (in `useChartJs.ts`):
- delegate to the gap-tolerant `'x'` hit-test (which doesn't choke on the sparse fill/spanGaps elements),
- then return only the **one non-fill line nearest the cursor's Y**.

Use it for both the chart `interaction` (hover-highlight) and the `tooltip`, so hover stays single-line — the behaviour #864 wanted — without the crash.

## Files
- `composables/useChartJs.ts` — register `singleNearest` (idempotent, guarded on `Chart.Interaction.modes.x`)
- `components/MetricsLineChart.vue` — `interaction.mode` + `tooltip.mode` → `singleNearest`

## Testing
- Typecheck + manual compare-mode hover check still to be run (I opened the PR but have not independently re-verified the build).
- Hover the bandwidth chart in compare mode (multiple sessions, band fills visible) — previously crashed, now reads out the single nearest line.

Follow-up to #864 / #861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)