### PR TITLE
fix(dashboard+proxy): testing.html session list — server broadcast on delete + client resync (#944)

### DIFF
--- a/content/dashboard-v3/src/composables/usePlayers.ts
+++ b/content/dashboard-v3/src/composables/usePlayers.ts
@@ -109,6 +109,12 @@ export function usePlayers() {
   // open. The picker page mounts usePlayers() exactly once today, but
   // making it pool-safe means future callers can't accidentally
   // multiply sockets.
+  // Resync on reconnect: SSE carries created/updated/deleted deltas, but any
+  // event that fires while the stream is down — especially `deleted` — is lost,
+  // so the list would stay stale after an outage (#944). On every return to
+  // 'open' AFTER the first connect, re-pull the authoritative list. The first
+  // 'open' is skipped because the query already fetches on mount.
+  let hasConnected = false;
   const sub = subscribeAllPlayers({
     onCreated: (d) => ingest('created', d),
     onUpdated: (d) => ingest('updated', d),
@@ -117,7 +123,13 @@ export function usePlayers() {
       const id = d?.player_id || d?.id;
       if (id) removeFromList(id);
     },
-    onStateChange: (s) => { sseState.value = s; },
+    onStateChange: (s) => {
+      sseState.value = s;
+      if (s === 'open') {
+        if (hasConnected) query.refetch();
+        hasConnected = true;
+      }
+    },
   });
 
   onScopeDispose(() => sub.release());

--- a/content/dashboard-v3/src/pages/Testing.vue
+++ b/content/dashboard-v3/src/pages/Testing.vue
@@ -165,6 +165,11 @@ async function releaseAll() {
   for (const p of players.value) {
     try { await deletePlayer(p.id); } catch (e) { console.error(e); }
   }
+  // deletePlayer only issues the DELETE — the list's sole removal path is the
+  // SSE `deleted` event (usePlayers.removeFromList). If the stream isn't
+  // delivering, the cards would linger, so re-pull the authoritative list
+  // ourselves rather than relying on SSE to clear the display (#944).
+  await refetch();
 }
 
 function portOf(p: PlayerRecord): string {

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -3874,6 +3874,16 @@ func (a *App) handleSession(w http.ResponseWriter, r *http.Request) {
 				a.clearShapeApplyState(port)
 			}
 		}
+		// #944: a DELETE doesn't itself broadcast, so the v2 `player.deleted`
+		// event (a snapshot diff) only fires when a SURVIVING session next
+		// POSTs metrics. When this delete empties the list there's no survivor
+		// to trigger it, so poke the hub with an empty frame — otherwise the
+		// dashboard's session list stays stale after "release all" / deleting
+		// the last session. Deletes that leave survivors self-heal on the next
+		// metrics tick, so only the empties-the-list case needs the poke.
+		if len(removed) > 0 && len(a.getSessionList()) == 0 {
+			a.broadcastEmptySessions()
+		}
 		writeJSON(w, map[string]string{"message": "Session deleted successfully"})
 		return
 	}
@@ -10017,6 +10027,24 @@ func (a *App) emitSessionEvent(session SessionData) {
 	rev := atomic.AddUint64(&a.sessionsBroadcastSeq, 1)
 	preMarshaled := a.buildSessionsEvent(normalized, rev, 0, nil)
 	a.sessionsHub.Broadcast(normalized, rev, preMarshaled)
+}
+
+// broadcastEmptySessions pokes the session hub with a zero-length frame so the
+// v2 SSE `player.deleted` diff advances when NO live session remains to trigger
+// it (#944). The v2 adapter (SubscribeSessions) re-reads the live session list
+// on any hub broadcast and diffs it — but the hub only broadcasts on a live
+// session's metrics POST (emitSessionEvent), never on a DELETE. So deleting the
+// LAST session leaves nothing to POST, the diff never runs, and the dashboard
+// keeps showing the gone session. An EMPTY payload drives that diff while
+// keeping /api/sessions/stream consumers (the forwarder) from writing rows —
+// see the #470 note above on why a full-list re-broadcast is off the table.
+func (a *App) broadcastEmptySessions() {
+	if a.sessionsHub == nil {
+		return
+	}
+	rev := atomic.AddUint64(&a.sessionsBroadcastSeq, 1)
+	preMarshaled := a.buildSessionsEvent(nil, rev, 0, nil)
+	a.sessionsHub.Broadcast(nil, rev, preMarshaled)
 }
 
 func (a *App) removeInactiveSessions() {

--- a/go-proxy/cmd/server/v2_adapter.go
+++ b/go-proxy/cmd/server/v2_adapter.go
@@ -349,6 +349,15 @@ func (a *v2Adapter) DeletePlayer(playerID string) bool {
 			a.app.armTransportFaultLoop(port, "none", 1, transportUnitsSeconds, 0)
 		}
 	}
+	// #944: v2 `player.deleted` is a snapshot-diff artifact that only advances
+	// when the session hub broadcasts — which happens on a live session's
+	// metrics POST, never on a DELETE. If this delete empties the list there's
+	// no survivor to trigger it, so poke the hub with an empty frame; the v2
+	// adapter re-reads the (now empty) live list and fires player.deleted.
+	// Deletes that leave survivors self-heal on the next metrics tick.
+	if len(a.app.getSessionList()) == 0 {
+		a.app.broadcastEmptySessions()
+	}
 	return true
 }
 


### PR DESCRIPTION
Fixes #944.

Two-layer fix for the stale session list on `testing.html`.

## Root cause (server)

The v2 `player.deleted` SSE event is a **snapshot-diff artifact** (`events.go` `handleSessionSnapshot`), and the diff only advances when the session hub **broadcasts** — which happens on a **live session's metrics POST**, never on a DELETE. So deleting the **last** session / "release all" leaves no survivor to POST → the diff never runs → `player.deleted` never fires. (Inactive-timeout ends already clear, because that path broadcasts via `synthesizeTerminalSessionEvent`. Only the two explicit delete APIs — v1 `/api/session/{id}` and v2 `/api/v2/players/{id}`, both separate code — were broken.)

## Fixes

**Server (`go-proxy`)** — new `App.broadcastEmptySessions()` pokes the hub with a zero-length frame when a delete empties the list, in **both** `handleSession` (v1) and `v2Adapter.DeletePlayer` (v2, the dashboard's path). The v2 adapter re-reads the empty live list and fires `player.deleted`; the empty payload keeps `/api/sessions/stream` consumers from writing rows (avoids the #470 duplicate-event regression). Deletes leaving survivors self-heal on the next metrics tick.

**Client (`dashboard-v3`)** — belt-and-suspenders:
- `Testing.vue` — `await refetch()` after the `releaseAll` DELETE loop.
- `usePlayers.ts` — `refetch()` on every SSE return-to-`open` after the first connect (resync after any outage).

## Verification

- Server: registered a session, POSTed metrics, deleted the last one via `/api/v2/players/{id}` on :21000 → `player.deleted` now appears on `/api/v2/events` (was silent before). `go build`/`go vet` clean.
- Client: `vue-tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
