### PR TITLE
feat: 1s low-latency segment rung (s1/master_1s) + converged LL generator

### DIFF
--- a/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
+++ b/android/InfiniteStreamPlayer/app/src/main/java/com/infinitestream/player/state/PlayerState.kt
@@ -63,7 +63,7 @@ enum class Protocol(val label: String) {
     }
 }
 enum class Segment(val label: String, val suffix: String) {
-    LL("LL", ""), TWO("2s", "_2s"), SIX("6s", "_6s");
+    LL("LL", ""), ONE("1s", "_1s"), TWO("2s", "_2s"), SIX("6s", "_6s");
 
     companion object {
         /** Map an `is.segment` launch-arg / wire value (iOS `SegmentLength`
@@ -71,6 +71,7 @@ enum class Segment(val label: String, val suffix: String) {
          *  label form too. null = unrecognised. #797. */
         fun fromArg(raw: String): Segment? = when (raw.trim().lowercase()) {
             "ll" -> LL
+            "s1", "1s" -> ONE
             "s2", "2s" -> TWO
             "s6", "6s" -> SIX
             else -> null
@@ -211,6 +212,7 @@ data class UiState(
             if (codec != Codec.AUTO && inferCodec(c.name) != codec) return@filter false
             when (segment) {
                 Segment.LL -> c.hasLL ?: true
+                Segment.ONE -> c.supportsSegment(1)
                 Segment.TWO -> c.supportsSegment(2)
                 Segment.SIX -> c.supportsSegment(6)
             }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/Models.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/Models.swift
@@ -229,12 +229,14 @@ enum StreamProtocol: String, CaseIterable, Identifiable, Codable {
 
 enum SegmentLength: String, CaseIterable, Identifiable, Codable {
     case ll
+    case s1
     case s2
     case s6
     var id: String { rawValue }
     var label: String {
         switch self {
         case .ll: return "LL"
+        case .s1: return "1s"
         case .s2: return "2s"
         case .s6: return "6s"
         }
@@ -243,6 +245,7 @@ enum SegmentLength: String, CaseIterable, Identifiable, Codable {
     var suffix: String {
         switch self {
         case .ll: return ""
+        case .s1: return "_1s"
         case .s2: return "_2s"
         case .s6: return "_6s"
         }
@@ -251,11 +254,13 @@ enum SegmentLength: String, CaseIterable, Identifiable, Codable {
     /// Worst-case (max) segment duration in seconds — segments aren't exactly the
     /// nominal length, so this is the ceiling the manifest declares. Used to size
     /// the startup forward-buffer cap (3× this): 6s-nominal tops out ~7s, 2s-
-    /// nominal ~9s (LL shares the 6s ceiling).
+    /// nominal ~9s (LL shares the 6s ceiling). 1s-nominal (TARGETDURATION 2)
+    /// tops out ~3s.
     var maxSegmentSeconds: Double {
         switch self {
         case .ll, .s6: return 7
         case .s2: return 9
+        case .s1: return 3
         }
     }
 }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -856,6 +856,7 @@ final class PlayerViewModel: ObservableObject {
             }
             switch segment {
             case .ll: return item.supportsLL
+            case .s1: return item.supportsSegment(1)
             case .s2: return item.supportsSegment(2)
             case .s6: return item.supportsSegment(6)
             }
@@ -880,6 +881,7 @@ final class PlayerViewModel: ObservableObject {
             }
             switch segment {
             case .ll: return item.supportsLL
+            case .s1: return item.supportsSegment(1)
             case .s2: return item.supportsSegment(2)
             case .s6: return item.supportsSegment(6)
             }

--- a/go-live/cmd/server/main.go
+++ b/go-live/cmd/server/main.go
@@ -70,12 +70,12 @@ func main() {
 	// Master playlist: /go-live/{content}/master.m3u8
 	router.HandleFunc("/go-live/{content}/master.m3u8", h.OnDemandMasterPlaylist).Methods(http.MethodGet, http.MethodHead)
 	// Master playlist with virtual durations
-	router.HandleFunc("/go-live/{content}/master_{duration:(?:2s|6s)}.m3u8", h.OnDemandMasterPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
-	router.HandleFunc("/go-live/{content}/{duration:(?:2s|6s)}/master.m3u8", h.OnDemandMasterPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
+	router.HandleFunc("/go-live/{content}/master_{duration:(?:1s|2s|6s)}.m3u8", h.OnDemandMasterPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
+	router.HandleFunc("/go-live/{content}/{duration:(?:1s|2s|6s)}/master.m3u8", h.OnDemandMasterPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
 
 	// Variant playlists with virtual durations
-	router.HandleFunc("/go-live/{content}/playlist_{duration:(?:2s|6s)}_{variant:.*}\\.m3u8", h.OnDemandVariantPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
-	router.HandleFunc("/go-live/{content}/{duration:(?:2s|6s)}/{variant:.*\\.m3u8}", h.OnDemandVariantPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
+	router.HandleFunc("/go-live/{content}/playlist_{duration:(?:1s|2s|6s)}_{variant:.*}\\.m3u8", h.OnDemandVariantPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
+	router.HandleFunc("/go-live/{content}/{duration:(?:1s|2s|6s)}/{variant:.*\\.m3u8}", h.OnDemandVariantPlaylistDuration).Methods(http.MethodGet, http.MethodHead)
 	// Variant playlists: /go-live/{content}/{variant}.m3u8
 	// This catches paths like /go-live/content/1080p/index.m3u8
 	router.HandleFunc("/go-live/{content}/{variant:.*\\.m3u8}", h.OnDemandVariantPlaylist).Methods(http.MethodGet, http.MethodHead)

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -444,6 +444,7 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 	}
 
 	llMasterWritten := false
+	master1sWritten := false
 	master2sWritten := false
 	master6sWritten := false
 	// One-shot "content fully warm" timing: how long from worker spawn until all
@@ -453,14 +454,20 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 	warmupLogged := false
 	lastLLUpdate := time.Time{}
 	lastSegLL := int64(-1)
+	lastSeg1 := int64(-1)
 	lastSeg2 := int64(-1)
 	lastSeg6 := int64(-1)
 	loopCountLL := 0
+	loopCount1 := 0
 	loopCount2 := 0
 	loopCount6 := 0
 	lastDashSeg2 := int64(-1)
 	lastDashSeg6 := int64(-1)
 	var recentLLTicks []struct {
+		at  time.Time
+		dur time.Duration
+	}
+	var recent1sTicks []struct {
 		at  time.Time
 		dur time.Duration
 	}
@@ -516,6 +523,17 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 				llMasterWritten = true
 			}
 		}
+		if !master1sWritten {
+			masterData, err := os.ReadFile(inputPath)
+			if err == nil {
+				updated := rewriteMasterForDuration(masterData, "1s", variantURIs, audioURIs)
+				if err := fileutil.WriteAtomic(durationOutputPath(content, durationMasterFilename("1s")), updated); err == nil {
+					master1sWritten = true
+				} else {
+					logf("ERROR: Failed to write 1s master playlist: %v\n", err)
+				}
+			}
+		}
 		if !master2sWritten {
 			masterData, err := os.ReadFile(inputPath)
 			if err == nil {
@@ -538,7 +556,7 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 				}
 			}
 		}
-		if !warmupLogged && llMasterWritten && master2sWritten && master6sWritten {
+		if !warmupLogged && llMasterWritten && master1sWritten && master2sWritten && master6sWritten {
 			warmupLogged = true
 			logf("[GO-LIVE][WARMUP] all master playlists ready: content=%s warmup=%.3fs variants=%d\n",
 				content, time.Since(workerStart).Seconds(), len(variantURIs))
@@ -643,6 +661,121 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 			lastLLUpdate = now
 			updatedLL = true
 			_ = updatedLL
+		}
+
+		currentSeg1 := int64(math.Floor(timeOffset / 1.0))
+		if lastSeg1 >= 0 && currentSeg1 < lastSeg1 {
+			loopCount1++
+			logf("[GO-LIVE:LOOP][1s] wrap_detected content=%s loop_count=%d prev_seg=%d seg=%d\n", content, loopCount1, lastSeg1, currentSeg1)
+		}
+		if currentSeg1 != lastSeg1 {
+			tickStart := time.Now()
+			for _, variant := range masterInfo.MasterPlaylist.Variants {
+				if variant == nil {
+					continue
+				}
+				variantInfo, byteranges, err := loader.LoadPlaylistInfoWithByteranges(folder, variant.URI)
+				if err != nil {
+					logf("ERROR: Failed to load variant %s: %v\n", variant.URI, err)
+					continue
+				}
+				variantFilename := filepath.Base(variant.URI)
+				if strings.Contains(variant.URI, "/") {
+					variantFilename = variant.URI
+				}
+				variantOutputPath := durationVariantOutputPath(content, "1s", variantFilename)
+				os.MkdirAll(filepath.Dir(variantOutputPath), 0755)
+				rangeGen := &generator.RangeHLSGenerator{}
+				playlistContent, err := rangeGen.GenerateVariantPlaylist(
+					variantInfo.MediaPlaylist,
+					byteranges,
+					variantInfo.RelPath,
+					variantInfo.SegmentMap,
+					timeNow,
+					loopCount1,
+					minDuration,
+					maxDuration,
+					"1s",
+					prefix,
+					content,
+					totalDuration,
+					timeOffset,
+				)
+				if err != nil {
+					logf("ERROR: Failed to generate 1s variant %s: %v\n", variant.URI, err)
+					continue
+				}
+				if err := fileutil.WriteAtomic(variantOutputPath, []byte(playlistContent)); err != nil {
+					logf("ERROR: Failed to write 1s variant %s: %v\n", variant.URI, err)
+					continue
+				}
+			}
+			for _, audioURI := range audioURIs {
+				variantInfo, byteranges, err := loader.LoadPlaylistInfoWithByteranges(folder, audioURI)
+				if err != nil {
+					logf("ERROR: Failed to load audio %s: %v\n", audioURI, err)
+					continue
+				}
+				audioOutputPath := durationVariantOutputPath(content, "1s", audioURI)
+				os.MkdirAll(filepath.Dir(audioOutputPath), 0755)
+				rangeGen := &generator.RangeHLSGenerator{}
+				playlistContent, err := rangeGen.GenerateVariantPlaylist(
+					variantInfo.MediaPlaylist,
+					byteranges,
+					variantInfo.RelPath,
+					variantInfo.SegmentMap,
+					timeNow,
+					loopCount1,
+					minDuration,
+					maxDuration,
+					"1s",
+					prefix,
+					content,
+					totalDuration,
+					timeOffset,
+				)
+				if err != nil {
+					logf("ERROR: Failed to generate 1s audio %s: %v\n", audioURI, err)
+					continue
+				}
+				if err := fileutil.WriteAtomic(audioOutputPath, []byte(playlistContent)); err != nil {
+					logf("ERROR: Failed to write 1s audio %s: %v\n", audioURI, err)
+					continue
+				}
+			}
+			tickElapsed := time.Since(tickStart)
+			recent1sTicks = append(recent1sTicks, struct {
+				at  time.Time
+				dur time.Duration
+			}{at: time.Now(), dur: tickElapsed})
+			cutoff := time.Now().Add(-5 * time.Minute)
+			total := time.Duration(0)
+			count := 0
+			pruned := recent1sTicks[:0]
+			for _, sample := range recent1sTicks {
+				if sample.at.After(cutoff) {
+					pruned = append(pruned, sample)
+					total += sample.dur
+					count++
+				}
+			}
+			recent1sTicks = pruned
+			avg := 0.0
+			if count > 0 {
+				avg = total.Seconds() / float64(count)
+			}
+			logf("[GO-LIVE:HLS][1s] tick=%.3fs avg_5m=%.3fs\n",
+				tickElapsed.Seconds(), avg)
+			rangeTickMu.Lock()
+			rangeTickByKey[fmt.Sprintf("%s|%s", content, "1s")] = tickStats{
+				LastTick:  tickElapsed.Seconds(),
+				Avg5m:     avg,
+				Variants:  len(masterInfo.MasterPlaylist.Variants),
+				Audio:     len(audioURIs),
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			}
+			rangeTickMu.Unlock()
+			lastSeg1 = currentSeg1
 		}
 
 		currentSeg2 := int64(math.Floor(timeOffset / 2.0))
@@ -1487,9 +1620,11 @@ func (h *Handler) OnDemandVariantPlaylist(w http.ResponseWriter, r *http.Request
 	content := vars["content"]
 	variant := vars["variant"]
 
-	if strings.HasPrefix(variant, "master_2s") || strings.HasPrefix(variant, "master_6s") {
+	if strings.HasPrefix(variant, "master_1s") || strings.HasPrefix(variant, "master_2s") || strings.HasPrefix(variant, "master_6s") {
 		duration := "2s"
-		if strings.HasPrefix(variant, "master_6s") {
+		if strings.HasPrefix(variant, "master_1s") {
+			duration = "1s"
+		} else if strings.HasPrefix(variant, "master_6s") {
 			duration = "6s"
 		}
 		r = mux.SetURLVars(r, map[string]string{
@@ -1500,9 +1635,11 @@ func (h *Handler) OnDemandVariantPlaylist(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if strings.HasPrefix(variant, "playlist_2s_") || strings.HasPrefix(variant, "playlist_6s_") {
+	if strings.HasPrefix(variant, "playlist_1s_") || strings.HasPrefix(variant, "playlist_2s_") || strings.HasPrefix(variant, "playlist_6s_") {
 		duration := "2s"
-		if strings.HasPrefix(variant, "playlist_6s_") {
+		if strings.HasPrefix(variant, "playlist_1s_") {
+			duration = "1s"
+		} else if strings.HasPrefix(variant, "playlist_6s_") {
 			duration = "6s"
 		}
 		r = mux.SetURLVars(r, map[string]string{
@@ -2052,13 +2189,16 @@ func injectMasterStartTag(data []byte, offsetSeconds float64) []byte {
 	return []byte(tag + text)
 }
 
-// masterStartOffsetForDuration converts a "2s"/"6s" duration string into the
+// masterStartOffsetForDuration converts a "1s"/"2s"/"6s" duration string into the
 // recommended live-edge TIME-OFFSET. Must match the media playlists'
 // HOLD-BACK (3× TARGETDURATION), where TARGETDURATION is the integer
-// ceiling of actual segment duration — 2s segments round to 2 (→6s offset),
+// ceiling of actual segment duration — 1s segments round to 1 (→3s offset),
+// 2s segments round to 2 (→6s offset),
 // 6s segments actually encode at 6.006s and round to 7 (→21s offset).
 func masterStartOffsetForDuration(duration string) float64 {
 	switch duration {
+	case "1s":
+		return 3.0
 	case "2s":
 		return 6.0
 	case "6s":

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -589,6 +589,8 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 					loopCountLL,
 					minDuration,
 					maxDuration,
+					totalDuration,
+					timeOffset,
 				)
 				if err != nil {
 					logf("ERROR: Failed to generate variant %s: %v\n", variant.URI, err)
@@ -616,6 +618,8 @@ func runUnifiedHLSWorker(ctx context.Context, worker *hlsWorker) {
 					loopCountLL,
 					minDuration,
 					maxDuration,
+					totalDuration,
+					timeOffset,
 				)
 				if err != nil {
 					logf("ERROR: Failed to generate audio %s: %v\n", audioURI, err)
@@ -1823,6 +1827,8 @@ func runContinuousLLHLS(ctx context.Context, inputPath, outputPath, content stri
 				loopCount,
 				minDuration,
 				maxDuration,
+				0,
+				0,
 			)
 
 			if err != nil {
@@ -1858,6 +1864,8 @@ func runContinuousLLHLS(ctx context.Context, inputPath, outputPath, content stri
 				loopCount,
 				minDuration,
 				maxDuration,
+				0,
+				0,
 			)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "ERROR: Failed to generate audio %s: %v\n", audioURI, err)

--- a/go-live/pkg/generator/ll_hls.go
+++ b/go-live/pkg/generator/ll_hls.go
@@ -64,6 +64,15 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	// Auto-detect content characteristics from first segment
 	segmentDuration, partialsPerSegment, partialDuration := detectContentCharacteristics(pl, byteranges)
 
+	// Determine TARGETDURATION from the actual GOP-aligned sub-segment sizes.
+	// We split each underlying segment into sub-segments that start at each
+	// INDEPENDENT fragment (≈1s GOPs), so the largest sub-segment governs
+	// TARGETDURATION (ceil of the max group duration → ~1). This drops the
+	// AVPlayer HOLD-BACK floor from 18s (with a 6s EXTINF) to 3s.
+	subSegTargetDuration := computeSubSegmentTargetDuration(pl, byteranges, partialDuration, segmentDuration)
+	// HOLD-BACK is 3 × TARGETDURATION per RFC 8216 recommendation.
+	holdBack := 3.0 * float64(subSegTargetDuration)
+
 	// Playlist position remains absolute-time based.
 	timeOffset := math.Mod(timeNow, minDuration)
 
@@ -122,7 +131,7 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	// LL-HLS playlist header
 	sb.WriteString("#EXTM3U\n")
 	sb.WriteString("#EXT-X-VERSION:10\n") // Version 10 for LL-HLS
-	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", int(segmentDuration)))
+	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", subSegTargetDuration))
 	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", sequence))
 	// EXT-X-DISCONTINUITY-SEQUENCE is REQUIRED by RFC 8216 §4.3.3.3 when the
 	// playlist contains an EXT-X-DISCONTINUITY tag. Required for cross-variant
@@ -132,7 +141,7 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 
 	// LL-HLS specific tags
 	sb.WriteString(fmt.Sprintf("#EXT-X-PART-INF:PART-TARGET=%.3f\n", partialDuration))
-	sb.WriteString("#EXT-X-SERVER-CONTROL:PART-HOLD-BACK=3.0\n")
+	sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f,PART-HOLD-BACK=3.0\n", holdBack))
 
 	// Program date time
 	sb.WriteString(fmt.Sprintf("#EXT-X-PROGRAM-DATE-TIME:%s\n", pdt.Format("2006-01-02T15:04:05.000Z")))
@@ -187,20 +196,8 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 			segmentURI := baseURI(segment.URI)
 			fragments := byteranges[segment.URI]
 
-			// Write all partials for this complete segment
-			for _, fragment := range fragments {
-				partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
-					partialDuration, segmentURI, fragment.Length, fragment.Offset)
-
-				if fragment.Independent {
-					partTag += ",INDEPENDENT=YES"
-				}
-
-				sb.WriteString(partTag + "\n")
-			}
-
-			sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", segment.Duration.Seconds()))
-			sb.WriteString(segmentURI + "\n")
+			// Emit GOP-aligned sub-segments (each ≈1s) with their partials.
+			writeCompleteSegmentSubSegments(&sb, segmentURI, fragments, partialDuration)
 
 			accumulatedDuration += segment.Duration.Seconds()
 		}
@@ -228,20 +225,8 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 		segmentURI := baseURI(segment.URI)
 		fragments := byteranges[segment.URI]
 
-		// Write all partials for this complete segment
-		for _, fragment := range fragments {
-			partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
-				partialDuration, segmentURI, fragment.Length, fragment.Offset)
-
-			if fragment.Independent {
-				partTag += ",INDEPENDENT=YES"
-			}
-
-			sb.WriteString(partTag + "\n")
-		}
-
-		sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", segment.Duration.Seconds()))
-		sb.WriteString(segmentURI + "\n")
+		// Emit GOP-aligned sub-segments (each ≈1s) with their partials.
+		writeCompleteSegmentSubSegments(&sb, segmentURI, fragments, partialDuration)
 
 		accumulatedDuration += segment.Duration.Seconds()
 
@@ -256,27 +241,129 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 		segmentURI := baseURI(currentSegment.URI)
 		fragments := byteranges[currentSegment.URI]
 
-		// For current segment: show partials from 0 up to current_partial_idx (inclusive)
-		for partialIdx := 0; partialIdx <= currentPartialIdx && partialIdx < len(fragments); partialIdx++ {
-			fragment := fragments[partialIdx]
-			partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
-				partialDuration, segmentURI, fragment.Length, fragment.Offset)
+		// Only fragments up to current_partial_idx (inclusive) are "live".
+		availableCount := currentPartialIdx + 1
+		if availableCount > len(fragments) {
+			availableCount = len(fragments)
+		}
+		segmentComplete := currentPartialIdx >= len(fragments)-1
 
-			if fragment.Independent {
-				partTag += ",INDEPENDENT=YES"
+		// Walk the available fragments, grouping into GOP-aligned sub-segments
+		// that start at each INDEPENDENT fragment. A group is emitted as a
+		// closed sub-segment (parts + #EXT-X-BYTERANGE + #EXTINF) only once its
+		// closing boundary is known — either the next INDEPENDENT fragment has
+		// appeared, or the whole segment is complete. The trailing, not-yet-
+		// closed group stays as bare #EXT-X-PART lines (no #EXTINF yet),
+		// preserving the existing live-edge behaviour.
+		groups := groupFragmentsByGOP(fragments[:availableCount])
+		for gi, group := range groups {
+			// A group is closed if it is not the last available group, or if
+			// it is the last group AND the segment is complete (no more
+			// fragments will arrive to extend it).
+			closed := gi < len(groups)-1 || segmentComplete
+
+			// Emit every part in the group (unchanged part formatting).
+			for _, fragment := range group {
+				partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
+					partialDuration, segmentURI, fragment.Length, fragment.Offset)
+				if fragment.Independent {
+					partTag += ",INDEPENDENT=YES"
+				}
+				sb.WriteString(partTag + "\n")
 			}
 
-			sb.WriteString(partTag + "\n")
-		}
-
-		// Only write EXTINF if current segment is complete (all partials available)
-		if currentPartialIdx >= len(fragments)-1 {
-			sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", currentSegment.Duration.Seconds()))
-			sb.WriteString(segmentURI + "\n")
+			if closed {
+				writeSubSegmentTail(&sb, segmentURI, group, partialDuration)
+			}
 		}
 	}
 
 	return sb.String(), nil
+}
+
+// groupFragmentsByGOP splits a contiguous run of fragments into GOP-aligned
+// sub-segment groups. A new group begins at every INDEPENDENT fragment (a
+// keyframe boundary); following non-independent fragments accumulate into the
+// current group until the next INDEPENDENT fragment or end of input. If the
+// first fragment is not independent (e.g. mid-GOP at a window edge), it seeds
+// the first group so no fragment is dropped.
+func groupFragmentsByGOP(fragments []parser.ByteRange) [][]parser.ByteRange {
+	var groups [][]parser.ByteRange
+	var current []parser.ByteRange
+	for _, fragment := range fragments {
+		if fragment.Independent && len(current) > 0 {
+			groups = append(groups, current)
+			current = nil
+		}
+		current = append(current, fragment)
+	}
+	if len(current) > 0 {
+		groups = append(groups, current)
+	}
+	return groups
+}
+
+// writeSubSegmentTail emits the #EXT-X-BYTERANGE + #EXTINF + URI lines that
+// close one GOP-aligned sub-segment. The byterange spans the contiguous run of
+// the group's fragments (length = sum of fragment lengths, offset = first
+// fragment offset); the EXTINF duration = sum of the group's part durations
+// (≈ len(group) × partialDuration).
+func writeSubSegmentTail(sb *strings.Builder, segmentURI string, group []parser.ByteRange, partialDuration float64) {
+	if len(group) == 0 {
+		return
+	}
+	totalLength := 0
+	for _, fragment := range group {
+		totalLength += fragment.Length
+	}
+	firstOffset := group[0].Offset
+	groupDuration := float64(len(group)) * partialDuration
+
+	sb.WriteString(fmt.Sprintf("#EXT-X-BYTERANGE:%d@%d\n", totalLength, firstOffset))
+	sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", groupDuration))
+	sb.WriteString(segmentURI + "\n")
+}
+
+// writeCompleteSegmentSubSegments emits all GOP-aligned sub-segments for a
+// fully-available underlying segment: every part, then a closing
+// #EXT-X-BYTERANGE + #EXTINF per sub-segment group.
+func writeCompleteSegmentSubSegments(sb *strings.Builder, segmentURI string, fragments []parser.ByteRange, partialDuration float64) {
+	for _, group := range groupFragmentsByGOP(fragments) {
+		for _, fragment := range group {
+			partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
+				partialDuration, segmentURI, fragment.Length, fragment.Offset)
+			if fragment.Independent {
+				partTag += ",INDEPENDENT=YES"
+			}
+			sb.WriteString(partTag + "\n")
+		}
+		writeSubSegmentTail(sb, segmentURI, group, partialDuration)
+	}
+}
+
+// computeSubSegmentTargetDuration returns the integer ceiling of the largest
+// GOP-aligned sub-segment duration across the playlist's segments. This is the
+// EXT-X-TARGETDURATION for the sub-segmented LL playlist (≈1 for ~1s GOPs).
+// Falls back to the segment duration if no fragment byteranges are available.
+func computeSubSegmentTargetDuration(pl *playlist.Media, byteranges map[string][]parser.ByteRange, partialDuration float64, segmentDuration float64) int {
+	maxGroupDuration := 0.0
+	if pl != nil {
+		for _, seg := range pl.Segments {
+			if seg == nil {
+				continue
+			}
+			for _, group := range groupFragmentsByGOP(byteranges[seg.URI]) {
+				if d := float64(len(group)) * partialDuration; d > maxGroupDuration {
+					maxGroupDuration = d
+				}
+			}
+		}
+	}
+	if maxGroupDuration <= 0 {
+		// No byterange data — preserve prior behaviour (whole-segment EXTINF).
+		return int(segmentDuration)
+	}
+	return int(math.Ceil(maxGroupDuration))
 }
 
 func joinURI(relPath, uri string) string {

--- a/go-live/pkg/generator/ll_hls.go
+++ b/go-live/pkg/generator/ll_hls.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"strings"
 	"sync"
@@ -42,14 +41,16 @@ func logOncePerSecondLL(message string) {
 // LLHLSGenerator generates LL-HLS playlists
 type LLHLSGenerator struct{}
 
-func writeLoopDateRange(sb *strings.Builder, loopCount int, at time.Time, marker string) {
-	timestamp := at.UTC().Format("2006-01-02T15:04:05.000Z")
-	// Loop boundary marker for downstream analytics and loop counters.
-	// sb.WriteString(fmt.Sprintf("#EXT-X-DATERANGE:ID=\"loop-%d-%s\",CLASS=\"com.infinite.loop\",START-DATE=\"%s\",X-LOOP-COUNT=\"%d\"\n", loopCount, marker, timestamp, loopCount))
-	logOncePerSecondLL(fmt.Sprintf("[GO-LIVE:LOOP][LL] marker=%s loop_count=%d start_date=%s", marker, loopCount, timestamp))
-}
-
-// GenerateVariantPlaylist generates a single variant playlist with byte-range partials
+// GenerateVariantPlaylist generates a single LL-HLS variant playlist.
+//
+// The LL playlist is, by construction, the 1s range playlist (the `s1` rung
+// built by buildRangeSegments with targetSeconds=1) PLUS per-segment
+// EXT-X-PART tags and the LL-only header. It shares ALL of the
+// MEDIA-SEQUENCE / DISCONTINUITY-SEQUENCE / sliding-window / loop-wrap math
+// with the range generator via generateVariantPlaylistCore, so the sequence
+// number is derived from len(segments) — the flat 1s-segment count — and can
+// never drift (the historical bug where the underlying-6s-segment count was
+// used for MEDIA-SEQUENCE while ~6× as many EXTINFs aged out of the window).
 func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	pl *playlist.Media,
 	byteranges map[string][]parser.ByteRange,
@@ -59,311 +60,35 @@ func (g *LLHLSGenerator) GenerateVariantPlaylist(
 	loopCount int,
 	minDuration float64,
 	maxDuration float64,
+	syncTotalDuration float64,
+	syncTimeOffset float64,
 ) (string, error) {
+	_ = maxDuration
 
-	// Auto-detect content characteristics from first segment
-	segmentDuration, partialsPerSegment, partialDuration := detectContentCharacteristics(pl, byteranges)
+	// PART-TARGET (the ~200ms partial duration). Detected from the first
+	// underlying segment's fragment count, matching prior behaviour.
+	_, _, partialDuration := detectContentCharacteristics(pl, byteranges)
 
-	// Determine TARGETDURATION from the actual GOP-aligned sub-segment sizes.
-	// We split each underlying segment into sub-segments that start at each
-	// INDEPENDENT fragment (≈1s GOPs), so the largest sub-segment governs
-	// TARGETDURATION (ceil of the max group duration → ~1). This drops the
-	// AVPlayer HOLD-BACK floor from 18s (with a 6s EXTINF) to 3s.
-	subSegTargetDuration := computeSubSegmentTargetDuration(pl, byteranges, partialDuration, segmentDuration)
-	// HOLD-BACK is 3 × TARGETDURATION per RFC 8216 recommendation.
-	holdBack := 3.0 * float64(subSegTargetDuration)
-
-	// Playlist position remains absolute-time based.
-	timeOffset := math.Mod(timeNow, minDuration)
-
-	// Calculate PDT (Program Date Time)
-	pdtSeconds := timeNow - maxDuration
-	pdt := time.Unix(int64(pdtSeconds), 0).UTC()
-
-	// Calculate which segment we're on using ideal segment duration
-	// This matches live.py approach and handles variable-length final segments correctly
-	numSegments := countSegments(pl)
-	idealSegmentDuration := minDuration / float64(numSegments)
-	currentSegmentIdx := int(timeOffset / idealSegmentDuration)
-
-	// Clamp to valid range
-	if currentSegmentIdx >= numSegments {
-		currentSegmentIdx = numSegments - 1
-	}
-	if currentSegmentIdx < 0 {
-		currentSegmentIdx = 0
+	// Build the SAME flat 1s segments the s1 range rung uses (group ~5
+	// fragments → one 1s segment), so the LL's complete segments are
+	// byte-identical to s1. Each rangeSegment now also carries its Fragments,
+	// which the core emits as EXT-X-PART tags.
+	const llTargetSeconds = 1.0
+	segments, totalDuration, err := buildRangeSegments(pl, byteranges, llTargetSeconds, true)
+	if err != nil {
+		return "", err
 	}
 
-	// Calculate which partial within the current segment
-	segmentStartTime := float64(currentSegmentIdx) * idealSegmentDuration
-	timeWithinSegment := timeOffset - segmentStartTime
-	currentPartialIdx := int(timeWithinSegment / partialDuration)
-
-	// Clamp partial index to valid range
-	if currentPartialIdx > partialsPerSegment-1 {
-		currentPartialIdx = partialsPerSegment - 1
-	}
-	if currentPartialIdx < 0 {
-		currentPartialIdx = 0
-	}
-
-	// Calculate media sequence (segment number)
-	sequence := (loopCount * numSegments) + currentSegmentIdx
-
-	// Pre-compute the window wrap decision here so we can emit the correct
-	// EXT-X-DISCONTINUITY-SEQUENCE in the playlist header below. The actual
-	// window-building logic further down uses the same computation.
-	segmentsNeededForDiscSeq := int(MAX_LIVE_WINDOW_DURATION / idealSegmentDuration)
-	wrapAroundForDiscSeq := currentSegmentIdx < segmentsNeededForDiscSeq-1
-	firstSegLoop := loopCount
-	if wrapAroundForDiscSeq {
-		// Wrapping: first segment in window comes from the previous loop,
-		// and this playlist contains the discontinuity marker itself.
-		firstSegLoop = loopCount - 1
-		if firstSegLoop < 0 {
-			firstSegLoop = 0
-		}
-	}
-
-	// Build playlist
-	var sb strings.Builder
-
-	// LL-HLS playlist header
-	sb.WriteString("#EXTM3U\n")
-	sb.WriteString("#EXT-X-VERSION:10\n") // Version 10 for LL-HLS
-	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", subSegTargetDuration))
-	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", sequence))
-	// EXT-X-DISCONTINUITY-SEQUENCE is REQUIRED by RFC 8216 §4.3.3.3 when the
-	// playlist contains an EXT-X-DISCONTINUITY tag. Required for cross-variant
-	// synchronization during ABR evaluation; absence causes AVPlayer -12642
-	// "No matching mediaFile found from playlist".
-	sb.WriteString(fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", firstSegLoop))
-
-	// LL-HLS specific tags
-	sb.WriteString(fmt.Sprintf("#EXT-X-PART-INF:PART-TARGET=%.3f\n", partialDuration))
-	sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f,PART-HOLD-BACK=3.0\n", holdBack))
-
-	// Program date time
-	sb.WriteString(fmt.Sprintf("#EXT-X-PROGRAM-DATE-TIME:%s\n", pdt.Format("2006-01-02T15:04:05.000Z")))
-
-	// Start time-offset: 3.0 seconds to match PART-HOLD-BACK
-	sb.WriteString("#EXT-X-START:TIME-OFFSET=-3.0,PRECISE=YES\n")
-
-	// Init segment (fMP4 initialization)
-	if segmentMap != "" {
-		sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", baseURI(segmentMap)))
-	}
-
-	// Add discontinuity at loop boundary
-	if currentSegmentIdx == 0 {
-		writeLoopDateRange(&sb, loopCount, pdt, "head")
-		sb.WriteString("#EXT-X-DISCONTINUITY\n")
-		if segmentMap != "" {
-			sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", baseURI(segmentMap)))
-		}
-	}
-
-	// Calculate sliding window - how many past segments to show
-	// Use idealSegmentDuration so audio/video windows align on segment count.
-	segmentsNeeded := int(MAX_LIVE_WINDOW_DURATION / idealSegmentDuration)
-
-	// Handle wrap-around at loop boundary
-	var startIdx int
-	var wrapAround bool
-
-	if currentSegmentIdx < segmentsNeeded-1 {
-		// Need to wrap around - show segments from end of previous loop
-		segmentsFromEnd := segmentsNeeded - 1 - currentSegmentIdx
-		startIdx = numSegments - segmentsFromEnd
-		wrapAround = true
-	} else {
-		// Normal case - enough segments in current position
-		startIdx = currentSegmentIdx - segmentsNeeded + 1
-		wrapAround = false
-	}
-
-	accumulatedDuration := 0.0
-
-	// FIRST: Write all PAST segments (fully available, in chronological order)
-	// Handle wrap-around case: segments from end of video, then segments from beginning
-	if wrapAround {
-		// Write segments from end of video (previous loop)
-		for segIdx := startIdx; segIdx < numSegments; segIdx++ {
-			segment := getSegment(pl, segIdx)
-			if segment == nil {
-				continue
-			}
-			segmentURI := baseURI(segment.URI)
-			fragments := byteranges[segment.URI]
-
-			// Emit GOP-aligned sub-segments (each ≈1s) with their partials.
-			writeCompleteSegmentSubSegments(&sb, segmentURI, fragments, partialDuration)
-
-			accumulatedDuration += segment.Duration.Seconds()
-		}
-
-		// Add discontinuity before switching from previous loop to current loop segments
-		boundaryAt := pdt.Add(time.Duration(accumulatedDuration * float64(time.Second)))
-		writeLoopDateRange(&sb, loopCount, boundaryAt, "wrap")
-		sb.WriteString("#EXT-X-DISCONTINUITY\n")
-		if segmentMap != "" {
-			sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", baseURI(segmentMap)))
-		}
-	}
-
-	// Write segments from current loop (0 to current_segment_idx)
-	startSegIdx := 0
-	if !wrapAround {
-		startSegIdx = startIdx
-	}
-
-	for segIdx := startSegIdx; segIdx < currentSegmentIdx; segIdx++ {
-		segment := getSegment(pl, segIdx)
-		if segment == nil {
-			continue
-		}
-		segmentURI := baseURI(segment.URI)
-		fragments := byteranges[segment.URI]
-
-		// Emit GOP-aligned sub-segments (each ≈1s) with their partials.
-		writeCompleteSegmentSubSegments(&sb, segmentURI, fragments, partialDuration)
-
-		accumulatedDuration += segment.Duration.Seconds()
-
-		if accumulatedDuration >= MAX_LIVE_WINDOW_DURATION {
-			break
-		}
-	}
-
-	// LAST: Write the CURRENT segment (live edge - may be incomplete)
-	currentSegment := getSegment(pl, currentSegmentIdx)
-	if currentSegment != nil {
-		segmentURI := baseURI(currentSegment.URI)
-		fragments := byteranges[currentSegment.URI]
-
-		// Only fragments up to current_partial_idx (inclusive) are "live".
-		availableCount := currentPartialIdx + 1
-		if availableCount > len(fragments) {
-			availableCount = len(fragments)
-		}
-		segmentComplete := currentPartialIdx >= len(fragments)-1
-
-		// Walk the available fragments, grouping into GOP-aligned sub-segments
-		// that start at each INDEPENDENT fragment. A group is emitted as a
-		// closed sub-segment (parts + #EXT-X-BYTERANGE + #EXTINF) only once its
-		// closing boundary is known — either the next INDEPENDENT fragment has
-		// appeared, or the whole segment is complete. The trailing, not-yet-
-		// closed group stays as bare #EXT-X-PART lines (no #EXTINF yet),
-		// preserving the existing live-edge behaviour.
-		groups := groupFragmentsByGOP(fragments[:availableCount])
-		for gi, group := range groups {
-			// A group is closed if it is not the last available group, or if
-			// it is the last group AND the segment is complete (no more
-			// fragments will arrive to extend it).
-			closed := gi < len(groups)-1 || segmentComplete
-
-			// Emit every part in the group (unchanged part formatting).
-			for _, fragment := range group {
-				partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
-					partialDuration, segmentURI, fragment.Length, fragment.Offset)
-				if fragment.Independent {
-					partTag += ",INDEPENDENT=YES"
-				}
-				sb.WriteString(partTag + "\n")
-			}
-
-			if closed {
-				writeSubSegmentTail(&sb, segmentURI, group, partialDuration)
-			}
-		}
-	}
-
-	return sb.String(), nil
-}
-
-// groupFragmentsByGOP splits a contiguous run of fragments into GOP-aligned
-// sub-segment groups. A new group begins at every INDEPENDENT fragment (a
-// keyframe boundary); following non-independent fragments accumulate into the
-// current group until the next INDEPENDENT fragment or end of input. If the
-// first fragment is not independent (e.g. mid-GOP at a window edge), it seeds
-// the first group so no fragment is dropped.
-func groupFragmentsByGOP(fragments []parser.ByteRange) [][]parser.ByteRange {
-	var groups [][]parser.ByteRange
-	var current []parser.ByteRange
-	for _, fragment := range fragments {
-		if fragment.Independent && len(current) > 0 {
-			groups = append(groups, current)
-			current = nil
-		}
-		current = append(current, fragment)
-	}
-	if len(current) > 0 {
-		groups = append(groups, current)
-	}
-	return groups
-}
-
-// writeSubSegmentTail emits the #EXT-X-BYTERANGE + #EXTINF + URI lines that
-// close one GOP-aligned sub-segment. The byterange spans the contiguous run of
-// the group's fragments (length = sum of fragment lengths, offset = first
-// fragment offset); the EXTINF duration = sum of the group's part durations
-// (≈ len(group) × partialDuration).
-func writeSubSegmentTail(sb *strings.Builder, segmentURI string, group []parser.ByteRange, partialDuration float64) {
-	if len(group) == 0 {
-		return
-	}
-	totalLength := 0
-	for _, fragment := range group {
-		totalLength += fragment.Length
-	}
-	firstOffset := group[0].Offset
-	groupDuration := float64(len(group)) * partialDuration
-
-	sb.WriteString(fmt.Sprintf("#EXT-X-BYTERANGE:%d@%d\n", totalLength, firstOffset))
-	sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", groupDuration))
-	sb.WriteString(segmentURI + "\n")
-}
-
-// writeCompleteSegmentSubSegments emits all GOP-aligned sub-segments for a
-// fully-available underlying segment: every part, then a closing
-// #EXT-X-BYTERANGE + #EXTINF per sub-segment group.
-func writeCompleteSegmentSubSegments(sb *strings.Builder, segmentURI string, fragments []parser.ByteRange, partialDuration float64) {
-	for _, group := range groupFragmentsByGOP(fragments) {
-		for _, fragment := range group {
-			partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
-				partialDuration, segmentURI, fragment.Length, fragment.Offset)
-			if fragment.Independent {
-				partTag += ",INDEPENDENT=YES"
-			}
-			sb.WriteString(partTag + "\n")
-		}
-		writeSubSegmentTail(sb, segmentURI, group, partialDuration)
-	}
-}
-
-// computeSubSegmentTargetDuration returns the integer ceiling of the largest
-// GOP-aligned sub-segment duration across the playlist's segments. This is the
-// EXT-X-TARGETDURATION for the sub-segmented LL playlist (≈1 for ~1s GOPs).
-// Falls back to the segment duration if no fragment byteranges are available.
-func computeSubSegmentTargetDuration(pl *playlist.Media, byteranges map[string][]parser.ByteRange, partialDuration float64, segmentDuration float64) int {
-	maxGroupDuration := 0.0
-	if pl != nil {
-		for _, seg := range pl.Segments {
-			if seg == nil {
-				continue
-			}
-			for _, group := range groupFragmentsByGOP(byteranges[seg.URI]) {
-				if d := float64(len(group)) * partialDuration; d > maxGroupDuration {
-					maxGroupDuration = d
-				}
-			}
-		}
-	}
-	if maxGroupDuration <= 0 {
-		// No byterange data — preserve prior behaviour (whole-segment EXTINF).
-		return int(segmentDuration)
-	}
-	return int(math.Ceil(maxGroupDuration))
+	return generateVariantPlaylistCore(segments, totalDuration, segmentMap, relPath, timeNow, loopCount, minDuration, syncTotalDuration, syncTimeOffset, variantPlaylistOptions{
+		emitPartials: true,
+		useByterange: true,
+		renderURI: func(uri string) string {
+			return baseURI(uri)
+		},
+		partTarget:   partialDuration,
+		partHoldBack: 3.0,
+		loopMarker:   "LL",
+	})
 }
 
 func joinURI(relPath, uri string) string {
@@ -412,23 +137,4 @@ func detectContentCharacteristics(pl *playlist.Media, byteranges map[string][]pa
 		segmentDuration, fragmentCount, partialDuration))
 
 	return segmentDuration, fragmentCount, partialDuration
-}
-
-// countSegments counts non-nil segments in playlist
-func countSegments(pl *playlist.Media) int {
-	count := 0
-	for _, seg := range pl.Segments {
-		if seg != nil {
-			count++
-		}
-	}
-	return count
-}
-
-// getSegment safely gets a segment by index
-func getSegment(pl *playlist.Media, idx int) *playlist.MediaSegment {
-	if idx < 0 || idx >= len(pl.Segments) {
-		return nil
-	}
-	return pl.Segments[idx]
 }

--- a/go-live/pkg/generator/range_hls.go
+++ b/go-live/pkg/generator/range_hls.go
@@ -18,6 +18,12 @@ type rangeSegment struct {
 	Offset   int
 	Length   int
 	Duration float64
+	// Fragments holds the underlying ~200ms fragment byteranges that make up
+	// this 1s segment, in order. Populated only on the byterange path (the
+	// only path that has fragment-level data). Consumed by the LL-HLS variant
+	// to emit one EXT-X-PART tag per fragment; the non-partials 2s/6s/1s path
+	// ignores it, so this field is purely additive.
+	Fragments []parser.ByteRange
 }
 
 // RangeHLSGenerator generates virtual 2s/6s playlists without partials.
@@ -72,6 +78,62 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 	if err != nil {
 		return "", err
 	}
+
+	return generateVariantPlaylistCore(segments, totalDuration, segmentMap, relPath, timeNow, loopCount, minDuration, syncTotalDuration, syncTimeOffset, variantPlaylistOptions{
+		emitPartials: false,
+		useByterange: useByterange,
+		renderURI: func(uri string) string {
+			return absoluteSegmentURI(prefix, content, joinRelPath(relPath, uri))
+		},
+		loopMarker: "RANGE",
+	})
+}
+
+// variantPlaylistOptions captures the per-variant differences between the
+// non-partials range playlists (2s/6s/1s) and the LL-HLS playlist. Everything
+// else — the flat-segment list, the MEDIA-SEQUENCE / DISCONTINUITY-SEQUENCE /
+// sliding-window / loop-wrap math, and the PDT — is shared in
+// generateVariantPlaylistCore so the LL playlist is structurally identical to
+// the 1s range playlist (same `len(segments)`-derived sequence) PLUS partials.
+type variantPlaylistOptions struct {
+	// emitPartials turns on the LL-HLS behaviour: an EXT-X-PART tag per
+	// underlying fragment before each segment's EXTINF, the LL-only header
+	// tags (EXT-X-PART-INF, PART-HOLD-BACK), and the live-edge tail of bare
+	// EXT-X-PART lines for the still-incomplete current segment.
+	emitPartials bool
+	// useByterange controls whether the closed segments carry an
+	// EXT-X-BYTERANGE line (only the byterange path — targetSeconds < 6 — has
+	// per-segment offsets).
+	useByterange bool
+	// renderURI maps a parsed segment/init URI to the form the playlist emits
+	// (absolute prefix/content path for range, bare filename for LL).
+	renderURI func(string) string
+	// partTarget / partHoldBack are only consulted when emitPartials is true.
+	partTarget   float64
+	partHoldBack float64
+	// loopMarker tags the once-per-second loop-boundary log line (RANGE / LL).
+	loopMarker string
+}
+
+// generateVariantPlaylistCore builds a media playlist from a flat list of 1s
+// segments. The MEDIA-SEQUENCE / DISCONTINUITY-SEQUENCE / window / wrap math is
+// derived from len(segments) — the flat sub-segment count — so a given segment
+// keeps a stable, monotonic sequence number across reloads (the drift bug that
+// the old underlying-segment counting LL path suffered from is impossible here
+// by construction). opts.emitPartials adds the EXT-X-PART tags + LL header on
+// top of the otherwise-identical structure.
+func generateVariantPlaylistCore(
+	segments []rangeSegment,
+	totalDuration float64,
+	segmentMap string,
+	relPath string,
+	timeNow float64,
+	loopCount int,
+	minDuration float64,
+	syncTotalDuration float64,
+	syncTimeOffset float64,
+	opts variantPlaylistOptions,
+) (string, error) {
 	if totalDuration <= 0 && minDuration > 0 {
 		totalDuration = minDuration
 	}
@@ -178,10 +240,14 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 
 	var sb strings.Builder
 	sb.WriteString("#EXTM3U\n")
-	// Version 9 is required because the playlist emits EXT-X-SERVER-CONTROL
-	// (below). AVPlayer rejects v7 playlists that carry v9-era tags with
-	// -12646 "playlist parse error".
-	sb.WriteString("#EXT-X-VERSION:9\n")
+	if opts.emitPartials {
+		sb.WriteString("#EXT-X-VERSION:10\n") // Version 10 for LL-HLS
+	} else {
+		// Version 9 is required because the playlist emits EXT-X-SERVER-CONTROL
+		// (below). AVPlayer rejects v7 playlists that carry v9-era tags with
+		// -12646 "playlist parse error".
+		sb.WriteString("#EXT-X-VERSION:9\n")
+	}
 	sb.WriteString(fmt.Sprintf("#EXT-X-TARGETDURATION:%d\n", int(math.Ceil(maxSegDuration))))
 	sb.WriteString(fmt.Sprintf("#EXT-X-MEDIA-SEQUENCE:%d\n", firstSeq))
 	// EXT-X-DISCONTINUITY-SEQUENCE is REQUIRED by RFC 8216 §4.3.3.3 whenever
@@ -195,58 +261,103 @@ func (g *RangeHLSGenerator) GenerateVariantPlaylist(
 	sb.WriteString(fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d\n", startLoop))
 	// EXT-X-SERVER-CONTROL HOLD-BACK is a media-playlist-only tag (RFC 8216
 	// §4.3.3.8). HLS spec requires HOLD-BACK >= 3× TARGETDURATION — note
-	// TARGETDURATION is the integer ceiling (7 for 6.006s segments), not the
-	// exact segment duration, so using 3× maxSegDuration would fall below
-	// the minimum (18.018 < 21) and AVPlayer rejects with -12646 "playlist
-	// parse error". Explicit declaration is preferred over relying on
-	// player defaults; other players (hls.js, ExoPlayer, Shaka) may default
-	// differently.
+	// TARGETDURATION is the integer ceiling (2 for 1.001s sub-segments), not
+	// the exact segment duration, so using 3× maxSegDuration would fall below
+	// the minimum and AVPlayer rejects with -12646 "playlist parse error".
+	// Explicit declaration is preferred over relying on player defaults; other
+	// players (hls.js, ExoPlayer, Shaka) may default differently.
 	targetDurationSecs := int(math.Ceil(maxSegDuration))
 	liveHoldBack := 3.0 * float64(targetDurationSecs)
-	sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f\n", liveHoldBack))
+	if opts.emitPartials {
+		// LL-HLS header: PART-INF advertises the partial target, and the
+		// SERVER-CONTROL line carries PART-HOLD-BACK in addition to HOLD-BACK.
+		sb.WriteString(fmt.Sprintf("#EXT-X-PART-INF:PART-TARGET=%.3f\n", opts.partTarget))
+		sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f,PART-HOLD-BACK=%.1f\n", liveHoldBack, opts.partHoldBack))
+	} else {
+		sb.WriteString(fmt.Sprintf("#EXT-X-SERVER-CONTROL:HOLD-BACK=%.3f\n", liveHoldBack))
+	}
 	// EXT-X-START in the variant matters because hls.js (and some other
 	// players) only honor TIME-OFFSET in the *media* playlist; the master
 	// inheritance is widely under-implemented. Without this, hls.js parks at
 	// the oldest segment in the sliding window and never seeks to live —
 	// the player ends up ~MAX_LIVE_WINDOW_DURATION seconds behind real time.
-	// Match HOLD-BACK so the seek target and steady-state target agree.
+	// Match HOLD-BACK so the seek target and steady-state target agree — for BOTH
+	// the range rungs and LL. We previously joined LL at PART-HOLD-BACK (closer to
+	// live), but without CAN-BLOCK-RELOAD AVPlayer cannot sustain its buffer riding
+	// the parts that close and rebuffers; joining at HOLD-BACK (the complete-segment
+	// edge, same as the partial-less 1s rung) keeps the parts available without
+	// yanking the player into the zone it stalls in.
 	sb.WriteString(fmt.Sprintf("#EXT-X-START:TIME-OFFSET=-%.3f,PRECISE=YES\n", liveHoldBack))
 	sb.WriteString(fmt.Sprintf("#EXT-X-PROGRAM-DATE-TIME:%s\n", pdt.Format("2006-01-02T15:04:05.000Z")))
 
 	if segmentMap != "" {
-		sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", absoluteSegmentURI(prefix, content, joinRelPath(relPath, segmentMap))))
+		sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", opts.renderURI(joinRelPath(relPath, segmentMap))))
 	}
 
-	writeSegmentRange := func(seg rangeSegment) {
+	// writeSegment emits one CLOSED segment: when emitPartials is on, the
+	// segment's EXT-X-PART fragment tags precede its EXT-X-BYTERANGE / EXTINF /
+	// URI; otherwise it is exactly the non-partials range output.
+	writeSegment := func(seg rangeSegment) {
+		if opts.emitPartials {
+			uri := opts.renderURI(joinRelPath(relPath, seg.URI))
+			for _, frag := range seg.Fragments {
+				partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
+					opts.partTarget, uri, frag.Length, frag.Offset)
+				if frag.Independent {
+					partTag += ",INDEPENDENT=YES"
+				}
+				sb.WriteString(partTag + "\n")
+			}
+		}
 		sb.WriteString(fmt.Sprintf("#EXTINF:%.3f,\n", seg.Duration))
-		if useByterange && seg.Length > 0 {
+		if opts.useByterange && seg.Length > 0 {
 			sb.WriteString(fmt.Sprintf("#EXT-X-BYTERANGE:%d@%d\n", seg.Length, seg.Offset))
 		}
-		sb.WriteString(absoluteSegmentURI(prefix, content, joinRelPath(relPath, seg.URI)) + "\n")
+		sb.WriteString(opts.renderURI(joinRelPath(relPath, seg.URI)) + "\n")
 	}
 
 	if wrap {
 		tailDuration := 0.0
 		for i := windowStartIdx; i < len(segments); i++ {
-			writeSegmentRange(segments[i])
+			writeSegment(segments[i])
 			tailDuration += segments[i].Duration
 		}
 		boundaryAt := pdt.Add(time.Duration(tailDuration * float64(time.Second)))
-		writeRangeLoopDateRange(&sb, loopCount, boundaryAt, "wrap")
+		writeRangeLoopDateRange(&sb, loopCount, boundaryAt, opts.loopMarker)
 		sb.WriteString("#EXT-X-DISCONTINUITY\n")
 		if segmentMap != "" {
-			sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", absoluteSegmentURI(prefix, content, joinRelPath(relPath, segmentMap))))
+			sb.WriteString(fmt.Sprintf("#EXT-X-MAP:URI=\"%s\"\n", opts.renderURI(joinRelPath(relPath, segmentMap))))
 		}
 		remainingDuration := MAX_LIVE_WINDOW_DURATION - tailDuration
 		for i := 0; i <= availableIdx && remainingDuration > 0; i++ {
-			writeSegmentRange(segments[i])
+			writeSegment(segments[i])
 			remainingDuration -= segments[i].Duration
 		}
 	} else {
 		windowDuration := 0.0
 		for i := windowStartIdx; i <= availableIdx && windowDuration < MAX_LIVE_WINDOW_DURATION; i++ {
-			writeSegmentRange(segments[i])
+			writeSegment(segments[i])
 			windowDuration += segments[i].Duration
+		}
+	}
+
+	// LL live-edge tail: the current still-incomplete segment is emitted as
+	// bare EXT-X-PART lines with NO #EXTINF, exactly as the old LL path did at
+	// the live edge. availableIdx is the last CLOSED segment that was written
+	// above; currentIdx is the live one. Emitting it only when
+	// currentIdx == availableIdx+1 guarantees it was NOT already written as a
+	// closed segment (no duplication) — and this holds in both the wrap and
+	// non-wrap branches, since in both the closed loops stop at availableIdx.
+	if opts.emitPartials && currentIdx == availableIdx+1 && currentIdx >= 0 && currentIdx < len(segments) {
+		live := segments[currentIdx]
+		uri := opts.renderURI(joinRelPath(relPath, live.URI))
+		for _, frag := range live.Fragments {
+			partTag := fmt.Sprintf("#EXT-X-PART:DURATION=%.3f,URI=\"%s\",BYTERANGE=\"%d@%d\"",
+				opts.partTarget, uri, frag.Length, frag.Offset)
+			if frag.Independent {
+				partTag += ",INDEPENDENT=YES"
+			}
+			sb.WriteString(partTag + "\n")
 		}
 	}
 
@@ -313,10 +424,11 @@ func buildRangeSegments(pl *playlist.Media, byteranges map[string][]parser.ByteR
 			}
 			duration := fragmentDuration * float64(len(group))
 			segments = append(segments, rangeSegment{
-				URI:      seg.URI,
-				Offset:   group[0].Offset,
-				Length:   length,
-				Duration: duration,
+				URI:       seg.URI,
+				Offset:    group[0].Offset,
+				Length:    length,
+				Duration:  duration,
+				Fragments: group,
 			})
 			totalDuration += duration
 		}

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -605,7 +605,7 @@ func applyAppConfigPatch(s map[string]any, c any) {
 		}
 	}
 	if v, present := m["segment"]; present {
-		setEnum("segment", v, "ll", "s2", "s6")
+		setEnum("segment", v, "ll", "s1", "s2", "s6")
 	}
 	if v, present := m["protocol"]; present {
 		setEnum("protocol", v, "hls", "dash")

--- a/go-upload/internal/util/content.go
+++ b/go-upload/internal/util/content.go
@@ -250,6 +250,9 @@ func availableSegmentDurations(contentPath string, hasHls bool, native *int) []i
 	if hasHls {
 		set[2] = true
 		set[6] = true
+		if contentHasPartials(contentPath) { // 1s rung is composed from LL partials (go-live groups parts into ~1s GOP sub-segments)
+			set[1] = true
+		}
 	}
 	if native != nil {
 		set[*native] = true

--- a/tests/characterization/modes/runconfig.go
+++ b/tests/characterization/modes/runconfig.go
@@ -31,7 +31,7 @@ type runConfig struct {
 	appium      bool
 }
 
-var segmentRawValue = map[string]string{"2s": "s2", "6s": "s6", "ll": "ll"}
+var segmentRawValue = map[string]string{"1s": "s1", "2s": "s2", "6s": "s6", "ll": "ll"}
 
 // readRunConfig parses the CHAR_* axes. isAppium gates the launch-arg axes
 // (segment, LocalProxy) which need XCUITest processArguments — they're
@@ -42,7 +42,7 @@ func readRunConfig(t *testing.T, isAppium bool) runConfig {
 
 	if v := strings.TrimSpace(os.Getenv("CHAR_SEGMENT")); v != "" {
 		if _, ok := segmentRawValue[v]; !ok {
-			t.Fatalf("CHAR_SEGMENT must be one of 2s|6s|ll (got %q)", v)
+			t.Fatalf("CHAR_SEGMENT must be one of 1s|2s|6s|ll (got %q)", v)
 		}
 		if isAppium {
 			cfg.segment = v

--- a/tools/harness-cli/cmd/harness/appconfig.go
+++ b/tools/harness-cli/cmd/harness/appconfig.go
@@ -25,7 +25,7 @@ Use this to reconfigure a RUNNING app between plays without a cold relaunch.
 'app.<field>' bootstrap args for that; this command targets subsequent plays.)
 
 Flags:
-  --segment LADDER     ll | s2 | s6
+  --segment LADDER     ll | s1 | s2 | s6
   --protocol PROTO     hls | dash
   --live-offset SEC    seconds behind live edge (>=0; 0 = manifest/Go-Live decides)
   --peak-bitrate MBPS  ABR ceiling in Mbps (>=0; 0 = no cap)
@@ -95,10 +95,10 @@ func buildAppConfigBody(segment, protocol string, liveOffset float64, peakBitrat
 	ac := map[string]any{}
 	if set["segment"] {
 		switch segment {
-		case "ll", "s2", "s6":
+		case "ll", "s1", "s2", "s6":
 			ac["segment"] = segment
 		default:
-			return nil, fmt.Errorf("invalid --segment %q (want ll|s2|s6)", segment)
+			return nil, fmt.Errorf("invalid --segment %q (want ll|s1|s2|s6)", segment)
 		}
 	}
 	if set["protocol"] {

--- a/tools/harness-cli/internal/charmatrix/expand.go
+++ b/tools/harness-cli/internal/charmatrix/expand.go
@@ -383,8 +383,8 @@ func validateArm(a *Arm) error {
 	if a.Protocol != "" && a.Protocol != "hls" && a.Protocol != "dash" {
 		return fmt.Errorf("protocol %q invalid (hls|dash)", a.Protocol)
 	}
-	if a.Segment != "" && a.Segment != "s2" && a.Segment != "s6" && a.Segment != "ll" {
-		return fmt.Errorf("segment %q invalid (s2|s6|ll)", a.Segment)
+	if a.Segment != "" && a.Segment != "s1" && a.Segment != "s2" && a.Segment != "s6" && a.Segment != "ll" {
+		return fmt.Errorf("segment %q invalid (s1|s2|s6|ll)", a.Segment)
 	}
 	if a.Role != "" && a.Role != string(sweep.ArmControl) && a.Role != string(sweep.ArmVariant) {
 		return fmt.Errorf("role %q invalid (control|variant)", a.Role)

--- a/tools/harness-cli/internal/charmatrix/spec.go
+++ b/tools/harness-cli/internal/charmatrix/spec.go
@@ -78,7 +78,7 @@ type Arm struct {
 	Reps      int    `json:"reps,omitempty"`       // confirmation reps (overrides the spec default)
 
 	// --- client knobs (is.* — launch arg, cold relaunch on change) ---
-	Segment            string   `json:"is.segment,omitempty"`              // s2 | s6 | ll (empty = app default s6)
+	Segment            string   `json:"is.segment,omitempty"`              // s1 | s2 | s6 | ll (empty = app default s6)
 	Protocol           string   `json:"is.protocol,omitempty"`             // hls | dash
 	Codec              string   `json:"is.codec,omitempty"`                // h264 | hevc | av1
 	AppLiveOffset      *float64 `json:"is.live_offset,omitempty"`          // app-side target-latency override


### PR DESCRIPTION
## Summary

Adds a **1-second low-latency segment rung** to the platform end-to-end, and reworks the LL-HLS generator so it shares the same correct flat-segment machinery (fixing a `MEDIA-SEQUENCE` drift that broke playback on both players).

## What's in it

| area | change |
|---|---|
| **`master_1s`** | go-live serves `master_1s` — 1s GOP-aligned virtual segments, no partials — via the existing `range_hls` generator |
| **`s1` plumbing** | `is.segment=s1` → `master_1s` across iOS (`SegmentLength.s1`), Android (`Segment.ONE`), go-upload catalogue (`segment_durations` reports `1` for partial-bearing clips), go-proxy (v2 app_config enum), and the harness char-matrix validator |
| **converged LL** | the LL (1s+partials) generator now reuses `range_hls`'s flat 1s segments + `firstSeq` sequence/window math via a shared `generateVariantPlaylistCore`, layering `EXT-X-PART` on top; joins at `HOLD-BACK`. −357 lines of divergent code removed |

## The MEDIA-SEQUENCE fix (the meat)

The old LL split each 6s segment into ~6 one-second sub-segments but kept `EXT-X-MEDIA-SEQUENCE` counting the **underlying** 6s segments. Measured on the live server, a given sub-segment's sequence number **decreased** across reloads (`segment_00037@432`: seq 65 → 55) — illegal per RFC 8216. That triggered ExoPlayer `HlsPlaylistTracker$PlaylistResetException` and corrupted AVPlayer's live-edge tracking (gaps, `-12312`). The converged LL builds the same flat 1s list as `s1` and counts `MEDIA-SEQUENCE` 1:1 — correct by construction. The byte-ranges were proven **pixel-identical** to the full segments throughout; only the sequence bookkeeping was wrong.

## Testing

- **4-sim iOS ladder** (`s6/s2/s1/ll`): clean monotonic offsets 21 / 12 / 6 / 6s.
- **Cross-platform** (iOS sims + Google TV Streamer via Device Farm): the sequence fix took the Android LL from `PlaylistResetException` → clean playback at ~7s.
- **30-min shared-valley soak** (one master arms a valley bandwidth pattern, all 4 segments bound to it): `s1` rode the full half-hour with **0 stalls** at ~6.3s; `s6` clean at 21s; `ll` (partials) collapsed (~6 min stalling, `-12889` live-edge timeout) under the bandwidth troughs.

## Outcome

**`s1` (1s, no partials) is the dependable cross-platform ~6s low-latency rung** — clean on iOS, Android, and through a sustained valley. The LL (1s+partials) is now *generated correctly* and plays clean on Android, but stays fragile on iOS / under variable bandwidth without `CAN-BLOCK-RELOAD` (a separate server feature). Both ship; `s1` is the one to prefer for reliable low latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
