### PR TITLE
feat(qe): non-blocking 'sweep add' authoring + activate the overnight loop

### DIFF
--- a/.claude/skills/test-author/SKILL.md
+++ b/.claude/skills/test-author/SKILL.md
@@ -8,7 +8,18 @@ last_reviewed: 2026-06-23
 
 Operationalises the **test contract** in [`.claude/standards/characterization-principles.md`](../../standards/characterization-principles.md) — but as a *fill-the-blanks* helper, not an interrogation. Parse the request, resolve every blank from the registry below, **echo the resolved spec so the operator sees what was assumed**, and dry-run verify. The echo-back is the safety net; questions are the exception.
 
-**Conventions:** follows [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md) — no-guessing (§2), pass-signal-is-DATA (§5), Bash-first (§1). **This skill authors specs; it does not run them** (running is `make characterize-*` / `harness char matrix`).
+**Conventions:** follows [`.claude/skills/CONVENTIONS.md`](../CONVENTIONS.md) — no-guessing (§2), pass-signal-is-DATA (§5), Bash-first (§1). **This skill authors specs.** It can then either hand the spec to the unattended runner (**enqueue**, non-blocking) or leave it for a synchronous run (`make characterize-*` / `harness char matrix`) — see *Two ways to run* below.
+
+## Two ways to run an authored test
+
+A synchronous run blocks for the whole 5–10 min (bootstrap → cold launch → settle → stream). Most exploratory asks don't need you to watch — so prefer **enqueue**:
+
+- **Enqueue (default for exploration, non-blocking).** Resolve the one-liner, then drop ONE experiment on the sweep queue and return immediately:
+  `harness sweep add --class config --platform ipad-sim --mode pyramid --content <live> [--rate-mbps N | --pattern P --step-seconds S] [--segment s2|s6|ll] [--why "…"]`
+  The unattended runner (`tools/qe-offhours.sh`, kind=`manual` jumps the seed backlog) claims it; the verdict lands in `sweep_runs`. Read it later with `harness sweep agenda` / `harness sweep ls done` / `harness query`. Queue several adds in seconds, then walk away. (Multi-clip breadth without N adds: `harness sweep seed --contents a,b,c`.)
+- **Synchronous (when you want to watch it now, or need the full arm table / A-B matrix).** Author the YAML and run `harness char matrix <file>` (parallel arms, `axes:`/`groups:`) or `make characterize-*`.
+
+Enqueue is single-experiment + queue-driven; a `char matrix` YAML is the right tool for an A/B `axes:` sweep you want rendered as one table. Driving the *whole* unattended loop is still the `sweep` skill — this skill only adds individual items to it.
 
 ## The rule: assume-and-surface, ask-only-on-consequential-ambiguity
 
@@ -40,7 +51,7 @@ Operationalises the **test contract** in [`.claude/standards/characterization-pr
 2. **Resolve** every blank from the registry; verify content against `/api/content`.
 3. **Echo the resolved spec** — a short table: behavior, class, platform(s), content (confirmed), held-constant, what-varies (namespaced knobs), pass signal, cost. Mark anything assumed.
 4. **Ask** only the consequential blank(s), if any (per the rule).
-5. **Verify** — write the YAML to `tests/characterization/matrix/scratch/<name>.yaml` (gitignored — throwaway by default, no `git status` noise) and `harness char matrix <file> --dry-run` (shows the expanded arms); for server-behavior, name the exact `go test … -run TestServer<X>`.
+5. **Verify** — for the **enqueue** path, just run `harness sweep add …` (it validates flags + content resolution and prints the queued id). For a **char-matrix** spec, write the YAML to `tests/characterization/matrix/scratch/<name>.yaml` (gitignored — throwaway by default, no `git status` noise) and check it **offline** first with `harness char matrix <file> --validate` (Load+Expand, fails fast on an unknown field / bad axis, no network); use `--dry-run` when you also want the expanded arm table. Both are offline — `api.New` never dials, so neither needs a reachable `--base`. For server-behavior, name the exact `go test … -run TestServer<X>`.
 6. **Promote on request** — specs default to `scratch/`; most are throwaway. After a run the user likes, OFFER to keep it: `git mv tests/characterization/matrix/scratch/<name>.yaml tests/characterization/matrix/ && git add` (now tracked + covered by the `matrix/*.yaml` validation glob). Never promote unasked.
 
 ## char-matrix knob reference (authoritative — `internal/charmatrix/spec.go`)

--- a/tools/com.infinitestream.qe-offhours.plist
+++ b/tools/com.infinitestream.qe-offhours.plist
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  QE Lab off-hours runner LaunchAgent (#772) — fires tools/qe-offhours.sh at
+  21:00 daily; the script self-bounds to a 05:00 deadline or an empty backlog.
+
+  This is a per-USER LaunchAgent (not a system daemon) on purpose: the runner
+  drives iOS simulators + appium, which need a logged-in GUI session. So the
+  Mac must be logged in and awake — `caffeinate -is` (below) keeps it awake on
+  AC while the run is in flight, but the machine still has to be powered on and
+  unlocked-enough for the GUI session to exist.
+
+  Install (per user):
+    cp tools/com.infinitestream.qe-offhours.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.infinitestream.qe-offhours.plist
+  Run it once now (out of schedule), to smoke-test:
+    launchctl kickstart -k gui/$(id -u)/com.infinitestream.qe-offhours
+  Inspect / remove:
+    launchctl print gui/$(id -u)/com.infinitestream.qe-offhours
+    launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.infinitestream.qe-offhours.plist
+
+  Machine-specific values (PATH, repo path, sim UDIDs, base URL) mirror the
+  defaults baked into tools/qe-offhours.sh. Edit BOTH if they drift, or override
+  here — the EnvironmentVariables below win over the script's `${QE_*:-default}`.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.infinitestream.qe-offhours</string>
+
+  <!-- Run the script under caffeinate so an overnight sweep isn't cut short by
+       idle/AC sleep. -i = prevent idle sleep, -s = prevent sleep on AC. -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bash</string>
+    <string>-lc</string>
+    <string>exec /usr/bin/caffeinate -is /opt/homebrew/bin/bash "$QE_REPO/tools/qe-offhours.sh"</string>
+  </array>
+
+  <!-- 21:00 every day. The script computes its own 05:00 deadline + budget. -->
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>21</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <!-- Scheduled only — don't also fire on every login/bootstrap. -->
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <!-- launchd agents get a minimal PATH; spell out every tool the runner
+         shells: bash/jq (homebrew), go, harness (~/.local/bin), xcrun/curl/
+         caffeinate (/usr/bin), adb (Android SDK), appium/node (nvm). -->
+    <key>PATH</key>
+    <string>/Users/jonathanoliver/.local/bin:/opt/homebrew/bin:/usr/local/go/bin:/Users/jonathanoliver/.nvm/versions/node/v20.19.6/bin:/Users/jonathanoliver/Library/Android/sdk/platform-tools:/usr/bin:/bin:/usr/sbin:/sbin</string>
+
+    <key>QE_REPO</key>
+    <string>/Users/jonathanoliver/Projects/smashing</string>
+
+    <key>HARNESS_BASE_URL</key>
+    <string>https://dev.jeoliver.com:21000</string>
+
+    <key>HARNESS_INSECURE</key>
+    <string>1</string>
+
+    <!-- Default clip the seed/probe stream (matches .env CHAR_CONTENT). -->
+    <key>QE_CONTENT</key>
+    <string>insane_newer_p200_h264</string>
+
+    <!-- Simulator UDIDs the runner binds per platform (mirror qe-offhours.sh
+         defaults). iPad (A16) for ipad-sim; Fleet iPhone 15 #1 for iphone-sim. -->
+    <key>QE_IPADSIM_UDID</key>
+    <string>6E1441F3-EEAD-43E4-ABEC-FA0BC2BEDCE2</string>
+    <key>QE_IPHONESIM_UDID</key>
+    <string>4D62CB39-BAB7-4294-99D7-8E28FBCD0FF0</string>
+  </dict>
+
+  <!-- Early-failure safety net; the script itself reopens stdout/err onto
+       ~/Library/Logs/qe-offhours.log once it starts. -->
+  <key>StandardOutPath</key>
+  <string>/Users/jonathanoliver/Library/Logs/qe-offhours.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jonathanoliver/Library/Logs/qe-offhours.err.log</string>
+</dict>
+</plist>

--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -32,7 +32,7 @@ import (
 // reusing the sweep's config-on-connect bootstrap and measurement helpers.
 func cmdChar(client *api.Client, args []string, asJSON bool) error {
 	if len(args) == 0 {
-		return errors.New("usage: harness char matrix <spec.yaml> [--dry-run] [--char-dir DIR] [--duration-s N]")
+		return errors.New("usage: harness char matrix <spec.yaml> [--validate|--dry-run] [--char-dir DIR] [--duration-s N]")
 	}
 	switch args[0] {
 	case "matrix":
@@ -50,11 +50,12 @@ func cmdChar(client *api.Client, args []string, asJSON bool) error {
 // spec delegates to the existing fleet go-test backend.
 func cmdCharMatrix(client *api.Client, args []string, asJSON bool) error {
 	if len(args) < 1 || args[0] == "" {
-		return errors.New("usage: harness char matrix <spec.yaml|-> [--dry-run] [--char-dir DIR] [--duration-s N]")
+		return errors.New("usage: harness char matrix <spec.yaml|-> [--validate|--dry-run] [--char-dir DIR] [--duration-s N]")
 	}
 	specPath := args[0]
 	fs := flag.NewFlagSet("char matrix", flag.ContinueOnError)
 	dryRun := fs.Bool("dry-run", false, "expand + print the planned arms; touch no sessions")
+	validate := fs.Bool("validate", false, "load + expand only; report ok/error and exit non-zero on a bad spec (offline, no table)")
 	charDir := fs.String("char-dir", envOrDefault("CHAR_DIR", "tests/characterization"), "path to the characterization Go module (drives the probe via `go test`)")
 	durationOverride := fs.Int("duration-s", 0, "override every arm's play window (seconds)")
 	group := fs.String("group", "", "group_id to born-group every arm's session (dashboard A/B compare)")
@@ -87,6 +88,20 @@ func cmdCharMatrix(client *api.Client, args []string, asJSON bool) error {
 	if err != nil {
 		return err
 	}
+
+	// --validate: the spec loaded + expanded cleanly. Report and stop — quiet
+	// pass/fail for the test-author skill's fast loop and CI, no network, no
+	// arm table (that's --dry-run). A bad spec already returned non-nil above.
+	if *validate {
+		if asJSON {
+			return json.NewEncoder(os.Stdout).Encode(map[string]any{
+				"spec": spec.Name, "arms": len(arms), "parallel": spec.Parallel, "ok": true,
+			})
+		}
+		fmt.Printf("spec OK: %s — %d arm(s), parallel=%v\n", spec.Name, len(arms), spec.Parallel)
+		return nil
+	}
+
 	fmt.Fprintf(os.Stderr, "char matrix run id: %s\n", runID)
 
 	// Dry run: show the plan (one row per arm, no measurements) and stop. Pure —

--- a/tools/harness-cli/cmd/harness/sweep.go
+++ b/tools/harness-cli/cmd/harness/sweep.go
@@ -21,10 +21,22 @@ forwarder API on the harness's --base deploy (no local files). Findings are
 promoted to GitHub Issues elsewhere.
 
 Subcommands:
-  seed [--class C][--full] populate backlog/ with the starter set.
+  seed [--class C][--full][--contents a,b,c]
+                           populate backlog/ with the starter set.
                            --class config (default: realistic stream/network)
                            or fault (explicit-error recovery). --full widens
-                           past the narrow depth-first ipad-sim set.
+                           past the narrow depth-first ipad-sim set. --contents
+                           seeds the recipe set against each clip (default: the
+                           .env CHAR_CONTENT single clip).
+  add [flags]              enqueue ONE operator-authored experiment (kind=manual)
+                           without running it — the runner picks it up and the
+                           verdict lands in sweep_runs. Non-blocking authoring:
+                           drop it and read 'sweep agenda' / 'query' later.
+                           --class --platform --protocol --content --mode
+                           --segment --duration-s --reps --why ; shape:
+                           --rate-mbps --pattern --step-seconds --margin-pct ;
+                           fault (class=fault): --fault-type --fault-kind
+                           --fault-frequency --fault-mode .
   status                   counts per bucket (backlog/running/done/…)
   ls <status>              list experiments in a bucket (one line each)
   next [--claim --owner O] show the highest-score backlog experiment;
@@ -78,6 +90,8 @@ func cmdSweep(client *api.Client, args []string, asJSON bool) error {
 	switch args[0] {
 	case "seed":
 		return cmdSweepSeed(client, args[1:], asJSON)
+	case "add":
+		return cmdSweepAdd(client, args[1:], asJSON)
 	case "status":
 		return cmdSweepStatus(client, args[1:], asJSON)
 	case "ls":
@@ -123,6 +137,7 @@ func cmdSweepSeed(client *api.Client, args []string, asJSON bool) error {
 	full := fs.Bool("full", false, "widen the seed across all platforms (default narrow depth-first)")
 	class := fs.String("class", "config", "sweep class: config (realistic stream/network) | fault (error-recovery)")
 	platform := fs.String("platform", "", "seed only this platform (e.g. androidtv); overrides --full/narrow")
+	contents := fs.String("contents", "", "comma-separated clips to seed the recipe set against (default: the .env CHAR_CONTENT single clip)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -130,23 +145,28 @@ func cmdSweepSeed(client *api.Client, args []string, asJSON bool) error {
 	if c != sweep.ClassConfig && c != sweep.ClassFault {
 		return fmt.Errorf("invalid --class %q: config|fault", *class)
 	}
+	var clips []string
+	for _, p := range strings.Split(*contents, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			clips = append(clips, p)
+		}
+	}
 	s, err := openStore(client)
 	if err != nil {
 		return err
 	}
-	var exps []*sweep.Experiment
+	var platformsOverride []string
 	if *platform != "" {
-		exps = sweep.Seed(c, *full, nowUTC(), *platform)
-	} else {
-		exps = sweep.Seed(c, *full, nowUTC())
+		platformsOverride = []string{*platform}
 	}
+	exps := sweep.SeedContents(c, *full, nowUTC(), clips, platformsOverride...)
 	for _, e := range exps {
 		if err := s.Save(sweep.StatusBacklog, e); err != nil {
 			return err
 		}
 	}
 	if asJSON {
-		return json.NewEncoder(os.Stdout).Encode(map[string]any{"seeded": len(exps), "full": *full, "class": *class})
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"seeded": len(exps), "full": *full, "class": *class, "contents": clips})
 	}
 	mode := "narrow (depth-first, ipad-sim)"
 	if *full {
@@ -155,7 +175,123 @@ func cmdSweepSeed(client *api.Client, args []string, asJSON bool) error {
 	if *platform != "" {
 		mode = "platform=" + *platform
 	}
-	fmt.Printf("seeded %d %s-class experiments into backlog (%s) — %s\n", len(exps), c, s.Label(), mode)
+	clipNote := "default clip"
+	if len(clips) > 0 {
+		clipNote = fmt.Sprintf("%d clip(s): %s", len(clips), strings.Join(clips, ", "))
+	}
+	fmt.Printf("seeded %d %s-class experiments into backlog (%s) — %s, %s\n", len(exps), c, s.Label(), mode, clipNote)
+	return nil
+}
+
+// cmdSweepAdd enqueues ONE operator-authored experiment (kind=manual) onto the
+// backlog without running it — the producer half of the producer/consumer loop.
+// Authoring a test becomes a non-blocking drop: the runner (qe-offhours.sh)
+// claims it, and the verdict lands in sweep_runs for later reading. Mirrors the
+// Experiment construction in internal/sweep/seed.go so an ad-hoc item schedules
+// consistently with seeded ones (same scoring, same launch mode).
+func cmdSweepAdd(client *api.Client, args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("sweep add", flag.ContinueOnError)
+	class := fs.String("class", "config", "sweep class: config | fault")
+	platform := fs.String("platform", "ipad-sim", "ipad-sim | iphone | appletv | androidtv | web")
+	protocol := fs.String("protocol", "hls", "hls | dash")
+	content := fs.String("content", "", "catalogue clip (default: .env CHAR_CONTENT); verify live via /api/content first")
+	mode := fs.String("mode", "steps", "playback motion: steps | pyramid | rampup | rampdown | downshift_severity | transient_shock | startup | abort | …")
+	segment := fs.String("segment", "", "master variant the probe requests: s2 | s6 | ll (empty = app default s6)")
+	durationS := fs.Int("duration-s", 0, "per-run window in seconds (0 = runner/probe default)")
+	reps := fs.Int("reps", 1, "confirmation reps requested")
+	why := fs.String("why", "", "rationale recorded on the row (why this test)")
+	id := fs.String("id", "", "explicit experiment id (default: auto manual-… with a unique stamp)")
+	// shape (config-class network motion)
+	rate := fs.Float64("rate-mbps", 0, "static bandwidth cap in Mbps (0 = no static cap)")
+	pattern := fs.String("pattern", "", "ladder-derived pattern: pyramid | valley | ramp_up | ramp_down | square_wave | transient_shock")
+	stepSeconds := fs.Int("step-seconds", 0, "pattern step length (6|12|18|24|60|120)")
+	marginPct := fs.Int("margin-pct", 0, "pattern headroom margin %")
+	// fault (fault-class only)
+	faultType := fs.String("fault-type", "", "500 | timeout | corrupted | connection_refused | …")
+	faultKind := fs.String("fault-kind", "", "request kind to fault: segment | manifest | master_manifest | init | audio_segment")
+	faultFreq := fs.Int("fault-frequency", 0, "fault cadence count")
+	faultMode := fs.String("fault-mode", "", "requests | seconds | failures_per_seconds | failures_per_packets")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c := sweep.Class(*class)
+	if c != sweep.ClassConfig && c != sweep.ClassFault {
+		return fmt.Errorf("invalid --class %q: config|fault", *class)
+	}
+	clip := sweep.ContentOrDefault(*content)
+
+	e := &sweep.Experiment{
+		CreatedAt:  nowUTC(),
+		Class:      c,
+		Platform:   *platform,
+		LaunchMode: sweep.LaunchModeAppium, // the only mode TestSweepProbe supports
+		Protocol:   *protocol,
+		Content:    clip,
+		Segment:    *segment,
+		Mode:       *mode,
+		DurationS:  *durationS,
+		Kind:       sweep.KindManual,
+		Reps:       *reps,
+		Depth:      0,
+		Why:        "manual_add",
+		WhyText:    *why,
+	}
+	if strings.TrimSpace(*why) == "" {
+		e.WhyText = fmt.Sprintf("operator-authored %s-class probe: %s on %s/%s", c, *mode, *platform, *protocol)
+	}
+
+	// Shape: a static cap and/or a ladder-derived pattern (config-class motion).
+	if *rate > 0 || *pattern != "" {
+		sh := &sweep.Shape{Pattern: *pattern, StepSeconds: *stepSeconds, MarginPct: *marginPct}
+		if *rate > 0 {
+			r := *rate
+			sh.RateMbps = &r
+		}
+		e.Shape = sh
+	}
+
+	// Fault: fault-class only; building one on a config-class item is a mistake.
+	if *faultType != "" {
+		if c != sweep.ClassFault {
+			return fmt.Errorf("--fault-type set but --class is %q; faults are fault-class only", c)
+		}
+		e.Fault = &sweep.Fault{
+			Type:        *faultType,
+			RequestKind: *faultKind,
+			Frequency:   *faultFreq,
+			Mode:        *faultMode,
+		}
+	}
+
+	if *id != "" {
+		e.ID = *id
+	} else {
+		// UnixNano keeps repeated adds in the same second distinct (the queue
+		// collapses by exp_id, so a stable id would overwrite the prior add).
+		e.ID = fmt.Sprintf("manual-%s-%s-%s-%s-%d", c, *platform, *protocol, *mode, time.Now().UnixNano())
+	}
+	e.Score = sweep.DefaultWeights().Score(e)
+
+	s, err := openStore(client)
+	if err != nil {
+		return err
+	}
+	if err := s.Save(sweep.StatusBacklog, e); err != nil {
+		return err
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(e)
+	}
+	fmt.Printf("enqueued %s (kind=manual, score=%.1f) → backlog\n", e.ID, e.Score)
+	fmt.Printf("  %s-class %s on %s/%s · content=%s%s\n", c, *mode, *platform, *protocol, clip,
+		func() string {
+			if *segment != "" {
+				return " · segment=" + *segment
+			}
+			return ""
+		}())
+	fmt.Println("  the runner will claim it; read the verdict later via 'harness sweep agenda' / 'harness sweep ls done'")
 	return nil
 }
 

--- a/tools/harness-cli/internal/sweep/experiment.go
+++ b/tools/harness-cli/internal/sweep/experiment.go
@@ -63,6 +63,7 @@ type Kind string
 
 const (
 	KindSeed       Kind = "seed"       // broad starter cell
+	KindManual     Kind = "manual"     // operator-authored ad-hoc probe (`sweep add`); jumps the seed backlog, stays below hit-derived work
 	KindIsolation  Kind = "isolation"  // one-factor-at-a-time probe off a confirmed hit (non-recursive)
 	KindHypothesis Kind = "hypothesis" // proactive A/B comparison (non-recursive)
 	KindBisect     Kind = "bisect"     // recursive narrowing of a continuous axis (depth-bounded)

--- a/tools/harness-cli/internal/sweep/scheduler.go
+++ b/tools/harness-cli/internal/sweep/scheduler.go
@@ -26,6 +26,8 @@ func kindRank(k Kind) float64 {
 		return 3
 	case KindHypothesis:
 		return 2
+	case KindManual:
+		return 1.5 // an operator-authored ad-hoc probe jumps the seed backlog but yields to any hit-derived follow-up
 	case KindSeed:
 		return 1
 	default:

--- a/tools/harness-cli/internal/sweep/scheduler_test.go
+++ b/tools/harness-cli/internal/sweep/scheduler_test.go
@@ -116,6 +116,61 @@ func TestLiveOffsetMatrixArms(t *testing.T) {
 	}
 }
 
+func TestSeedContentsMultiClip(t *testing.T) {
+	clips := []string{"clip_a", "clip_b", "clip_c"}
+	es := SeedContents(ClassConfig, false, "2026-06-13T00:00:00Z", clips)
+	// 1 platform × protocols × clips × recipes.
+	want := len(seedProtocols) * len(clips) * len(recipesFor(ClassConfig))
+	if len(es) != want {
+		t.Fatalf("multi-content seed want %d, got %d", want, len(es))
+	}
+	seen := map[string]bool{}
+	byClip := map[string]int{}
+	for _, e := range es {
+		if seen[e.ID] {
+			t.Fatalf("duplicate seed id across clips: %s", e.ID)
+		}
+		seen[e.ID] = true
+		byClip[e.Content]++
+	}
+	// Every requested clip is represented, none extra.
+	if len(byClip) != len(clips) {
+		t.Fatalf("want %d distinct clips, got %d (%v)", len(clips), len(byClip), byClip)
+	}
+	for _, c := range clips {
+		if byClip[c] != len(seedProtocols)*len(recipesFor(ClassConfig)) {
+			t.Fatalf("clip %s seeded %d times, want %d", c, byClip[c], len(seedProtocols)*len(recipesFor(ClassConfig)))
+		}
+	}
+}
+
+func TestSeedContentsEmptyFallsBackToDefaultClip(t *testing.T) {
+	// nil/empty contents must reproduce Seed exactly (same count, ids, content).
+	a := Seed(ClassConfig, false, "t")
+	b := SeedContents(ClassConfig, false, "t", nil)
+	if len(a) != len(b) {
+		t.Fatalf("empty contents diverged from Seed: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID || a[i].Content != b[i].Content || a[i].Content != SeedContent {
+			t.Fatalf("empty contents diverged at %d: %q/%q", i, a[i].ID, b[i].ID)
+		}
+	}
+}
+
+func TestManualKindOutranksSeedBelowHits(t *testing.T) {
+	// A manual ad-hoc probe must jump the seed backlog but yield to hit-derived
+	// work (isolation/bisect/hypothesis).
+	if kindRank(KindManual) <= kindRank(KindSeed) {
+		t.Fatalf("manual must outrank seed: manual=%v seed=%v", kindRank(KindManual), kindRank(KindSeed))
+	}
+	for _, k := range []Kind{KindHypothesis, KindBisect, KindIsolation} {
+		if kindRank(KindManual) >= kindRank(k) {
+			t.Fatalf("manual must yield to %s: manual=%v %s=%v", k, kindRank(KindManual), k, kindRank(k))
+		}
+	}
+}
+
 func TestSeedFaultClass(t *testing.T) {
 	es := Seed(ClassFault, false, "2026-06-13T00:00:00Z")
 	want := len(seedProtocols) * len(faultRecipes)

--- a/tools/harness-cli/internal/sweep/seed.go
+++ b/tools/harness-cli/internal/sweep/seed.go
@@ -116,13 +116,23 @@ func recipesFor(class Class) []seedRecipe {
 	return append(out, liveOffsetRecipes...)
 }
 
-// Seed builds the starter backlog for one class. full=false is the narrow
-// depth-first set (iPad-sim only); full=true widens across the physical-device
-// platforms. `now` is the RFC3339 UTC stamp for created_at (passed in so
-// callers control the clock). Scores are stamped with the default weights.
-// Seed builds the starter experiment set. platformsOverride (optional) targets a
+// Seed builds the starter backlog for one class against the single default clip
+// (SeedContent). full=false is the narrow depth-first set (iPad-sim only);
+// full=true widens across the physical-device platforms. `now` is the RFC3339
+// UTC stamp for created_at (passed in so callers control the clock). Scores are
+// stamped with the default weights. platformsOverride (optional) targets a
 // specific platform (e.g. "androidtv") instead of the narrow/full defaults.
 func Seed(class Class, full bool, now string, platformsOverride ...string) []*Experiment {
+	return SeedContents(class, full, now, nil, platformsOverride...)
+}
+
+// SeedContents is Seed widened across a list of clips: the recipe set is seeded
+// once per content (platforms × protocols × contents × recipes), so one seed
+// call can cover several pieces of content instead of just SeedContent. A nil/
+// empty contents list falls back to the single default clip (so Seed's behaviour
+// — and its ids — are unchanged). The content slug is folded into the id only
+// when more than one clip is seeded, keeping single-clip ids stable.
+func SeedContents(class Class, full bool, now string, contents []string, platformsOverride ...string) []*Experiment {
 	if class == "" {
 		class = ClassConfig
 	}
@@ -133,39 +143,63 @@ func Seed(class Class, full bool, now string, platformsOverride ...string) []*Ex
 	if len(platformsOverride) > 0 {
 		platforms = platformsOverride
 	}
+	if len(contents) == 0 {
+		contents = []string{SeedContent}
+	}
+	multiContent := len(contents) > 1
 	recipes := recipesFor(class)
 	w := DefaultWeights()
 	var out []*Experiment
 	for _, p := range platforms {
 		for _, proto := range seedProtocols {
-			for _, r := range recipes {
-				e := &Experiment{
-					ID:                  fmt.Sprintf("seed-%s-%s-%s-%s-%s", class, p, proto, r.family, r.mode),
-					CreatedAt:           now,
-					Class:               class,
-					Platform:            p,
-					LaunchMode:          LaunchModeAppium, // every item is driven by appium (the only mode the probe supports), incl. the physical Android TV
-					Protocol:            proto,
-					Content:             SeedContent,
-					Segment:             r.segment,
-					Mode:                r.mode,
-					ContentManipulation: cloneCM(r.cm),
-					Shape:               cloneShape(r.shape),
-					TransferTimeouts:    cloneTransfer(r.transfer),
-					Fault:               cloneFault(r.fault),
-					Kind:                KindSeed,
-					Group:               groupID(r.groupSlug, p),
-					Reps:                1,
-					Depth:               0,
-					Why:                 "starter_seed",
-					WhyText:             seedWhyText(r, class, p, proto),
+			for _, clip := range contents {
+				for _, r := range recipes {
+					id := fmt.Sprintf("seed-%s-%s-%s-%s-%s", class, p, proto, r.family, r.mode)
+					if multiContent {
+						id += "-" + contentSlug(clip)
+					}
+					e := &Experiment{
+						ID:                  id,
+						CreatedAt:           now,
+						Class:               class,
+						Platform:            p,
+						LaunchMode:          LaunchModeAppium, // every item is driven by appium (the only mode the probe supports), incl. the physical Android TV
+						Protocol:            proto,
+						Content:             clip,
+						Segment:             r.segment,
+						Mode:                r.mode,
+						ContentManipulation: cloneCM(r.cm),
+						Shape:               cloneShape(r.shape),
+						TransferTimeouts:    cloneTransfer(r.transfer),
+						Fault:               cloneFault(r.fault),
+						Kind:                KindSeed,
+						Group:               groupID(r.groupSlug, p),
+						Reps:                1,
+						Depth:               0,
+						Why:                 "starter_seed",
+						WhyText:             seedWhyText(r, class, p, proto),
+					}
+					e.Score = w.Score(e)
+					out = append(out, e)
 				}
-				e.Score = w.Score(e)
-				out = append(out, e)
 			}
 		}
 	}
 	return out
+}
+
+// contentSlug sanitises a clip name into an id-safe fragment (alphanumerics and
+// '_' kept, everything else dropped) so a multi-content seed yields unique,
+// readable ids.
+func contentSlug(clip string) string {
+	var b strings.Builder
+	for _, r := range clip {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // groupID expands a recipe's group slug into a per-platform comparison group


### PR DESCRIPTION
## What

Closes the two real gaps in the existing producer/consumer sweep system (#772) so it can find/triage oddities without babysitting each run.

### Authoring = enqueue, not block
- **`harness sweep add`** — enqueue ONE operator-authored experiment (new `kind=manual`) onto the ClickHouse queue without running it. The runner claims it; the verdict lands in `sweep_runs`. Turns 5–10 min synchronous authoring into a non-blocking drop.
- **`kind=manual`** scheduling rank `1.5` — jumps the seed backlog but yields to hit-derived isolation/bisect/hypothesis follow-ups.
- **`harness sweep seed --contents a,b,c`** — seed the recipe set across several clips (`SeedContents`); a nil list reproduces the old single-clip `Seed` exactly.
- **`harness char matrix --validate`** — quiet offline `Load`+`Expand` pass/fail (exit 1 on a bad spec) for the test-author fast loop + CI.
- **`test-author` skill** — documents the enqueue vs synchronous run paths + the offline-validate step.

### Activate the loop
- **`tools/com.infinitestream.qe-offhours.plist`** — the missing LaunchAgent `qe-offhours.sh` references; fires it at 21:00 under `caffeinate -is` with a correct `PATH` + UDIDs/content/base. Install/kickstart/bootout in the header.

## Test
- Build + full `go test ./...` green, incl. 3 new sweep tests (multi-content, empty-fallback, manual rank).
- `--validate` offline: good → exit 0, unknown field → exit 1.
- `sweep add` verified live against test-dev: add → backlog → `agenda` "claim & run" → deleted, queue left clean.

## Note
The plan assumed `char matrix --dry-run` needed a live base — that was wrong (`api.New` never dials, so `--dry-run` was already offline). `--validate` was still added for its quiet pass/fail semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
