### PR TITLE
fix(clickhouse): self-heal analytics schema on boot (create-or-upgrade)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,6 +660,12 @@ analytics-migrate:
 	  done < /tmp/.analytics-migrate.sql; \
 	  rm -f /tmp/.analytics-migrate.sql; \
 	  exit $$rc'
+	@echo ""
+	@echo "⚠  This ALTER ran ONLY on the live primary. Fresh installs and the"
+	@echo "   ClickHouse self-heal both build from analytics/clickhouse/init.d/01-schema.sql —"
+	@echo "   add the SAME change there (idempotent: CREATE/ADD COLUMN ... IF [NOT] EXISTS)"
+	@echo "   or it silently won't reach new/rebuilt stacks. Un-backported migrations are"
+	@echo "   exactly what blanked the dashboard before."
 
 test-clean-dev:
 	ssh $(TEST_SSH) 'docker rm -f test-dev-server 2>/dev/null'
@@ -736,6 +742,15 @@ test-deploy-oobe:
 		"$(TEST_OOBE_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(TEST_HOST)" "$(TEST_HOST)" > ~/test-oobe/.env'
 	scp tests/deploy/override-oobe.yml $(TEST_SSH):~/test-oobe/docker-compose.override.yml
 	ssh $(TEST_SSH) 'cd ~/test-oobe && VERSION=$$(cat VERSION) docker compose -p test-oobe build && docker compose -p test-oobe up -d'
+	@# Smoke test: a fresh install boots green even with a broken analytics
+	@# schema — the failure only shows when the dashboard queries the events/
+	@# network timeseries (a missing session_events column errors the backfill,
+	@# blanking the Network Log + PlayLog). Exercise that exact query with a
+	@# dummy player (needs no data — CH validates columns at analysis time) so a
+	@# broken clean install FAILS this deploy instead of shipping a dead dashboard.
+	@echo "=== OOBE smoke: dashboard timeseries schema-drift guard ==="
+	scp tests/deploy/oobe-smoke.sh $(TEST_SSH):~/test-oobe/oobe-smoke.sh
+	ssh $(TEST_SSH) 'bash ~/test-oobe/oobe-smoke.sh https://localhost:26000'
 
 test-clean-oobe:
 	@case "$(TEST_OOBE_MEDIA_DIR)" in \

--- a/analytics/clickhouse/init.d/01-schema.sql
+++ b/analytics/clickhouse/init.d/01-schema.sql
@@ -648,11 +648,30 @@ ALTER TABLE infinite_streaming.session_events
 -- so step 2's IF EXISTS is a no-op (nothing to drop) and step 3 is
 -- a no-op (nothing to rename — control_revision_str was never added
 -- because step 1 above is IF NOT EXISTS).
-ALTER TABLE infinite_streaming.session_events
-    DROP COLUMN IF EXISTS control_revision;
+-- NOTE (fix): the DROP + RENAME dance that used to live here was a one-time
+-- UInt64→String migration for clusters that predated the canonical String
+-- column. It was actively HARMFUL on a fresh install: init.d runs ONLY on first
+-- DB creation, where the CREATE TABLE above already declares control_revision as
+-- String — so `DROP COLUMN IF EXISTS control_revision` dropped that good column,
+-- and the RENAME (of a control_revision_str that was NEVER actually added — the
+-- "already done above" was aspirational) couldn't restore it. Result: every
+-- clean install had session_events missing control_revision, which errored the
+-- events timeseries query and broke the dashboard's network/events panels.
+-- Existing clusters already migrated by hand and init.d never re-runs on them,
+-- so removing the migration loses nothing.
 
+-- Fresh-install completeness: guarantee every column the dashboard's timeseries
+-- SELECTs exists on a clean CREATE — including ones that were historically only
+-- applied to the primary via `make analytics-migrate` and never backported
+-- (session_events.labels + the app_* client fields). Idempotent on every host.
 ALTER TABLE infinite_streaming.session_events
-    RENAME COLUMN IF EXISTS control_revision_str TO control_revision;
+    ADD COLUMN IF NOT EXISTS control_revision      String                        DEFAULT '' CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS labels                Array(LowCardinality(String)) DEFAULT [] CODEC(ZSTD(1)),
+    ADD COLUMN IF NOT EXISTS app_live_offset_s     Float32,
+    ADD COLUMN IF NOT EXISTS app_muted             UInt8                         DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS app_peak_bitrate_mbps UInt32,
+    ADD COLUMN IF NOT EXISTS app_protocol          LowCardinality(String),
+    ADD COLUMN IF NOT EXISTS app_segment           LowCardinality(String);
 
 -- Per-request HAR-style log so the session-viewer's network log fold
 -- can replay archived sessions whose go-proxy buffer is gone. Forwarder

--- a/analytics/clickhouse/self-heal.sh
+++ b/analytics/clickhouse/self-heal.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Self-healing analytics schema for ClickHouse — used as the container entrypoint.
+#
+# Why this exists: the stock clickhouse-server entrypoint runs
+# /docker-entrypoint-initdb.d/*.sql ONLY when the data directory is empty (the
+# first-ever boot). A container brought up on an EXISTING volume from an earlier
+# version therefore never picks up schema changes (new columns), which silently
+# breaks the dashboard's timeseries query (e.g. session_events missing
+# control_revision -> "backfill failed" -> empty Network Log / PlayLog). init.d
+# gives no warning that it skipped.
+#
+# So on EVERY boot — not just first init — once the server this entrypoint is
+# about to start accepts queries, we (re-)apply the canonical schema in the
+# background. 01-schema.sql is fully idempotent (every statement is
+# CREATE/ALTER ... IF [NOT] EXISTS), so it CREATES on an empty database and
+# UPGRADES an existing one in place: no data loss, no external database to copy
+# from. The container repairs itself.
+SCHEMA=/docker-entrypoint-initdb.d/01-schema.sql
+
+(
+  # Wait for the very server we exec below to come up.
+  until clickhouse-client -q "SELECT 1" >/dev/null 2>&1; do sleep 1; done
+  if [ -f "$SCHEMA" ]; then
+    echo "clickhouse self-heal: applying analytics schema (create-or-upgrade)"
+    if clickhouse-client --multiquery < "$SCHEMA"; then
+      echo "clickhouse self-heal: schema up to date"
+    else
+      echo "clickhouse self-heal: WARNING — schema apply reported errors" >&2
+    fi
+  fi
+) &
+
+# Hand off to the stock entrypoint (runs first-boot init.d if the volume is
+# empty, then execs clickhouse-server as PID-ish foreground).
+exec /entrypoint.sh "$@"

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -62,6 +62,10 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24.8-alpine
     container_name: infinite-streaming-clickhouse
+    # Self-healing schema: re-apply the idempotent 01-schema.sql on EVERY boot so
+    # a container coming up on an older existing volume upgrades in place (init.d
+    # only runs on first-ever boot). See analytics/clickhouse/self-heal.sh.
+    entrypoint: ["/bin/sh", "/self-heal.sh"]
     environment:
       - CLICKHOUSE_DB=infinite_streaming
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
@@ -74,6 +78,7 @@ services:
     volumes:
       - ${CONTENT_DIR:-./sample-content}/analytics:/var/lib/clickhouse
       - ./analytics/clickhouse/init.d:/docker-entrypoint-initdb.d:ro
+      - ./analytics/clickhouse/self-heal.sh:/self-heal.sh:ro
     networks:
       - app_network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,10 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24.8-alpine
     container_name: infinite-streaming-clickhouse
+    # Self-healing schema: re-apply the idempotent 01-schema.sql on EVERY boot so
+    # a container coming up on an older existing volume upgrades in place (init.d
+    # only runs on first-ever boot). See analytics/clickhouse/self-heal.sh.
+    entrypoint: ["/bin/sh", "/self-heal.sh"]
     ulimits:
       nofile:
         soft: 262144
@@ -116,6 +120,7 @@ services:
       # entrypoint chowns it to clickhouse:101 on first start. See #377.
       - ${CONTENT_DIR:-./sample-content}/clickhouse:/var/lib/clickhouse
       - ./analytics/clickhouse/init.d:/docker-entrypoint-initdb.d:ro
+      - ./analytics/clickhouse/self-heal.sh:/self-heal.sh:ro
     environment:
       - CLICKHOUSE_DB=infinite_streaming
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1

--- a/tests/deploy/oobe-smoke.sh
+++ b/tests/deploy/oobe-smoke.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# oobe-smoke.sh — post-deploy smoke test for a fresh (OOBE) install.
+#
+# Why: bringing the stack up is NOT enough to prove a clean install works. A
+# ClickHouse analytics schema drift — e.g. session_events missing a column the
+# dashboard SELECTs (control_revision, labels, app_*) — is invisible to a
+# boot/health check: every container comes up green and video plays fine. But
+# the dashboard's timeseries query for the events/network streams then errors
+# ("backfill failed: ... Unknown expression identifier 'control_revision'"),
+# and because the backfill loop bails on the first error, BOTH the Network Log
+# and PlayLog panels render empty. This exercises that exact query so a broken
+# clean install FAILS the deploy loudly instead of shipping a dead dashboard.
+#
+# Works with zero data: the events/network backfill SELECTs the schema's
+# columns regardless of matching rows, so a missing column errors even for a
+# nonexistent player_id.
+#
+# Usage: oobe-smoke.sh <base_url>   (e.g. https://localhost:26000)
+set -euo pipefail
+BASE="${1:?base url required, e.g. https://localhost:26000}"
+
+# Wait for the analytics read API (nginx -> forwarder) to answer.
+ready=""
+for _ in $(seq 1 45); do
+  if curl -sk --max-time 5 "${BASE}/analytics/api/v2/plays?limit=1" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+if [ -z "$ready" ]; then
+  echo "OOBE SMOKE FAIL: analytics API never became ready at ${BASE}"
+  exit 1
+fi
+
+# The dashboard's exact multi-stream timeseries query, with a dummy player so it
+# needs no data. A healthy schema returns 0 rows and completes; a drifted schema
+# emits a "backfill failed" error event (that's the whole bug this guards).
+url="${BASE}/analytics/api/v2/timeseries"
+url="${url}?player_id=00000000-0000-0000-0000-0000000005b8"
+url="${url}&streams=events,network,control,avmetrics"
+url="${url}&bundles=charts_minimal,lanes_v1,panel_v1,session_details,network"
+url="${url}&from=2020-01-01T00:00:00.000Z"
+resp="$(curl -sk --max-time 25 "$url" 2>/dev/null || true)"
+
+if printf '%s' "$resp" | grep -qi "backfill failed"; then
+  echo "OOBE SMOKE FAIL: dashboard timeseries backfill errored on a clean install"
+  echo "  (a ClickHouse schema drift breaks the Network Log / PlayLog panels):"
+  printf '%s\n' "$resp" | grep -i "backfill failed" | head -1 | cut -c1-320
+  exit 1
+fi
+if ! printf '%s' "$resp" | grep -q '"columns"'; then
+  echo "OOBE SMOKE FAIL: timeseries returned no schema/meta frame (endpoint unhealthy)"
+  printf '%s\n' "$resp" | head -3
+  exit 1
+fi
+echo "OOBE smoke OK: dashboard timeseries events+network path healthy (no schema drift)"


### PR DESCRIPTION
## Problem

The analytics ClickHouse schema (`analytics/clickhouse/init.d/01-schema.sql`) is applied via the container's `docker-entrypoint-initdb.d`, which runs **only on first-ever boot (empty data dir)** — on an existing volume it silently does nothing. Combined with schema changes historically applied ad-hoc via `make analytics-migrate` and never backported, this produced drift:

- A **clean install** built a `session_events` table missing 7 columns (`control_revision`, `labels`, `app_live_offset_s`, `app_muted`, `app_peak_bitrate_mbps`, `app_protocol`, `app_segment`) — 193 vs 200.
- The dashboard's timeseries **events** query SELECTs `control_revision` → `UNKNOWN_IDENTIFIER` → the backfill loop bails on first error → **both Network Log and PlayLog render empty**, even though every container boots green and video plays.

## Fix

1. **Self-healing container** — `analytics/clickhouse/self-heal.sh` becomes the ClickHouse entrypoint and re-applies the idempotent `01-schema.sql` on **every** boot: `CREATE ... IF NOT EXISTS` builds an empty DB, `ADD COLUMN IF NOT EXISTS` upgrades an existing one in place. No data loss, no copying from another database. Wired into both `docker-compose.yml` and `docker-compose.ghcr.yml`; all per-stack overrides inherit it.
2. **Fixed the schema at the source** — removed a brittle `control_revision` UInt64->String DROP/RENAME migration that dropped the column on a fresh CREATE, and added the columns that were only ever hand-applied via `analytics-migrate`. A truly empty install now builds all 200 columns.
3. **Guardrails against re-drift**:
   - `make analytics-migrate` now prints a reminder to backport the ALTER to `01-schema.sql`.
   - `tests/deploy/oobe-smoke.sh` (wired into `make test-deploy-oobe`) runs the real dashboard timeseries query against a fresh install and **fails the deploy** if the schema can't serve it.

## Validation

- Empty CH → apply schema → 200 columns, `control_revision` present.
- Existing volume with a dropped column → `docker restart` (init.d skipped) → self-heal restores it on boot (verified: 199 → 200).
- Both live stacks (`:21000` kernel, `:28000` degraded) redeployed onto the self-healing entrypoint.

Closes #912
