### PR TITLE
feat(fleet): defer config-on-connect to the probe — avoid large-fleet bootstrap 503 (#937)

### DIFF
--- a/go-proxy/pkg/charplan/plan.go
+++ b/go-proxy/pkg/charplan/plan.go
@@ -55,9 +55,18 @@ type RunPlan struct {
 // &true/&false = force. This replaces the old ""-vs-"false" magic-string logic.
 type ArmConfig struct {
 	// binding
-	PlayerID string `json:"player_id"`          // bootstrapped config-on-connect session id ("" => probe skips this index)
+	PlayerID string `json:"player_id"`          // config-on-connect session id ("" => probe skips this index)
 	Platform string `json:"platform,omitempty"` // per-arm platform capability (mixed fleets)
 	Content  string `json:"content,omitempty"`  // resolved clip (the CLI already applied its default)
+
+	// deferred config-on-connect (#937): the CLI COMPUTES the recipe but hands the
+	// probe the ready-to-GET blob instead of GETting it up front, so the session is
+	// materialised only AFTER a farm device is reserved — bounding live proxy
+	// sessions by device count, not arm count (avoids the large-fleet 503). Empty
+	// BootstrapCfgB64 => the session was already bootstrapped up front (legacy path);
+	// the probe then skips the deferred GET.
+	BootstrapCfgB64 string `json:"bootstrap_cfg_b64,omitempty"` // base64 proxy.cfg PlayerPatch blob
+	GroupID         string `json:"group_id,omitempty"`          // born-group id for the connect param
 
 	// client launch-arg knobs (cold relaunch on change → ProbeLaunchArgs)
 	Segment            string `json:"segment,omitempty"`

--- a/go-proxy/pkg/charplan/plan_test.go
+++ b/go-proxy/pkg/charplan/plan_test.go
@@ -54,7 +54,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		FleetCount: 2,
 		DurationS:  300,
 		Arms: []ArmConfig{
-			{PlayerID: "p0", Platform: "ipad-sim", Segment: "s2", Muted: &tr, PatternMaster: true},
+			{PlayerID: "p0", Platform: "ipad-sim", Segment: "s2", Muted: &tr, PatternMaster: true, BootstrapCfgB64: "eyJ4IjoxfQ", GroupID: "grp-A"},
 			{PlayerID: "p1", Platform: "iphone", Segment: "s6", PeakBitrateMbps: 8},
 		},
 	}
@@ -74,6 +74,14 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 	if got.Arms[1].Muted != nil {
 		t.Errorf("nil *bool should round-trip as nil, got %v", *got.Arms[1].Muted)
+	}
+	// Deferred config-on-connect fields (#937) must survive the wire, or the probe
+	// silently skips its GET and the session is never configured.
+	if got.Arms[0].BootstrapCfgB64 != "eyJ4IjoxfQ" || got.Arms[0].GroupID != "grp-A" {
+		t.Errorf("bootstrap_cfg_b64/group_id lost in round-trip: %q / %q", got.Arms[0].BootstrapCfgB64, got.Arms[0].GroupID)
+	}
+	if got.Arms[1].BootstrapCfgB64 != "" {
+		t.Errorf("empty BootstrapCfgB64 should omit/round-trip empty, got %q", got.Arms[1].BootstrapCfgB64)
 	}
 }
 

--- a/tests/characterization/modes/char_matrix_fleet_test.go
+++ b/tests/characterization/modes/char_matrix_fleet_test.go
@@ -190,10 +190,27 @@ func runCharMatrixArmOnDevice(t *testing.T, p runner.Platform, dev runner.Device
 		_ = launcher.Close()
 	})
 
+	// Deferred config-on-connect (#937): the CLI built this arm's full proxy.cfg
+	// blob but did NOT GET it up front — doing so would allocate every arm's session
+	// before any device is reserved and exhaust the proxy pool (503) on a large
+	// fleet. Now that a device is reserved (LaunchToHome, above) and t.Cleanup is
+	// registered to release it on any failure, materialise the session HERE, before
+	// playback. The fleet caps concurrent devices at ≤4, so ≤4 sessions live at once.
+	// Empty BootstrapCfgB64 => the CLI already bootstrapped up front (legacy/sequential
+	// path) — skip. A GET failure after a device is reserved is fatal for this arm;
+	// t.Cleanup frees the device + session.
+	if cfg.BootstrapCfgB64 != "" {
+		if berr := runner.ConfigureOnConnectCfg(setupCtx, plan.BaseURL, cfg.Content, cfg.PlayerID, cfg.GroupID, cfg.BootstrapCfgB64); berr != nil {
+			t.Fatalf("deferred config-on-connect (arm %d, player_id=%s): %v", dev.FleetIndex, cfg.PlayerID, berr)
+		}
+		t.Logf("arm %d: config-on-connect materialised (deferred, post-reserve)", dev.FleetIndex)
+	}
+
 	// NO proxy reset here. The flow is reset → configure-on-connect → play, and
 	// config-on-connect IS the reset+configure step: each arm gets a fresh
 	// player_id whose session is created AND fully provisioned (shape+cap+faults+
-	// content) by the bootstrap GET in char.go before this test runs. A reset
+	// content) by the deferred config-on-connect GET above (or, on the legacy path,
+	// by the bootstrap GET in char.go before this test runs). A reset
 	// AFTER that bootstrap (what used to live here) reverted the session to the
 	// global INFINITE_STREAM_DEFAULT_RATE_MBPS baseline (100 Mbps) — wiping the
 	// config-on-connect rate cap — so the player streamed unthrottled for the ~2s

--- a/tests/characterization/runner/bootstrap.go
+++ b/tests/characterization/runner/bootstrap.go
@@ -125,6 +125,81 @@ func ConfigureOnConnect(ctx context.Context, playerID, groupID string, groupBroa
 	return nil
 }
 
+// ConfigureOnConnectCfg materialises a session from a full base64 proxy.cfg blob
+// (the merge-patch escape hatch) instead of flat proxy.* keys. The fleet char-matrix
+// probe uses it to DEFER its config-on-connect GET until AFTER a farm device is
+// reserved (#937): the CLI builds the blob (it needs the API client to resolve the
+// patch) and stows it in the RunPlan; the probe GETs it here, so pool slots are
+// bounded by reserved devices, not arm count. baseURL falls back to HARNESS_BASE_URL
+// when empty; clip falls back to a discovered one. The group is mirrored
+// (broadcast) — matching the up-front shaperBootstrapURL the matrix used before.
+func ConfigureOnConnectCfg(ctx context.Context, baseURL, clip, playerID, groupID, cfgB64 string) error {
+	if playerID == "" {
+		return fmt.Errorf("ConfigureOnConnectCfg: empty playerID")
+	}
+	if cfgB64 == "" {
+		return fmt.Errorf("ConfigureOnConnectCfg: empty cfgB64")
+	}
+	base := strings.TrimSpace(baseURL)
+	if base == "" {
+		base = bootstrapBaseURL()
+	}
+	client := bootstrapHTTPClient()
+	if strings.TrimSpace(clip) == "" {
+		u, perr := url.Parse(strings.TrimRight(base, "/"))
+		if perr != nil {
+			return fmt.Errorf("ConfigureOnConnectCfg: parse base URL: %w", perr)
+		}
+		var derr error
+		if clip, derr = discoverClip(ctx, client, u.Scheme, u.Host); derr != nil {
+			return fmt.Errorf("ConfigureOnConnectCfg: %w", derr)
+		}
+	}
+	bootURL, err := cfgBootstrapURL(base, clip, playerID, groupID, cfgB64)
+	if err != nil {
+		return fmt.Errorf("ConfigureOnConnectCfg: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bootURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("ConfigureOnConnectCfg GET: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("ConfigureOnConnectCfg: proxy returned %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	return nil
+}
+
+// cfgBootstrapURL builds the shaper config-on-connect GET URL for a base64 proxy.cfg
+// blob: the shaper port derived from the API port (21000 → 21081), player_id +
+// optional group_id + proxy.cfg query args, on the given clip's master playlist.
+// Mirrors the CLI's shaperBootstrapURL so the deferred (probe-side) GET is identical
+// to the up-front one (#937).
+func cfgBootstrapURL(base, clip, playerID, groupID, cfgB64 string) (string, error) {
+	u, err := url.Parse(strings.TrimRight(base, "/"))
+	if err != nil {
+		return "", fmt.Errorf("cfgBootstrapURL: parse base URL: %w", err)
+	}
+	host, apiPort := splitHostPort(u.Host)
+	shaperBase := net.JoinHostPort(host, shaperPortFromUIPort(apiPort))
+	q := url.Values{}
+	q.Set("player_id", playerID)
+	if groupID != "" {
+		q.Set("group_id", groupID) // mirrored group (broadcast) — no group_broadcast=false
+	}
+	q.Set("proxy.cfg", cfgB64)
+	return fmt.Sprintf("%s://%s/go-live/%s/master_6s.m3u8?%s",
+		u.Scheme, shaperBase, url.PathEscape(clip), q.Encode()), nil
+}
+
 func bootstrapBaseURL() string {
 	if v := strings.TrimSpace(os.Getenv("HARNESS_BASE_URL")); v != "" {
 		return v

--- a/tests/characterization/runner/bootstrap_cfg_test.go
+++ b/tests/characterization/runner/bootstrap_cfg_test.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestCfgBootstrapURL guards the deferred config-on-connect URL (#937): the probe
+// must GET the SAME shape the CLI's up-front shaperBootstrapURL produced — the
+// shaper port derived from the API port, and player_id / group_id / proxy.cfg as
+// query args on the clip's master playlist.
+func TestCfgBootstrapURL(t *testing.T) {
+	got, err := cfgBootstrapURL("https://host.example:21000", "big buck", "PID-1", "grp-9", "BLOB==")
+	if err != nil {
+		t.Fatalf("cfgBootstrapURL: %v", err)
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("result not a URL: %v", err)
+	}
+	if u.Scheme != "https" {
+		t.Errorf("scheme = %q, want https", u.Scheme)
+	}
+	if u.Host != "host.example:21081" { // 21000 API → 21081 shaper
+		t.Errorf("host = %q, want host.example:21081 (shaper port)", u.Host)
+	}
+	if !strings.HasPrefix(u.Path, "/go-live/") || !strings.HasSuffix(u.Path, "/master_6s.m3u8") {
+		t.Errorf("path = %q, want /go-live/<clip>/master_6s.m3u8", u.Path)
+	}
+	// The clip must be path-escaped in the emitted URL (space → %20).
+	if !strings.Contains(got, "/go-live/big%20buck/master_6s.m3u8") {
+		t.Errorf("clip not path-escaped in URL: %q", got)
+	}
+	q := u.Query()
+	if q.Get("player_id") != "PID-1" {
+		t.Errorf("player_id = %q, want PID-1", q.Get("player_id"))
+	}
+	if q.Get("group_id") != "grp-9" {
+		t.Errorf("group_id = %q, want grp-9", q.Get("group_id"))
+	}
+	if q.Get("proxy.cfg") != "BLOB==" {
+		t.Errorf("proxy.cfg = %q, want BLOB==", q.Get("proxy.cfg"))
+	}
+	// group_broadcast must be absent — the matrix group is mirrored (broadcast).
+	if _, ok := q["group_broadcast"]; ok {
+		t.Errorf("group_broadcast should be absent (mirrored group), got %q", q.Get("group_broadcast"))
+	}
+}
+
+// TestCfgBootstrapURLNoGroup: an ungrouped arm omits group_id entirely.
+func TestCfgBootstrapURLNoGroup(t *testing.T) {
+	got, err := cfgBootstrapURL("https://h:30000", "clip", "PID", "", "B")
+	if err != nil {
+		t.Fatalf("cfgBootstrapURL: %v", err)
+	}
+	u, _ := url.Parse(got)
+	if u.Host != "h:30081" {
+		t.Errorf("host = %q, want h:30081", u.Host)
+	}
+	if _, ok := u.Query()["group_id"]; ok {
+		t.Errorf("group_id should be absent when empty, got %q", u.Query().Get("group_id"))
+	}
+}

--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -200,10 +200,11 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 	planArms := make([]charplan.ArmConfig, len(arms))
 
 	// Bootstrap-phase crash-reap (#938): driveFleet's handler only covers the play
-	// window. An interrupt DURING this bootstrap loop — before any device is reserved
-	// — would otherwise orphan the config-on-connect sessions already created here,
-	// exhausting the proxy pool for the next run. Track the bootstrapped player_ids
-	// and release them if we're signalled before driveFleet takes over.
+	// window. Track the prepared player_ids and release their sessions if we're
+	// signalled before driveFleet takes over. With deferred config-on-connect (#937)
+	// the probe — not this loop — creates the sessions, so this is usually a no-op
+	// during build; it still guards the legacy up-front path and is harmless (a
+	// delete of a not-yet-created session just errors and is swallowed).
 	var bootMu sync.Mutex
 	var bootstrapped []string
 	bootSig := make(chan os.Signal, 1)
@@ -248,8 +249,12 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 		playerID := uuid.NewString()
 		res.PlayerID = playerID
 
+		// Fleet path: BUILD the config-on-connect blob but don't GET it — the probe
+		// GETs it after reserving a device (#937). experimentPlayerPatch still needs
+		// the API client (it resolves content-manipulation variants), so the build
+		// stays here; only the pool-slot-consuming GET moves to the probe.
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		_, berr := bootstrapMatrixSession(ctx, client, clip, playerID, group, e)
+		cfgB64, groupID, _, berr := buildMatrixBootstrapCfg(ctx, client, clip, group, e)
 		cancel()
 		if berr != nil {
 			res.Err = "bootstrap: " + berr.Error()
@@ -257,7 +262,7 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 			continue // no CHAR_ARM_i_PLAYER_ID emitted → that fleet index skips
 		}
 		results[i] = res
-		fmt.Fprintf(os.Stderr, "bootstrapped arm %d/%d: %s (player_id=%s)\n", i+1, len(arms), a.ID, playerID)
+		fmt.Fprintf(os.Stderr, "prepared arm %d/%d: %s (player_id=%s)\n", i+1, len(arms), a.ID, playerID)
 		// CHAR_ARM_<i>_PLATFORM is the ONLY per-arm env still emitted — fleet.go's
 		// generic resolver reads it to assign a device of the right platform to each
 		// fleet index (mixed-platform fleets, #860), and it's shared by every fleet
@@ -265,7 +270,10 @@ func runMatrixParallel(client *api.Client, arms []*charmatrix.Arm, charDir strin
 		// RunPlan below (the probe reads CHAR_RUN_PLAN_FILE), so the old flat
 		// CHAR_ARM_<i>_{SEGMENT,CODEC,MUTED,…} surface is gone.
 		armEnv = append(armEnv, fmt.Sprintf("CHAR_ARM_%d_PLATFORM=%s", i, a.Platform))
-		planArms[i] = a.ToArmConfig(playerID, clip, rl, i == patternMaster)
+		ac := a.ToArmConfig(playerID, clip, rl, i == patternMaster)
+		ac.BootstrapCfgB64 = cfgB64 // probe GETs this after reserving a device (#937)
+		ac.GroupID = groupID
+		planArms[i] = ac
 		bootMu.Lock()
 		bootstrapped = append(bootstrapped, playerID)
 		bootMu.Unlock()
@@ -594,27 +602,39 @@ func runArmSequential(client *api.Client, a *charmatrix.Arm, charDir string, dur
 	return res
 }
 
-// bootstrapMatrixSession materialises an in-memory experiment's recipe onto a
-// proxy session via config-on-connect (no store round-trip): build the combined
-// PlayerPatch, base64 it onto the shaper master URL, and GET it. A 3xx means the
-// session is configured (#712 applies before the redirect); 4xx/5xx is a reject.
-// Mirrors cmdSweepBootstrap's HTTP handling.
-func bootstrapMatrixSession(ctx context.Context, client *api.Client, clip, playerID, group string, e *sweep.Experiment) ([]string, error) {
+// buildMatrixBootstrapCfg builds an arm's config-on-connect payload WITHOUT GETting
+// it: the combined PlayerPatch base64'd into the proxy.cfg blob, plus the resolved
+// group_id. Needs the API client (experimentPlayerPatch resolves content-manipulation
+// allowed_variants against the catalog). The fleet path carries the returned blob in
+// the RunPlan so the probe GETs it lazily, after a device is reserved (#937).
+func buildMatrixBootstrapCfg(ctx context.Context, client *api.Client, clip, group string, e *sweep.Experiment) (cfgB64, groupID string, summary []string, err error) {
 	patch, summary, err := experimentPlayerPatch(ctx, client, clip, e)
 	if err != nil {
-		return nil, err
+		return "", "", nil, err
 	}
 	cfgJSON, err := json.Marshal(patch)
 	if err != nil {
-		return nil, err
+		return "", "", nil, err
 	}
-	cfgB64 := base64.RawURLEncoding.EncodeToString(cfgJSON)
+	cfgB64 = base64.RawURLEncoding.EncodeToString(cfgJSON)
 	// The arm's own group (stamped by compare:/groups: in Expand) wins so paired
 	// arms arrive born-grouped on the dashboard; the --group CLI flag is the
 	// fallback for an ungrouped matrix the operator wants to tag by hand.
-	groupID := e.Group
+	groupID = e.Group
 	if groupID == "" {
 		groupID = group
+	}
+	return cfgB64, groupID, summary, nil
+}
+
+// bootstrapMatrixSession builds AND GETs the config-on-connect URL up front (the
+// single-device sequential path). A 3xx means the session is configured (#712
+// applies before the redirect); 4xx/5xx is a reject. Fleet runs instead defer the
+// GET to the probe via buildMatrixBootstrapCfg + the RunPlan (#937).
+func bootstrapMatrixSession(ctx context.Context, client *api.Client, clip, playerID, group string, e *sweep.Experiment) ([]string, error) {
+	cfgB64, groupID, summary, err := buildMatrixBootstrapCfg(ctx, client, clip, group, e)
+	if err != nil {
+		return nil, err
 	}
 	bootURL, err := shaperBootstrapURL(client.BaseURL, clip, playerID, groupID, cfgB64)
 	if err != nil {


### PR DESCRIPTION
> **Stacked on #940 (#938).** Base is the `feat/938-crash-reap` branch so this diff shows only #937's changes. Retarget to `dev` after #940 merges.

## Problem

The CLI GETs every arm's config-on-connect session **up front** — all before any device is touched — so live proxy sessions are bounded by **arm count**, not reserved-device count. A large char-matrix opens more sessions than the config-on-connect pool holds and **503s at bootstrap** (the `appium-farm` skill's documented failure mode).

## Fix — allocate the device, then configure the session

The CLI still **computes** each arm's recipe (it needs the API client to resolve content-manipulation variants), but the **probe GETs it lazily**, right after it reserves a farm device. The fleet caps concurrent devices at ≤4, so ≤4 concurrent sessions ⇒ the pool never exhausts.

- **`charplan.ArmConfig`** gains `BootstrapCfgB64` (base64 `proxy.cfg` blob) + `GroupID`; the CLI stashes them in the `RunPlan` instead of GETting. (`GroupBroadcast` was **not** added — the matrix group is mirrored, exactly as the old `shaperBootstrapURL`; verified against the reverted stub's over-scoping.)
- **`char.go`**: `buildMatrixBootstrapCfg` builds the patch+blob without GETting; `runMatrixParallel` carries the blob in the plan. The single-device **sequential** and **sweep-fan** paths keep the up-front GET (`bootstrapMatrixSession`) — they're ≤4 arms, no pool pressure.
- **`runner.ConfigureOnConnectCfg`** GETs the deferred blob. The probe calls it after `LaunchToHome` reserves a device **and** `t.Cleanup` is registered (so a failed GET frees the device + session), **before** the HOME barrier / playback. Empty `BootstrapCfgB64` ⇒ legacy up-front path, probe skips.

## Tests

- `charplan` round-trip of the new wire fields (guards the "plumb everywhere" trap).
- `cfgBootstrapURL` shaper-port derivation (21000→21081) + `player_id`/`group_id`/`proxy.cfg` query construction + clip path-escaping + the no-group case.
- build / vet / test green across all three modules. (The pre-existing env-dependent `TestProbeLaunchArgsGolden` failure is unrelated — it fails identically on the base branch.)

## ⚠️ Verification needed before merge

The correctness of the deferral rests on one ordering assumption: **the app hits the per-session proxy only at `ResumePlayback`, not at the home screen** — so the deferred GET (placed before the HOME barrier) still lands before the player's first stream byte. This holds by design (catalog fetches go to the API origin, not the shaper port) but **can only be confirmed on a live fleet**. A large char-matrix fleet run must pass before this merges.

## Context

Implements the deferred-config design in `.claude/findings/deferred-config-on-connect-fleet-503-2026-07-10.md`; the "allocate before configure" fix from the farm-vs-Grid review. Complements #938 (crash-reap of the same sessions).

Closes #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
