### PR TITLE
feat(910): degraded (http-only) shaping mode + no-NET_ADMIN build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,19 @@ RUN cd /build/go-proxy && \
 
 FROM alpine:3.24
 
+# KERNEL_SHAPING=1 (default) installs the NET_ADMIN traffic-shaping binaries:
+# iproute2 (tc/ip) + nftables (nft). Build with --build-arg KERNEL_SHAPING=0 for
+# a degraded / no-NET_ADMIN image (Cloud Run / Fargate / PaaS) — those binaries
+# are omitted entirely and nothing calls them in http-only mode
+# (SHAPING_FORCE_DEGRADED short-circuits the boot probe; runtime shaping is gated
+# off via kernelRateOn/kernelNetemOn). See #910.
+ARG KERNEL_SHAPING=1
+
 # Install dependencies first (expensive, rarely changes - gets cached)
 RUN \
   apk update && \
-  apk add iproute2 iperf nftables openssl && \
+  if [ "$KERNEL_SHAPING" = "1" ]; then apk add iproute2 nftables; fi && \
+  apk add iperf openssl && \
   apk add nginx && \
   apk add ffmpeg && \
   apk add python3 py3-pip && \

--- a/Makefile
+++ b/Makefile
@@ -588,6 +588,50 @@ test-deploy-dev-http:
 	scp tests/deploy/override-dev-http.yml $(TEST_SSH):~/test-dev-http/docker-compose.override.yml
 	ssh $(TEST_SSH) 'cd ~/test-dev-http && VERSION=$$(cat VERSION) docker compose build && docker compose up -d'
 
+# test-deploy-dev-degraded (#910) — a SECOND full stack on the 28xxx band that
+# emulates a host with NO NET_ADMIN: the go-proxy boot probe is forced to
+# http-only (SHAPING_FORCE_DEGRADED in override-dev-degraded.yml), so
+# rate/delay/loss + transport faults report unavailable and the dashboard shows
+# the degraded UX. Runs alongside the real test-dev (:21000, kernel) so you can
+# A/B kernel vs no-TC. TLS off + shared content library, same as the HTTP mirror.
+TEST_DEGRADED_MEDIA_DIR ?= /home/$(shell echo $(TEST_SSH) | cut -d@ -f1)/test-dev-degraded-media
+# Advertise on the SAME public hostname as test-dev (dev.jeoliver.com — the only
+# SAN on the mounted cert), just a different port, so devices trust the cert and
+# fetch the catalogue (a .local host would cert-mismatch → empty catalogue).
+INFINITE_STREAM_ANNOUNCE_URL_DEGRADED ?= https://dev.jeoliver.com:28000
+test-deploy-dev-degraded:
+	@echo "=== Dev (DEGRADED / no-TC): local working tree (port 28000) ==="
+	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev-degraded'
+	@echo "Syncing local working tree (excluding .git and .gitignore matches)..."
+	rsync -az --delete \
+		--filter=':- .gitignore' \
+		--exclude='.git/' \
+		--exclude='.env' \
+		--exclude='certs/' \
+		./ $(TEST_SSH):~/test-dev-degraded/
+	@if [ -f content/dashboard-v3/package.json ]; then \
+		echo "Building & pushing dashboard-v3 (Vue)..."; \
+		(cd content/dashboard-v3 && npm run --silent build) && \
+		ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev-degraded/content/dashboard/v3' && \
+		rsync -az --delete content/dashboard/v3/ $(TEST_SSH):~/test-dev-degraded/content/dashboard/v3/; \
+	else \
+		echo "dashboard-v3 not present, skipping Vue build"; \
+	fi
+	ssh -n $(TEST_SSH) 'printf "COMPOSE_PROJECT_NAME=test-dev-degraded\nCONTENT_DIR=%s\nSHARED_CONTENT_DIR=%s\nINFINITE_STREAM_RENDEZVOUS_URL=%s\nINFINITE_STREAM_ANNOUNCE_URL=%s\nINFINITE_STREAM_ANNOUNCE_LABEL=test-dev-degraded\nINFINITE_STREAM_BASE_URL=%s\nINFINITE_STREAM_TLS=\nINFINITE_STREAM_TLS_SAN=\n" "$(TEST_DEGRADED_MEDIA_DIR)" "$(TEST_MEDIA_DIR)" "$(INFINITE_STREAM_RENDEZVOUS_URL)" "$(INFINITE_STREAM_ANNOUNCE_URL_DEGRADED)" "$(INFINITE_STREAM_ANNOUNCE_URL_DEGRADED)" > ~/test-dev-degraded/.env'
+	@# TLS on (HTTPS, same as test-dev). rsync excludes certs/, so seed this
+	@# stack's mkcert certs from test-dev's (per-hostname, valid on :28000).
+	ssh -n $(TEST_SSH) 'mkdir -p ~/test-dev-degraded/certs && cp ~/test-dev/certs/localhost.pem ~/test-dev/certs/localhost-key.pem ~/test-dev-degraded/certs/'
+	scp tests/deploy/override-dev-degraded.yml $(TEST_SSH):~/test-dev-degraded/docker-compose.override.yml
+	@# Only the core services — the LLM/label sidecars (token-deriver,
+	@# label-{deriver,scorer,trainer}) use FIXED container names shared across
+	@# stacks, so a second copy conflicts with test-dev's. This stack doesn't
+	@# need them (it's for exercising the degraded shaping UX).
+	ssh $(TEST_SSH) 'cd ~/test-dev-degraded && VERSION=$$(cat VERSION) docker compose build go-server forwarder clickhouse grafana && docker compose up -d go-server forwarder clickhouse grafana'
+	@# NOTE: no schema step here — the ClickHouse container self-heals its
+	@# analytics schema on every boot (see analytics/clickhouse/self-heal.sh +
+	@# the clickhouse entrypoint in docker-compose.yml), so it create-or-upgrades
+	@# in place whether this stack's volume is empty or from an earlier version.
+
 # Iterate on Grafana provisioning (dashboards / datasources) without
 # touching go-server. Sessions keep flowing live; Grafana auto-reloads
 # the dashboard JSON within 30s, but we --force-recreate to pick it up

--- a/analytics/go-forwarder/labels.go
+++ b/analytics/go-forwarder/labels.go
@@ -824,6 +824,18 @@ func computeControlLabels(r *ctrlRow) []string {
 		return []string{SevInfo + "=" + synthMark + "session_start"}
 	case "session_end":
 		return []string{SevInfo + "=" + synthMark + "session_end"}
+	case "shaping_degraded":
+		// #910: the session ran without full kernel shaping (http-only, whether
+		// probed or forced). Warning severity — a configured cap may not be
+		// active, so an operator must not read the play as if it were. A
+		// per-mode label rides alongside so `--label-has shaping_http_only`
+		// works. Mode comes off the proxy `info` string
+		// ("mode=<m> forced=<b> unavailable=<...>").
+		out := []string{SevWarning + "=" + synthMark + "shaping_degraded"}
+		if mode := shapingModeFromInfo(r.Info); mode != "" {
+			out = append(out, SevWarning+"="+synthMark+"shaping_"+mode)
+		}
+		return out
 	// Generic fallback when the changed field isn't yet enumerated.
 	case "control_change":
 		return []string{SevInfo + "=" + synthMark + "control_change"}
@@ -916,6 +928,34 @@ func patternModeFromInfo(info string) string {
 		}
 	}
 	return string(b)
+}
+
+// shapingModeFromInfo pulls the shaping mode out of a shaping_degraded
+// control_event's `info` string ("mode=<m> forced=<b> unavailable=<...>",
+// space-separated — NOT JSON) and sanitises it into a label-safe token
+// (hyphens → underscore; e.g. "http-only" → "http_only"). Returns "" when no
+// mode token is present. Issue #910.
+func shapingModeFromInfo(info string) string {
+	for _, tok := range strings.Fields(info) {
+		rest, ok := strings.CutPrefix(tok, "mode=")
+		if !ok {
+			continue
+		}
+		b := make([]byte, 0, len(rest))
+		for i := 0; i < len(rest); i++ {
+			c := rest[i]
+			switch {
+			case c >= 'A' && c <= 'Z',
+				c >= 'a' && c <= 'z',
+				c >= '0' && c <= '9':
+				b = append(b, c)
+			case c == '-', c == '_':
+				b = append(b, '_')
+			}
+		}
+		return string(b)
+	}
+	return ""
 }
 
 // isSegmentPath matches HLS / DASH media segment extensions.

--- a/analytics/go-forwarder/labels_test.go
+++ b/analytics/go-forwarder/labels_test.go
@@ -891,3 +891,35 @@ func TestNetFailureSignatureInheritsErrorSeverity(t *testing.T) {
 		t.Fatalf("timeout signature should inherit error severity: want %q in %v", want, got)
 	}
 }
+
+// TestShapingDegradedControlLabels pins the #910 degraded-shaping labels:
+// a warning-tier synthesized `shaping_degraded` plus a per-mode label parsed
+// from the proxy `info` string (space-separated, hyphen→underscore).
+func TestShapingDegradedControlLabels(t *testing.T) {
+	got := computeControlLabels(&ctrlRow{
+		Event: "shaping_degraded",
+		Info:  "mode=http-only forced=true unavailable=rate;delay;loss;transport_fault",
+	})
+	for _, want := range []string{
+		SevWarning + "=" + synthMark + "shaping_degraded",
+		SevWarning + "=" + synthMark + "shaping_http_only",
+	} {
+		if !hasLabel(got, want) {
+			t.Fatalf("missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestShapingModeFromInfo(t *testing.T) {
+	cases := map[string]string{
+		"mode=http-only forced=true unavailable=rate": "http_only",
+		"mode=kernel":  "kernel",
+		"forced=false": "",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := shapingModeFromInfo(in); got != want {
+			t.Fatalf("shapingModeFromInfo(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/content/dashboard-v3/src/components/FaultRules.vue
+++ b/content/dashboard-v3/src/components/FaultRules.vue
@@ -23,6 +23,7 @@
 import { computed, ref, toRef, watch } from 'vue';
 import { usePlayer } from '@/composables/usePlayer';
 import { useManifestVariants } from '@/composables/useManifestVariants';
+import { useSessionShaping } from '@/composables/useSessionShaping';
 import type { FaultRule } from '@/repo/v2-repo';
 
 type Surface = 'segment' | 'manifest' | 'master_manifest' | 'all' | 'transport';
@@ -90,6 +91,16 @@ const {
 } = usePlayer(toRef(props, 'playerId'));
 
 const activeTab = ref<Surface>('all');
+
+// #910: transport faults (DROP/REJECT) need nftables — the ONLY fault surface
+// that isn't portable. In a degraded (http-only) session the Transport tab
+// collapses to an "unavailable" notice; the HTTP surfaces stay live (they're
+// proxy-userspace and work on any host). Sourced from the shared session-shaping
+// model so this can't drift from the Network Shaping fold.
+const { degraded, effMode } = useSessionShaping(toRef(props, 'playerId'));
+const transportDisabled = computed(
+  () => activeTab.value === 'transport' && degraded.value,
+);
 
 function findRule(surface: Exclude<Surface, 'transport'>): FaultRule | null {
   const rules = player.value?.fault_rules ?? [];
@@ -432,7 +443,8 @@ function consLabel(surface: Surface): string {
       <button
         v-for="s in SURFACES"
         :key="s.key"
-        :class="{ active: activeTab === s.key }"
+        :class="{ active: activeTab === s.key, unavailable: s.key === 'transport' && degraded }"
+        :title="s.key === 'transport' && degraded ? `Transport faults need nftables — unavailable in ${effMode} mode` : ''"
         @click="activeTab = s.key"
       >
         {{ s.label }}
@@ -445,7 +457,11 @@ function consLabel(surface: Surface): string {
     </div>
 
     <div class="panel">
-      <p v-if="activeTab === 'all'" class="note">
+      <p v-if="transportDisabled" class="shaping-unavailable">
+        Transport faults are unavailable in <strong>{{ effMode }}</strong> mode.
+        This feature requires NET_ADMIN access.
+      </p>
+      <p v-else-if="activeTab === 'all'" class="note">
         Faults configured here apply to <strong>every</strong> request. They
         override per-surface rules on the same player when both would match.
       </p>
@@ -454,6 +470,10 @@ function consLabel(surface: Surface): string {
         before this surface-specific rule on most requests.
       </p>
 
+      <!-- #910: in a degraded (Faults-only) session the Transport surface has no
+           controls at all — just the notice above. The HTTP surfaces render
+           normally. -->
+      <template v-if="!transportDisabled">
       <div class="row">
         <label>Failure Type</label>
         <div class="radio-group">
@@ -575,6 +595,7 @@ function consLabel(surface: Surface): string {
           </div>
         </div>
       </div>
+      </template>
 
     </div>
   </div>
@@ -607,6 +628,17 @@ function consLabel(surface: Surface): string {
   color: #2563eb;
   border-bottom-color: #2563eb;
 }
+/* #910 — Transport tab when the host / session can't do nftables. Greyed so it
+   reads as "not available here"; still clickable so the operator can open it
+   and see the explanatory notice + disabled controls. */
+.tabs button.unavailable {
+  color: #b91c1c;
+  opacity: 0.6;
+}
+.tabs button.unavailable.active {
+  color: #b91c1c;
+  border-bottom-color: #fca5a5;
+}
 .dot {
   display: inline-block;
   width: 6px;
@@ -634,6 +666,18 @@ function consLabel(surface: Surface): string {
   padding: 8px 10px;
   border-radius: 6px;
   margin: 0;
+}
+/* #910 — matches NetworkShaping.vue's .ns-unavailable so the degraded-mode
+   "unavailable" notices read as one consistent (red) treatment. */
+.shaping-unavailable {
+  margin: 0;
+  font-size: 13px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 14px;
+  border-radius: 8px;
+  line-height: 1.5;
 }
 
 .row {

--- a/content/dashboard-v3/src/components/NetworkShaping.vue
+++ b/content/dashboard-v3/src/components/NetworkShaping.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+/**
+ * NetworkShaping.vue — the body of the "Network Shaping" fold.
+ *
+ * In a degraded (Faults-only) session there is NO kernel shaping, so the whole
+ * fold collapses to a single "not available" message — no sliders, no profiles,
+ * no pattern editor (#910). In kernel mode it renders the normal controls:
+ * the rate/delay/loss sliders + link profiles, then the Pattern engine.
+ *
+ * Wrapping both pages' identical `ShapeSliders + Pattern` block here keeps the
+ * degraded/kernel decision in ONE place (Testing.vue + TestingSession.vue both
+ * mount this).
+ */
+import { toRef } from 'vue';
+import ShapeSliders from '@/components/ShapeSliders.vue';
+import NetworkShapingPattern from '@/components/NetworkShapingPattern.vue';
+import { useSessionShaping } from '@/composables/useSessionShaping';
+
+const props = defineProps<{ playerId: string }>();
+const { degraded, effMode } = useSessionShaping(toRef(props, 'playerId'));
+</script>
+
+<template>
+  <div v-if="degraded" class="ns-unavailable">
+    Network shaping is unavailable in <strong>{{ effMode }}</strong> mode — this
+    session has no kernel shaping (rate / delay / loss / pattern). This feature
+    requires NET_ADMIN access.
+  </div>
+  <template v-else>
+    <ShapeSliders :player-id="playerId" />
+    <h3 class="subhead">Pattern</h3>
+    <NetworkShapingPattern :player-id="playerId" />
+  </template>
+</template>
+
+<style scoped>
+.ns-unavailable {
+  font-size: 13px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 14px;
+  border-radius: 8px;
+  line-height: 1.5;
+}
+.subhead {
+  margin: 20px 0 12px 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+</style>

--- a/content/dashboard-v3/src/components/ShapingModeControl.vue
+++ b/content/dashboard-v3/src/components/ShapingModeControl.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+/**
+ * ShapingModeControl.vue — #910 per-session shaping-mode tristate.
+ *
+ * Sits directly under the "Session Controls" heading because it governs MORE
+ * than the Network Shaping fold: Faults-only also disables the Transport
+ * fault tab (needs nftables) and the Pattern engine (kernel rate-stepping),
+ * while leaving the portable HTTP-fault surface (errors / hung / corrupted /
+ * content / timeouts) fully live.
+ *
+ * Visibility (see useSessionShaping): hidden on a kernel-capable host in normal
+ * use — kernel is just used. Shown in developer mode (the A/B instrument) or
+ * when the host genuinely can't kernel-shape (fallback picker, Kernel disabled).
+ */
+import { toRef } from 'vue';
+import { useSessionShaping } from '@/composables/useSessionShaping';
+
+const props = defineProps<{ playerId: string }>();
+const {
+  showControl,
+  kernelSelectable,
+  developerMode,
+  activeId,
+  degraded,
+  effMode,
+  settingMode,
+  modeError,
+  setShapingMode,
+  SHAPING_MODES,
+} = useSessionShaping(toRef(props, 'playerId'));
+</script>
+
+<template>
+  <div v-if="showControl" class="shaping-mode-block">
+    <span class="shaping-mode-title">
+      Session shaping
+      <span v-if="degraded" class="shaping-mode-flag">degraded: {{ effMode }}</span>
+    </span>
+    <div class="shaping-mode-seg" role="group" aria-label="Session shaping mode">
+      <button
+        v-for="m in SHAPING_MODES"
+        :key="m.id"
+        type="button"
+        class="shaping-mode-btn"
+        :class="{ active: activeId === m.id }"
+        :disabled="settingMode || (m.id === '' && !kernelSelectable)"
+        :title="m.id === '' && !kernelSelectable ? 'This host has no NET_ADMIN — kernel shaping unavailable' : ''"
+        @click="setShapingMode(m.id)"
+      >
+        {{ m.label }}
+      </button>
+    </div>
+    <span class="shaping-mode-hint">
+      <template v-if="!kernelSelectable">
+        This host can't do kernel shaping (no NET_ADMIN) — pick how this session
+        degrades. Rate/delay/loss and transport faults won't take effect; HTTP
+        faults still do.
+      </template>
+      <template v-else-if="developerMode">
+        Developer A/B: force THIS session into Faults-only to compare against the
+        kernel path. Kernel shaping (rate/delay/loss) and transport faults are
+        gated in Faults-only; HTTP faults still fire.
+      </template>
+    </span>
+    <span v-if="modeError" class="shaping-mode-error">⚠️ {{ modeError }}</span>
+  </div>
+</template>
+
+<style scoped>
+/* #910 per-session shaping-mode tristate — sits under the Session Controls
+   heading, above the fault/shaping folds it governs. */
+.shaping-mode-block {
+  display: grid;
+  gap: 6px;
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fafafa;
+}
+.shaping-mode-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.shaping-mode-flag {
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #991b1b;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+}
+.shaping-mode-seg {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  overflow: hidden;
+  width: fit-content;
+}
+.shaping-mode-btn {
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #374151;
+  background: #fff;
+  border: none;
+  border-right: 1px solid #d1d5db;
+  cursor: pointer;
+}
+.shaping-mode-btn:last-child {
+  border-right: none;
+}
+.shaping-mode-btn:hover:not(:disabled) {
+  background: #f9fafb;
+}
+.shaping-mode-btn.active {
+  background: #2563eb;
+  color: #fff;
+}
+.shaping-mode-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.shaping-mode-hint {
+  font-size: 11px;
+  color: #6b7280;
+}
+.shaping-mode-hint:empty {
+  display: none;
+}
+.shaping-mode-error {
+  font-size: 11px;
+  color: #991b1b;
+}
+</style>

--- a/content/dashboard-v3/src/components/StatusBanners.vue
+++ b/content/dashboard-v3/src/components/StatusBanners.vue
@@ -23,6 +23,13 @@ interface NftablesInfo {
   status?: string;
   platform?: string;
   reason?: string;
+  // #910 capability-probe fields.
+  mode?: string; // "kernel" | "http-only"
+  forced?: boolean;
+  rate?: boolean;
+  delay?: boolean;
+  loss?: boolean;
+  transport_fault?: boolean;
 }
 
 const nftablesInfo = ref<NftablesInfo | null>(null);
@@ -40,15 +47,36 @@ async function fetchCapabilities() {
 
 onMounted(fetchCapabilities);
 
+// #910: a session is degraded whenever ANY network-shaping control is
+// unavailable — full http-only (all off) OR partial kernel (e.g. tc works but
+// nftables transport faults don't). We must surface it either way so a
+// configured cap is never mistaken for active.
 const shapingBanner = computed<string | null>(() => {
-  // Only flag when the server actively reported the shaper is off.
-  // A fetch failure most often means the v2 proxy isn't deployed —
-  // not the same problem; don't spam a banner.
-  if (!nftablesInfo.value) return null;
-  if (nftablesInfo.value.status === 'enabled') return null;
-  const platform = nftablesInfo.value.platform || 'unknown';
-  const reason = nftablesInfo.value.reason || 'Traffic shaping is unavailable.';
-  return `Network shaping disabled (${platform}): ${reason}`;
+  const info = nftablesInfo.value;
+  // A fetch failure most often means the v2 proxy isn't deployed — not the
+  // same problem; don't spam a banner.
+  if (!info) return null;
+  const controls: Array<[string, boolean | undefined]> = [
+    ['rate', info.rate],
+    ['delay', info.delay],
+    ['loss', info.loss],
+    ['transport faults', info.transport_fault],
+  ];
+  // Older proxies (pre-#910) don't send the per-control booleans; fall back
+  // to the coarse status flag so those deploys still get the basic banner.
+  const hasFields = controls.some(([, v]) => typeof v === 'boolean');
+  const unavailable = controls.filter(([, v]) => v === false).map(([n]) => n);
+  const degraded = hasFields ? unavailable.length > 0 : info.status !== 'enabled';
+  if (!degraded) return null;
+
+  const mode = info.mode || (info.status === 'enabled' ? 'kernel' : 'http-only');
+  const forcedNote = info.forced ? ' — forced for testing' : '';
+  if (hasFields && unavailable.length > 0) {
+    return `Shaping mode: ${mode}${forcedNote}. Unavailable on this host: ${unavailable.join(', ')}. These controls are shown disabled — a configured value will NOT take effect.`;
+  }
+  const platform = info.platform || 'unknown';
+  const reason = info.reason || 'Traffic shaping is unavailable.';
+  return `Network shaping disabled (${platform})${forcedNote}: ${reason}`;
 });
 </script>
 

--- a/content/dashboard-v3/src/composables/useBaselineRate.ts
+++ b/content/dashboard-v3/src/composables/useBaselineRate.ts
@@ -16,8 +16,23 @@
 import { computed } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 
+// ShapingCapabilities mirrors the proxy's boot-time probe result surfaced on
+// /api/v2/info.shaping (#910): which network-shaping controls the kernel can
+// actually apply on this host, plus the resolved mode. The dashboard reads
+// this to disable/annotate controls instead of showing a phantom cap.
+export interface ShapingCapabilities {
+  rate: boolean;
+  delay: boolean;
+  loss: boolean;
+  transport_fault: boolean;
+  mode: string; // "kernel" | "http-only"
+  forced: boolean;
+  reason: string;
+}
+
 interface ProxyInfo {
   default_rate_mbps?: number;
+  shaping?: ShapingCapabilities;
   // Other Info fields (version, content_dir, ...) exist but we don't
   // need them here; keep the type minimal so future Info additions
   // don't churn this file.
@@ -45,4 +60,42 @@ export function useBaselineRate() {
     return typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 0;
   });
   return { baselineMbps, isLoading: query.isLoading, isError: query.isError };
+}
+
+/**
+ * useShapingCapabilities — exposes the proxy's shaping-capability probe
+ * (#910) off the same cached /api/v2/info query as useBaselineRate (no extra
+ * fetch). `degraded` is the single flag the UI keys off to show the
+ * degraded-mode banner and grey out unavailable controls.
+ *
+ * Defaults are permissive (all controls available, mode "kernel") until the
+ * info request resolves, so the UI doesn't flash "disabled" on load.
+ */
+export function useShapingCapabilities() {
+  const query = useQuery<ProxyInfo>({
+    queryKey: ['proxy', 'info'],
+    queryFn: fetchProxyInfo,
+    staleTime: 5 * 60_000,
+    retry: 1,
+  });
+  const shaping = computed<ShapingCapabilities>(() => {
+    const s = query.data.value?.shaping;
+    // Permissive fallback pre-resolve / on older proxies without the field.
+    return (
+      s ?? {
+        rate: true,
+        delay: true,
+        loss: true,
+        transport_fault: true,
+        mode: 'kernel',
+        forced: false,
+        reason: '',
+      }
+    );
+  });
+  const degraded = computed(() => {
+    const s = shaping.value;
+    return !s.rate || !s.delay || !s.loss || !s.transport_fault;
+  });
+  return { shaping, degraded, isLoading: query.isLoading, isError: query.isError };
 }

--- a/content/dashboard-v3/src/composables/useSessionShaping.ts
+++ b/content/dashboard-v3/src/composables/useSessionShaping.ts
@@ -1,0 +1,115 @@
+/**
+ * useSessionShaping — the per-session view of #910's shaping-mode state,
+ * shared by the ShapingModeControl (the tristate), ShapeSliders (rate/delay/
+ * loss gating), FaultRules (transport-tab gating) and NetworkShapingPattern.
+ *
+ * One place owns the whole model so the four consumers can't drift:
+ *
+ *   - `forcedMode`  — the per-SESSION override ("" | "http-only"), read off the
+ *     raw session (getPlayer requests ?include=raw). This is the A/B
+ *     instrument: force ONE session degraded while the host + every other
+ *     session stay on the kernel path.
+ *   - `effMode`     — the mode that actually applies to this session: a forced
+ *     degrade overrides the host's own capability ("kernel" | "http-only").
+ *   - `controlAvailable(c)` / `badgeFor(c)` — per-control (rate/delay/loss/
+ *     transport) "is the kernel backing this?" + the disabled-badge text.
+ *
+ * Visibility (the operator never sees a pointless choice):
+ *   - `showControl`      — render the tristate only when it's meaningful:
+ *     developer mode (the A/B instrument, on any box) OR the host genuinely
+ *     can't kernel-shape (then it's the fallback picker). On a kernel-capable
+ *     host in normal use it's HIDDEN — kernel is just used.
+ *   - `kernelSelectable` — the Kernel option is only pickable when the host can
+ *     actually do it; on a NET_ADMIN-less host it shows disabled.
+ */
+import { computed, ref, type Ref } from 'vue';
+import { useQueryClient } from '@tanstack/vue-query';
+import { usePlayer } from '@/composables/usePlayer';
+import { useShapingCapabilities } from '@/composables/useBaselineRate';
+
+// id === '' is the kernel (full-shaping) mode; the API takes 'off' for it.
+// The only degraded mode is http-only: no network shaping, HTTP faults still
+// fire. (A userspace-approximation mode was considered and dropped — a proxy
+// above TCP can't faithfully reproduce rate/delay/loss.)
+export const SHAPING_MODES: Array<{ id: string; label: string }> = [
+  { id: '',          label: 'Kernel' },
+  { id: 'http-only', label: 'Faults-only' },
+];
+
+export function useSessionShaping(playerId: Ref<string>) {
+  const { player } = usePlayer(playerId);
+  const { shaping } = useShapingCapabilities();
+  const qc = useQueryClient();
+
+  // `?developer=1` — the shared convention (SessionDetails, ShellLayout, Grid).
+  const developerMode = computed(
+    () => new URLSearchParams(window.location.search).get('developer') === '1',
+  );
+
+  // Host-level: can this box do full kernel shaping at all? All four controls
+  // must probe available AND the mode must not be env-forced-degraded.
+  const hostCanKernel = computed(() => {
+    const s = shaping.value;
+    return !s.forced && s.rate && s.delay && s.loss && s.transport_fault;
+  });
+
+  const forcedMode = computed<string>(
+    () => ((player.value as any)?.raw_session?.shaping_forced_mode as string) || '',
+  );
+
+  // A forced degrade overrides the host mode; otherwise inherit the host's.
+  const effMode = computed(() => forcedMode.value || shaping.value.mode || 'kernel');
+  const degraded = computed(() => effMode.value !== 'kernel');
+
+  // The segmented control's highlighted button ('' for kernel).
+  const activeId = computed(() => (effMode.value === 'kernel' ? '' : effMode.value));
+
+  const showControl = computed(() => developerMode.value || !hostCanKernel.value);
+  const kernelSelectable = computed(() => hostCanKernel.value);
+
+  const settingMode = ref(false);
+  const modeError = ref('');
+
+  // Drives the per-session degrade endpoint (by player_id) and refreshes the
+  // player so raw_session.shaping_forced_mode + all gating recompute.
+  async function setShapingMode(mode: string) {
+    if (settingMode.value || mode === forcedMode.value) return;
+    // Can't pick the kernel path on a host that can't do it.
+    if (mode === '' && !kernelSelectable.value) return;
+    settingMode.value = true;
+    modeError.value = '';
+    try {
+      const res = await fetch('/api/nftables/shaping-mode', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ player_id: playerId.value, mode: mode || 'off' }),
+      });
+      if (!res.ok) {
+        modeError.value =
+          res.status === 404
+            ? 'No active proxy session for this player — start playback first.'
+            : `Couldn't set shaping mode (HTTP ${res.status}).`;
+      }
+    } catch (e) {
+      modeError.value = `Couldn't set shaping mode: ${e instanceof Error ? e.message : String(e)}`;
+    } finally {
+      await qc.invalidateQueries({ queryKey: ['player', playerId.value] });
+      settingMode.value = false;
+    }
+  }
+
+  return {
+    developerMode,
+    hostCanKernel,
+    forcedMode,
+    effMode,
+    degraded,
+    activeId,
+    showControl,
+    kernelSelectable,
+    settingMode,
+    modeError,
+    setShapingMode,
+    SHAPING_MODES,
+  };
+}

--- a/content/dashboard-v3/src/pages/Testing.vue
+++ b/content/dashboard-v3/src/pages/Testing.vue
@@ -28,8 +28,8 @@ import { useGroups } from '@/composables/useGroups';
 import { deviceContentLabel, groupNameFor } from '@/composables/useSessionLabels';
 import type { PlayerRecord } from '@/repo/v2-repo';
 import * as repo from '@/repo/v2-repo';
-import ShapeSliders from '@/components/ShapeSliders.vue';
-import NetworkShapingPattern from '@/components/NetworkShapingPattern.vue';
+import NetworkShaping from '@/components/NetworkShaping.vue';
+import ShapingModeControl from '@/components/ShapingModeControl.vue';
 import TransferTimeouts from '@/components/TransferTimeouts.vue';
 import ContentManipulation from '@/components/ContentManipulation.vue';
 import FaultRules from '@/components/FaultRules.vue';
@@ -299,6 +299,13 @@ const sortedPlayers = computed<PlayerRecord[]>(() => {
 
             <h3 class="session-controls-heading">Session Controls</h3>
 
+            <!-- #910 per-session shaping mode. Governs MORE than the Network
+                 Shaping fold (also gates the Transport fault tab + Pattern),
+                 so it sits above them all. Hidden on a kernel-capable host in
+                 normal use — shown in developer mode or when the host can't
+                 kernel-shape. Same control as testing-session.html. -->
+            <ShapingModeControl :player-id="activePlayer.id" />
+
             <!-- Control panels — same as testing-session.html. These
                  mutate live server state so they stay outside
                  SessionDisplay (which is read-only). The Delete
@@ -317,9 +324,7 @@ const sortedPlayers = computed<PlayerRecord[]>(() => {
             </CollapsibleSection>
 
             <CollapsibleSection title="Network Shaping" :open="true" persist-key="network-shaping">
-              <ShapeSliders :player-id="activePlayer.id" />
-              <h3 class="subhead">Pattern</h3>
-              <NetworkShapingPattern :player-id="activePlayer.id" />
+              <NetworkShaping :player-id="activePlayer.id" />
             </CollapsibleSection>
 
             <h3 class="session-controls-heading">Session Display</h3>

--- a/content/dashboard-v3/src/pages/TestingSession.vue
+++ b/content/dashboard-v3/src/pages/TestingSession.vue
@@ -10,8 +10,8 @@
 import { computed } from 'vue';
 import { useUrlSearchParams } from '@vueuse/core';
 import { usePlayer } from '@/composables/usePlayer';
-import ShapeSliders from '@/components/ShapeSliders.vue';
-import NetworkShapingPattern from '@/components/NetworkShapingPattern.vue';
+import NetworkShaping from '@/components/NetworkShaping.vue';
+import ShapingModeControl from '@/components/ShapingModeControl.vue';
 import TransferTimeouts from '@/components/TransferTimeouts.vue';
 import ContentManipulation from '@/components/ContentManipulation.vue';
 import FaultRules from '@/components/FaultRules.vue';
@@ -187,6 +187,14 @@ const chatScope = computed<ChatScope>(() => ({
 
         <h3 class="session-controls-heading">Session Controls</h3>
 
+        <!-- #910 per-session shaping mode. Governs MORE than the Network
+             Shaping fold: a degraded mode also disables the Transport fault
+             tab + the Pattern engine below, while the portable HTTP-fault
+             surface stays live. Hidden on a kernel-capable host in normal use
+             (see useSessionShaping) — only shown in developer mode or when the
+             host can't kernel-shape. -->
+        <ShapingModeControl :player-id="playerId" />
+
         <!-- Control panels — order mirrors legacy testing-session.html.
              These mutate server state and so are LIVE-only; the
              archive session-viewer omits them. -->
@@ -203,9 +211,7 @@ const chatScope = computed<ChatScope>(() => ({
         </CollapsibleSection>
 
         <CollapsibleSection title="Network Shaping" :open="true" persist-key="network-shaping">
-          <ShapeSliders :player-id="playerId" />
-          <h3 class="subhead">Pattern</h3>
-          <NetworkShapingPattern :player-id="playerId" />
+          <NetworkShaping :player-id="playerId" />
         </CollapsibleSection>
 
         <h3 class="session-controls-heading">Session Display</h3>

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -371,7 +371,13 @@ type App struct {
 	// INFINITE_STREAM_DEFAULT_RATE_MBPS. 0 = no cap (today's behaviour);
 	// non-zero = the deployment's interpretation of "no operator
 	// override." See issue #480.
-	defaultRateMbps    int
+	defaultRateMbps int
+	// shaping is the boot-time capability probe result (#910): which
+	// network-shaping controls the kernel actually backs on this host, plus
+	// the resolved mode. Read-only after startup, so no lock. Surfaced on
+	// /api/v2/info and /api/nftables/capabilities; drives the dashboard's
+	// degraded-mode banner and per-control disablement.
+	shaping            shapingCaps
 	client             *http.Client
 	portMap            PortMapping
 	shapeMu            sync.Mutex
@@ -859,6 +865,24 @@ type TcTrafficManager struct {
 	// "is a filter currently installed?" check for cleanup.
 	icmpFilterMu       sync.Mutex
 	icmpFilterIPByPort map[int]string
+
+	// #910 honesty gates. Set once at boot from the shaping probe (or a
+	// forced degraded mode) via SetKernelShaping. When false, the matching
+	// public apply method no-ops instead of touching the kernel, so a
+	// forced-degraded box (where tc actually works) genuinely doesn't shape.
+	// Default true (NewTcTrafficManager) so existing callers/tests are
+	// unaffected until the boot probe narrows them.
+	kernelRate  bool
+	kernelNetem bool
+
+	// #910 per-session (per-port) degrade. When a single session is forced
+	// degraded on an otherwise-capable box (the A/B instrument), its bound
+	// port is registered here and the kernel apply no-ops for JUST that port,
+	// leaving every other session shaping normally. Set/cleared by the App
+	// from the session's shaping_forced_mode.
+	portGateMu   sync.Mutex
+	portRateOff  map[int]bool
+	portNetemOff map[int]bool
 }
 
 type ShapeApplyState struct {
@@ -1049,6 +1073,14 @@ func (a *App) recordSessionStart(session SessionData, manifestURL string) {
 		}
 	}
 	a.emitControlEventForSession(sessionID, "proxy", "session_start", manifestURL)
+	// #910: mark every session that starts under degraded shaping so the
+	// control_events timeline (and the dashboard chip) shows it plainly. Uses
+	// the session's EFFECTIVE caps (host probe narrowed by any per-session
+	// shaping_forced_mode), so a single forced-degraded session is marked even
+	// on a fully-capable box. Source `auto` — a server-detected condition.
+	if eff := a.effectiveShapingForSession(session); eff.degraded() {
+		a.emitControlEventForSession(sessionID, "auto", "shaping_degraded", eff.degradedInfo())
+	}
 }
 
 func (a *App) recordSessionEnd(session SessionData, reason string) {
@@ -1180,12 +1212,274 @@ func (s *NftShapeStep) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// shapingCaps is the package-main mirror of server.ShapingCapabilities —
+// the boot-time result of probing which network-shaping controls the kernel
+// can actually apply on this host. Kept as a main-local type so the probe
+// (which needs TcTrafficManager / exec) stays out of the v2/server package;
+// v2Adapter.ShapingCapabilities maps it across the boundary. Issue #910.
+type shapingCaps struct {
+	rate           bool
+	delay          bool
+	loss           bool
+	transportFault bool
+	forced         bool
+	mode           string
+	reason         string
+}
+
+// degraded reports whether this host is running with anything less than full
+// kernel shaping — i.e. at least one control is unavailable (or forced off).
+// The dashboard + logged data must surface this so an operator is never
+// misled into thinking a configured cap is active. Issue #910.
+func (c shapingCaps) degraded() bool {
+	return !c.rate || !c.delay || !c.loss || !c.transportFault
+}
+
+// kernelRateOn / kernelNetemOn report whether the KERNEL should apply the
+// control for these caps. Only genuine "kernel" mode drives the kernel —
+// "http-only" does no network shaping, so it leaves the kernel untouched.
+// Issue #910.
+func (c shapingCaps) kernelRateOn() bool  { return c.mode == "kernel" && c.rate }
+func (c shapingCaps) kernelNetemOn() bool { return c.mode == "kernel" && (c.delay || c.loss) }
+
+// degradedInfo is the `info` payload carried on the shaping_degraded control
+// event: the resolved mode plus the semicolon-separated list of unavailable
+// controls (semicolons, not commas — commas/`=` are dropped by the forwarder's
+// label encoder; see reference_labelplay_value_encoding). Issue #910.
+func (c shapingCaps) degradedInfo() string {
+	var missing []string
+	if !c.rate {
+		missing = append(missing, "rate")
+	}
+	if !c.delay {
+		missing = append(missing, "delay")
+	}
+	if !c.loss {
+		missing = append(missing, "loss")
+	}
+	if !c.transportFault {
+		missing = append(missing, "transport_fault")
+	}
+	return fmt.Sprintf("mode=%s forced=%t unavailable=%s", c.mode, c.forced, strings.Join(missing, ";"))
+}
+
+// detectShapingCapabilities probes, once at boot, whether the kernel
+// facilities behind each network-shaping control actually apply on this host
+// — tc HTB (rate), tc netem (delay/loss), and nftables (transport faults).
+//
+// SHAPING_FORCE_DEGRADED overrides the live probe so degraded mode can be
+// exercised on a host that DOES have NET_ADMIN (the A/B instrument for #910):
+//
+//	http-only → all shaping controls reported unavailable (only HTTP faults)
+//
+// Any other value (empty/off/kernel) runs the real probe. Issue #910.
+// normalizeShapingMode canonicalises an operator-supplied forced-mode string
+// to "http-only" | "" (empty = off / inherit host). Issue #910.
+func normalizeShapingMode(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "http-only", "httponly", "http":
+		return "http-only"
+	default:
+		return ""
+	}
+}
+
+// forcedShapingCaps returns the capability set implied by a forced degraded
+// mode, or (_, false) when the string doesn't name one. Shared by the boot
+// env override and the per-session toggle (#910). The only degraded mode is
+// http-only, which leaves the KERNEL untouched (network shaping off, HTTP
+// faults still fire).
+func forcedShapingCaps(mode string) (shapingCaps, bool) {
+	switch normalizeShapingMode(mode) {
+	case "http-only":
+		return shapingCaps{
+			mode:   "http-only",
+			forced: true,
+			reason: "forced http-only (network shaping disabled; HTTP faults only)",
+		}, true
+	default:
+		return shapingCaps{}, false
+	}
+}
+
+func detectShapingCapabilities(t *TcTrafficManager) shapingCaps {
+	raw := strings.ToLower(strings.TrimSpace(getenv("SHAPING_FORCE_DEGRADED", "")))
+	if c, ok := forcedShapingCaps(raw); ok {
+		c.reason = "forced via SHAPING_FORCE_DEGRADED — " + c.reason
+		return c
+	}
+	switch raw {
+	case "", "off", "kernel":
+		// fall through to the live probe
+	default:
+		log.Printf("SHAPING_FORCE_DEGRADED=%q unrecognised (want http-only|off); running live probe", raw)
+	}
+
+	if runtime.GOOS != "linux" || t == nil {
+		return shapingCaps{
+			mode:   "http-only",
+			reason: "network shaping requires Linux with tc/netem/nftables; HTTP faults only",
+		}
+	}
+
+	rate, netem := t.probeTcCapabilities()
+	transport := probeNftCapability()
+	c := shapingCaps{rate: rate, delay: netem, loss: netem, transportFault: transport}
+	switch {
+	case rate && netem && transport:
+		c.mode = "kernel"
+	case !rate && !netem && !transport:
+		c.mode = "http-only"
+		c.reason = "no kernel shaping (tc/netem/nftables unavailable); HTTP faults only"
+	default:
+		// Partial kernel: some controls apply, some don't. Mode stays
+		// "kernel" (the working controls really are kernel-backed); the
+		// per-control booleans carry the truth the UI greys out from.
+		c.mode = "kernel"
+		c.reason = "partial kernel shaping: " + missingShapingControls(rate, netem, transport)
+	}
+	return c
+}
+
+// missingShapingControls builds a human list of the unavailable controls for
+// the partial-kernel reason string. Issue #910.
+func missingShapingControls(rate, netem, transport bool) string {
+	var missing []string
+	if !rate {
+		missing = append(missing, "rate (no sch_htb)")
+	}
+	if !netem {
+		missing = append(missing, "delay/loss (no sch_netem)")
+	}
+	if !transport {
+		missing = append(missing, "transport faults (no nftables)")
+	}
+	if len(missing) == 0 {
+		return "none"
+	}
+	return strings.Join(missing, ", ") + " unavailable"
+}
+
+// probeTcCapabilities checks whether tc HTB (rate) and tc netem (delay/loss)
+// actually apply on the shaping interface by installing and removing a
+// throwaway class + qdisc under the shared HTB root. It reuses the same root
+// the live path needs (idempotent), then adds/removes only a scratch leaf, so
+// it never disturbs real per-session shaping. Holds tcMu for the duration —
+// at boot there is no contention, but this keeps it consistent with every
+// other tc-tree mutation (#746). Issue #910.
+func (t *TcTrafficManager) probeTcCapabilities() (rate bool, netem bool) {
+	if runtime.GOOS != "linux" || t == nil {
+		return false, false
+	}
+	t.tcMu.Lock()
+	defer t.tcMu.Unlock()
+
+	// Rate: the shared HTB root must install. If it can't, tc shaping is
+	// unavailable entirely (no sch_htb / no NET_ADMIN).
+	if err := t.ensureRootQdiscCore(); err != nil {
+		log.Printf("SHAPING probe: tc HTB root unavailable: %v", err)
+		return false, false
+	}
+	rate = true
+
+	// Netem: add a scratch HTB class under the root + a netem qdisc, then
+	// remove both. Scratch handles are chosen high to avoid colliding with
+	// any per-port class (which derive from the port number).
+	const scratchClass = "1:0ffe"
+	const scratchHandle = "0ffe:"
+	_ = exec.Command("tc", "class", "add", "dev", t.interfaceName,
+		"parent", "1:", "classid", scratchClass, "htb", "rate", "1000mbit").Run()
+	if err := exec.Command("tc", "qdisc", "add", "dev", t.interfaceName,
+		"parent", scratchClass, "handle", scratchHandle, "netem", "delay", "1ms").Run(); err == nil {
+		netem = true
+	} else {
+		log.Printf("SHAPING probe: tc netem unavailable: %v", err)
+	}
+	// Best-effort cleanup (deleting the class also drops its child qdisc).
+	_ = exec.Command("tc", "qdisc", "del", "dev", t.interfaceName,
+		"parent", scratchClass, "handle", scratchHandle).Run()
+	_ = exec.Command("tc", "class", "del", "dev", t.interfaceName,
+		"classid", scratchClass).Run()
+	return rate, netem
+}
+
+// probeNftCapability reports whether nftables can install the transport-fault
+// table/chain on this host. It calls the same ensureTransportFaultChain the
+// live DROP/REJECT path uses (idempotent), so a success leaves the host in the
+// state the real path expects. Issue #910.
+func probeNftCapability() bool {
+	if runtime.GOOS != "linux" {
+		return false
+	}
+	if err := ensureTransportFaultChain(); err != nil {
+		log.Printf("SHAPING probe: nftables transport faults unavailable: %v", err)
+		return false
+	}
+	return true
+}
+
 func NewTcTrafficManager(interfaceName string, debug bool) *TcTrafficManager {
 	return &TcTrafficManager{
 		interfaceName:      interfaceName,
 		debug:              debug,
 		icmpFilterIPByPort: map[int]string{},
+		// #910: gates default OPEN — every existing caller (and test) expects
+		// the manager to attempt the kernel apply. SetKernelShaping narrows
+		// them at boot when the probe (or a forced degraded mode) says a
+		// control isn't kernel-backed.
+		kernelRate:   true,
+		kernelNetem:  true,
+		portRateOff:  map[int]bool{},
+		portNetemOff: map[int]bool{},
 	}
+}
+
+// SetPortShapingGate registers (or clears) a per-port kernel-apply gate for
+// the #910 per-session degrade. rateOff/netemOff true → the matching kernel
+// apply no-ops for this port only, leaving other sessions shaping normally.
+// Idempotent; clearing removes the entry.
+func (t *TcTrafficManager) SetPortShapingGate(port int, rateOff, netemOff bool) {
+	if t == nil {
+		return
+	}
+	t.portGateMu.Lock()
+	defer t.portGateMu.Unlock()
+	if rateOff {
+		t.portRateOff[port] = true
+	} else {
+		delete(t.portRateOff, port)
+	}
+	if netemOff {
+		t.portNetemOff[port] = true
+	} else {
+		delete(t.portNetemOff, port)
+	}
+}
+
+func (t *TcTrafficManager) portRateGated(port int) bool {
+	t.portGateMu.Lock()
+	defer t.portGateMu.Unlock()
+	return t.portRateOff[port]
+}
+
+func (t *TcTrafficManager) portNetemGated(port int) bool {
+	t.portGateMu.Lock()
+	defer t.portGateMu.Unlock()
+	return t.portNetemOff[port]
+}
+
+// SetKernelShaping is the #910 universal honesty backstop. It gates the two
+// kernel-apply entry points (UpdateRateLimit / UpdateNetem) so EVERY caller —
+// the v2 apply path, the legacy /api/nftables/* handlers, the pattern netem
+// setup, the #480 baseline — no-ops instead of shaping when the host (or a
+// forced degraded mode) can't back the control. Called once after the boot
+// probe; read-lock-free thereafter (booleans set before any session).
+func (t *TcTrafficManager) SetKernelShaping(rate, netem bool) {
+	if t == nil {
+		return
+	}
+	t.kernelRate = rate
+	t.kernelNetem = netem
 }
 
 func (t *TcTrafficManager) IsActive() bool {
@@ -1343,6 +1637,18 @@ func (t *TcTrafficManager) GetPortConfig(port int) (map[string]interface{}, erro
 // can't wipe this port's leaf class mid-apply, then delegates to the lock-free
 // core.
 func (t *TcTrafficManager) UpdateRateLimit(port int, rateMbps float64) error {
+	// #910 honesty backstop — no kernel rate shaping when the host (or a
+	// forced degraded mode) can't back it. No-op success so callers proceed
+	// as if "no cap requested"; the degraded condition is surfaced by the
+	// session's shaping_degraded event + the dashboard's disabled controls.
+	if !t.kernelRate || t.portRateGated(port) {
+		reason := "kernel_rate_unavailable"
+		if t.kernelRate {
+			reason = "session_forced_degraded"
+		}
+		log.Printf("NETSHAPE rate gated port=%d rate_mbps=%.3f reason=%s (#910)", port, rateMbps, reason)
+		return nil
+	}
 	t.tcMu.Lock()
 	defer t.tcMu.Unlock()
 	return t.updateRateLimitCore(port, rateMbps)
@@ -1873,6 +2179,16 @@ func netemImpairmentArgs(p NetemParams) []string {
 // UpdateNetem is the public, lock-acquiring entrypoint. It holds t.tcMu for the
 // whole netem mutation (#746) and delegates to the lock-free core.
 func (t *TcTrafficManager) UpdateNetem(port int, p NetemParams) error {
+	// #910 honesty backstop — no kernel netem (delay/loss/jitter) when the
+	// host (or a forced degraded mode) can't back it. No-op success.
+	if !t.kernelNetem || t.portNetemGated(port) {
+		reason := "kernel_netem_unavailable"
+		if t.kernelNetem {
+			reason = "session_forced_degraded"
+		}
+		log.Printf("NETSHAPE netem gated port=%d delay_ms=%d loss_pct=%.3f reason=%s (#910)", port, p.DelayMs, p.LossPct, reason)
+		return nil
+	}
 	t.tcMu.Lock()
 	defer t.tcMu.Unlock()
 	return t.updateNetemCore(port, p)
@@ -2297,6 +2613,26 @@ func main() {
 
 	app.sessionsSnap.Store(&emptySessions)
 
+	// Probe kernel shaping capability once at boot and log the resolved mode
+	// (#910). This is what the dashboard reads to disable/annotate controls
+	// instead of showing a phantom cap on a host without tc/netem/nftables.
+	app.shaping = detectShapingCapabilities(app.traffic)
+	// #910: narrow the kernel-apply gates to what this host/mode actually
+	// backs. Only genuine "kernel" mode drives the kernel — "http-only" does no
+	// network shaping, so it leaves the kernel untouched.
+	if app.traffic != nil {
+		kernelMode := app.shaping.mode == "kernel"
+		app.traffic.SetKernelShaping(kernelMode && app.shaping.rate, kernelMode && (app.shaping.delay || app.shaping.loss))
+	}
+	if app.shaping.reason != "" {
+		log.Printf("SHAPING MODE: %s — %s [rate=%t delay=%t loss=%t transport_fault=%t forced=%t]",
+			app.shaping.mode, app.shaping.reason,
+			app.shaping.rate, app.shaping.delay, app.shaping.loss, app.shaping.transportFault, app.shaping.forced)
+	} else {
+		log.Printf("SHAPING MODE: %s [rate=%t delay=%t loss=%t transport_fault=%t]",
+			app.shaping.mode, app.shaping.rate, app.shaping.delay, app.shaping.loss, app.shaping.transportFault)
+	}
+
 	go app.trackPortThroughput()
 	app.restoreTransportFaultSchedules()
 	// Re-install tc rate/delay/loss state for every session that
@@ -2347,6 +2683,8 @@ func main() {
 	router.HandleFunc("/api/version", app.handleVersion).Methods(http.MethodGet)
 	router.HandleFunc("/api/nftables/port/{port}", app.handleNftPort).Methods(http.MethodGet)
 	router.HandleFunc("/api/nftables/bandwidth/{port}", app.handleNftBandwidth).Methods(http.MethodPost)
+	router.HandleFunc("/api/nftables/shaping-mode/{port}", app.handleNftShapingMode).Methods(http.MethodPost)
+	router.HandleFunc("/api/nftables/shaping-mode", app.handleNftShapingMode).Methods(http.MethodPost)
 	router.HandleFunc("/api/nftables/loss/{port}", app.handleNftLoss).Methods(http.MethodPost)
 	router.HandleFunc("/api/nftables/shape/{port}", app.handleNftShape).Methods(http.MethodPost)
 	router.HandleFunc("/api/nftables/pattern/{port}", app.handleNftPattern).Methods(http.MethodPost)
@@ -3769,13 +4107,27 @@ func (a *App) handleNftStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *App) handleNftCapabilities(w http.ResponseWriter, r *http.Request) {
-	status := "disabled"
-	reason := "traffic shaping requires Linux (tc/netem)"
-	if runtime.GOOS == "linux" {
-		status = "enabled"
-		reason = ""
+	// #910: report the real boot-time probe, not a bare GOOS check. "enabled"
+	// only when kernel shaping is actually usable (full or partial); "disabled"
+	// when there is no kernel shaping at all (http-only). The per-control
+	// booleans + mode let the dashboard grey out exactly what's missing rather
+	// than showing a phantom cap.
+	c := a.shaping
+	status := "enabled"
+	if !c.rate && !c.delay && !c.loss && !c.transportFault {
+		status = "disabled"
 	}
-	writeJSON(w, map[string]string{"status": status, "platform": runtime.GOOS, "reason": reason})
+	writeJSON(w, map[string]interface{}{
+		"status":          status,
+		"platform":        runtime.GOOS,
+		"reason":          c.reason,
+		"mode":            c.mode,
+		"forced":          c.forced,
+		"rate":            c.rate,
+		"delay":           c.delay,
+		"loss":            c.loss,
+		"transport_fault": c.transportFault,
+	})
 }
 
 func (a *App) handleNftPort(w http.ResponseWriter, r *http.Request) {
@@ -4106,17 +4458,40 @@ func (a *App) runShapePatternLoop(ctx context.Context, port int, steps []NftShap
 	}
 }
 
+// disablePatternForPort is THE canonical "clear all pattern state" for a port.
+// A pattern lives in THREE representations that MUST be cleared together, or the
+// dashboard shows a phantom "pattern running" after a stop (issue #910):
+//
+//  1. the in-memory step loop            (shapeLoops + shapeStates)
+//  2. the v1 session fields              (nftables_pattern_*)
+//  3. the v2 stash                       (_v2_shape_pattern) — the dashboard's
+//     shape.pattern is built from THIS, not the nftables_pattern_* fields, so
+//     leaving it behind is exactly what made a stopped pattern re-read as
+//     running through the v2 API.
+//
+// Every disable path (shaping-mode switch, switch-to-sliders, group reset,
+// session release) MUST go through here so no representation can drift. If you
+// add a new pattern field/representation, clear it HERE and extend
+// TestDisablePatternClearsAllRepresentations so the invariant is enforced.
 func (a *App) disablePatternForPort(port int) {
-	a.stopShapeLoop(port)
+	a.stopShapeLoop(port) // (1) in-memory loop + shapeStates
 	a.updateSessionsByPortWithControl(port, map[string]interface{}{
-		"nftables_pattern_enabled": false,
-		"nftables_pattern_steps":   []NftShapeStep{},
-		"nftables_pattern_step":    nil,
+		// (2) v1 session fields — enabled/steps/step + the runtime display fields
+		// that otherwise linger and re-read as a running pattern.
+		"nftables_pattern_enabled":           false,
+		"nftables_pattern_steps":             []NftShapeStep{},
+		"nftables_pattern_step":              nil,
+		"nftables_pattern_step_runtime":      nil,
+		"nftables_pattern_rate_runtime_mbps": nil,
+		"nftables_pattern_step_runtime_at":   nil,
+		"nftables_pattern_template_mode":     "",
+		// (3) v2 stash. nil is equivalent to the v2 PATCH path's delete for every
+		// reader (all type-assert to map / nil-check first).
+		"_v2_shape_pattern": nil,
 	}, "")
-	// Emit pattern_disabled to control_events for every session on
-	// this port. Without this hook the dashboard's PlayLog "Control"
-	// bucket stayed silent on toggle paths that bypass
-	// applySessionSettingsUpdate (e.g. switching to sliders mode,
+	// Emit pattern_disabled to control_events for every session on this port.
+	// Without this hook the dashboard's PlayLog "Control" bucket stayed silent on
+	// toggle paths that bypass applySessionSettingsUpdate (switch-to-sliders,
 	// session release, group reset). Issue #474 follow-up.
 	a.emitControlEventForPort(port, "proxy", "pattern_disabled", "")
 }
@@ -4675,6 +5050,16 @@ func (a *App) armTransportFaultLoop(port int, faultType string, consecutiveThres
 		a.setTransportFaultSessionState(port, "none", false, "", 0, 0)
 		return
 	}
+	// #910: honesty gate — if nftables can't back transport faults on this
+	// host, OR this session is forced degraded, don't arm the loop and pretend
+	// it's active. Per-session effective caps so one forced-degraded session
+	// is gated while others on the box keep faulting. The session-level
+	// shaping_degraded event marks the play; the dashboard greys the control.
+	if eff := a.effectiveShapingForPort(port); !eff.transportFault {
+		log.Printf("FAULT transport degraded port=%d control=transport_fault reason=capability_unavailable mode=%s requested_type=%s", port, eff.mode, faultType)
+		a.setTransportFaultSessionState(port, "none", false, "", 0, 0)
+		return
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	a.faultMu.Lock()
 	a.faultLoops[port] = cancel
@@ -5005,6 +5390,133 @@ func (a *App) handleNftBandwidth(w http.ResponseWriter, r *http.Request) {
 		"nftables_bandwidth_mbps": rateMbps,
 	}, "")
 	writeJSON(w, map[string]interface{}{"success": true, "port": port, "rate": fmt.Sprintf("%g Mbps", rateMbps)})
+}
+
+// handleNftShapingMode sets (or clears) a per-session forced degraded shaping
+// mode on ONE session (#910). Body: {"mode":"http-only"|"off",
+// "player_id":"..."}. The session is addressed by the path {port} (harness /
+// curl) OR by player_id in the body (the dashboard, which works by player_id
+// and doesn't know the proxy port). Lets ONE session run degraded while others
+// on the same box shape normally — the A/B instrument.
+func (a *App) handleNftShapingMode(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		Mode     string `json:"mode"`
+		PlayerID string `json:"player_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "invalid json"})
+		return
+	}
+	// Resolve the target port: explicit path {port} wins; else map player_id.
+	port := 0
+	if portStr := mux.Vars(r)["port"]; portStr != "" {
+		mappedPort, _ := a.portMap.MapExternalPort(portStr)
+		p, err := strconv.Atoi(mappedPort)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			writeJSON(w, map[string]string{"error": "invalid port"})
+			return
+		}
+		port = p
+	} else if payload.PlayerID != "" {
+		p, ok := a.portForPlayerID(payload.PlayerID)
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(w, map[string]string{"error": "no active session for player_id"})
+			return
+		}
+		port = p
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]string{"error": "port or player_id required"})
+		return
+	}
+	mode := normalizeShapingMode(payload.Mode) // "" | http-only
+	log.Printf("SHAPING mode set port=%d mode=%q (#910)", port, mode)
+	// Persist the forced mode on the session(s) bound to the port, then
+	// reconcile the kernel + gate state.
+	a.updateSessionsByPortWithControl(port, map[string]interface{}{
+		"shaping_forced_mode": mode,
+	}, "")
+	a.applyForcedShapingModeForPort(port)
+	eff := a.effectiveShapingForPort(port)
+	writeJSON(w, map[string]interface{}{
+		"success":  true,
+		"port":     port,
+		"mode":     eff.mode,
+		"forced":   eff.forced,
+		"degraded": eff.degraded(),
+	})
+}
+
+// applyForcedShapingModeForPort reconciles kernel + gate state after a port's
+// session shaping_forced_mode changed. Degrading: tear down any kernel shaping
+// already on the port BEFORE closing the gate (a closed gate would no-op the
+// teardown), then close it and emit a shaping_degraded event. Clearing: re-open
+// the gate and re-apply the session's stored shape. Issue #910.
+func (a *App) applyForcedShapingModeForPort(port int) {
+	if a.traffic == nil {
+		return
+	}
+	sess, found := a.sessionForPort(port)
+	eff := a.shaping
+	if found {
+		eff = a.effectiveShapingForSession(sess)
+	}
+	degraded := !eff.kernelRateOn() || !eff.kernelNetemOn()
+	if degraded {
+		// Faults-only means NO kernel path at all, so tear down every kernel-backed
+		// control on the port — not just gate it (#910). Fully clear the pattern
+		// first (all 3 representations) so its next tick can't re-arm a rate
+		// mid-teardown and the dashboard stops showing a "running" pattern.
+		a.disablePatternForPort(port)
+		a.traffic.SetPortShapingGate(port, false, false) // open for teardown
+		_ = a.traffic.UpdateRateLimit(port, 0)
+		_ = a.traffic.UpdateNetem(port, NetemParams{})
+		a.clearShapeApplyState(port)
+		a.syncPortShapingGate(port, eff) // close per effective
+		// Transport faults (nftables drop/reject) are kernel-backed too — stop the
+		// loop and remove the rule so the session can't keep dropping packets while
+		// the UI shows the Transport control disabled. (#910)
+		a.stopTransportFaultLoop(port)
+		if err := clearTransportFaultRule(port); err != nil {
+			log.Printf("SHAPING degraded transport-clear failed port=%d err=%v", port, err)
+		}
+		a.setTransportFaultSessionState(port, "none", false, "", 0, 0)
+		// Reset the STORED shape (operator intent), not just the kernel state, so
+		// the dashboard's "Limit (rate_mbps)" line and the impairment values drop
+		// to 0 instead of charting a phantom cap the session no longer enforces.
+		// effective_rate_limit_mbps is re-derived on the next normalize. (#910)
+		a.updateSessionsByPortWithControl(port, map[string]interface{}{
+			"nftables_bandwidth_mbps":         float64(0),
+			"nftables_delay_ms":               float64(0),
+			"nftables_packet_loss":            float64(0),
+			"nftables_jitter_ms":              float64(0),
+			"nftables_loss_correlation_pct":   float64(0),
+			"nftables_jitter_correlation_pct": float64(0),
+		}, "")
+		if found {
+			a.emitControlEventForSession(getString(sess, "session_id"), "harness", "shaping_degraded", eff.degradedInfo())
+		}
+		log.Printf("SHAPING per-session degraded port=%d mode=%s (#910)", port, eff.mode)
+		return
+	}
+	a.syncPortShapingGate(port, eff) // open
+	// #910: returning to kernel is a clean slate — fully clear any pattern so one
+	// armed before the degrade doesn't resurrect in the editor or re-run.
+	a.disablePatternForPort(port)
+	a.clearShapeApplyState(port)
+	if found {
+		// Re-read: disablePatternForPort mutated the session, so applySessionShaping
+		// must see the pattern-free state (else it skips the rate apply thinking a
+		// pattern still owns it).
+		if s, ok := a.sessionForPort(port); ok {
+			sess = s
+		}
+		a.applySessionShaping(sess, port)
+	}
+	log.Printf("SHAPING per-session restored port=%d mode=%s (#910)", port, eff.mode)
 }
 
 func (a *App) handleNftLoss(w http.ResponseWriter, r *http.Request) {
@@ -6121,11 +6633,23 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 		} else if a.defaultRateMbps > 0 && a.traffic != nil {
 			if internalPortInt, err := strconv.Atoi(assignedInternalPort); err == nil {
-				effective := a.effectiveRate(0)
-				if err := a.traffic.UpdateRateLimit(internalPortInt, effective); err != nil {
-					log.Printf("baseline rate cap apply failed port=%d rate=%g: %v", internalPortInt, effective, err)
+				// #910 honesty gate: the #480 baseline cap is a direct kernel
+				// apply that bypasses applyShapeIfChanged, so it needs its own
+				// capability check — otherwise a forced-degraded session (on a
+				// box where tc works) would silently cap at the baseline while
+				// reporting shaping off. This else-branch skips applySessionShaping
+				// so we also register the per-port gate here for consistency.
+				eff := a.effectiveShapingForSession(sessionData)
+				a.syncPortShapingGate(internalPortInt, eff)
+				if !eff.kernelRateOn() {
+					log.Printf("baseline rate cap skipped port=%d reason=capability_unavailable mode=%s (#480/#910)", internalPortInt, eff.mode)
 				} else {
-					log.Printf("baseline rate cap applied port=%d rate=%g Mbps (#480)", internalPortInt, effective)
+					effective := a.effectiveRate(0)
+					if err := a.traffic.UpdateRateLimit(internalPortInt, effective); err != nil {
+						log.Printf("baseline rate cap apply failed port=%d rate=%g: %v", internalPortInt, effective, err)
+					} else {
+						log.Printf("baseline rate cap applied port=%d rate=%g Mbps (#480)", internalPortInt, effective)
+					}
 				}
 			}
 		}
@@ -7263,11 +7787,79 @@ func manipulateDASHManifest(body []byte, cm ContentManipulation) ([]byte, error)
 	return body, nil
 }
 
+// effectiveShapingForSession resolves the capabilities in force for one
+// session: the host probe (a.shaping) narrowed by any per-session
+// shaping_forced_mode. A session can only be MORE degraded than the host,
+// never more capable, so a forced degraded mode always wins. Issue #910.
+func (a *App) effectiveShapingForSession(session SessionData) shapingCaps {
+	if c, ok := forcedShapingCaps(getString(session, "shaping_forced_mode")); ok {
+		return c
+	}
+	return a.shaping
+}
+
+// portForPlayerID resolves the proxy port bound to a player_id (via its
+// session's x_forwarded_port), or (0, false) when the player has no active
+// session. Lets the dashboard (which addresses players by id) drive the
+// per-session shaping-mode endpoint. #910.
+func (a *App) portForPlayerID(playerID string) (int, bool) {
+	if playerID == "" {
+		return 0, false
+	}
+	for _, sess := range a.sessionsView() {
+		// Case-insensitive: iOS emits UPPERCASE UUIDs, but the dashboard
+		// canonicalises player_ids to lowercase before calling — an exact
+		// match silently misses (the documented case-sensitivity trap).
+		if strings.EqualFold(getString(sess, "player_id"), playerID) {
+			if p, err := strconv.Atoi(getString(sess, "x_forwarded_port")); err == nil {
+				return p, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// sessionForPort returns the session bound to a proxy port (matched on
+// x_forwarded_port), or (nil, false) when none is bound. #910.
+func (a *App) sessionForPort(port int) (SessionData, bool) {
+	portStr := strconv.Itoa(port)
+	for _, sess := range a.sessionsView() {
+		if getString(sess, "x_forwarded_port") == portStr {
+			return sess, true
+		}
+	}
+	return nil, false
+}
+
+// effectiveShapingForPort looks up the session bound to a proxy port and
+// returns its effective shaping caps, falling back to the host caps when no
+// session is bound. Used by the port-keyed apply paths (transport arm). #910.
+func (a *App) effectiveShapingForPort(port int) shapingCaps {
+	if sess, ok := a.sessionForPort(port); ok {
+		return a.effectiveShapingForSession(sess)
+	}
+	return a.shaping
+}
+
+// syncPortShapingGate pushes a session's effective kernel-apply gate down to
+// the traffic manager so the per-port backstop no-ops the kernel for a
+// forced-degraded session (and re-opens it when the force is lifted). #910.
+func (a *App) syncPortShapingGate(port int, eff shapingCaps) {
+	if a.traffic == nil {
+		return
+	}
+	a.traffic.SetPortShapingGate(port, !eff.kernelRateOn(), !eff.kernelNetemOn())
+}
+
 func (a *App) applySessionShaping(session SessionData, port int) {
 	if a.traffic == nil || runtime.GOOS != "linux" {
 		log.Printf("NETSHAPE apply skipped port=%d reason=traffic_unavailable_or_non_linux runtime=%s traffic_nil=%t", port, runtime.GOOS, a.traffic == nil)
 		return
 	}
+	// #910: register/refresh this session's per-port kernel gate before any
+	// apply, so a forced-degraded session no-ops the kernel while others on
+	// the same box keep shaping. Applies whether or not a pattern is running.
+	a.syncPortShapingGate(port, a.effectiveShapingForSession(session))
 	if getBool(session, "nftables_pattern_enabled") || sessionHasPatternSteps(session) {
 		// Pattern loop owns the rate while enabled; avoid per-request overrides.
 		log.Printf("NETSHAPE apply skipped port=%d reason=pattern_enabled pattern_enabled=%t pattern_steps=%t", port, getBool(session, "nftables_pattern_enabled"), sessionHasPatternSteps(session))
@@ -7328,28 +7920,48 @@ func (a *App) applyShapeIfChanged(port int, rate float64, np NetemParams) error 
 		log.Printf("NETSHAPE apply skipped port=%d reason=unchanged rate_mbps=%.3f delay_ms=%d loss_pct=%.3f", port, rate, delay, loss)
 		return nil
 	}
+	// #910: honesty gate. When the host (or a forced degraded mode) can't
+	// back a control, we must NOT touch the kernel for it — on the forced-
+	// degraded A/B box tc actually works, so applying anyway would silently
+	// shape while the operator believes shaping is off. We skip the kernel
+	// call, log it, and still converge the apply state so we don't spin. The
+	// session_start `shaping_degraded` control event + the labels[] marker
+	// make the degraded condition visible; the request value is retained but
+	// the dashboard greys it out (task #3).
+	canRate := a.shaping.rate
+	canNetem := a.shaping.delay || a.shaping.loss // one netem qdisc backs both
 	if rate == 0 && delay == 0 && loss == 0 {
 		log.Printf("NETSHAPE apply clear port=%d", port)
-		if err := a.traffic.UpdateRateLimit(port, 0); err != nil {
-			return err
+		if canRate {
+			if err := a.traffic.UpdateRateLimit(port, 0); err != nil {
+				return err
+			}
 		}
 		a.setShapeApplyState(port, desired)
 		return nil
 	}
 	rateChanged := !ok || math.Abs(last.rate-rate) > eps
 	if rateChanged {
-		log.Printf("NETSHAPE apply rate_change port=%d from_mbps=%.3f to_mbps=%.3f", port, last.rate, rate)
-		if err := a.traffic.UpdateRateLimit(port, rate); err != nil {
-			return err
+		if canRate {
+			log.Printf("NETSHAPE apply rate_change port=%d from_mbps=%.3f to_mbps=%.3f", port, last.rate, rate)
+			if err := a.traffic.UpdateRateLimit(port, rate); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("NETSHAPE apply degraded port=%d control=rate reason=capability_unavailable mode=%s requested_mbps=%.3f", port, a.shaping.mode, rate)
 		}
 	}
 	netemChanged := !ok || last.delay != delay || last.jitter != np.JitterMs ||
 		math.Abs(last.loss-loss) > eps || math.Abs(last.lossCorr-np.LossCorrelationPct) > eps ||
 		math.Abs(last.delCorr-np.JitterCorrelationPct) > eps
 	if netemChanged {
-		log.Printf("NETSHAPE apply netem_change port=%d from_delay_ms=%d to_delay_ms=%d from_loss_pct=%.3f to_loss_pct=%.3f jitter_ms=%d loss_corr_pct=%.1f del_corr_pct=%.1f", port, last.delay, delay, last.loss, loss, np.JitterMs, np.LossCorrelationPct, np.JitterCorrelationPct)
-		if err := a.traffic.UpdateNetem(port, np); err != nil {
-			return err
+		if canNetem {
+			log.Printf("NETSHAPE apply netem_change port=%d from_delay_ms=%d to_delay_ms=%d from_loss_pct=%.3f to_loss_pct=%.3f jitter_ms=%d loss_corr_pct=%.1f del_corr_pct=%.1f", port, last.delay, delay, last.loss, loss, np.JitterMs, np.LossCorrelationPct, np.JitterCorrelationPct)
+			if err := a.traffic.UpdateNetem(port, np); err != nil {
+				return err
+			}
+		} else {
+			log.Printf("NETSHAPE apply degraded port=%d control=netem reason=capability_unavailable mode=%s requested_delay_ms=%d requested_loss_pct=%.3f", port, a.shaping.mode, delay, loss)
 		}
 	}
 	a.setShapeApplyState(port, desired)
@@ -7550,11 +8162,21 @@ func (a *App) trackPortThroughput() {
 		}
 		adjacent1sRate, hasAdjacent1s := adjacentBacklogActiveRate(state.samples, shortCutoff)
 
+		// #910: mbps_shaper_* is derived from the TC HTB queue backlog — a
+		// KERNEL-shaper metric. In a degraded (faults-only) session the rate gate
+		// is closed and no kernel shaping applies, so the shaper metric is
+		// meaningless. Suppress it (and its rolling average) so it goes away
+		// rather than reporting a phantom shaper — matching a host with no tc.
+		shaperGated := a.traffic != nil && a.traffic.portRateGated(port)
+
 		var mbpsShaperRate interface{}
-		if backlogActive && hasAdjacent1s {
+		if backlogActive && hasAdjacent1s && !shaperGated {
 			mbpsShaperRate = math.Round((adjacent1sRate * 100)) / 100
 		} else {
 			mbpsShaperRate = nil
+		}
+		if shaperGated {
+			state.a1sHistory = state.a1sHistory[:0]
 		}
 		// Record non-nil a1s values and compute a6s as their rolling average over 6s.
 		if v, ok := mbpsShaperRate.(float64); ok {
@@ -9131,8 +9753,8 @@ func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData
 			portStr = getString(session, "x_forwarded_port_external")
 		}
 		if portNum, ok := a.sessionPortToInternal(portStr); ok {
-			if pattern, ok := a.getShapePattern(portNum); ok {
-				session["nftables_pattern_enabled"] = len(pattern.Steps) > 0
+			if pattern, ok := a.getShapePattern(portNum); ok && len(pattern.Steps) > 0 {
+				session["nftables_pattern_enabled"] = true
 				session["nftables_pattern_steps"] = pattern.Steps
 				if pattern.ActiveAt != "" {
 					session["nftables_pattern_step"] = pattern.ActiveStep
@@ -9143,6 +9765,12 @@ func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData
 			} else {
 				session["nftables_pattern_enabled"] = false
 				session["nftables_pattern_steps"] = []NftShapeStep{}
+				if getString(session, "nftables_pattern_driven_by") == "" {
+					session["nftables_pattern_step"] = nil
+					session["nftables_pattern_step_runtime"] = nil
+					session["nftables_pattern_rate_runtime_mbps"] = nil
+					session["nftables_pattern_step_runtime_at"] = nil
+				}
 			}
 		}
 		// nftables_bandwidth_mbps holds the operator's raw intent —

--- a/go-proxy/cmd/server/openapi.go
+++ b/go-proxy/cmd/server/openapi.go
@@ -18,162 +18,162 @@
 
 package main
 
-//	@Summary  List active sessions
-//	@Tags     sessions
-//	@Produce  json
-//	@Success  200 {array}  object  "Each item is a normalized session record (~80 fields). Subset returned to the dashboard; harness-cli reads the full record from /api/session/{id}."
-//	@Router   /api/sessions [get]
+// @Summary  List active sessions
+// @Tags     sessions
+// @Produce  json
+// @Success  200 {array}  object  "Each item is a normalized session record (~80 fields). Subset returned to the dashboard; harness-cli reads the full record from /api/session/{id}."
+// @Router   /api/sessions [get]
 func docsListSessions() {}
 
-//	@Summary  Get one session
-//	@Tags     sessions
-//	@Param    id   path      string true "session_id"
-//	@Produce  json
-//	@Success  200  {object}  object "Full session record including fault counters, shaping state, player metrics, manifest_variants."
-//	@Failure  404  {object}  map[string]string
-//	@Router   /api/session/{id} [get]
+// @Summary  Get one session
+// @Tags     sessions
+// @Param    id   path      string true "session_id"
+// @Produce  json
+// @Success  200  {object}  object "Full session record including fault counters, shaping state, player metrics, manifest_variants."
+// @Failure  404  {object}  map[string]string
+// @Router   /api/session/{id} [get]
 func docsGetSession() {}
 
-//	@Summary  Delete one session
-//	@Description Removes the session from the in-memory map and frees its dedicated proxy port.
-//	@Tags     sessions
-//	@Param    id   path  string true "session_id"
-//	@Success  204  "No Content"
-//	@Router   /api/session/{id} [delete]
+// @Summary  Delete one session
+// @Description Removes the session from the in-memory map and frees its dedicated proxy port.
+// @Tags     sessions
+// @Param    id   path  string true "session_id"
+// @Success  204  "No Content"
+// @Router   /api/session/{id} [delete]
 func docsDeleteSession() {}
 
-//	@Summary  Patch session settings
-//	@Description Optimistic-concurrency PATCH used for fault config + shaping flags.
-//	@Description Body envelope: `{set: {field: value, ...}, fields: [field, ...], base_revision: "<iso8601>"}`.
-//	@Description Returns 409 with the current control_revision when base_revision is stale.
-//	@Tags     sessions
-//	@Param    id        path    string                 true  "session_id"
-//	@Param    envelope  body    PatchSessionRequest    true  "Set+fields+base_revision envelope"
-//	@Produce  json
-//	@Success  200       {object} PatchSessionResponse
-//	@Failure  409       {object} ConflictResponse      "control_revision conflict"
-//	@Router   /api/session/{id} [patch]
+// @Summary  Patch session settings
+// @Description Optimistic-concurrency PATCH used for fault config + shaping flags.
+// @Description Body envelope: `{set: {field: value, ...}, fields: [field, ...], base_revision: "<iso8601>"}`.
+// @Description Returns 409 with the current control_revision when base_revision is stale.
+// @Tags     sessions
+// @Param    id        path    string                 true  "session_id"
+// @Param    envelope  body    PatchSessionRequest    true  "Set+fields+base_revision envelope"
+// @Produce  json
+// @Success  200       {object} PatchSessionResponse
+// @Failure  409       {object} ConflictResponse      "control_revision conflict"
+// @Router   /api/session/{id} [patch]
 func docsPatchSession() {}
 
-//	@Summary  Wipe every session
-//	@Description Destructive: clears all sessions, fault config, and nftables shaping. Confirm before calling.
-//	@Tags     sessions
-//	@Success  200
-//	@Router   /api/clear-sessions [post]
+// @Summary  Wipe every session
+// @Description Destructive: clears all sessions, fault config, and nftables shaping. Confirm before calling.
+// @Tags     sessions
+// @Success  200
+// @Router   /api/clear-sessions [post]
 func docsClearSessions() {}
 
-//	@Summary  Stream session-state diffs (SSE)
-//	@Description Long-lived `text/event-stream` connection. Server emits one `data:` frame per session-record change (debounced ~250ms). Optional `player_id` query param filters to one player.
-//	@Description
-//	@Description Each `data:` frame is a JSON-encoded `SessionStreamFrame` (see schemas).
-//	@Description Heartbeat: comment line `: ping` every ~15s. Reconnect on disconnect; the proxy does not replay missed frames.
-//	@Tags     streams
-//	@Param    player_id query string false "filter frames to one player_id"
-//	@Produce  text/event-stream
-//	@Success  200 {object} SessionStreamFrame "JSON payload of one SSE data frame"
-//	@Router   /api/sessions/stream [get]
+// @Summary  Stream session-state diffs (SSE)
+// @Description Long-lived `text/event-stream` connection. Server emits one `data:` frame per session-record change (debounced ~250ms). Optional `player_id` query param filters to one player.
+// @Description
+// @Description Each `data:` frame is a JSON-encoded `SessionStreamFrame` (see schemas).
+// @Description Heartbeat: comment line `: ping` every ~15s. Reconnect on disconnect; the proxy does not replay missed frames.
+// @Tags     streams
+// @Param    player_id query string false "filter frames to one player_id"
+// @Produce  text/event-stream
+// @Success  200 {object} SessionStreamFrame "JSON payload of one SSE data frame"
+// @Router   /api/sessions/stream [get]
 func docsSessionStream() {}
 
-//	@Summary  Stream per-request network events (SSE)
-//	@Description Long-lived `text/event-stream` connection. Server emits one `data:` frame per HTTP request as it lands in any session's ring buffer.
-//	@Description
-//	@Description Each `data:` frame is a JSON-encoded `NetworkStreamFrame` (see schemas), shape `{session_id, entry: NetworkLogEntry}`.
-//	@Description Heartbeat: comment line `: ping` every 15s. Reconnect on disconnect; nothing is replayed. Wrapped by `harness-cli tail`.
-//	@Tags     streams
-//	@Produce  text/event-stream
-//	@Success  200 {object} NetworkStreamFrame "JSON payload of one SSE data frame"
-//	@Router   /api/network/stream [get]
+// @Summary  Stream per-request network events (SSE)
+// @Description Long-lived `text/event-stream` connection. Server emits one `data:` frame per HTTP request as it lands in any session's ring buffer.
+// @Description
+// @Description Each `data:` frame is a JSON-encoded `NetworkStreamFrame` (see schemas), shape `{session_id, entry: NetworkLogEntry}`.
+// @Description Heartbeat: comment line `: ping` every 15s. Reconnect on disconnect; nothing is replayed. Wrapped by `harness-cli tail`.
+// @Tags     streams
+// @Produce  text/event-stream
+// @Success  200 {object} NetworkStreamFrame "JSON payload of one SSE data frame"
+// @Router   /api/network/stream [get]
 func docsNetworkStream() {}
 
-//	@Summary  Get one session's network ring buffer
-//	@Description One-shot snapshot of the per-session in-memory request log (HAR-shaped). Bounded; older entries fall off as new ones arrive.
-//	@Tags     network
-//	@Param    id   path      string  true  "session_id"
-//	@Produce  json
-//	@Success  200  {array}   NetworkLogEntry
-//	@Router   /api/session/{id}/network [get]
+// @Summary  Get one session's network ring buffer
+// @Description One-shot snapshot of the per-session in-memory request log (HAR-shaped). Bounded; older entries fall off as new ones arrive.
+// @Tags     network
+// @Param    id   path      string  true  "session_id"
+// @Produce  json
+// @Success  200  {array}   NetworkLogEntry
+// @Router   /api/session/{id}/network [get]
 func docsGetNetworkLog() {}
 
-//	@Summary  Apply transport shaping to a port
-//	@Description nftables/tc rate + delay + loss on the proxy's egress for one session port. Setting any axis disables an active pattern on the same port.
-//	@Tags     shaping
-//	@Param    port  path  string         true  "session-bound port (e.g. 30281)"
-//	@Param    body  body  ShapeRequest   true  "rate / delay / loss"
-//	@Produce  json
-//	@Success  200   {object} object
-//	@Router   /api/nftables/shape/{port} [post]
+// @Summary  Apply transport shaping to a port
+// @Description nftables/tc rate + delay + loss on the proxy's egress for one session port. Setting any axis disables an active pattern on the same port.
+// @Tags     shaping
+// @Param    port  path  string         true  "session-bound port (e.g. 30281)"
+// @Param    body  body  ShapeRequest   true  "rate / delay / loss"
+// @Produce  json
+// @Success  200   {object} object
+// @Router   /api/nftables/shape/{port} [post]
 func docsNftShape() {}
 
-//	@Summary  Install a step pattern on a port
-//	@Description Time-boxed sequence of rate steps (ramp_up, square_wave, etc). steps=[] clears.
-//	@Tags     shaping
-//	@Param    port  path  string         true  "session-bound port"
-//	@Param    body  body  PatternRequest true  "steps + template_mode"
-//	@Produce  json
-//	@Success  200   {object} object
-//	@Router   /api/nftables/pattern/{port} [post]
+// @Summary  Install a step pattern on a port
+// @Description Time-boxed sequence of rate steps (ramp_up, square_wave, etc). steps=[] clears.
+// @Tags     shaping
+// @Param    port  path  string         true  "session-bound port"
+// @Param    body  body  PatternRequest true  "steps + template_mode"
+// @Produce  json
+// @Success  200   {object} object
+// @Router   /api/nftables/pattern/{port} [post]
 func docsNftPattern() {}
 
-//	@Summary  Set port bandwidth alone
-//	@Tags     shaping
-//	@Param    port  path  string  true  "session-bound port"
-//	@Param    body  body  BandwidthRequest true "{rate_mbps}"
-//	@Success  200
-//	@Router   /api/nftables/bandwidth/{port} [post]
+// @Summary  Set port bandwidth alone
+// @Tags     shaping
+// @Param    port  path  string  true  "session-bound port"
+// @Param    body  body  BandwidthRequest true "{rate_mbps}"
+// @Success  200
+// @Router   /api/nftables/bandwidth/{port} [post]
 func docsNftBandwidth() {}
 
-//	@Summary  Set port packet loss alone
-//	@Tags     shaping
-//	@Param    port  path  string  true  "session-bound port"
-//	@Param    body  body  LossRequest true "{loss_pct}"
-//	@Success  200
-//	@Router   /api/nftables/loss/{port} [post]
+// @Summary  Set port packet loss alone
+// @Tags     shaping
+// @Param    port  path  string  true  "session-bound port"
+// @Param    body  body  LossRequest true "{loss_pct}"
+// @Success  200
+// @Router   /api/nftables/loss/{port} [post]
 func docsNftLoss() {}
 
-//	@Summary  Inspect current shaping for a port
-//	@Tags     shaping
-//	@Param    port path string true "session-bound port"
-//	@Produce  json
-//	@Success  200  {object} object
-//	@Router   /api/nftables/port/{port} [get]
+// @Summary  Inspect current shaping for a port
+// @Tags     shaping
+// @Param    port path string true "session-bound port"
+// @Produce  json
+// @Success  200  {object} object
+// @Router   /api/nftables/port/{port} [get]
 func docsNftPort() {}
 
-//	@Summary  Global nftables status
-//	@Tags     shaping
-//	@Produce  json
-//	@Success  200 {object} object
-//	@Router   /api/nftables/status [get]
+// @Summary  Global nftables status
+// @Tags     shaping
+// @Produce  json
+// @Success  200 {object} object
+// @Router   /api/nftables/status [get]
 func docsNftStatus() {}
 
-//	@Summary  Kernel shaping primitives available
-//	@Description Reports whether netem, htb, and per-port rules are operational.
-//	@Tags     shaping
-//	@Produce  json
-//	@Success  200 {object} object
-//	@Router   /api/nftables/capabilities [get]
+// @Summary  Kernel shaping primitives available
+// @Description Reports whether netem, htb, and per-port rules are operational.
+// @Tags     shaping
+// @Produce  json
+// @Success  200 {object} object
+// @Router   /api/nftables/capabilities [get]
 func docsNftCapabilities() {}
 
-//	@Summary  External IPs the harness is reachable from
-//	@Tags     diagnostics
-//	@Produce  json
-//	@Success  200 {object} object
-//	@Router   /api/external-ips [get]
+// @Summary  External IPs the harness is reachable from
+// @Tags     diagnostics
+// @Produce  json
+// @Success  200 {object} object
+// @Router   /api/external-ips [get]
 func docsExternalIPs() {}
 
-//	@Summary  Proxy version
-//	@Tags     diagnostics
-//	@Produce  json
-//	@Success  200 {object} object
-//	@Router   /api/version [get]
+// @Summary  Proxy version
+// @Tags     diagnostics
+// @Produce  json
+// @Success  200 {object} object
+// @Router   /api/version [get]
 func docsVersion() {}
 
-//	@Summary  Player-side metrics ingestion
-//	@Description Players post their internal metrics here. Not for ops use.
-//	@Tags     internal
-//	@Param    id path string true "session_id"
-//	@Param    body body object true "player metrics"
-//	@Success  200
-//	@Router   /api/session/{id}/metrics [post]
+// @Summary  Player-side metrics ingestion
+// @Description Players post their internal metrics here. Not for ops use.
+// @Tags     internal
+// @Param    id path string true "session_id"
+// @Param    body body object true "player metrics"
+// @Success  200
+// @Router   /api/session/{id}/metrics [post]
 func docsPostMetrics() {}
 
 // Request/response types referenced from the @Param / @Success blocks above.

--- a/go-proxy/cmd/server/shaping_gate_test.go
+++ b/go-proxy/cmd/server/shaping_gate_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// #910 per-session degraded-shaping toggle: pins the pure logic (mode
+// normalisation, forced-cap resolution, effective-cap resolution, kernel-gate
+// predicates) and the per-port kernel-apply gate short-circuit. The only
+// degraded mode is http-only (network shaping off, HTTP faults still fire).
+
+func TestNormalizeShapingMode(t *testing.T) {
+	cases := map[string]string{
+		"http-only": "http-only",
+		"HTTP-ONLY": "http-only",
+		"httponly":  "http-only",
+		"http":      "http-only",
+		"kernel":    "",
+		"off":       "",
+		"":          "",
+		"userspace": "",
+		"bogus":     "",
+	}
+	for in, want := range cases {
+		if got := normalizeShapingMode(in); got != want {
+			t.Errorf("normalizeShapingMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestForcedShapingCaps(t *testing.T) {
+	httpOnly, ok := forcedShapingCaps("http-only")
+	if !ok || httpOnly.mode != "http-only" || httpOnly.rate || httpOnly.delay || httpOnly.loss || httpOnly.transportFault {
+		t.Fatalf("http-only caps wrong: %+v ok=%v", httpOnly, ok)
+	}
+	if !httpOnly.degraded() || httpOnly.kernelRateOn() || httpOnly.kernelNetemOn() {
+		t.Fatalf("http-only should be degraded with kernel off: %+v", httpOnly)
+	}
+	if _, ok := forcedShapingCaps("kernel"); ok {
+		t.Fatalf("'kernel' is not a forced mode")
+	}
+	if _, ok := forcedShapingCaps("userspace"); ok {
+		t.Fatalf("'userspace' is no longer a forced mode")
+	}
+}
+
+func kernelCaps() shapingCaps {
+	return shapingCaps{rate: true, delay: true, loss: true, transportFault: true, mode: "kernel"}
+}
+
+func TestEffectiveShapingForSession(t *testing.T) {
+	app := &App{shaping: kernelCaps()}
+
+	// No forced mode → inherits the (kernel) host caps.
+	if eff := app.effectiveShapingForSession(SessionData{}); eff.mode != "kernel" || !eff.kernelRateOn() {
+		t.Fatalf("no forced mode should inherit kernel host caps: %+v", eff)
+	}
+	// Forced http-only on a kernel box → session is degraded, kernel gated.
+	eff := app.effectiveShapingForSession(SessionData{"shaping_forced_mode": "http-only"})
+	if eff.mode != "http-only" || eff.kernelRateOn() || eff.kernelNetemOn() || !eff.degraded() {
+		t.Fatalf("forced http-only should degrade the session: %+v", eff)
+	}
+}
+
+func TestPerPortShapingGate(t *testing.T) {
+	nm := NewTcTrafficManager("lo", false)
+	// Gates default open.
+	if nm.portRateGated(30181) || nm.portNetemGated(30181) {
+		t.Fatalf("gates should default open")
+	}
+	// Close the rate gate for one port only.
+	nm.SetPortShapingGate(30181, true, false)
+	if !nm.portRateGated(30181) || nm.portNetemGated(30181) {
+		t.Fatalf("rate gate should be closed, netem open for 30181")
+	}
+	if nm.portRateGated(30281) {
+		t.Fatalf("other ports must be unaffected (per-session, not global)")
+	}
+	// A gated port no-ops the kernel apply (returns nil WITHOUT shelling to tc).
+	if err := nm.UpdateRateLimit(30181, 5); err != nil {
+		t.Fatalf("gated UpdateRateLimit should no-op nil, got %v", err)
+	}
+	// Clearing re-opens.
+	nm.SetPortShapingGate(30181, false, false)
+	if nm.portRateGated(30181) {
+		t.Fatalf("rate gate should re-open after clear")
+	}
+}
+
+// #910 canonical-clear invariant. A pattern lives in THREE representations —
+// the in-memory step loop, the v1 nftables_pattern_* session fields, and the v2
+// `_v2_shape_pattern` stash the dashboard renders shape.pattern from. They must
+// clear together; the phantom "pattern running" bug was the v2 stash surviving a
+// stop. This pins the invariant so any future divergence fails here.
+func TestDisablePatternClearsAllRepresentations(t *testing.T) {
+	const port = 30181
+	sess := SessionData{
+		"player_id":        "aaaaaaaa-0000-0000-0000-000000000001",
+		"session_id":       "sess-1",
+		"x_forwarded_port": "30181",
+		// (2) v1 session fields — a live pattern with runtime state.
+		"nftables_pattern_enabled":           true,
+		"nftables_pattern_steps":             []NftShapeStep{{RateMbps: 30, DurationSeconds: 6, Enabled: true}},
+		"nftables_pattern_step":              2,
+		"nftables_pattern_step_runtime":      2,
+		"nftables_pattern_rate_runtime_mbps": 7.7,
+		"nftables_pattern_step_runtime_at":   "2026-07-07T00:00:00Z",
+		"nftables_pattern_template_mode":     "pyramid",
+		// (3) v2 stash — what the dashboard's shape.pattern is built from.
+		"_v2_shape_pattern": map[string]interface{}{
+			"template": "pyramid",
+			"steps":    []any{map[string]any{"rate_mbps": 30.0, "duration_seconds": 6.0, "enabled": true}},
+		},
+	}
+	a := newFanoutTestApp([]SessionData{sess}, map[int]ShapeApplyState{})
+	// (1) in-memory loop state.
+	cancelled := false
+	a.shapeStates = map[int]NftShapePattern{port: {
+		Steps:          []NftShapeStep{{RateMbps: 30, DurationSeconds: 6, Enabled: true}},
+		ActiveStep:     2,
+		ActiveRateMbps: 7.7,
+		ActiveAt:       "2026-07-07T00:00:00Z",
+	}}
+	a.shapeLoops = map[int]context.CancelFunc{port: func() { cancelled = true }}
+
+	a.disablePatternForPort(port)
+
+	// (1) in-memory representation gone + loop cancelled.
+	if _, ok := a.getShapePattern(port); ok {
+		t.Errorf("in-memory shapeStates still present after disable")
+	}
+	if _, ok := a.shapeLoops[port]; ok {
+		t.Errorf("shapeLoops[%d] not deleted", port)
+	}
+	if !cancelled {
+		t.Errorf("pattern loop context not cancelled")
+	}
+
+	// Read the mutated session back.
+	var got SessionData
+	for _, s := range a.sessionsView() {
+		if getString(s, "x_forwarded_port") == "30181" {
+			got = s
+		}
+	}
+	if got == nil {
+		t.Fatal("session not found after disable")
+	}
+	// (2) v1 fields cleared.
+	if getBool(got, "nftables_pattern_enabled") {
+		t.Errorf("nftables_pattern_enabled still true")
+	}
+	if steps, ok := got["nftables_pattern_steps"].([]NftShapeStep); !ok || len(steps) != 0 {
+		t.Errorf("nftables_pattern_steps not empty: %v", got["nftables_pattern_steps"])
+	}
+	for _, k := range []string{
+		"nftables_pattern_rate_runtime_mbps",
+		"nftables_pattern_step_runtime",
+		"nftables_pattern_step_runtime_at",
+	} {
+		if got[k] != nil {
+			t.Errorf("%s not cleared: %v", k, got[k])
+		}
+	}
+	if tm := getString(got, "nftables_pattern_template_mode"); tm != "" {
+		t.Errorf("template_mode not cleared: %q", tm)
+	}
+	// (3) v2 stash cleared — the invariant that FAILED before the fix; this is
+	// the source the dashboard's shape.pattern is built from.
+	if got["_v2_shape_pattern"] != nil {
+		t.Errorf("_v2_shape_pattern not cleared (v2 shape.pattern would still render): %v", got["_v2_shape_pattern"])
+	}
+}

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -184,6 +184,24 @@ func (a *v2Adapter) DefaultRateMbps() int {
 	return a.app.defaultRateMbps
 }
 
+// ShapingCapabilities maps the package-main boot-time probe result across the
+// v1/v2 boundary. Issue #910.
+func (a *v2Adapter) ShapingCapabilities() server.ShapingCapabilities {
+	if a == nil || a.app == nil {
+		return server.ShapingCapabilities{Mode: "http-only", Reason: "proxy not initialised"}
+	}
+	c := a.app.shaping
+	return server.ShapingCapabilities{
+		Rate:           c.rate,
+		Delay:          c.delay,
+		Loss:           c.loss,
+		TransportFault: c.transportFault,
+		Mode:           c.mode,
+		Forced:         c.forced,
+		Reason:         c.reason,
+	}
+}
+
 // networkEntryToMap converts a typed v1 ring-buffer entry into the
 // loosely-typed map shape v2's translator consumes. Mirrors the keys
 // in NetworkLogEntry.

--- a/go-proxy/internal/v2/server/fake_adapter_test.go
+++ b/go-proxy/internal/v2/server/fake_adapter_test.go
@@ -15,6 +15,7 @@ import (
 // store's sessionsMu single-mutex contract).
 type fakeAdapter struct {
 	defaultRateMbps int
+	shaping         ShapingCapabilities
 	mu              sync.Mutex
 	sessions        []map[string]any
 
@@ -202,6 +203,13 @@ type fakeTransportFaultCall struct {
 // baseline can set a.defaultRateMbps via a helper.
 func (a *fakeAdapter) DefaultRateMbps() int {
 	return a.defaultRateMbps
+}
+
+// ShapingCapabilities test stub — returns the zero value (all controls
+// unavailable, mode "") unless a test sets a.shaping to exercise a specific
+// mode. Issue #910.
+func (a *fakeAdapter) ShapingCapabilities() ShapingCapabilities {
+	return a.shaping
 }
 
 // ApplyPatternToPlayer test stub — records the call for assertions.

--- a/go-proxy/internal/v2/server/handlers_read.go
+++ b/go-proxy/internal/v2/server/handlers_read.go
@@ -28,6 +28,7 @@ func (s *Server) GetApiV2Info(w http.ResponseWriter, r *http.Request) {
 		ApiVersions: &versions,
 	}
 	defaultRate := 0
+	var shaping ShapingCapabilities
 	if s.v1 != nil {
 		v := s.v1.Version()
 		base.Version = &v
@@ -38,6 +39,7 @@ func (s *Server) GetApiV2Info(w http.ResponseWriter, r *http.Request) {
 		an := s.v1.AnalyticsEnabled()
 		base.AnalyticsEnabled = &an
 		defaultRate = s.v1.DefaultRateMbps()
+		shaping = s.v1.ShapingCapabilities()
 	}
 	type infoWithDefaults struct {
 		oapigen.Info
@@ -47,8 +49,13 @@ func (s *Server) GetApiV2Info(w http.ResponseWriter, r *http.Request) {
 		// dashboard reads this to render the persistent baseline
 		// chip and to label the slider position at 0.
 		DefaultRateMbps int `json:"default_rate_mbps"`
+		// Shaping capability probe (#910): per-control kernel availability
+		// + resolved mode. The dashboard reads this to disable/annotate the
+		// network-shaping controls on a host without tc/netem/nftables
+		// instead of showing a phantom cap. Extra field pending a schema bump.
+		Shaping ShapingCapabilities `json:"shaping"`
 	}
-	writeJSON(w, http.StatusOK, infoWithDefaults{Info: base, DefaultRateMbps: defaultRate})
+	writeJSON(w, http.StatusOK, infoWithDefaults{Info: base, DefaultRateMbps: defaultRate, Shaping: shaping})
 }
 
 // ----- Players (reads) -----------------------------------------------------

--- a/go-proxy/internal/v2/server/v1adapter.go
+++ b/go-proxy/internal/v2/server/v1adapter.go
@@ -138,6 +138,38 @@ type V1Adapter interface {
 	// (and any PATCH that requests "no override," i.e. rate_mbps=0 or
 	// null) get this cap. See issue #480.
 	DefaultRateMbps() int
+
+	// ShapingCapabilities reports the per-control kernel availability and
+	// the resolved shaping mode detected once at boot. The dashboard reads
+	// this to disable/annotate the network-shaping controls that would
+	// otherwise show a phantom cap on a host without tc/netem/nftables.
+	// Issue #910.
+	ShapingCapabilities() ShapingCapabilities
+}
+
+// ShapingCapabilities reports, per network-shaping control, whether the
+// kernel facility that backs it actually applies on this host, plus the
+// resolved shaping mode. Probed once at boot (detectShapingCapabilities in
+// package main). The per-control booleans are authoritative for the UI; Mode
+// is a coarse banner label. Issue #910.
+type ShapingCapabilities struct {
+	// Per-control kernel availability. Rate is tc HTB; Delay/Loss are tc
+	// netem; TransportFault is nftables. A false here means the control is
+	// unavailable on this host and must NOT be presented as an active cap.
+	Rate           bool `json:"rate"`
+	Delay          bool `json:"delay"`
+	Loss           bool `json:"loss"`
+	TransportFault bool `json:"transport_fault"`
+	// Mode is the resolved shaping backend: "kernel" (tc/netem present) or
+	// "http-only" (no kernel shaping — only the portable HTTP-fault surface
+	// works).
+	Mode string `json:"mode"`
+	// Forced is true when SHAPING_FORCE_DEGRADED overrode the live probe,
+	// used to exercise degraded mode on a host that DOES have NET_ADMIN.
+	Forced bool `json:"forced"`
+	// Reason is a short human string for the banner + startup log (e.g.
+	// "no sch_netem/sch_htb" or "forced via SHAPING_FORCE_DEGRADED").
+	Reason string `json:"reason"`
 }
 
 // ShapePatternStep is the v1-shaped step the adapter expects. Mirrors

--- a/tests/deploy/override-dev-degraded.yml
+++ b/tests/deploy/override-dev-degraded.yml
@@ -1,0 +1,74 @@
+services:
+  go-server:
+    container_name: test-dev-degraded-server
+    # #910 degraded-mode stack — IDENTICAL to test-dev (:21000): same image +
+    # code, same TLS (HTTPS), same mounted mkcert certs. The ONLY difference is
+    # SHAPING_FORCE_DEGRADED=http-only below, which overrides the boot-time
+    # shaping probe so the proxy behaves as if the host had NO NET_ADMIN
+    # (no tc/netem/nftables): rate/delay/loss + transport faults report
+    # unavailable and the dashboard shows the degraded UX; HTTP faults still
+    # work. Runs on the 28xxx band so you can A/B kernel (:21000) vs no-TC.
+    #
+    # Genuine no-NET_ADMIN deploy: drop the base compose's `cap_add: [NET_ADMIN]`
+    # and `privileged: true` (via compose's !reset) so this container runs exactly
+    # like a locked-down managed service (Cloud Run / Fargate / PaaS) that forbids
+    # them. Safe because SHAPING_FORCE_DEGRADED=http-only short-circuits the boot
+    # capability probe and the runtime shaping is gated off (kernelRateOn/
+    # kernelNetemOn == false), so the proxy never shells out to tc/nft at all.
+    cap_add: !reset []
+    privileged: false
+    # Build a distinct, leaner image WITHOUT the NET_ADMIN binaries (iproute2/
+    # nftables) — see Dockerfile KERNEL_SHAPING. Own tag so it doesn't clobber
+    # the kernel `infinite-streaming` image the primary (:21000) runs. Nothing
+    # calls tc/nft in http-only mode, so the image ships without them.
+    image: infinite-streaming-degraded
+    build:
+      args:
+        KERNEL_SHAPING: "0"
+    volumes:
+      # Same mkcert certs as test-dev — TLS certs are per-hostname, not per-port,
+      # so the localhost.pem for jonathanoliver-ubuntu.local is valid on :28000.
+      # The deploy target copies ~/test-dev/certs into this stack's dir.
+      - ./certs:/media/certs:ro
+      # Share the encoded content library from the primary test-dev (no
+      # re-upload/re-encode); this stack keeps its OWN state under CONTENT_DIR.
+      - ${SHARED_CONTENT_DIR}/dynamic_content:/media/dynamic_content
+      - ${SHARED_CONTENT_DIR}/originals:/media/originals
+      - ${SHARED_CONTENT_DIR}/uploads:/media/uploads
+    environment:
+      # TLS-only external listen on 30000; in-container go-proxy → nginx uses the
+      # cleartext loopback listener on 30005 (same as test-dev).
+      - INFINITE_STREAM_UPSTREAM_PORT=30005
+      - INFINITE_STREAM_DEFAULT_RATE_MBPS=100
+      # The whole point of this stack: force the degraded probe result.
+      - SHAPING_FORCE_DEGRADED=http-only
+    ports:
+      !override
+      - "28000:30000"
+      - "28081:30081"
+      - "28181:30181"
+      - "28281:30281"
+      - "28381:30381"
+      - "28481:30481"
+      - "28581:30581"
+      - "28681:30681"
+      - "28781:30781"
+      - "28881:30881"
+  clickhouse:
+    container_name: test-dev-degraded-clickhouse
+    ports:
+      !override
+      - "127.0.0.1:28123:8123"
+  grafana:
+    container_name: test-dev-degraded-grafana
+    ports: !override []
+    environment:
+      - GF_SERVER_ROOT_URL=https://dev.jeoliver.com:28000/grafana/
+  forwarder:
+    container_name: test-dev-degraded-forwarder
+    environment:
+      # HTTPS to the proxy SSE — this stack runs TLS on, same as test-dev.
+      - FORWARDER_SSE_URL=https://go-server:30081/api/sessions/stream
+      - FORWARDER_CLICKHOUSE_URL=http://clickhouse:8123
+      - FORWARDER_CLICKHOUSE_DB=infinite_streaming
+      - FORWARDER_CLICKHOUSE_TABLE=session_events

--- a/tests/deploy/override-dev.yml
+++ b/tests/deploy/override-dev.yml
@@ -22,6 +22,11 @@ services:
       # the issue describes don't recur. Prod-style deployments leave
       # this unset (= 0 = unlimited) to preserve today's behaviour.
       - INFINITE_STREAM_DEFAULT_RATE_MBPS=100
+      # #910: force http-only (degraded) shaping even on this NET_ADMIN box, so
+      # the fallback can be exercised + A/B'd against real tc/netem. Empty
+      # (default) = off = live kernel probe. Set at `docker compose up` time:
+      #   SHAPING_FORCE_DEGRADED=http-only docker compose up -d go-server
+      - SHAPING_FORCE_DEGRADED=${SHAPING_FORCE_DEGRADED:-}
     ports:
       !override
       - "21000:30000"


### PR DESCRIPTION
Closes #910.

**Approach note:** the issue originally proposed a *userspace fallback shaping* path. That was explored and dropped as misleading (a userspace approximation reads like real shaping but isn't). Instead this lands a first-class **degraded (http-only) mode**: when the host can't kernel-shape, the proxy reports those controls *unavailable* rather than silently approximating them.

## Degraded shaping mode (`feat`, e1cafe66)
- **go-proxy**: boot-time capability probe (`probeTcCapabilities` / `probeNftCapability`) + a `SHAPING_FORCE_DEGRADED` override, resolved into a `shapingCaps{mode}` that gates every apply via `kernelRateOn` / `kernelNetemOn`. In http-only mode the proxy never touches the kernel; rate/delay/loss + transport faults report unavailable. `ShapingCapabilities` is surfaced across the v1/v2 boundary.
- **dashboard-v3**: `ShapingModeControl` (Kernel / Faults-only) under Session Controls, shown only in developer mode or when the host can't kernel-shape; degraded modes disable the transport-fault + network-shaping controls with a clear "requires NET_ADMIN" message. Adds `NetworkShaping` + `useSessionShaping`.
- **forwarder**: `shaping_degraded` control label (+ per-mode `shaping_<mode>`) so a degraded session is tagged in the dashboard and queryable via `--label-has`.

## No-NET_ADMIN build + A/B deploy stack (`build`, fea75c54)
- **Dockerfile**: `ARG KERNEL_SHAPING=1` gates `iproute2` (tc) + `nftables` (nft). Build with `--build-arg KERNEL_SHAPING=0` for a degraded image that ships without the privileged networking binaries — nothing calls them in http-only mode.
- **override-dev-degraded.yml**: a second full stack on the 28xxx band that drops the base compose's caps (`cap_add: !reset []` + `privileged: false`), builds its own leaner image tag (`infinite-streaming-degraded`) so it doesn't clobber the kernel image, and forces `SHAPING_FORCE_DEGRADED=http-only`.
- **Makefile**: `test-deploy-dev-degraded` — runs alongside test-dev (`:21000`, kernel) so you can A/B kernel vs no-TC, sharing the encoded content library.

## Verified live (both stacks, from one source tree)
| | `:21000` full kernel | `:28000` lean degraded |
|---|---|---|
| image | `infinite-streaming` | `infinite-streaming-degraded` |
| tc / nft | present | **absent** |
| privileged / caps | `true` / `[NET_ADMIN]` | `false` / `[]` |
| shaping mode | `kernel` | `http-only` |

On `:28000` (genuinely unprivileged, no tc/nft binaries): `TestServerFault` passes and the Network Log fills end to end — 718 network rows / 250 faulted / 63×503. HTTP faults + network log fully functional; only the kernel-shaping axes are off, as intended.
