### PR TITLE
feat(qoe): whole-play qoe_tier_* + new qoe_exit_* (state-at-close)

### DIFF
--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -132,8 +132,10 @@ type playLabelState struct {
 	// A label is emitted only on its rising edge (off→on): its first
 	// determination, or a new instance after it cleared. While a condition
 	// stays continuously true it is suppressed (no per-heartbeat repeats).
-	// The terminal row force-emits the still-true set so the summary +
-	// qoe_tier_* reflect end state. nil until first use.
+	// The terminal row no longer force-emits the still-true set: the
+	// end-state grade is emitted separately as qoe_exit_* (conditions active
+	// at close), and the whole-play grade qoe_tier_* reads worstSeen below.
+	// nil until first use.
 	qoeActive map[string]struct{}
 	// #657 — clear-cooldown re-arm. qoeLastOn records the last row-time each
 	// qoe label was TRUE. A rising edge re-fires only if the label has been
@@ -141,6 +143,12 @@ type playLabelState struct {
 	// above/below its threshold within the cooldown counts as one episode
 	// (one chip) instead of re-chipping on every re-crossing. nil until use.
 	qoeLastOn map[string]time.Time
+	// Whole-play worst-severity accumulator. Folded on EVERY row (lifecycle
+	// labels + qoe conditions true on the row + terminal outcome) so the
+	// terminal qoe_tier_* grades the ENTIRE playback, not just the end state
+	// — a mid-play critical that recovered still downgrades the tier. "" =
+	// nothing ranked yet. The end-state grade is qoe_exit_* (current-at-close).
+	worstSeen string
 	// LRU touch for GC.
 	seen time.Time
 }
@@ -388,6 +396,12 @@ func computeEventLabelsWithState(s *labelState, r *row) []string {
 			out = []string{bufferingLabel(dur, bufferingContext(ps, now))}
 		}
 	}
+
+	// Fold this row's lifecycle labels into the whole-play worst-severity
+	// accumulator before the qoe labeler layers on (it folds its own
+	// conditions and reads worstSeen for the terminal qoe_tier_*). This is
+	// what lets a mid-play stall_frozen/wedge count toward the whole-play tier.
+	ps.worstSeen = worseSeverity(ps.worstSeen, worstSeverity(out))
 
 	// #550 Phase 3 — threshold-based QoE auto-labels. Orthogonal to the
 	// LastEvent switch above; layered on whatever the event arm emitted.
@@ -844,6 +858,33 @@ func worstSeverity(labels []string) string {
 		return SevInfo
 	}
 	return ""
+}
+
+// sevRank orders severities for the whole-play worst-severity accumulator.
+// "" (nothing ranked) is 0; error outranks critical to match worstSeverity's
+// own precedence.
+func sevRank(s string) int {
+	switch s {
+	case SevError:
+		return 4
+	case SevCritical:
+		return 3
+	case SevWarning:
+		return 2
+	case SevInfo:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// worseSeverity returns whichever of two severity strings ranks higher — the
+// fold step for the per-play worstSeen accumulator.
+func worseSeverity(a, b string) string {
+	if sevRank(b) > sevRank(a) {
+		return b
+	}
+	return a
 }
 
 // parseChTs parses CH's "YYYY-MM-DD HH:MM:SS.fff" timestamp form (or

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -722,7 +722,13 @@ func TestQoEReFiresOnNewInstance(t *testing.T) {
 	}
 }
 
-func TestQoETerminalSummaryForcesStillTrue(t *testing.T) {
+// TestQoETerminalNoForceEmitTwoAxes — the terminal row no longer force-emits
+// still-true conditions (each appears once, at its rising edge, on the
+// per-moment timeline). Instead it carries two aggregates: qoe_exit_* (state at
+// close) and qoe_tier_* (whole-play grade). A VST-concerning that fired at
+// startup and stayed true is NOT re-stamped on the terminal row, but both
+// aggregates read warning → acceptable.
+func TestQoETerminalNoForceEmitTwoAxes(t *testing.T) {
 	s := newLabelState()
 	concerning := qoeLabel(SevWarning, "qoe_vst_concerning")
 	mk := func(ts, ev, status string) *row {
@@ -730,13 +736,40 @@ func TestQoETerminalSummaryForcesStillTrue(t *testing.T) {
 	}
 	computeEventLabelsWithState(s, mk("2026-06-03 00:00:01.000", "", "in_progress")) // first determination (emits)
 	computeEventLabelsWithState(s, mk("2026-06-03 00:00:02.000", "", "in_progress")) // sustained (suppressed)
-	// Terminal row: summary must force-emit the still-true VST + the tier.
 	got := computeEventLabelsWithState(s, mk("2026-06-03 00:00:03.000", "session_end", "completed"))
-	if !hasLabel(got, concerning) {
-		t.Fatalf("terminal summary must carry still-true %s: %v", concerning, got)
+	if hasLabel(got, concerning) {
+		t.Fatalf("terminal row must NOT force-emit the still-true %s: %v", concerning, got)
+	}
+	if !hasLabel(got, qoeLabel(SevWarning, "qoe_exit_acceptable")) {
+		t.Fatalf("qoe_exit must reflect state-at-close (warning → acceptable): %v", got)
 	}
 	if !hasLabel(got, qoeLabel(SevWarning, "qoe_tier_acceptable")) {
-		t.Fatalf("tier must reflect the summary (warning → acceptable): %v", got)
+		t.Fatalf("qoe_tier must reflect whole-play (warning → acceptable): %v", got)
+	}
+}
+
+// TestQoETierWholePlayVsExit — the two aggregates diverge: a mid-play critical
+// (a freeze) that recovered downgrades the whole-play qoe_tier_* to
+// unacceptable, but qoe_exit_* stays premium because the stream was clean at
+// the moment the user closed it.
+func TestQoETierWholePlayVsExit(t *testing.T) {
+	s := newLabelState()
+	mk := func(ts, ev, status string) *row {
+		return &row{Ts: ts, PlayerID: "p", PlayID: "x", LastEvent: ev, PlaybackStatus: status}
+	}
+	computeEventLabelsWithState(s, mk("2026-06-05 00:00:01.000", "play_start", "in_progress"))
+	// Mid-play freeze (critical), then recovery to clean.
+	if got := computeEventLabelsWithState(s, mk("2026-06-05 00:00:05.000", "frozen", "in_progress")); !hasLabel(got, SevCritical+"=stall_frozen") {
+		t.Fatalf("frozen row should emit stall_frozen: %v", got)
+	}
+	computeEventLabelsWithState(s, mk("2026-06-05 00:00:10.000", "", "in_progress")) // recovered, clean
+	// Clean close.
+	got := computeEventLabelsWithState(s, mk("2026-06-05 00:05:00.000", "session_end", "completed"))
+	if !hasLabel(got, qoeLabel(SevCritical, "qoe_tier_unacceptable")) {
+		t.Fatalf("whole-play tier must be unacceptable (mid-play freeze): %v", got)
+	}
+	if !hasLabel(got, qoeLabel(SevInfo, "qoe_exit_premium")) {
+		t.Fatalf("exit must be premium (clean at close): %v", got)
 	}
 }
 
@@ -760,11 +793,14 @@ func TestQoELeadingTerminalIgnored(t *testing.T) {
 			t.Fatalf("leading play_end must not emit %s: %v", bad, got)
 		}
 	}
-	// Play opens (restart), then a real clean terminal — should still get a
-	// tier, proving the guard wasn't consumed by the leaked frame.
-	computeEventLabelsWithState(s, &row{Ts: "2026-06-04 00:00:01.100", PlayerID: "p", PlayID: "x", LastEvent: "restart", PlaybackStatus: "in_progress"})
+	// Play opens (play_start — a clean, non-terminal open), then a real clean
+	// terminal — should still get a premium tier, proving the guard wasn't
+	// consumed by the leaked frame. (Opening with `restart` would inject a
+	// critical restart_auto_recovery, which now correctly downgrades the
+	// whole-play tier — a separate behavior, not what this test isolates.)
+	computeEventLabelsWithState(s, &row{Ts: "2026-06-04 00:00:01.100", PlayerID: "p", PlayID: "x", LastEvent: "play_start", PlaybackStatus: "in_progress"})
 	end := computeEventLabelsWithState(s, &row{Ts: "2026-06-04 00:05:00.000", PlayerID: "p", PlayID: "x", LastEvent: "play_end", PlaybackStatus: "completed", PlayingTimeMs: 290000})
 	if !hasLabel(end, qoeLabel(SevInfo, "qoe_tier_premium")) {
-		t.Fatalf("real terminal after the play opened should still get a tier: %v", end)
+		t.Fatalf("real terminal after the play opened should still get a premium tier: %v", end)
 	}
 }

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -202,51 +202,61 @@ func computeQoEEventLabels(cfg *QoEThresholds, ps *playLabelState, r *row, now t
 	}
 	ps.qoeActive = next
 
-	// ── Terminal row: summary (current-at-end) + outcome + tier ────────
+	// Fold this row's qoe conditions (ALL true-on-row, not just the emitted
+	// rising edges) into the whole-play worst-severity accumulator — so a
+	// condition that flared and recovered mid-play still counts toward the
+	// terminal qoe_tier_*.
+	ps.worstSeen = worseSeverity(ps.worstSeen, worstSeverity(current))
+
+	// ── Terminal row: two aggregates + outcome ─────────────────────────
+	// No force-emit: the per-moment timeline carries each condition once, at
+	// its true rising edge. The terminal row instead carries two summaries —
+	// qoe_exit_* (state at close) and qoe_tier_* (whole-play grade).
 	if firstTerminal {
-		// Force-emit every still-true condition not already emitted this row
-		// (edge-trigger AND cooldown both suppress repeats), so the summary
-		// row carries the full current-at-end set and qoe_tier_* reads it right.
-		emitted := make(map[string]struct{}, len(out))
-		for _, l := range out {
-			emitted[l] = struct{}{}
-		}
-		for _, l := range current {
-			if _, e := emitted[l]; !e {
-				emitted[l] = struct{}{}
-				out = append(out, l)
-			}
-		}
-		// Startup outcome (terminal-only).
+		// Terminal outcome (whole-play failure state), terminal-only.
+		var outcome []string
 		switch {
 		case r.PlaybackStatus == "abandoned_start":
-			// Exit before video start — a user can simply bail during
-			// startup. Warning, not a system failure.
-			out = append(out, qoeLabel(SevWarning, "qoe_ebvs"))
+			// Exit before video start — a user can bail during startup.
+			// Warning, not a system failure.
+			outcome = append(outcome, qoeLabel(SevWarning, "qoe_ebvs"))
 		case isFailedStatus(r.PlaybackStatus) && r.VideoFirstFrameTimeMs == 0:
-			out = append(out, qoeLabel(SevError, "qoe_vsf"))
+			outcome = append(outcome, qoeLabel(SevError, "qoe_vsf"))
 		case isFailedStatus(r.PlaybackStatus) && r.VideoFirstFrameTimeMs > 0:
-			out = append(out, qoeLabel(SevError, "qoe_msf"))
+			outcome = append(outcome, qoeLabel(SevError, "qoe_msf"))
 		}
-		// Tier from the full terminal-row label set (worst severity).
-		out = append(out, qoeTierLabel(out))
+		out = append(out, outcome...)
+
+		// qoe_exit_* — worst severity of conditions STILL ACTIVE at close
+		// (current-at-end) + the terminal outcome. "What they were looking at
+		// when they left" — a churn/abandonment proxy, distinct from overall.
+		exitSev := worseSeverity(worstSeverity(current), worstSeverity(outcome))
+		out = append(out, tierFromSeverity("qoe_exit", exitSev))
+
+		// qoe_tier_* — worst severity seen ANYWHERE in the play (whole-play
+		// grade). Fold the terminal outcome in first so a terminal-only
+		// failure counts even though it never appeared on an earlier row.
+		ps.worstSeen = worseSeverity(ps.worstSeen, worstSeverity(outcome))
+		out = append(out, tierFromSeverity("qoe_tier", ps.worstSeen))
+
 		ps.terminalEmitted = true
 	}
 
 	return out
 }
 
-// qoeTierLabel collapses the row's worst qoe severity into one tier
-// label. No warning/critical/error ⇒ premium; worst == warning ⇒
-// acceptable; worst >= critical ⇒ unacceptable.
-func qoeTierLabel(labels []string) string {
-	switch worstSeverity(labels) {
+// tierFromSeverity maps a worst-severity to a tri-level tier label under the
+// given scope: "qoe_tier" (whole-play grade) or "qoe_exit" (state at close).
+// No warning/critical/error ⇒ premium; worst == warning ⇒ acceptable;
+// worst >= critical ⇒ unacceptable.
+func tierFromSeverity(scope, sev string) string {
+	switch sev {
 	case SevError, SevCritical:
-		return qoeLabel(SevCritical, "qoe_tier_unacceptable")
+		return qoeLabel(SevCritical, scope+"_unacceptable")
 	case SevWarning:
-		return qoeLabel(SevWarning, "qoe_tier_acceptable")
+		return qoeLabel(SevWarning, scope+"_acceptable")
 	default: // info or none
-		return qoeLabel(SevInfo, "qoe_tier_premium")
+		return qoeLabel(SevInfo, scope+"_premium")
 	}
 }
 

--- a/content/dashboard-v3/src/lib/labelGlossary.ts
+++ b/content/dashboard-v3/src/lib/labelGlossary.ts
@@ -43,9 +43,17 @@ const GLOSSARY: Record<string, Entry> = {
   stall_frozen: { what: 'The playhead froze — no progress while not paused', how: 'position stopped advancing (wall-clock confirmed)' },
   timejump: { what: 'The playhead jumped discontinuously', how: 'position moved more than wall-clock elapsed' },
 
-  // ── tiers (composite QoE verdict) ────────────────────────────────────────
-  qoe_tier_unacceptable: { what: 'Overall QoE tier: unacceptable', how: 'composite of startup + rebuffer + quality signals' },
-  qoe_tier_acceptable: { what: 'Overall QoE tier: acceptable (below premium)' },
+  // ── tiers (two axes) ─────────────────────────────────────────────────────
+  // qoe_tier_* = WHOLE-PLAY grade (worst QoE severity seen anywhere in the
+  // play). qoe_exit_* = state at CLOSE (conditions still active on the final
+  // row + terminal outcome) — a churn/abandonment proxy. They diverge when a
+  // play hit a critical mid-play but recovered: tier_unacceptable, exit_premium.
+  qoe_tier_unacceptable: { what: 'Whole-play QoE: unacceptable', how: 'worst severity seen anywhere in the play was critical/error' },
+  qoe_tier_acceptable: { what: 'Whole-play QoE: acceptable (below premium)', how: 'worst severity seen anywhere in the play was a warning' },
+  qoe_tier_premium: { what: 'Whole-play QoE: premium', how: 'no warning/critical/error seen during the play' },
+  qoe_exit_unacceptable: { what: 'State at close: unacceptable', how: 'a critical/error condition was still active when the play ended' },
+  qoe_exit_acceptable: { what: 'State at close: acceptable', how: 'a warning condition was still active when the play ended' },
+  qoe_exit_premium: { what: 'State at close: premium', how: 'nothing degraded was active when the play ended' },
 
   // ── ABR / quality ────────────────────────────────────────────────────────
   qoe_downshift_storm: { what: 'ABR thrashing down', how: '> downshift_storm_threshold (3) downshifts in downshift_storm_window_s (30s)' },


### PR DESCRIPTION
## What
Split the QoE tier into two orthogonal aggregates and stop force-emitting summary labels onto `play_end`.

- **`qoe_tier_*` → whole-play grade** — worst severity seen *anywhere* in the play (new `playLabelState.worstSeen` accumulator, folded every row over lifecycle labels + qoe conditions + terminal outcome). A mid-play critical that recovered now downgrades the tier.
- **`qoe_exit_*` (new) → state at close** — worst severity of conditions still active on the terminal row + terminal outcome. The old current-at-end tier semantics, kept as a first-class **churn / abandonment** signal.

## Why
`qoe_tier_*` used to grade only the terminal row's labels, so a play that froze mid-stream but recovered read as `premium`. Keeping that working under edge-triggering (#595) required force-emitting still-true conditions onto `play_end` — duplicating labels that already fired at their rising edge (this is what polluted the dashboard focus-window selector). Computing the tier from an accumulator removes the need for the force-emit entirely; the two changes reinforce each other.

They can diverge, which is the point: a play that hit a critical mid-play but recovered is `qoe_tier_unacceptable` **and** `qoe_exit_premium`.

## Changes
- `qoe_labels.go` — remove terminal force-emit; fold `current` into `worstSeen`; emit `qoe_exit_*` (current-at-close + outcome) and `qoe_tier_*` (whole-play); `qoeTierLabel` → `tierFromSeverity(scope, sev)`.
- `labels.go` — `worstSeen` field; fold lifecycle labels into it per row; `sevRank` / `worseSeverity` helpers.
- `labels_test.go` — force-emit test rewritten to assert no-force-emit + both aggregates; new `TestQoETierWholePlayVsExit`; leading-terminal test opener `restart`→`play_start`.
- `labelGlossary.ts` — document both families.

## Notes
- **Computed at ingest** — historical rows keep the old current-at-end tier; only new plays get the split.
- **Downstream (not on this branch):** harness `report.go` (on `feat/880-study-report`) QoE-scopes the char-report verdict on `qoe_tier` — it should learn `qoe_exit_*` is also a summary aggregate.
- Behavior change: `restart_auto_recovery` (an involuntary mid-play restart) now counts toward the whole-play tier — intended; a restart is a real degradation.

## Verification
- `go test ./...` (forwarder) green; `go vet` + `gofmt` clean; module builds.
- `vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
