### PR TITLE
feat(926): structure-driven rendition model for DASH — variant/resolution fault scoping for .mpd

### DIFF
--- a/go-proxy/cmd/server/fault_dash.go
+++ b/go-proxy/cmd/server/fault_dash.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+// DASH MPD parsing for the structure-driven rendition model (#926). go-live
+// serves SegmentList MPDs whose SegmentURL/Initialization paths are the SAME
+// CMAF segment dirs HLS uses (/720p/…, /audio/…), so once the .mpd is parsed the
+// existing dir-keyed _rendition_map (and the classifier that reads it) handles
+// DASH segments unchanged. Only the map-population source differs: the MPD
+// instead of HLS media playlists.
+
+type mpdManifest struct {
+	XMLName xml.Name    `xml:"MPD"`
+	Periods []mpdPeriod `xml:"Period"`
+}
+
+type mpdPeriod struct {
+	AdaptationSets []mpdAdaptationSet `xml:"AdaptationSet"`
+}
+
+type mpdAdaptationSet struct {
+	ContentType     string              `xml:"contentType,attr"`
+	MimeType        string              `xml:"mimeType,attr"`
+	Representations []mpdRepresentation `xml:"Representation"`
+}
+
+type mpdRepresentation struct {
+	ID          string          `xml:"id,attr"`
+	Bandwidth   int             `xml:"bandwidth,attr"`
+	Width       int             `xml:"width,attr"`
+	Height      int             `xml:"height,attr"`
+	Codecs      string          `xml:"codecs,attr"`
+	MimeType    string          `xml:"mimeType,attr"`
+	SegmentList *mpdSegmentList `xml:"SegmentList"`
+}
+
+type mpdSegmentList struct {
+	Initialization mpdInit         `xml:"Initialization"`
+	SegmentURLs    []mpdSegmentURL `xml:"SegmentURL"`
+}
+
+type mpdInit struct {
+	SourceURL string `xml:"sourceURL,attr"`
+}
+
+type mpdSegmentURL struct {
+	Media string `xml:"media,attr"`
+}
+
+// parseDASHManifest parses an MPD into the video variant ladder (for
+// manifest_variants + the dashboard) and the full segmentDir → rendition map.
+// Video vs audio comes from the AdaptationSet's contentType / the
+// Representation's mimeType — manifest structure, not URL spelling. Returns
+// nil, nil on a body that isn't a parseable MPD.
+func parseDASHManifest(body []byte) (videoVariants []PlaylistInfo, renditions map[string]renditionInfo) {
+	var mpd mpdManifest
+	if err := xml.Unmarshal(body, &mpd); err != nil || len(mpd.Periods) == 0 {
+		return nil, nil
+	}
+	renditions = map[string]renditionInfo{}
+	for _, period := range mpd.Periods {
+		for _, as := range period.AdaptationSets {
+			for _, rep := range as.Representations {
+				dir := dashRepDir(rep)
+				if dir == "" {
+					continue
+				}
+				if dashRepIsAudio(as, rep) {
+					renditions[dir] = renditionInfo{Kind: "audio"}
+					continue
+				}
+				res := ""
+				if rep.Width > 0 && rep.Height > 0 {
+					res = fmt.Sprintf("%dx%d", rep.Width, rep.Height)
+				}
+				videoVariants = append(videoVariants, PlaylistInfo{URL: dir, Bandwidth: rep.Bandwidth, Resolution: res})
+			}
+		}
+	}
+	// Rung = bandwidth-ascending position across the collected video variants.
+	for idx, v := range videoVariants {
+		renditions[v.URL] = renditionInfo{
+			Kind: "video", Resolution: v.Resolution, BandwidthBps: v.Bandwidth, Rung: rungIndexOf(videoVariants, idx),
+		}
+	}
+	if len(renditions) == 0 {
+		return nil, nil
+	}
+	return videoVariants, renditions
+}
+
+// dashRepIsAudio reports whether a Representation is audio, by the
+// AdaptationSet contentType or the Representation/AdaptationSet mimeType.
+func dashRepIsAudio(as mpdAdaptationSet, rep mpdRepresentation) bool {
+	if strings.HasPrefix(strings.ToLower(as.ContentType), "audio") {
+		return true
+	}
+	mime := rep.MimeType
+	if mime == "" {
+		mime = as.MimeType
+	}
+	return strings.HasPrefix(strings.ToLower(mime), "audio")
+}
+
+// dashRepDir returns the rendition directory a Representation's segments live
+// under, from its SegmentList Initialization / SegmentURL paths.
+func dashRepDir(rep mpdRepresentation) string {
+	if rep.SegmentList == nil {
+		return ""
+	}
+	if rep.SegmentList.Initialization.SourceURL != "" {
+		return renditionDirOf(rep.SegmentList.Initialization.SourceURL)
+	}
+	for _, su := range rep.SegmentList.SegmentURLs {
+		if su.Media != "" {
+			return renditionDirOf(su.Media)
+		}
+	}
+	return ""
+}
+
+// mergeRenditionMap records every dir→rendition entry on the session.
+func mergeRenditionMap(session SessionData, renditions map[string]renditionInfo) {
+	for dir, info := range renditions {
+		setRenditionDir(session, dir, info)
+	}
+}

--- a/go-proxy/cmd/server/fault_dash_test.go
+++ b/go-proxy/cmd/server/fault_dash_test.go
@@ -1,0 +1,90 @@
+package main
+
+import "testing"
+
+// A trimmed go-live SegmentList MPD: a video AdaptationSet (3 rungs) + an audio
+// AdaptationSet, segment/init paths under the same CMAF dirs HLS uses.
+const sampleMPD = `<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="dynamic">
+  <Period id="loop_3" start="PT1003S">
+    <AdaptationSet id="0" contentType="video" par="16:9">
+      <Representation id="0" bandwidth="775917" codecs="avc1.64001e" mimeType="video/mp4" width="640" height="360">
+        <SegmentList>
+          <Initialization sourceURL="360p/init.mp4"/>
+          <SegmentURL media="360p/segment_00038.m4s"/>
+        </SegmentList>
+      </Representation>
+      <Representation id="3" bandwidth="3561627" codecs="avc1.64001f" mimeType="video/mp4" width="1280" height="720">
+        <SegmentList>
+          <Initialization sourceURL="720p/init.mp4"/>
+          <SegmentURL media="720p/segment_00038.m4s"/>
+        </SegmentList>
+      </Representation>
+      <Representation id="8" bandwidth="33595654" codecs="avc1.640033" mimeType="video/mp4" width="3840" height="2160">
+        <SegmentList>
+          <Initialization sourceURL="2160p/init.mp4"/>
+          <SegmentURL media="2160p/segment_00038.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" contentType="audio" lang="en">
+      <Representation id="9" bandwidth="212379" codecs="mp4a.40.2" mimeType="audio/mp4">
+        <SegmentList>
+          <Initialization sourceURL="audio/init.mp4"/>
+          <SegmentURL media="audio/segment_00038.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`
+
+func TestParseDASHManifest(t *testing.T) {
+	variants, renditions := parseDASHManifest([]byte(sampleMPD))
+	if len(variants) != 3 {
+		t.Fatalf("video variants = %d, want 3", len(variants))
+	}
+	// Rendition map: 3 video dirs + 1 audio.
+	if len(renditions) != 4 {
+		t.Fatalf("rendition map = %d entries, want 4; got %v", len(renditions), renditions)
+	}
+	// Bandwidth-ascending rungs: 360p=0, 720p=1, 2160p=2.
+	for dir, wantRung := range map[string]int{"360p": 0, "720p": 1, "2160p": 2} {
+		r := renditions[dir]
+		if r.Kind != "video" || r.Rung != wantRung {
+			t.Errorf("%s: kind=%q rung=%d, want video/%d", dir, r.Kind, r.Rung, wantRung)
+		}
+	}
+	if renditions["720p"].Resolution != "1280x720" {
+		t.Errorf("720p resolution = %q, want 1280x720", renditions["720p"].Resolution)
+	}
+	if renditions["audio"].Kind != "audio" {
+		t.Errorf("audio dir kind = %q, want audio", renditions["audio"].Kind)
+	}
+}
+
+// TestDASHClassificationEndToEnd: parse the MPD → merge onto the session → DASH
+// segments (same CMAF dirs) classify with authoritative resolution/rung/audio,
+// and a resolution-scoped fault matches the right rung only.
+func TestDASHClassificationEndToEnd(t *testing.T) {
+	s := SessionData{}
+	_, renditions := parseDASHManifest([]byte(sampleMPD))
+	mergeRenditionMap(s, renditions)
+
+	rc := classifyRequest(s, "/go-live/c/720p/segment_00040.m4s", true, false, false)
+	if rc.Kind != "segment" || rc.Resolution != "1280x720" || rc.RungIndex != 1 {
+		t.Errorf("DASH 720p seg: kind=%q res=%q rung=%d, want segment/1280x720/1", rc.Kind, rc.Resolution, rc.RungIndex)
+	}
+	rc = classifyRequest(s, "/go-live/c/audio/segment_00040.m4s", true, false, false)
+	if rc.Kind != "audio_segment" || !rc.IsAudio {
+		t.Errorf("DASH audio seg: kind=%q isAudio=%v, want audio_segment/true", rc.Kind, rc.IsAudio)
+	}
+
+	rules := []any{map[string]any{"id": "r", "type": "500",
+		"filter": map[string]any{"variant": map[string]any{"resolutions": []any{"1280x720"}}}}}
+	if _, ok := matchFaultRule(rules, classifyRequest(s, "/go-live/c/720p/segment_1.m4s", true, false, false)); !ok {
+		t.Error("DASH 720p segment should match resolutions=[1280x720]")
+	}
+	if _, ok := matchFaultRule(rules, classifyRequest(s, "/go-live/c/2160p/segment_1.m4s", true, false, false)); ok {
+		t.Error("DASH 2160p segment must NOT match resolutions=[1280x720]")
+	}
+}

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -6764,7 +6764,7 @@ func (a *App) handleProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	upstreamURL := fmt.Sprintf("http://%s:%s/%s", a.upstreamHost, a.upstreamPort, escapedPath)
-	contentType, isMasterManifest, isManifest, isSegment, playlistInfo, audioURIs, renditionDir := a.getContentType(upstreamURL)
+	contentType, isMasterManifest, isManifest, isSegment, playlistInfo, audioURIs, renditionDir := a.getContentType(upstreamURL, sessionData)
 	requestKind := requestKindLabel(isSegment, isManifest, isMasterManifest)
 	// #919 Tier 1: cache the manifest-declared audio rendition URIs so the fault
 	// classifier can identify audio playlists structurally. Only the master
@@ -7935,7 +7935,7 @@ func (a *App) applyShapeIfChanged(port int, rate float64, np NetemParams) error 
 // ladder (EXT-X-STREAM-INF) plus the audio rendition URIs (EXT-X-MEDIA
 // TYPE=AUDIO). The audio URIs are the structure-driven signal the fault
 // classifier uses to identify audio playlists — replacing filename guessing.
-func (a *App) getContentType(target string) (string, bool, bool, bool, []PlaylistInfo, []string, string) {
+func (a *App) getContentType(target string, session SessionData) (string, bool, bool, bool, []PlaylistInfo, []string, string) {
 	parsed, err := url.Parse(target)
 	if err != nil {
 		return "", false, false, false, nil, nil, ""
@@ -8021,6 +8021,24 @@ func (a *App) getContentType(target string) (string, bool, bool, bool, []Playlis
 		return contentType, false, true, false, nil, nil, ""
 	}
 	if strings.Contains(strings.ToLower(contentType), "dash") || strings.Contains(strings.ToLower(contentType), "mpd") {
+		// #926: parse the MPD to build the video ladder + segmentDir→rendition
+		// map. go-live's DASH is CMAF — the same segment dirs as HLS — so once
+		// the map is populated the classifier scopes DASH segments unchanged.
+		if getReq, err := http.NewRequest(http.MethodGet, parsed.String(), nil); err == nil {
+			ctxGet, cancelGet := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelGet()
+			getReq = getReq.WithContext(ctxGet)
+			if getResp, derr := a.client.Do(getReq); derr == nil {
+				defer getResp.Body.Close()
+				if getResp.StatusCode < 400 {
+					body, _ := io.ReadAll(io.LimitReader(getResp.Body, 8<<20))
+					if variants, renditions := parseDASHManifest(body); len(renditions) > 0 {
+						mergeRenditionMap(session, renditions)
+						return contentType, false, true, false, variants, nil, ""
+					}
+				}
+			}
+		}
 		return contentType, false, true, false, nil, nil, ""
 	}
 	return contentType, false, false, true, nil, nil, ""

--- a/tests/server_behavior/server_dash_rendition_test.go
+++ b/tests/server_behavior/server_dash_rendition_test.go
@@ -1,0 +1,63 @@
+// server_dash_rendition_test.go — #926 live integration.
+//
+// Fetching the DASH .mpd through the proxy must populate the session's
+// _rendition_map (segmentDir → video resolution/rung | audio), parsed from the
+// MPD's AdaptationSet/Representation/SegmentList. That's what gives DASH the
+// same structure-driven fault scoping as HLS (the classification + scoping
+// logic on top is covered by fault_dash_test.go and TestServerScopeByRendition).
+package server_behavior
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDASHRenditionMapPopulates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("DASH rendition check skipped in short mode")
+	}
+	p := newProbe(t)
+	mpdURL := strings.Replace(p.masterURL, "master_6s.m3u8", "manifest_6s.mpd", 1)
+	if mpdURL == p.masterURL {
+		t.Skipf("no DASH manifest URL derivable from %q", p.masterURL)
+	}
+	if _, _, err := httpGet(p.c, mpdURL); err != nil {
+		t.Fatalf("fetch .mpd through proxy: %v", err)
+	}
+	time.Sleep(750 * time.Millisecond) // let the session write persist
+
+	sm, err := getSessionMap(p.c, p.apiBase, p.playerID)
+	if err != nil {
+		t.Fatalf("session map: %v", err)
+	}
+	rm, ok := sm["_rendition_map"].(map[string]any)
+	if !ok || len(rm) == 0 {
+		t.Fatalf("_rendition_map not populated from the DASH .mpd; got %v", sm["_rendition_map"])
+	}
+
+	var video, audio int
+	var sawResolution bool
+	for _, raw := range rm {
+		m, _ := raw.(map[string]any)
+		switch m["kind"] {
+		case "video":
+			video++
+			if res, _ := m["resolution"].(string); res != "" {
+				sawResolution = true
+			}
+		case "audio":
+			audio++
+		}
+	}
+	t.Logf("_rendition_map from .mpd: %d entries (video=%d audio=%d)", len(rm), video, audio)
+	if video == 0 {
+		t.Error("no video renditions mapped from the DASH .mpd")
+	}
+	if audio == 0 {
+		t.Error("no audio rendition mapped from the DASH .mpd")
+	}
+	if !sawResolution {
+		t.Error("video renditions have no resolution — width/height not parsed from the MPD")
+	}
+}


### PR DESCRIPTION
## What

Completes the rendition model for **DASH** (HLS was #922). DASH variant/resolution/bandwidth fault scoping now works — it didn't at all before (the proxy had zero `.mpd` rendition awareness).

## How it's clean

go-live serves **CMAF**, so DASH segments are the *same files and dirs* as HLS (`/720p/segment_*.m4s`, `/audio/…`). The classifier's dir-keyed `_rendition_map` (from #922) already handles those segments — the only missing piece was **populating it from the `.mpd`** instead of from HLS media playlists.

- `fault_dash.go` — minimal MPD parser (`encoding/xml`): `MPD/Period/AdaptationSet/Representation/SegmentList`. `parseDASHManifest` → video variant ladder (bandwidth + `WxH`) + `segmentDir → {video rung/resolution | audio}` map, classified by `AdaptationSet contentType` / `Representation mimeType` (structure, not spelling).
- `getContentType` — previously returned nothing for a `.mpd` (never fetched the body). Now the DASH branch GETs + parses it, merges the rendition map onto the session, returns the video variants (→ `manifest_variants`, so the dashboard shows DASH renditions). Gains a `session` param.

Everything downstream (`classifyRequest`, variant scoping) already consumes `_rendition_map`, so DASH gets it for free.

## Tests

- **Unit** (`fault_dash_test.go`): parse a go-live SegmentList MPD → 3 video variants + audio, correct bandwidth-ascending rungs + resolutions; DASH 720p segment → `segment/1280x720/rung-1`, audio → `audio_segment`, `resolutions=[1280x720]` matches 720p only.
- **Live** (`server_dash_rendition_test.go`, :28000): fetching the real `.mpd` through the proxy populated `_rendition_map` (4 video + 1 audio, resolutions present).
- **HLS regression**: `TestServerFault` / `Scope` / `ScopeByRendition` still green.

Context: DASH is a live path on Android/ExoPlayer (confirmed streaming against :21000). iOS AVPlayer can't play DASH (greyed out in #928).

Closes #926.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
