### PR TITLE
fix(proxy): custom/dynamic patterns get a stable pattern_enabled_<sig> label

### DIFF
--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log"
 	"math"
@@ -3933,6 +3934,19 @@ func (a *App) applyShapePattern(port int, steps []NftShapeStep, np NetemParams) 
 				break
 			}
 		}
+	}
+	if mode == "" && stepCount > 0 {
+		// Custom / unnamed pattern — no template mode (hand-edited steps via the
+		// testing UI, or a pattern applied without a named template). Derive a
+		// stable signature from the step profile so it still earns a distinct
+		// `pattern_enabled_custom_<sig>` label instead of collapsing every custom
+		// pattern into one bare `pattern_enabled` — otherwise "which pattern is
+		// running", especially dynamically-applied ones, is unfilterable.
+		h := fnv.New32a()
+		for _, s := range cleanSteps {
+			fmt.Fprintf(h, "%.3f:%g;", s.RateMbps, s.DurationSeconds)
+		}
+		mode = fmt.Sprintf("custom_%08x", h.Sum32())
 	}
 	info := fmt.Sprintf(`{"mode":%q,"steps":%d,"rate_mbps_first":%.3f,"delay_ms":%d,"packet_loss":%.3f}`,
 		mode, stepCount, firstRate, delayMs, loss)

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -795,6 +795,9 @@ func applyShapePatch(srv *Server, s map[string]any, shape any) {
 func applyPatternPatch(s map[string]any, pat any) {
 	if pat == nil {
 		delete(s, "_v2_shape_pattern")
+		// Clear the template name too so a later custom/unnamed pattern isn't
+		// mislabeled with a stale template.
+		delete(s, "nftables_pattern_template_mode")
 		// Setting nftables_pattern_enabled=false here is harmless;
 		// applyShapePattern with empty steps will write the same
 		// keys via updateSessionsByPortWithControl. Keeping the
@@ -807,6 +810,16 @@ func applyPatternPatch(s map[string]any, pat any) {
 		return
 	}
 	s["_v2_shape_pattern"] = m
+	// Mirror the template NAME onto the session field the pattern_enabled control
+	// event reads (nftables_pattern_template_mode), so a named template
+	// (valley / ramp_up / …) is labeled `pattern_enabled_<name>` instead of
+	// falling back to a step-profile signature. Absent/empty template leaves it
+	// unset → the proxy's signature fallback names it `custom_<hash>`.
+	if t, ok := m["template"].(string); ok && t != "" && t != "sliders" {
+		s["nftables_pattern_template_mode"] = t
+	} else {
+		delete(s, "nftables_pattern_template_mode")
+	}
 }
 
 // extractPatternSteps reads the v2 pattern stash from the session map


### PR DESCRIPTION
Piece ③ — makes **pattern filterable even when started dynamically via the web page**.

The forwarder already emits `pattern_enabled_<mode>` when a mode is present (`labels.go:795`). The gap was purely proxy-side: `mode` was sourced only from `nftables_pattern_template_mode`, which is **empty** for hand-edited/dynamic patterns and sweep patterns — so every such pattern collapsed into a bare `pattern_enabled`, undistinguishable.

**Fix:** when the template mode is empty but steps exist, derive a stable **fnv signature** from the step rate/duration profile → `mode = custom_<hash>`. Every pattern — named template, sweep, or custom dynamic — now carries a distinct `pattern_enabled_custom_<sig>` label, so identical patterns group and different ones separate. Named templates are unchanged.

`go build` / `go vet` clean. **Live verification needs a real pattern apply + play** (config-on-connect / runtime toggle) — verifying alongside ② with one sweep run.

Note: a *signature* isn't a friendly name; for friendly names on custom dynamic patterns the web-UI apply would also need to pass a `mode`. This guarantees distinguishability regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)