### PR TITLE
fix(qoe): widen rate_cap_breach factor 1.10 → 1.25

### DIFF
--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -413,17 +413,17 @@ func TestQoEAbrStartupGate(t *testing.T) {
 
 func TestQoERateCapBreach(t *testing.T) {
 	want := qoeLabel(SevWarning, "qoe_rate_cap_breach")
-	// #657: gate on the kernel-measured served rate. 12 > 10*1.10=11 → breach.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
-		t.Fatalf("served 12 over cap 10 should breach: %v", got)
+	// #657: gate on the kernel-measured served rate. 13 > 10*1.25=12.5 → breach.
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 13, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("served 13 over cap 10 should breach: %v", got)
 	}
 	// Fallback to the proxy per-segment transfer rate when nftables is absent.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", MbpsTransferRate: 12, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
-		t.Fatalf("transfer-rate fallback 12 over cap 10 should breach: %v", got)
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", MbpsTransferRate: 13, EffectiveRateLimitMbps: 10}); !hasLabel(got, want) {
+		t.Fatalf("transfer-rate fallback 13 over cap 10 should breach: %v", got)
 	}
-	// 10.5 < 11 → no breach.
-	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 10.5, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
-		t.Fatalf("served 10.5 within factor should not breach: %v", got)
+	// 12 < 10*1.25=12.5 → no breach (would have breached under the old 1.10).
+	if got := evalQoE(&row{Ts: tsBase, PlayerID: "p", PlayID: "x", PlaybackStatus: "in_progress", NftablesBandwidthMbps: 12, EffectiveRateLimitMbps: 10}); hasLabel(got, want) {
+		t.Fatalf("served 12 within factor should not breach: %v", got)
 	}
 	// #657: a client network_bitrate over-read (30) must NOT breach when the
 	// server actually delivered under the cap (the whole point of the re-base).

--- a/analytics/go-forwarder/p90_threshold.json
+++ b/analytics/go-forwarder/p90_threshold.json
@@ -24,7 +24,7 @@
   "network": {
     "ttfb_breach_ms": 500,
     "transfer_stall_ms": 5000,
-    "rate_cap_breach_factor": 1.10,
+    "rate_cap_breach_factor": 1.25,
     "cmcd_mtp_drift_ratio": 0.5
   },
   "abr": {

--- a/analytics/go-forwarder/qoe_thresholds.go
+++ b/analytics/go-forwarder/qoe_thresholds.go
@@ -145,7 +145,7 @@ func qoeDefaults() *QoEThresholds {
 	t.Continuity.StallBurstWindowS = 60
 	t.Network.TTFBBreachMs = 500
 	t.Network.TransferStallMs = 5000
-	t.Network.RateCapBreachFactor = 1.10
+	t.Network.RateCapBreachFactor = 1.25
 	t.Network.CMCDMTPDriftRatio = 0.5
 	t.ABR.BitrateUnderutilizedRatio = 0.5   // variant using < half the link
 	t.ABR.AbrHeadroomMargin = 0.85          // need ~15% headroom to sustain a rung

--- a/content/dashboard-v3/src/lib/labelGlossary.ts
+++ b/content/dashboard-v3/src/lib/labelGlossary.ts
@@ -85,7 +85,7 @@ const GLOSSARY: Record<string, Entry> = {
   shift_down: { what: 'ABR shifted down a rung (informational)' },
 
   // ── network / transport (per-request) ────────────────────────────────────
-  qoe_rate_cap_breach: { what: 'Measured bitrate exceeded the applied cap', how: 'network bitrate > cap × rate_cap_breach_factor (1.10) — often an AVPlayer burst over-read' },
+  qoe_rate_cap_breach: { what: 'Measured bitrate exceeded the applied cap', how: 'network bitrate > cap × rate_cap_breach_factor (1.25) — often an AVPlayer burst over-read' },
   qoe_transfer_stall: { what: 'A segment transfer stalled mid-flight', how: 'no bytes received for transfer_stall_ms (5s)' },
   qoe_ttfb_breach: { what: 'Time-to-first-byte slow', how: 'responseStart − requestEnd > ttfb_breach_ms (500ms) — stream-level TTFB, generous on HTTP/2 keep-alive' },
   master_manifest_failure: { what: 'The master playlist request failed' },


### PR DESCRIPTION
Bumps `rate_cap_breach_factor` 1.10 → **1.25**: `qoe_rate_cap_breach` now fires only when the served rate exceeds the cap by 25% (was 10%), cutting marginal/burst over-cap false positives.

- `qoe_thresholds.go` compiled default + `p90_threshold.json` profile → 1.25
- glossary tooltip baked value → 1.25
- `TestQoERateCapBreach` re-based to the new boundary (13 breaches cap 10; 12 does not — 12 *would* have breached under the old 1.10)

Verified: `go test -run RateCapBreach` green, `p90` JSON valid, `vue-tsc` clean.

Note: unchanged here — the separately-flagged field bug (label uses `nftables_bandwidth_mbps` = operator intent as "served"). This PR only widens the margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)