### PR TITLE
feat(harness): variant-scope + --continuous flags for harness fault add

### DIFF
--- a/tools/harness-cli/cmd/harness/fault.go
+++ b/tools/harness-cli/cmd/harness/fault.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/api"
@@ -33,11 +34,24 @@ add flags:
   --url-substr S   match URLs containing S; comma-separated for multi-pattern
                    (e.g. --url-substr 2160p,1440p,1080p)
   --url-regex R    match URLs matching R (regex mode)
-  --frequency N    cadence numerator (default 1)
+  --frequency N    cadence numerator (default 1); 0 = one-shot burst
   --mode MODE      requests | seconds | failures_per_seconds
                    (default requests)
   --consecutive N  consecutive-failures count (default 1)
+  --continuous     fault EVERY matching request until cleared
+                   (shorthand for --frequency 0 --consecutive 0)
   --id ID          override server-generated rule_id (uuid)
+
+variant-scope flags (match by manifest-declared properties; all AND
+together, and never match audio/init/master requests):
+  --resolution WxH   comma-separated resolutions, e.g. 3840x2160,2560x1440
+  --rung-index N     comma-separated rung indexes (0 = lowest bitrate)
+  --rung-position P  comma-separated symbolic positions, evaluated against
+                     the current ladder: top, second_from_top,
+                     bottom, second_from_bottom
+  --bandwidth-above BPS  match variants whose BANDWIDTH > BPS
+  --bandwidth-below BPS  match variants whose BANDWIDTH < BPS
+  --codec-prefix S       match variants whose CODECS starts with S
 
 <target> may be a full UUID, a >=6-char hex prefix, a label value
 (device/name), a player IP, or a substring of the User-Agent.
@@ -104,6 +118,10 @@ func cmdFaultList(client *api.Client, args []string, asJSON bool) error {
 		if r.Filter != nil && r.Filter.UrlMatch != nil {
 			url = fmt.Sprintf(" url[%s]=%s", r.Filter.UrlMatch.Mode, strings.Join(r.Filter.UrlMatch.Patterns, "|"))
 		}
+		variant := ""
+		if r.Filter != nil && r.Filter.Variant != nil {
+			variant = " variant[" + variantSummary(r.Filter.Variant) + "]"
+		}
 		freq, mode, cons := 1, "requests", 1
 		if r.Frequency != nil {
 			freq = *r.Frequency
@@ -114,8 +132,12 @@ func cmdFaultList(client *api.Client, args []string, asJSON bool) error {
 		if r.Consecutive != nil {
 			cons = *r.Consecutive
 		}
-		fmt.Printf("%d. %-12s type=%-10s kind=%-10s freq=%d/%s consec=%d%s\n",
-			i+1, shortRuleID(id), string(r.Type), kind, freq, mode, cons, url)
+		cadence := fmt.Sprintf("freq=%d/%s consec=%d", freq, mode, cons)
+		if freq == 0 && cons == 0 {
+			cadence = "continuous"
+		}
+		fmt.Printf("%d. %-12s type=%-10s kind=%-10s %s%s%s\n",
+			i+1, shortRuleID(id), string(r.Type), kind, cadence, variant, url)
 	}
 	return nil
 }
@@ -132,6 +154,13 @@ func cmdFaultAdd(client *api.Client, args []string, asJSON bool) error {
 	freq := fs.Int("frequency", 1, "cadence numerator")
 	mode := fs.String("mode", "requests", "requests|seconds|failures_per_seconds")
 	cons := fs.Int("consecutive", 1, "consecutive failures")
+	continuous := fs.Bool("continuous", false, "fault every matching request until cleared (frequency=0 consecutive=0)")
+	resolution := fs.String("resolution", "", "comma-separated variant resolutions (WxH)")
+	rungIndex := fs.String("rung-index", "", "comma-separated rung indexes (0 = lowest bitrate)")
+	rungPosition := fs.String("rung-position", "", "comma-separated symbolic rung positions")
+	bwAbove := fs.Int("bandwidth-above", -1, "match variants with BANDWIDTH above this (bps)")
+	bwBelow := fs.Int("bandwidth-below", -1, "match variants with BANDWIDTH below this (bps)")
+	codecPrefix := fs.String("codec-prefix", "", "match variants whose CODECS starts with this")
 	ruleID := fs.String("id", "", "explicit rule_id (uuid)")
 	if err := fs.Parse(args[1:]); err != nil {
 		return err
@@ -139,11 +168,14 @@ func cmdFaultAdd(client *api.Client, args []string, asJSON bool) error {
 	if *typ == "" {
 		return errors.New("--type is required")
 	}
-	target := args[0]
-	ctx := context.Background()
-	pid, err := client.Resolve(ctx, target)
-	if err != nil {
-		return err
+	// --continuous is shorthand for (frequency=0, consecutive=0). Reject
+	// combining it with an explicit --frequency/--consecutive so the
+	// operator can't quietly get a cadence they didn't mean.
+	if *continuous {
+		if flagSet(fs, "frequency") || flagSet(fs, "consecutive") {
+			return errors.New("--continuous cannot be combined with --frequency/--consecutive")
+		}
+		*freq, *cons = 0, 0
 	}
 
 	rule := proxy.FaultRule{
@@ -156,15 +188,40 @@ func cmdFaultAdd(client *api.Client, args []string, asJSON bool) error {
 	if *ruleID != "" {
 		rule.Id = ruleID
 	}
-	if filter, err := buildFilter(*kindCSV, *urlSubstr, *urlRegex); err != nil {
+	// Build (and validate) the filter before touching the network, so a
+	// typo in --kind/--rung-position/etc. fails fast without a round-trip.
+	filter, err := buildFilter(faultFilterInput{
+		kindCSV:        *kindCSV,
+		urlSubstr:      *urlSubstr,
+		urlRegex:       *urlRegex,
+		resolutions:    *resolution,
+		rungIndexes:    *rungIndex,
+		rungPositions:  *rungPosition,
+		bandwidthAbove: *bwAbove,
+		bandwidthBelow: *bwBelow,
+		codecPrefix:    *codecPrefix,
+	})
+	if err != nil {
 		return err
-	} else if filter != nil {
-		rule.Filter = filter
+	}
+	rule.Filter = filter
+
+	target := args[0]
+	ctx := context.Background()
+	pid, err := client.Resolve(ctx, target)
+	if err != nil {
+		return err
 	}
 
 	action := fmt.Sprintf("fault add type=%s", *typ)
 	if *kindCSV != "" {
 		action += " kind=" + *kindCSV
+	}
+	if *continuous {
+		action += " continuous"
+	}
+	if rule.Filter != nil && rule.Filter.Variant != nil {
+		action += " variant[" + variantSummary(rule.Filter.Variant) + "]"
 	}
 	newETag, err := client.AddFaultRule(ctx, pid, action, rule)
 	if err != nil {
@@ -310,13 +367,35 @@ func cmdFaultClear(client *api.Client, args []string, asJSON bool) error {
 	return nil
 }
 
-func buildFilter(kindCSV, urlSubstr, urlRegex string) (*proxy.FaultFilter, error) {
-	if kindCSV == "" && urlSubstr == "" && urlRegex == "" {
+// faultFilterInput collects every CLI flag that contributes to a
+// FaultFilter, so buildFilter has one testable signature rather than a
+// growing positional argument list. Unset numeric variant bounds are
+// signalled by -1.
+type faultFilterInput struct {
+	kindCSV        string
+	urlSubstr      string
+	urlRegex       string
+	resolutions    string // csv "WxH,WxH"
+	rungIndexes    string // csv ints
+	rungPositions  string // csv symbolic positions
+	bandwidthAbove int    // -1 = unset
+	bandwidthBelow int    // -1 = unset
+	codecPrefix    string
+}
+
+func (in faultFilterInput) empty() bool {
+	return in.kindCSV == "" && in.urlSubstr == "" && in.urlRegex == "" &&
+		in.resolutions == "" && in.rungIndexes == "" && in.rungPositions == "" &&
+		in.bandwidthAbove < 0 && in.bandwidthBelow < 0 && in.codecPrefix == ""
+}
+
+func buildFilter(in faultFilterInput) (*proxy.FaultFilter, error) {
+	if in.empty() {
 		return nil, nil
 	}
 	f := &proxy.FaultFilter{}
-	if kindCSV != "" {
-		parts := strings.Split(kindCSV, ",")
+	if in.kindCSV != "" {
+		parts := strings.Split(in.kindCSV, ",")
 		kinds := make([]proxy.FaultFilterRequestKind, 0, len(parts))
 		for _, p := range parts {
 			k := proxy.FaultFilterRequestKind(strings.TrimSpace(p))
@@ -327,22 +406,145 @@ func buildFilter(kindCSV, urlSubstr, urlRegex string) (*proxy.FaultFilter, error
 		}
 		f.RequestKind = &kinds
 	}
-	if urlSubstr != "" && urlRegex != "" {
+	if in.urlSubstr != "" && in.urlRegex != "" {
 		return nil, errors.New("--url-substr and --url-regex are mutually exclusive")
 	}
-	if urlSubstr != "" {
-		// Comma-separated → multi-pattern. v1's matcher OR's the list,
+	if in.urlSubstr != "" {
+		// Comma-separated → multi-pattern. The matcher OR's the list,
 		// so a single rule can scope to e.g. "2160p,1440p,1080p" and
 		// fault every video variant without touching audio.
-		patterns := splitTrimNonEmpty(urlSubstr)
+		patterns := splitTrimNonEmpty(in.urlSubstr)
 		if len(patterns) > 0 {
 			f.UrlMatch = &proxy.UrlMatch{Mode: proxy.Substring, Patterns: patterns}
 		}
 	}
-	if urlRegex != "" {
-		f.UrlMatch = &proxy.UrlMatch{Mode: proxy.Regex, Patterns: []string{urlRegex}}
+	if in.urlRegex != "" {
+		f.UrlMatch = &proxy.UrlMatch{Mode: proxy.Regex, Patterns: []string{in.urlRegex}}
 	}
+	variant, err := buildVariant(in)
+	if err != nil {
+		return nil, err
+	}
+	f.Variant = variant
 	return f, nil
+}
+
+// buildVariant assembles a VariantPredicate from the variant-scope flags,
+// or returns nil when none are set. The server rejects an empty
+// `variant: {}`, so a nil (absent) predicate is the correct "no variant
+// narrowing" signal — never an empty struct.
+func buildVariant(in faultFilterInput) (*proxy.VariantPredicate, error) {
+	v := &proxy.VariantPredicate{}
+	set := false
+	if in.resolutions != "" {
+		res := splitTrimNonEmpty(in.resolutions)
+		if len(res) > 0 {
+			v.Resolutions = &res
+			set = true
+		}
+	}
+	if in.rungIndexes != "" {
+		idxs, err := parseCSVInts(in.rungIndexes)
+		if err != nil {
+			return nil, fmt.Errorf("--rung-index: %w", err)
+		}
+		if len(idxs) > 0 {
+			v.RungIndexes = &idxs
+			set = true
+		}
+	}
+	if in.rungPositions != "" {
+		positions := make([]proxy.VariantPredicateRungPositions, 0)
+		for _, p := range splitTrimNonEmpty(in.rungPositions) {
+			pos := proxy.VariantPredicateRungPositions(p)
+			if !pos.Valid() {
+				return nil, fmt.Errorf("invalid --rung-position %q (want top|second_from_top|bottom|second_from_bottom)", p)
+			}
+			positions = append(positions, pos)
+		}
+		if len(positions) > 0 {
+			v.RungPositions = &positions
+			set = true
+		}
+	}
+	if in.bandwidthAbove >= 0 {
+		bw := in.bandwidthAbove
+		v.BandwidthAbove = &bw
+		set = true
+	}
+	if in.bandwidthBelow >= 0 {
+		bw := in.bandwidthBelow
+		v.BandwidthBelow = &bw
+		set = true
+	}
+	if in.codecPrefix != "" {
+		cp := in.codecPrefix
+		v.CodecPrefix = &cp
+		set = true
+	}
+	if !set {
+		return nil, nil
+	}
+	return v, nil
+}
+
+// parseCSVInts parses a comma-separated list of integers, ignoring blank
+// entries. Used by --rung-index.
+func parseCSVInts(s string) ([]int, error) {
+	out := []int{}
+	for _, p := range splitTrimNonEmpty(s) {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not an integer", p)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// variantSummary renders a VariantPredicate compactly for `fault list`,
+// showing only the sub-predicates that are set.
+func variantSummary(v *proxy.VariantPredicate) string {
+	parts := []string{}
+	if v.Resolutions != nil && len(*v.Resolutions) > 0 {
+		parts = append(parts, "res="+strings.Join(*v.Resolutions, "|"))
+	}
+	if v.RungIndexes != nil && len(*v.RungIndexes) > 0 {
+		ss := make([]string, 0, len(*v.RungIndexes))
+		for _, n := range *v.RungIndexes {
+			ss = append(ss, strconv.Itoa(n))
+		}
+		parts = append(parts, "rung="+strings.Join(ss, "|"))
+	}
+	if v.RungPositions != nil && len(*v.RungPositions) > 0 {
+		ss := make([]string, 0, len(*v.RungPositions))
+		for _, p := range *v.RungPositions {
+			ss = append(ss, string(p))
+		}
+		parts = append(parts, "pos="+strings.Join(ss, "|"))
+	}
+	if v.BandwidthAbove != nil {
+		parts = append(parts, "bw>"+strconv.Itoa(*v.BandwidthAbove))
+	}
+	if v.BandwidthBelow != nil {
+		parts = append(parts, "bw<"+strconv.Itoa(*v.BandwidthBelow))
+	}
+	if v.CodecPrefix != nil && *v.CodecPrefix != "" {
+		parts = append(parts, "codec="+*v.CodecPrefix)
+	}
+	return strings.Join(parts, ",")
+}
+
+// flagSet reports whether the named flag was explicitly passed on the
+// command line (as opposed to sitting at its default).
+func flagSet(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 // splitTrimNonEmpty parses a comma-separated string into its trimmed

--- a/tools/harness-cli/cmd/harness/fault_test.go
+++ b/tools/harness-cli/cmd/harness/fault_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jonathaneoliver/infinite-streaming/tools/harness-cli/internal/v2gen/proxy"
+)
+
+// unsetVariant is a faultFilterInput with the numeric variant bounds at
+// their "unset" sentinel (-1), matching what the add-command flag
+// defaults produce. Tests start from this and set only the fields under
+// test.
+func unsetVariant() faultFilterInput {
+	return faultFilterInput{bandwidthAbove: -1, bandwidthBelow: -1}
+}
+
+func TestBuildFilter_EmptyIsNil(t *testing.T) {
+	f, err := buildFilter(unsetVariant())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f != nil {
+		t.Errorf("no flags → filter should be nil, got %+v", f)
+	}
+}
+
+func TestBuildFilter_RequestKindOnly_NoVariant(t *testing.T) {
+	in := unsetVariant()
+	in.kindCSV = "segment,partial"
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f == nil || f.RequestKind == nil {
+		t.Fatalf("request_kind not set: %+v", f)
+	}
+	if got := *f.RequestKind; len(got) != 2 || string(got[0]) != "segment" || string(got[1]) != "partial" {
+		t.Errorf("request_kind = %v, want [segment partial]", got)
+	}
+	// A kind-only filter must NOT synthesize an empty variant predicate —
+	// the server rejects `variant: {}`.
+	if f.Variant != nil {
+		t.Errorf("kind-only filter must leave Variant nil, got %+v", f.Variant)
+	}
+}
+
+func TestBuildFilter_InvalidKind(t *testing.T) {
+	in := unsetVariant()
+	in.kindCSV = "segment,bogus"
+	if _, err := buildFilter(in); err == nil {
+		t.Error("expected error on invalid --kind, got nil")
+	}
+}
+
+func TestBuildFilter_URLModesMutuallyExclusive(t *testing.T) {
+	in := unsetVariant()
+	in.urlSubstr = "2160p"
+	in.urlRegex = `\d+p`
+	if _, err := buildFilter(in); err == nil {
+		t.Error("--url-substr + --url-regex should be rejected")
+	}
+}
+
+func TestBuildFilter_URLSubstrMultiPattern(t *testing.T) {
+	in := unsetVariant()
+	in.urlSubstr = "2160p, 1440p ,1080p"
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.UrlMatch == nil || f.UrlMatch.Mode != proxy.Substring {
+		t.Fatalf("url_match not substring: %+v", f.UrlMatch)
+	}
+	if got := f.UrlMatch.Patterns; len(got) != 3 || got[0] != "2160p" || got[1] != "1440p" || got[2] != "1080p" {
+		t.Errorf("patterns = %v, want [2160p 1440p 1080p] (trimmed)", got)
+	}
+}
+
+func TestBuildVariant_Resolutions(t *testing.T) {
+	in := unsetVariant()
+	in.resolutions = "3840x2160,2560x1440"
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.Resolutions == nil {
+		t.Fatalf("resolutions not set: %+v", f.Variant)
+	}
+	if got := *f.Variant.Resolutions; len(got) != 2 || got[0] != "3840x2160" || got[1] != "2560x1440" {
+		t.Errorf("resolutions = %v", got)
+	}
+}
+
+func TestBuildVariant_RungIndexes(t *testing.T) {
+	in := unsetVariant()
+	in.rungIndexes = "0,4,5"
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.RungIndexes == nil {
+		t.Fatalf("rung_indexes not set: %+v", f.Variant)
+	}
+	if got := *f.Variant.RungIndexes; len(got) != 3 || got[0] != 0 || got[1] != 4 || got[2] != 5 {
+		t.Errorf("rung_indexes = %v, want [0 4 5]", got)
+	}
+}
+
+func TestBuildVariant_RungIndexNonInt(t *testing.T) {
+	in := unsetVariant()
+	in.rungIndexes = "0,top"
+	if _, err := buildFilter(in); err == nil {
+		t.Error("non-integer --rung-index should error")
+	}
+}
+
+func TestBuildVariant_RungPositions(t *testing.T) {
+	in := unsetVariant()
+	in.rungPositions = "top,bottom"
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.RungPositions == nil {
+		t.Fatalf("rung_positions not set: %+v", f.Variant)
+	}
+	got := *f.Variant.RungPositions
+	if len(got) != 2 || got[0] != proxy.Top || got[1] != proxy.Bottom {
+		t.Errorf("rung_positions = %v, want [top bottom]", got)
+	}
+}
+
+func TestBuildVariant_RungPositionInvalid(t *testing.T) {
+	in := unsetVariant()
+	in.rungPositions = "top,middle"
+	if _, err := buildFilter(in); err == nil {
+		t.Error("invalid --rung-position should error")
+	}
+}
+
+func TestBuildVariant_BandwidthBounds(t *testing.T) {
+	in := unsetVariant()
+	in.bandwidthAbove = 5_000_000
+	in.bandwidthBelow = 20_000_000
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.BandwidthAbove == nil || f.Variant.BandwidthBelow == nil {
+		t.Fatalf("bandwidth bounds not set: %+v", f.Variant)
+	}
+	if *f.Variant.BandwidthAbove != 5_000_000 || *f.Variant.BandwidthBelow != 20_000_000 {
+		t.Errorf("bandwidth = (%d,%d)", *f.Variant.BandwidthAbove, *f.Variant.BandwidthBelow)
+	}
+}
+
+func TestBuildVariant_CodecPrefix(t *testing.T) {
+	in := unsetVariant()
+	in.codecPrefix = "avc1."
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.CodecPrefix == nil || *f.Variant.CodecPrefix != "avc1." {
+		t.Fatalf("codec_prefix not set: %+v", f.Variant)
+	}
+}
+
+// A variant predicate AND-combines its sub-predicates. Multiple flags
+// populate one VariantPredicate, not several.
+func TestBuildVariant_CombinedANDs(t *testing.T) {
+	in := unsetVariant()
+	in.resolutions = "3840x2160"
+	in.bandwidthAbove = 10_000_000
+	f, err := buildFilter(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant == nil || f.Variant.Resolutions == nil || f.Variant.BandwidthAbove == nil {
+		t.Errorf("combined predicate incomplete: %+v", f.Variant)
+	}
+}
+
+// The unset sentinel (-1) must never leak into the wire as bandwidth_above:
+// with no variant flags set, Variant stays nil.
+func TestBuildVariant_UnsetSentinelStaysNil(t *testing.T) {
+	f, err := buildFilter(faultFilterInput{kindCSV: "segment", bandwidthAbove: -1, bandwidthBelow: -1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.Variant != nil {
+		t.Errorf("no variant flags → Variant must be nil, got %+v", f.Variant)
+	}
+}
+
+func TestParseCSVInts(t *testing.T) {
+	got, err := parseCSVInts(" 0, 4 ,5,")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 || got[0] != 0 || got[1] != 4 || got[2] != 5 {
+		t.Errorf("parseCSVInts = %v, want [0 4 5]", got)
+	}
+	if _, err := parseCSVInts("1,x"); err == nil {
+		t.Error("non-integer entry should error")
+	}
+}
+
+func TestVariantSummary(t *testing.T) {
+	res := []string{"3840x2160"}
+	idx := []int{0, 4}
+	pos := []proxy.VariantPredicateRungPositions{proxy.Top}
+	above := 5_000_000
+	v := &proxy.VariantPredicate{
+		Resolutions:    &res,
+		RungIndexes:    &idx,
+		RungPositions:  &pos,
+		BandwidthAbove: &above,
+	}
+	got := variantSummary(v)
+	want := "res=3840x2160,rung=0|4,pos=top,bw>5000000"
+	if got != want {
+		t.Errorf("variantSummary = %q, want %q", got, want)
+	}
+}

--- a/tools/harness-cli/cmd/harness/sweep_run.go
+++ b/tools/harness-cli/cmd/harness/sweep_run.go
@@ -708,7 +708,12 @@ func toProxyFaultRule(f *sweep.Fault) (proxy.FaultRule, error) {
 	}
 	m := proxy.FaultRuleMode(mode)
 	rule.Mode = &m
-	if filter, err := buildFilter(f.RequestKind, f.URLSubstr, ""); err != nil {
+	if filter, err := buildFilter(faultFilterInput{
+		kindCSV:        f.RequestKind,
+		urlSubstr:      f.URLSubstr,
+		bandwidthAbove: -1,
+		bandwidthBelow: -1,
+	}); err != nil {
 		return rule, err
 	} else if filter != nil {
 		rule.Filter = filter


### PR DESCRIPTION
## What

Adds the v2 fault interface's variant-scope predicate and continuous cadence to the `harness fault add` CLI. The dashboard could already do both (#929/#930); the CLI could only express `request_kind` + `url_match`, so device-free variant-scope testing from the terminal wasn't possible. The generated types and wire path already carried the full shape — only the flag surface was missing.

## Changes (`tools/harness-cli/`)

- **`fault add`** — new variant flags `--resolution`, `--rung-index`, `--rung-position`, `--bandwidth-above`, `--bandwidth-below`, `--codec-prefix` (populate `FaultFilter.Variant`), and `--continuous` (shorthand for `frequency=0 consecutive=0`; rejected if combined with an explicit `--frequency`/`--consecutive`).
- **`buildFilter`** takes a `faultFilterInput` struct (was 3 positional args); **`buildVariant`** returns nil for an all-unset predicate so the server never sees a rejected `variant: {}`. Filter is built + validated **before** the network resolve, so bad flags fail fast without a round-trip.
- **`fault list`** renders variant scope and shows `continuous` for `(0,0)`.
- **`fault_test.go`** — 16 unit cases over the flag→`FaultRule` mapping, validation errors, the unset sentinel, and `variantSummary`.

## Verification

- `go test ./...` green across harness-cli; `gofmt` / `go vet` clean.
- Fast-fail validation: `--rung-position middle` and `--continuous --frequency 5` both error before any network call.
- **End-to-end on `:21000` via the CLI** (`bucks_bunny_p200_h264`): `fault add --resolution 1920x1080 --continuous` -> every in-scope 1080p segment returned **503** (continuous fires every request), out-of-scope 720p stayed **200**.

## Follow-ups (not in this PR)

- e2e `server_behavior` coverage of continuous `(0,0)` and resolution/rung variant scoping (currently only `bandwidth_above` + url-token).
- `api/openapi/v2/proxy.yaml` is stale: doesn't document `(0,0)=continuous` or `resolutions:[]`=match-nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
