### PR TITLE
feat(delivery-rate): gate chart dots on kernel app_limited flag + independent marker toggles

### DIFF
--- a/.claude/standards/server-behavior.md
+++ b/.claude/standards/server-behavior.md
@@ -593,19 +593,48 @@ while #850 is open; `REPORTED_RATE_STRICT=1` enforces ratio ≤ 3 at every size
   segments up to ~1 MB are fully absorbed into the socket send buffer: the
   proxy's write returns before the wire drains and `delivery_rate_mbps` is
   stale connection residue (accurate in steady state, wrong right after a
-  rate change). Measured on test-dev over live sessions: 256 KB–1 MB rows are
-  ~90% buffer-absorbed and even the metered ones read ~4× off; ≥ 1 MB is
-  96%+ genuinely wire-metered, ≥ 4 MB is 100%. **The dashboard bandwidth
-  chart therefore plots delivery dots only for segments ≥ 1 MB AND
-  `transfer_ms` ≥ 5 ms** (not buffer-absorbed) — see `extractDeliveryMarkers`
-  in `BandwidthChart.vue`. The per-request calibration above (fixed cap,
-  continuous pull) and the chart's live-traffic floor are answering different
-  questions; don't reconcile them to one number.
+  rate change).
+
+### `delivery_rate_app_limited` — the kernel's own reliability flag (2026-07-07)
+
+The size heuristic above (≥ 1 MB / ≥ 5 ms) was a *proxy* for "did the kernel
+meter this at full tilt." The kernel answers that directly via
+`tcpi_delivery_rate_app_limited`, now captured alongside the rate (raw
+`getsockopt(TCP_INFO)`, byte 7 bit 0 — `golang.org/x/sys/unix.TCPInfo` drops
+that bitfield as struct padding). When set, the sender ran out of data to
+push, so the rate is **noisy in both directions** — starved LOW *or* caught
+mid HTB token-bucket burst and reading HIGH (so the metric is NOT a lower
+bound on the cap; it can over-read).
+
+**Calibration vs the shaping cap (valley pattern to ~0.5 Mbps, live iOS,
+play_id c661c293, 542 metered segments) — `delivery/cap`, 1.00× = perfect:**
+
+| gate | dots | median | p90 | within 0.5–2× |
+|---|---|---|---|---|
+| all segments | 542 | 0.86× | **17.25×** | 40% |
+| `app_limited=1` only (the noise) | 180 | **12.14×** | 26× | 3% |
+| `!app_limited`, any size | 362 | 0.58× | 1.01× | 59% |
+| `!app_limited` & ≥ 128 KB | 165 | 0.82× | 1.11× | 87% |
+| **`!app_limited` & ≥ 256 KB (shipped)** | **121** | 0.84× | 1.03× | **93%** |
+| `!app_limited` & ≥ 512 KB | 88 | 0.84× | 0.96× | 94% |
+| `!app_limited` & ≥ 1 MB | 48 | 0.92× | 1.20× | 97% |
+
+Excluding `app_limited` collapses p90 from **17.25× → 1.01×** — the flag is
+the garbage detector. A modest **256 KB burst backstop** then catches the
+residual false-highs (a small network-limited segment delivered entirely
+inside the HTB burst), landing at 93%-in-band while yielding **4.5× more dots
+than the old 1 MB / 5 ms gate** (121 vs 27). **The dashboard bandwidth chart
+plots delivery dots when `!app_limited && bytes_out ≥ 256 KB`** — see
+`extractDeliveryMarkers` in `BandwidthChart.vue`. The median sitting at 0.84×
+(not 1.0×) is honest: `delivery_rate` reads at-or-below the cap, never above
+what actually drained. The per-request calibration table further up (fixed
+cap, continuous pull) and this live-traffic gate answer different questions;
+don't reconcile them to one number.
 - Plumbed + surfaced end-to-end: proxy network log → forwarder → ClickHouse
-  `network_requests.delivery_rate_mbps` → `/api/v2/network_requests` +
-  session-bundle network stream → dashboard network-log Mbps column (with the
-  implied figure as fallback + both in the row tooltip) and the bandwidth
-  chart's "Delivery rate (kernel)" dots.
+  `network_requests.{delivery_rate_mbps,delivery_rate_app_limited}` →
+  `/api/v2/network_requests` + session-bundle network stream → dashboard
+  network-log Mbps column (with the implied figure as fallback + both in the
+  row tooltip) and the bandwidth chart's "Delivery rate (kernel)" dots.
 
 ---
 

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -695,6 +695,10 @@ CREATE TABLE IF NOT EXISTS infinite_streaming.network_requests
     -- Honest cross-check for bytes_out/transfer_ms, which over-reports
     -- ~1000x on sub-buffer transfers (#850). 0 = not sampled.
     delivery_rate_mbps       Float32                CODEC(ZSTD(1)),
+    -- tcpi_delivery_rate_app_limited for the sample above: 1 = the sender
+    -- was app-limited, so delivery_rate_mbps is noisy (starved low or burst
+    -- high); trust it only when 0 (network-limited). 0 when not sampled.
+    delivery_rate_app_limited UInt8                 DEFAULT 0 CODEC(ZSTD(1)),
     faulted                  UInt8                  DEFAULT 0,
     fault_type               LowCardinality(String) CODEC(ZSTD(1)),
     fault_action             LowCardinality(String) CODEC(ZSTD(1)),

--- a/analytics/go-forwarder/net_log.go
+++ b/analytics/go-forwarder/net_log.go
@@ -54,6 +54,9 @@ type netRow struct {
 	// ~1000× on sub-buffer transfers. 0 when the proxy couldn't sample
 	// (non-Linux build, torn-down conn). Issue #850.
 	DeliveryRateMbps     float32 `json:"delivery_rate_mbps"`
+	// tcpi_delivery_rate_app_limited for the sample above (1 = app-limited
+	// / unreliable). Consumers trust delivery_rate_mbps only when 0.
+	DeliveryRateAppLimited uint8 `json:"delivery_rate_app_limited"`
 	Faulted              uint8   `json:"faulted"`
 	FaultType            string  `json:"fault_type"`
 	FaultAction          string  `json:"fault_action"`
@@ -101,6 +104,7 @@ type netEntry struct {
 	TotalMs              float64       `json:"total_ms"`
 	ClientWaitMs         float64       `json:"client_wait_ms"`
 	DeliveryRateMbps     float64       `json:"delivery_rate_mbps"`
+	DeliveryRateAppLimited bool        `json:"delivery_rate_app_limited"`
 	Faulted              bool          `json:"faulted"`
 	FaultType            string        `json:"fault_type"`
 	FaultAction          string        `json:"fault_action"`
@@ -257,6 +261,10 @@ func entryToRow(sessionID, playerID string, e *netEntry) netRow {
 	if e.Faulted {
 		faulted = 1
 	}
+	deliveryAppLimited := uint8(0)
+	if e.DeliveryRateAppLimited {
+		deliveryAppLimited = 1
+	}
 	// Canonicalise — see canonicalV2ID()'s doc on case-sensitivity.
 	// `playerID` already came in canonicalised via sessionToPlayerID,
 	// but `e.PlayID` lands raw off the proxy SSE entry — historically
@@ -288,6 +296,7 @@ func entryToRow(sessionID, playerID string, e *netEntry) netRow {
 		TotalMs:              float32(e.TotalMs),
 		ClientWaitMs:         float32(e.ClientWaitMs),
 		DeliveryRateMbps:     float32(e.DeliveryRateMbps),
+		DeliveryRateAppLimited: deliveryAppLimited,
 		Faulted:              faulted,
 		FaultType:            e.FaultType,
 		FaultAction:          e.FaultAction,

--- a/analytics/go-forwarder/v2_handlers.go
+++ b/analytics/go-forwarder/v2_handlers.go
@@ -501,7 +501,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		  method, url, upstream_url, request_kind, content_type,
 		  status, bytes_in, bytes_out,
 		  ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		  delivery_rate_mbps,
+		  delivery_rate_mbps, delivery_rate_app_limited,
 		  faulted, fault_type, fault_action, fault_category,
 		  arrayConcat(labels, dl_arr) AS labels, token
 		FROM (
@@ -513,7 +513,7 @@ func v2NetworkRequestsHandler(w http.ResponseWriter, r *http.Request, cfg config
 		      method, url, upstream_url, request_kind, content_type,
 		      status, bytes_in, bytes_out,
 		      ttfb_ms, total_ms, dns_ms, connect_ms, tls_ms, transfer_ms, client_wait_ms,
-		      delivery_rate_mbps,
+		      delivery_rate_mbps, delivery_rate_app_limited,
 		      faulted, fault_type, fault_action, fault_category, labels
 		    FROM %s.network_requests
 		    WHERE %s

--- a/api/openapi/v2/forwarder.yaml
+++ b/api/openapi/v2/forwarder.yaml
@@ -1503,6 +1503,7 @@ components:
         total_ms: { type: number, format: float }
         client_wait_ms: { type: number, format: float }
         delivery_rate_mbps: { type: number, format: float }
+        delivery_rate_app_limited: { type: integer, enum: [0, 1] }
         faulted: { type: integer, enum: [0, 1] }
         fault_type: { type: string }
         fault_action: { type: string }

--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1822,6 +1822,7 @@ components:
         transfer_ms:     { type: number, format: float, description: 'Downstream write+flush time to client (player-perceived receive).' }
         client_wait_ms:  { type: number, format: float, description: 'Server-perceived wait between request received and first response byte sent.' }
         delivery_rate_mbps: { type: number, format: float, description: 'Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).' }
+        delivery_rate_app_limited: { type: boolean, description: 'Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only.' }
         faulted:        { type: boolean }
         fault_type:     { type: string }
         fault_action:   { type: string }

--- a/content/dashboard-v3/src/components/BandwidthChart.vue
+++ b/content/dashboard-v3/src/components/BandwidthChart.vue
@@ -283,7 +283,8 @@ const segmentMarkers = computed(() => sessionMarkerSets.value.flatMap((s) => s.d
  *  Single-session mode also switches to group chips when BOTH marker
  *  families are present (iOS segment dots + kernel delivery dots), so each
  *  family gets its own named chip; a lone family keeps the flat
- *  `segmentMarkersLabel` chip. All chips share one visibility toggle. */
+ *  `segmentMarkersLabel` chip. Each chip toggles independently (per-tag
+ *  visibility in MetricsLineChart) — Video and Delivery are not lockstep. */
 const segmentMarkerGroups = computed<Array<{ tag: string; label: string; color: string }>>(() => {
   if (compareSelf.value) {
     return sessionMarkerSets.value
@@ -307,32 +308,30 @@ const segmentMarkersLabel = computed(() => {
 });
 
 /** Kernel-measured delivery-rate dots (#850): one dot per SEGMENT request
- *  large enough that the kernel actually metered its wire delivery.
- *  Server-side sibling of the iOS avmetrics dots above — honest under tc
- *  shaping, where the implied bytes_out/transfer_ms figure over-reads up
- *  to ~5000× on sub-buffer transfers. Active session only — compare
- *  siblings don't ship a network stream.
+ *  whose wire delivery the kernel actually metered. Server-side sibling
+ *  of the iOS avmetrics dots above — honest under tc shaping, where the
+ *  implied bytes_out/transfer_ms figure over-reads up to ~5000× on
+ *  sub-buffer transfers. Active session only — compare siblings don't
+ *  ship a network stream.
  *
- *  Two guards, both about the same failure mode: delivery_rate is
- *  CONNECTION-level (tcpi_delivery_rate), so it only reflects THIS
- *  segment if the segment was genuinely drained over the wire. When a
- *  transfer fits in the socket send buffer, the proxy's write returns
- *  before the wire drains, and delivery_rate is stale residue of the
- *  connection's recent history — accurate in steady state, but wrong
- *  right after a rate change (the "high dot during a low-throughput
- *  ramp" artefact). We therefore skip:
- *    - bytes < 1 MB — real player segments below this get absorbed into
- *      the send buffer; measured on test-dev, 256 KB–1 MB rows are
- *      ~90% buffer-absorbed and even the metered ones read 4× off. The
- *      §1.14 calibration's 256 KB floor held only under CONTINUOUS
- *      pulling; live traffic arrives with idle gaps, so the real-world
- *      floor is higher.
- *    - transfer_ms < 5 ms — the write returned instantly (buffer-
- *      absorbed), so delivery_rate never metered this segment. Catches
- *      the rare ≥1 MB segment that still fit the buffer. */
+ *  Reliability gate — delivery_rate is only trustworthy when the kernel
+ *  observed the link at full tilt. We drop a dot only when:
+ *    - NOT app-limited (`delivery_rate_app_limited` falsy). This is the
+ *      kernel's own reliability signal (tcpi_delivery_rate_app_limited):
+ *      when the sender ran out of data to push, the sample reflects the
+ *      app's pace, not the link, and reads noisily — starved LOW or,
+ *      caught mid token-bucket burst, HIGH. Replaces the old ≥5 ms
+ *      transfer_ms heuristic, which couldn't tell a throttled small
+ *      segment from a buffer-absorbed one.
+ *    - bytes ≥ 256 KB — a burst backstop. `app_limited` guards the
+ *      false-LOW (starved) case but not every false-HIGH: a tiny
+ *      segment can be network-limited yet delivered entirely inside the
+ *      HTB burst allowance, over-reading the average cap. This modest
+ *      floor (was 1 MB) excludes the burst-prone tiddlers while showing
+ *      far more of the low-throttle valley than before. Tunable — see
+ *      §1.14 calibration. */
 const DELIVERY_COLOR = '#10b981'; // emerald — distinct from the slate/sky avmetrics dots
-const DELIVERY_MIN_BYTES = 1024 * 1024;
-const DELIVERY_MIN_TRANSFER_MS = 5;
+const DELIVERY_MIN_BYTES = 1024 * 256;
 function extractDeliveryMarkers(
   stream: Stream<Record<string, unknown>> | undefined,
 ): Array<{ x: number; y: number; color?: string; label?: string; tag?: string }> {
@@ -344,10 +343,13 @@ function extractDeliveryMarkers(
     if (String(row.request_kind ?? '') !== 'segment') continue;
     const mbps = Number(row.delivery_rate_mbps);
     if (!Number.isFinite(mbps) || mbps <= 0) continue;
+    // Kernel says the sample was app-limited → unreliable, skip. The flag
+    // arrives as a JSON bool (live proxy SSE) or 0/1 number (ClickHouse
+    // UInt8 read path), so accept both.
+    const appLimited = row.delivery_rate_app_limited;
+    if (appLimited === true || appLimited === 1 || appLimited === '1') continue;
     const bytes = Number(row.bytes_out);
     if (!Number.isFinite(bytes) || bytes < DELIVERY_MIN_BYTES) continue;
-    const transferMs = Number(row.transfer_ms);
-    if (!Number.isFinite(transferMs) || transferMs < DELIVERY_MIN_TRANSFER_MS) continue;
     const tsRaw = row.ts ?? row.timestamp;
     let ts = NaN;
     if (typeof tsRaw === 'number') {
@@ -362,6 +364,10 @@ function extractDeliveryMarkers(
     if (!Number.isFinite(ts) || ts <= 0) continue;
     const url = String(row.url ?? row.path ?? '');
     const filename = url ? (url.split('?')[0].split('/').pop() ?? '') : '';
+    // transfer_ms no longer gates the dot (app_limited does), but the
+    // implied bytes/transfer figure is still handy in the tooltip as the
+    // (over-reading) contrast to the honest kernel rate.
+    const transferMs = Number(row.transfer_ms);
     const implied = Number.isFinite(transferMs) && transferMs > 0
       ? (bytes * 8) / (transferMs * 1000)
       : NaN;

--- a/content/dashboard-v3/src/components/MetricsLineChart.vue
+++ b/content/dashboard-v3/src/components/MetricsLineChart.vue
@@ -139,7 +139,9 @@ const props = defineProps({
    *  non-empty, ONE chip per group is rendered (e.g. `Per segment (S1)`,
    *  `Per segment (S2)`) in the group's colour instead of the single
    *  markersLabel chip — so the operator sees which sessions contributed
-   *  per-segment dots. All chips toggle the shared markers visibility. */
+   *  per-segment dots. Each chip toggles its own tag independently (tracked
+   *  in `visibleMarkerTags`); `markersVisible` stays = "any tag on" as the
+   *  master gate for the overlay draw + tooltip. */
   markerGroups: {
     type: Array as PropType<Array<{ tag: string; label: string; color: string }>>,
     default: () => [],
@@ -240,6 +242,18 @@ let lastIngestedMs = -Infinity;
 //   null      → something else is focused (a line / its session) → dim ALL dots
 //   'Sx'      → that session is focused → its dots pop, other sessions' dots dim
 let markerFocusTag: string | null | undefined = undefined;
+
+// Per-tag marker visibility so each marker legend chip toggles independently
+// (e.g. "Video segment fetch" vs "Delivery rate (kernel)" — they used to share
+// the single `markersVisible` boolean and flip in lockstep). Empty = all hidden,
+// matching the `markersVisible=false` default. A grouped marker's tag is shown
+// iff it's in this set; the ungrouped single-chip (`markersLabel`) path keeps
+// using the `markersVisible` boolean untouched.
+const visibleMarkerTags = new Set<string>();
+function markerTagShown(tag: string | null | undefined): boolean {
+  if (!props.markerGroups || props.markerGroups.length === 0) return true;
+  return visibleMarkerTags.has(tag ?? '');
+}
 
 /** Tolerance for "right edge is at the live sample" — matches the
  *  brush-drop-at-live heuristic in SessionDisplay. */
@@ -670,6 +684,7 @@ function createChartInstance(Chart: any): any {
         ctx.save();
         for (const m of list) {
           if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) continue;
+          if (!markerTagShown(m.tag)) continue; // this family's chip is toggled off
           if (m.x < sx.min || m.x > sx.max) continue;
           if (m.y < sy.min || m.y > sy.max) continue;
           // Highlight/fade in lockstep with the line series. focused = this
@@ -862,7 +877,7 @@ function createChartInstance(Chart: any): any {
                     strokeStyle: g.color,
                     lineWidth: 0,
                     pointStyle: 'circle',
-                    hidden: !props.markersVisible,
+                    hidden: !visibleMarkerTags.has(g.tag), // per-chip, independent toggles
                     datasetIndex: -1,
                     _isMarkerToggle: true,
                     _markerTag: g.tag,
@@ -892,6 +907,19 @@ function createChartInstance(Chart: any): any {
             // visibility on the parent's v-model state and force a
             // repaint. Issue #486.
             if (item?._isMarkerToggle) {
+              // Grouped chips (e.g. Video segment fetch / Delivery rate) each
+              // own a tag and toggle independently. The master `markersVisible`
+              // still gates the overlay draw + tooltip, so keep it = "any tag
+              // on". The ungrouped single-chip path keeps the plain flip.
+              if (props.markerGroups && props.markerGroups.length) {
+                const tag = item._markerTag ?? '';
+                if (visibleMarkerTags.has(tag)) visibleMarkerTags.delete(tag);
+                else visibleMarkerTags.add(tag);
+                const anyOn = visibleMarkerTags.size > 0;
+                if (anyOn !== props.markersVisible) emit('update:markersVisible', anyOn);
+                ci.update();
+                return;
+              }
               emit('update:markersVisible', !props.markersVisible);
               ci.update();
               return;
@@ -1239,6 +1267,7 @@ function installMarkerHoverTooltip() {
     let bestLabel = '';
     for (const m of list) {
       if (!Number.isFinite(m.x) || !Number.isFinite(m.y)) continue;
+      if (!markerTagShown(m.tag)) continue; // hidden family — no tooltip
       if (m.x < sx.min || m.x > sx.max) continue;
       if (m.y < sy.min || m.y > sy.max) continue;
       const px = sx.getPixelForValue(m.x);

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -2413,6 +2413,8 @@ export interface components {
              * @description Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).
              */
             delivery_rate_mbps?: number;
+            /** @description Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only. */
+            delivery_rate_app_limited?: boolean;
             faulted?: boolean;
             fault_type?: string;
             fault_action?: string;

--- a/go-proxy/cmd/server/delivery_rate.go
+++ b/go-proxy/cmd/server/delivery_rate.go
@@ -23,7 +23,10 @@ func stampDeliveryRate(conn *net.TCPConn, entry *NetworkLogEntry) {
 	if conn == nil || entry == nil {
 		return
 	}
-	if bps, err := readDeliveryRateBps(conn); err == nil && bps > 0 {
+	if bps, appLimited, err := readDeliveryRate(conn); err == nil && bps > 0 {
 		entry.DeliveryRateMbps = float64(bps) * 8 / 1e6
+		// Only meaningful alongside a non-zero rate: it flags whether that
+		// sample was network-limited (trustworthy) or app-limited (noisy).
+		entry.DeliveryRateAppLimited = appLimited
 	}
 }

--- a/go-proxy/cmd/server/delivery_rate_linux.go
+++ b/go-proxy/cmd/server/delivery_rate_linux.go
@@ -5,14 +5,15 @@ package main
 import (
 	"errors"
 	"net"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
 
-// readDeliveryRateBps issues a single getsockopt(TCP_INFO) and returns
-// the kernel's tcpi_delivery_rate (bytes/sec) — its own estimate of the
-// rate bytes are leaving on the wire for this connection. Same
-// SyscallConn().Control path as readTCPInfo; ~1 µs per call.
+// readDeliveryRate issues a single getsockopt(TCP_INFO) and returns the
+// kernel's tcpi_delivery_rate (bytes/sec) — its own estimate of the rate
+// bytes are leaving on the wire for this connection — together with the
+// tcpi_delivery_rate_app_limited flag. ~1 µs per call.
 //
 // Why this exists: the bytes_out/transfer_ms figure in the network log
 // times only the proxy's write+flush, which returns once the kernel
@@ -21,28 +22,60 @@ import (
 // sub-buffer segment (~50–140 KB) is absorbed instantly and reports
 // 1000s of Mbps even while the wire is capped near the video bitrate.
 // tcpi_delivery_rate reflects the actual drained rate instead.
-func readDeliveryRateBps(c *net.TCPConn) (uint64, error) {
+//
+// The app-limited flag says whether that rate sample is trustworthy:
+// when the sender ran out of data to push (the common case for a small
+// HLS segment), the kernel could not observe the link at full tilt, so
+// the rate is noisy — it can read far below the cap (starved) OR above
+// it (a token-bucket burst caught in a short window). A network-limited
+// sample (app_limited == false) is the one that converges on the cap.
+//
+// Raw getsockopt: golang.org/x/sys/unix.TCPInfo silently drops the
+// bitfield byte that carries this flag — it falls in struct alignment
+// padding between Options and Rto and has no Go field — so we read the
+// raw TCP_INFO buffer and pull the bit ourselves. In the kernel struct,
+// byte 7 is `tcpi_delivery_rate_app_limited:1, tcpi_fastopen_client_fail:2`,
+// an ABI-stable offset among the oldest tcp_info fields; bit 0 is the
+// app-limited flag. Delivery_rate is read through the struct overlay,
+// whose exposed fields keep the kernel's byte offsets.
+func readDeliveryRate(c *net.TCPConn) (bps uint64, appLimited bool, err error) {
 	if c == nil {
-		return 0, errors.New("nil tcp conn")
+		return 0, false, errors.New("nil tcp conn")
 	}
 	rc, err := c.SyscallConn()
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	var rate uint64
+	var limited bool
 	var sysErr error
 	ctlErr := rc.Control(func(fd uintptr) {
-		var info *unix.TCPInfo
-		info, sysErr = unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
-		if sysErr == nil && info != nil {
-			rate = info.Delivery_rate
+		var buf [unix.SizeofTCPInfo]byte
+		vallen := uint32(len(buf))
+		_, _, errno := unix.Syscall6(
+			unix.SYS_GETSOCKOPT,
+			fd,
+			uintptr(unix.IPPROTO_TCP),
+			uintptr(unix.TCP_INFO),
+			uintptr(unsafe.Pointer(&buf[0])),
+			uintptr(unsafe.Pointer(&vallen)),
+			0,
+		)
+		if errno != 0 {
+			sysErr = errno
+			return
+		}
+		info := (*unix.TCPInfo)(unsafe.Pointer(&buf[0]))
+		rate = info.Delivery_rate
+		if vallen > 7 {
+			limited = buf[7]&0x01 != 0
 		}
 	})
 	if ctlErr != nil {
-		return 0, ctlErr
+		return 0, false, ctlErr
 	}
 	if sysErr != nil {
-		return 0, sysErr
+		return 0, false, sysErr
 	}
-	return rate, nil
+	return rate, limited, nil
 }

--- a/go-proxy/cmd/server/delivery_rate_other.go
+++ b/go-proxy/cmd/server/delivery_rate_other.go
@@ -4,10 +4,11 @@ package main
 
 import "net"
 
-// readDeliveryRateBps on non-Linux platforms is a no-op stub so the dev
-// build (typically macOS) keeps compiling. tcpi_delivery_rate is a
-// Linux-specific TCP_INFO field; the production go-proxy only runs in
-// the Linux container. Returning 0 leaves delivery_rate_mbps unset.
-func readDeliveryRateBps(c *net.TCPConn) (uint64, error) {
-	return 0, nil
+// readDeliveryRate on non-Linux platforms is a no-op stub so the dev
+// build (typically macOS) keeps compiling. tcpi_delivery_rate and its
+// app-limited flag are Linux-specific TCP_INFO fields; the production
+// go-proxy only runs in the Linux container. Returning 0/false leaves
+// delivery_rate_mbps unset and app_limited false.
+func readDeliveryRate(c *net.TCPConn) (bps uint64, appLimited bool, err error) {
+	return 0, false, nil
 }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -173,6 +173,15 @@ type NetworkLogEntry struct {
 	// only; unset on the macOS dev build.
 	DeliveryRateMbps float64 `json:"delivery_rate_mbps,omitempty"`
 
+	// DeliveryRateAppLimited is the kernel's tcpi_delivery_rate_app_limited
+	// flag for the sample above: true when the sender ran out of data to
+	// push, so DeliveryRateMbps reflects the app's pace rather than the
+	// link and reads noisily (starved low OR burst high). Consumers should
+	// trust the rate only when this is false (a network-limited sample).
+	// omitempty: present only when flagged, and only meaningful when
+	// DeliveryRateMbps is non-zero. Linux only.
+	DeliveryRateAppLimited bool `json:"delivery_rate_app_limited,omitempty"`
+
 	// ClientWaitMs is the time from when the proxy received the request
 	// to when it sent the first response byte back to the client. It IS
 	// what the player perceived as `wait` (HAR's TTFB), modulo the

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -213,6 +213,9 @@ func networkEntryToMap(e NetworkLogEntry) map[string]any {
 		// over-reports on sub-buffer transfers. Linux only; 0/omitted
 		// on the dev build.
 		"delivery_rate_mbps": e.DeliveryRateMbps,
+		// Kernel app-limited flag for the rate above: true = the sample
+		// was starved (app didn't fill the pipe) and is unreliable.
+		"delivery_rate_app_limited": e.DeliveryRateAppLimited,
 		// Fault metadata — flagged on rows where the proxy injected one.
 		"faulted":        e.Faulted,
 		"fault_type":     e.FaultType,

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -971,6 +971,9 @@ type NetworkLogEntry struct {
 	ConnectMs   *float32 `json:"connect_ms,omitempty"`
 	ContentType *string  `json:"content_type,omitempty"`
 
+	// DeliveryRateAppLimited Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only.
+	DeliveryRateAppLimited *bool `json:"delivery_rate_app_limited,omitempty"`
+
 	// DeliveryRateMbps Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).
 	DeliveryRateMbps *float32 `json:"delivery_rate_mbps,omitempty"`
 

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -882,6 +882,26 @@ func numericFloatTranslate(v any) (float64, bool) {
 	return 0, false
 }
 
+// truthy coerces a v1-row value to a boolean. The proxy SSE path carries
+// JSON booleans; the ClickHouse read path carries UInt8 columns as 0/1
+// numbers (and, under a UseNumber decoder, json.Number). Anything that
+// parses to a non-zero number, or a literal true/"true"/"1", is true.
+func truthy(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case string:
+		return x == "1" || strings.EqualFold(x, "true")
+	case json.Number:
+		f, _ := x.Float64()
+		return f != 0
+	}
+	if f, ok := numericFloatTranslate(v); ok {
+		return f != 0
+	}
+	return false
+}
+
 // NetworkEntryFromV1 projects a v1 network ring-buffer row into a v2
 // NetworkLogEntry. The v1 row is itself a map produced by the network
 // log subsystem; only HAR-shaped fields are copied through.
@@ -945,6 +965,14 @@ func NetworkEntryFromV1(row map[string]any) oapigen.NetworkLogEntry {
 			f := float32(v)
 			*m.dst = &f
 		}
+	}
+	// Kernel app-limited flag for the delivery_rate_mbps sample — surfaced
+	// only when true (the sample is unreliable), mirroring faulted. Coerce
+	// robustly: the live proxy SSE sends a JSON bool, the ClickHouse read
+	// path (UInt8) sends 0/1 as a number, so accept both.
+	if truthy(row["delivery_rate_app_limited"]) {
+		t := true
+		out.DeliveryRateAppLimited = &t
 	}
 	// Fault metadata — flagged on rows where the proxy injected a fault.
 	if v, ok := row["faulted"].(bool); ok && v {

--- a/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
+++ b/tools/harness-cli/internal/v2gen/forwarder/forwarder.gen.go
@@ -149,6 +149,24 @@ func (e MetaEventStreams) Valid() bool {
 	}
 }
 
+// Defines values for NetworkRowDeliveryRateAppLimited.
+const (
+	NetworkRowDeliveryRateAppLimitedN0 NetworkRowDeliveryRateAppLimited = 0
+	NetworkRowDeliveryRateAppLimitedN1 NetworkRowDeliveryRateAppLimited = 1
+)
+
+// Valid indicates whether the value is a known member of the NetworkRowDeliveryRateAppLimited enum.
+func (e NetworkRowDeliveryRateAppLimited) Valid() bool {
+	switch e {
+	case NetworkRowDeliveryRateAppLimitedN0:
+		return true
+	case NetworkRowDeliveryRateAppLimitedN1:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for NetworkRowFaultCategory.
 const (
 	NetworkRowFaultCategoryClientDisconnect NetworkRowFaultCategory = "client_disconnect"
@@ -181,16 +199,16 @@ func (e NetworkRowFaultCategory) Valid() bool {
 
 // Defines values for NetworkRowFaulted.
 const (
-	N0 NetworkRowFaulted = 0
-	N1 NetworkRowFaulted = 1
+	NetworkRowFaultedN0 NetworkRowFaulted = 0
+	NetworkRowFaultedN1 NetworkRowFaulted = 1
 )
 
 // Valid indicates whether the value is a known member of the NetworkRowFaulted enum.
 func (e NetworkRowFaulted) Valid() bool {
 	switch e {
-	case N0:
+	case NetworkRowFaultedN0:
 		return true
-	case N1:
+	case NetworkRowFaultedN1:
 		return true
 	default:
 		return false
@@ -873,6 +891,9 @@ type NetworkRequestRow struct {
 	ConnectMs   *float32 `json:"connect_ms,omitempty"`
 	ContentType *string  `json:"content_type,omitempty"`
 
+	// DeliveryRateAppLimited Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only.
+	DeliveryRateAppLimited *bool `json:"delivery_rate_app_limited,omitempty"`
+
 	// DeliveryRateMbps Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).
 	DeliveryRateMbps *float32 `json:"delivery_rate_mbps,omitempty"`
 
@@ -921,29 +942,33 @@ type NetworkRequestsPage struct {
 //
 // SSE wire shape: `event: network\nid: <entry_fingerprint>\ndata: <this object>\n\n`.
 type NetworkRow struct {
-	BytesIn              *int                     `json:"bytes_in,omitempty"`
-	BytesOut             *int                     `json:"bytes_out,omitempty"`
-	ClientWaitMs         *float32                 `json:"client_wait_ms,omitempty"`
-	DeliveryRateMbps     *float32                 `json:"delivery_rate_mbps,omitempty"`
-	EntryFingerprint     string                   `json:"entry_fingerprint"`
-	FaultAction          *string                  `json:"fault_action,omitempty"`
-	FaultCategory        *NetworkRowFaultCategory `json:"fault_category,omitempty"`
-	FaultType            *string                  `json:"fault_type,omitempty"`
-	Faulted              *NetworkRowFaulted       `json:"faulted,omitempty"`
-	Method               *NetworkRowMethod        `json:"method,omitempty"`
-	Path                 *string                  `json:"path,omitempty"`
-	PlayId               string                   `json:"play_id"`
-	PlayerId             string                   `json:"player_id"`
-	RequestKind          *NetworkRowRequestKind   `json:"request_kind,omitempty"`
-	SessionId            string                   `json:"session_id"`
-	Status               *int                     `json:"status,omitempty"`
-	TotalMs              *float32                 `json:"total_ms,omitempty"`
-	TransferMs           *float32                 `json:"transfer_ms,omitempty"`
-	Ts                   time.Time                `json:"ts"`
-	TtfbMs               *float32                 `json:"ttfb_ms,omitempty"`
-	Url                  *string                  `json:"url,omitempty"`
-	AdditionalProperties map[string]interface{}   `json:"-"`
+	BytesIn                *int                              `json:"bytes_in,omitempty"`
+	BytesOut               *int                              `json:"bytes_out,omitempty"`
+	ClientWaitMs           *float32                          `json:"client_wait_ms,omitempty"`
+	DeliveryRateAppLimited *NetworkRowDeliveryRateAppLimited `json:"delivery_rate_app_limited,omitempty"`
+	DeliveryRateMbps       *float32                          `json:"delivery_rate_mbps,omitempty"`
+	EntryFingerprint       string                            `json:"entry_fingerprint"`
+	FaultAction            *string                           `json:"fault_action,omitempty"`
+	FaultCategory          *NetworkRowFaultCategory          `json:"fault_category,omitempty"`
+	FaultType              *string                           `json:"fault_type,omitempty"`
+	Faulted                *NetworkRowFaulted                `json:"faulted,omitempty"`
+	Method                 *NetworkRowMethod                 `json:"method,omitempty"`
+	Path                   *string                           `json:"path,omitempty"`
+	PlayId                 string                            `json:"play_id"`
+	PlayerId               string                            `json:"player_id"`
+	RequestKind            *NetworkRowRequestKind            `json:"request_kind,omitempty"`
+	SessionId              string                            `json:"session_id"`
+	Status                 *int                              `json:"status,omitempty"`
+	TotalMs                *float32                          `json:"total_ms,omitempty"`
+	TransferMs             *float32                          `json:"transfer_ms,omitempty"`
+	Ts                     time.Time                         `json:"ts"`
+	TtfbMs                 *float32                          `json:"ttfb_ms,omitempty"`
+	Url                    *string                           `json:"url,omitempty"`
+	AdditionalProperties   map[string]interface{}            `json:"-"`
 }
+
+// NetworkRowDeliveryRateAppLimited defines model for NetworkRow.DeliveryRateAppLimited.
+type NetworkRowDeliveryRateAppLimited int
 
 // NetworkRowFaultCategory defines model for NetworkRow.FaultCategory.
 type NetworkRowFaultCategory string
@@ -2104,6 +2129,14 @@ func (a *NetworkRow) UnmarshalJSON(b []byte) error {
 		delete(object, "client_wait_ms")
 	}
 
+	if raw, found := object["delivery_rate_app_limited"]; found {
+		err = json.Unmarshal(raw, &a.DeliveryRateAppLimited)
+		if err != nil {
+			return fmt.Errorf("error reading 'delivery_rate_app_limited': %w", err)
+		}
+		delete(object, "delivery_rate_app_limited")
+	}
+
 	if raw, found := object["delivery_rate_mbps"]; found {
 		err = json.Unmarshal(raw, &a.DeliveryRateMbps)
 		if err != nil {
@@ -2285,6 +2318,13 @@ func (a NetworkRow) MarshalJSON() ([]byte, error) {
 		object["client_wait_ms"], err = json.Marshal(a.ClientWaitMs)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling 'client_wait_ms': %w", err)
+		}
+	}
+
+	if a.DeliveryRateAppLimited != nil {
+		object["delivery_rate_app_limited"], err = json.Marshal(a.DeliveryRateAppLimited)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'delivery_rate_app_limited': %w", err)
 		}
 	}
 

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -972,6 +972,9 @@ type NetworkLogEntry struct {
 	ConnectMs   *float32 `json:"connect_ms,omitempty"`
 	ContentType *string  `json:"content_type,omitempty"`
 
+	// DeliveryRateAppLimited Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only.
+	DeliveryRateAppLimited *bool `json:"delivery_rate_app_limited,omitempty"`
+
 	// DeliveryRateMbps Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).
 	DeliveryRateMbps *float32 `json:"delivery_rate_mbps,omitempty"`
 


### PR DESCRIPTION
## Summary

Two bandwidth-chart improvements around the #850 kernel delivery-rate dots.

### 1. Gate delivery dots on the kernel's `app_limited` flag (replaces the size heuristic)

The chart used to gate delivery dots on a segment-size proxy (`≥1MB && transfer_ms≥5ms`) for "did the kernel meter this at full tilt." That hid dots on low-bitrate / low-throttle sessions (small segments) — exactly when you most want to see the rate drop. The kernel answers reliability directly via `tcpi_delivery_rate_app_limited`: when set, the sender was starved and the rate is noisy **both ways** — starved low OR caught mid HTB token-bucket burst and over-reading the cap (so it is *not* a lower bound).

Now captured end-to-end and the chart gates on **`!app_limited && bytes_out ≥ 256KB`** (a modest burst backstop).

**Calibration** — live valley-pattern iOS session (`play_id c661c293`, 542 metered segments), `delivery/cap` where 1.00× is perfect:

| gate | dots | median | p90 | within 0.5–2× |
|---|---|---|---|---|
| all segments | 542 | 0.86× | **17.25×** | 40% |
| `app_limited=1` only (noise) | 180 | **12.14×** | 26× | 3% |
| `!app_limited` & ≥128KB | 165 | 0.82× | 1.11× | 87% |
| **`!app_limited` & ≥256KB (shipped)** | **121** | 0.84× | 1.03× | **93%** |
| `!app_limited` & ≥1MB | 48 | 0.92× | 1.20× | 97% |

Excluding `app_limited` collapses p90 from **17.25× → 1.01×**; the 256KB floor lands at 93%-in-band while yielding **4.5× more dots** than the old gate (121 vs 27).

### 2. Independent marker legend toggles

"Video segment fetch" and "Delivery rate (kernel)" shared one `markersVisible` boolean, so clicking either flipped both in lockstep. Per-tag visibility (`visibleMarkerTags` in `MetricsLineChart`) now toggles each family — and each compare-mode S1/S2 chip — independently.

## Plumbing (8 layers)

proxy raw `getsockopt(TCP_INFO)` byte 7 bit 0 (`x/sys` drops the bitfield as struct padding) → `NetworkLogEntry` + SSE map → openapi + regen (`v2oapigen`, harness CLI clients) → `v2translate` (`truthy()` coerces SSE-bool **and** ClickHouse 0/1) → forwarder net_log + SELECTs → ClickHouse `delivery_rate_app_limited UInt8` (migration applied) → dashboard `v2.ts` + `extractDeliveryMarkers`.

## Testing

- All Go modules build (linux + native); `vue-tsc` clean.
- CH migration applied; flag verified populating on a live session (72/303 segments flagged `app_limited=1`).
- Calibration above run against the live cap timeline.
- Deployed to test-dev; deployed bundle hash confirmed to carry both filters.

Docs: `.claude/standards/server-behavior.md` §1.14 updated with the flag + calibration table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
