### PR TITLE
fix(dashboard): developer mode (?developer=1) is no longer sticky

### DIFF
--- a/content/dashboard-v3/src/components/ShellLayout.vue
+++ b/content/dashboard-v3/src/components/ShellLayout.vue
@@ -463,16 +463,16 @@ const restrictContent = computed(
   () => typeof window !== 'undefined' && !isInternalNetworkHost(window.location.hostname),
 );
 
-// Developer mode — reuses the established `?developer=1` convention (shared-nav.js,
-// SessionDetails, Grid). Sticky: `?developer=1` persists to localStorage so dev-only
-// nav items survive navigation; `?developer=0` clears it.
+// Developer mode — the `?developer=1` convention (shared-nav.js, SessionDetails,
+// playback/quartet, …). NOT sticky: honoured only when the CURRENT URL carries
+// `?developer=1`, matching every other consumer. (This component used to persist
+// it to localStorage, so dev-only nav like QE Lab leaked across sessions.) Also
+// clears any stale `ismDeveloperMode` a previous sticky build left behind.
 const isDeveloper = ref<boolean>((() => {
   if (typeof window === 'undefined') return false;
   try {
-    const p = new URLSearchParams(window.location.search).get('developer');
-    if (p === '1') { localStorage.setItem('ismDeveloperMode', '1'); return true; }
-    if (p === '0') { localStorage.removeItem('ismDeveloperMode'); return false; }
-    return localStorage.getItem('ismDeveloperMode') === '1';
+    localStorage.removeItem('ismDeveloperMode'); // un-stick past persistence
+    return new URLSearchParams(window.location.search).get('developer') === '1';
   } catch {
     return false;
   }


### PR DESCRIPTION
"QE Lab" (the Sweep page) was leaking into the sidebar across sessions: `ShellLayout.vue` uniquely **persisted** `?developer=1` to `localStorage['ismDeveloperMode']`, so a single `?developer=1` visit kept dev-only nav visible indefinitely.

Every other consumer (`SessionDetails.vue`, `shared-nav.js`, `playback.html`, `quartet.html`) already reads the URL param directly (non-sticky). This makes `ShellLayout` match:
- `isDeveloper` is true **only** when the current URL has `?developer=1`.
- Clears any stale `ismDeveloperMode` on load, so already-stuck sessions un-stick automatically.

**Verified on test-dev:** with `?developer=1` QE Lab shows and nothing is persisted; without it — even after seeding a stale `ismDeveloperMode=1` — QE Lab is hidden and the key is cleared.

Note (out of scope): the Sweep **page** itself (`Sweep.vue`) still isn't developer-gated — only the nav link is hidden. Direct URL access remains possible; happy to add a page-level guard as a follow-up if you want it truly blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)