### PR TITLE
feat(sweep): char-matrix YAML ↔ queue bridge (import/export round-trip) — #873

### DIFF
--- a/tools/harness-cli/cmd/harness/sweep.go
+++ b/tools/harness-cli/cmd/harness/sweep.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/charmatrix"
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
 )
 
@@ -37,6 +39,17 @@ Subcommands:
                            --rate-mbps --pattern --step-seconds --margin-pct ;
                            fault (class=fault): --fault-type --fault-kind
                            --fault-frequency --fault-mode .
+  import [--from] <yaml>   prime the queue from a char-matrix YAML spec: expand
+                           its arms and insert each as a (kind=hypothesis)
+                           experiment. Refuses loudly if an arm sets client-only
+                           is.* knobs the queue can't carry (run those via
+                           'harness char matrix'). [--dry-run prints the rows].
+  export <id|--fan PARENT|--rep-group G>
+                           author a re-runnable char-matrix YAML from the queue:
+                           a single experiment, an isolation fan (control +
+                           variants), or a rep-batch. Prints YAML to stdout —
+                           redirect it to a file 'harness char matrix' can run.
+                           [--name NAME].
   status                   counts per bucket (backlog/running/done/…)
   ls <status>              list experiments in a bucket (one line each)
   next [--claim --owner O] show the highest-score backlog experiment;
@@ -92,6 +105,10 @@ func cmdSweep(client *api.Client, args []string, asJSON bool) error {
 		return cmdSweepSeed(client, args[1:], asJSON)
 	case "add":
 		return cmdSweepAdd(client, args[1:], asJSON)
+	case "import":
+		return cmdSweepImport(client, args[1:], asJSON)
+	case "export":
+		return cmdSweepExport(client, args[1:], asJSON)
 	case "status":
 		return cmdSweepStatus(client, args[1:], asJSON)
 	case "ls":
@@ -293,6 +310,195 @@ func cmdSweepAdd(client *api.Client, args []string, asJSON bool) error {
 		}())
 	fmt.Println("  the runner will claim it; read the verdict later via 'harness sweep agenda' / 'harness sweep ls done'")
 	return nil
+}
+
+// cmdSweepImport primes the queue from an authored char-matrix YAML spec — the
+// "run this hand-written spec through the sweep" direction (#873). It reuses
+// charmatrix Load+Expand (no fork), maps each arm → Experiment via ToExperiment,
+// and inserts them as backlog rows the loop schedules like any seeded work.
+// Imported arms enter at the normal seed reps (≥1) — import never pre-confirms,
+// so the n=1 discipline holds.
+func cmdSweepImport(client *api.Client, args []string, asJSON bool) error {
+	// Accept the spec path as a positional or via --from; '-' reads stdin
+	// (treated as a positional even though it begins with '-').
+	var path string
+	rest := args
+	if len(args) > 0 && (args[0] == "-" || !strings.HasPrefix(args[0], "-")) {
+		path, rest = args[0], args[1:]
+	}
+	fs := flag.NewFlagSet("sweep import", flag.ContinueOnError)
+	from := fs.String("from", "", "char-matrix YAML spec to import ('-' = stdin)")
+	dryRun := fs.Bool("dry-run", false, "print the queue rows that would be inserted; insert nothing")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	if path == "" {
+		path = *from
+	}
+	if path == "" {
+		return errors.New("usage: harness sweep import [--from] <spec.yaml|-> [--dry-run]")
+	}
+
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return fmt.Errorf("read spec: %w", err)
+	}
+	spec, err := charmatrix.Load(data)
+	if err != nil {
+		return err
+	}
+	arms, err := charmatrix.Expand(spec)
+	if err != nil {
+		return err
+	}
+
+	idSafe := strings.NewReplacer("/", "-", " ", "-")
+	exps := make([]*sweep.Experiment, 0, len(arms))
+	for _, a := range arms {
+		// Never silently lose a knob the queue can't represent (the LabelPlay
+		// trap): if an arm sets client-only is.* knobs, refuse and point at the
+		// runner that DOES honour them.
+		if dropped := a.DroppedClientKnobs(); len(dropped) > 0 {
+			return fmt.Errorf("arm %q sets client-only knobs the sweep queue can't carry: %s — remove them, or run this spec with 'harness char matrix' (which honours is.* launch args)",
+				a.ID, strings.Join(dropped, ", "))
+		}
+		e := a.ToExperiment()
+		e.ID = "import-" + idSafe.Replace(a.ID)
+		e.CreatedAt = nowUTC()
+		if e.Reps == 0 {
+			e.Reps = 1
+		}
+		e.Why = "imported"
+		e.WhyText = "imported from char-matrix spec " + spec.Name
+		e.Score = sweep.DefaultWeights().Score(e)
+		exps = append(exps, e)
+	}
+
+	if *dryRun {
+		if asJSON {
+			return json.NewEncoder(os.Stdout).Encode(map[string]any{"spec": spec.Name, "would_insert": len(exps), "experiments": exps})
+		}
+		fmt.Printf("DRY RUN — %d experiment(s) from spec %q would enter backlog:\n", len(exps), spec.Name)
+		for _, e := range exps {
+			fmt.Printf("  %-44s %-9s %-5s %-18s group=%s arm=%s\n", e.ID, e.Platform, e.Protocol, e.Mode, e.Group, e.Arm)
+		}
+		return nil
+	}
+
+	s, err := openStore(client)
+	if err != nil {
+		return err
+	}
+	for _, e := range exps {
+		if err := s.Save(sweep.StatusBacklog, e); err != nil {
+			return err
+		}
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"spec": spec.Name, "imported": len(exps)})
+	}
+	fmt.Printf("imported %d experiment(s) from spec %q → backlog (%s)\n", len(exps), spec.Name, s.Label())
+	return nil
+}
+
+// cmdSweepExport authors a re-runnable char-matrix YAML from queue experiments —
+// the "turn what sweep found into a deterministic regression spec" direction
+// (#873). It serialises a single experiment, an isolation fan (control +
+// single-axis-flip variants, gathered by Parent), or a rep-batch, and prints the
+// YAML to stdout for redirection into a file `harness char matrix` runs.
+func cmdSweepExport(client *api.Client, args []string, asJSON bool) error {
+	var id string
+	rest := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		id, rest = args[0], args[1:]
+	}
+	fs := flag.NewFlagSet("sweep export", flag.ContinueOnError)
+	fan := fs.String("fan", "", "export the isolation fan rooted at this parent experiment id")
+	repGroup := fs.String("rep-group", "", "export every experiment in this rep-group")
+	name := fs.String("name", "", "spec name (default derived from the selector)")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	// Exactly one selector.
+	selectors := 0
+	for _, set := range []bool{id != "", *fan != "", *repGroup != ""} {
+		if set {
+			selectors++
+		}
+	}
+	if selectors != 1 {
+		return errors.New("usage: harness sweep export <id> | --fan <parent-id> | --rep-group <g> [--name NAME]")
+	}
+
+	s, err := openStore(client)
+	if err != nil {
+		return err
+	}
+	all, err := s.List("") // every status — a found fan can span buckets
+	if err != nil {
+		return err
+	}
+
+	var picked []*sweep.Experiment
+	specName := *name
+	switch {
+	case id != "":
+		for _, e := range all {
+			if e.ID == id {
+				picked = append(picked, e)
+			}
+		}
+		if len(picked) == 0 {
+			return fmt.Errorf("no experiment with id %q in the queue", id)
+		}
+		if specName == "" {
+			specName = "export-" + id
+		}
+	case *fan != "":
+		for _, e := range all {
+			if e.Parent == *fan {
+				picked = append(picked, e)
+			}
+		}
+		if len(picked) == 0 {
+			return fmt.Errorf("no fan members with parent %q (an isolation fan stamps Parent on its control+variants)", *fan)
+		}
+		if specName == "" {
+			specName = "fan-" + *fan
+		}
+	case *repGroup != "":
+		for _, e := range all {
+			if e.RepGroup == *repGroup {
+				picked = append(picked, e)
+			}
+		}
+		if len(picked) == 0 {
+			return fmt.Errorf("no experiments in rep-group %q", *repGroup)
+		}
+		if specName == "" {
+			specName = "repgroup-" + *repGroup
+		}
+	}
+
+	spec, err := charmatrix.SpecFromExperiments(specName, picked)
+	if err != nil {
+		return err
+	}
+	out, err := charmatrix.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{"spec": spec.Name, "yaml": string(out)})
+	}
+	_, err = os.Stdout.Write(out)
+	return err
 }
 
 // cmdSweepAnnotate records the LLM's interpretation (what happened / where /

--- a/tools/harness-cli/internal/charmatrix/bridge.go
+++ b/tools/harness-cli/internal/charmatrix/bridge.go
@@ -1,0 +1,185 @@
+package charmatrix
+
+// bridge.go is the char-matrix YAML ↔ sweep queue adapter (issue #873). It is the
+// inverse of expand.go's ToExperiment: where ToExperiment compiles an authored
+// Arm into a queue Experiment (the import direction), this file reconstructs an
+// Arm — and a whole runnable Spec — from queue Experiments (the export
+// direction), plus the YAML emitter and the silent-drop guard.
+//
+// Lossless intent: every recipe knob BOTH models carry (Class/Platform/Protocol/
+// Segment/Mode/Shape/Fault/ContentManipulation/TransferTimeouts + Group/Role +
+// Muted/Reps/DurationS) round-trips. The knobs that exist ONLY on the client Arm
+// (is.codec / is.peak_bitrate_mbps / is.live_offset / is.starts_first_variant)
+// have no field on sweep.Experiment, so ToExperiment necessarily drops them —
+// DroppedClientKnobs surfaces that so `import` can refuse loudly rather than lose
+// them silently (the LabelPlay silent-drop trap).
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+	"gopkg.in/yaml.v3"
+)
+
+// DroppedClientKnobs lists the client-only is.* knobs this arm sets that
+// ToExperiment cannot carry onto a sweep.Experiment. Non-empty ⇒ importing the
+// arm into the queue would silently lose them; the caller must refuse or warn.
+// (Muted is NOT here — ToExperiment carries it onto Experiment.Muted.)
+func (a *Arm) DroppedClientKnobs() []string {
+	var dropped []string
+	if a.Codec != "" {
+		dropped = append(dropped, "is.codec")
+	}
+	if a.AppLiveOffset != nil {
+		dropped = append(dropped, "is.live_offset")
+	}
+	if a.PeakBitrateMbps != 0 {
+		dropped = append(dropped, "is.peak_bitrate_mbps")
+	}
+	if a.StartsFirstVariant != nil {
+		dropped = append(dropped, "is.starts_first_variant")
+	}
+	return dropped
+}
+
+// ArmFromExperiment is the export inverse of ToExperiment: it reconstructs the
+// flat char-matrix Arm from a queue Experiment. The server-side recipe is
+// emitted in its canonical nested form (proxy.shape / proxy.fault /
+// proxy.content_manipulation / proxy.transfer_timeouts) — the flat proxy.*
+// conveniences are an input-only ergonomic that ToExperiment folds INTO the
+// nested block, so a re-import reads them back identically. Client-only knobs are
+// not recoverable, but a queue Experiment never had them, so nothing is lost on
+// this path (the loss, if any, was guarded at import via DroppedClientKnobs).
+//
+// Pointers are deep-cloned so the returned Arm shares no state with e.
+func ArmFromExperiment(e *sweep.Experiment) *Arm {
+	return &Arm{
+		ID:                  e.ID,
+		Group:               e.Group,
+		Role:                string(e.Arm),
+		Platform:            e.Platform,
+		Content:             e.Content,
+		Mode:                e.Mode,
+		Class:               string(e.Class),
+		DurationS:           e.DurationS,
+		Reps:                e.Reps,
+		Segment:             e.Segment,
+		Protocol:            e.Protocol,
+		Muted:               cloneBool(e.Muted),
+		Shape:               cloneShape(e.Shape),
+		Fault:               cloneFault(e.Fault),
+		ContentManipulation: cloneCM(e.ContentManipulation),
+		TransferTimeouts:    cloneXfer(e.TransferTimeouts),
+	}
+}
+
+// SpecFromExperiments assembles a runnable Spec from queue experiments. Members
+// that share a non-empty Group and carry control/variant roles become a Group{}
+// (so `harness char matrix` re-pairs them on the dashboard, the way an isolation
+// fan or A/B batch ran); everything else becomes a flat Arm. Output is
+// deterministic: groups and arms are sorted by id. The result is byte-stable
+// across calls so it can back a golden round-trip test.
+func SpecFromExperiments(name string, exps []*sweep.Experiment) (*Spec, error) {
+	if name == "" {
+		return nil, fmt.Errorf("spec name is required")
+	}
+	if len(exps) == 0 {
+		return nil, fmt.Errorf("no experiments to export")
+	}
+
+	// Partition by Group. A group with a control + ≥1 variant exports as a
+	// Group{}; anything else (ungrouped, or a group with no clear control)
+	// exports as standalone arms so nothing is silently merged.
+	byGroup := map[string][]*sweep.Experiment{}
+	var groupOrder []string
+	for _, e := range exps {
+		if _, seen := byGroup[e.Group]; !seen && e.Group != "" {
+			groupOrder = append(groupOrder, e.Group)
+		}
+		byGroup[e.Group] = append(byGroup[e.Group], e)
+	}
+	sort.Strings(groupOrder)
+
+	spec := &Spec{Name: name}
+
+	for _, g := range groupOrder {
+		members := byGroup[g]
+		var control *sweep.Experiment
+		var variants []*sweep.Experiment
+		for _, e := range members {
+			switch e.Arm {
+			case sweep.ArmControl:
+				if control == nil { // first control wins; extras fall through to flat arms
+					control = e
+					continue
+				}
+			case sweep.ArmVariant:
+				variants = append(variants, e)
+				continue
+			}
+			// no usable role → treat as a standalone arm
+			spec.Arms = append(spec.Arms, ArmFromExperiment(e))
+		}
+		if control != nil && len(variants) > 0 {
+			sort.Slice(variants, func(i, j int) bool { return variants[i].ID < variants[j].ID })
+			grp := &Group{ID: g, Control: ArmFromExperiment(control)}
+			for _, v := range variants {
+				grp.Variants = append(grp.Variants, ArmFromExperiment(v))
+			}
+			spec.Groups = append(spec.Groups, grp)
+		} else {
+			// incomplete pairing: emit whatever members as flat arms
+			if control != nil {
+				spec.Arms = append(spec.Arms, ArmFromExperiment(control))
+			}
+			for _, v := range variants {
+				spec.Arms = append(spec.Arms, ArmFromExperiment(v))
+			}
+		}
+	}
+
+	// Ungrouped experiments → flat arms.
+	for _, e := range byGroup[""] {
+		spec.Arms = append(spec.Arms, ArmFromExperiment(e))
+	}
+	sort.Slice(spec.Arms, func(i, j int) bool { return spec.Arms[i].ID < spec.Arms[j].ID })
+
+	return spec, nil
+}
+
+// Marshal renders a Spec back to YAML, mirroring Load in reverse: the typed Spec
+// is JSON-encoded (so the dotted is.*/proxy.* json tags become the keys), funneled
+// through a generic map, then YAML-encoded. yaml.v3 emits map keys in sorted
+// order, so the output is deterministic — the "modulo ordering" the round-trip
+// allows. The emitted YAML is accepted by Load unchanged.
+func Marshal(spec *Spec) ([]byte, error) {
+	jsonBytes, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("spec→json: %w", err)
+	}
+	var generic any
+	if err := json.Unmarshal(jsonBytes, &generic); err != nil {
+		return nil, fmt.Errorf("json→generic: %w", err)
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(generic); err != nil {
+		return nil, fmt.Errorf("generic→yaml: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("yaml close: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func cloneBool(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+	v := *b
+	return &v
+}

--- a/tools/harness-cli/internal/charmatrix/bridge_test.go
+++ b/tools/harness-cli/internal/charmatrix/bridge_test.go
@@ -1,0 +1,188 @@
+package charmatrix
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+// recipeKey is the comparable subset of an Experiment: the knobs BOTH models
+// carry. It excludes the fields the bridge legitimately re-stamps (ID, Group,
+// Arm/Role, CreatedAt, Score, Kind, LaunchMode) so the round-trip is judged on
+// recipe losslessness, not bookkeeping.
+func recipeKey(t *testing.T, e *sweep.Experiment) string {
+	t.Helper()
+	norm := struct {
+		Class     sweep.Class
+		Platform  string
+		Protocol  string
+		Content   string
+		Segment   string
+		Mode      string
+		DurationS int
+		Reps      int
+		Muted     *bool
+		Shape     *sweep.Shape
+		Fault     *sweep.Fault
+		CM        *sweep.ContentManipulation
+		Xfer      *sweep.TransferTimeouts
+	}{
+		e.ClassOrDefault(), e.Platform, e.Protocol, e.Content, e.Segment, e.Mode,
+		e.DurationS, e.Reps, e.Muted, e.Shape, e.Fault, e.ContentManipulation, e.TransferTimeouts,
+	}
+	b, err := json.Marshal(norm)
+	if err != nil {
+		t.Fatalf("marshal recipe key: %v", err)
+	}
+	return string(b)
+}
+
+func expsFromYAML(t *testing.T, src []byte) []*sweep.Experiment {
+	t.Helper()
+	spec, err := Load(src)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	arms, err := Expand(spec)
+	if err != nil {
+		t.Fatalf("expand: %v", err)
+	}
+	out := make([]*sweep.Experiment, len(arms))
+	for i, a := range arms {
+		out[i] = a.ToExperiment()
+	}
+	return out
+}
+
+func keyMultiset(t *testing.T, exps []*sweep.Experiment) map[string]int {
+	t.Helper()
+	m := map[string]int{}
+	for _, e := range exps {
+		m[recipeKey(t, e)]++
+	}
+	return m
+}
+
+// TestBridgeRoundTripLossless: YAML → Experiments → Spec → YAML → Experiments
+// preserves every shared recipe knob (shape pattern, fault, content-manipulation,
+// segment, transfer-timeouts), across the group-pairing form.
+func TestBridgeRoundTripLossless(t *testing.T) {
+	src := []byte(`
+name: bridge-rt
+class: config
+defaults:
+  platform: ipad-sim
+  content: clip_x
+  mode: pyramid
+  is.segment: s2
+  proxy.shape:
+    pattern: pyramid
+    step_seconds: 12
+    rate_mbps: 1.5
+groups:
+  - id: g-shape
+    control: {}
+    variants:
+      - proxy.shape:
+          pattern: valley
+          step_seconds: 6
+      - proxy.content_manipulation:
+          strip_avg_bandwidth: true
+      - proxy.transfer_timeouts:
+          active_seconds: 10
+          applies_segments: true
+`)
+	first := expsFromYAML(t, src)
+	if len(first) != 4 { // control + 3 variants
+		t.Fatalf("want 4 arms from the group, got %d", len(first))
+	}
+
+	spec, err := SpecFromExperiments("bridge-rt", first)
+	if err != nil {
+		t.Fatalf("SpecFromExperiments: %v", err)
+	}
+	// The control+variants pairing survives as a Group, not scattered arms.
+	if len(spec.Groups) != 1 || len(spec.Arms) != 0 {
+		t.Fatalf("want 1 group / 0 flat arms, got %d groups / %d arms", len(spec.Groups), len(spec.Arms))
+	}
+	if len(spec.Groups[0].Variants) != 3 || spec.Groups[0].Control == nil {
+		t.Fatalf("group must keep control + 3 variants, got control=%v variants=%d",
+			spec.Groups[0].Control != nil, len(spec.Groups[0].Variants))
+	}
+
+	out, err := Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	second := expsFromYAML(t, out)
+
+	if a, b := keyMultiset(t, first), keyMultiset(t, second); !mapsEqual(a, b) {
+		t.Fatalf("round-trip lost a recipe knob.\n exported yaml:\n%s\n first=%v\n second=%v", out, a, b)
+	}
+}
+
+// TestBridgeMarshalDeterministic: the same spec marshals byte-identically twice
+// (golden tests depend on this — yaml.v3 sorts map keys).
+func TestBridgeMarshalDeterministic(t *testing.T) {
+	src := []byte("name: det\nclass: config\ndefaults:\n  platform: ipad-sim\n  mode: steps\naxes:\n  is.segment: [s2, s6]\n")
+	exps := expsFromYAML(t, src)
+	spec, err := SpecFromExperiments("det", exps)
+	if err != nil {
+		t.Fatalf("spec: %v", err)
+	}
+	a, err := Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal a: %v", err)
+	}
+	b, err := Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal b: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatalf("marshal not deterministic:\n--- a ---\n%s\n--- b ---\n%s", a, b)
+	}
+}
+
+// TestDroppedClientKnobsGuard: client-only is.* knobs that ToExperiment can't
+// carry are reported (so import refuses), while carried knobs are not.
+func TestDroppedClientKnobsGuard(t *testing.T) {
+	peak := 3
+	off := 5.0
+	yes := true
+	a := &Arm{
+		Codec:              "hevc",
+		PeakBitrateMbps:    peak,
+		AppLiveOffset:      &off,
+		StartsFirstVariant: &yes,
+		// carried knobs — must NOT be flagged:
+		Segment: "s2", Muted: &yes, Shape: &sweep.Shape{Pattern: "valley"},
+	}
+	got := a.DroppedClientKnobs()
+	want := map[string]bool{"is.codec": true, "is.peak_bitrate_mbps": true, "is.live_offset": true, "is.starts_first_variant": true}
+	if len(got) != len(want) {
+		t.Fatalf("want %d dropped knobs, got %v", len(want), got)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Fatalf("unexpected dropped knob %q (carried knobs must not be flagged)", k)
+		}
+	}
+	// An arm with only carried knobs drops nothing.
+	clean := &Arm{Segment: "s6", Muted: &yes, Protocol: "hls"}
+	if d := clean.DroppedClientKnobs(); len(d) != 0 {
+		t.Fatalf("clean arm should drop nothing, got %v", d)
+	}
+}
+
+func mapsEqual(a, b map[string]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #873.

Bridges the autonomous `sweep` queue to char-matrix YAML in **both directions**: prime the queue from a hand-authored spec, and author a re-runnable spec from what sweep found. YAML is the interchange format; ClickHouse stays master for scheduling/scoring/claiming.

## What

- **`harness sweep import [--from] <yaml>`** — `Load`+`Expand` a char-matrix spec (reuses `internal/charmatrix`, no fork) → `ToExperiment` per arm → insert as `kind=hypothesis` backlog rows. `--dry-run` prints the would-be rows. Imported arms enter at `reps≥1` (never pre-confirmed — the n=1 discipline holds).
- **`harness sweep export <id | --fan PARENT | --rep-group G>`** — author a valid char-matrix YAML from a single experiment, an isolation fan (control + variants, gathered by `Parent`), or a rep-batch; printed to stdout.
- **`internal/charmatrix/bridge.go`** — the round-trip adapter: `ArmFromExperiment` (export inverse of the existing `ToExperiment`), `SpecFromExperiments` (control/variant pairing → `Group{}`, else flat arms), `Marshal` (`Load` in reverse, deterministic via yaml.v3 key sort), and **`DroppedClientKnobs`** — the silent-drop guard.

## Lossless + no silent drop

Round-trip is lossless for every knob both models share (`Class/Platform/Protocol/Segment/Mode/Shape/Fault/ContentManipulation/TransferTimeouts` + `Group/Role/Muted/Reps/DurationS`) — they're the same `sweep.*` types on both sides. The knobs that exist **only** on the client Arm (`is.codec`/`is.peak_bitrate_mbps`/`is.live_offset`/`is.starts_first_variant`) have no field on `sweep.Experiment`, so `import` **refuses loudly** rather than dropping them silently (the LabelPlay trap), pointing at `harness char matrix`.

## Note on homing

The issue suggested the adapter live beside `go-proxy/pkg/charplan`, but that's not possible for the `Experiment ↔ Arm` mapping: `sweep.Experiment` lives in `tools/harness-cli/internal/sweep`, which `go-proxy` can't import (separate module + `internal/`). It's homed in `harness-cli/internal/charmatrix` (which already imports `sweep` and owns `ToExperiment`).

## Test

- Build + full `go test ./...` green, incl. 3 new bridge tests: round-trip golden (knob multiset preserved through YAML→Experiments→Spec→YAML→Experiments), deterministic marshal, drop-guard.
- **Live vs test-dev:** import a 2-arm valley spec → `sweep ls` shows both → `export` → `harness char matrix --validate` accepts the exported YAML → queue cleaned up.

## Acceptance criteria
- [x] `sweep import` queues the spec's arms (verified via `sweep ls`).
- [x] `sweep export` emits YAML that `harness char matrix` runs unchanged (validated).
- [x] Lossless round-trip golden passes; unsupported-knob cases error explicitly.
- [x] CH-master scheduling unchanged; reps discipline intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
