### PR TITLE
fix(viewer): play-scope the events cache + restore the "this play only" toggle

### DIFF
--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -92,12 +92,15 @@ const props = defineProps<{
    *  (above the control panels), so they pass this flag and SessionDisplay
    *  omits the duplicate panel from its stack. */
   hideSessionDetails?: boolean;
-  /** SessionViewer "show before/after" toggle. When true the SSE
-   *  drops the play_id filter and widens fromMs/toMs to the cached
-   *  play bounds ± 5 minutes so the operator can scroll through the
-   *  surrounding context for the same player. Default: false — the
-   *  view is locked to this play. */
-  showContext?: boolean;
+  /** Play-scope filter. Default true → the SSE + caches are locked to
+   *  this play_id. False → drop the filter so neighbouring plays of the
+   *  same player land in the caches (pairs with a widened window). */
+  scopeToPlay?: boolean;
+  /** Symmetric time-window padding (ms) added on each side of the URL
+   *  start/end so the operator can widen the view for context. Repeatable
+   *  from SessionViewer's Expand control. The end side is clamped to now
+   *  (never padded into the future). Default 0. */
+  windowPadMs?: number;
   /** Initial time window. Caller (SessionViewer reading the URL)
    *  passes startMs (ms-since-epoch) and endMs. endMs = null means
    *  "follow live edge" — the SSE backfills from startMs but doesn't
@@ -499,31 +502,32 @@ if (props.startMs != null && props.endMs != null) {
   windowBoundsRef.value = { min: props.startMs, max: props.startMs };
 }
 
-/** Effective play_id for the SSE subscription. `showContext = true`
- *  drops the play_id filter so rows from neighbouring plays of the
- *  same player land in the caches. */
+/** Effective play_id for the SSE subscription. scopeToPlay=false drops
+ *  the play_id filter so rows from neighbouring plays of the same player
+ *  land in the caches. */
 const effectivePlayIdRef = computed<string | null>(() =>
-  props.showContext ? null : playIdRef.value,
+  props.scopeToPlay === false ? null : playIdRef.value,
 );
 
 /** Reactive fromMs / toMs for the SSE.
- *  - Base case (showContext off): use the URL's startMs/endMs as-is.
+ *  - windowPadMs = 0 (default): use the URL's startMs/endMs as-is.
  *    endMs=null means "follow live" — pass through as null so SSE
  *    tails the live edge.
- *  - showContext on: widen by CONTEXT_PAD_MS on each side so the
- *    operator can scroll through before/after; toMs stays null when
+ *  - windowPadMs > 0: widen by that much on each side so the operator
+ *    can scroll through before/after. The end side is clamped to now so
+ *    padding never reaches into the future; toMs stays null when
  *    end_time was "live". */
-const CONTEXT_PAD_MS = 5 * 60 * 1000;
 const fromMsRef = computed<number | null>(() => {
   const startMs = props.startMs ?? windowBoundsRef.value?.min ?? null;
   if (startMs == null) return null;
-  return props.showContext ? startMs - CONTEXT_PAD_MS : startMs;
+  return startMs - (props.windowPadMs ?? 0);
 });
 const toMsRef = computed<number | null>(() => {
   // end_time=live (props.endMs == null but startMs set) → no upper
-  // bound on the SSE backfill, regardless of showContext.
+  // bound on the SSE backfill, regardless of padding.
   if (props.endMs == null) return null;
-  return props.showContext ? props.endMs + CONTEXT_PAD_MS : props.endMs;
+  const pad = props.windowPadMs ?? 0;
+  return pad > 0 ? Math.min(props.endMs + pad, Date.now()) : props.endMs;
 });
 
 /* ─── Refetch-on-pan (#587) ─────────────────────────────────────────
@@ -591,14 +595,14 @@ function onLifecycleToggle(kind: LifecycleKind, e: Event) {
 
 // Fallback: when the URL didn't carry start_time/end_time, capture
 // the play's bounds the first time samples arrive in archive mode
-// so windowBoundsRef can drive the SSE re-subscribe on showContext
-// toggles. Skipped when URL props are present — those take precedence.
+// so windowBoundsRef can drive the SSE re-subscribe on window-pad
+// changes. Skipped when URL props are present — those take precedence.
 watch(
   () => timeseries.events.rangeBounds.value,
   (b) => {
     if (!b) return;
     if (props.startMs != null) return;   // URL gave us the truth
-    if (props.showContext) return;        // wider window, don't anchor on it
+    if ((props.windowPadMs ?? 0) > 0) return; // widened window, don't anchor on it
     if (props.followLive) return;         // live mode uses liveFromRef (#587)
     if (!playIdRef.value) return;         // live mode
     if (windowBoundsRef.value !== null) return;
@@ -612,6 +616,22 @@ watch(
 // — and so any earlier reactive code (window watcher, brush clamps)
 // sees a coord instance even though it gets consumed mostly later.
 const coord = useChartCoordination(coordId);
+
+// Widening the window (Expand, or the auto-widen when "this play only" is
+// unchecked) loads more data but the focus brush stays pinned to the original
+// play span — so the added context isn't actually visible. Grow the brush to
+// the widened request window whenever windowPadMs changes; Reset (pad → 0)
+// snaps it back to the play's own span. Guarded to archive views with a
+// bounded end (toMs set) — live-follow keeps its null range.
+watch(
+  () => props.windowPadMs ?? 0,
+  () => {
+    const from = fromMsRef.value;
+    const to = toMsRef.value;
+    if (from == null || to == null) return;
+    coord.setRange({ min: from, max: to });
+  },
+);
 
 // A new play (new play_id) on the same player keeps the chosen Bitrate Y-max +
 // zoom width (the view scope is play-independent), but the absolute-position
@@ -666,7 +686,7 @@ let hasPinnedBrush = false;
 function tryPinBrush(min: number | null, max: number | null) {
   if (hasPinnedBrush) return;
   if (min == null || max == null) return;
-  if (props.showContext) return;
+  if ((props.windowPadMs ?? 0) > 0) return;
   if (coord.state.range !== null) return;
   coord.setRange({ min, max });
   hasPinnedBrush = true;
@@ -685,7 +705,7 @@ watch(
   (b) => {
     if (hasPinnedBrush) return;
     if (!b) return;
-    if (props.showContext) return;
+    if ((props.windowPadMs ?? 0) > 0) return;
     if (!playIdRef.value) return;
     tryPinBrush(b.min - 5000, b.max);
   },

--- a/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
+++ b/content/dashboard-v3/src/composables/useSessionTimeSeries.ts
@@ -376,10 +376,28 @@ export function useSessionTimeSeries(
   }
 
   /** Append one parsed row to the named pending queue. Cheap: no
-   *  reactive writes happen here. */
+   *  reactive writes happen here.
+   *
+   *  Play-scope guard: when the subscription is pinned to a specific
+   *  play_id, drop any row belonging to a different play of the same
+   *  player. The server already filters, but events + network flow
+   *  through the player-keyed ring (unlike control/avmetrics, which
+   *  re-query per play), so a stale/rotated live subscription could
+   *  otherwise leak a neighbouring play's rows into the events-derived
+   *  lanes (the PLAY ID / VIDEO RES / bitrate swim-lanes). Enforcing the
+   *  invariant here keeps the cache play-scoped regardless of how a row
+   *  arrived. When the viewer's "this play only" filter is off the
+   *  subscription's playId is null, so this is a no-op and neighbouring
+   *  plays are intentionally kept. Case-insensitive:
+   *  iOS emits uppercase UUIDs; CH stores canonical lowercase. */
   function enqueueRow(data: string, queue: Record<string, unknown>[]) {
     let row: Record<string, unknown>;
     try { row = JSON.parse(data); } catch { return; }
+    const scope = playId.value;
+    if (scope) {
+      const rid = row.play_id;
+      if (typeof rid === 'string' && rid && rid.toLowerCase() !== scope.toLowerCase()) return;
+    }
     queue.push(row);
   }
 

--- a/content/dashboard-v3/src/pages/SessionViewer.vue
+++ b/content/dashboard-v3/src/pages/SessionViewer.vue
@@ -13,7 +13,7 @@
  * routes display panels to the side-channel store in v2-repo instead
  * of the live `/api/v2/players` fetch.
  */
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/vue-query';
 import ShellLayout from '@/components/ShellLayout.vue';
 import SessionDisplay from '@/components/SessionDisplay.vue';
@@ -47,6 +47,25 @@ const playerId = computed<string>(() =>
 const playId = computed<string | null>(() =>
   comparePlays.length ? (comparePlays[activeIdx.value].playId ?? null) : urlPlayId,
 );
+
+// Two independent viewer controls (paired with the enqueueRow play-scope
+// guard in useSessionTimeSeries):
+//   scopeToPlay — the play_id row filter. Default on = only this play.
+//   expandSteps — repeatable window widening; each step = ±5 min, end
+//                 clamped to now by SessionDisplay so it never pads into
+//                 the future. windowPadMs is the derived symmetric pad.
+const CONTEXT_STEP_MS = 5 * 60 * 1000;
+const scopeToPlay = ref(true);
+const expandSteps = ref(0);
+const windowPadMs = computed(() => expandSteps.value * CONTEXT_STEP_MS);
+
+// Unchecking "this play only" against a tight URL window would show nothing
+// new (neighbouring plays fall outside it), so auto-expand one step the
+// first time the filter is dropped. Re-checking leaves the window as-is
+// (use Reset to snap back).
+watch(scopeToPlay, (on) => {
+  if (!on && expandSteps.value === 0) expandSteps.value = 1;
+});
 
 /** Initial time window. New canonical param names are `from` / `to`
  *  (shorter, no `:` in compact ISO → no `%3A` clutter). Legacy
@@ -248,9 +267,41 @@ const backHref = '/dashboard/sessions.html';
               <span class="meta-label">player</span>
               <code class="id-pill" :title="playerId">{{ playerId || '(no player)' }}</code>
               <span class="meta-label">play</span>
-              <code class="id-pill" :title="playId ?? '(all plays)'">{{ playId ?? '(all plays)' }}</code>
+              <code
+                class="id-pill"
+                :class="{ 'id-pill-disabled': !scopeToPlay }"
+                :title="!scopeToPlay ? `${playId} — filter off, showing all plays in the window` : (playId ?? '(all plays)')"
+              >{{ playId ?? '(all plays)' }}</code>
             </div>
             <div class="banner-actions">
+              <label
+                class="banner-toggle"
+                :class="{ disabled: !playId }"
+                :title="scopeToPlay
+                  ? 'Showing only this play. Uncheck to include neighbouring plays of this player (auto-widens the window)'
+                  : `Showing all of this player's plays in the window. Check to lock to this play`"
+              >
+                <input type="checkbox" v-model="scopeToPlay" :disabled="!playId" />
+                This play only
+              </label>
+              <button
+                type="button"
+                class="banner-btn"
+                @click="expandSteps++"
+                :disabled="!playId"
+                :title="`Widen the window ±5 min for more context (end won't pass now). Currently ±${expandSteps * 5} min — click again for more`"
+              >
+                ⊕ Expand 5m<span v-if="expandSteps"> · ±{{ expandSteps * 5 }}m</span>
+              </button>
+              <button
+                v-if="expandSteps"
+                type="button"
+                class="banner-btn"
+                @click="expandSteps = 0"
+                title="Reset the window back to this play's span"
+              >
+                ⊙ Reset
+              </button>
               <button
                 type="button"
                 class="banner-btn"
@@ -271,6 +322,8 @@ const backHref = '/dashboard/sessions.html';
             :play-id="playId"
             :start-ms="startMs"
             :end-ms="endMs"
+            :scope-to-play="scopeToPlay"
+            :window-pad-ms="windowPadMs"
             :compare-plays="comparePlays"
           />
         </template>
@@ -435,6 +488,24 @@ const backHref = '/dashboard/sessions.html';
   color: #fff;
 }
 .banner-btn.disabled { opacity: 0.4; pointer-events: none; }
+
+/* "This play only" filter checkbox — styled to sit alongside .banner-btn. */
+.banner-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #1f2937;
+  cursor: pointer;
+  user-select: none;
+}
+.banner-toggle input { cursor: pointer; margin: 0; }
+.banner-toggle.disabled { opacity: 0.4; pointer-events: none; }
 
 .empty {
   text-align: center;


### PR DESCRIPTION
Fixes #886.

## What
The session-viewer rendered a **neighbouring play of the same player** in the events-derived swim-lanes (PLAY ID / VIDEO RES / PLAYERSTATE / bitrate), while CONTROL + AVMETRICS were correctly play-scoped. Hard-refresh cleared it → client-side stale/cross-play cache, not the server. This PR fixes the leak **and** replaces the play-scoping UI with two clean, independent controls.

## Root cause
Events + network flow through the **player-keyed ring**; control/avmetrics bypass it (dedicated per-play CH pollers). A stale/rotated live subscription could leave cross-play rows in the events cache, and `EventsTimeline` builds the PLAY ID lane from the *distinct play_ids in `timeseries.events`* — so the extra play appeared. There was no per-row play-scope guard at ingest.

## Changes
1. **`useSessionTimeSeries.enqueueRow`** — when pinned to a `play_id`, drop rows whose `play_id` differs (case-insensitive). Enforces the play-scope invariant at the cache boundary (matching the server + ring-backfill filters). No-op when the filter is off.
2. **`SessionDisplay`** — split the single `showContext` prop into two orthogonal props:
   - `scopeToPlay` (default true) — the play_id filter.
   - `windowPadMs` (default 0) — symmetric time-window padding; the end side is clamped to `now` so it never pads into the future. The brush anchor/pin guards now key on "window widened", not the filter.
3. **`SessionViewer`** — two controls replacing the old single toggle:
   - ☑ **This play only** checkbox (the filter).
   - **⊕ Expand 5m** — repeatable; each click widens the window ±5 min (shows `±Nm`), plus **⊙ Reset**.
   - Unchecking the filter against a tight URL window **auto-expands one step** so neighbouring plays are actually visible.
   - The play pill strikes through when the filter is off.

## Verification
- `vue-tsc --noEmit` clean.
- Server confirmed correct (`/api/v2/timeseries` returns only the pinned play in archive + live) — this brings the client to the same invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
