### PR TITLE
feat(922): structure-driven rendition model (HLS Tier 2) — variant/resolution fault scoping matches real segments

### DIFF
--- a/go-proxy/cmd/server/fault_classify.go
+++ b/go-proxy/cmd/server/fault_classify.go
@@ -85,6 +85,86 @@ func matchesAudioURI(audioURIs []string, decodedPath, base string) bool {
 	return false
 }
 
+// renditionInfo describes the rendition a segment directory belongs to, learned
+// from the media playlist that lists that dir's segments (#922 Tier 2).
+type renditionInfo struct {
+	Kind         string // "video" | "audio"
+	Resolution   string
+	BandwidthBps int
+	Rung         int
+}
+
+// recordRenditionDir maps a rendition directory (e.g. "720p", "audio") to the
+// rendition the just-parsed media playlist represents: video resolution/rung
+// resolved from the master's variant ladder, or audio. Stored on the session
+// under _rendition_map for classifyRequest to consult. The playlist filename is
+// matched against the master's declared variant / audio URIs — structure, not
+// spelling.
+func recordRenditionDir(session SessionData, playlistFilename, dir string) {
+	if dir == "" {
+		return
+	}
+	base := pathBase(playlistFilename)
+	variants := getManifestVariants(session)
+	for idx, v := range variants {
+		if renditionPlaylistMatches(v.URL, base, playlistFilename) {
+			setRenditionDir(session, dir, renditionInfo{
+				Kind: "video", Resolution: v.Resolution, BandwidthBps: v.Bandwidth, Rung: rungIndexOf(variants, idx),
+			})
+			return
+		}
+	}
+	for _, u := range getStringSlice(session, "manifest_audio_uris") {
+		if renditionPlaylistMatches(u, base, playlistFilename) {
+			setRenditionDir(session, dir, renditionInfo{Kind: "audio"})
+			return
+		}
+	}
+}
+
+// renditionPlaylistMatches reports whether a request for playlistPath (basename
+// requestBase) is the media playlist declared in the master as declaredURL.
+func renditionPlaylistMatches(declaredURL, requestBase, requestPath string) bool {
+	if declaredURL == "" {
+		return false
+	}
+	return pathBase(declaredURL) == requestBase || strings.HasSuffix(requestPath, declaredURL)
+}
+
+func setRenditionDir(session SessionData, dir string, info renditionInfo) {
+	m, _ := session["_rendition_map"].(map[string]any)
+	if m == nil {
+		m = map[string]any{}
+		session["_rendition_map"] = m
+	}
+	m[dir] = map[string]any{
+		"kind":       info.Kind,
+		"resolution": info.Resolution,
+		"bandwidth":  info.BandwidthBps,
+		"rung":       info.Rung,
+	}
+}
+
+// getRenditionDir looks up the rendition a segment directory belongs to.
+func getRenditionDir(session SessionData, dir string) (renditionInfo, bool) {
+	m, _ := session["_rendition_map"].(map[string]any)
+	if m == nil {
+		return renditionInfo{}, false
+	}
+	raw, _ := m[dir].(map[string]any)
+	if raw == nil {
+		return renditionInfo{}, false
+	}
+	res, _ := raw["resolution"].(string)
+	kind, _ := raw["kind"].(string)
+	return renditionInfo{
+		Kind:         kind,
+		Resolution:   res,
+		BandwidthBps: intFromInterface(raw["bandwidth"]),
+		Rung:         intFromInterface(raw["rung"]),
+	}, true
+}
+
 // isAudioPlaylistName reports whether a media-playlist basename is the audio
 // rendition. Audio SEGMENTS live under an `/audio/` directory (caught by
 // pathParent), but the audio media PLAYLIST sits in the content root named
@@ -117,6 +197,15 @@ func classifyRequest(session SessionData, filename string, isSegment, isManifest
 	base := pathBase(decoded)
 	parent := strings.ToLower(pathParent(decoded))
 	isAudio := audioParentTokens[parent]
+	// #922 Tier 2: for a segment/init, the rendition map (built from the media
+	// playlist that authoritatively lists this directory's segments) is the
+	// structure-driven signal — it overrides the dir-name heuristic for audio
+	// and carries the real resolution/rung. Falls back to the heuristics below
+	// until that dir's playlist has transited.
+	rmInfo, rmOK := getRenditionDir(session, parent)
+	if rmOK && isSegment {
+		isAudio = rmInfo.Kind == "audio"
+	}
 	// Audio media playlists sit in the content root (not under /audio/), so the
 	// pathParent check misses them. Prefer the STRUCTURE-DRIVEN signal: the
 	// EXT-X-MEDIA audio URIs parsed from the master (manifest_audio_uris). Only
@@ -165,7 +254,13 @@ func classifyRequest(session SessionData, filename string, isSegment, isManifest
 	// (segment / partial). init keeps RungIndex -1 — an init fetch is
 	// per-rendition but carries no ABR-decision semantics of its own.
 	if !isAudio && !rc.IsInit {
-		if idx, info, ok := matchVariantIndex(variants, decoded); ok {
+		if rmOK && rmInfo.Kind == "video" {
+			// #922 Tier 2: authoritative resolution/rung from the parsed media
+			// playlist — no URL-token scoring guesswork.
+			rc.RungIndex = rmInfo.Rung
+			rc.Resolution = rmInfo.Resolution
+			rc.BandwidthBps = rmInfo.BandwidthBps
+		} else if idx, info, ok := matchVariantIndex(variants, decoded); ok {
 			rc.RungIndex = idx
 			rc.Resolution = info.Resolution
 			rc.BandwidthBps = info.Bandwidth

--- a/go-proxy/cmd/server/fault_rendition_test.go
+++ b/go-proxy/cmd/server/fault_rendition_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	m3u8 "github.com/grafov/m3u8"
+)
+
+// TestMediaRenditionDir: parse a real media playlist and confirm the rendition
+// dir comes from its EXT-X-MAP / segment paths (absolute in go-live output).
+func TestMediaRenditionDir(t *testing.T) {
+	media := `#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-TARGETDURATION:6
+#EXT-X-MAP:URI="/go-live/c/720p/init.mp4"
+#EXTINF:6.0,
+/go-live/c/720p/segment_00000.m4s
+#EXTINF:6.0,
+/go-live/c/720p/segment_00001.m4s
+`
+	pl, lt, err := m3u8.DecodeFrom(bufio.NewReader(bytes.NewReader([]byte(media))), true)
+	if err != nil || lt != m3u8.MEDIA {
+		t.Fatalf("decode: %v listType=%v", err, lt)
+	}
+	if got := mediaRenditionDir(pl.(*m3u8.MediaPlaylist)); got != "720p" {
+		t.Errorf("mediaRenditionDir = %q, want 720p", got)
+	}
+}
+
+// TestRenditionMap_AuthoritativeClassification is the #922 Tier 2 payoff: once a
+// dir's media playlist has transited, a segment in that dir classifies with the
+// TRUE resolution + rung (which matchVariantIndex can't derive, since the video
+// variant URL is a playlist name that shares nothing with the segment dir), and
+// a resolution-scoped fault rule finally matches the right rung only.
+func TestRenditionMap_AuthoritativeClassification(t *testing.T) {
+	s := SessionData{
+		"manifest_variants": []PlaylistInfo{
+			{URL: "playlist_6s_360p.m3u8", Bandwidth: 800_000, Resolution: "640x360"},
+			{URL: "playlist_6s_720p.m3u8", Bandwidth: 4_000_000, Resolution: "1280x720"},
+			{URL: "playlist_6s_2160p.m3u8", Bandwidth: 12_000_000, Resolution: "3840x2160"},
+		},
+		"manifest_audio_uris": []string{"playlist_6s_audio.m3u8"},
+	}
+	// Media playlists transit → record their segment dirs.
+	recordRenditionDir(s, "/go-live/c/playlist_6s_720p.m3u8", "720p")
+	recordRenditionDir(s, "/go-live/c/playlist_6s_2160p.m3u8", "2160p")
+	recordRenditionDir(s, "/go-live/c/playlist_6s_audio.m3u8", "audio")
+
+	rc := classifyRequest(s, "/go-live/c/720p/segment_00017.m4s", true, false, false)
+	if rc.Kind != "segment" || rc.Resolution != "1280x720" || rc.RungIndex != 1 {
+		t.Errorf("720p segment: kind=%q res=%q rung=%d, want segment/1280x720/1", rc.Kind, rc.Resolution, rc.RungIndex)
+	}
+	rc = classifyRequest(s, "/go-live/c/2160p/segment_00017.m4s", true, false, false)
+	if rc.Resolution != "3840x2160" || rc.RungIndex != 2 {
+		t.Errorf("2160p segment: res=%q rung=%d, want 3840x2160/2", rc.Resolution, rc.RungIndex)
+	}
+	rc = classifyRequest(s, "/go-live/c/audio/segment_00017.m4s", true, false, false)
+	if rc.Kind != "audio_segment" || !rc.IsAudio || rc.RungIndex != -1 {
+		t.Errorf("audio segment: kind=%q isAudio=%v rung=%d, want audio_segment/true/-1", rc.Kind, rc.IsAudio, rc.RungIndex)
+	}
+
+	// A resolution-scoped rule now targets 720p only — the whole point.
+	rules := []any{map[string]any{"id": "r", "type": "500",
+		"filter": map[string]any{"variant": map[string]any{"resolutions": []any{"1280x720"}}}}}
+	if _, ok := matchFaultRule(rules, classifyRequest(s, "/go-live/c/720p/segment_1.m4s", true, false, false)); !ok {
+		t.Error("720p segment should match resolutions=[1280x720]")
+	}
+	if _, ok := matchFaultRule(rules, classifyRequest(s, "/go-live/c/2160p/segment_1.m4s", true, false, false)); ok {
+		t.Error("2160p segment must NOT match resolutions=[1280x720]")
+	}
+}
+
+// TestRenditionMap_AudioDirNotNamedAudio proves the map is structure-driven, not
+// spelling-driven: an audio rendition whose segments live under a dir NOT named
+// "audio" still classifies as audio, because the map keyed it from the playlist
+// that the master declared as EXT-X-MEDIA TYPE=AUDIO.
+func TestRenditionMap_AudioDirNotNamedAudio(t *testing.T) {
+	s := SessionData{
+		"manifest_variants":   []PlaylistInfo{{URL: "v720.m3u8", Bandwidth: 4_000_000, Resolution: "1280x720"}},
+		"manifest_audio_uris": []string{"soundtrack.m3u8"},
+	}
+	recordRenditionDir(s, "/go-live/c/soundtrack.m3u8", "aac_en") // segments under /aac_en/, not /audio/
+	rc := classifyRequest(s, "/go-live/c/aac_en/segment_5.m4s", true, false, false)
+	if rc.Kind != "audio_segment" || !rc.IsAudio {
+		t.Errorf("aac_en segment: kind=%q isAudio=%v, want audio_segment/true (structure over spelling)", rc.Kind, rc.IsAudio)
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6764,13 +6764,20 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	upstreamURL := fmt.Sprintf("http://%s:%s/%s", a.upstreamHost, a.upstreamPort, escapedPath)
-	contentType, isMasterManifest, isManifest, isSegment, playlistInfo, audioURIs := a.getContentType(upstreamURL)
+	contentType, isMasterManifest, isManifest, isSegment, playlistInfo, audioURIs, renditionDir := a.getContentType(upstreamURL)
 	requestKind := requestKindLabel(isSegment, isManifest, isMasterManifest)
 	// #919 Tier 1: cache the manifest-declared audio rendition URIs so the fault
 	// classifier can identify audio playlists structurally. Only the master
 	// parse yields these; preserve the prior list on non-master requests.
 	if len(audioURIs) > 0 {
 		sessionData["manifest_audio_uris"] = audioURIs
+	}
+	// #922 Tier 2: when a media playlist transits, record the rendition its
+	// segment directory belongs to (video resolution/rung or audio) — parsed
+	// from the playlist's own segment list, so segment classification is
+	// authoritative instead of URL-token guessing.
+	if isManifest && renditionDir != "" {
+		recordRenditionDir(sessionData, filename, renditionDir)
 	}
 	segmentTransferStartedAt := time.Time{}
 	segmentTransferStartBytes := int64(0)
@@ -7928,24 +7935,24 @@ func (a *App) applyShapeIfChanged(port int, rate float64, np NetemParams) error 
 // ladder (EXT-X-STREAM-INF) plus the audio rendition URIs (EXT-X-MEDIA
 // TYPE=AUDIO). The audio URIs are the structure-driven signal the fault
 // classifier uses to identify audio playlists — replacing filename guessing.
-func (a *App) getContentType(target string) (string, bool, bool, bool, []PlaylistInfo, []string) {
+func (a *App) getContentType(target string) (string, bool, bool, bool, []PlaylistInfo, []string, string) {
 	parsed, err := url.Parse(target)
 	if err != nil {
-		return "", false, false, false, nil, nil
+		return "", false, false, false, nil, nil, ""
 	}
 	if parsed.Hostname() != "" {
 		parsed.Host = fmt.Sprintf("%s:%s", parsed.Hostname(), a.upstreamPort)
 	}
 	headReq, err := http.NewRequest(http.MethodHead, parsed.String(), nil)
 	if err != nil {
-		return "", false, false, false, nil, nil
+		return "", false, false, false, nil, nil, ""
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	headReq = headReq.WithContext(ctx)
 	resp, err := a.client.Do(headReq)
 	if err != nil {
-		return "", false, false, false, nil, nil
+		return "", false, false, false, nil, nil, ""
 	}
 	contentType := resp.Header.Get("Content-Type")
 	resp.Body.Close()
@@ -7967,11 +7974,11 @@ func (a *App) getContentType(target string) (string, bool, bool, bool, []Playlis
 		getReq = getReq.WithContext(ctxGet)
 		getResp, err := a.client.Do(getReq)
 		if err != nil {
-			return contentType, false, true, false, nil, nil
+			return contentType, false, true, false, nil, nil, ""
 		}
 		defer getResp.Body.Close()
 		if getResp.StatusCode >= 400 {
-			return contentType, false, true, false, nil, nil
+			return contentType, false, true, false, nil, nil, ""
 		}
 		contentType = getResp.Header.Get("Content-Type")
 		body, _ := io.ReadAll(getResp.Body)
@@ -8000,18 +8007,23 @@ func (a *App) getContentType(target string) (string, bool, bool, bool, []Playlis
 					// declaration instead of filename spelling. Dedup across variants
 					// (all video variants reference the same audio GROUP-ID).
 					audioURIs := extractAudioURIs(master)
-					return contentType, true, false, false, infos, audioURIs
+					return contentType, true, false, false, infos, audioURIs, ""
 				case m3u8.MEDIA:
-					return contentType, false, true, false, nil, nil
+					// #922 Tier 2: the media playlist authoritatively lists its
+					// segment (and EXT-X-MAP init) paths, so the rendition dir it
+					// belongs to is unambiguous — the caller maps that dir to this
+					// playlist's rendition (video resolution/rung or audio).
+					media := playlist.(*m3u8.MediaPlaylist)
+					return contentType, false, true, false, nil, nil, mediaRenditionDir(media)
 				}
 			}
 		}
-		return contentType, false, true, false, nil, nil
+		return contentType, false, true, false, nil, nil, ""
 	}
 	if strings.Contains(strings.ToLower(contentType), "dash") || strings.Contains(strings.ToLower(contentType), "mpd") {
-		return contentType, false, true, false, nil, nil
+		return contentType, false, true, false, nil, nil, ""
 	}
-	return contentType, false, false, true, nil, nil
+	return contentType, false, false, true, nil, nil, ""
 }
 
 // extractAudioURIs collects the EXT-X-MEDIA TYPE=AUDIO rendition URIs declared
@@ -8041,6 +8053,40 @@ func extractAudioURIs(master *m3u8.MasterPlaylist) []string {
 		}
 	}
 	return uris
+}
+
+// mediaRenditionDir returns the directory a media playlist's segments live under
+// — the stable, STRUCTURE-DRIVEN rendition identifier (#922 Tier 2). The
+// playlist lists its segment + EXT-X-MAP init paths authoritatively, so the dir
+// is unambiguous no matter how the playlist file itself is named. "" if the
+// playlist carries no segment/map to key off.
+func mediaRenditionDir(media *m3u8.MediaPlaylist) string {
+	if media == nil {
+		return ""
+	}
+	for _, seg := range media.Segments {
+		if seg == nil {
+			continue
+		}
+		if seg.Map != nil && seg.Map.URI != "" {
+			return renditionDirOf(seg.Map.URI)
+		}
+		if seg.URI != "" {
+			return renditionDirOf(seg.URI)
+		}
+	}
+	return ""
+}
+
+// renditionDirOf extracts the rendition directory token (lowercased) from a
+// segment/init path or URL — the last path element before the file. e.g.
+// "/go-live/c/720p/segment_00047.m4s" → "720p"; "audio/init.mp4" → "audio".
+func renditionDirOf(uri string) string {
+	u := uri
+	if parsed, err := url.Parse(uri); err == nil && parsed.Path != "" {
+		u = parsed.Path
+	}
+	return strings.ToLower(pathParent(strings.TrimPrefix(u, "/")))
 }
 
 func (a *App) trackPortThroughput() {

--- a/tests/server_behavior/server_scope_rendition_test.go
+++ b/tests/server_behavior/server_scope_rendition_test.go
@@ -1,0 +1,71 @@
+// server_scope_rendition_test.go — #922 Tier 2 end-to-end.
+//
+// Proves fault scoping by a VARIANT predicate (here bandwidth) matches real
+// segments — which only works because the proxy builds an authoritative
+// segmentDir→rendition map by parsing each media playlist as it transits
+// (pullVariant fetches it). Before Tier 2 the classifier couldn't map a segment
+// path to its bandwidth/resolution (the variant URL is a playlist name sharing
+// nothing with the segment dir), so a variant-predicate fault matched nothing.
+package server_behavior
+
+import (
+	"testing"
+	"time"
+)
+
+func TestServerScopeByRendition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("rendition scope check skipped in short mode")
+	}
+	p := newProbe(t)
+	if len(p.variants) < 2 {
+		t.Skipf("need >=2 variants, got %d", len(p.variants))
+	}
+	freq := envInt("SCOPE_FREQUENCY", 3)
+	samples := envInt("SCOPE_SAMPLES", 30)
+	status := env("FAULT_TYPE", "503")
+	wantStatus := faultStatusForType(status)
+
+	faultVar := p.variants[0]                 // top (highest bandwidth)
+	otherVar := p.variants[len(p.variants)-1] // bottom
+	if faultVar.BandwidthBps <= otherVar.BandwidthBps {
+		t.Fatalf("variants not bandwidth-distinct: top=%d bottom=%d", faultVar.BandwidthBps, otherVar.BandwidthBps)
+	}
+
+	// Fetch both media playlists so the proxy records their rendition dirs
+	// (segmentDir → {bandwidth,...}) — the map this feature is about.
+	fseg := p.pullVariant(faultVar.URL)
+	oseg := p.pullVariant(otherVar.URL)
+	if len(fseg) == 0 || len(oseg) == 0 {
+		t.Fatalf("could not pull segments: top=%d bottom=%d", len(fseg), len(oseg))
+	}
+	t.Logf("in-scope top=%.2f Mbps ; out-of-scope bottom=%.2f Mbps",
+		float64(faultVar.BandwidthBps)/1e6, float64(otherVar.BandwidthBps)/1e6)
+
+	// Scope a segment fault to variants ABOVE the bottom variant's bandwidth —
+	// isolates the top variant. Matched by rc.BandwidthBps, resolved from the
+	// rendition map, NOT by any URL token.
+	rule := faultRuleV2("segment", status, freq, 1)
+	rule["filter"].(map[string]any)["variant"] = map[string]any{
+		"bandwidth_above": faultVar.BandwidthBps - 1,
+	}
+	if err := setFaultsV2(p, rule); err != nil {
+		t.Fatalf("arm rendition-scoped fault: %v", err)
+	}
+	defer clearFaultsV2(p)
+	time.Sleep(settleKernel)
+
+	inHist := p.pullStatuses(t, func() []string { return p.pullVariant(faultVar.URL) }, samples)
+	outHist := p.pullStatuses(t, func() []string { return p.pullVariant(otherVar.URL) }, samples)
+	inFaults := inHist[wantStatus]
+	outFaults := outHist[wantStatus]
+	t.Logf("in-scope(top): hist=%v faults(%d)=%d ; out-of-scope(bottom): hist=%v faults=%d",
+		inHist, wantStatus, inFaults, outHist, outFaults)
+
+	if inFaults == 0 {
+		t.Errorf("bandwidth-scoped fault produced ZERO faults on the in-scope (top) variant over %d samples — Tier 2 map not resolving segment bandwidth", samples)
+	}
+	if outFaults != 0 {
+		t.Errorf("scope leaked: %d faults on the out-of-scope (bottom) variant, want 0", outFaults)
+	}
+}


### PR DESCRIPTION
## What

Fault scoping by a **variant predicate** (resolution / rung / bandwidth) now matches real HLS segments. Before, the classifier couldn't map a segment path to its rendition — the video variant URL is a playlist name (`playlist_6s_720p.m3u8`) sharing nothing structural with the segment dir (`/720p/…`), so `matchVariantIndex` guessed and a variant-scoped rule matched nothing.

## How

As each media playlist transits the proxy, `getContentType` parses it and returns the directory its segments (+ `EXT-X-MAP` init) live under — authoritative, because the playlist lists those paths. The caller records `segmentDir → {video resolution/rung | audio}` on `_rendition_map` (video rung/resolution from the master's variant ladder, audio from the EXT-X-MEDIA URIs). `classifyRequest` consults that map first, falling back to the `pathParent`/`matchVariantIndex` heuristics only until a dir's playlist has been seen.

Bonus: audio classification is now naming-robust — an audio rendition whose segments live under a dir NOT called `audio` still classifies as audio.

## Tests

- **Unit** (`fault_rendition_test.go`): media-playlist dir parse; authoritative resolution+rung for 720p/2160p segments; a resolution-scoped rule matches the right rung only; audio-under-a-non-audio-dir still classifies audio.
- **Live** (`server_scope_rendition_test.go`, on :28000): a bandwidth-scoped fault hit the top variant 10×, the bottom variant **0×** — matched via the rendition map, not a URL token. Full fault suite (`TestServerFault`/`Scope`/`Content`/`SocketFaults`) still green.

## Scope

HLS only. The DASH counterpart (`go-live/pkg/dash/mpd.go` ignores `contentType`; no `manifest_variants` for `.mpd`) is split to https://github.com/jonathaneoliver/infinite-streaming/issues/926.

Refs #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
