### PR TITLE
fix(fleet): crash-reap orphaned config-on-connect sessions on abnormal exit (#938)

### DIFF
--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -197,6 +198,32 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 	// a zero-value ArmConfig (empty PlayerID), so its fleet index skips — exactly
 	// like the old "no CHAR_ARM_i_PLAYER_ID emitted" behavior.
 	planArms := make([]charplan.ArmConfig, len(arms))
+
+	// Bootstrap-phase crash-reap (#938): driveFleet's handler only covers the play
+	// window. An interrupt DURING this bootstrap loop — before any device is reserved
+	// — would otherwise orphan the config-on-connect sessions already created here,
+	// exhausting the proxy pool for the next run. Track the bootstrapped player_ids
+	// and release them if we're signalled before driveFleet takes over.
+	var bootMu sync.Mutex
+	var bootstrapped []string
+	bootSig := make(chan os.Signal, 1)
+	signal.Notify(bootSig, os.Interrupt, syscall.SIGTERM)
+	bootStop := make(chan struct{})
+	go func() {
+		select {
+		case <-bootSig:
+			bootMu.Lock()
+			ids := append([]string(nil), bootstrapped...)
+			bootMu.Unlock()
+			fmt.Fprintf(os.Stderr, "\ninterrupted during bootstrap — releasing %d config-on-connect session(s)\n", len(ids))
+			for _, pid := range ids {
+				reapProxySession(client, pid)
+			}
+			os.Exit(130)
+		case <-bootStop:
+		}
+	}()
+
 	window := 0
 	for i, a := range arms {
 		res := charmatrix.ArmResult{Arm: a, IntendedOff: intendedOf(a)}
@@ -239,7 +266,14 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 		// CHAR_ARM_<i>_{SEGMENT,CODEC,MUTED,…} surface is gone.
 		armEnv = append(armEnv, fmt.Sprintf("CHAR_ARM_%d_PLATFORM=%s", i, a.Platform))
 		planArms[i] = a.ToArmConfig(playerID, clip, rl, i == patternMaster)
+		bootMu.Lock()
+		bootstrapped = append(bootstrapped, playerID)
+		bootMu.Unlock()
 	}
+	// Bootstrap done — hand signal handling to driveFleet (which forwards to the test
+	// binary and reaps post-exit). Stop our handler so the two don't both fire.
+	signal.Stop(bootSig)
+	close(bootStop)
 	if window <= 0 {
 		window = 60
 	}
@@ -370,10 +404,52 @@ func driveFleet(client *api.Client, platform string, n, windowS int, charDir str
 	// Without this, devices leak "busy" across runs until create-session hangs
 	// to its 180s timeout (#853). Scoped to THIS run's devices via the manifest.
 	reapDeviceFarm(deviceFarmBaseURL(), manifestUDIDs(manifest))
+	// Crash-reap the config-on-connect proxy sessions this run bootstrapped (#938).
+	// The graceful path frees them inside the test binary's t.Cleanup (sess.Release),
+	// but a SIGKILL'd or panicked binary never runs that — the sessions then linger
+	// and exhaust the proxy's config-on-connect pool, 503-ing the next run. Since the
+	// CLI (not the killed child) makes this call, it survives a hard kill of the test
+	// process; it's idempotent, so double-releasing a graceful run's sessions is fine.
+	reapProxySessions(client, planArms)
 	if werr != nil {
 		return fmt.Errorf("go test TestCharMatrixFleet (dir=%s): %w", charDir, werr)
 	}
 	return nil
+}
+
+// reapProxySessions best-effort DELETEs the go-proxy config-on-connect sessions a
+// fleet run bootstrapped, addressed by player_id from the plan. Empty player_ids
+// (skipped/bootstrap-failed arms) are ignored; an already-released session's delete
+// just errors and is swallowed — the whole thing is best-effort cleanup (#938).
+func reapProxySessions(client *api.Client, planArms []charplan.ArmConfig) {
+	for _, pid := range planPlayerIDs(planArms) {
+		reapProxySession(client, pid)
+	}
+}
+
+// planPlayerIDs returns the non-empty player_ids in a plan — the sessions actually
+// bootstrapped. Skipped/bootstrap-failed arms carry a zero-value ArmConfig (empty
+// PlayerID) and are dropped, so the reap only targets sessions that really exist.
+func planPlayerIDs(planArms []charplan.ArmConfig) []string {
+	var ids []string
+	for _, a := range planArms {
+		if pid := strings.TrimSpace(a.PlayerID); pid != "" {
+			ids = append(ids, pid)
+		}
+	}
+	return ids
+}
+
+// reapProxySession releases one config-on-connect session by player_id (no-op on
+// empty). Best-effort with a short timeout so a slow/dead proxy can't wedge teardown.
+func reapProxySession(client *api.Client, playerID string) {
+	pid := strings.TrimSpace(playerID)
+	if pid == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+	defer cancel()
+	_ = client.DeletePlayer(ctx, pid, "crash-reap")
 }
 
 // deviceFarmBaseURL is the appium server hosting the device-farm plugin.

--- a/tools/harness-cli/cmd/harness/char_reap_test.go
+++ b/tools/harness-cli/cmd/harness/char_reap_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jonathaneoliver/infinite-streaming/go-proxy/pkg/charplan"
+)
+
+// TestPlanPlayerIDs guards the crash-reap targeting (#938): only sessions that were
+// actually bootstrapped (non-empty player_id) get released. Skipped/bootstrap-failed
+// arms carry a zero-value ArmConfig and MUST be dropped, or a stray "" would try to
+// delete a non-existent session (and, worse, mask which arms really leaked).
+func TestPlanPlayerIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		arms []charplan.ArmConfig
+		want []string
+	}{
+		{"nil plan", nil, nil},
+		{"all bootstrapped", []charplan.ArmConfig{{PlayerID: "a"}, {PlayerID: "b"}}, []string{"a", "b"}},
+		{
+			"skipped arms (empty) dropped",
+			[]charplan.ArmConfig{{PlayerID: "a"}, {}, {PlayerID: "c"}},
+			[]string{"a", "c"},
+		},
+		{"whitespace-only is empty", []charplan.ArmConfig{{PlayerID: "  "}, {PlayerID: "d"}}, []string{"d"}},
+		{"all skipped → nothing to reap", []charplan.ArmConfig{{}, {}}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := planPlayerIDs(tt.arms)
+			if len(got) != len(tt.want) {
+				t.Fatalf("planPlayerIDs = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("planPlayerIDs[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Crash-reap the go-proxy **config-on-connect sessions** a fleet run bootstrapped, so a killed/panicked run doesn't leave them lingering and exhaust the pool → 503 the next run.

`reapDeviceFarm` already unblocks the farm **device** post-exit, but nothing released the proxy **sessions** — that release lived only inside the test binary's `t.Cleanup` (`sess.Release`), which a `SIGKILL`/panic never runs.

## Changes

- **`driveFleet`** now calls `reapProxySessions()` post-exit alongside `reapDeviceFarm` — deletes every `player_id` in the plan via the same `client.DeletePlayer` the graceful path uses. The **CLI** (not the killed child) makes this call, so it survives a hard kill of the test process; idempotent, so double-releasing a graceful run's sessions is harmless.
- **`runMatrixParallel`** gains a **bootstrap-phase signal handler**: an interrupt during the bootstrap loop — before `driveFleet` installs its own child-forwarding handler, when no device is reserved yet — now releases the sessions bootstrapped so far instead of orphaning them. Stopped before `driveFleet` so the two never both fire.
- `planPlayerIDs()` extracts the non-empty (actually-bootstrapped) player_ids — unit-tested for the skip-empty/whitespace targeting.

## Scope / limits

- **SIGKILL of the CLI itself** stays out-of-process — no in-process handler can run; `farm.sh free`/`reset` remain the recovery path, as documented in the appium-farm skill.
- Full kill-path verification (kill a live fleet run mid-play, assert a clean `farm.sh status`) needs real devices; this PR covers the reap **targeting** (unit test) and reuses the already-production `DeletePlayer` primitive. Worth one live large-fleet kill-test before relying on it.

## Context

The "one legit Device-Farm-mechanism win" from the farm-vs-Grid review (`.claude/findings/appium-farm-vs-grid-decision-2026-07-10.md`). Sibling of #853 (graceful-interrupt teardown, closed) — extends the same guarantee to hard kills. Complements #937 (config-on-connect pool exhaustion at bootstrap).

Closes #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
