### PR TITLE
feat(dashboard): event bars on metric charts + Player State timeline

### DIFF
--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -30,7 +30,7 @@ import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf, useCompareSiblings, sessionMarkerColor, SELF_MARKER_COLOR } from '@/composables/useCompareContext';
 import { compareBandwidthSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
-import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
+import type { LifecycleMarker, EventMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 const props = defineProps<{
@@ -41,6 +41,8 @@ const props = defineProps<{
   coordId?: string;
   /** Shared player-lifecycle vertical lines, passed straight to MetricsLineChart. */
   lifecycleMarkers?: LifecycleMarker[];
+  /** Focus-window event bars (severity-filtered), forwarded to MetricsLineChart. */
+  eventMarkers?: EventMarker[];
   eventsStream: Stream<Record<string, unknown>>;
   /** AVMetrics stream — used to overlay per-segment throughput dots
    *  on the bandwidth chart (issue #486). Optional so existing
@@ -557,6 +559,7 @@ const compareOverlays = useCompareOverlays((sib) => {
     :player-id="playerId"
     :coord-id="coordId"
     :lifecycle-markers="lifecycleMarkers"
+    :event-markers="eventMarkers"
     title="Bandwidth"
     unit="Mbps"
     :series="series"

--- a/content/dashboard-v3/src/components/BufferChart.vue
+++ b/content/dashboard-v3/src/components/BufferChart.vue
@@ -11,7 +11,7 @@ import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
 import { compareBufferSeries } from '@/composables/compareSeries';
 import type { Stream } from '@/composables/useSessionTimeSeries';
-import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
+import type { LifecycleMarker, EventMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
 defineProps<{
@@ -21,6 +21,8 @@ defineProps<{
   coordId?: string;
   /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
   lifecycleMarkers?: LifecycleMarker[];
+  /** Focus-window event bars (severity-filtered), forwarded to MetricsLineChart. */
+  eventMarkers?: EventMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -62,6 +64,7 @@ const series = computed<SeriesSpec[]>(() =>
     :player-id="playerId"
     :coord-id="coordId"
     :lifecycle-markers="lifecycleMarkers"
+    :event-markers="eventMarkers"
     title="Buffer & live offset"
     unit="buffer (s)"
     :series="series"

--- a/content/dashboard-v3/src/components/EventsTimeline.vue
+++ b/content/dashboard-v3/src/components/EventsTimeline.vue
@@ -31,7 +31,7 @@ import { computed, onBeforeUnmount, ref, toRef, watch } from 'vue';
 import { ensureVisTimeline } from '@/composables/useChartJs';
 import { useChartCoordination, DEFAULT_FOCUS_MS } from '@/composables/useChartCoordination';
 import type { Stream } from '@/composables/useSessionTimeSeries';
-import { useLifecycleLineVisibility, type LifecycleMarker } from '@/composables/useLifecycleMarkers';
+import { useLifecycleLineVisibility, type LifecycleMarker, type EventMarker } from '@/composables/useLifecycleMarkers';
 import { nearestVariantByBitrate } from '@/composables/useManifestVariants';
 
 interface LaneCfg { label: string; color: string }
@@ -254,6 +254,9 @@ const props = defineProps<{
    *  with the same lines on the value charts. Per-type visibility comes from
    *  the shared toggle (useLifecycleLineVisibility). */
   lifecycleMarkers?: LifecycleMarker[];
+  /** Severity-coloured focus-window event bars (mirrored from the metric
+   *  charts) — drawn as vis custom-time lines across every lane. */
+  eventMarkers?: EventMarker[];
 }>();
 const coord = useChartCoordination(computed(() => props.coordId ?? props.playerId));
 const { lineVisibility } = useLifecycleLineVisibility();
@@ -1687,6 +1690,35 @@ watch(
   { immediate: true },
 );
 
+// Event-bar custom-time lines — mirror syncLifecycleLines. id `ev-<sev>-<ms>`
+// lands as a CSS class so the per-severity rules recolour each line; evLines
+// doubles as the id→detail lookup for the shared hover tooltip.
+const evLines = new Map<string, string>();
+function evIdFor(m: EventMarker): string {
+  return `ev-${m.sev}-${Math.round(m.ms)}`;
+}
+async function syncEventLines(): Promise<void> {
+  await ensureTimeline();
+  if (!timeline) return;
+  const desired = new Map<string, { ms: number; detail: string }>();
+  for (const m of props.eventMarkers ?? []) {
+    if (!Number.isFinite(m.ms)) continue;
+    desired.set(evIdFor(m), { ms: m.ms, detail: m.detail });
+  }
+  for (const id of [...evLines.keys()]) {
+    if (!desired.has(id)) {
+      try { timeline.removeCustomTime(id); } catch { /* ignore */ }
+      evLines.delete(id);
+    }
+  }
+  for (const [id, { ms, detail }] of desired) {
+    if (!evLines.has(id)) {
+      try { timeline.addCustomTime(new Date(ms), id); evLines.set(id, detail); } catch { /* ignore */ }
+    }
+  }
+}
+watch(() => props.eventMarkers, () => { void syncEventLines(); }, { immediate: true });
+
 /* Lifecycle-line hover tooltip — same custom-DOM approach as the cursor
  * tooltip, but hit-tests EVERY lifecycle custom-time element and shows the
  * nearest one's detail (restart reason / play_id / terminal status). */
@@ -1708,7 +1740,7 @@ function installLifecycleHoverTooltip() {
     const my = e.clientY - cRect.top;
     let bestDist = 6; // px tolerance
     let bestText = '';
-    const els = c.querySelectorAll('.vis-custom-time[class*="lc-"]');
+    const els = c.querySelectorAll('.vis-custom-time[class*="lc-"], .vis-custom-time[class*="ev-"]');
     els.forEach((el) => {
       const lineX = el.getBoundingClientRect().left - cRect.left;
       const d = Math.abs(mx - lineX);
@@ -1717,6 +1749,7 @@ function installLifecycleHoverTooltip() {
       let detail = '';
       el.classList.forEach((cls) => {
         if (cls.startsWith('lc-') && lcLines.has(cls)) detail = lcLines.get(cls) as string;
+        else if (cls.startsWith('ev-') && evLines.has(cls)) detail = evLines.get(cls) as string;
       });
       if (detail) { bestDist = d; bestText = detail; }
     });
@@ -2008,6 +2041,17 @@ onBeforeUnmount(() => {
   z-index: 4;
 }
 .events-timeline :deep(.vis-custom-time[class*='lc-server_loop-']::before) { border-top-color: #84cc16; }
+
+/* Event-bar custom-time lines (severity-coloured), mirrored from the metric
+ * charts. z-index 3 keeps them beneath the lifecycle lines (4) + cursor (5). */
+.events-timeline :deep(.vis-custom-time[class*='ev-critical-']) { border-left: 1.5px dashed #dc2626 !important; z-index: 3; }
+.events-timeline :deep(.vis-custom-time[class*='ev-critical-']::before) { border-top-color: #dc2626; }
+.events-timeline :deep(.vis-custom-time[class*='ev-error-']) { border-left: 1.5px dashed #f97316 !important; z-index: 3; }
+.events-timeline :deep(.vis-custom-time[class*='ev-error-']::before) { border-top-color: #f97316; }
+.events-timeline :deep(.vis-custom-time[class*='ev-warning-']) { border-left: 1.5px dashed #eab308 !important; z-index: 3; }
+.events-timeline :deep(.vis-custom-time[class*='ev-warning-']::before) { border-top-color: #eab308; }
+.events-timeline :deep(.vis-custom-time[class*='ev-info-']) { border-left: 1.5px dashed #0ea5e9 !important; z-index: 3; }
+.events-timeline :deep(.vis-custom-time[class*='ev-info-']::before) { border-top-color: #0ea5e9; }
 
 /* vis-timeline label panel + labelset pinned to the SAME 60px width
  * as the Chart.js charts' left y-axis (see MetricsLineChart.Y_WIDTH)

--- a/content/dashboard-v3/src/components/FPSChart.vue
+++ b/content/dashboard-v3/src/components/FPSChart.vue
@@ -17,7 +17,7 @@ import { computed, ref, watch } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
 import { tsOfRow } from '@/composables/chRowAdapter';
-import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
+import type { LifecycleMarker, EventMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
 import { compareFpsSeries } from '@/composables/compareSeries';
@@ -29,6 +29,8 @@ const props = defineProps<{
   coordId?: string;
   /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
   lifecycleMarkers?: LifecycleMarker[];
+  /** Focus-window event bars (severity-filtered), forwarded to MetricsLineChart. */
+  eventMarkers?: EventMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -142,6 +144,7 @@ const series = computed<SeriesSpec[]>(() => {
     :player-id="playerId"
     :coord-id="coordId"
     :lifecycle-markers="lifecycleMarkers"
+    :event-markers="eventMarkers"
     title="Frame rate (derived)"
     unit="fps"
     :series="series"

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -26,6 +26,7 @@ import { tsOfRow, chRowToPlayerRecord } from '@/composables/chRowAdapter';
 import {
   useLifecycleLineVisibility,
   type LifecycleMarker,
+  type EventMarker,
 } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 
@@ -151,6 +152,13 @@ const props = defineProps({
    *  per-type toggle (useLifecycleLineVisibility), not a prop. */
   lifecycleMarkers: {
     type: Array as PropType<LifecycleMarker[]>,
+    default: () => [],
+  },
+  /** Severity-coloured vertical event bars — the focus-window events mirrored
+   *  from SessionDisplay's event filter (so the severity selector drives them).
+   *  Drawn thin + translucent so the line series stays readable. */
+  eventMarkers: {
+    type: Array as PropType<EventMarker[]>,
     default: () => [],
   },
   /** Grouped-sibling overlays (issue #579 compare mode). Each entry is
@@ -753,6 +761,38 @@ function createChartInstance(Chart: any): any {
         }
         ctx.restore();
       },
+    }, {
+      /** Focus-window event bars (severity-filtered), drawn thin + translucent
+       *  so they overlay without swamping the series or the lifecycle lines. */
+      id: 'eventLines',
+      afterDatasetsDraw(c: any) {
+        const list = props.eventMarkers;
+        if (!list || list.length === 0) return;
+        const sx = c.scales?.x;
+        const sy = c.scales?.y;
+        if (!sx || !sy) return;
+        const ctx = c.ctx;
+        ctx.save();
+        for (const m of list) {
+          if (!Number.isFinite(m.ms) || m.ms < sx.min || m.ms > sx.max) continue;
+          const x = sx.getPixelForValue(m.ms);
+          // Translucent dashed full-height line.
+          ctx.globalAlpha = 0.8;
+          ctx.lineWidth = 1.5;
+          ctx.setLineDash([3, 3]);
+          ctx.beginPath();
+          ctx.moveTo(x, sy.top);
+          ctx.lineTo(x, sy.bottom);
+          ctx.strokeStyle = m.color;
+          ctx.stroke();
+          // Solid findable cap at the top — also the natural hover target.
+          ctx.globalAlpha = 1;
+          ctx.setLineDash([]);
+          ctx.fillStyle = m.color;
+          ctx.fillRect(x - 1.5, sy.top, 3, 5);
+        }
+        ctx.restore();
+      },
     }],
     options: {
       responsive: true,
@@ -1280,7 +1320,7 @@ function installLifecycleHoverTooltip() {
   if (!c) return;
   c.addEventListener('mousemove', (e) => {
     const list = visibleLifecycleMarkers();
-    if (list.length === 0 || !chart) {
+    if ((list.length === 0 && props.eventMarkers.length === 0) || !chart) {
       if (lcTooltipVisible.value) lcTooltipVisible.value = false;
       return;
     }
@@ -1297,6 +1337,16 @@ function installLifecycleHoverTooltip() {
     let bestDist = 6; // px tolerance
     let bestText = '';
     for (const m of list) {
+      if (!Number.isFinite(m.ms) || m.ms < sx.min || m.ms > sx.max) continue;
+      const px = sx.getPixelForValue(m.ms);
+      const d = Math.abs(mx - px);
+      if (d < bestDist) {
+        bestDist = d;
+        bestText = m.detail;
+      }
+    }
+    // Event bars share the same tooltip + proximity search.
+    for (const m of props.eventMarkers) {
       if (!Number.isFinite(m.ms) || m.ms < sx.min || m.ms > sx.max) continue;
       const px = sx.getPixelForValue(m.ms);
       const d = Math.abs(mx - px);
@@ -1945,6 +1995,14 @@ watch(
 // state. Cheap: chart.update('none') skips animations.
 watch(
   () => props.markers,
+  () => { try { chart?.update('none'); } catch { /* ignore */ } },
+  { deep: false },
+);
+
+// Redraw when the event-bar set changes (severity filter, focus window, or the
+// "Event bars" toggle emptying it) so the eventLines plugin repaints.
+watch(
+  () => props.eventMarkers,
   () => { try { chart?.update('none'); } catch { /* ignore */ } },
   { deep: false },
 );

--- a/content/dashboard-v3/src/components/RTTChart.vue
+++ b/content/dashboard-v3/src/components/RTTChart.vue
@@ -9,7 +9,7 @@
 import { computed, toRef } from 'vue';
 import MetricsLineChart, { type SeriesSpec } from './MetricsLineChart.vue';
 import type { Stream } from '@/composables/useSessionTimeSeries';
-import type { LifecycleMarker } from '@/composables/useLifecycleMarkers';
+import type { LifecycleMarker, EventMarker } from '@/composables/useLifecycleMarkers';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import { usePlayer } from '@/composables/usePlayer';
 import { useCompareOverlays, useCompareSelf } from '@/composables/useCompareContext';
@@ -22,6 +22,8 @@ const props = defineProps<{
   coordId?: string;
   /** Shared player-lifecycle vertical lines, forwarded to MetricsLineChart. */
   lifecycleMarkers?: LifecycleMarker[];
+  /** Focus-window event bars (severity-filtered), forwarded to MetricsLineChart. */
+  eventMarkers?: EventMarker[];
   eventsStream: Stream<Record<string, unknown>>;
 }>();
 
@@ -95,6 +97,7 @@ const series = computed<SeriesSpec[]>(() => {
     :player-id="playerId"
     :coord-id="coordId"
     :lifecycle-markers="lifecycleMarkers"
+    :event-markers="eventMarkers"
     title="Round-trip time"
     unit="ms"
     :series="series"

--- a/content/dashboard-v3/src/components/SessionDisplay.vue
+++ b/content/dashboard-v3/src/components/SessionDisplay.vue
@@ -68,6 +68,7 @@ import {
   LIFECYCLE_STYLE,
   LIFECYCLE_KINDS,
   type LifecycleKind,
+  type EventMarker,
 } from '@/composables/useLifecycleMarkers';
 import { useCompareMode } from '@/composables/useCompareMode';
 import { useGroupSiblings } from '@/composables/useGroupSiblings';
@@ -877,7 +878,7 @@ function toggleTier(p: Severity) {
 const visiblePriority = ref<Record<Severity, boolean>>({
   error: true, critical: true, warning: true, info: false, testing: false,
 });
-function togglePriorityVisibility(p: Severity, e: MouseEvent) {
+function togglePriorityVisibility(p: Severity, e: Event) {
   e.stopPropagation();
   const willBeVisible = !visiblePriority.value[p];
   visiblePriority.value[p] = willBeVisible;
@@ -976,6 +977,42 @@ const filteredEvents = computed<AnnotatedEvent[]>(
     return true;
   }),
 );
+
+// Focus-window event bars for the metric charts: mirror the SAME filtered
+// event set the timeline/filter shows, as thin vertical lines on every chart.
+// Deduped to one line per timestamp at its worst severity (a row with several
+// labels shares one ts). Driven by the same visiblePriority + category filter
+// as `filteredEvents`, so the severity selector already governs what appears.
+// The charts clip to their own x-window, so only in-focus events render.
+// Vivid per-severity colours for the chart event bars — more saturated than the
+// pastel filter-chip borders so a 1.5px line reads against the series + grid.
+const EVENT_BAR_COLOR: Record<Severity, string> = {
+  critical: '#dc2626', error: '#f97316', warning: '#eab308', info: '#0ea5e9', testing: '#94a3b8',
+};
+// The "Event bars" per-severity checkboxes are wired to the SAME
+// visiblePriority the focus-window event filter uses, so the two stay in sync.
+// The bars therefore come straight from filteredEvents (already severity-,
+// category- and type-filtered). One bar per timestamp at its worst severity.
+const EVENT_BAR_LEGEND = SEVERITY_ORDER.map((s) => ({ sev: s, color: EVENT_BAR_COLOR[s], label: SEVERITY_META[s].label }));
+const eventMarkers = computed<EventMarker[]>(() => {
+  const byMs = new Map<number, { sev: Severity; types: string[] }>();
+  for (const ev of filteredEvents.value) {
+    const e = byMs.get(ev._ts);
+    const type = ev.type ?? 'event';
+    if (!e) byMs.set(ev._ts, { sev: ev._p, types: [type] });
+    else {
+      e.types.push(type);
+      if (SEVERITY_ORDER.indexOf(ev._p) < SEVERITY_ORDER.indexOf(e.sev)) e.sev = ev._p;
+    }
+  }
+  const out: EventMarker[] = [];
+  for (const [ms, e] of byMs) {
+    const uniq = [...new Set(e.types)];
+    const shown = uniq.slice(0, 6).join(', ') + (uniq.length > 6 ? `, +${uniq.length - 6} more` : '');
+    out.push({ ms, sev: e.sev, color: EVENT_BAR_COLOR[e.sev], detail: `${new Date(ms).toLocaleTimeString()} · ${e.sev}\n${shown}` });
+  }
+  return out;
+});
 
 const tierCounts = computed<Record<Severity, number>>(() => {
   const c: Record<Severity, number> = { error: 0, critical: 0, warning: 0, info: 0, testing: 0 };
@@ -1840,7 +1877,7 @@ function skipToEnd() {
         :from-ms="cycleBandsDomain.fromMs"
         :to-ms="cycleBandsDomain.toMs"
       />
-      <EventsTimeline :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" :lifecycle-markers="lifecycleMarkers" />
+      <EventsTimeline :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :control-stream="timeseries.control" :lifecycle-markers="lifecycleMarkers" :event-markers="eventMarkers" />
     </CollapsibleSection>
 
     <CollapsibleSection title="Bitrate Chart etc" :open="true" eager persist-key="bitrate-chart">
@@ -1863,11 +1900,22 @@ function skipToEnd() {
           {{ LIFECYCLE_STYLE[k].label }}
         </label>
       </div>
+      <!-- Event-bar per-severity toggles (default to the focus-window severity
+           selection). Each governs whether that level's bars overlay the charts,
+           coloured to its severity. -->
+      <div class="lifecycle-toggles">
+        <span class="lt-label">Event bars:</span>
+        <label v-for="s in EVENT_BAR_LEGEND" :key="s.sev" class="lt-item">
+          <input type="checkbox" :checked="visiblePriority[s.sev]" @change="togglePriorityVisibility(s.sev, $event)" />
+          <span class="lt-sw" :style="{ background: s.color }" />
+          {{ s.label }}
+        </label>
+      </div>
       <div class="chart-stack">
-        <BandwidthChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :lifecycle-markers="lifecycleMarkers" />
-        <BufferChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
-        <RTTChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
-        <FPSChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" />
+        <BandwidthChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :avmetrics-stream="timeseries.avmetrics" :lifecycle-markers="lifecycleMarkers" :event-markers="eventMarkers" />
+        <BufferChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" :event-markers="eventMarkers" />
+        <RTTChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" :event-markers="eventMarkers" />
+        <FPSChart :player-id="archivePlayerId" :coord-id="coordId" :events-stream="timeseries.events" :lifecycle-markers="lifecycleMarkers" :event-markers="eventMarkers" />
       </div>
     </CollapsibleSection>
 

--- a/content/dashboard-v3/src/composables/useLifecycleMarkers.ts
+++ b/content/dashboard-v3/src/composables/useLifecycleMarkers.ts
@@ -34,6 +34,22 @@ export interface LifecycleMarker {
   detail: string;
 }
 
+/** A severity-coloured vertical event bar overlaid on the metric charts —
+ *  the focus-window events, mirrored from SessionDisplay's event filter (so
+ *  the severity selector drives them). Distinct from LifecycleMarker (the
+ *  fixed restart/play_start/play_end lines): these are the filtered per-label
+ *  events, one thin line per timestamp, coloured by severity. */
+export interface EventMarker {
+  /** ms-since-epoch x-position of the line. */
+  ms: number;
+  /** Line colour (severity-derived). */
+  color: string;
+  /** Worst severity at this ts (drives the timeline custom-time id + CSS). */
+  sev: string;
+  /** Hover tooltip text: time · worst-severity + the event type(s) at this ts. */
+  detail: string;
+}
+
 /** Per-kind visual style + legend label. Restart is a single fixed colour
  *  (amber, matching the existing PLAYBACK-lane RESTART dot) regardless of
  *  reason — the reason shows on hover. */


### PR DESCRIPTION
Draws the severity-tagged focus-window events as vertical bars across **every metric chart** (Bandwidth / Buffer / RTT / FPS) **and the Player State timeline**, so events line up everywhere.

- **Per-severity checkboxes** (Critical / Error / Warning / Info) with colour swatches, **wired to the focus-window event filter** (`visiblePriority`) — toggling a bar checkbox moves the focus-window selection and vice-versa. Bars come from `filteredEvents` (severity + category + type filtered), one bar per timestamp at its worst severity.
- **Metric charts:** `eventLines` draw plugin (vivid per-severity colour, dashed line + solid top cap), hover shows `time · severity + type(s)`, redraw-on-change watcher.
- **Player State timeline:** event bars as vis custom-time lines (`ev-<sev>-<ms>`, CSS-coloured per severity), sharing the lifecycle-line hover tooltip.

**Verified on test-dev:** metric-chart bars pixel-confirmed (79 cols → 42 with Warning off); timeline shows 22 `ev-` lines; toggling a bar checkbox updates both the bars and the focus-window filter (22 → 7 lines). `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)