### PR TITLE
feat(harness): availableDevices() farm roster + `harness devices` (#948)

### DIFF
--- a/tools/harness-cli/cmd/harness/char.go
+++ b/tools/harness-cli/cmd/harness/char.go
@@ -501,6 +501,16 @@ type farmDevice struct {
 	UDID string `json:"udid"`
 	Host string `json:"host"`
 	Busy bool   `json:"busy"`
+	// Capability + availability fields (issue #948). The farm's /device
+	// response carries these alongside udid/host/busy; the reap path ignores
+	// them, but availableDevices() reads them to build the serviceable roster.
+	Offline     bool   `json:"offline"`
+	UserBlocked bool   `json:"userBlocked"`
+	RealDevice  bool   `json:"realDevice"`
+	Platform    string `json:"platform"` // "ios" | "tvos" | "android"
+	SDK         string `json:"sdk"`      // OS/SDK version, e.g. "26.5"
+	Name        string `json:"name"`
+	State       string `json:"state"` // sims: "Booted"/"Shutdown"; real devices: absent
 }
 
 // reapDeviceFarm poll-unblocks the device-farm devices THIS run acquired (udids,

--- a/tools/harness-cli/cmd/harness/devicefarm_roster.go
+++ b/tools/harness-cli/cmd/harness/devicefarm_roster.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// DeviceCapability is one device-farm device's matchable attributes + live
+// availability, distilled from the farm's /device-farm/api/device response
+// (issue #948). It is what the scheduler (the sweep dispatcher) reads to decide
+// (a) which work is serviceable right now — scenario 3's availability gate — and
+// (b) how many free devices of a capability it can pack work across — scenario 2.
+type DeviceCapability struct {
+	UDID     string `json:"udid"`
+	Name     string `json:"name"`
+	Platform string `json:"platform"` // "ios" | "tvos" | "android"
+	Real     bool   `json:"real"`     // hardware vs simulator
+	Version  string `json:"version"`  // OS/SDK version, e.g. "26.5"
+	Host     string `json:"host"`
+
+	Busy    bool `json:"busy"`    // in an active session
+	Offline bool `json:"offline"` // farm can't reach the node
+	Blocked bool `json:"blocked"` // userBlocked — reserved by another consumer
+	Booted  bool `json:"booted"`  // sim is running; real devices are always true
+
+	// Free is the single availability verdict: allocatable to a new session
+	// right now. A shutdown sim is still Free — the farm boots it on session
+	// create — so bootability is captured by Booted, not folded into Free.
+	Free bool `json:"free"`
+}
+
+// availableDevices fetches the live device-farm roster and returns every device
+// as a typed DeviceCapability (issue #948). It does NOT filter — the caller
+// picks what it needs (FreeDevices for allocation, the full list to answer "does
+// this capability exist at all" for the gate). Returns nil on any transport or
+// decode error, so an unreachable farm reads as "no devices" rather than a hard
+// failure — the sweep's existing no-device Skip path then applies.
+func availableDevices(base string) []DeviceCapability {
+	client := &http.Client{Timeout: 6 * time.Second}
+	resp, err := client.Get(base + "/device-farm/api/device")
+	if err != nil {
+		return nil
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return parseFarmRoster(raw)
+}
+
+// parseFarmRoster decodes the farm's /device response into DeviceCapability. Pure
+// (no I/O) so the mapping — the availability verdict especially — is unit-testable
+// against captured farm JSON. A body that isn't the expected array yields nil.
+func parseFarmRoster(raw []byte) []DeviceCapability {
+	var all []farmDevice
+	if json.Unmarshal(raw, &all) != nil {
+		return nil
+	}
+	out := make([]DeviceCapability, 0, len(all))
+	for _, d := range all {
+		// Real devices report no simulator state; treat them as always booted.
+		// Sims are booted only when the farm reports state=="Booted".
+		booted := d.RealDevice || strings.EqualFold(strings.TrimSpace(d.State), "Booted")
+		dc := DeviceCapability{
+			UDID:     d.UDID,
+			Name:     d.Name,
+			Platform: strings.ToLower(strings.TrimSpace(d.Platform)),
+			Real:     d.RealDevice,
+			Version:  strings.TrimSpace(d.SDK),
+			Host:     d.Host,
+			Busy:     d.Busy,
+			Offline:  d.Offline,
+			Blocked:  d.UserBlocked,
+			Booted:   booted,
+		}
+		// Free ⇔ not in a session, reachable, and not reserved by another
+		// consumer. Boot state is deliberately NOT a factor — the farm boots a
+		// shutdown sim on POST /session.
+		dc.Free = !d.Busy && !d.Offline && !d.UserBlocked
+		out = append(out, dc)
+	}
+	return out
+}
+
+// cmdDevices prints the live device-farm roster (issue #948): the observable
+// face of availableDevices(). Human table by default, `--json` for scripting,
+// `--free` to list only the allocatable set. Read-only; no session touched.
+func cmdDevices(args []string, asJSON bool) error {
+	fs := flag.NewFlagSet("devices", flag.ContinueOnError)
+	freeOnly := fs.Bool("free", false, "list only devices allocatable right now")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	devs := availableDevices(deviceFarmBaseURL())
+	if *freeOnly {
+		devs = FreeDevices(devs)
+	}
+	if asJSON {
+		return json.NewEncoder(os.Stdout).Encode(devs)
+	}
+	if len(devs) == 0 {
+		fmt.Printf("no devices (farm %s unreachable or empty)\n", deviceFarmBaseURL())
+		return nil
+	}
+	fmt.Printf("%-38s  %-8s  %-4s  %-7s  %-6s  %s\n", "UDID", "PLATFORM", "KIND", "VERSION", "STATE", "NAME")
+	for _, d := range devs {
+		kind := "sim"
+		if d.Real {
+			kind = "real"
+		}
+		state := "free"
+		switch {
+		case d.Busy:
+			state = "busy"
+		case d.Offline:
+			state = "offline"
+		case d.Blocked:
+			state = "blocked"
+		case !d.Booted:
+			state = "free*" // free but not yet booted (farm boots on demand)
+		}
+		fmt.Printf("%-38s  %-8s  %-4s  %-7s  %-6s  %s\n", d.UDID, d.Platform, kind, d.Version, state, d.Name)
+	}
+	return nil
+}
+
+// FreeDevices returns only the devices allocatable to a new session right now.
+// This is the roster the concurrent dispatcher (issue #950) sizes its worker
+// pool against.
+func FreeDevices(devs []DeviceCapability) []DeviceCapability {
+	var out []DeviceCapability
+	for _, d := range devs {
+		if d.Free {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/tools/harness-cli/cmd/harness/devicefarm_roster_test.go
+++ b/tools/harness-cli/cmd/harness/devicefarm_roster_test.go
@@ -1,0 +1,82 @@
+package main
+
+import "testing"
+
+// A trimmed capture of the live /device-farm/api/device response (issue #948):
+// one busy real iPhone, one free booted iPad sim, one shutdown tvOS sim, one
+// offline sim, and one userBlocked sim — covering every availability branch.
+const farmRosterJSON = `[
+  {"udid":"00008120-REAL","name":"Jonathans iPhone","platform":"ios","realDevice":true,"deviceType":"real","sdk":"26.5","host":"http://h:4723","busy":true,"offline":false,"userBlocked":false},
+  {"udid":"IPAD-SIM-1","name":"iPad Pro","platform":"ios","realDevice":false,"deviceType":"simulator","sdk":"26.4","state":"Booted","host":"http://h:4723","busy":false,"offline":false,"userBlocked":false},
+  {"udid":"TV-SIM-1","name":"Apple TV","platform":"tvos","realDevice":false,"deviceType":"simulator","sdk":"26.4","state":"Shutdown","host":"http://h:4723","busy":false,"offline":false,"userBlocked":false},
+  {"udid":"OFFLINE-SIM","name":"Dead sim","platform":"ios","realDevice":false,"deviceType":"simulator","sdk":"26.4","state":"Booted","host":"http://h:4723","busy":false,"offline":true,"userBlocked":false},
+  {"udid":"BLOCKED-SIM","name":"Reserved sim","platform":"ios","realDevice":false,"deviceType":"simulator","sdk":"26.4","state":"Booted","host":"http://h:4723","busy":false,"offline":false,"userBlocked":true}
+]`
+
+func TestParseFarmRoster(t *testing.T) {
+	devs := parseFarmRoster([]byte(farmRosterJSON))
+	if len(devs) != 5 {
+		t.Fatalf("got %d devices, want 5", len(devs))
+	}
+	byUDID := map[string]DeviceCapability{}
+	for _, d := range devs {
+		byUDID[d.UDID] = d
+	}
+
+	// Real device: always booted, platform lower-cased, version from sdk, busy ⇒ not free.
+	real := byUDID["00008120-REAL"]
+	if !real.Real || real.Platform != "ios" || real.Version != "26.5" || !real.Booted {
+		t.Errorf("real iPhone mapped wrong: %+v", real)
+	}
+	if real.Free {
+		t.Errorf("busy real iPhone should not be Free: %+v", real)
+	}
+
+	// Booted free sim ⇒ Free.
+	sim := byUDID["IPAD-SIM-1"]
+	if sim.Real || !sim.Booted || !sim.Free {
+		t.Errorf("free booted iPad sim should be Free & booted: %+v", sim)
+	}
+
+	// Shutdown sim ⇒ NOT booted but STILL Free (farm boots on session create).
+	tv := byUDID["TV-SIM-1"]
+	if tv.Booted {
+		t.Errorf("shutdown sim should report Booted=false: %+v", tv)
+	}
+	if !tv.Free {
+		t.Errorf("shutdown sim should still be Free (bootable on demand): %+v", tv)
+	}
+	if tv.Platform != "tvos" {
+		t.Errorf("tv platform = %q, want tvos", tv.Platform)
+	}
+
+	// Offline and blocked ⇒ not Free.
+	if byUDID["OFFLINE-SIM"].Free {
+		t.Errorf("offline sim should not be Free")
+	}
+	if byUDID["BLOCKED-SIM"].Free {
+		t.Errorf("userBlocked sim should not be Free")
+	}
+
+	// FreeDevices returns exactly the two allocatable ones (booted sim + shutdown sim).
+	free := FreeDevices(devs)
+	if len(free) != 2 {
+		t.Fatalf("FreeDevices = %d, want 2 (IPAD-SIM-1, TV-SIM-1)", len(free))
+	}
+	freeSet := map[string]bool{}
+	for _, d := range free {
+		freeSet[d.UDID] = true
+	}
+	if !freeSet["IPAD-SIM-1"] || !freeSet["TV-SIM-1"] {
+		t.Errorf("FreeDevices missing expected UDIDs: %+v", freeSet)
+	}
+}
+
+func TestParseFarmRosterBadJSON(t *testing.T) {
+	if got := parseFarmRoster([]byte(`{"not":"an array"}`)); got != nil {
+		t.Errorf("non-array body should parse to nil, got %+v", got)
+	}
+	if got := parseFarmRoster(nil); got != nil {
+		t.Errorf("nil body should parse to nil, got %+v", got)
+	}
+}

--- a/tools/harness-cli/cmd/harness/main.go
+++ b/tools/harness-cli/cmd/harness/main.go
@@ -68,6 +68,9 @@ Operator/CLI:
   procedure soak|abr-sweep|fault-soak <target>
                                multi-step composed test procedures
   sweep seed|status|ls|next    automated fault-sweep queue (#772)
+  devices [--free]             list the live Appium device-farm roster —
+                               capability + availability (--free = only
+                               allocatable right now; #948)
   char matrix <spec.yaml>      run a declarative YAML characterization
                                matrix: axes → cartesian arms, per-arm
                                config-on-connect + probe + offset table
@@ -174,6 +177,8 @@ func main() {
 		exit(cmdSweep(client, args[1:], g.asJSON))
 	case "char":
 		exit(cmdChar(client, args[1:], g.asJSON))
+	case "devices":
+		exit(cmdDevices(args[1:], g.asJSON))
 	case "post":
 		exit(cmdPost(client, args[1:], g.asJSON))
 	case "help", "--help", "-h":


### PR DESCRIPTION
Sub-task **A** of epic #946. Closes #948.

## What
Expose the live Appium device-farm roster as typed `DeviceCapability` (platform, real|sim, version, udid, busy/offline/blocked/booted → `Free`).

- Extend `farmDevice` with the fields the farm already returns (`platform`, `sdk`, `realDevice`, `offline`, `userBlocked`, `state`).
- `parseFarmRoster`: pure body→`[]DeviceCapability` mapping, unit-tested against a captured farm response. `Free ⇔ !busy && !offline && !blocked`; a shutdown sim stays `Free` (farm boots on `POST /session`) with `Booted=false`.
- `availableDevices(base)` fetches + parses; nil on unreachable farm.
- `harness devices [--free]` prints the roster (table + `--json`).

## Why
Foundational for the scheduler: what's serviceable now (scenario 3's gate) and how many free devices to pack work across (scenario 2). Blocks #949, #950, #952.

## Verification
Unit tests (`parseFarmRoster` incl. shutdown/offline/blocked/real branches + `FreeDevices`) pass. Live-verified against the running farm — enumerated the real iPhone, 4 Fleet iPhone 15 sims, and the tvOS sims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
