### PR TITLE
fix(qoe): gate live_offset_* and fps_dip behind first frame

### DIFF
--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -348,12 +348,17 @@ func TestQoEMinVariantStuck(t *testing.T) {
 }
 
 func TestQoEFPSDip(t *testing.T) {
-	// dropped/(displayed+dropped) ≥ 0.2.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", FramesDisplayed: 81, FramesDropped: 19}); hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
+	// dropped/(displayed+dropped) ≥ 0.2. Rows carry a first frame — fps is
+	// gated behind playback start (no stable render rate before then).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoFirstFrameTimeMs: 100, FramesDisplayed: 81, FramesDropped: 19}); hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
 		t.Fatalf("19%% drop should not dip: %v", got)
 	}
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", FramesDisplayed: 80, FramesDropped: 20}); !hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoFirstFrameTimeMs: 100, FramesDisplayed: 80, FramesDropped: 20}); !hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
 		t.Fatalf("20%% drop should dip: %v", got)
+	}
+	// Pre-first-frame: a high drop ratio must NOT fire (startup gate).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoFirstFrameTimeMs: 0, FramesDisplayed: 80, FramesDropped: 20}); hasLabel(got, qoeLabel(SevWarning, "qoe_fps_dip")) {
+		t.Fatalf("pre-first-frame fps must not fire: %v", got)
 	}
 }
 
@@ -499,7 +504,7 @@ func TestQoENetworkRowLabels(t *testing.T) {
 func TestQoELiveOffset(t *testing.T) {
 	mk := func(off, cfgd float32) []string {
 		return evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
-			RecommendedOffsetS: 5, LiveOffsetS: off, ConfiguredOffsetS: cfgd})
+			VideoFirstFrameTimeMs: 100, RecommendedOffsetS: 5, LiveOffsetS: off, ConfiguredOffsetS: cfgd})
 	}
 	concerning := qoeLabel(SevWarning, "qoe_live_offset_concerning")
 	breach := qoeLabel(SevCritical, "qoe_live_offset_breach")
@@ -532,12 +537,33 @@ func TestQoELiveOffset(t *testing.T) {
 }
 
 func TestQoELiveOffsetSilentOnVOD(t *testing.T) {
-	// No recommended offset (VOD) → no live labels.
-	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", LiveOffsetS: 60})
+	// No recommended offset (VOD) → no live labels. First frame present so
+	// it's the VOD/no-rec path being tested, not the startup gate.
+	got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", VideoFirstFrameTimeMs: 100, LiveOffsetS: 60})
 	for _, l := range got {
 		if l == qoeLabel(SevWarning, "qoe_live_offset_concerning") || l == qoeLabel(SevCritical, "qoe_live_offset_breach") {
 			t.Fatalf("VOD row should emit no live-offset label: %v", got)
 		}
+	}
+}
+
+// TestQoELiveOffsetStartupGate — a breach-magnitude offset must NOT fire
+// before the first frame (the playhead is still at 0 during startup buffering
+// and live_offset_s is uninitialised, e.g. edge+recommended). The same offset
+// with a first frame present DOES fire. Guards the whole-play tier against a
+// spurious startup breach (the d1412504 case).
+func TestQoELiveOffsetStartupGate(t *testing.T) {
+	breach := qoeLabel(SevCritical, "qoe_live_offset_breach")
+	// excess = 120 - 21 = 99 ≫ the 10s breach margin.
+	pre := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+		VideoFirstFrameTimeMs: 0, RecommendedOffsetS: 21, LiveOffsetS: 120})
+	if hasLabel(pre, breach) {
+		t.Fatalf("pre-first-frame offset must not breach: %v", pre)
+	}
+	post := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress",
+		VideoFirstFrameTimeMs: 2493, RecommendedOffsetS: 21, LiveOffsetS: 120})
+	if !hasLabel(post, breach) {
+		t.Fatalf("post-first-frame offset breach should fire: %v", post)
 	}
 }
 

--- a/analytics/go-forwarder/qoe_labels.go
+++ b/analytics/go-forwarder/qoe_labels.go
@@ -370,7 +370,20 @@ func minVariantStuckLabel(cfg *QoEThresholds, ps *playLabelState, r *row, now ti
 // the proxy for "displayed fps fell below (1 - ratio) of nominal".
 // Uses the cumulative displayed/dropped counters (per-interval rate is
 // Phase 4 work).
+// playbackStarted reports whether the play has rendered its first frame.
+// Metrics derived from the playhead — live_offset and displayed frame rate —
+// are meaningless before then: during startup buffering the playhead sits at
+// position 0 and those fields carry uninitialised/settling values (e.g. a
+// live_offset of edge+recommended, which trips a spurious offset breach). Labels
+// built from them gate on this so one garbage startup sample can't poison the
+// whole-play tier. video_first_frame_time_ms is sticky — set once the first
+// frame renders, then resent on every heartbeat.
+func playbackStarted(r *row) bool { return r.VideoFirstFrameTimeMs > 0 }
+
 func fpsDipLabel(cfg *QoEThresholds, r *row) string {
+	if !playbackStarted(r) {
+		return "" // no stable render rate before the first frame
+	}
 	total := r.FramesDisplayed + uint64(r.FramesDropped)
 	if total == 0 {
 		return ""
@@ -504,6 +517,9 @@ func cmcdMTPDriftLabel(cfg *QoEThresholds, r *row) string {
 // manifest advertised a recommended offset (rec > 0) — VOD has none, so
 // these stay silent there.
 func liveOffsetLabels(cfg *QoEThresholds, r *row) []string {
+	if !playbackStarted(r) {
+		return nil // offset is invalid pre-first-frame (playhead still at 0)
+	}
 	rec := float64(r.RecommendedOffsetS)
 	if rec <= 0 {
 		return nil


### PR DESCRIPTION
## What
Gate `qoe_live_offset_*` and `qoe_fps_dip` behind the first frame, so they don't fire on invalid startup samples.

## Why
`live_offset_s` and displayed-fps are meaningless before playback renders a frame. During startup buffering the playhead is at `position_s=0` and `live_offset_s` carries an uninitialised value — on play `d1412504` it read **120.12s** at **+0.02s** (`= live_edge 99.12 + recommended 21`), tripping a **critical `qoe_live_offset_breach`**. By the first frame the offset was already back to the 21s target. With the new whole-play `qoe_tier` (#885), that single garbage sample graded an otherwise-clean play **unacceptable**.

## Fix
`liveOffsetLabels` and `fpsDipLabel` early-return unless `playbackStarted(r)` (`VideoFirstFrameTimeMs > 0`) — the same startup-gate pattern the ABR (`qoe_abr_conservative` / `ladder_gap`) and `qoe_throughput_divergence` labels already use (`StartupGraceMs`). `video_first_frame_time_ms` is sticky, so post-startup rows are unaffected.

## Tests
- `TestQoEFPSDip` / `TestQoELiveOffset` / `TestQoELiveOffsetSilentOnVOD` rows now carry a first frame (still exercise the thresholds / VOD path).
- New `TestQoELiveOffsetStartupGate`: pre-first-frame breach must not fire, post-first-frame does; fps pre-first-frame case added.
- `go test ./...` green, `go vet` + `gofmt` clean.

## Notes
- Independent of #885 but most valuable with it (the whole-play tier is what the spurious startup breach poisoned). Off `dev`; both touch `qoe_labels.go` in different functions, so no conflict expected.
- Follow-up candidates (not here): `qoe_min_variant_stuck`, `qoe_downshift_overshoot`, `qoe_rate_cap_breach` could use the settle-grace too (documented iOS startup quirks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
