### PR TITLE
feat(labels): derived net_failure signature — collapse network failure facets into one chip

### DIFF
--- a/.claude/standards/label-facets.md
+++ b/.claude/standards/label-facets.md
@@ -1,0 +1,65 @@
+# Label facets vs. whole-tuple tokens
+
+How to encode a multi-dimensional condition in the `labels[]` vocabulary
+(`<severity>=<event>`, synth-marked `*`). Read before adding a label that
+carries more than one dimension.
+
+## The axes of a network failure
+
+A failed `network_requests` row is one event seen along independent axes:
+
+| axis | values |
+|---|---|
+| kind | `segment` · `manifest` · `master_manifest` |
+| transport-cause | `client_disconnect` · `socket` · `active_timeout` · `idle_timeout` · `transport` |
+| outcome | `incomplete` · `timeout` · `other` · `http_4xx` · `http_5xx` |
+
+These are emitted as **separate facet labels** (`*segment_failure`,
+`*transport_disconnect`, `fault_incomplete`, …) so each axis stays
+independently queryable via `has(labels, …)`, carries its own severity, and
+grows the vocabulary linearly instead of as a cross-product.
+
+## The rule
+
+**Decompose a condition into per-axis facet labels only on surfaces where each
+axis is single-valued per row.** A `network_requests` row is exactly one HTTP
+request, so kind/cause/outcome are single-valued — the facets reconstruct one
+unambiguous tuple.
+
+**On rows that can carry several incidents at once** (a `session_events`
+heartbeat snapshot, a `play_end` rollup) keep labels as **pre-fused
+whole-tuple tokens** (`qoe_stall_severe_midplay`). A flat *set* of per-axis
+facets cannot say which cause pairs with which kind when two incidents share a
+row.
+
+**Never** combine: decomposed facets **+** a multi-incident row **+** no
+correlation id. That's the one encoding that loses information. If you ever
+must decompose a multi-incident surface, bind each tuple with an instance id
+(`i1.kind=…`, `i2.kind=…`) — or just don't decompose it.
+
+## Identity: derive, don't fuse
+
+When you want a single nameable identifier for a decomposed failure (to read,
+dedup, or `GROUP BY`), **derive** a canonical whole-tuple signature from the
+facets — do not fuse the axes into the stored label *name*.
+
+- Network surface (#892): the forwarder emits `*net_failure:<kind>/<cause>/<outcome>`
+  alongside the facets, at their worst severity. `netFailureSignature()` in
+  `analytics/go-forwarder/labels.go` mirrors the facet logic so they never
+  disagree. The dashboard renders it as one collapsed chip
+  (`collapseNetFailureLabels` / `humanizeNetFailure` in
+  `content/dashboard-v3/src/lib/labelGlossary.ts`) with the facets on hover.
+
+Normalize for storage/query (facets); denormalize for identity/eyes (signature).
+
+## Rejected alternatives (and when to reconsider)
+
+- **Fused enum names** (`segment_incomplete_transport_disconnect`): kills
+  per-axis filtering + per-facet severity, explodes the vocabulary. Never.
+- **Axis-keyed labels** (`net.kind=segment`): clean greenfield model, but a
+  breaking rename across forwarder/CH/glossary/harness/dashboard. Reserve for a
+  ground-up label-grammar revision.
+- **Correlation/instance ids**: only needed if a multi-incident surface is ever
+  decomposed. Today none are.
+- **A stored `failure_signature` column**: unnecessary — the signature-as-label
+  already gives `has()` / `GROUP BY`. Add only if a label lookup proves too slow.

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -623,6 +623,20 @@ func computeNetworkLabelsWithState(s *labelState, r *netRow) []string {
 		}
 	}
 
+	// Derived whole-tuple signature (#892). A network_requests row is ONE
+	// HTTP request, so kind × transport-cause × outcome are single-valued —
+	// exactly one tuple, no grouping ambiguity. Emit it ALONGSIDE (not
+	// instead of) the facets so the dashboard can show one collapsed chip
+	// while the facets stay independently queryable. Worst facet severity so
+	// the classification-tier bump is unchanged.
+	if sig := netFailureSignature(r); sig != "" {
+		sev := worstSeverity(out)
+		if sev == "" {
+			sev = SevWarning
+		}
+		out = append(out, sev+"="+synthMark+"net_failure:"+sig)
+	}
+
 	// Synthesized: request_retry on the second fetch of the same URL
 	// within 1-4 s, but ONLY when the previous fetch failed (status
 	// >= 400 OR faulted). Without that guard, normal LL-HLS manifest
@@ -646,6 +660,92 @@ func computeNetworkLabelsWithState(s *labelState, r *netRow) []string {
 	}
 
 	return out
+}
+
+// netFailureSignature composes the orthogonal failure facets of a single
+// network request — kind × transport-cause × outcome — into one canonical
+// whole-tuple string, e.g. "segment/client_disconnect/incomplete". Because a
+// network_requests row is exactly one HTTP request, each axis is single-valued
+// and the tuple is unambiguous (see .claude/standards/label-facets.md). Mirrors
+// the facet logic above so the signature and the facet labels never disagree.
+// Returns "" when the row is not a failure. Order: kind / cause / outcome;
+// cause is omitted when the row isn't faulted; outcome falls back to the HTTP
+// status class on a non-faulted >=400.
+func netFailureSignature(r *netRow) string {
+	if !(r.Status >= 400 || r.Faulted != 0) {
+		return ""
+	}
+
+	// kind — mirror the per-kind failure switch.
+	var kind string
+	switch r.RequestKind {
+	case "master_manifest":
+		kind = "master_manifest"
+	case "manifest", "audio_manifest":
+		kind = "manifest"
+	case "segment", "audio_segment", "init", "partial":
+		kind = "segment"
+	default:
+		kind = strings.ToLower(strings.TrimSpace(r.RequestKind))
+		if kind == "" {
+			kind = "request"
+		}
+	}
+
+	// outcome — mirror the fault classification, else the HTTP status class.
+	var outcome string
+	if r.Faulted != 0 {
+		ft := strings.ToLower(r.FaultType)
+		switch {
+		case strings.Contains(ft, "timeout"):
+			outcome = "timeout"
+		case strings.Contains(ft, "corrupt"),
+			strings.Contains(ft, "partial"),
+			strings.Contains(ft, "abandon"):
+			outcome = "incomplete"
+		default:
+			if r.Status >= 200 && r.Status < 300 {
+				outcome = "incomplete"
+			} else {
+				outcome = "other"
+			}
+		}
+	} else if r.Status >= 500 {
+		outcome = "http_5xx"
+	} else if r.Status >= 400 {
+		outcome = "http_4xx"
+	}
+
+	// cause — mirror the transport-fault classification (faulted rows only).
+	var cause string
+	if r.Faulted != 0 {
+		switch strings.ToLower(r.FaultCategory) {
+		case "socket":
+			cause = "socket"
+		case "client_disconnect":
+			cause = "client_disconnect"
+		case "transfer_timeout":
+			ft := strings.ToLower(r.FaultType)
+			switch {
+			case strings.Contains(ft, "active"):
+				cause = "active_timeout"
+			case strings.Contains(ft, "idle"):
+				cause = "idle_timeout"
+			default:
+				cause = "transport"
+			}
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	parts = append(parts, kind)
+	if cause != "" {
+		parts = append(parts, cause)
+	}
+	if outcome != "" {
+		parts = append(parts, outcome)
+	}
+	return strings.Join(parts, "/")
 }
 
 // computeControlLabels stamps a control_events row's labels at ingest.

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -830,3 +830,64 @@ func TestQoELeadingTerminalIgnored(t *testing.T) {
 		t.Fatalf("real terminal after the play opened should still get a premium tier: %v", end)
 	}
 }
+
+// --- Derived whole-tuple net_failure signature (#892) ----------------
+
+func TestNetFailureSignature(t *testing.T) {
+	cases := []struct {
+		name string
+		row  netRow
+		want string
+	}{
+		{"clean 2xx segment → no signature", netRow{Status: 200, RequestKind: "segment"}, ""},
+		{"client disconnect on segment (2xx partial)", netRow{Status: 200, Faulted: 1, RequestKind: "segment", FaultType: "partial", FaultCategory: "client_disconnect"}, "segment/client_disconnect/incomplete"},
+		{"socket drop on init (2xx corrupt)", netRow{Status: 200, Faulted: 1, RequestKind: "init", FaultType: "corrupt", FaultCategory: "socket"}, "segment/socket/incomplete"},
+		{"idle timeout on audio segment", netRow{Status: 0, Faulted: 1, RequestKind: "audio_segment", FaultType: "transfer_idle_timeout", FaultCategory: "transfer_timeout"}, "segment/idle_timeout/timeout"},
+		{"active timeout on segment", netRow{Status: 0, Faulted: 1, RequestKind: "segment", FaultType: "transfer_active_timeout", FaultCategory: "transfer_timeout"}, "segment/active_timeout/timeout"},
+		{"404 manifest, not faulted → status outcome", netRow{Status: 404, RequestKind: "manifest"}, "manifest/http_4xx"},
+		{"503 master manifest, not faulted", netRow{Status: 503, RequestKind: "master_manifest"}, "master_manifest/http_5xx"},
+		{"faulted with unknown category → cause omitted", netRow{Status: 200, Faulted: 1, RequestKind: "segment", FaultType: "partial", FaultCategory: ""}, "segment/incomplete"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.row
+			if got := netFailureSignature(&r); got != tc.want {
+				t.Fatalf("netFailureSignature = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The signature rides ALONGSIDE the facets (never replaces them) so each axis
+// stays independently queryable, and it inherits the worst facet severity so
+// the classification-tier bump is unchanged.
+func TestNetFailureSignatureStacksWithFacets(t *testing.T) {
+	s := newLabelState()
+	got := computeNetworkLabelsWithState(s, &netRow{
+		Ts: tsBase, Status: 200, Faulted: 1, RequestKind: "segment",
+		FaultType: "partial", FaultCategory: "client_disconnect",
+	})
+	for _, want := range []string{
+		SevWarning + "=fault_incomplete",
+		SevWarning + "=" + synthMark + "segment_failure",
+		SevWarning + "=" + synthMark + "transport_disconnect",
+		SevWarning + "=" + synthMark + "net_failure:segment/client_disconnect/incomplete",
+	} {
+		if !hasLabel(got, want) {
+			t.Fatalf("missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestNetFailureSignatureInheritsErrorSeverity(t *testing.T) {
+	s := newLabelState()
+	got := computeNetworkLabelsWithState(s, &netRow{
+		Ts: tsBase, Status: 0, Faulted: 1, RequestKind: "segment",
+		FaultType: "transfer_active_timeout", FaultCategory: "transfer_timeout",
+	})
+	// fault_timeout is an error facet → the signature must be error-sev too.
+	want := SevError + "=" + synthMark + "net_failure:segment/active_timeout/timeout"
+	if !hasLabel(got, want) {
+		t.Fatalf("timeout signature should inherit error severity: want %q in %v", want, got)
+	}
+}

--- a/content/dashboard-v3/src/components/NetworkLog.vue
+++ b/content/dashboard-v3/src/components/NetworkLog.vue
@@ -20,6 +20,7 @@ import type { NetworkLogEntry } from '@/repo/v2-repo';
 import { usePlayer } from '@/composables/usePlayer';
 import { useChartCoordination } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
+import { collapseNetFailureLabels, humanizeNetFailure, labelTooltip } from '@/lib/labelGlossary';
 
 const props = defineProps<{
   playerId: string;
@@ -213,7 +214,13 @@ function labelSeverity(label: string): 'info' | 'warning' | 'critical' | 'error'
 function labelName(label: string): string {
   const eq = label.indexOf('=');
   const tail = eq > 0 ? label.slice(eq + 1) : label;
-  return tail.startsWith('*') ? tail.slice(1) : tail;
+  const ev = tail.startsWith('*') ? tail.slice(1) : tail;
+  return ev.startsWith('net_failure:') ? humanizeNetFailure(ev) : ev;
+}
+// A net_failure signature chip gets the composed tooltip; every other chip
+// keeps the raw label on hover (unchanged behaviour).
+function labelChipTitle(label: string): string {
+  return label.includes('net_failure:') ? (labelTooltip(label) || label) : label;
 }
 
 function isSuccessful(e: NetworkLogEntry): boolean {
@@ -662,11 +669,11 @@ function onRowsWheel(e: WheelEvent) {
           <div class="cell c-flags" :style="{ color: flagsFor(r).color }">{{ flagsFor(r).text }}</div>
           <div class="cell c-labels">
             <span
-              v-for="l in r.labels"
+              v-for="l in collapseNetFailureLabels(r.labels)"
               :key="l"
               class="nl-label-chip"
               :class="'label-' + labelSeverity(l)"
-              :title="l"
+              :title="labelChipTitle(l)"
             >{{ labelName(l) }}</span>
             <span v-if="!r.labels.length" class="dash">—</span>
           </div>

--- a/content/dashboard-v3/src/components/PlayLog.vue
+++ b/content/dashboard-v3/src/components/PlayLog.vue
@@ -24,6 +24,7 @@
 import { computed, nextTick, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import { usePlayer } from '@/composables/usePlayer';
 import { useChartCoordination } from '@/composables/useChartCoordination';
+import { collapseNetFailureLabels, humanizeNetFailure, labelTooltip } from '@/lib/labelGlossary';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 
 const props = defineProps<{
@@ -506,6 +507,25 @@ function rowLabels(r: Row): string[] {
   // control_events rows carry their own labels[] (see
   // computeControlLabels in labels.go) so no synthesis is needed.
   return [];
+}
+
+/** Chip list for display: collapse a failed network row's facet labels under
+ *  its derived `net_failure:` signature (#892) so the line reads as one
+ *  failure. rowLabels() (the query/tint surface) is left untouched — the
+ *  signature carries the worst facet severity, so the row tint is unchanged. */
+function displayLabels(r: Row): string[] {
+  return collapseNetFailureLabels(rowLabels(r));
+}
+/** Chip text: humanise the net_failure signature; every other label keeps its
+ *  existing form (event name with the `*` synth mark). */
+function labelChipText(l: string): string {
+  const tail = l.slice(l.indexOf('=') + 1);
+  const ev = tail.replace(/^\*/, '');
+  return ev.startsWith('net_failure:') ? humanizeNetFailure(ev) : tail;
+}
+/** Chip hover: composed tooltip for the signature, raw label otherwise. */
+function labelChipTitle(l: string): string {
+  return l.includes('net_failure:') ? (labelTooltip(l) || l) : l;
 }
 
 /** #506 batch-derived per-row token, LEFT-JOINed by the forwarder
@@ -1109,12 +1129,12 @@ function onRowsWheel(e: WheelEvent) {
           <div class="cell c-flags" :style="{ color: rowFlags(r).color }">{{ rowFlags(r).text }}</div>
           <div class="cell c-labels">
             <span
-              v-for="l in rowLabels(r)"
+              v-for="l in displayLabels(r)"
               :key="l"
               class="label-chip"
               :class="`label-${labelSeverity(l)}`"
-              :title="l"
-            >{{ l.slice(l.indexOf('=') + 1) }}</span>
+              :title="labelChipTitle(l)"
+            >{{ labelChipText(l) }}</span>
           </div>
           <div class="cell c-player" :title="r.playerId">{{ shortId(r.playerId) }}</div>
           <div class="cell c-play" :title="r.playId">{{ shortId(r.playId) }}</div>

--- a/content/dashboard-v3/src/lib/labelGlossary.ts
+++ b/content/dashboard-v3/src/lib/labelGlossary.ts
@@ -181,6 +181,70 @@ function patternModeWhat(ev: string): string | undefined {
     : `Traffic-shaping pattern advanced a step (mode: ${mode})`;
 }
 
+/**
+ * Derived whole-tuple network-failure signature (#892):
+ * `net_failure:<kind>/<cause>/<outcome>` — one collapsed chip summarising the
+ * orthogonal facets of a single failed request (a network_requests row is one
+ * HTTP request, so the tuple is unambiguous). The facet labels stay in
+ * labels[] for filtering; this is the human-facing roll-up.
+ */
+const NET_FAILURE_PREFIX = 'net_failure:';
+const NET_FAILURE_CAUSE: Record<string, string> = {
+  client_disconnect: 'the client dropped it mid-transfer',
+  socket: 'the socket was cut',
+  active_timeout: 'an active-transfer timeout fired',
+  idle_timeout: 'an idle-transfer timeout fired',
+  transport: 'a transport timeout fired',
+};
+const NET_FAILURE_OUTCOME: Record<string, string> = {
+  incomplete: 'left incomplete',
+  timeout: 'timed out',
+  other: 'failed',
+  http_4xx: 'returned 4xx',
+  http_5xx: 'returned 5xx',
+};
+
+/** humanizeNetFailure turns `net_failure:segment/client_disconnect/incomplete`
+ *  into `segment · client_disconnect · incomplete` for the collapsed chip. */
+export function humanizeNetFailure(ev: string): string {
+  return ev.slice(NET_FAILURE_PREFIX.length).split('/').join(' · ');
+}
+
+function netFailureWhat(ev: string): string | undefined {
+  if (!ev.startsWith(NET_FAILURE_PREFIX)) return undefined;
+  const parts = ev.slice(NET_FAILURE_PREFIX.length).split('/');
+  const kind = parts[0] ?? '';
+  // outcome is always last; the optional cause sits between kind and outcome.
+  const outcome = parts.length > 1 ? parts[parts.length - 1] : '';
+  const cause = parts.length > 2 ? parts[1] : '';
+  const kindTxt = kind === 'master_manifest' ? 'master-playlist'
+    : kind === 'manifest' ? 'playlist' : kind;
+  const outTxt = NET_FAILURE_OUTCOME[outcome] ?? outcome;
+  const causeTxt = cause ? ` — ${NET_FAILURE_CAUSE[cause] ?? cause}` : '';
+  return `One request: a ${kindTxt} ${outTxt}${causeTxt}. `
+    + `Whole-tuple summary of the kind/cause/outcome facets on this row (each still filterable).`;
+}
+
+/** The facet events a net_failure signature rolls up. When the signature is
+ *  present on a row these are hidden from the inline chips (still in labels[]
+ *  for filtering) and surfaced via the signature chip's tooltip. */
+const NET_FAILURE_FACETS = new Set<string>([
+  'segment_failure', 'manifest_failure', 'master_manifest_failure',
+  'transport_socket', 'transport_disconnect',
+  'transfer_active_timeout', 'transfer_idle_timeout', 'transport_failure',
+  'fault_incomplete', 'fault_timeout', 'fault_other',
+  'http_4xx', 'http_5xx',
+]);
+
+/** collapseNetFailureLabels drops the constituent facet labels from a row's
+ *  chip list IFF a net_failure signature is present, so the line reads as one
+ *  failure. No-op otherwise. The input labels[] is untouched (query surface). */
+export function collapseNetFailureLabels(labels: string[]): string[] {
+  const hasSig = labels.some((l) => eventOf(l).startsWith(NET_FAILURE_PREFIX));
+  if (!hasSig) return labels;
+  return labels.filter((l) => !NET_FAILURE_FACETS.has(eventOf(l)));
+}
+
 /** eventOf strips the `<severity>=` prefix and any leading `*` marker. */
 export function eventOf(label: string): string {
   const eq = label.indexOf('=');
@@ -191,7 +255,7 @@ export function eventOf(label: string): string {
 /** labelTooltip returns a hover string ("what · how") for a label, or '' if unknown. */
 export function labelTooltip(label: string): string {
   const ev = eventOf(label);
-  const dyn = anomalyWhat(ev) ?? patternModeWhat(ev);
+  const dyn = anomalyWhat(ev) ?? patternModeWhat(ev) ?? netFailureWhat(ev);
   if (dyn) return dyn;
   const e = GLOSSARY[ev];
   if (!e) return '';
@@ -201,5 +265,6 @@ export function labelTooltip(label: string): string {
 /** hasGlossary reports whether a label has a definition (to style it as hoverable). */
 export function hasGlossary(label: string): boolean {
   const ev = eventOf(label);
-  return anomalyWhat(ev) !== undefined || patternModeWhat(ev) !== undefined || GLOSSARY[ev] !== undefined;
+  return anomalyWhat(ev) !== undefined || patternModeWhat(ev) !== undefined
+    || netFailureWhat(ev) !== undefined || GLOSSARY[ev] !== undefined;
 }


### PR DESCRIPTION
Closes #892.

## What
A failed network request stamps several **orthogonal facet labels** (kind × transport-cause × outcome) — e.g. `fault_incomplete` + `*segment_failure` + `*transport_disconnect`. On a Play/Network Log line that reads like *three* failures when it's **one** request. This adds a **derived whole-tuple signature** so the line reads as one thing, without collapsing the queryable facet vocabulary.

## Why this shape (not a fused enum / axis-keys / correlation-ids)
A `network_requests` row **is one HTTP request** → every axis is single-valued → the tuple is unambiguous, so the signature can be derived safely here. Facets stay the query primitive (per-axis `has(labels,…)`, per-facet severity, linear vocabulary); the signature is the human identity, derived not fused. Full rationale + the invariant in `.claude/standards/label-facets.md`.

## Changes
**Forwarder** (`analytics/go-forwarder/labels.go`)
- `netFailureSignature(r)` composes `kind/cause/outcome` (cause omitted when not faulted; outcome falls back to `http_4xx`/`http_5xx`), mirroring the existing facet switches so they can't disagree.
- Emits `*net_failure:<sig>` **alongside** the facets, at `worstSeverity(facets)` — one extra `LowCardinality` value in the existing `labels[]`; **no schema change, no new column, no plumb-everywhere tax, no query regression.**
- Tests: `TestNetFailureSignature` (8 cases), `…StacksWithFacets`, `…InheritsErrorSeverity`.

**Dashboard**
- `labelGlossary.ts`: `collapseNetFailureLabels()` (drops the constituent facet chips only when a signature is present — display only, `labels[]` untouched), `humanizeNetFailure()`, `netFailureWhat()` tooltip matcher wired into `labelTooltip`/`hasGlossary`.
- `NetworkLog.vue` + `PlayLog.vue`: render the signature as one collapsed chip (`segment · client_disconnect · incomplete`) with facets on hover.

**Standard**: `.claude/standards/label-facets.md` — decompose into facets only where each axis is single-valued per row; multi-incident rows stay whole-tuple tokens; never mix decomposition + multi-incident + no correlation id.

## Verification
- `go test ./... -run NetFailure` green (emit, stacking, severity inheritance).
- `vue-tsc --noEmit` clean.
- Deployed to test-dev; existing plays render unchanged (501 rows / 71 chips, no console errors) — collapse is a no-op until a row carries a signature.
- **Note:** labels bake at ingest, so the live collapsed chip only appears on **new** HTTP-faulted traffic post-deploy (historical rows won't retroactively carry it). A fault-injection sim run to capture the chip visually is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
