### PR TITLE
feat(910): add shape.mode (kernel|http_only) to the v2 player model (#920)

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1470,6 +1470,22 @@ components:
         jitter_correlation_pct: { type: number, format: float, minimum: 0, maximum: 100, description: 'Correlation for the delay distribution (~25% ≈ real link). Only meaningful with `jitter_ms` > 0.' }
         pattern:          { $ref: '#/components/schemas/Pattern' }
         transport_fault:  { $ref: '#/components/schemas/TransportFault' }
+        mode:
+          type: string
+          enum: [kernel, http_only]
+          default: kernel
+          description: >
+            Per-session degraded shaping mode (#910). `http_only` forces this
+            ONE session onto the HTTP-only path: kernel rate / delay / loss /
+            netem AND transport faults are gated OFF, while HTTP faults still
+            fire. `kernel` (default) = inherit the host's shaping capability
+            (full kernel shaping when the box has NET_ADMIN + tc + nftables).
+            A session can only be MORE degraded than the host, never less — on
+            a NET_ADMIN-less host every session is effectively `http_only`
+            regardless of this field. Maps to v1 `shaping_forced_mode`
+            (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot
+            override is `SHAPING_FORCE_DEGRADED` (env), independent of this
+            per-session control. *Broadcasts to group on PATCH.*
         # Pattern runtime telemetry — read-only mirror of which step in
         # `pattern.steps` the kernel is currently enforcing. The
         # dashboard reads these to draw the live target line on the

--- a/content/dashboard-v3/src/composables/usePlayer.ts
+++ b/content/dashboard-v3/src/composables/usePlayer.ts
@@ -322,8 +322,13 @@ export function usePlayer(playerId: Ref<string>) {
     error: query.error,
     sseState: sse.state,
 
-    // Shape (rate / delay / loss / pattern / transport_fault)
+    // Shape (rate / delay / loss / pattern / transport_fault / mode)
     setShape: (partial: Partial<Shape>) => patchShape.mutate(partial),
+    // Awaitable variant — resolves on success, rejects with the HTTP error
+    // (err.status) on failure. Used where the caller needs to surface a
+    // per-error message (e.g. the #910 shaping-mode control's 404 "start
+    // playback first"). Optimistic update + rollback still apply.
+    setShapeAsync: (partial: Partial<Shape>) => patchShape.mutateAsync(partial),
     // setRate disarms any active throughput pattern — the rate slider and
     // the pattern are mutually exclusive sources-of-truth for the kernel
     // cap. Delay and loss are orthogonal axes that can coexist with a

--- a/content/dashboard-v3/src/composables/useSessionShaping.ts
+++ b/content/dashboard-v3/src/composables/useSessionShaping.ts
@@ -23,9 +23,9 @@
  *     actually do it; on a NET_ADMIN-less host it shows disabled.
  */
 import { computed, ref, type Ref } from 'vue';
-import { useQueryClient } from '@tanstack/vue-query';
 import { usePlayer } from '@/composables/usePlayer';
 import { useShapingCapabilities } from '@/composables/useBaselineRate';
+import type { Shape } from '@/repo/v2-repo';
 
 // id === '' is the kernel (full-shaping) mode; the API takes 'off' for it.
 // The only degraded mode is http-only: no network shaping, HTTP faults still
@@ -37,9 +37,8 @@ export const SHAPING_MODES: Array<{ id: string; label: string }> = [
 ];
 
 export function useSessionShaping(playerId: Ref<string>) {
-  const { player } = usePlayer(playerId);
+  const { player, setShapeAsync } = usePlayer(playerId);
   const { shaping } = useShapingCapabilities();
-  const qc = useQueryClient();
 
   // `?developer=1` — the shared convention (SessionDetails, ShellLayout, Grid).
   const developerMode = computed(
@@ -70,8 +69,12 @@ export function useSessionShaping(playerId: Ref<string>) {
   const settingMode = ref(false);
   const modeError = ref('');
 
-  // Drives the per-session degrade endpoint (by player_id) and refreshes the
-  // player so raw_session.shaping_forced_mode + all gating recompute.
+  // Drives the per-session degrade via a v2 `shape.mode` PATCH (#920 — the
+  // legacy POST /api/nftables/shaping-mode is retired here). usePlayer's
+  // optimistic patchShape carries the If-Match/control_revision handshake and
+  // refetches authoritative state on success/conflict, so raw_session
+  // .shaping_forced_mode + all gating recompute. The internal ids are '' /
+  // 'http-only'; the v2 enum is 'kernel' / 'http_only'.
   async function setShapingMode(mode: string) {
     if (settingMode.value || mode === forcedMode.value) return;
     // Can't pick the kernel path on a host that can't do it.
@@ -79,21 +82,14 @@ export function useSessionShaping(playerId: Ref<string>) {
     settingMode.value = true;
     modeError.value = '';
     try {
-      const res = await fetch('/api/nftables/shaping-mode', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ player_id: playerId.value, mode: mode || 'off' }),
-      });
-      if (!res.ok) {
-        modeError.value =
-          res.status === 404
-            ? 'No active proxy session for this player — start playback first.'
-            : `Couldn't set shaping mode (HTTP ${res.status}).`;
-      }
+      await setShapeAsync({ mode: mode === 'http-only' ? 'http_only' : 'kernel' } as Partial<Shape>);
     } catch (e) {
-      modeError.value = `Couldn't set shaping mode: ${e instanceof Error ? e.message : String(e)}`;
+      const status = (e as { status?: number })?.status;
+      modeError.value =
+        status === 404
+          ? 'No active proxy session for this player — start playback first.'
+          : `Couldn't set shaping mode${status ? ` (HTTP ${status})` : `: ${e instanceof Error ? e.message : String(e)}`}.`;
     } finally {
-      await qc.invalidateQueries({ queryKey: ['player', playerId.value] });
       settingMode.value = false;
     }
   }

--- a/content/dashboard-v3/src/types/v2.ts
+++ b/content/dashboard-v3/src/types/v2.ts
@@ -1854,6 +1854,12 @@ export interface components {
             jitter_correlation_pct?: number;
             pattern?: components["schemas"]["Pattern"];
             transport_fault?: components["schemas"]["TransportFault"];
+            /**
+             * @description Per-session degraded shaping mode (#910). `http_only` forces this ONE session onto the HTTP-only path: kernel rate / delay / loss / netem AND transport faults are gated OFF, while HTTP faults still fire. `kernel` (default) = inherit the host's shaping capability (full kernel shaping when the box has NET_ADMIN + tc + nftables). A session can only be MORE degraded than the host, never less — on a NET_ADMIN-less host every session is effectively `http_only` regardless of this field. Maps to v1 `shaping_forced_mode` (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot override is `SHAPING_FORCE_DEGRADED` (env), independent of this per-session control. *Broadcasts to group on PATCH.*
+             * @default kernel
+             * @enum {string}
+             */
+            mode: "kernel" | "http_only";
             /** @description 1-based index of the currently active step in `pattern.steps`. 0 when pattern is disabled or in an inter-step idle gap. */
             readonly pattern_step?: number | null;
             /** @description Same as `pattern_step` but reset whenever the pattern definition changes (the runtime cursor, separate from any cached UI step). */

--- a/content/dashboard/api-docs/forwarder-v2.yaml
+++ b/content/dashboard/api-docs/forwarder-v2.yaml
@@ -1068,6 +1068,7 @@ components:
         device_class: { type: string, description: "Device taxonomy class (phone|tablet|tv|…). From the typed column (#550 Phase 4)." }
         device_model: { type: string, description: "Device model identifier (e.g. 'iPhone15,2'). From the typed column." }
         player_tech:  { type: string, description: "Player technology (e.g. 'AVPlayer'). From the typed column." }
+        player_tech_version: { type: string, description: "Player engine version, paired with player_tech (Media3/ExoPlayer lib version on Android; OS version on iOS). From the typed column." }
         app_version:  { type: string, description: "Client app version. From the typed column." }
         os_version:   { type: string, description: "OS version, 'major.minor' (or just 'major'), joined from os_version_major/os_version_minor." }
         content_id:   { type: string, description: "Content identifier — duplicated here so the object is self-contained for the viewer header." }
@@ -1501,6 +1502,8 @@ components:
         transfer_ms: { type: number, format: float }
         total_ms: { type: number, format: float }
         client_wait_ms: { type: number, format: float }
+        delivery_rate_mbps: { type: number, format: float }
+        delivery_rate_app_limited: { type: integer, enum: [0, 1] }
         faulted: { type: integer, enum: [0, 1] }
         fault_type: { type: string }
         fault_action: { type: string }

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1470,6 +1470,22 @@ components:
         jitter_correlation_pct: { type: number, format: float, minimum: 0, maximum: 100, description: 'Correlation for the delay distribution (~25% ≈ real link). Only meaningful with `jitter_ms` > 0.' }
         pattern:          { $ref: '#/components/schemas/Pattern' }
         transport_fault:  { $ref: '#/components/schemas/TransportFault' }
+        mode:
+          type: string
+          enum: [kernel, http_only]
+          default: kernel
+          description: >
+            Per-session degraded shaping mode (#910). `http_only` forces this
+            ONE session onto the HTTP-only path: kernel rate / delay / loss /
+            netem AND transport faults are gated OFF, while HTTP faults still
+            fire. `kernel` (default) = inherit the host's shaping capability
+            (full kernel shaping when the box has NET_ADMIN + tc + nftables).
+            A session can only be MORE degraded than the host, never less — on
+            a NET_ADMIN-less host every session is effectively `http_only`
+            regardless of this field. Maps to v1 `shaping_forced_mode`
+            (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot
+            override is `SHAPING_FORCE_DEGRADED` (env), independent of this
+            per-session control. *Broadcasts to group on PATCH.*
         # Pattern runtime telemetry — read-only mirror of which step in
         # `pattern.steps` the kernel is currently enforcing. The
         # dashboard reads these to draw the live target line on the
@@ -1821,6 +1837,8 @@ components:
         tls_ms:          { type: number, format: float, description: 'Upstream TLS handshake time.' }
         transfer_ms:     { type: number, format: float, description: 'Downstream write+flush time to client (player-perceived receive).' }
         client_wait_ms:  { type: number, format: float, description: 'Server-perceived wait between request received and first response byte sent.' }
+        delivery_rate_mbps: { type: number, format: float, description: 'Kernel-measured shaped delivery rate (tcpi_delivery_rate, Mbps) sampled at end of transfer. Honest cross-check for bytes_out/transfer_ms, which over-reports on sub-buffer transfers (#850). Connection-level; 0/absent when not sampled (non-Linux build).' }
+        delivery_rate_app_limited: { type: boolean, description: 'Kernel tcpi_delivery_rate_app_limited flag for the delivery_rate_mbps sample. true = the sender was starved (app-limited), so the rate reflects the app not the link and reads noisily (starved low or burst high); trust delivery_rate_mbps only when false (network-limited). Only meaningful when delivery_rate_mbps is non-zero. Linux only.' }
         faulted:        { type: boolean }
         fault_type:     { type: string }
         fault_action:   { type: string }

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -620,6 +620,32 @@ func (a *v2Adapter) ApplyShapeToPlayer(playerID string) error {
 	return nil
 }
 
+// ApplyShapingModeToPlayer reconciles the #910 per-session degraded gate on
+// the player's bound port after a v2 PATCH changed `shaping_forced_mode`.
+// Delegates to applyForcedShapingModeForPort, the same reconcile the v1
+// /api/nftables/shaping-mode endpoint runs.
+func (a *v2Adapter) ApplyShapingModeToPlayer(playerID string) error {
+	if a == nil || a.app == nil {
+		return nil
+	}
+	for _, s := range a.app.sessionsView() { // #740 read-only: matches player, reads port
+		if !matchesPlayerID(getString(s, "player_id"), playerID) {
+			continue
+		}
+		portStr := getString(s, "x_forwarded_port")
+		if portStr == "" {
+			return nil
+		}
+		port, perr := strconv.Atoi(portStr)
+		if perr != nil {
+			return nil
+		}
+		a.app.applyForcedShapingModeForPort(port)
+		return nil
+	}
+	return nil
+}
+
 // ApplyPatternToPlayer drives v1's pattern step-engine on the player's
 // bound port via applyShapePattern. Empty steps disarm the loop.
 func (a *v2Adapter) ApplyPatternToPlayer(playerID string, steps []server.ShapePatternStep, imp server.LinkImpairment) error {

--- a/go-proxy/internal/v2/server/fake_adapter_test.go
+++ b/go-proxy/internal/v2/server/fake_adapter_test.go
@@ -21,9 +21,10 @@ type fakeAdapter struct {
 
 	// Test-side observation hooks for kernel-apply calls. Real adapter
 	// drives v1's nftables / tc helpers; the fake just records.
-	shapeApplyCalls     []string
-	transportFaultCalls []fakeTransportFaultCall
-	patternApplyCalls   []fakePatternCall
+	shapeApplyCalls       []string
+	shapingModeApplyCalls []string
+	transportFaultCalls   []fakeTransportFaultCall
+	patternApplyCalls     []fakePatternCall
 
 	// SubscribeSessions delivers snapshots whenever sessionsChanged
 	// fires; pretests can call it directly to drive the diff.
@@ -173,6 +174,13 @@ func labelsMapEqual(a, b map[string]any) bool {
 func (a *fakeAdapter) ApplyShapeToPlayer(playerID string) error {
 	a.mu.Lock()
 	a.shapeApplyCalls = append(a.shapeApplyCalls, playerID)
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *fakeAdapter) ApplyShapingModeToPlayer(playerID string) error {
+	a.mu.Lock()
+	a.shapingModeApplyCalls = append(a.shapingModeApplyCalls, playerID)
 	a.mu.Unlock()
 	return nil
 }

--- a/go-proxy/internal/v2/server/handlers_integration_test.go
+++ b/go-proxy/internal/v2/server/handlers_integration_test.go
@@ -785,6 +785,65 @@ func TestPatch_ImpairmentKnobsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPatch_ShapingMode_DegradeAndClear is the #920 parity guard: a v2
+// `shape.mode` PATCH must drive v1's `shaping_forced_mode` and fire the kernel
+// gate reconcile (ApplyShapingModeToPlayer) — the same effect the legacy
+// POST /api/nftables/shaping-mode endpoint had. This is the field that
+// unblocks the #919 native-evaluator refactor.
+func TestPatch_ShapingMode_DegradeAndClear(t *testing.T) {
+	a, _, ts := newTestServer(t)
+	pid := uuid.New().String()
+	initialRev := "2020-01-01T00:00:00.000000000Z"
+	a.addPlayer(pid, initialRev, nil)
+
+	// Degrade: shape.mode=http_only → v1 shaping_forced_mode="http-only".
+	body := `{"shape":{"mode":"http_only"}}`
+	status, respBody, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+pid, body,
+		map[string]string{"If-Match": `"` + initialRev + `"`})
+	if status != http.StatusOK {
+		t.Fatalf("degrade status %d body=%s (shape.mode must be a supported path, not 501)", status, respBody)
+	}
+	stored, _ := a.SessionByPlayerID(pid)
+	if stored["shaping_forced_mode"] != "http-only" {
+		t.Errorf("shaping_forced_mode = %v, want %q", stored["shaping_forced_mode"], "http-only")
+	}
+	// Response shape must round-trip the mode so the dashboard control reflects it.
+	if !strings.Contains(string(respBody), `"mode":"http_only"`) {
+		t.Errorf("PATCH response did not round-trip shape.mode; body=%s", respBody)
+	}
+	// The kernel gate reconcile must have fired.
+	a.mu.Lock()
+	degradeCalls := append([]string{}, a.shapingModeApplyCalls...)
+	a.mu.Unlock()
+	if !containsString(degradeCalls, pid) {
+		t.Errorf("ApplyShapingModeToPlayer not called on degrade for %s; calls=%v", pid, degradeCalls)
+	}
+
+	// Clear: shape.mode=kernel → v1 shaping_forced_mode="" (inherit host caps).
+	rev2, _ := stored["control_revision"].(string)
+	if rev2 == "" {
+		t.Fatalf("no control_revision after degrade PATCH; stored=%v", stored["control_revision"])
+	}
+	status2, respBody2, _ := mustDo(t, ts, "PATCH", "/api/v2/players/"+pid, `{"shape":{"mode":"kernel"}}`,
+		map[string]string{"If-Match": `"` + rev2 + `"`})
+	if status2 != http.StatusOK {
+		t.Fatalf("clear status %d body=%s", status2, respBody2)
+	}
+	stored2, _ := a.SessionByPlayerID(pid)
+	if stored2["shaping_forced_mode"] != "" {
+		t.Errorf("shaping_forced_mode after clear = %v, want empty", stored2["shaping_forced_mode"])
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
 func TestPatch_TransportFault_ArmsKernel(t *testing.T) {
 	a, _, ts := newTestServer(t)
 	pid := uuid.New().String()

--- a/go-proxy/internal/v2/server/handlers_mutate.go
+++ b/go-proxy/internal/v2/server/handlers_mutate.go
@@ -334,6 +334,16 @@ func (s *Server) PatchApiV2PlayersPlayerId(w http.ResponseWriter, r *http.Reques
 			_ = s.v1.ApplyShapeToPlayer(p)
 		}
 	}
+	// #910 degrade reconcile runs AFTER the rate/delay/loss push so a combined
+	// {rate, mode:http_only} patch ends degraded (gate closed tears the rate
+	// back down); a {mode:kernel} clear re-opens the gate and re-applies the
+	// stored shape inside ApplyShapingModeToPlayer.
+	if shapingModeTouched(paths) {
+		_ = s.v1.ApplyShapingModeToPlayer(pidStr)
+		for _, p := range broadcastTouched {
+			_ = s.v1.ApplyShapingModeToPlayer(p)
+		}
+	}
 	if transportFaultTouched(paths) {
 		applyTransportFaultFromSession(s, post, pidStr)
 		for _, p := range broadcastTouched {
@@ -385,6 +395,7 @@ func unsupportedPaths(paths []string) []string {
 		case p == "shape.jitter_correlation_pct": // #826
 		case p == "shape.transport_fault", strings.HasPrefix(p, "shape.transport_fault."):
 		case p == "shape.pattern", strings.HasPrefix(p, "shape.pattern."):
+		case p == "shape.mode": // #910 per-session degraded mode
 		case p == "shape":
 		case p == "fault_rules":
 		case p == "transfer_timeouts", strings.HasPrefix(p, "transfer_timeouts."):
@@ -405,6 +416,20 @@ func shapeFieldsTouched(paths []string) bool {
 		switch p {
 		case "shape", "shape.rate_mbps", "shape.delay_ms", "shape.loss_pct",
 			"shape.jitter_ms", "shape.loss_correlation_pct", "shape.jitter_correlation_pct": // #826
+			return true
+		}
+	}
+	return false
+}
+
+// shapingModeTouched reports whether the patch touches the #910 per-session
+// degraded mode (`shape.mode`). Used to decide whether to invoke
+// ApplyShapingModeToPlayer after a successful PATCH — the mode change has to
+// reconcile the kernel gate (tear down / re-apply shaping) separately from the
+// rate/delay/loss push that ApplyShapeToPlayer does.
+func shapingModeTouched(paths []string) bool {
+	for _, p := range paths {
+		if p == "shape" || p == "shape.mode" {
 			return true
 		}
 	}
@@ -729,6 +754,9 @@ func applyShapePatch(srv *Server, s map[string]any, shape any) {
 		s["transport_failure_frequency"] = 0
 		s["transport_consecutive_failures"] = 1
 		s["transport_failure_mode"] = "failures_per_seconds"
+		// Wholesale wipe also clears the #910 degrade back to kernel (inherit
+		// host caps) — `shape: null` is "operator cleared all shaping intent."
+		s["shaping_forced_mode"] = ""
 		return
 	}
 	shapeMap, ok := shape.(map[string]any)
@@ -779,12 +807,30 @@ func applyShapePatch(srv *Server, s map[string]any, shape any) {
 			s["nftables_jitter_correlation_pct"] = f
 		}
 	}
+	if v, present := shapeMap["mode"]; present {
+		// #910 per-session degraded mode. v2 `http_only` → v1
+		// `shaping_forced_mode="http-only"`; anything else (incl. "kernel"
+		// or null) clears to "" = inherit host caps. The kernel/gate
+		// reconcile runs post-PATCH via ApplyShapingModeToPlayer.
+		s["shaping_forced_mode"] = v1ShapingForcedMode(v)
+	}
 	if tf, present := shapeMap["transport_fault"]; present {
 		applyTransportFaultPatch(s, tf)
 	}
 	if pat, present := shapeMap["pattern"]; present {
 		applyPatternPatch(s, pat)
 	}
+}
+
+// v1ShapingForcedMode maps a v2 `shape.mode` value to the v1
+// `shaping_forced_mode` storage string. Only `http_only` names a degraded
+// mode; "kernel", null, and anything unrecognised clear to "" (inherit host
+// caps). Mirrors normalizeShapingMode in package main. Issue #910.
+func v1ShapingForcedMode(v any) string {
+	if s, ok := v.(string); ok && s == "http_only" {
+		return "http-only"
+	}
+	return ""
 }
 
 // applyPatternPatch stashes the v2 pattern shape on `_v2_shape_pattern`

--- a/go-proxy/internal/v2/server/handlers_plays.go
+++ b/go-proxy/internal/v2/server/handlers_plays.go
@@ -342,6 +342,9 @@ func (s *Server) PatchApiV2PlaysPlayId(w http.ResponseWriter, r *http.Request, p
 	} else if shapeFieldsTouched(paths) {
 		_ = s.v1.ApplyShapeToPlayer(playerID)
 	}
+	if shapingModeTouched(paths) {
+		_ = s.v1.ApplyShapingModeToPlayer(playerID)
+	}
 	if transportFaultTouched(paths) {
 		applyTransportFaultFromSession(s, post, playerID)
 	}

--- a/go-proxy/internal/v2/server/v1adapter.go
+++ b/go-proxy/internal/v2/server/v1adapter.go
@@ -117,6 +117,14 @@ type V1Adapter interface {
 	// non-Linux or has no traffic manager.
 	ApplyShapeToPlayer(playerID string) error
 
+	// ApplyShapingModeToPlayer reconciles the #910 per-session degraded gate
+	// on the player's bound port after `shaping_forced_mode` changed: degrading
+	// tears down any kernel shaping and closes the apply gate (HTTP faults
+	// still fire); clearing re-opens the gate and re-applies the session's
+	// stored shape. No-op when the proxy is non-Linux or has no traffic
+	// manager. Reads the mode from the session — no argument needed.
+	ApplyShapingModeToPlayer(playerID string) error
+
 	// ApplyTransportFaultToPlayer arms the transport-fault loop on the
 	// player's bound port with the supplied type/cadence. type="none"
 	// disarms.

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -544,6 +544,24 @@ func (e ReplayGapEventType) Valid() bool {
 	}
 }
 
+// Defines values for ShapeMode.
+const (
+	HttpOnly ShapeMode = "http_only"
+	Kernel   ShapeMode = "kernel"
+)
+
+// Valid indicates whether the value is a known member of the ShapeMode enum.
+func (e ShapeMode) Valid() bool {
+	switch e {
+	case HttpOnly:
+		return true
+	case Kernel:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for TransportFaultMode.
 const (
 	TransportFaultModeFailuresPerPackets TransportFaultMode = "failures_per_packets"
@@ -2041,7 +2059,10 @@ type Shape struct {
 	// LossCorrelationPct Burst correlation for `loss_pct` → netem `loss <pct>% <corr>%`. 0 ⇒ independent-uniform loss (legacy). Higher = burstier.
 	LossCorrelationPct *float32 `json:"loss_correlation_pct,omitempty"`
 	LossPct            *float32 `json:"loss_pct,omitempty"`
-	Pattern            *Pattern `json:"pattern,omitempty"`
+
+	// Mode Per-session degraded shaping mode (#910). `http_only` forces this ONE session onto the HTTP-only path: kernel rate / delay / loss / netem AND transport faults are gated OFF, while HTTP faults still fire. `kernel` (default) = inherit the host's shaping capability (full kernel shaping when the box has NET_ADMIN + tc + nftables). A session can only be MORE degraded than the host, never less — on a NET_ADMIN-less host every session is effectively `http_only` regardless of this field. Maps to v1 `shaping_forced_mode` (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot override is `SHAPING_FORCE_DEGRADED` (env), independent of this per-session control. *Broadcasts to group on PATCH.*
+	Mode    *ShapeMode `json:"mode,omitempty"`
+	Pattern *Pattern   `json:"pattern,omitempty"`
 
 	// PatternRateRuntimeMbps Effective rate the kernel is enforcing right now from the active step. Distinct from `rate_mbps` (the static fallback when pattern is off).
 	PatternRateRuntimeMbps *float32 `json:"pattern_rate_runtime_mbps,omitempty"`
@@ -2061,6 +2082,9 @@ type Shape struct {
 	// are mutually exclusive at the kernel rule level.
 	TransportFault *TransportFault `json:"transport_fault,omitempty"`
 }
+
+// ShapeMode Per-session degraded shaping mode (#910). `http_only` forces this ONE session onto the HTTP-only path: kernel rate / delay / loss / netem AND transport faults are gated OFF, while HTTP faults still fire. `kernel` (default) = inherit the host's shaping capability (full kernel shaping when the box has NET_ADMIN + tc + nftables). A session can only be MORE degraded than the host, never less — on a NET_ADMIN-less host every session is effectively `http_only` regardless of this field. Maps to v1 `shaping_forced_mode` (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot override is `SHAPING_FORCE_DEGRADED` (env), independent of this per-session control. *Broadcasts to group on PATCH.*
+type ShapeMode string
 
 // StreamEvent Discriminated union. `type` selects the variant. Heartbeat frames
 // carry no data and exist only to keep idle proxies / load balancers

--- a/go-proxy/pkg/v2translate/translate.go
+++ b/go-proxy/pkg/v2translate/translate.go
@@ -752,12 +752,21 @@ func shapeFromSession(s map[string]any) *oapigen.Shape {
 	tfType, _ := s["transport_failure_type"].(string)
 	pattern, _ := s["_v2_shape_pattern"].(map[string]any)
 	drivenBy, _ := s["nftables_pattern_driven_by"].(string)
+	// #910 per-session degraded mode. "http-only" is a shape-bearing state on
+	// its own — a session forced degraded with no rate/delay/loss must still
+	// surface `shape.mode` so the dashboard's mode control reflects it.
+	forcedMode, _ := s["shaping_forced_mode"].(string)
+	degraded := forcedMode == "http-only"
 
 	if rate == 0 && delay == 0 && loss == 0 && jitter == 0 && lossCorr == 0 && jitterCorr == 0 &&
-		(tfType == "" || tfType == "none") && pattern == nil && drivenBy == "" {
+		(tfType == "" || tfType == "none") && pattern == nil && drivenBy == "" && !degraded {
 		return nil
 	}
 	out := &oapigen.Shape{}
+	if degraded {
+		m := oapigen.HttpOnly
+		out.Mode = &m
+	}
 	if rate > 0 {
 		r := float32(rate)
 		out.RateMbps = &r

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -545,6 +545,24 @@ func (e ReplayGapEventType) Valid() bool {
 	}
 }
 
+// Defines values for ShapeMode.
+const (
+	HttpOnly ShapeMode = "http_only"
+	Kernel   ShapeMode = "kernel"
+)
+
+// Valid indicates whether the value is a known member of the ShapeMode enum.
+func (e ShapeMode) Valid() bool {
+	switch e {
+	case HttpOnly:
+		return true
+	case Kernel:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for TransportFaultMode.
 const (
 	TransportFaultModeFailuresPerPackets TransportFaultMode = "failures_per_packets"
@@ -2042,7 +2060,10 @@ type Shape struct {
 	// LossCorrelationPct Burst correlation for `loss_pct` → netem `loss <pct>% <corr>%`. 0 ⇒ independent-uniform loss (legacy). Higher = burstier.
 	LossCorrelationPct *float32 `json:"loss_correlation_pct,omitempty"`
 	LossPct            *float32 `json:"loss_pct,omitempty"`
-	Pattern            *Pattern `json:"pattern,omitempty"`
+
+	// Mode Per-session degraded shaping mode (#910). `http_only` forces this ONE session onto the HTTP-only path: kernel rate / delay / loss / netem AND transport faults are gated OFF, while HTTP faults still fire. `kernel` (default) = inherit the host's shaping capability (full kernel shaping when the box has NET_ADMIN + tc + nftables). A session can only be MORE degraded than the host, never less — on a NET_ADMIN-less host every session is effectively `http_only` regardless of this field. Maps to v1 `shaping_forced_mode` (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot override is `SHAPING_FORCE_DEGRADED` (env), independent of this per-session control. *Broadcasts to group on PATCH.*
+	Mode    *ShapeMode `json:"mode,omitempty"`
+	Pattern *Pattern   `json:"pattern,omitempty"`
 
 	// PatternRateRuntimeMbps Effective rate the kernel is enforcing right now from the active step. Distinct from `rate_mbps` (the static fallback when pattern is off).
 	PatternRateRuntimeMbps *float32 `json:"pattern_rate_runtime_mbps,omitempty"`
@@ -2062,6 +2083,9 @@ type Shape struct {
 	// are mutually exclusive at the kernel rule level.
 	TransportFault *TransportFault `json:"transport_fault,omitempty"`
 }
+
+// ShapeMode Per-session degraded shaping mode (#910). `http_only` forces this ONE session onto the HTTP-only path: kernel rate / delay / loss / netem AND transport faults are gated OFF, while HTTP faults still fire. `kernel` (default) = inherit the host's shaping capability (full kernel shaping when the box has NET_ADMIN + tc + nftables). A session can only be MORE degraded than the host, never less — on a NET_ADMIN-less host every session is effectively `http_only` regardless of this field. Maps to v1 `shaping_forced_mode` (`http_only`↔`"http-only"`, `kernel`↔`""`). The server-wide boot override is `SHAPING_FORCE_DEGRADED` (env), independent of this per-session control. *Broadcasts to group on PATCH.*
+type ShapeMode string
 
 // StreamEvent Discriminated union. `type` selects the variant. Heartbeat frames
 // carry no data and exist only to keep idle proxies / load balancers


### PR DESCRIPTION
## What

Adds `Shape.mode` (`kernel` | `http_only`, default `kernel`) to the v2 player model and plumbs it end to end. This is the per-session degraded/http-only shaping toggle from #910 — the **one v1 control field with no v2 equivalent**, and the single gap the #919 distinguishing check surfaced. Without it the planned native `fault_rules`/shape evaluator can't express degraded mode, so **#920 unblocks #919 step 2**.

## Layers

- **Spec** — `api/openapi/v2/proxy.yaml` `Shape.mode`; regenerated `oapigen.gen.go`, dashboard `v2.ts`, harness `proxy.gen.go`, docs mirror.
- **Read (v1→v2)** — `shapeFromSession` projects `shaping_forced_mode` → `shape.mode`; a degraded-only session is now shape-bearing.
- **Write (v2→v1)** — `applyShapePatch` maps `shape.mode` → `shaping_forced_mode` (`http_only`↔`"http-only"`, else `""`); `shape.mode` admitted in path validation; `shape: null` clears the degrade to kernel.
- **Kernel reconcile** — new `ApplyShapingModeToPlayer` delegates to the existing `applyForcedShapingModeForPort` (same gate teardown/re-apply the v1 endpoint runs), fired post-PATCH on player- and play-level patches incl. group broadcast.
- **Dashboard** — `useSessionShaping.setShapingMode` PATCHes `shape.mode` via `usePlayer`'s optimistic/If-Match path (new `setShapeAsync`), retiring the raw `POST /api/nftables/shaping-mode` from the UI. The v1 endpoint stays live (removed later by #919).

## Test

`TestPatch_ShapingMode_DegradeAndClear` — a v2 `shape.mode` PATCH sets `shaping_forced_mode`, round-trips in the response, and fires the gate reconcile; `kernel` clears it.

Full `internal/v2/server` + `v2translate` + `cmd/server` suites green; gofmt/vet clean; dashboard `vue-tsc` + `npm run build` pass.

## Notes

- The v1 `/api/nftables/shaping-mode` endpoint is left live; only the dashboard writer moved to v2.
- `content/dashboard/api-docs/forwarder-v2.yaml` is an unrelated docs-mirror re-sync (pre-existing drift vs its committed source) swept in by `sync-api-docs`.

Precursor to #919. Related: #910. Closes #920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
