### PR TITLE
feat(go-live): serve manifest_1s.mpd — 1s DASH variant (#931)

### DIFF
--- a/go-live/cmd/server/main.go
+++ b/go-live/cmd/server/main.go
@@ -94,6 +94,7 @@ func main() {
 	fmt.Println("  GET  /go-live/{content}/master.m3u8 - On-demand master playlist")
 	fmt.Println("  GET  /go-live/{content}/{variant}.m3u8 - On-demand variant playlist")
 	fmt.Println("  GET  /go-live/{content}/manifest.mpd - On-demand DASH MPD (LL)")
+	fmt.Println("  GET  /go-live/{content}/manifest_1s.mpd - On-demand DASH MPD (1s)")
 	fmt.Println("  GET  /go-live/{content}/manifest_2s.mpd - On-demand DASH MPD (2s)")
 	fmt.Println("  GET  /go-live/{content}/manifest_6s.mpd - On-demand DASH MPD (6s)")
 	fmt.Println()

--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -1210,7 +1210,11 @@ func (h *Handler) OnDemandDashManifest(w http.ResponseWriter, r *http.Request) {
 
 	variant, duration, llMode, mpdPathForLoad := parseDashVariant(pathPart)
 	if variant == "ll" {
-		if strings.Contains(pathPart, "manifest_2s.mpd") {
+		if strings.Contains(pathPart, "manifest_1s.mpd") {
+			variant = "1s"
+			duration = 1
+			llMode = false
+		} else if strings.Contains(pathPart, "manifest_2s.mpd") {
 			variant = "2s"
 			duration = 2
 			llMode = false
@@ -1301,6 +1305,11 @@ func parseDashVariant(pathPart string) (string, int, bool, string) {
 	lookupBase := base
 
 	switch base {
+	case "manifest_1s.mpd":
+		variant = "1s"
+		duration = 1
+		llMode = false
+		lookupBase = "manifest.mpd"
 	case "manifest_2s.mpd":
 		variant = "2s"
 		duration = 2
@@ -1314,7 +1323,7 @@ func parseDashVariant(pathPart string) (string, int, bool, string) {
 	case "manifest.mpd":
 		variant = "ll"
 	default:
-		if len(parts) >= 2 && (parts[0] == "2s" || parts[0] == "6s") {
+		if len(parts) >= 2 && (parts[0] == "1s" || parts[0] == "2s" || parts[0] == "6s") {
 			variant = parts[0]
 			llMode = false
 			if parsed, err := strconv.Atoi(strings.TrimSuffix(parts[0], "s")); err == nil {
@@ -1344,6 +1353,7 @@ func runDashGeneratorAll(ctx context.Context, genKey string, mpdData *dash.MPDDa
 
 	variants := []dashVariantSpec{
 		{name: "ll", duration: 6, llMode: true},
+		{name: "1s", duration: 1, llMode: false},
 		{name: "2s", duration: 2, llMode: false},
 		{name: "6s", duration: 6, llMode: false},
 	}
@@ -1453,9 +1463,9 @@ func runDashGeneratorAll(ctx context.Context, genKey string, mpdData *dash.MPDDa
 			}
 			dashCacheMu.Unlock()
 
-			logf("[GO-LIVE:DASH] Tick generation: total=%.3fs avg_5m=%.3fs content=%s ll=%.3fs 2s=%.3fs 6s=%.3fs\n",
+			logf("[GO-LIVE:DASH] Tick generation: total=%.3fs avg_5m=%.3fs content=%s ll=%.3fs 1s=%.3fs 2s=%.3fs 6s=%.3fs\n",
 				tickElapsed.Seconds(), avg, content,
-				durByVariant["ll"].Seconds(), durByVariant["2s"].Seconds(), durByVariant["6s"].Seconds())
+				durByVariant["ll"].Seconds(), durByVariant["1s"].Seconds(), durByVariant["2s"].Seconds(), durByVariant["6s"].Seconds())
 		}
 		select {
 		case <-ctx.Done():

--- a/go-live/internal/api/handlers_test.go
+++ b/go-live/internal/api/handlers_test.go
@@ -1,0 +1,35 @@
+package api
+
+import "testing"
+
+// TestParseDashVariant covers the DASH manifest routing, including the 1s
+// variant added in #931. The three flat manifest_Ns.mpd forms and the nested
+// {duration}/…/manifest.mpd form must all resolve to the right (variant,
+// duration, llMode, lookupBase); everything else falls back to LL.
+func TestParseDashVariant(t *testing.T) {
+	cases := []struct {
+		path     string
+		variant  string
+		duration int
+		llMode   bool
+		lookup   string
+	}{
+		{"insane/manifest_1s.mpd", "1s", 1, false, "insane/manifest.mpd"},
+		{"insane/manifest_2s.mpd", "2s", 2, false, "insane/manifest.mpd"},
+		{"insane/manifest_6s.mpd", "6s", 6, false, "insane/manifest.mpd"},
+		{"insane/manifest.mpd", "ll", 6, true, "insane/manifest.mpd"},
+		// bare (no content dir) still parses
+		{"manifest_1s.mpd", "1s", 1, false, "manifest.mpd"},
+		// nested duration-prefixed form (non-manifest.mpd base reaches the
+		// default branch, where 1s now sits alongside 2s/6s)
+		{"1s/insane.mpd", "1s", 1, false, "insane.mpd"},
+	}
+	for _, c := range cases {
+		variant, duration, llMode, lookup := parseDashVariant(c.path)
+		if variant != c.variant || duration != c.duration || llMode != c.llMode || lookup != c.lookup {
+			t.Errorf("parseDashVariant(%q) = (%q,%d,%v,%q), want (%q,%d,%v,%q)",
+				c.path, variant, duration, llMode, lookup,
+				c.variant, c.duration, c.llMode, c.lookup)
+		}
+	}
+}

--- a/go-live/pkg/dash/mpd.go
+++ b/go-live/pkg/dash/mpd.go
@@ -484,8 +484,17 @@ func parseSegmentTimeline(segTimeline *etree.Element, timescale int) (*timelineD
 	}, nil
 }
 
+// usesVirtualSegments reports whether a variant duration is synthesized by
+// regrouping the base (6s) fmp4 fragments into shorter segments via their
+// .byteranges sidecars, rather than served from the base SegmentList directly.
+// The 1s and 2s variants are both sub-base regroupings; LL and 6s use the base
+// segments as-is (LL just exposes them with partial-segment availability).
+func usesVirtualSegments(duration int) bool {
+	return duration == 1 || duration == 2
+}
+
 func ensureVirtualSegments(data *MPDData, duration int) (int, float64) {
-	if duration != 2 {
+	if !usesVirtualSegments(duration) {
 		return data.SegmentCount, data.SegmentDuration
 	}
 	if data.VirtualSegmentsByDur[duration] == nil {
@@ -652,7 +661,7 @@ func GenerateLiveMPD(data *MPDData, timeNow time.Time, streamName string, durati
 	fmt.Fprintf(os.Stderr, "[GO-LIVE:DASH] Base MPD: totalDuration=%.3f segmentDuration=%.3f segmentCount=%d\n",
 		totalDuration, segmentDuration, segmentCount)
 
-	if duration == 2 {
+	if usesVirtualSegments(duration) {
 		virtualCount, virtualDuration := ensureVirtualSegments(data, duration)
 		if virtualCount > 0 {
 			segmentCount = virtualCount
@@ -687,7 +696,7 @@ func GenerateLiveMPD(data *MPDData, timeNow time.Time, streamName string, durati
 	elapsedTime := timeOffset
 	availabilityOffset := segmentDuration
 	if llMode {
-		if duration == 2 {
+		if usesVirtualSegments(duration) {
 			availabilityOffset = detectPartialDuration(data, duration, baseSegmentDuration)
 		} else {
 			availabilityOffset = detectPartialDuration(data, duration, segmentDuration)
@@ -982,7 +991,7 @@ func buildExplicitSegmentList(representation *etree.Element, data *MPDData, wind
 	virtualSegments := []virtualSegment{}
 	usePartials := llMode
 
-	if duration == 2 {
+	if usesVirtualSegments(duration) {
 		if byDur, ok := data.VirtualSegmentsByDur[duration]; ok {
 			virtualSegments = byDur[repID]
 			if len(virtualSegments) > 0 {
@@ -1006,7 +1015,7 @@ func buildExplicitSegmentList(representation *etree.Element, data *MPDData, wind
 		segList.CreateAttr("timescale", segMeta.timescale)
 	}
 	if segMeta.initialization != nil {
-		if duration == 2 || duration == 4 {
+		if usesVirtualSegments(duration) || duration == 4 {
 			initURL := segMeta.initialization.SelectAttrValue("sourceURL", "")
 			if initURL != "" {
 				segMeta.initialization.RemoveAttr("sourceURL")
@@ -1062,7 +1071,7 @@ func buildExplicitSegmentList(representation *etree.Element, data *MPDData, wind
 		}
 
 		segmentBasePath := baseMediaPath
-		if duration == 2 {
+		if usesVirtualSegments(duration) {
 			segmentBasePath = prefixDashPath(data.Rel, segmentBasePath)
 		}
 

--- a/go-live/pkg/dash/mpd_test.go
+++ b/go-live/pkg/dash/mpd_test.go
@@ -1,0 +1,20 @@
+package dash
+
+import "testing"
+
+// usesVirtualSegments gates the fragment-regrouping path. The base package is 6s;
+// LL and 6s serve the base SegmentList directly, while 1s and 2s are synthesized
+// by regrouping the base fmp4 fragments. 1s was added alongside 2s (#931).
+func TestUsesVirtualSegments(t *testing.T) {
+	cases := map[int]bool{
+		1: true,  // regrouped sub-base variant (#931)
+		2: true,  // regrouped sub-base variant
+		4: false, // not a served variant; init-prefix special-cased elsewhere
+		6: false, // base segments, served directly
+	}
+	for duration, want := range cases {
+		if got := usesVirtualSegments(duration); got != want {
+			t.Errorf("usesVirtualSegments(%d) = %v, want %v", duration, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds the `manifest_1s.mpd` DASH variant. DASH exposed only LL/2s/6s while HLS already had 1s — an omission, not a constraint.

## Why there was no barrier

Every segment-length variant is synthesized at request time by regrouping the same base 6s fmp4 fragments via their `.byteranges` sidecars (no re-encode). The encoder's 1s GOP means every 1s boundary lands on a keyframe, so 1s is the finest cleanly-synthesizable length. The grouping math (`buildVirtualSegmentsForRep`) was already duration-generic; the only thing blocking 1s was a literal `duration != 2` guard.

## Changes (`go-live/` only)

- **`pkg/dash/mpd.go`** — extract `usesVirtualSegments(d)` (`1s || 2s`) and route the six `duration == 2` fragment-regrouping / path-prefix gates through it, so 1s takes the same synthesis path as 2s.
- **`internal/api/handlers.go`** — `parseDashVariant` case + nested-path branch + the `OnDemandDashManifest` LL-fallback; add `1s` to the generator's variant list (auto-generated & cached each tick) and the tick log.
- **`cmd/server/main.go`** — help-output line.
- **tests** — `usesVirtualSegments` classification + `parseDashVariant` routing.

## Verification

Live on `:21000` (`bucks_bunny_p200_h264`):

| Manifest | HTTP | Segments in window | Median seg dur |
|---|---|---|---|
| `manifest_1s.mpd` | 200 | 180 | **1.000s** |
| `manifest_2s.mpd` | 200 | 90 | 2.000s |
| `manifest_6s.mpd` | 200 | 30 | 6.000s |

Clean 6:3:1 ratio. Confirmed playing on Android TV.

Resolves the server half of #931 — 1s-under-DASH is now genuinely served rather than gated out of the Android picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
