### PR TITLE
feat(dashboard): complete the label glossary — hover tips for every label

### DIFF
--- a/content/dashboard-v3/src/lib/labelGlossary.ts
+++ b/content/dashboard-v3/src/lib/labelGlossary.ts
@@ -15,31 +15,48 @@ interface Entry {
   how?: string;
 }
 
+// Threshold values in `how` text are the compiled-in defaults from
+// qoe_thresholds.go (config-driven, movable via FORWARDER_QOE_THRESHOLDS_PATH).
+// Duration bands `<1s / 1–3s / ≥3s` are hardcoded in the forwarder's
+// durationBucket() and are NOT config-driven.
 const GLOSSARY: Record<string, Entry> = {
-  // ── terminal / player failures ───────────────────────────────────────────
+  // ── terminal / player failures & recovery ────────────────────────────────
   qoe_vsf: { what: 'Video Start Failure — playback never produced a first frame', how: 'startup ended in error before any frame' },
   qoe_msf: { what: 'Mid-Stream Failure — playback started then died and did not recover', how: 'fatal error after first frame' },
   qoe_ebvs: { what: 'Exit Before Video Start — abandoned during startup', how: 'session ended while still buffering, > ebvs_threshold_ms (10s)' },
   player_error: { what: 'The player reported a hard error', how: 'client-emitted error event' },
-  restart_auto_recovery: { what: 'The player auto-restarted to recover from a wedge', how: 'a new attempt_id appeared without user action' },
+  player_stuck: { what: 'The player auto-paused mid-stall', how: 'rate→0 with buffer drained — a hard stall that did not reach .failed' },
+  wedge_detected: { what: 'Confirmed hard playback wedge', how: 'AVPlayer -12880 + sustained no-progress' },
+  user_marked_911: { what: 'Operator flagged this moment (forensic 911 mark)', how: 'manual user_marked event' },
+  restart_reload: { what: 'Operator-initiated player reload', how: 'restart attributed to a manual reload' },
   restart_user_retry: { what: 'The user manually retried playback', how: 'restart attributed to a user action' },
+  restart_auto_recovery: { what: 'The player auto-restarted to recover from a wedge', how: 'a new attempt_id appeared without user action' },
+  restart_auto_recovery_failure: { what: 'Auto-recovery restart that failed to recover', how: 'involuntary restart, recovery unsuccessful' },
+  restart_auto_recovery_stuck: { what: 'Auto-recovery restart that stayed stuck', how: 'involuntary restart, still no progress after' },
+  restart_auto_recovery_live_resync: { what: 'Auto-recovery via jump-to-live seek', how: 'involuntary restart resolved by seeking to the live edge' },
 
   // ── startup ──────────────────────────────────────────────────────────────
   qoe_vst_concerning: { what: 'Video Start Time slow', how: 'time-to-first-frame > vst_concerning_ms (5s)' },
   qoe_vst_breach: { what: 'Video Start Time very slow', how: 'time-to-first-frame > vst_breach_ms (10s)' },
-  qoe_buffering_long_startup: { what: 'Long buffering during startup', how: 'pre-first-frame buffering over the long threshold' },
-  qoe_buffering_severe_startup: { what: 'Severe buffering during startup', how: 'pre-first-frame buffering over the severe threshold' },
-  qoe_stall_long_startup: { what: 'Long stall during startup' },
-  qoe_stall_severe_startup: { what: 'Severe stall during startup' },
+  qoe_buffering_short_startup: { what: 'Brief buffering during startup', how: 'pre-first-frame buffering <1s' },
+  qoe_buffering_long_startup: { what: 'Long buffering during startup', how: 'pre-first-frame buffering 1–3s' },
+  qoe_buffering_severe_startup: { what: 'Severe buffering during startup', how: 'pre-first-frame buffering ≥3s' },
+  qoe_stall_short_startup: { what: 'Brief stall during startup', how: 'startup stall <1s (within 10s of first frame)' },
+  qoe_stall_long_startup: { what: 'Long stall during startup', how: 'startup stall 1–3s' },
+  qoe_stall_severe_startup: { what: 'Severe stall during startup', how: 'startup stall ≥3s' },
 
-  // ── continuity / rebuffering ─────────────────────────────────────────────
+  // ── continuity / rebuffering (mid-play + scrub) ──────────────────────────
   qoe_cirr_concerning: { what: 'Rebuffer ratio elevated (Connection-Induced Rebuffer Ratio)', how: 'rebuffer_time / playing_time > cirr_concerning (0.002)' },
   qoe_cirr_breach: { what: 'Rebuffer ratio high', how: 'rebuffer_time / playing_time > cirr_breach (0.004)' },
   qoe_cirt_concerning: { what: 'Long individual rebuffers (Connection-Induced Rebuffer Time)', how: 'mean rebuffer-event duration > cirt_concerning_ms (1s)' },
   qoe_cirt_breach: { what: 'Very long individual rebuffers', how: 'mean rebuffer-event duration > cirt_breach_ms (2s)' },
-  qoe_stall_long_midplay: { what: 'Long stall during mid-play' },
-  qoe_stall_severe_midplay: { what: 'Severe stall during mid-play', how: '≥ stall_burst_threshold (3) stalls in stall_burst_window_s (60s)' },
-  qoe_buffering_severe_scrub: { what: 'Severe buffering after a seek/scrub' },
+  qoe_stall_burst: { what: 'Stall thrashing', how: '> stall_burst_threshold (3) stalls in stall_burst_window_s (60s)' },
+  qoe_stall_short_midplay: { what: 'Brief mid-play stall', how: 'a single mid-play stall <1s' },
+  qoe_stall_long_midplay: { what: 'Long stall during mid-play', how: 'a single mid-play stall 1–3s' },
+  qoe_stall_severe_midplay: { what: 'Severe stall during mid-play', how: 'a single mid-play stall ≥3s' },
+  qoe_buffering_short_scrub: { what: 'Brief buffering after a seek/scrub', how: 'post-seek buffering <1s' },
+  qoe_buffering_long_scrub: { what: 'Buffering after a seek/scrub', how: 'post-seek buffering 1–3s' },
+  qoe_buffering_severe_scrub: { what: 'Severe buffering after a seek/scrub', how: 'post-seek buffering ≥3s' },
   stall_frozen: { what: 'The playhead froze — no progress while not paused', how: 'position stopped advancing (wall-clock confirmed)' },
   timejump: { what: 'The playhead jumped discontinuously', how: 'position moved more than wall-clock elapsed' },
 
@@ -62,43 +79,70 @@ const GLOSSARY: Record<string, Entry> = {
   qoe_abr_conservative: { what: 'ABR under-using the link', how: 'selected variant < bitrate_underutilized_ratio (50%) of available throughput' },
   qoe_ladder_gap: { what: 'No ladder rung fits the available throughput', how: 'next rung needs more than abr_headroom_margin (85%) of throughput' },
   qoe_throughput_divergence: { what: 'Client vs server throughput disagree', how: 'network_bitrate diverges > throughput_divergence_factor (15%) from server throughput' },
+  qoe_cmcd_mtp_drift: { what: 'CMCD client throughput drifts from server', how: 'CMCD measured throughput diverges > cmcd_mtp_drift_ratio (50%) from the server transfer rate' },
   qoe_fps_dip: { what: 'Displayed frame rate dipped', how: 'displayed fps < fps_dip_ratio (80%) of nominal' },
   shift_up: { what: 'ABR shifted up a rung (informational)' },
   shift_down: { what: 'ABR shifted down a rung (informational)' },
 
-  // ── network / transport ──────────────────────────────────────────────────
+  // ── network / transport (per-request) ────────────────────────────────────
   qoe_rate_cap_breach: { what: 'Measured bitrate exceeded the applied cap', how: 'network bitrate > cap × rate_cap_breach_factor (1.10) — often an AVPlayer burst over-read' },
   qoe_transfer_stall: { what: 'A segment transfer stalled mid-flight', how: 'no bytes received for transfer_stall_ms (5s)' },
+  qoe_ttfb_breach: { what: 'Time-to-first-byte slow', how: 'responseStart − requestEnd > ttfb_breach_ms (500ms) — stream-level TTFB, generous on HTTP/2 keep-alive' },
   master_manifest_failure: { what: 'The master playlist request failed' },
   manifest_failure: { what: 'A media playlist request failed' },
   segment_failure: { what: 'A media segment request failed' },
   http_4xx: { what: 'An HTTP 4xx response on a request' },
   http_5xx: { what: 'An HTTP 5xx response on a request' },
-  slow_segment: { what: 'A segment fetch was slow (but completed)' },
+  slow_request: { what: 'A request was slow (but completed)', how: 'client wait > 2s (hardcoded)' },
+  slow_segment: { what: 'A segment fetch was slow (but completed)', how: 'segment transfer > 6s (hardcoded)' },
   stall_segment: { what: 'A segment fetch stalled' },
+  transport_socket: { what: 'Transport fault: socket-level drop/reject', how: 'nftables DROP/REJECT on the connection' },
   transport_disconnect: { what: 'The connection dropped at the transport layer', how: 'client/socket disconnect mid-request' },
+  transport_failure: { what: 'Transport fault: unspecified transfer-timeout variant', how: 'transfer_timeout with neither active nor idle sub-flavour' },
   transfer_active_timeout: { what: 'Server closed a transfer for exceeding the active (total) timeout' },
   transfer_idle_timeout: { what: 'Server closed a transfer for exceeding the idle (no-bytes) timeout' },
+  request_retry: { what: 'Retry of a just-failed request', how: 'same URL re-fetched 1ms–4s after the previous fetch failed' },
 
   // ── live edge ────────────────────────────────────────────────────────────
   qoe_live_offset_concerning: { what: 'Playhead drifting behind the live edge', how: '> offset_concerning_margin_s (3s) beyond the recommended live offset' },
   qoe_live_offset_breach: { what: 'Playhead well behind the live edge', how: '> offset_breach_margin_s (10s) beyond the recommended live offset' },
+  qoe_live_offset_tight: { what: 'Playhead closer to live than the manifest target', how: '≥ offset_tight_margin_s (3s) CLOSER to live than recommended — less buffer than the stream asked for' },
+  qoe_holdback_deviation: { what: 'Configured live offset deviates from the manifest recommendation', how: '|configured − recommended| > holdback_deviation_s (2s)' },
 
   // ── injected-fault markers (from fault-injection tests, not real defects) ─
   fault_timeout: { what: 'INJECTED fault: a timeout was applied (fault test, expected)' },
   fault_other: { what: 'INJECTED fault: a non-categorised fault was applied (fault test, expected)' },
   fault_incomplete: { what: 'INJECTED fault: a transfer was cut off by an injected fault (fault test)' },
+
+  // ── control-plane (operator / harness actions) ───────────────────────────
+  fault_on: { what: 'A runtime fault was toggled ON', how: 'proxy fault activated — will degrade playback by design' },
+  fault_off: { what: 'A runtime fault was cleared', how: 'proxy fault deactivated (resolved bookend)' },
   fault_rule_enabled: { what: 'A fault rule was armed on the session (test metadata)' },
   fault_rule_disabled: { what: 'A fault rule was cleared (test metadata)' },
+  fault_rule_config_change: { what: 'A fault rule was reconfigured (test metadata)' },
+  pattern_enabled: { what: 'A traffic-shaping pattern was armed', how: 'proxy applyShapePattern (mode in the info payload)' },
+  pattern_disabled: { what: 'A traffic-shaping pattern was cleared' },
+  pattern_step: { what: 'A traffic-shaping pattern advanced a step', how: 'next rate/step in the active pattern' },
+  pattern_config_change: { what: 'A traffic-shaping pattern was reconfigured' },
+  shaper_changed: { what: 'The network rate shaper changed' },
+  shaper_config_change: { what: 'The rate shaper was reconfigured' },
+  timeouts_changed: { what: 'Transfer-timeout config changed on the session' },
+  label_changed: { what: 'Session KV labels were updated', how: 'operator/harness _v2_labels bridged into labels[]' },
+  content_changed: { what: 'The session content was swapped' },
+  control_change: { what: 'A session control setting changed (generic)' },
 
   // ── lifecycle / info ─────────────────────────────────────────────────────
   first_frame: { what: 'First decoded frame rendered (startup succeeded)' },
   play_start: { what: 'Playback started' },
   play_end: { what: 'Playback ended' },
+  session_start: { what: 'Session opened' },
+  session_end: { what: 'Session ended (clean)' },
+  server_start: { what: 'Proxy / server (re)started', how: 'boot marker; info carries restored/skipped/baseline' },
+  live_resync: { what: 'Jump-to-live seek nudge', how: 'a recovery action (METHOD 3), not a failure' },
   loop_server: { what: 'The origin is looping VOD-as-live (test content marker)' },
-  // VOMM anomaly labels (`anomaly_<cond>_<surf>`, and legacy `unexpected_<cond>`)
-  // are matched by prefix in anomalyWhat() below, not enumerated here — the
-  // family is 4 conditions × 2 surfaces. See analytics/tools/derive_labels.py.
+  // VOMM anomaly labels (`anomaly_<cond>_<surf>`, legacy `unexpected_<cond>`) and
+  // per-mode pattern labels (`pattern_enabled_<mode>`, `pattern_step_<mode>`) are
+  // matched by prefix below (anomalyWhat / patternModeWhat), not enumerated here.
 };
 
 /**
@@ -121,6 +165,22 @@ function anomalyWhat(ev: string): string | undefined {
     + `surprising vs trained plays${where}`;
 }
 
+/**
+ * Per-mode traffic-shaping control labels: `pattern_enabled_<mode>` /
+ * `pattern_step_<mode>` (e.g. pattern_enabled_rampUp). The base `pattern_enabled`
+ * / `pattern_step` live in GLOSSARY; this covers the mode-suffixed variants the
+ * Sessions filter emits.
+ */
+const PATTERN_RE = /^pattern_(enabled|step)_(.+)$/;
+function patternModeWhat(ev: string): string | undefined {
+  const m = PATTERN_RE.exec(ev);
+  if (!m) return undefined;
+  const [, kind, mode] = m;
+  return kind === 'enabled'
+    ? `Traffic-shaping pattern armed (mode: ${mode})`
+    : `Traffic-shaping pattern advanced a step (mode: ${mode})`;
+}
+
 /** eventOf strips the `<severity>=` prefix and any leading `*` marker. */
 export function eventOf(label: string): string {
   const eq = label.indexOf('=');
@@ -131,8 +191,8 @@ export function eventOf(label: string): string {
 /** labelTooltip returns a hover string ("what · how") for a label, or '' if unknown. */
 export function labelTooltip(label: string): string {
   const ev = eventOf(label);
-  const anom = anomalyWhat(ev);
-  if (anom) return anom;
+  const dyn = anomalyWhat(ev) ?? patternModeWhat(ev);
+  if (dyn) return dyn;
   const e = GLOSSARY[ev];
   if (!e) return '';
   return e.how ? `${e.what} · ${e.how}` : e.what;
@@ -141,5 +201,5 @@ export function labelTooltip(label: string): string {
 /** hasGlossary reports whether a label has a definition (to style it as hoverable). */
 export function hasGlossary(label: string): boolean {
   const ev = eventOf(label);
-  return anomalyWhat(ev) !== undefined || GLOSSARY[ev] !== undefined;
+  return anomalyWhat(ev) !== undefined || patternModeWhat(ev) !== undefined || GLOSSARY[ev] !== undefined;
 }


### PR DESCRIPTION
## What
Make the dashboard label glossary complete — every severity-tagged label the forwarder emits now has a hover tooltip (`labelTooltip`).

## Changes
- **~40 new entries** across lifecycle/recovery, stall/buffering short bands, ABR/network, live-edge, and the **control-plane** action labels (`fault_on/off`, `pattern_*`, `shaper_*`, `timeouts_changed`, `label_changed`, `content_changed`, `control_change`, `fault_rule_config_change`, `session_start/end`, `server_start`, `live_resync`, `player_stuck`, `wedge_detected`, `user_marked_911`, the `restart_auto_recovery_*` variants).
- **Thresholds baked in** — every threshold-based tooltip now carries the compiled-in default (`ttfb_breach_ms` 500ms; `qoe_stall_burst` 3-in-60s; `qoe_live_offset_tight` 3s; `qoe_holdback_deviation` 2s; `qoe_cmcd_mtp_drift` 50%; `slow_request` 2s; `slow_segment` 6s).
- **7 vague entries enriched** with their real duration band (`<1s` / `1–3s` / `≥3s`, hardcoded in `durationBucket`).
- **1 correctness fix** — `qoe_stall_severe_midplay`'s `how` described the `qoe_stall_burst` *count* ("≥3 stalls in 60s"); it's actually a single mid-play stall `≥3s`. (`qoe_ebvs`'s `(10s)` was verified correct — `ebvs_threshold_ms` exists — and left as-is.)
- **Per-mode pattern labels** (`pattern_enabled_<mode>`, `pattern_step_<mode>`) resolve via a new prefix matcher, mirroring the `anomaly_*` family; base names are enumerated.

## Verification
- `vue-tsc --noEmit` clean.
- Coverage script: every label the Go forwarder emits (minus the retired `video_startup_long`/`_severe`) resolves via `GLOSSARY` or a prefix matcher — empty diff.

## Notes
- Threshold values are the compiled-in defaults (movable via `FORWARDER_QOE_THRESHOLDS_PATH`); the file header already documents this caveat. Duration bands are hardcoded, phrased as fixed bands.
- Testing-tier KV metadata (`run_id`, `sweep`, `exp_id`, …) come in via `label_changed` as *values*, not fixed events — covered by the `label_changed` tooltip rather than per-key entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
