### PR TITLE
fix(dashboard): PlayLog shares the pinned coord (archive Play Log was empty)

### DIFF
--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -28,6 +28,12 @@ import type { Stream } from '@/composables/useSessionTimeSeries';
 
 const props = defineProps<{
   playerId: string;
+  /** Shared chart-coordination key (SessionDisplay's `view:<player>`) so the
+   *  Play Log's focus window matches every other panel. Falls back to playerId,
+   *  but SessionDisplay MUST pass it — otherwise the log reads an unpinned coord
+   *  bucket and shows nothing in archive views (#828 wired every other panel but
+   *  missed PlayLog). Data still keys off playerId. Mirrors NetworkLog. */
+  coordId?: string;
   /** play_id from the URL, used as the fallback `play_id` value for
    *  event rows — the events SSE doesn't yet project play_id (the
    *  derivation in events_query.go doesn't carry it through the
@@ -46,7 +52,7 @@ const props = defineProps<{
 
 const playerIdRef = toRef(props, 'playerId');
 usePlayer(playerIdRef); // keep the SSE subscription warm
-const coord = useChartCoordination(playerIdRef);
+const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 
 /** Real player UUID for display purposes. The `playerId` prop is the
  *  shared cache key used by useChartCoordination + the streams cache;

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -1889,6 +1889,7 @@ function skipToEnd() {
            forwarder for a pre-joined view. -->
       <PlayLog
         :player-id="archivePlayerId"
+        :coord-id="coordId"
         :play-id="playIdRef"
         :events-stream="timeseries.events"
         :network-stream="timeseries.network"


### PR DESCRIPTION
## What
The **Play Log** panel was empty for **archived** plays in the session-viewer (0/0/0/0, stuck "● Live"), while every other panel rendered fine.

## Root cause (#828, 2026-06-21)
#828 introduced the `coordId = "view:<player>"` chart-coordination key + a `:coord-id` prop, and wired it to NetworkLog / EventsTimeline / the charts — **but missed PlayLog**. PlayLog kept calling `useChartCoordination(playerIdRef)`, keying coord on its `playerId` prop (the `archive:<player>:<play>` id in the viewer). So it read a *different, unpinned* coord bucket than the one SessionDisplay pins.

In **archive** views SessionDisplay pins the `view:` coord to the URL time window; PlayLog's `archive:` bucket stayed unpinned, so its `effectiveRange` fell back to the live tail (near *now*) and its window filter dropped every 20:15 row → empty. **Live** views (testing.html) were unaffected — nothing pins in live mode, so both buckets track the live edge (that's why it "worked on testing.html").

Confirmed by runtime instrumentation: the brush pins correctly under `view:00ac272b…` and stays pinned, yet PlayLog resolved coord under `archive:00ac272b:…`.

## Fix (mirrors NetworkLog)
- `PlayLog.vue`: accept a `coordId?: string` prop; `useChartCoordination(computed(() => props.coordId ?? props.playerId))`. Data still keys off `playerId`.
- `SessionDisplay.vue`: pass `:coord-id="coordId"` to `<PlayLog>`.

## Verified
- `vue-tsc --noEmit` clean.
- On test-dev, an archived play's Play Log now shows **501 rows** (Events 217 / Network 145 / Control 35 / AVMetrics 104), `live=false` — was 0/0/0/0 stuck "● Live".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
