### PR TITLE
feat(sweep): run isolation fans concurrently on the device-farm fleet — #874

### DIFF
--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -170,36 +170,22 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 	// ladder would build a pyramid that only spans its reduced range. Prefer the
 	// first full-ladder arm carrying the pattern; fall back to the first pattern
 	// arm (with a warning) if none is full.
-	patternMaster, firstPatternArm := -1, -1
-	for i, a := range arms {
-		if shapePattern(a) == "" {
-			continue
-		}
-		if firstPatternArm < 0 {
-			firstPatternArm = i
-		}
-		e := a.ToExperiment()
-		if e.ContentManipulation == nil || e.ContentManipulation.AllowedVariants == "" {
-			patternMaster = i
-			break
-		}
-	}
-	if patternMaster < 0 {
-		patternMaster = firstPatternArm
-		if patternMaster >= 0 {
-			fmt.Fprintf(os.Stderr, "warn: no full-ladder arm to master the pattern — arm %d masters with a thinned ladder\n", patternMaster)
-		}
+	patternMaster, thinned := charmatrix.PatternMasterIndex(arms)
+	if thinned {
+		fmt.Fprintf(os.Stderr, "warn: no full-ladder arm to master the pattern — arm %d masters with a thinned ladder\n", patternMaster)
 	}
 
 	// Startup/recovery knobs are run-level (the same for every arm) — the probe
 	// used to read these from its own env; the CLI now resolves them once and
 	// stamps each arm. ParseBool is the single local_proxy/auto_recovery parser;
 	// WithDefaults (per arm, below) fills the false/true defaults.
-	fwdBuffer := strings.TrimSpace(os.Getenv("CHAR_FWD_BUFFER_S"))
-	fwdRelease := strings.TrimSpace(os.Getenv("CHAR_FWD_RELEASE"))
-	persistPeak := strings.TrimSpace(os.Getenv("CHAR_PERSIST_PEAK"))
-	localProxy := charplan.ParseBool(os.Getenv("CHAR_LOCAL_PROXY"))
-	autoRecovery := charplan.ParseBool(os.Getenv("CHAR_AUTO_RECOVERY"))
+	rl := charmatrix.RunLevel{
+		StartupFwdBufferS:  strings.TrimSpace(os.Getenv("CHAR_FWD_BUFFER_S")),
+		StartupFwdRelease:  strings.TrimSpace(os.Getenv("CHAR_FWD_RELEASE")),
+		PersistentPeakMbps: strings.TrimSpace(os.Getenv("CHAR_PERSIST_PEAK")),
+		LocalProxy:         charplan.ParseBool(os.Getenv("CHAR_LOCAL_PROXY")),
+		AutoRecovery:       charplan.ParseBool(os.Getenv("CHAR_AUTO_RECOVERY")),
+	}
 
 	results := make([]charmatrix.ArmResult, len(arms))
 	var armEnv []string
@@ -248,29 +234,7 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 		// RunPlan below (the probe reads CHAR_RUN_PLAN_FILE), so the old flat
 		// CHAR_ARM_<i>_{SEGMENT,CODEC,MUTED,…} surface is gone.
 		armEnv = append(armEnv, fmt.Sprintf("CHAR_ARM_%d_PLATFORM=%s", i, a.Platform))
-		arm := charplan.ArmConfig{
-			PlayerID:           playerID,
-			Platform:           a.Platform,
-			Content:            clip,
-			Segment:            a.Segment,
-			LiveOffsetS:        a.ClientLiveOffsetS(),
-			Protocol:           a.Protocol,
-			Codec:              a.Codec,
-			PeakBitrateMbps:    a.PeakBitrateMbps,
-			StartsFirstVariant: charplan.ParseBool(a.StartsFirstVariantS()),
-			Muted:              charplan.ParseBool(a.MutedS()),
-			StartupFwdBufferS:  fwdBuffer,
-			StartupFwdRelease:  fwdRelease,
-			PersistentPeakMbps: persistPeak,
-			LocalProxy:         localProxy,
-			AutoRecovery:       autoRecovery,
-			Pattern:            shapePattern(a),
-			StepS:              shapeStepS(a),
-			MarginPct:          shapeMargin(a),
-			PatternMaster:      i == patternMaster,
-		}
-		arm.WithDefaults()
-		planArms[i] = arm
+		planArms[i] = a.ToArmConfig(playerID, clip, rl, i == patternMaster)
 	}
 	if window <= 0 {
 		window = 60
@@ -627,9 +591,9 @@ func driveProbe(client *api.Client, a *charmatrix.Arm, playerID, clip string, du
 		"CHAR_SWEEP_PEAK_BITRATE="+strconv.Itoa(a.PeakBitrateMbps),
 		"CHAR_SWEEP_FIRST_VARIANT="+a.StartsFirstVariantS(),
 		"CHAR_SWEEP_MUTED="+a.MutedS(),
-		"CHAR_SWEEP_PATTERN="+shapePattern(a),
-		"CHAR_SWEEP_STEP_S="+strconv.Itoa(shapeStepS(a)),
-		"CHAR_SWEEP_MARGIN="+strconv.Itoa(shapeMargin(a)),
+		"CHAR_SWEEP_PATTERN="+a.ShapePattern(),
+		"CHAR_SWEEP_STEP_S="+strconv.Itoa(a.ShapeStepS()),
+		"CHAR_SWEEP_MARGIN="+strconv.Itoa(a.ShapeMargin()),
 		"CHAR_CONTENT="+clip,
 	)
 	if err := cmd.Run(); err != nil {
@@ -673,30 +637,9 @@ func measureArm(client *api.Client, a *charmatrix.Arm, playerID string, res *cha
 
 // --- small local helpers --------------------------------------------------
 
-// shapePattern / shapeStepS / shapeMargin extract the post-launch bandwidth
-// pattern from an arm's proxy.shape. The pattern is NOT applied by the
-// config-on-connect bootstrap (experimentPlayerPatch defers it); the probe arms
-// it after playback starts via ApplyPattern, so the runner passes it through env.
-func shapePattern(a *charmatrix.Arm) string {
-	if a.Shape != nil {
-		return a.Shape.Pattern
-	}
-	return ""
-}
-
-func shapeStepS(a *charmatrix.Arm) int {
-	if a.Shape != nil && a.Shape.StepSeconds > 0 {
-		return a.Shape.StepSeconds
-	}
-	return 12
-}
-
-func shapeMargin(a *charmatrix.Arm) int {
-	if a.Shape != nil && a.Shape.MarginPct > 0 {
-		return a.Shape.MarginPct
-	}
-	return 5
-}
+// shapePattern/shapeStepS/shapeMargin moved to charmatrix as Arm methods
+// (Arm.ShapePattern/ShapeStepS/ShapeMargin) so the fleet-fan path (#874) reuses
+// the same projection.
 
 func intendedOf(a *charmatrix.Arm) float64 {
 	if off, ok := a.IntendedLiveOffset(); ok {

--- a/tools/harness-cli/cmd/harness/sweep.go
+++ b/tools/harness-cli/cmd/harness/sweep.go
@@ -78,6 +78,12 @@ Subcommands:
                            how) onto Result.Note [--from found].
   reap [--max-age-min N]   return running experiments orphaned by a dead runner
                            to backlog (default 60; ~2× the longest expected run).
+  run-fan <parent-id> [--dry-run] [--duration-s N]
+                           run a ≥2-arm isolation fan CONCURRENTLY on the device
+                           farm — one device per arm, all sharing the isolation
+                           group/pattern (control masters; variants bind). Reuses
+                           the char-matrix fleet path. --dry-run prints the
+                           RunPlan. Singletons stay on the single-device probe.
   isolate <id> --flip axis=value [--flip …]
                            materialise an OFAT isolation fan off a confirmed
                            hit (control + one variant per flip) into backlog/.
@@ -109,6 +115,8 @@ func cmdSweep(client *api.Client, args []string, asJSON bool) error {
 		return cmdSweepImport(client, args[1:], asJSON)
 	case "export":
 		return cmdSweepExport(client, args[1:], asJSON)
+	case "run-fan":
+		return cmdSweepRunFan(client, args[1:], asJSON)
 	case "status":
 		return cmdSweepStatus(client, args[1:], asJSON)
 	case "ls":

--- a/tools/harness-cli/cmd/harness/sweep.go
+++ b/tools/harness-cli/cmd/harness/sweep.go
@@ -469,13 +469,16 @@ func cmdSweepExport(client *api.Client, args []string, asJSON bool) error {
 			specName = "export-" + id
 		}
 	case *fan != "":
+		// The isolation fan is the control + flip variants (Kind==isolation);
+		// filtering on Kind excludes confirmation reps that share the same Parent
+		// (same-recipe re-runs, not flip variants) — consistent with run-fan.
 		for _, e := range all {
-			if e.Parent == *fan {
+			if e.Parent == *fan && e.Kind == sweep.KindIsolation {
 				picked = append(picked, e)
 			}
 		}
 		if len(picked) == 0 {
-			return fmt.Errorf("no fan members with parent %q (an isolation fan stamps Parent on its control+variants)", *fan)
+			return fmt.Errorf("no isolation-fan members with parent %q (an isolation fan stamps Parent + Kind=isolation on its control+variants)", *fan)
 		}
 		if specName == "" {
 			specName = "fan-" + *fan

--- a/tools/harness-cli/cmd/harness/sweep_fleet.go
+++ b/tools/harness-cli/cmd/harness/sweep_fleet.go
@@ -1,0 +1,207 @@
+package main
+
+// sweep_fleet.go runs a sweep ISOLATION FAN concurrently on the device farm —
+// one device per arm, all sharing the isolation group/pattern (issue #874) —
+// instead of serially on one operator-pinned sim. It reuses the char-matrix
+// fleet machinery: a fan Experiment → charmatrix.Arm (ArmFromExperiment, #873) →
+// charplan.ArmConfig (ToArmConfig) → a charplan.RunPlan driven through driveFleet
+// → TestCharMatrixFleet → resolveFleetDeviceFarm. The single-device path stays
+// the default for singletons (the normal sweep loop) — only ≥2-arm fans fan out.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/charplan"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/charmatrix"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+// runLevelFromEnv resolves the run-level startup/recovery knobs once, the same
+// way runMatrixParallel does (shared by every arm in the fleet).
+func runLevelFromEnv() charmatrix.RunLevel {
+	return charmatrix.RunLevel{
+		StartupFwdBufferS:  strings.TrimSpace(os.Getenv("CHAR_FWD_BUFFER_S")),
+		StartupFwdRelease:  strings.TrimSpace(os.Getenv("CHAR_FWD_RELEASE")),
+		PersistentPeakMbps: strings.TrimSpace(os.Getenv("CHAR_PERSIST_PEAK")),
+		LocalProxy:         charplan.ParseBool(os.Getenv("CHAR_LOCAL_PROXY")),
+		AutoRecovery:       charplan.ParseBool(os.Getenv("CHAR_AUTO_RECOVERY")),
+	}
+}
+
+// buildFanRunPlan converts a sweep isolation fan into a charplan.RunPlan: each
+// experiment → ArmFromExperiment (#873) → ToArmConfig with its bootstrapped
+// player_id; the first full-ladder pattern arm masters (slaves bind via the
+// shared isolation group). playerIDs is index-aligned with fan ("" =
+// bootstrap-failed → zero-value ArmConfig → that fleet index skips). Pure (no
+// I/O), so it is unit-testable as the deterministic core of #874.
+func buildFanRunPlan(fan []*sweep.Experiment, playerIDs []string, rl charmatrix.RunLevel, baseURL, manifest string, durationS int) *charplan.RunPlan {
+	arms := fanArms(fan)
+	master, _ := charmatrix.PatternMasterIndex(arms)
+	planArms := make([]charplan.ArmConfig, len(fan))
+	for i, a := range arms {
+		if i >= len(playerIDs) || playerIDs[i] == "" {
+			continue // zero-value ArmConfig → the probe skips this fleet index
+		}
+		clip := sweep.ContentOrDefault(fan[i].Content)
+		planArms[i] = a.ToArmConfig(playerIDs[i], clip, rl, i == master)
+	}
+	if durationS <= 0 {
+		durationS = 60
+	}
+	platform := ""
+	if len(fan) > 0 {
+		platform = fan[0].Platform
+	}
+	return &charplan.RunPlan{
+		BaseURL:        baseURL,
+		Platform:       platform,
+		FleetCount:     len(fan),
+		DurationS:      durationS,
+		DeviceManifest: manifest,
+		Arms:           planArms,
+	}
+}
+
+// fanArms projects a fan of experiments into char-matrix arms (the #873 bridge),
+// preserving order so FleetIndex == position.
+func fanArms(fan []*sweep.Experiment) []*charmatrix.Arm {
+	arms := make([]*charmatrix.Arm, len(fan))
+	for i, e := range fan {
+		arms[i] = charmatrix.ArmFromExperiment(e)
+	}
+	return arms
+}
+
+// fanWindow is the shared play window: the longest arm's duration, or 60.
+func fanWindow(fan []*sweep.Experiment, override int) int {
+	if override > 0 {
+		return override
+	}
+	w := 0
+	for _, e := range fan {
+		if e.DurationS > w {
+			w = e.DurationS
+		}
+	}
+	if w <= 0 {
+		w = 60
+	}
+	return w
+}
+
+func cmdSweepRunFan(client *api.Client, args []string, asJSON bool) error {
+	var parent string
+	rest := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		parent, rest = args[0], args[1:]
+	}
+	fs := flag.NewFlagSet("sweep run-fan", flag.ContinueOnError)
+	dryRun := fs.Bool("dry-run", false, "build + print the fleet RunPlan; bootstrap nothing, launch no devices")
+	durationS := fs.Int("duration-s", 0, "shared play window in seconds (0 = longest arm's, default 60)")
+	charDir := fs.String("char-dir", envOrDefault("CHAR_DIR", "tests/characterization"), "path to the characterization Go module (drives the fleet probe)")
+	if err := fs.Parse(rest); err != nil {
+		return err
+	}
+	if parent == "" {
+		return errors.New("usage: harness sweep run-fan <parent-experiment-id> [--dry-run] [--duration-s N]")
+	}
+
+	s, err := openStore(client)
+	if err != nil {
+		return err
+	}
+	all, err := s.List("") // a fan can span buckets (control in found, variants in backlog)
+	if err != nil {
+		return err
+	}
+	// The isolation fan is the control + single-axis-flip variants IsolationFan
+	// stamped with Parent==parent AND Kind==isolation. Filtering on Kind excludes
+	// confirmation reps (same Parent, but same-recipe re-runs, not flip variants)
+	// so a rep-batch never gets folded into the fleet fan.
+	var fan []*sweep.Experiment
+	for _, e := range all {
+		if e.Parent == parent && e.Kind == sweep.KindIsolation {
+			fan = append(fan, e)
+		}
+	}
+	sort.Slice(fan, func(i, j int) bool { return fan[i].ID < fan[j].ID })
+
+	// Gate: only ≥2-arm fans fan out. A singleton stays on the single-device
+	// probe (the normal sweep loop) — the loop's cost-per-tick discipline.
+	if len(fan) < 2 {
+		return fmt.Errorf("run-fan needs a ≥2-arm isolation fan; parent %q has %d member(s). A singleton runs on the single-device probe (claim it via the normal sweep loop)", parent, len(fan))
+	}
+
+	rl := runLevelFromEnv()
+	window := fanWindow(fan, *durationS)
+
+	if *dryRun {
+		// Placeholder player_ids so the plan is fully populated for inspection;
+		// no session is bootstrapped, no device is touched.
+		ph := make([]string, len(fan))
+		for i := range ph {
+			ph[i] = fmt.Sprintf("dry-run-arm-%d", i)
+		}
+		plan := buildFanRunPlan(fan, ph, rl, client.BaseURL, "", window)
+		if asJSON {
+			return json.NewEncoder(os.Stdout).Encode(plan)
+		}
+		arms := fanArms(fan)
+		master, thinned := charmatrix.PatternMasterIndex(arms)
+		fmt.Printf("DRY RUN — fleet RunPlan for fan parent %q: %d arms, group=%q, shared window=%ds\n",
+			parent, len(fan), fan[0].Group, window)
+		for i, e := range fan {
+			pattern := arms[i].ShapePattern()
+			if pattern == "" {
+				pattern = "-"
+			}
+			fmt.Printf("  arm %d  %-44s platform=%-9s seg=%-3s pattern=%-8s master=%v\n",
+				i, e.ID, e.Platform, e.Segment, pattern, i == master)
+		}
+		if master < 0 {
+			fmt.Println("note: no pattern arm — nothing masters a shared bandwidth timeline")
+		} else if thinned {
+			fmt.Printf("note: master arm %d has a thinned ladder (no full-ladder pattern arm)\n", master)
+		}
+		return nil
+	}
+
+	// Real run: bootstrap each arm into the SHARED isolation group (so the proxy
+	// propagates the master's pattern to all), then drive the fleet — one device
+	// per arm — via the existing TestCharMatrixFleet path (device-farm allocation,
+	// #853 release-on-interrupt + reap all live in driveFleet).
+	playerIDs := make([]string, len(fan))
+	var armEnv []string
+	for i, e := range fan {
+		clip := sweep.ContentOrDefault(e.Content)
+		pid := uuid.NewString()
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		_, berr := bootstrapMatrixSession(ctx, client, clip, pid, e.Group, e)
+		cancel()
+		if berr != nil {
+			fmt.Fprintf(os.Stderr, "arm %d bootstrap failed (%s): %v — fleet index %d will skip\n", i, e.ID, berr, i)
+			continue
+		}
+		playerIDs[i] = pid
+		armEnv = append(armEnv, fmt.Sprintf("CHAR_ARM_%d_PLATFORM=%s", i, e.Platform))
+		fmt.Fprintf(os.Stderr, "bootstrapped arm %d/%d: %s (player_id=%s)\n", i+1, len(fan), e.ID, pid)
+	}
+
+	plan := buildFanRunPlan(fan, playerIDs, rl, client.BaseURL, "", window)
+	if err := driveFleet(client, fan[0].Platform, len(fan), window, *charDir, armEnv, plan.Arms); err != nil {
+		return fmt.Errorf("fleet run: %w", err)
+	}
+	fmt.Printf("fan %q drove %d arms concurrently on the fleet; analyze each via 'harness sweep analyze <id> --play <play_id>'\n", parent, len(fan))
+	return nil
+}

--- a/tools/harness-cli/cmd/harness/sweep_fleet_test.go
+++ b/tools/harness-cli/cmd/harness/sweep_fleet_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/charmatrix"
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+func fanExp(id, seg string, arm sweep.Arm, pattern bool) *sweep.Experiment {
+	e := &sweep.Experiment{
+		ID: id, Platform: "ipad-sim", Protocol: "hls", Content: "clip_x",
+		Segment: seg, Group: "iso-abc", Arm: arm, Parent: "p1",
+	}
+	if pattern {
+		e.Shape = &sweep.Shape{Pattern: "valley", StepSeconds: 12}
+	}
+	return e
+}
+
+func TestBuildFanRunPlan(t *testing.T) {
+	fan := []*sweep.Experiment{
+		fanExp("iso-abc-control", "s2", sweep.ArmControl, true),
+		fanExp("iso-abc-segment", "s6", sweep.ArmVariant, true),
+		fanExp("iso-abc-platform", "s2", sweep.ArmVariant, true),
+	}
+	playerIDs := []string{"pid0", "pid1", ""} // arm 2 bootstrap-failed → must skip
+
+	plan := buildFanRunPlan(fan, playerIDs, charmatrix.RunLevel{}, "https://base", "/tmp/man", 90)
+
+	if plan.FleetCount != 3 || len(plan.Arms) != 3 {
+		t.Fatalf("fleet shape wrong: count=%d arms=%d", plan.FleetCount, len(plan.Arms))
+	}
+	if plan.DurationS != 90 || plan.Platform != "ipad-sim" || plan.BaseURL != "https://base" || plan.DeviceManifest != "/tmp/man" {
+		t.Fatalf("run-level fields wrong: %+v", plan)
+	}
+	if plan.Arms[0].PlayerID != "pid0" || plan.Arms[1].PlayerID != "pid1" {
+		t.Fatalf("player ids not bound: %+v", plan.Arms)
+	}
+	// The empty-playerID arm stays a zero-value ArmConfig so its fleet index skips.
+	if plan.Arms[2].PlayerID != "" || plan.Arms[2].Segment != "" {
+		t.Fatalf("empty-playerID arm must be zero-value, got %+v", plan.Arms[2])
+	}
+	// Per-arm segment survives the Experiment→Arm→ArmConfig round-trip.
+	if plan.Arms[0].Segment != "s2" || plan.Arms[1].Segment != "s6" {
+		t.Fatalf("segments wrong: %q %q", plan.Arms[0].Segment, plan.Arms[1].Segment)
+	}
+	// Exactly one arm masters the shared pattern, and it's a bound arm.
+	masters := 0
+	for _, a := range plan.Arms {
+		if a.PatternMaster {
+			masters++
+		}
+	}
+	if masters != 1 || !plan.Arms[0].PatternMaster {
+		t.Fatalf("want exactly arm 0 as pattern master, got masters=%d arm0=%v", masters, plan.Arms[0].PatternMaster)
+	}
+}
+
+func TestBuildFanRunPlanWindowDefault(t *testing.T) {
+	fan := []*sweep.Experiment{
+		fanExp("c", "s2", sweep.ArmControl, false),
+		fanExp("v", "s6", sweep.ArmVariant, false),
+	}
+	// override 0 + no per-arm duration → falls back to 60.
+	plan := buildFanRunPlan(fan, []string{"a", "b"}, charmatrix.RunLevel{}, "", "", 0)
+	if plan.DurationS != 60 {
+		t.Fatalf("default window want 60, got %d", plan.DurationS)
+	}
+	// No pattern anywhere → no master.
+	for i, a := range plan.Arms {
+		if a.PatternMaster {
+			t.Fatalf("no pattern arm should master, arm %d does", i)
+		}
+	}
+}

--- a/tools/harness-cli/internal/charmatrix/armconfig.go
+++ b/tools/harness-cli/internal/charmatrix/armconfig.go
@@ -1,0 +1,106 @@
+package charmatrix
+
+// armconfig.go projects a char-matrix Arm into the typed charplan.ArmConfig the
+// fleet probe reads (issue #874). This mapping used to live inline in the CLI's
+// runMatrixParallel (cmd/harness/char.go); it is extracted here so BOTH the
+// char-matrix fleet path AND the sweep isolation-fan fleet path build ArmConfigs
+// the same way, instead of duplicating the projection (the issue's "prefer
+// reusing over duplicating allocation logic").
+
+import (
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/charplan"
+)
+
+// RunLevel carries the startup/recovery knobs that are the SAME for every arm in
+// a run (the CLI resolves them once from CHAR_* env and stamps each arm).
+type RunLevel struct {
+	StartupFwdBufferS  string
+	StartupFwdRelease  string
+	PersistentPeakMbps string
+	LocalProxy         *bool // nil = resolver default (false, forced off for characterization)
+	AutoRecovery       *bool // nil = resolver default (true, the #865 default-ON)
+}
+
+// ShapePattern / ShapeStepS / ShapeMargin extract the post-launch bandwidth
+// pattern from the arm's proxy.shape. The pattern is NOT applied by the
+// config-on-connect bootstrap (it is deferred); the probe arms it after playback
+// starts via ApplyPattern. Defaults mirror charplan.Default{StepS,MarginPct}.
+func (a *Arm) ShapePattern() string {
+	if a.Shape != nil {
+		return a.Shape.Pattern
+	}
+	return ""
+}
+
+func (a *Arm) ShapeStepS() int {
+	if a.Shape != nil && a.Shape.StepSeconds > 0 {
+		return a.Shape.StepSeconds
+	}
+	return charplan.DefaultStepS
+}
+
+func (a *Arm) ShapeMargin() int {
+	if a.Shape != nil && a.Shape.MarginPct > 0 {
+		return a.Shape.MarginPct
+	}
+	return charplan.DefaultMarginPct
+}
+
+// ToArmConfig projects the arm into the typed handoff the probe reads. playerID
+// is the already-bootstrapped config-on-connect session ("" => the probe skips
+// that fleet index); content is the resolved clip (the caller applied its
+// default); rl carries the run-level startup/recovery knobs; patternMaster marks
+// the one arm that arms the shared bandwidth pattern (slaves bind via the proxy
+// group). WithDefaults is applied so the returned config is fully resolved.
+func (a *Arm) ToArmConfig(playerID, content string, rl RunLevel, patternMaster bool) charplan.ArmConfig {
+	ac := charplan.ArmConfig{
+		PlayerID:           playerID,
+		Platform:           a.Platform,
+		Content:            content,
+		Segment:            a.Segment,
+		LiveOffsetS:        a.ClientLiveOffsetS(),
+		Protocol:           a.Protocol,
+		Codec:              a.Codec,
+		PeakBitrateMbps:    a.PeakBitrateMbps,
+		StartsFirstVariant: charplan.ParseBool(a.StartsFirstVariantS()),
+		Muted:              charplan.ParseBool(a.MutedS()),
+		StartupFwdBufferS:  rl.StartupFwdBufferS,
+		StartupFwdRelease:  rl.StartupFwdRelease,
+		PersistentPeakMbps: rl.PersistentPeakMbps,
+		LocalProxy:         rl.LocalProxy,
+		AutoRecovery:       rl.AutoRecovery,
+		Pattern:            a.ShapePattern(),
+		StepS:              a.ShapeStepS(),
+		MarginPct:          a.ShapeMargin(),
+		PatternMaster:      patternMaster,
+	}
+	ac.WithDefaults()
+	return ac
+}
+
+// PatternMasterIndex picks the arm that should master a grouped bandwidth
+// pattern: the first FULL-ladder arm carrying a pattern (a thinned ladder would
+// build a pattern that only spans its reduced range), else the first pattern arm,
+// else -1 (no pattern in the set — nothing to master). thinnedFallback reports
+// whether the chosen master had to fall back to a thinned ladder (the caller may
+// warn), so the selection logic stays in one place.
+func PatternMasterIndex(arms []*Arm) (master int, thinnedFallback bool) {
+	master, firstPatternArm := -1, -1
+	for i, a := range arms {
+		if a.ShapePattern() == "" {
+			continue
+		}
+		if firstPatternArm < 0 {
+			firstPatternArm = i
+		}
+		e := a.ToExperiment()
+		if e.ContentManipulation == nil || e.ContentManipulation.AllowedVariants == "" {
+			return i, false // a full-ladder pattern arm — the ideal master
+		}
+	}
+	// No full-ladder pattern arm: fall back to the first pattern arm (if any).
+	if firstPatternArm >= 0 {
+		return firstPatternArm, true
+	}
+	return -1, false
+}

--- a/tools/harness-cli/internal/charmatrix/armconfig_test.go
+++ b/tools/harness-cli/internal/charmatrix/armconfig_test.go
@@ -1,0 +1,75 @@
+package charmatrix
+
+import (
+	"testing"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/sweep"
+)
+
+func TestToArmConfig(t *testing.T) {
+	yes := true
+	a := &Arm{
+		Platform: "ipad-sim", Segment: "s2", Protocol: "hls", Codec: "hevc",
+		PeakBitrateMbps: 3, Muted: &yes,
+		Shape: &sweep.Shape{Pattern: "valley", StepSeconds: 18, MarginPct: 10},
+	}
+	rl := RunLevel{StartupFwdBufferS: "2", AutoRecovery: &yes}
+	ac := a.ToArmConfig("pid-1", "clip_x", rl, true)
+
+	if ac.PlayerID != "pid-1" || ac.Platform != "ipad-sim" || ac.Content != "clip_x" {
+		t.Fatalf("binding wrong: %+v", ac)
+	}
+	if ac.Segment != "s2" || ac.Protocol != "hls" || ac.Codec != "hevc" || ac.PeakBitrateMbps != 3 {
+		t.Fatalf("client knobs wrong: %+v", ac)
+	}
+	if ac.Pattern != "valley" || ac.StepS != 18 || ac.MarginPct != 10 || !ac.PatternMaster {
+		t.Fatalf("pattern wrong: %+v", ac)
+	}
+	if ac.StartupFwdBufferS != "2" {
+		t.Fatalf("run-level not carried: %+v", ac)
+	}
+	if ac.Muted == nil || !*ac.Muted {
+		t.Fatalf("muted not carried")
+	}
+	// WithDefaults: local_proxy defaults to false (non-nil), auto_recovery true.
+	if ac.LocalProxy == nil || *ac.LocalProxy {
+		t.Fatalf("WithDefaults local_proxy not applied: %v", ac.LocalProxy)
+	}
+	if ac.AutoRecovery == nil || !*ac.AutoRecovery {
+		t.Fatalf("auto_recovery wrong: %v", ac.AutoRecovery)
+	}
+}
+
+func TestToArmConfigShapeDefaults(t *testing.T) {
+	// No shape → empty pattern, but StepS/MarginPct default via WithDefaults.
+	ac := (&Arm{Platform: "ipad-sim"}).ToArmConfig("p", "c", RunLevel{}, false)
+	if ac.Pattern != "" {
+		t.Fatalf("no shape should mean no pattern, got %q", ac.Pattern)
+	}
+	if ac.StepS != 12 || ac.MarginPct != 5 {
+		t.Fatalf("WithDefaults step/margin wrong: step=%d margin=%d", ac.StepS, ac.MarginPct)
+	}
+}
+
+func TestPatternMasterIndex(t *testing.T) {
+	full := func() *Arm { return &Arm{Shape: &sweep.Shape{Pattern: "valley"}} }
+	none := func() *Arm { return &Arm{} }
+	thinned := func() *Arm { return &Arm{Shape: &sweep.Shape{Pattern: "valley"}, AllowedVariants: "drop-top-rung"} }
+
+	// A full-ladder pattern arm is preferred even when a thinned one precedes it.
+	if m, th := PatternMasterIndex([]*Arm{thinned(), full(), none()}); m != 1 || th {
+		t.Fatalf("full-ladder preferred: want 1/false, got %d/%v", m, th)
+	}
+	// Only thinned pattern arms → fall back to the first, flagged thinned.
+	if m, th := PatternMasterIndex([]*Arm{none(), thinned()}); m != 1 || !th {
+		t.Fatalf("thinned fallback: want 1/true, got %d/%v", m, th)
+	}
+	// No pattern anywhere → -1.
+	if m, th := PatternMasterIndex([]*Arm{none(), none()}); m != -1 || th {
+		t.Fatalf("no pattern: want -1/false, got %d/%v", m, th)
+	}
+	// First full-ladder wins among several.
+	if m, _ := PatternMasterIndex([]*Arm{full(), full()}); m != 0 {
+		t.Fatalf("first full-ladder: want 0, got %d", m)
+	}
+}


### PR DESCRIPTION
Addresses #874. **Stacked on #873 (PR #876)** — base is the #873 branch so this diff shows only #874's changes; reuses its `ArmFromExperiment` bridge. Merge #876 first, then this retargets to `dev`.

## What

Run a ≥2-arm sweep **isolation fan** (control + single-axis-flip variants) concurrently across the device farm — one device per arm, all sharing the isolation group/pattern — instead of serially on one pinned sim. Cross-`platform` / mixed sim+real-iPhone flips become actually parallel.

**Reuse, not duplicate** — the fan rides the existing char-matrix fleet path:
```
fan Experiment → charmatrix.Arm (ArmFromExperiment, #873)
              → charplan.ArmConfig (ToArmConfig)
              → charplan.RunPlan → driveFleet → TestCharMatrixFleet → resolveFleetDeviceFarm
```

- **`internal/charmatrix/armconfig.go`** — extracts the `Arm→ArmConfig` projection that lived **inline** in `char.go`'s `runMatrixParallel` into a reusable `Arm.ToArmConfig` + `RunLevel` + `Shape{Pattern,StepS,Margin}` methods + `PatternMasterIndex`. `char.go` now calls these (matrix path unchanged — existing tests prove parity); the fan path reuses the same projection.
- **`cmd/harness/sweep_fleet.go`** — `buildFanRunPlan` (pure: fan → RunPlan, one full-ladder pattern master, empty-player_id arms skip) + **`harness sweep run-fan <parent> [--dry-run]`**: gathers the fan by `Parent + Kind==isolation` (so confirmation reps are **not** folded in), gates ≥2 arms (singletons stay on the single-device probe), bootstraps each into the shared isolation group, drives the fleet.

## Test

- Unit: `ToArmConfig` parity, `PatternMasterIndex` (full-ladder preferred / thinned fallback / none), `buildFanRunPlan` golden (arm count, one master, skip-on-empty-player_id, window default). Build+vet green across **go-proxy, harness-cli, tests/characterization**.
- Live (dry-run): isolate a `notable` → a cross-platform fan (`ipad-sim` control master + `iphone-sim` variant) → `run-fan --dry-run` emits the 2-arm RunPlan with correct per-arm platforms; the rep is excluded; the no-fan case is refused.

## NOT yet verified (hardware) — honest scope

- The live **≥2-device concurrent launch** and the **mixed sim+real-iPhone off-farm hybrid arm** need multiple farm devices I couldn't exercise this session.
- The **`qe-offhours.sh` runner** still needs a fan-aware invocation path (it drives plain `TestSweepProbe` per claim today). That runner integration is a follow-up.

## Acceptance criteria
- [x] ≥2-arm fan builds a concurrent fleet RunPlan, one device per arm, shared group/pattern (dry-run verified; deterministic core unit-tested).
- [ ] Live cross-platform + mixed sim+real-iPhone fans (needs hardware).
- [x] Depth-1 / singleton stays on the single-device path (gate refuses non-fans).
- [x] Reuses the #873 RunPlan/Arm mapping rather than duplicating allocation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
