### PR TITLE
fix(ios): grey out the DASH protocol option — AVPlayer can't play .mpd

### DIFF
--- a/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
+++ b/apple/InfiniteStreamPlayer/InfiniteStreamPlayer/SettingsOverlay.swift
@@ -310,8 +310,13 @@ private struct PickerList: View {
             }
         case .proto:
             ForEach(Array(StreamProtocol.allCases.enumerated()), id: \.element.id) { idx, p in
+                // DASH is greyed out on iOS: AVPlayer (AVURLAsset) can't play an
+                // MPEG-DASH .mpd — it just probes and fails. HLS only here; the
+                // Android/ExoPlayer app is where DASH plays.
                 PickerItem(label: p.label, selected: p == vm.streamProtocol, compact: compact,
-                           axID: "proto-\(p.rawValue)") {
+                           axID: "proto-\(p.rawValue)",
+                           disabled: p == .dash,
+                           disabledNote: p == .dash ? "not supported by AVPlayer" : nil) {
                     vm.setProtocol(p); onBack()
                 }
                 .focused($itemIdx, equals: idx)
@@ -400,14 +405,24 @@ private struct PickerItem: View {
     // item carries no identifier (SwiftUI default) — only the pickers a test
     // needs to drive set one.
     var axID: String? = nil
+    // Greyed-out, non-selectable option (e.g. DASH on iOS: AVPlayer can't play
+    // a .mpd). `disabledNote` shows why, inline.
+    var disabled: Bool = false
+    var disabledNote: String? = nil
     let onTap: () -> Void
 
     var body: some View {
-        HStack {
+        HStack(spacing: Space.s2) {
             Text(label)
                 .font(compact ? AppType.body(size: 15) : AppType.body())
                 .foregroundColor(Tokens.fg)
                 .lineLimit(1)
+            if disabled, let note = disabledNote {
+                Text(note)
+                    .font(AppType.body(size: 12))
+                    .foregroundColor(Tokens.fg)
+                    .lineLimit(1)
+            }
             Spacer()
             if selected {
                 Image(systemName: "checkmark")
@@ -420,7 +435,9 @@ private struct PickerItem: View {
         .clipShape(RoundedRectangle(cornerRadius: Radius.row, style: .continuous))
         .cinematicFocus(cornerRadius: Radius.row)
         .contentShape(Rectangle())
-        .onTapGesture(perform: onTap)
+        .onTapGesture { if !disabled { onTap() } }
+        .opacity(disabled ? 0.4 : 1)
+        .allowsHitTesting(!disabled)
         .accessibilityIdentifier(axID ?? "")
     }
 }


### PR DESCRIPTION
## What

The iOS/tvOS app offered a **DASH** protocol option that never worked: AVPlayer / `AVURLAsset` has no MPEG-DASH support, so picking it just fetched `manifest.mpd`, probed it (`Range: bytes=0-1`), and failed. Confirmed in the data — the only `.mpd` fetches on the box are `AppleCoreMedia (iPhone)` probes, 9 in 30 days vs 567K `.m3u8`.

Grey it out: non-selectable (hit-testing off, 0.4 opacity) with an inline "not supported by AVPlayer" note, on both the **iOS and tvOS** targets (shared `SettingsOverlay`). HLS stays selectable, so anyone with a persisted DASH choice can switch back.

DASH remains a real path on the **Android/ExoPlayer** app (`DashMediaSource`), which is where it actually plays (verified: live ExoPlayer DASH play against :21000).

## Verified

`xcodebuild -scheme "InfiniteStreamPlayer (iOS)"` → **BUILD SUCCEEDED**. (Visual/on-device confirmation is yours.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
