### PR TITLE
fix(ios): sim preview decode-off + Settings-drawer tap routing

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/HomeScreen.swift
@@ -390,6 +390,13 @@ private struct HeroLiveVideo: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UIView {
         let view = HeroLayerView(frame: .zero)
+        // Decorative preview surface with no taps of its own. UIKit defaults
+        // isUserInteractionEnabled=true, which otherwise SWALLOWS touches landing
+        // here while the Settings drawer is open over Home — including the
+        // drawer's back chevron over the hero — because AppRoot's
+        // `.disabled(settingsOpen)` doesn't cross the UIViewRepresentable
+        // boundary into UIKit. Disabling touch lets those taps reach the overlay.
+        view.isUserInteractionEnabled = false
         // 720p variant — the hero surface is the visual centerpiece of
         // Home, so we trade the extra decode cost for the higher
         // resolution. Tiles stay at 360p for budget reasons.

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LivePreviewTile.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/LivePreviewTile.swift
@@ -190,6 +190,11 @@ private struct MutedLoopingTile: UIViewRepresentable {
 
     func makeUIView(context: Context) -> UIView {
         let view = TileLayerView(frame: .zero)
+        // Decorative preview surface — no taps of its own. Disable UIKit touch
+        // (default true) so it can't swallow taps meant for an overlay above it
+        // (the Settings drawer's back chevron over the LIVE row on Home); AppRoot's
+        // `.disabled(settingsOpen)` doesn't reach into this UIViewRepresentable.
+        view.isUserInteractionEnabled = false
         guard let url = StreamURLBuilder.tilePreviewURL(server: server, contentName: content.name) else {
             return view
         }

--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/PlayerViewModel.swift
@@ -2434,7 +2434,17 @@ final class PlayerViewModel: ObservableObject {
         // First launch: no key yet → use the device's hardware cap so
         // the user starts with the richest preview their hardware can
         // run. After that, persist whatever they've chosen.
-        let storedSlots = d.object(forKey: Self.flagPreviewVideoSlots) as? Int
+        //
+        // Read via integer(forKey:) when the key is PRESENT in any domain so an
+        // NSArgumentDomain launch arg (which arrives as a String, e.g. the
+        // harness's `-is.flag.preview_video_slots 0` to cut sim decode load)
+        // coerces correctly. The old `as? Int` failed that cast and silently
+        // fell back to hwCap, so the launch arg never turned previews off.
+        // Absent in every domain → nil, so the hwCap default below still wins
+        // for normal/manual launches (unchanged).
+        let storedSlots: Int? = d.object(forKey: Self.flagPreviewVideoSlots) != nil
+            ? d.integer(forKey: Self.flagPreviewVideoSlots)
+            : nil
         let hwCap = DecodeBudget.shared.hardwareCap
         previewVideoSlots = storedSlots.map { max(0, min($0, hwCap)) } ?? hwCap
         DecodeBudget.shared.setUserCap(previewVideoSlots)

--- a/tests/characterization/runner/appium.go
+++ b/tests/characterization/runner/appium.go
@@ -180,6 +180,12 @@ func (a *AppiumLauncher) SetLaunchArgs(args []string) {
 var baselineTestFlags = [][2]string{
 	{"-is.flag.4k", "true"},
 	{"-is.flag.peak_bitrate_mbps", "0"},
+	// Previews off: `0` decode slots so the home-screen preview-video tiles stay
+	// static thumbnails. Auto-playing previews add real GPU/decode load on the
+	// sims during launch + the fleet HOME barrier (every arm sits on the home
+	// screen before playback), which competes with the run. A mode that sets it
+	// explicitly wins. (App-side: PlayerViewModel reads this string-coerced.)
+	{"-is.flag.preview_video_slots", "0"},
 }
 
 func withBaselineTestFlags(args []string) []string {


### PR DESCRIPTION
Two small, independent iOS fixes split off from in-progress work.

## 1. Disable auto-playing home previews on sims during runs
Home auto-plays live preview videos (hero + LIVE tiles). On sims those add real GPU/decode load while every fleet arm sits on the HOME barrier before playback.
- `appium.go`: add `-is.flag.preview_video_slots 0` to `baselineTestFlags`.
- `PlayerViewModel.swift`: read `preview_video_slots` via `integer(forKey:)` when the key is present in **any** domain, so an `NSArgumentDomain` launch arg (arrives as a **String**) coerces to Int. The old `as? Int` failed that cast and silently fell back to the hardware cap — so the launch arg was a no-op. Absent key → hwCap default (normal/manual launches unchanged).

## 2. Decorative preview layers no longer swallow overlay taps
`HeroLiveVideo` + `MutedLoopingTile` are decorative `UIViewRepresentable` surfaces with no taps of their own, but UIKit defaults `isUserInteractionEnabled=true`, so they swallowed taps meant for an overlay above them — notably the Settings drawer's back chevron over the hero / LIVE row (SwiftUI's `.disabled(settingsOpen)` doesn't cross the UIViewRepresentable boundary). Set it `false`.

## Verification
`go vet ./tests/characterization/runner/` clean. Swift changes are compile-trivial (a property set + a cast fix) but **not built here** (no Xcode in this env) — worth a device/sim smoke before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)