### PR TITLE
fix(proxy,forwarder): attribute network_requests.player_id from request #1

### DIFF
--- a/analytics/go-forwarder/net_log.go
+++ b/analytics/go-forwarder/net_log.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
 )
 
 // netRow is the JSONEachRow shape for network_requests. Tags match the
@@ -53,64 +52,68 @@ type netRow struct {
 	// Honest cross-check for bytes_out/transfer_ms, which over-reports
 	// ~1000× on sub-buffer transfers. 0 when the proxy couldn't sample
 	// (non-Linux build, torn-down conn). Issue #850.
-	DeliveryRateMbps     float32 `json:"delivery_rate_mbps"`
+	DeliveryRateMbps float32 `json:"delivery_rate_mbps"`
 	// tcpi_delivery_rate_app_limited for the sample above (1 = app-limited
 	// / unreliable). Consumers trust delivery_rate_mbps only when 0.
-	DeliveryRateAppLimited uint8 `json:"delivery_rate_app_limited"`
-	Faulted              uint8   `json:"faulted"`
-	FaultType            string  `json:"fault_type"`
-	FaultAction          string  `json:"fault_action"`
-	FaultCategory        string  `json:"fault_category"`
-	RequestHeaders       string  `json:"request_headers"`
-	ResponseHeaders      string  `json:"response_headers"`
-	QueryString          string  `json:"query_string"`
+	DeliveryRateAppLimited uint8  `json:"delivery_rate_app_limited"`
+	Faulted                uint8  `json:"faulted"`
+	FaultType              string `json:"fault_type"`
+	FaultAction            string `json:"fault_action"`
+	FaultCategory          string `json:"fault_category"`
+	RequestHeaders         string `json:"request_headers"`
+	ResponseHeaders        string `json:"response_headers"`
+	QueryString            string `json:"query_string"`
 	// `,string` tag forces JSON serialization as a string. UInt64 values
 	// exceed JS's 2^53 safe-integer range, and the dashboard's per-row
 	// fpOf() compares fingerprints as strings — without `,string` the
 	// SSE-live overlay JSON would arrive as a precision-lossy JS Number
 	// and never match the same row's CH-backfill string, so the same
 	// network row got rendered twice in PlayLog.
-	EntryFingerprint     uint64  `json:"entry_fingerprint,string"`
+	EntryFingerprint uint64 `json:"entry_fingerprint,string"`
 	// Labels — see the corresponding field on `row` in main.go.
 	// Same vocabulary; <severity>=<event> strings stamped at ingest
 	// from computeNetworkLabels(). Drives the dashboard's row tint
 	// and chip rendering. Issue #473.
-	Labels               []string `json:"labels,omitempty"`
+	Labels []string `json:"labels,omitempty"`
 }
 
 // netEntry mirrors go-proxy's NetworkLogEntry. Only the fields we keep
 // are listed; unknown JSON keys are tolerated by the decoder.
 type netEntry struct {
-	Timestamp            time.Time     `json:"timestamp"`
-	Method               string        `json:"method"`
-	URL                  string        `json:"url"`
-	UpstreamURL          string        `json:"upstream_url"`
-	Path                 string        `json:"path"`
-	RequestKind          string        `json:"request_kind"`
-	Status               int           `json:"status"`
-	BytesIn              int64         `json:"bytes_in"`
-	BytesOut             int64         `json:"bytes_out"`
-	ContentType          string        `json:"content_type"`
-	PlayID               string        `json:"play_id"`
-	AttemptID            uint32        `json:"attempt_id"`
-	RequestHeaders       []nameValue   `json:"request_headers"`
-	ResponseHeaders      []nameValue   `json:"response_headers"`
-	QueryString          []nameValue   `json:"query_string"`
-	DNSMs                float64       `json:"dns_ms"`
-	ConnectMs            float64       `json:"connect_ms"`
-	TLSMs                float64       `json:"tls_ms"`
-	TTFBMs               float64       `json:"ttfb_ms"`
-	TransferMs           float64       `json:"transfer_ms"`
-	TotalMs              float64       `json:"total_ms"`
-	ClientWaitMs         float64       `json:"client_wait_ms"`
-	DeliveryRateMbps     float64       `json:"delivery_rate_mbps"`
+	Timestamp   time.Time `json:"timestamp"`
+	Method      string    `json:"method"`
+	URL         string    `json:"url"`
+	UpstreamURL string    `json:"upstream_url"`
+	Path        string    `json:"path"`
+	RequestKind string    `json:"request_kind"`
+	Status      int       `json:"status"`
+	BytesIn     int64     `json:"bytes_in"`
+	BytesOut    int64     `json:"bytes_out"`
+	ContentType string    `json:"content_type"`
+	PlayID      string    `json:"play_id"`
+	// PlayerID rides the proxy SSE entry off the request's own player_id query
+	// param (#911). Preferred over the session→player_id map (which is cold for
+	// a burst of early requests on a fresh stack); also used to warm that map.
+	PlayerID               string      `json:"player_id"`
+	AttemptID              uint32      `json:"attempt_id"`
+	RequestHeaders         []nameValue `json:"request_headers"`
+	ResponseHeaders        []nameValue `json:"response_headers"`
+	QueryString            []nameValue `json:"query_string"`
+	DNSMs                  float64     `json:"dns_ms"`
+	ConnectMs              float64     `json:"connect_ms"`
+	TLSMs                  float64     `json:"tls_ms"`
+	TTFBMs                 float64     `json:"ttfb_ms"`
+	TransferMs             float64     `json:"transfer_ms"`
+	TotalMs                float64     `json:"total_ms"`
+	ClientWaitMs           float64     `json:"client_wait_ms"`
+	DeliveryRateMbps       float64     `json:"delivery_rate_mbps"`
 	DeliveryRateAppLimited bool        `json:"delivery_rate_app_limited"`
-	Faulted              bool          `json:"faulted"`
-	FaultType            string        `json:"fault_type"`
-	FaultAction          string        `json:"fault_action"`
-	FaultCategory        string        `json:"fault_category"`
-	RequestRange         string        `json:"request_range"`
-	ResponseContentRange string        `json:"response_content_range"`
+	Faulted                bool        `json:"faulted"`
+	FaultType              string      `json:"fault_type"`
+	FaultAction            string      `json:"fault_action"`
+	FaultCategory          string      `json:"fault_category"`
+	RequestRange           string      `json:"request_range"`
+	ResponseContentRange   string      `json:"response_content_range"`
 }
 
 type nameValue struct {
@@ -151,6 +154,22 @@ func (s *sessionPlayerMap) lookup(sessionID string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.m[sessionID]
+}
+
+// resolveNetworkPlayerID picks the player_id for a network row (#911). The
+// entry's own player_id (stamped by the proxy off the request's query param) is
+// preferred because it's warm from request #1, whereas the session→player map
+// lags on a fresh stack (it's populated from session_events, which arrive after
+// a burst of early network requests). When the entry carries one we also LEARN
+// the mapping, so later same-session entries that didn't carry a player_id (some
+// sub-requests) attribute via the now-warm map instead of landing empty. Returns
+// the canonicalised (lowercase) id, or "" when neither source knows it yet.
+func resolveNetworkPlayerID(m *sessionPlayerMap, sessionID, entryPlayerID string) string {
+	if pid := canonicalV2ID(entryPlayerID); pid != "" {
+		m.set(sessionID, pid)
+		return pid
+	}
+	return m.lookup(sessionID)
 }
 
 func (s *sessionPlayerMap) prune(active map[string]struct{}) {
@@ -272,39 +291,39 @@ func entryToRow(sessionID, playerID string, e *netEntry) netRow {
 	// landed with mixed case and the dashboard / archive plays
 	// histogram missed them on lowercase JOINs.
 	return netRow{
-		Ts:                   e.Timestamp.UTC().Format("2006-01-02 15:04:05.000"),
-		SessionID:            sessionID,
-		PlayerID:             canonicalV2ID(playerID),
-		PlayID:               canonicalV2ID(e.PlayID),
-		AttemptID:            e.AttemptID,
-		Method:               e.Method,
-		URL:                  e.URL,
-		UpstreamURL:          e.UpstreamURL,
-		Path:                 e.Path,
-		RequestKind:          e.RequestKind,
-		Status:               uint16(e.Status),
-		BytesIn:              e.BytesIn,
-		BytesOut:             e.BytesOut,
-		ContentType:          e.ContentType,
-		RequestRange:         e.RequestRange,
-		ResponseContentRange: e.ResponseContentRange,
-		DNSMs:                float32(e.DNSMs),
-		ConnectMs:            float32(e.ConnectMs),
-		TLSMs:                float32(e.TLSMs),
-		TTFBMs:               float32(e.TTFBMs),
-		TransferMs:           float32(e.TransferMs),
-		TotalMs:              float32(e.TotalMs),
-		ClientWaitMs:         float32(e.ClientWaitMs),
-		DeliveryRateMbps:     float32(e.DeliveryRateMbps),
+		Ts:                     e.Timestamp.UTC().Format("2006-01-02 15:04:05.000"),
+		SessionID:              sessionID,
+		PlayerID:               canonicalV2ID(playerID),
+		PlayID:                 canonicalV2ID(e.PlayID),
+		AttemptID:              e.AttemptID,
+		Method:                 e.Method,
+		URL:                    e.URL,
+		UpstreamURL:            e.UpstreamURL,
+		Path:                   e.Path,
+		RequestKind:            e.RequestKind,
+		Status:                 uint16(e.Status),
+		BytesIn:                e.BytesIn,
+		BytesOut:               e.BytesOut,
+		ContentType:            e.ContentType,
+		RequestRange:           e.RequestRange,
+		ResponseContentRange:   e.ResponseContentRange,
+		DNSMs:                  float32(e.DNSMs),
+		ConnectMs:              float32(e.ConnectMs),
+		TLSMs:                  float32(e.TLSMs),
+		TTFBMs:                 float32(e.TTFBMs),
+		TransferMs:             float32(e.TransferMs),
+		TotalMs:                float32(e.TotalMs),
+		ClientWaitMs:           float32(e.ClientWaitMs),
+		DeliveryRateMbps:       float32(e.DeliveryRateMbps),
 		DeliveryRateAppLimited: deliveryAppLimited,
-		Faulted:              faulted,
-		FaultType:            e.FaultType,
-		FaultAction:          e.FaultAction,
-		FaultCategory:        e.FaultCategory,
-		RequestHeaders:       jsonOrEmpty(e.RequestHeaders),
-		ResponseHeaders:      jsonOrEmpty(e.ResponseHeaders),
-		QueryString:          jsonOrEmpty(e.QueryString),
-		EntryFingerprint:     netFingerprint(e),
+		Faulted:                faulted,
+		FaultType:              e.FaultType,
+		FaultAction:            e.FaultAction,
+		FaultCategory:          e.FaultCategory,
+		RequestHeaders:         jsonOrEmpty(e.RequestHeaders),
+		ResponseHeaders:        jsonOrEmpty(e.ResponseHeaders),
+		QueryString:            jsonOrEmpty(e.QueryString),
+		EntryFingerprint:       netFingerprint(e),
 	}
 }
 
@@ -372,8 +391,9 @@ func streamNetworkSSE(ctx context.Context, cfg config, seen *netSeen, out chan<-
 		if seen.check(ev.SessionID, fp) {
 			continue
 		}
+		pid := resolveNetworkPlayerID(sessionToPlayerID, ev.SessionID, ev.Entry.PlayerID)
 		select {
-		case out <- entryToRow(ev.SessionID, sessionToPlayerID.lookup(ev.SessionID), &ev.Entry):
+		case out <- entryToRow(ev.SessionID, pid, &ev.Entry):
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/analytics/go-forwarder/net_log_test.go
+++ b/analytics/go-forwarder/net_log_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+// #911: a network row must attribute to a player_id even on a cold session→player
+// map, by preferring the player_id the proxy stamped on the entry (off the
+// request's query param) and learning the mapping so later param-less
+// sub-requests for the same session also attribute instead of landing empty.
+func TestResolveNetworkPlayerID_PrefersEntryAndLearns(t *testing.T) {
+	m := newSessionPlayerMap()
+	const want = "859dc6dc-2ac3-40ad-8fae-ba22d4493b4a"
+
+	// Cold map + entry carries an uppercase player_id (iOS) → canonicalised.
+	if got := resolveNetworkPlayerID(m, "sess-2", "859DC6DC-2AC3-40AD-8FAE-BA22D4493B4A"); got != want {
+		t.Fatalf("entry pid: got %q want %q", got, want)
+	}
+	// ...and the mapping is LEARNED from it.
+	if lk := m.lookup("sess-2"); lk != want {
+		t.Fatalf("map not learned from entry: got %q want %q", lk, want)
+	}
+	// A later sub-request for the SAME session with NO player_id attributes via
+	// the now-warm map — the crux of #911 (previously landed empty).
+	if got := resolveNetworkPlayerID(m, "sess-2", ""); got != want {
+		t.Fatalf("param-less sub-request via learned map: got %q want %q", got, want)
+	}
+	// A different session that's never carried a player_id stays empty.
+	if got := resolveNetworkPlayerID(m, "sess-cold", ""); got != "" {
+		t.Fatalf("cold unknown session: got %q want empty", got)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -131,6 +131,16 @@ type NetworkLogEntry struct {
 	// events (user-reload, auto-recovery). Issue #280.
 	PlayID string `json:"play_id,omitempty"`
 
+	// PlayerID identifies the player that made this request, stamped from
+	// the request's `?player_id=` query param (raw/uppercase off iOS) so the
+	// attribution rides the request itself and does NOT depend on the session
+	// having been associated with a player_id yet. Without it, the forwarder's
+	// session→player_id map is cold for a burst of early requests on a fresh
+	// stack and those rows land with an empty player_id — invisible to the
+	// dashboard's player-filtered Network Log. The forwarder canonicalises it
+	// (lowercase) and also learns the session→player mapping from it. Issue #911.
+	PlayerID string `json:"player_id,omitempty"`
+
 	// AttemptID identifies which playback attempt within a play this
 	// request belongs to. The player initialises it to 1 on every
 	// new play and increments by 1 at every `restart` event
@@ -5666,6 +5676,9 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	// NetworkLogEntry created in this handler via the logEntry closure
 	// below.
 	playID := strings.TrimSpace(r.URL.Query().Get("play_id"))
+	// #911: hoisted above the logEntry closure so it can stamp entry.PlayerID
+	// off the request (warm from request #1), independent of session association.
+	playerID := strings.TrimSpace(r.URL.Query().Get("player_id"))
 	attemptIDStr := strings.TrimSpace(r.URL.Query().Get("attempt_id"))
 	// Client-supplied, play-scoped start (#587). Rotates with play_id;
 	// the proxy just carries it through to the session map so it reaches
@@ -5680,6 +5693,9 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	logEntry := func(sessionID string, entry NetworkLogEntry) {
 		if entry.PlayID == "" {
 			entry.PlayID = playID
+		}
+		if entry.PlayerID == "" {
+			entry.PlayerID = playerID // #911: attribute off the request itself
 		}
 		if entry.AttemptID == 0 {
 			entry.AttemptID = attemptID
@@ -5721,7 +5737,8 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	a.removeInactiveSessions()
 	sessionList := a.getSessionList()
 	sessionNumber := thirdFromLastDigit(externalPort)
-	playerID := r.URL.Query().Get("player_id")
+	// playerID hoisted above the logEntry closure (#911); keep it as the
+	// primary player-id source here for the rest of the handler.
 	playerHeader := r.Header.Get("player_id")
 	playerHeaderAlt := r.Header.Get("Player-ID")
 	playbackSessionHeader := r.Header.Get("X-Playback-Session-Id")
@@ -7816,6 +7833,11 @@ func (a *App) addNetworkLogEntry(sessionID string, entry NetworkLogEntry) {
 	}
 	if entry.PlayID == "" {
 		entry.PlayID = a.sessionStickyPlayID(sessionID)
+	}
+	if entry.PlayerID == "" {
+		// #911: sticky fallback for entries that didn't carry a player_id on the
+		// request (some sub-requests) — warms once the session is associated.
+		entry.PlayerID = a.sessionStickyPlayerID(sessionID)
 	}
 	if entry.AttemptID == 0 {
 		entry.AttemptID = a.sessionStickyAttemptID(sessionID)

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -200,6 +200,8 @@ func networkEntryToMap(e NetworkLogEntry) map[string]any {
 		"bytes_out":    e.BytesOut,
 		"content_type": e.ContentType,
 		"play_id":      e.PlayID,
+		"player_id":    e.PlayerID, // #911
+
 		// Phase timings — surfaced when httptrace populated them.
 		"dns_ms":         e.DNSMs,
 		"connect_ms":     e.ConnectMs,


### PR DESCRIPTION
## Problem

`network_requests` rows are attributed to a player via the forwarder's `sessionToPlayerID` map, which is populated from `session_events`. On a fresh stack — and the first burst of requests in **every** new play — that map is cold, so the early network rows land with an **empty `player_id`** and never appear in the dashboard's per-player Network Log (≈6 rows per fresh play, seen even on the primary).

This is orthogonal to the ClickHouse schema self-heal (#912/#913): that made the columns *exist*; this makes the `player_id` *value* correct from request #1.

## Fix

- **go-proxy**: stamp `player_id` on the proxy's own `NetworkLogEntry` from the request's `?player_id=` query param, with a sticky per-session fallback in `addNetworkLogEntry`; emit it over SSE via `networkEntryToMap`.
- **forwarder**: `resolveNetworkPlayerID()` **prefers** the entry's `player_id` and **learns** the session→player_id map from it, so later same-session sub-requests that didn't carry a `player_id` attribute via the now-warm map instead of landing empty. `streamNetworkSSE` uses it; covered by a unit test.

**Backward-compatible:** an entry with no `player_id` falls back to the existing map lookup — this only ever *adds* attribution.

## Validation

- Both modules build; `TestResolveNetworkPlayerID` passes.
- Verified earlier on the degraded stack: 62/62 network rows attributed, 0 empty, on a cold forwarder.

Closes #911
