### PR TITLE
fix(faults): variant-scoped fault correctness — dedup rungs, continuous (0,0), empty scope = none

### DIFF
--- a/.claude/standards/player-fault-response.md
+++ b/.claude/standards/player-fault-response.md
@@ -1,0 +1,104 @@
+# Player response to injected faults: ExoPlayer vs AVPlayer
+
+When you arm a fault on a variant and the player "keeps playing with no
+error," the fault engine is usually working fine — the *player* is
+absorbing it. iOS AVPlayer and Android ExoPlayer react to a faulted
+segment **very differently**, and that asymmetry burns hours if you
+assume the matching code is broken. It usually isn't (verify with the
+live probe in "Proving the match fires" below before blaming it).
+
+## The asymmetry (the thing that bit us — #919 era, 2026-07-09)
+
+| | iOS AVPlayer | Android ExoPlayer |
+|---|---|---|
+| Single transient segment error (one 503) | Tends to **downshift** away from the rung | **Retries** the segment (default `LoadErrorHandlingPolicy`, ~3 tries) and, if the retry lands in a clean cadence slot, **recovers and keeps playing** — no surfaced error, no rate shift |
+| Sustained failure on a rung | Downshifts | Downshifts / errors only once retries are exhausted |
+
+So the *same* intermittent fault makes iOS visibly rate-shift while
+Android looks unaffected. The 503s are still injected — they appear in
+the **network log** either way (the proxy returns them). "Playback
+continued" ≠ "no fault fired." Read the network log, not the player.
+
+## Consequence for fault testing
+
+To force an ExoPlayer/Android downshift you need failure the retries
+**can't escape**:
+
+- **Continuous** fault (see cadence below), or
+- `mode: requests` with **`consecutive` above ExoPlayer's retry budget**
+  (try `consecutive: 5`), so the segment + all its retries fail.
+
+A single intermittent 503 will never move ExoPlayer.
+
+The deterministic, platform-agnostic alternative is **Content
+Manipulation**: deselect the top variant from `allowed_variants` so it's
+removed from the manifest the player receives. A player can't request a
+rung that isn't advertised → guaranteed downshift on iOS *and* Android,
+no reliance on error handling.
+
+## Fault-cadence semantics (go-proxy native evaluator, #919/#925)
+
+The UI's frequency/consecutive sliders map to the native cadence engine
+(`fault_evaluate.go` → `FailureHandler` in `main.go`). Two edges that
+look like bugs but are (now) deliberate:
+
+- **`consecutive=0 AND frequency=0` → CONTINUOUS**: fault every matching
+  request until the rule is cleared. This is the UI default. Before the
+  2026-07-09 fix it clamped to `consec=1/freq=0` = a **one-shot single
+  failure** (fired once, then `resetFailureType` reverted it forever) —
+  which is why default-armed faults seemed to "do nothing," especially
+  on ExoPlayer. Guarded by `TestNativeContinuous`.
+- **`consecutive>0, frequency=0` → one-shot burst of N** then revert
+  (unchanged; `TestNativeOneShot`).
+- **`frequency>0` → repeating cycle** (unchanged).
+
+## Variant scope matching (what "select a variant" actually keys on)
+
+The scope checkboxes write **`filter.variant.resolutions`** — a list of
+**resolution strings** (e.g. `"3840x2160"`), NOT bitrate, NOT a URL id.
+The classifier assigns each segment a resolution from the rendition map
+(`_rendition_map`, dir→rendition), and both the scope list and the
+classifier draw that string from the **same manifest parse** — HLS master
+`RESOLUTION=` / DASH `<Representation>` width×height — so they can't
+silently mismatch. Comparison is case-insensitive exact
+(`containsStringFold`). See `fault_match.go:variantPredicateMatches`.
+
+Empty vs absent matters:
+
+- **`resolutions` absent** → no constraint → matches all video.
+- **`resolutions: []` present-but-empty** → operator scoped to zero
+  variants ("all unchecked") → **matches NOTHING**. Before the
+  2026-07-09 fix the backend skipped the empty list and matched
+  everything — the inverse of the UI's intent. Guarded by
+  `TestMatchFaultRule_EmptyResolutionsMatchesNothing`.
+
+A variant predicate only matches **video** requests (`rc.RungIndex >= 0`);
+audio/init/master (`RungIndex < 0`) never match it — that's what keeps a
+video-scoped rule off audio/init (#917). Audio is scoped via
+`request_kind: [audio_segment]`, not the variant filter.
+
+## Proving the match fires (no device needed)
+
+Register a session, populate the rendition map, arm the exact UI rule,
+and hit a real segment through the per-session proxy port:
+
+```bash
+H=jonathanoliver-ubuntu.local; C=insane_newer_p200_h264; PID=$(uuidgen)
+# register + populate _rendition_map, capture per-session port from the redirect
+FINAL=$(curl -skL "https://$H:21081/go-live/$C/manifest_6s.mpd?player_id=$PID" -o /tmp/m.mpd -w '%{url_effective}')
+PORT=$(echo "$FINAL" | sed -E 's#.*:([0-9]+)/.*#\1#')
+REV=$(curl -sk "https://$H:21000/api/v2/players/$PID" | python3 -c 'import sys,json;print(json.load(sys.stdin)["control_revision"])')
+# arm: continuous 4K segment fault (freq=0,consec=0)
+curl -sk -X PATCH "https://$H:21000/api/v2/players/$PID" -H 'Content-Type: application/merge-patch+json' -H "If-Match: $REV" \
+  -d '{"fault_rules":[{"id":"t","type":"503","frequency":0,"consecutive":0,"mode":"failures_per_seconds","filter":{"request_kind":["segment"],"variant":{"resolutions":["3840x2160"]}}}]}'
+# request a 2160p segment (dir must match the .mpd SegmentList dir) → expect 503
+curl -sk -o /dev/null -w '%{http_code}\n' "https://$H:$PORT/go-live/$C/2160p/segment_00045.m4s?player_id=$PID"
+```
+
+Live matrix that should hold (2160p segments): `resolutions:[]`→no 503;
+`["3840x2160"]`→all 503; `["1280x720"]`→no 503 on 2160p; no variant
+filter→all 503.
+
+Related: [`fault-injection-wire-contract.md`](fault-injection-wire-contract.md)
+(socket-phase wire shapes), [`avplayer-quirks.md`](avplayer-quirks.md),
+[`abr-decision-model.md`](abr-decision-model.md).

--- a/content/dashboard-v3/src/components/FaultRules.vue
+++ b/content/dashboard-v3/src/components/FaultRules.vue
@@ -305,11 +305,9 @@ function typeChoicesFor(surface: Surface): FaultTypeChoice[] {
 // Full ladder — fault injection targets any available variant, even ones thinned
 // out of the player's current manifest by allowed_variants (not just the allowed
 // subset). Bandwidth chart uses the thinned `variants`; this needs them all.
-const { variantsAll: rawManifestVariants } = useManifestVariants(toRef(props, 'playerId'));
-// Legacy sorts descending by bandwidth (highest rung first).
-const manifestVariants = computed(() => {
-  return rawManifestVariants.value.slice().sort((a, b) => (b.bandwidth ?? 0) - (a.bandwidth ?? 0));
-});
+// useManifestVariants already collapses duplicate rungs and sorts descending
+// by bandwidth (highest rung first), so the scope list is display-ready.
+const { variantsAll: manifestVariants } = useManifestVariants(toRef(props, 'playerId'));
 
 // Non-audio request kinds we enumerate on the "All" tab when audio
 // needs to be excluded explicitly (otherwise the All-tab rule has no

--- a/content/dashboard-v3/src/components/FaultRules.vue
+++ b/content/dashboard-v3/src/components/FaultRules.vue
@@ -455,6 +455,19 @@ function consLabel(surface: Surface): string {
   if (surface === 'transport') return 'Consecutive (secs)';
   return 'Consecutive';
 }
+
+// Plain-language readout of what the current (consecutive, frequency) pair
+// actually does — the freq=0 edges are non-obvious. Only the request-fault
+// surfaces run the native cadence engine these describe; transport uses a
+// separate path, so it gets no hint.
+function cadenceHint(surface: Surface): string {
+  if (surface === 'transport') return '';
+  const cons = getCons(surface);
+  const freq = getFreq(surface);
+  if (cons === 0 && freq === 0) return '0 / 0 → faults every request until cancelled';
+  if (freq === 0 && cons > 0) return `frequency 0 → one-shot: ${cons} then stops`;
+  return '';
+}
 </script>
 
 <template>
@@ -593,6 +606,10 @@ function consLabel(surface: Surface): string {
           @input="onFreqInput(activeTab, $event)"
         />
         <span class="val">{{ getFreq(activeTab) }}</span>
+      </div>
+
+      <div v-if="cadenceHint(activeTab)" class="row cadence-hint">
+        <span class="muted">{{ cadenceHint(activeTab) }}</span>
       </div>
 
       <!-- Transport-only readouts: live State + Fault Counters tile. -->
@@ -742,6 +759,14 @@ function consLabel(surface: Surface): string {
   font-size: 13px;
   color: #111827;
   text-align: right;
+}
+
+/* Cadence readout sits under the sliders, aligned with the slider column. */
+.cadence-hint {
+  margin-top: -6px;
+}
+.cadence-hint .muted {
+  grid-column: 2 / -1;
 }
 
 .scope { grid-template-columns: 120px 1fr; }

--- a/content/dashboard-v3/src/composables/useManifestVariants.ts
+++ b/content/dashboard-v3/src/composables/useManifestVariants.ts
@@ -27,9 +27,9 @@ export function useManifestVariants(playerId: Ref<string> | string) {
   const variants = computed<ManifestVariant[]>(() => {
     const p = player.value;
     const typed = p?.current_play?.manifest?.variants;
-    if (Array.isArray(typed) && typed.length) return typed;
+    if (Array.isArray(typed) && typed.length) return dedupSortVariants(typed);
     const flat = parseManifestVariants((p as any)?.raw_session?.manifest_variants);
-    if (flat.length) return flat as ManifestVariant[];
+    if (flat.length) return dedupSortVariants(flat as ManifestVariant[]);
     return [];
   });
 
@@ -44,11 +44,41 @@ export function useManifestVariants(playerId: Ref<string> | string) {
   const variantsAll = computed<ManifestVariant[]>(() => {
     const p = player.value;
     const all = parseManifestVariants((p as any)?.raw_session?.manifest_variants_all);
-    if (all.length) return all as ManifestVariant[];
+    if (all.length) return dedupSortVariants(all as ManifestVariant[]);
     return variants.value;
   });
 
   return { variants, variantsAll };
+}
+
+/**
+ * Collapse a raw variant ladder to one entry per DISTINCT rung, sorted by
+ * descending peak bandwidth (highest rung first). Two sources can carry
+ * duplicate rungs the scope/config pickers must not repeat:
+ *   - HLS masters legitimately list a video rendition once PER audio group
+ *     (stereo + surround) — same media-playlist URI, N EXT-X-STREAM-INF lines.
+ *   - Looping DASH MPDs accumulate <Period>s over the live window, each
+ *     carrying the same Representation ladder (fixed at the source in
+ *     parseDASHManifest, deduped here too for defence in depth).
+ * Keyed on `url` (the media-playlist URI for HLS, the segment dir for DASH),
+ * falling back to `resolution@bandwidth` when a source omits it. The nearest-
+ * match helpers below are order- and duplicate-insensitive, so only the
+ * enumerated pickers (fault scope, content manipulation, shaping pattern)
+ * need this normalisation.
+ */
+function dedupSortVariants<T extends { url?: string; resolution?: string; bandwidth?: number }>(
+  list: readonly T[],
+): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const v of list) {
+    const key = v?.url ?? `${v?.resolution ?? ''}@${v?.bandwidth ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(v);
+  }
+  out.sort((a, b) => (b?.bandwidth ?? 0) - (a?.bandwidth ?? 0));
+  return out;
 }
 
 /** Minimal manifest-variant shape the snap helper needs. */

--- a/go-proxy/cmd/server/fault_dash.go
+++ b/go-proxy/cmd/server/fault_dash.go
@@ -62,6 +62,11 @@ func parseDASHManifest(body []byte) (videoVariants []PlaylistInfo, renditions ma
 		return nil, nil
 	}
 	renditions = map[string]renditionInfo{}
+	// A looping live MPD accumulates one <Period> per loop over the live window,
+	// each carrying the SAME Representation ladder. The variant ladder is the
+	// SET of distinct renditions, not one entry per Period — so dedup by segment
+	// dir (the CMAF rendition key) and keep the first occurrence of each rung.
+	seenVideo := map[string]bool{}
 	for _, period := range mpd.Periods {
 		for _, as := range period.AdaptationSets {
 			for _, rep := range as.Representations {
@@ -73,6 +78,10 @@ func parseDASHManifest(body []byte) (videoVariants []PlaylistInfo, renditions ma
 					renditions[dir] = renditionInfo{Kind: "audio"}
 					continue
 				}
+				if seenVideo[dir] {
+					continue
+				}
+				seenVideo[dir] = true
 				res := ""
 				if rep.Width > 0 && rep.Height > 0 {
 					res = fmt.Sprintf("%dx%d", rep.Width, rep.Height)

--- a/go-proxy/cmd/server/fault_dash_test.go
+++ b/go-proxy/cmd/server/fault_dash_test.go
@@ -62,6 +62,54 @@ func TestParseDASHManifest(t *testing.T) {
 	}
 }
 
+// A looping live MPD carries one <Period> per loop over the live window, each
+// repeating the SAME Representation ladder. parseDASHManifest must collapse the
+// video ladder to its DISTINCT rungs (a ladder is a set), not emit one variant
+// per Period — otherwise the dashboard's scope/config pickers show each rung ×N.
+const sampleMPDMultiPeriod = `<?xml version="1.0"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic">
+  <Period id="loop_3" start="PT1003S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" bandwidth="775917" mimeType="video/mp4" width="640" height="360">
+        <SegmentList><Initialization sourceURL="360p/init.mp4"/><SegmentURL media="360p/segment_00038.m4s"/></SegmentList>
+      </Representation>
+      <Representation id="3" bandwidth="3561627" mimeType="video/mp4" width="1280" height="720">
+        <SegmentList><Initialization sourceURL="720p/init.mp4"/><SegmentURL media="720p/segment_00038.m4s"/></SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="loop_4" start="PT1503S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" bandwidth="775917" mimeType="video/mp4" width="640" height="360">
+        <SegmentList><Initialization sourceURL="360p/init.mp4"/><SegmentURL media="360p/segment_00058.m4s"/></SegmentList>
+      </Representation>
+      <Representation id="3" bandwidth="3561627" mimeType="video/mp4" width="1280" height="720">
+        <SegmentList><Initialization sourceURL="720p/init.mp4"/><SegmentURL media="720p/segment_00058.m4s"/></SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`
+
+func TestParseDASHManifestMultiPeriodDedup(t *testing.T) {
+	variants, renditions := parseDASHManifest([]byte(sampleMPDMultiPeriod))
+	// Two Periods × two rungs = four raw Representations, but the ladder is the
+	// two DISTINCT rungs.
+	if len(variants) != 2 {
+		t.Fatalf("video variants = %d, want 2 (deduped across Periods); got %v", len(variants), variants)
+	}
+	seen := map[string]bool{}
+	for _, v := range variants {
+		if seen[v.URL] {
+			t.Errorf("duplicate rung %q in deduped ladder", v.URL)
+		}
+		seen[v.URL] = true
+	}
+	// Rungs re-index over the DISTINCT set: 360p=0, 720p=1.
+	if renditions["360p"].Rung != 0 || renditions["720p"].Rung != 1 {
+		t.Errorf("rungs after dedup: 360p=%d 720p=%d, want 0/1", renditions["360p"].Rung, renditions["720p"].Rung)
+	}
+}
+
 // TestDASHClassificationEndToEnd: parse the MPD → merge onto the session → DASH
 // segments (same CMAF dirs) classify with authoritative resolution/rung/audio,
 // and a resolution-scoped fault matches the right rung only.

--- a/go-proxy/cmd/server/fault_evaluate.go
+++ b/go-proxy/cmd/server/fault_evaluate.go
@@ -66,6 +66,11 @@ func failureHandlerFromMatch(mf MatchedFault, st *ruleCadenceState) *FailureHand
 	if consecutive <= 0 {
 		consecutive = 1 // schema default; also what makes the cadence engine act
 	}
+	// consecutive=0 AND frequency=0 → continuous: fault every matching request
+	// until the rule is cleared, instead of the one-shot single failure the
+	// cadence math would otherwise produce. This is the intuitive meaning of
+	// the UI's default (0,0) — "on until I cancel it".
+	continuous := mf.Consecutive == 0 && mf.Frequency == 0
 	return &FailureHandler{
 		failureType:      normalizeRequestFailureType(mf.Type),
 		consecutiveUnits: consecutiveUnits,
@@ -74,6 +79,7 @@ func failureHandlerFromMatch(mf MatchedFault, st *ruleCadenceState) *FailureHand
 		consecutive:      consecutive,
 		failureAt:        st.failureAt,
 		failureRecoverAt: st.failureRecoverAt,
+		continuous:       continuous,
 	}
 }
 

--- a/go-proxy/cmd/server/fault_match.go
+++ b/go-proxy/cmd/server/fault_match.go
@@ -99,9 +99,16 @@ func variantPredicateMatches(vAny any, rc RequestClass) bool {
 			return false
 		}
 	}
-	if res, ok := v["resolutions"].([]any); ok && len(res) > 0 {
-		if rc.Resolution == "" || !containsStringFold(res, rc.Resolution) {
-			return false
+	if raw, present := v["resolutions"]; present {
+		if res, ok := raw.([]any); ok {
+			// A present but EMPTY resolutions list means the operator narrowed
+			// the scope to ZERO video variants (the UI's "all unchecked" state)
+			// → match nothing. This is distinct from an ABSENT key, which
+			// imposes no resolution constraint. A malformed (non-list) value is
+			// left lenient, matching faultFilterMatches' "never a silent 500".
+			if len(res) == 0 || rc.Resolution == "" || !containsStringFold(res, rc.Resolution) {
+				return false
+			}
 		}
 	}
 	if raw, ok := v["bandwidth_above"]; ok && raw != nil {

--- a/go-proxy/cmd/server/fault_match_test.go
+++ b/go-proxy/cmd/server/fault_match_test.go
@@ -116,6 +116,28 @@ func TestMatchFaultRule_VariantResolutionAndBandwidth(t *testing.T) {
 	}
 }
 
+// TestMatchFaultRule_EmptyResolutionsMatchesNothing: unchecking ALL variants in
+// the UI sends variant.resolutions=[] — an explicit "zero variants in scope".
+// That must match NOTHING, not everything. An ABSENT resolutions key (no
+// variant narrowing) still matches all video — the two are distinct.
+func TestMatchFaultRule_EmptyResolutionsMatchesNothing(t *testing.T) {
+	emptyRule := []any{rule("r", "503", map[string]any{"variant": map[string]any{"resolutions": []any{}}})}
+	for _, rc := range []RequestClass{
+		video(0, "640x360", 800_000),
+		video(4, "1920x1080", 8_000_000),
+		video(8, "3840x2160", 33_000_000),
+	} {
+		if _, ok := matchFaultRule(emptyRule, rc); ok {
+			t.Errorf("resolutions=[] must match NOTHING, but matched %s", rc.Resolution)
+		}
+	}
+	// Sanity: an ABSENT variant filter still matches all video (unchanged).
+	openRule := []any{rule("r", "503", map[string]any{})}
+	if _, ok := matchFaultRule(openRule, video(4, "1920x1080", 8_000_000)); !ok {
+		t.Error("no variant filter should still match video")
+	}
+}
+
 func TestMatchFaultRule_UrlMatchModes(t *testing.T) {
 	rc := RequestClass{Kind: "segment", RungIndex: 0, LadderSize: 5, Path: "/go-live/c/720p/segment_00017.m4s"}
 	cases := []struct {

--- a/go-proxy/cmd/server/fault_parity_test.go
+++ b/go-proxy/cmd/server/fault_parity_test.go
@@ -75,6 +75,28 @@ func TestNativeOneShot(t *testing.T) {
 	}
 }
 
+// TestNativeContinuous: consecutive=0 AND frequency=0 means "fault every
+// matching request until cleared" — NOT a one-shot. This is the UI default
+// (0,0), which previously clamped to consec=1/freq=0 and fired exactly once.
+func TestNativeContinuous(t *testing.T) {
+	const seg = "/go-live/c/720p/segment_%d.m4s"
+	now := time.Unix(1_700_000_000, 0)
+	for _, mode := range []string{"requests", "failures_per_seconds", "seconds"} {
+		s := seedSegmentFaultV2("503", 0, 0, mode)
+		fires := 0
+		for i := 1; i <= 25; i++ {
+			// advance wall-clock too, so a time-mode cadence couldn't hide behind
+			// a single window — continuous must fault regardless.
+			if runNativeSegment(s, fmt.Sprintf(seg, i), now.Add(time.Duration(i)*time.Second)) == "503" {
+				fires++
+			}
+		}
+		if fires != 25 {
+			t.Errorf("mode=%s continuous(0,0): fired %d/25, want 25 (every request)", mode, fires)
+		}
+	}
+}
+
 // TestNativeReArmResetsWindow is the #643 guard for the native engine: after a
 // one-shot half-fires, clearing _faultrule_state (what translateFaultRules does
 // on a re-arm PATCH) must deliver a FRESH full window, not resume the old one.

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -10796,6 +10796,12 @@ type FailureHandler struct {
 	failureAt        interface{}
 	failureRecoverAt interface{}
 	resetFailureType interface{}
+	// continuous faults EVERY matching request until the rule is cleared —
+	// the "on until I cancel it" mode. Set when both consecutive and
+	// frequency are 0 (see failureHandlerFromMatch). Short-circuits the
+	// cadence math so the rule never schedules a recovery window and never
+	// one-shot self-clears.
+	continuous bool
 }
 
 // refreshFailureStateFromLatest copies the fault-decision-relevant
@@ -10831,6 +10837,13 @@ func (h *FailureHandler) HandleFailure(count int, now time.Time) string {
 	}
 	if h.failureType == "none" {
 		return "none"
+	}
+	// Continuous mode: fault every matching request, no recovery window, no
+	// one-shot self-clear. The rule stays armed until the operator changes or
+	// clears it. This is what consecutive=0 & frequency=0 means (the UI's
+	// default) — "keep failing until I cancel it".
+	if h.continuous {
+		return h.failureType
 	}
 	if h.frequencyUnits == "seconds" {
 		h.handleFailureTime(count, now)


### PR DESCRIPTION
## Summary

Makes the variant-scoped fault UI behave the way its labels imply. Four
fixes across the go-proxy fault engine and the dashboard, split into two
commits. All verified live on :21000 and covered by unit tests.

## What was wrong

While driving variant faults to force ABR rate-shifts, three things
disagreed with the UI's intent:

1. **Duplicate rungs in the scope list.** A looping live DASH `.mpd`
   accumulates one `<Period>` per loop, each repeating the ladder, so
   `parseDASHManifest` emitted each rung once per Period (mixed ×2/×1
   during Period rolls). Also surfaced on the bandwidth/timeline paths.
2. **Default fault did nothing.** The UI default cadence `(consecutive=0,
   frequency=0)` clamped to a **one-shot single failure** — fired once,
   reverted forever. On ExoPlayer (which retries a transient error and
   recovers) that looked like the fault never fired at all.
3. **Deselecting all variants still injected errors.** The UI sends
   `filter.variant.resolutions: []` meaning "match nothing" (documented
   in `FaultRules.vue`), but the backend read an empty list as "no
   constraint → match all video" — the inverse.

Matching itself was never broken: the scope list and the classifier draw
the resolution string from the **same** manifest parse, and a live probe
confirmed `resolutions:["3840x2160"]` faults 2160p segments.

## Changes

**Commit 1 — dedup + sort** (`fix(variants)`)
- `parseDASHManifest` dedups video rungs by segment dir across Periods.
- `useManifestVariants` collapses duplicate rungs and sorts descending by
  bandwidth; `FaultRules.vue` drops its redundant re-sort.

**Commit 2 — fault semantics** (`fix(faults)`)
- `(0,0)` → **continuous** fault until cleared (`FailureHandler.continuous`).
- Present-but-empty `resolutions: []` → **matches nothing** (distinct from
  absent = no constraint).
- New standard: `.claude/standards/player-fault-response.md` (ExoPlayer vs
  AVPlayer fault response, cadence + scope semantics, live-probe recipe).

## Verification (live, :21000, 2160p segments)

| Selection | Filter | Result |
|---|---|---|
| None | `resolutions: []` | 0 faults ✅ |
| 4K | `resolutions: ["3840x2160"]` | all fault ✅ |
| 720p | `resolutions: ["1280x720"]` | 0 on 2160p ✅ |
| All | *no variant filter* | all fault ✅ |
| `(0,0)` cadence | — | every request faults (was 1) ✅ |

Tests: `TestParseDASHManifestMultiPeriodDedup`, `TestNativeContinuous`,
`TestMatchFaultRule_EmptyResolutionsMatchesNothing`. Full server test
package + frontend typecheck green.

## Notes

- PRs target `dev`, so this won't auto-close anything — close related
  issues manually if any.
- Follow-ups not in this PR: a "0 = until cancelled" slider label, and the
  separate vis-timeline `_onDataPush` console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
