### PR TITLE
fix(char): sweep probe taps the pinned clip tile, not the continue-watching hero

### DIFF
--- a/tests/characterization/modes/sweep_probe_test.go
+++ b/tests/characterization/modes/sweep_probe_test.go
@@ -117,8 +117,19 @@ func TestSweepProbe(t *testing.T) {
 		_ = sess.CloseViaUI(cleanupCtx) // clean client play_end
 		_ = sess.Release(cleanupCtx)    // delete the proxy session, free the slot
 	})
-	if err := appium.ResumePlayback(setupCtx, *picked); err != nil {
-		t.Fatalf("ResumePlayback: %v", err)
+	// When CHAR_CONTENT pins a clip, tap that clip's specific tile rather than
+	// the continue-watching hero (which races the catalogue load and can land on
+	// the featured clip — a pinned recipe otherwise silently streams Big Buck
+	// Bunny). Falls back to continue-watching inside ResumePlaybackClip when the
+	// clip tile never renders. Mirrors pyramid/char-matrix-fleet.
+	var rerr error
+	if clip := strings.TrimSpace(os.Getenv("CHAR_CONTENT")); clip != "" {
+		rerr = appium.ResumePlaybackClip(setupCtx, *picked, clipIDFromContent(clip))
+	} else {
+		rerr = appium.ResumePlayback(setupCtx, *picked)
+	}
+	if rerr != nil {
+		t.Fatalf("ResumePlayback: %v", rerr)
 	}
 
 	// Drive the bandwidth motion for a config-class pattern recipe: once the


### PR DESCRIPTION
## Problem
`TestSweepProbe` used `appium.ResumePlayback` (taps the continue-watching hero tile), which resolves to the featured fallback clip until the catalogue finishes loading. That races the content pin, so a sweep recipe pinned to `insane_newer_p200_h264` silently streamed Big Buck Bunny — putting every sweep probe result at risk of content misattribution.

## Fix
When `CHAR_CONTENT` is set, tap the pinned clip's own tile via `ResumePlaybackClip(clipIDFromContent(CHAR_CONTENT))` (continue-watching fallback retained inside `ResumePlaybackClip`). Mirrors the `pyramid` and `char-matrix-fleet` paths.

## Verification
- Before: 600/600 network requests hit `go-live/bucks_bunny_p200_h264`.
- After: 600/600 hit `go-live/insane_newer_p200_h264` (Fleet iPhone 15 sim, valley-pattern probe).
- `go vet ./tests/characterization/modes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
