### PR TITLE
docs(sweep): live-offset findings + coverage ledger + QE Lab board delete/clear

### DIFF
--- a/.claude/findings/live-offset-androidtv-untestable-2026-06-15.md
+++ b/.claude/findings/live-offset-androidtv-untestable-2026-06-15.md
@@ -1,5 +1,12 @@
 # Live-offset is currently untestable on Android TV — 2026-06-15
 
+> **⚠️ SUPERSEDED 2026-07-07.** The Android client lever (action item below / #793 step 4) is now
+> plumbed — `MainActivity.kt` parses `is.flag.live_offset_s` → `LiveConfiguration.setTargetOffsetMs`.
+> A 14-arm Android TV sweep confirms the app lever **works and overrides the manifest holdback**
+> (`recommended_offset_s = N`, `true_offset_s ≈ N` on s6). Android TV is **no longer untestable**.
+> See `.claude/findings/user-live-offset-crossplatform-2026-07-07.md` for the three-platform data.
+> The rest of this doc is retained for the 2026-06-15 state (no client lever, manifest-only).
+
 ## Summary
 A config-class sweep that sets `content_manipulation.live_offset` does **not** move the achieved
 offset on Android TV (ExoPlayer): the recipe asked for 6 s, the player ran at ~21.5 s the whole play.

--- a/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
+++ b/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
@@ -5,12 +5,14 @@
 
 ## TL;DR
 
-Driving one full sweep iteration end-to-end (`config` class, `import-F-s1-00`,
-s1/live_offset=0) surfaced **two structural gaps** between the single-device sweep
-state machine and the multi-device char-matrix fleet runner. The n=1 confirmation
-guard still reached the *correct* answer (the hit was a startup transient, **refuted**),
-but only because the verdict was recovered by querying play labels directly — the
-tooling could not carry the reps through the queue.
+Driving two full sweep iterations end-to-end (`config` class, `import-F-s1-00` and
+`-s1-02`, s1/live_offset 0 and 2) surfaced **three gaps**: two structural, between the
+single-device sweep state machine and the multi-device char-matrix fleet runner (A, B),
+and one oracle calibration bug — the cold first-of-batch play systematically false-flags
+`severe_startup` (C). The n=1 confirmation guard still reached the *correct* answer both
+times (the hits were startup transients, **refuted**), but only because the verdict was
+recovered by querying play labels directly — the tooling could not carry the reps through
+the queue.
 
 ## What happened (timeline)
 
@@ -32,7 +34,7 @@ tooling could not carry the reps through the queue.
      not found`**. `analyze` only reads `running/`; the char-matrix path never claimed
      the reps into it.
 
-## The two gaps
+## The three gaps
 
 ### Gap A — the fleet runner bypasses the sweep queue state machine
 `harness char matrix` drives the probe via config-on-connect but does **not** transition
@@ -48,6 +50,22 @@ The n=1 guard's reps get **`score = 0`** and there is **no claim-by-id**. `sweep
 is strictly score-ordered, so reps sit behind every score>0 seed indefinitely (the
 skill doc's "reps outrank seeds" does not hold in the CH scheduler). The only way to run
 them today is the fleet path (Gap A), which then can't record their verdict.
+
+### Gap C — the oracle false-positives on the cold first-of-batch play
+The `*qoe_buffering_severe_startup` → `qoe_tier_unacceptable` threshold trips on the sim's
+**first play after idle** (cold app launch), independent of the arm under test.
+**2 of 2** first-of-batch plays hit it with a near-identical signature:
+
+| exp | play | ffs_s | startup buf ms | verdict |
+|---|---|---|---|---|
+| import-F-s1-00 (N=0) | `176f259f` | 2.88 | 4588 | severe_startup → unacceptable |
+| import-F-s1-02 (N=2) | `b6e81396` | 2.70 | 4800 | severe_startup → unacceptable |
+
+Every follow-on play in the same batch ran ~1.0s ffs / ~1.5s buf (`tier_acceptable`).
+So every fresh sweep batch manufactures one false `aberration` on its first arm, which
+then costs a 3-rep confirmation cycle to refute. **Fix:** the probe should run a discarded
+**warmup play** (or the oracle should suppress `severe_startup` on the first cold launch
+of a session/device) so the first *scored* arm isn't paying the cold-start penalty.
 
 ## Evidence — the guard was right anyway (aberration refuted)
 

--- a/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
+++ b/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
@@ -1,0 +1,87 @@
+# Sweep queue ↔ char-matrix fleet path aren't integrated; confirm-reps are undrivable
+
+**Date:** 2026-07-10 · **Where:** `harness sweep` (issue #772) driven against test-dev (`:21000`), ipad-sim fleet
+**Tag:** **confirmed** (both gaps reproduced live in one loop iteration)
+
+## TL;DR
+
+Driving one full sweep iteration end-to-end (`config` class, `import-F-s1-00`,
+s1/live_offset=0) surfaced **two structural gaps** between the single-device sweep
+state machine and the multi-device char-matrix fleet runner. The n=1 confirmation
+guard still reached the *correct* answer (the hit was a startup transient, **refuted**),
+but only because the verdict was recovered by querying play labels directly — the
+tooling could not carry the reps through the queue.
+
+## What happened (timeline)
+
+1. `sweep next --claim` → `sweep bootstrap` → `TestSweepProbe` on Fleet iPhone 15 #1 →
+   `sweep analyze --confirm-reps 3`. Verdict **`aberration` → `found/`**, primary
+   `critical=*qoe_tier_unacceptable`. The n=1 guard enqueued 3 reps
+   (`rep-5314f5-1/2/3`, shared `rep_group`). **This half worked perfectly** — the
+   experiment moved backlog→running→found, and the board showed it in `running`.
+2. The reps landed in `backlog/` with **score 0**. `sweep next --claim` kept claiming
+   the score-197 seeds instead — the reps never got picked. There is **no claim-by-id**,
+   so the single-device path (`bootstrap`/`analyze`, which only load from `running/`)
+   can't drive them at all.
+3. Fell back to the documented rep-batch path: `sweep export --rep-group` →
+   `harness char matrix reps-5314f5.yaml`. All 3 reps **played fine** (79–80s each,
+   back-to-back on one sim — the appium-leak fix `dac1941c` holding). But:
+   - The QE Lab **`running` column stayed empty** the whole time (operator-visible
+     symptom: "I see a test on testing.html but nothing in QE Labs/running").
+   - `sweep analyze rep-5314f5-1 --play <id>` → **`load running/rep-5314f5-1: experiment
+     not found`**. `analyze` only reads `running/`; the char-matrix path never claimed
+     the reps into it.
+
+## The two gaps
+
+### Gap A — the fleet runner bypasses the sweep queue state machine
+`harness char matrix` drives the probe via config-on-connect but does **not** transition
+its experiments through the queue buckets (`backlog → running → done/found`). Consequences:
+- The QE Lab board (reads the `running/` bucket, i.e. `sweep_claims`) shows nothing
+  while a fleet batch runs — the operator has no board-level visibility.
+- `sweep analyze <id>` can't resolve a play produced by the fleet path (it loads from
+  `running/` only), so fleet-produced verdicts can't be recorded back to CH via the
+  normal command. The play *rows* exist and are queryable; the *experiment verdict* is orphaned.
+
+### Gap B — confirm-reps are unschedulable via the single-device path
+The n=1 guard's reps get **`score = 0`** and there is **no claim-by-id**. `sweep next`
+is strictly score-ordered, so reps sit behind every score>0 seed indefinitely (the
+skill doc's "reps outrank seeds" does not hold in the CH scheduler). The only way to run
+them today is the fleet path (Gap A), which then can't record their verdict.
+
+## Evidence — the guard was right anyway (aberration refuted)
+
+Recovered by `harness query play <id>` (label histogram), since `analyze` couldn't:
+
+| play | role | first_frame_s | startup buf ms | tier | driver label |
+|---|---|---|---|---|---|
+| `176f259f` | hit | 2.88 | 4588 | `critical=*qoe_tier_unacceptable` | `*qoe_buffering_severe_startup` + `*qoe_live_offset_concerning` |
+| `5f593c03` | rep 1 | 1.05 | 1593 | `warning=*qoe_tier_acceptable` | `*qoe_buffering_long_startup` |
+| `a689db98` | rep 2 | 1.22 | 1763 | `warning=*qoe_tier_acceptable` | `*qoe_buffering_long_startup` |
+| `51263097` | rep 3 | 0.97 | 1522 | `warning=*qoe_tier_acceptable` | `*qoe_buffering_long_startup` |
+
+The hit was a one-off **severe startup-buffering transient** (~3× the reps' first-frame +
+startup buffer) — the sim cold-launch/startup-join artifact already documented for N=0
+arms in `user-live-offset-crossplatform-2026-07-07.md`. `*qoe_live_offset_concerning`
+did not recur. Correct disposition: **not a real finding**; `import-F-s1-00` is a false
+positive in `found/`.
+
+## Fix directions (not yet implemented)
+
+- **Gap A:** have `char matrix` (when arms carry `exp_id`, i.e. sweep-sourced) claim each
+  arm into `running/` on launch and call the analyze/verdict path on completion — so the
+  fleet path *is* a valid sweep runner and the board reflects it. Alternatively teach
+  `sweep analyze` to accept an experiment from `backlog/` when a matching play exists.
+- **Gap B:** give confirm-reps a score that actually outranks seeds (or a dedicated
+  rep-claim path / `next --rep-group`), and/or add `sweep claim <id>` for by-id claiming.
+
+## Caveats
+
+- One iteration; both gaps are structural (not jitter), so n=1 is sufficient to confirm
+  *the gaps*. The refuted-transient disposition is n=3 (all reps agreed).
+- Observed on the `feat/sweep-lab` branch's harness build; verify against `dev` after merge.
+
+## Related
+- `.claude/findings/user-live-offset-crossplatform-2026-07-07.md` — the N=0 sim startup-join artifact this hit matched.
+- `docs/sweep-design.md` §5 (scheduler) / §7 (the loop); `tests/characterization/COVERAGE-LEDGER.md`.
+- Loop-engine epic **#772**.

--- a/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
+++ b/.claude/findings/sweep-queue-fleet-integration-gaps-2026-07-10.md
@@ -61,11 +61,20 @@ The `*qoe_buffering_severe_startup` → `qoe_tier_unacceptable` threshold trips 
 | import-F-s1-00 (N=0) | `176f259f` | 2.88 | 4588 | severe_startup → unacceptable |
 | import-F-s1-02 (N=2) | `b6e81396` | 2.70 | 4800 | severe_startup → unacceptable |
 
-Every follow-on play in the same batch ran ~1.0s ffs / ~1.5s buf (`tier_acceptable`).
-So every fresh sweep batch manufactures one false `aberration` on its first arm, which
-then costs a 3-rep confirmation cycle to refute. **Fix:** the probe should run a discarded
-**warmup play** (or the oracle should suppress `severe_startup` on the first cold launch
-of a session/device) so the first *scored* arm isn't paying the cold-start penalty.
+**Revised attribution (after 4 slow + 4 fast plays across 3 sims):** the penalty is
+**not** sim/client warmth — `severe_startup` recurred on a "warm" sim (#2, ffs 2.56s)
+while three *rapid back-to-back* plays on a colder sim (#3) ran fast (ffs 0.35–0.96s).
+The clean split is **time-since-last-play**: all 4 `severe_startup` plays followed an
+idle gap (session start, or a pause while writing up results); all 4 fast plays were
+rapid back-to-back. That points to a **server-side go-live per-content worker
+cold-start** — the worker idles out, then respins and regenerates the s1 (1s LL) segments
+on the next request, so the first play after idle eats the segment-generation latency.
+**Tag: needs-test.** Distinguishing test: after a forced idle, run two back-to-back plays
+of the same content — 1st slow / 2nd fast confirms worker cold-start; both slow points
+back at the client. **Fix (either layer):** keep the go-live worker warm (or pre-generate)
+for content under active sweep, and/or have the probe run a discarded warmup play so the
+first *scored* arm isn't paying the respin latency. The per-batch false `aberration` +
+3-rep refutation cost is the same regardless of which layer causes it.
 
 ## Evidence — the guard was right anyway (aberration refuted)
 

--- a/.claude/findings/user-live-offset-crossplatform-2026-07-07.md
+++ b/.claude/findings/user-live-offset-crossplatform-2026-07-07.md
@@ -1,0 +1,77 @@
+# User `live_offset` across iPhone (real) · iPhone (sim) · Android TV — 2026-07-07
+
+**Date:** 2026-07-07 · **Platforms:** real iPhone 15 (AVPlayer), iPhone 15 sim (AVPlayer), Google TV Streamer (ExoPlayer/Media3) · HLS-LL, content `insane_newer_p200_h264`
+**Levers:** app live-offset (`is.flag.live_offset_s` — Settings → Advanced → Live Offset). iOS applies it as a **seek** to `liveEdge − N`; Android applies it as ExoPlayer's native **`LiveConfiguration.targetOffsetMs`**.
+**Metrics (per play):** `wall = seekable_end_s − position_s` (distance to the last-advertised segment) · `true_offset_s = now − PROGRAM-DATE-TIME` (glass-to-glass, the sports-fan number) · `buffer_depth_s` (loaded − position) · `recommended_offset_s` (what the player targets).
+
+## TL;DR
+
+**How close you sit to the live broadcast for a dialed offset N is a *platform × segment* function, not just N.**
+
+- **iOS (AVPlayer):** `true_off ≈ N + 3×seg-holdback + ~4–6s pipeline`. The offset is a **seek behind the seekable edge, which already sits 3×seg behind live** → you're always ~holdback further back than you asked. Holdback = **21 / 9 / 6s** for **s6 / s2 / s1**.
+- **Android TV (ExoPlayer):** `true_off ≈ N` on coarse segments. `targetLiveOffset` sets latency **directly and overrides the manifest holdback** (`recommended_offset_s = N`, not 3×seg). **~28s closer to live than iOS on s6.**
+- **The gap is segment-dependent and collapses on s1:** on the 1s LL rung the holdback is only ~6s, so iOS is barely penalized and Android can't beat the ~6s LL floor → **all three converge to ~10–15s behind**.
+- **Real iPhone ≈ iPhone sim** on every metric → AVPlayer behaves identically on hardware and sim; all prior sim conclusions hold.
+- **Buffer trade:** iOS carries a **deep buffer that scales with N**; Android runs a **lean, ~flat LL buffer** (~2× less on s1/s2).
+- **Precedence (both levers set):** app lever wins the playhead on both. On iOS the manifest holdback still shows in `recommended_offset_s`; on Android the app target fully overrides it.
+
+## Data — steady-state, all `insane_newer` (median `wall` / median `true` / **mean** `buf` / median `recomm`)
+
+### s6 (6s segment · holdback 21)
+| N | iPhone (real) | iPhone (sim) | Android TV |
+|---|---|---|---|
+| 0 | −0.5 / 28.8 / 20.1 / 21 | 97.3 / 124.9 / 50.4 / 21 *(startup-join artifact)* | 17.9 / 24.8 / 16.8 / 23.3 |
+| 6 | 3.1 / 31.9 / 23.4 / 21 | 8.5 / 36.6 / 28.4 / 21 | 7.6 / **10.0** / 6.0 / 6 |
+| 12 | 11.2 / 40.1 / 31.3 / 21 | 13.5 / 40.6 / 33.5 / 21 | 5.8 / **13.9** / 9.1 / 12 |
+| 18 | 17.7 / 43.4 / 37.6 / 21 | 17.2 / 40.5 / 36.2 / 21 | 11.0 / **18.1** / 9.5 / 18 |
+| 24 | 22.1 / 53.0 / 42.4 / 21 | 28.5 / 55.9 / 48.1 / 21 | 16.2 / **24.0** / 14.4 / 24 |
+| 30 | 29.0 / 58.0 / 49.1 / 21 | 29.7 / 57.5 / 49.1 / 21 | 27.7 / **30.1** / 26.5 / 30 |
+| UX (24 + proxy 30) | 22.2 / 62.8 / 51.2 / **30** | 27.0 / 63.0 / 51.9 / **30** | 21.8 / **24.1** / 20.1 / **24** |
+
+### s2 (2s segment · holdback 9)
+| N | iPhone (real) | iPhone (sim) | Android TV |
+|---|---|---|---|
+| 2 | 1.0 / 13.3 / 9.1 / 9 | 1.7 / 13.6 / 10.5 / 9 | 5.0 / 7.6 / 3.6 / 4.1 |
+| 4 | 4.5 / 16.3 / 12.5 / 9 | 3.0 / 15.1 / 12.1 / 9 | 4.3 / 7.2 / 3.5 / 4.0 |
+| 6 | 5.9 / 17.8 / 13.9 / 9 | 6.7 / 18.2 / 14.8 / 9 | 6.0 / 8.5 / 4.5 / 6 |
+| 12 | 11.1 / 23.3 / 19.2 / 9 | 11.5 / 23.6 / 20.4 / 9 | 9.7 / 12.1 / 8.8 / 12 |
+
+### s1 (1s LL segment · holdback 6)
+| N | iPhone (real) | iPhone (sim) | Android TV |
+|---|---|---|---|
+| 2 | 3.0 / 10.5 / 8.2 / 6 | 2.7 / 10.9 / 8.6 / 6 | 5.0 / 12.7 / 7.3 / 5.1 |
+| 4 | 5.0 / 12.8 / 10.4 / 6 | 4.2 / 12.1 / 10.0 / 6 | 6.1 / 13.6 / 4.6 / 6.2 |
+| 6 | 5.7 / 13.3 / 10.7 / 6 | 6.2 / 14.6 / 12.1 / 6 | 6.2 / 15.0 / 5.2 / 6 |
+
+## Reading the numbers
+
+- **`recommended_offset_s` is the tell for the mechanism.** iOS = **3×seg holdback** (21/9/6), flat across N — the manifest governs. Android = **≈ N** on s6/s2 — the app's `targetLiveOffset` governs, overriding the manifest. (On s1 Android's `recomm` clamps to ~6, the LL floor, so it stops tracking N.)
+- **Behind-broadcast (`true_off`), s6:** iOS ≈ N + 27; Android ≈ N. At N=12 that's **40s vs 14s**; at N=24, **53–56s vs 24s**. Android is roughly the holdback (~28s) closer.
+- **Segment collapses the gap:** s6 gap ≈ 26–30s → s2 gap ≈ 5–11s → **s1 gap ≈ 0** (all ~10–15s). The *segment choice* is what actually buys live-ness; on s1 the platform barely matters.
+- **Buffer:** iOS `buf` grows with N (s6: 20→49; s1: 8→11). Android `buf` is lean and ~flat off the coarse rung (s1: ~5; s2: ~4). On s1/s2 iOS holds ~2× Android's buffer — more rebuffer cushion, at the cost of more memory + no closer to live.
+- **Real ≈ sim:** every s6/s2/s1 cell matches within ~2–5s. The lone exception is **sim s6 N=0 = 124.9** (a startup-join artifact — the real phone's N=0 is a sane 28.8, confirming it).
+
+## Methodology fix that made this possible
+
+Batched single-device sweeps were wedging: the sweep probe (`TestSweepProbe`) never called `appium.Close()`, so each arm **leaked its appium session** (held 2h by `newCommandTimeout`) **and the device-farm device lock**. The next back-to-back arm then failed `create session: context deadline exceeded`. Masked on iOS by 4-sim round-robin (wedge ~every 4); exposed on the 1-device Android TV / real iPhone (wedge every 1).
+
+**Fix (committed `dac1941c`, `feat/sweep-lab`):** a `t.Cleanup` calling `appium.Close()` — frees the lock + deletes the session per arm. Validated **14/14 back-to-back** on all three single-device rigs (Android TV, real iPhone) with **zero** farm-reset/unblock workaround.
+
+## Real-iPhone rig (for repeating)
+
+Real iPhone is driven **off the device farm**: go-ios RemoteXPC tunnel + a **plain appium on :4799** (not the farm's :4723). Gotchas hit, in order:
+1. **Tunnel needs a wired USB-C connect** (unlocked) to negotiate — wireless RSD alone left `ios tunnel ls` empty. Clear any stale `:60105` squatter first.
+2. **WDA code-signing:** export `CHAR_IOS_XCODE_ORG_ID=63328J83Q8`, `CHAR_IOS_XCODE_SIGNING_ID="Apple Development"`, `CHAR_IOS_WDA_BUNDLE_ID=com.jeoliver.WebDriverAgentRunner` (the probe runs from `tests/characterization/`, so the repo-root `.env` isn't auto-found — export them).
+3. **On-device: Settings → Developer → Enable UI Automation** (+ Developer Mode) — else WDA fails "Timed out while enabling automation mode."
+4. Probe env: `CHAR_SWEEP_PLATFORM=iphone`, `CHARACTERIZATION_DEVICE_UDID=00008120-000242DE1152201E` (hardware UDID), `CHAR_IOS_DIRECT_APPIUM_URL=http://localhost:4799`.
+
+## Caveats
+
+- **n=1 per cell.** Levels (platform gaps, iOS-2×-buffer) are large enough to be real; exact values jitter across reps. Confirm trends at `reps ≥ 3`.
+- `live_offset` enum is `{0,2,4,6,12,18,24,30,36,42}` (odd values rejected at import).
+- Android s1 `targetLiveOffset` not tracking N (clamps ~6) is worth a dedicated look — the LL rung may handle the target differently in ExoPlayer.
+
+## See also
+- `.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md` — the deeper iOS-sim-only honored-band analysis (the "seek beats holdback threshold" write-up).
+- `.claude/findings/live-offset-androidtv-untestable-2026-06-15.md` — **superseded**: the Android client lever (#793 step 4) is now plumbed and works; Android is no longer untestable.
+- Reproduce: sweep YAMLs `tests/characterization/matrix/user-live-offset*.yaml`; Android/iPhone arm sets seeded as `import-A-*` / `import-I-*`.

--- a/.claude/findings/user-live-offset-crossplatform-2026-07-07.md
+++ b/.claude/findings/user-live-offset-crossplatform-2026-07-07.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-07 · **Platforms:** real iPhone 15 (AVPlayer), iPhone 15 sim (AVPlayer), Google TV Streamer (ExoPlayer/Media3) · HLS-LL, content `insane_newer_p200_h264`
 **Levers:** app live-offset (`is.flag.live_offset_s` — Settings → Advanced → Live Offset). iOS applies it as a **seek** to `liveEdge − N`; Android applies it as ExoPlayer's native **`LiveConfiguration.targetOffsetMs`**.
-**Metrics (per play):** `wall = seekable_end_s − position_s` (distance to the last-advertised segment) · `true_offset_s = now − PROGRAM-DATE-TIME` (glass-to-glass, the sports-fan number) · `buffer_depth_s` (loaded − position) · `recommended_offset_s` (what the player targets).
+**Metrics (per play):** `true_offset_s = now − PROGRAM-DATE-TIME` — **this is the wall-clock offset** (`= now − playhead_wallclock_ms`, where `playhead_wallclock_ms = AVPlayerItem.currentDate()`; `PlayerViewModel.swift:3472`). Glass-to-glass latency behind the live broadcast — the sports-fan number, and the one to trust. · `buffer_depth_s` (loaded − position) · `recommended_offset_s` (what the player targets). *We dropped what an earlier draft mislabeled `wall`: it was really `edge_gap = seekable_end − position` (seek-headroom to the last **advertised** segment). It is **not** a wall-clock number — the wall-clock offset is `true_offset_s`. `edge_gap` excludes the hold-back (exactly where the platforms differ), its reference is player-specific + jumps per-segment, so it's noisy and not cross-platform comparable (negative at N=0 on iOS, non-monotonic on Android, a startup-join artifact on the sim).*
 
 ## TL;DR
 
@@ -15,33 +15,33 @@
 - **Buffer trade:** iOS carries a **deep buffer that scales with N**; Android runs a **lean, ~flat LL buffer** (~2× less on s1/s2).
 - **Precedence (both levers set):** app lever wins the playhead on both. On iOS the manifest holdback still shows in `recommended_offset_s`; on Android the app target fully overrides it.
 
-## Data — steady-state, all `insane_newer` (median `wall` / median `true` / **mean** `buf` / median `recomm`)
+## Data — steady-state, all `insane_newer` (median `true_off` / **mean** `buf` / median `recomm`)
 
 ### s6 (6s segment · holdback 21)
 | N | iPhone (real) | iPhone (sim) | Android TV |
 |---|---|---|---|
-| 0 | −0.5 / 28.8 / 20.1 / 21 | 97.3 / 124.9 / 50.4 / 21 *(startup-join artifact)* | 17.9 / 24.8 / 16.8 / 23.3 |
-| 6 | 3.1 / 31.9 / 23.4 / 21 | 8.5 / 36.6 / 28.4 / 21 | 7.6 / **10.0** / 6.0 / 6 |
-| 12 | 11.2 / 40.1 / 31.3 / 21 | 13.5 / 40.6 / 33.5 / 21 | 5.8 / **13.9** / 9.1 / 12 |
-| 18 | 17.7 / 43.4 / 37.6 / 21 | 17.2 / 40.5 / 36.2 / 21 | 11.0 / **18.1** / 9.5 / 18 |
-| 24 | 22.1 / 53.0 / 42.4 / 21 | 28.5 / 55.9 / 48.1 / 21 | 16.2 / **24.0** / 14.4 / 24 |
-| 30 | 29.0 / 58.0 / 49.1 / 21 | 29.7 / 57.5 / 49.1 / 21 | 27.7 / **30.1** / 26.5 / 30 |
-| UX (24 + proxy 30) | 22.2 / 62.8 / 51.2 / **30** | 27.0 / 63.0 / 51.9 / **30** | 21.8 / **24.1** / 20.1 / **24** |
+| 0 | 28.8 / 20.1 / 21 | 124.9 / 50.4 / 21 *(startup-join artifact)* | 24.8 / 16.8 / 23.3 |
+| 6 | 31.9 / 23.4 / 21 | 36.6 / 28.4 / 21 | **10.0** / 6.0 / 6 |
+| 12 | 40.1 / 31.3 / 21 | 40.6 / 33.5 / 21 | **13.9** / 9.1 / 12 |
+| 18 | 43.4 / 37.6 / 21 | 40.5 / 36.2 / 21 | **18.1** / 9.5 / 18 |
+| 24 | 53.0 / 42.4 / 21 | 55.9 / 48.1 / 21 | **24.0** / 14.4 / 24 |
+| 30 | 58.0 / 49.1 / 21 | 57.5 / 49.1 / 21 | **30.1** / 26.5 / 30 |
+| UX (24 + proxy 30) | 62.8 / 51.2 / **30** | 63.0 / 51.9 / **30** | **24.1** / 20.1 / **24** |
 
 ### s2 (2s segment · holdback 9)
 | N | iPhone (real) | iPhone (sim) | Android TV |
 |---|---|---|---|
-| 2 | 1.0 / 13.3 / 9.1 / 9 | 1.7 / 13.6 / 10.5 / 9 | 5.0 / 7.6 / 3.6 / 4.1 |
-| 4 | 4.5 / 16.3 / 12.5 / 9 | 3.0 / 15.1 / 12.1 / 9 | 4.3 / 7.2 / 3.5 / 4.0 |
-| 6 | 5.9 / 17.8 / 13.9 / 9 | 6.7 / 18.2 / 14.8 / 9 | 6.0 / 8.5 / 4.5 / 6 |
-| 12 | 11.1 / 23.3 / 19.2 / 9 | 11.5 / 23.6 / 20.4 / 9 | 9.7 / 12.1 / 8.8 / 12 |
+| 2 | 13.3 / 9.1 / 9 | 13.6 / 10.5 / 9 | 7.6 / 3.6 / 4.1 |
+| 4 | 16.3 / 12.5 / 9 | 15.1 / 12.1 / 9 | 7.2 / 3.5 / 4.0 |
+| 6 | 17.8 / 13.9 / 9 | 18.2 / 14.8 / 9 | 8.5 / 4.5 / 6 |
+| 12 | 23.3 / 19.2 / 9 | 23.6 / 20.4 / 9 | 12.1 / 8.8 / 12 |
 
 ### s1 (1s LL segment · holdback 6)
 | N | iPhone (real) | iPhone (sim) | Android TV |
 |---|---|---|---|
-| 2 | 3.0 / 10.5 / 8.2 / 6 | 2.7 / 10.9 / 8.6 / 6 | 5.0 / 12.7 / 7.3 / 5.1 |
-| 4 | 5.0 / 12.8 / 10.4 / 6 | 4.2 / 12.1 / 10.0 / 6 | 6.1 / 13.6 / 4.6 / 6.2 |
-| 6 | 5.7 / 13.3 / 10.7 / 6 | 6.2 / 14.6 / 12.1 / 6 | 6.2 / 15.0 / 5.2 / 6 |
+| 2 | 10.5 / 8.2 / 6 | 10.9 / 8.6 / 6 | 12.7 / 7.3 / 5.1 |
+| 4 | 12.8 / 10.4 / 6 | 12.1 / 10.0 / 6 | 13.6 / 4.6 / 6.2 |
+| 6 | 13.3 / 10.7 / 6 | 14.6 / 12.1 / 6 | 15.0 / 5.2 / 6 |
 
 ## Reading the numbers
 

--- a/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
+++ b/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
@@ -1,0 +1,85 @@
+# iOS user `live_offset` — when AVPlayer honors it vs. overrides it
+
+**Date:** 2026-07-05 · **Platform:** iPhone 15 simulator (ipad-sim), AVPlayer, HLS-LL
+**Signal:** `wall_offset = seekable_end_s − position_s` (the app seek's achieved offset behind the available live edge). `live_offset_s` / `true_offset_s` over-read (they include the HOLD-BACK + encode/deliver latency).
+
+## TL;DR
+
+The user (app) live-offset lever — `is.flag.live_offset_s`, a.k.a. **Settings → Advanced → Live Offset**, a seek to `liveEdge − N` — **is honored above a shallow, segment-scaled threshold and ignored/clamped below it.** The threshold is **~1–2 segment durations**, NOT the 3×-segment HOLD-BACK it was hypothesised to obey.
+
+- **Refuted (H-floor):** "the user setting is ignored until N ≥ 3×max-seg (the HOLD-BACK: 21 on s6, 9 on s2, 6 on s1)." It is honored well below the floor.
+- **Confirmed (H-seek):** honored down to ~1–2 segments (the seekable end-gap); the seek just can't place you within ~1 segment of the live edge.
+- **Confirmed:** the shallow threshold **scales with segment size** — the minimum offset you can hold is **~1.7s (s1), ~3.5s (s2), ~6–8s (s6)**. Smaller segments → sit closer to live.
+- **Precedence:** with both levers set, the **app seek wins the actual playhead**; the manifest (`proxy.live_offset`) sets only the advisory `recommended_offset_s`.
+
+## Method
+
+15 arms swept over the **sweep queue** (only possible after adding the 4 client launch knobs — codec/live_offset/peak_bitrate/starts_first_variant — to `sweep.Experiment`; see branch `feat/sweep-lab`). Plain play, no shaping; `proxy.live_offset=0` except the precedence arm. Each arm: `bootstrap --from backlog` → cold-launch `TestSweepProbe` with `CHAR_SWEEP_LIVE_OFFSET=N` on a Fleet iPhone 15 sim, 60s, then read `wall_offset` (steady-state median). YAMLs: `tests/characterization/matrix/user-live-offset.yaml` (+ `-fine`).
+
+## Data (steady-state median)
+
+| seg | N | wall | live_off | true_off | buf | recomm | honored? |
+|---|---|---|---|---|---|---|---|
+| s1 | 2 | 1.7 | 7.7 | 9.5 | 8.1 | 6 | ✅ |
+| s1 | 4 | 5.0 | 11 | 11.8 | 11 | 6 | ✅ |
+| s1 | 6 | 7.0 | 13 | 13.7 | 13 | 6 | ✅ |
+| s2 | 2 | 3.5 | 12.5 | 14.9 | 12.5 | 9 | ❌ clamp ~3.5 |
+| s2 | 4 | 3.6 | 12.6 | 14.7 | 13.1 | 9 | ❌ clamp ~3.5 |
+| s2 | 6 | 6 | 15 | 18 | 15.5 | 9 | ✅ |
+| s2 | 12 | 12 | 21 | 25 | 21.5 | 9 | ✅ |
+| s6 | 0 | ~0 | 21 | 23 | 14 | 21 | — baseline |
+| s6 | 6 | ~0 | 21 | 25 | 20 | 21 | ❌ ignored (edge) |
+| s6 | 12 | 11 | 32 | 38 | 32 | 21 | ✅ |
+| s6 | 18 | 16.5 | 37.5 | 43 | 38 | 21 | ✅ |
+| s6 | 24 | 23 | 44 | 53 | 44 | 21 | ✅ |
+| s6 | 30 | 28.5 | 49.5 | 56 | 50 | 21 | ✅ |
+| s6 | 24 + proxy30 | 21 | 51 | 60.8 | 51 | 30 | ✅ **app wins** (≈24, not 30) |
+| **s1** | **0 †** | 0.2 | 6.2 | **8.4** | 6.2 | 6 | — floor, **on insane_newer** |
+
+† All other rows played `bucks_bunny` (content-pin, see caveats); the s1 N=0 floor was re-run on the **correct** `insane_newer` stream. Config numbers match bucks_bunny exactly (`recomm=6`, `wall~0`) → behaviour is content-independent, so the honored-band/threshold results stand. Only `true_off` shifts: **+~1.6 s on insane_newer** (bucks_bunny s1 N=0 was 6.8), because it includes each content's encode/deliver pipeline latency. So the behind-broadcast *absolute* numbers below under-report the real stream by ~1.6 s.
+
+**Precedence (both levers set, `is.live_offset=24` vs `proxy.live_offset=30`):** the **app seek wins the playhead** — achieved `wall=21` (tracks the app's 24 within a segment; the pure app-24 arm gave 23), **not** the manifest's 30. The manifest offset surfaces only as `recommended_offset_s=30` (advisory) and in the deeper `live_offset=wall+recommended=51`. So the manifest sets the *recommended* position, the app seek sets the *actual* one (the seek runs after manifest bring-up). [n=1, ±1 segment]
+
+## Metric relationships (held across every arm)
+
+- **`live_offset_s = wall + recommended`** exactly (`recommended` = 3×seg HOLD-BACK = 21/9/6). So `live_offset_s` is "behind live *including* the advisory hold-back" — that's the fixed ~21/9/6 it always adds over `wall`.
+- **`true_offset_s ≈ live_offset_s + ~5`** — extra encode/deliver latency (the documented over-read).
+- **`buffer_depth ≈ live_offset_s`** — AVPlayer buffers *forward to the live edge*, so **deeper offset ⇒ proportionally deeper buffer** (~14–20s at the edge → ~50s at N=30). Second-order effect of the setting: more stall resilience + more latency + more memory, roughly linear.
+- **Unforced (N=0) the app rides the live edge (wall~0), not the 21s HOLD-BACK** — the manifest offset is advisory; the user seek (and default behaviour) override it.
+
+## Threshold, quantified
+
+| segment (dur) | min achievable offset (wall) | **closest to broadcast (true_off)** | honored from |
+|---|---|---|---|
+| s1 (1s) | ~1.7 s | **~9.5 s** | N ≥ 2 (tightest requestable) |
+| s2 (2s) | ~3.5 s | **~15 s** | N ≥ 6 (2 & 4 clamp to ~3.5) |
+| s6 (6s) | ~6–8 s | **~23 s** | N ≥ 12 (N=6 rode the edge) |
+
+The shallow *wall* threshold ≈ **1–2 segment durations**, well below the 3×seg HOLD-BACK.
+
+## Behind-broadcast latency (the sports-fan view)
+
+`wall_offset` is offset behind the *packaged edge*; the real "how far behind the live event" number is **`true_offset_s`** = wall-clock now − the playhead's `PROGRAM-DATE-TIME` (glass-to-glass latency). It decomposes as:
+
+> **`true_off ≈ (achieved wall) + 3×seg HOLD-BACK + ~2–4 s deliver latency`**
+> s1: 1.7 + 6 + 2 ≈ **9.5** · s2: 3.5 + 9 + 2 ≈ **15** · s6: 0 + 21 + 2 ≈ **23** · both-levers (app24+proxy30): 21 + 30 + ~10 ≈ **60.8**
+
+Implications:
+- **Segment size dominates liveness** — the 3×seg HOLD-BACK is the biggest term, so s1 gets ~2.5× closer to broadcast than s6 (~9.5 s vs ~23 s), no matter the offset setting.
+- **The user Live-Offset setting only makes you *further* behind** — every +N adds ~N s to `true_off` (s6 N=30 → 56 s).
+- **A deep manifest offset compounds it** — the precedence arm is the deepest (60.8 s) even though the app seek "won" the wall position, because `proxy=30` shifted the reference.
+- Absolute numbers are this rig's encode/deliver latency (synthetic live + sim); a production LL path could shave the ~2–4 s term, but the segment-size dominance holds.
+- **Validated liveness floor (correct stream):** `s1 N=0` on `insane_newer` → **`true_off ≈ 8.4 s`** (the true "closest to broadcast" on the intended content; the ~9.5 s in the threshold table is bucks_bunny's s1 N=2 and runs ~1–1.6 s low).
+
+## Caveats / provenance
+
+- **n=1 per arm.** Trends are monotonic within-run but not rep-confirmed.
+- **`live_offset` enum:** the harness validates it against `{0,2,4,6,12,18,24,30,36,42}` (the *proxy* manifest enum, applied to the *app* lever too), so odd values / <2 can't be requested — finest shallow resolution is 2.
+- **Content-pin quirk (#883) — mostly bucks_bunny:** the driver never set `CHAR_CONTENT`, so nearly all arms played `bucks_bunny` (continue-watching hero), not the pinned `insane_newer`. The requested `master_{1,2,6}s` variant + config loaded correctly regardless (verified via `manifest.master_url`; `recomm`=3×seg identical), so behaviour/thresholds are content-independent. **s1 N=0 was re-run on the correct `insane_newer` stream** (`CHAR_CONTENT` set): identical config (`recomm=6`, `wall~0`), `true_off` +~1.6 s. Net: the *config*-driven results hold on the real stream; the *absolute* behind-broadcast numbers here are bucks_bunny's — add ~1.6 s for insane_newer.
+- **#793 auto-verdict does NOT score the app lever** (it reads `recommended_offset_s`, the manifest lever) — all these runs mark *inconclusive*; `wall_offset` was read manually.
+- **Sim farm wedges after ~4 consecutive probes** — runs were batched with `farm.sh reset` between batches.
+
+## Related
+
+- [[reference_avplayer_cold_start_wedge]] · [[project_ios_startup_speed_levers]] · `docs/live-offset-testing.md` · `.claude/findings/live-offset-androidtv-untestable-2026-06-15.md`
+- Two-lever model: `proxy.live_offset` (manifest HOLD-BACK, obeys the 3×seg floor) vs `is.live_offset` (this app seek, obeys the ~1-2seg end-gap).

--- a/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
+++ b/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
@@ -3,6 +3,8 @@
 **Date:** 2026-07-05 · **Platform:** iPhone 15 simulator (ipad-sim), AVPlayer, HLS-LL
 **Signal:** `wall_offset = seekable_end_s − position_s` (the app seek's achieved offset behind the available live edge). `live_offset_s` / `true_offset_s` over-read (they include the HOLD-BACK + encode/deliver latency).
 
+> **Followed up 2026-07-07** with a three-platform sweep (real iPhone + sim + Android TV) on `insane_newer` — real iPhone ≈ this sim data, and Android/ExoPlayer applies the offset as a native `targetLiveOffset` (much closer to live). See `.claude/findings/user-live-offset-crossplatform-2026-07-07.md`.
+
 ## TL;DR
 
 The user (app) live-offset lever — `is.flag.live_offset_s`, a.k.a. **Settings → Advanced → Live Offset**, a seek to `liveEdge − N` — **is honored above a shallow, segment-scaled threshold and ignored/clamped below it.** The threshold is **~1–2 segment durations**, NOT the 3×-segment HOLD-BACK it was hypothesised to obey.

--- a/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
+++ b/.claude/findings/user-live-offset-honored-band-ios-2026-07-05.md
@@ -1,7 +1,7 @@
 # iOS user `live_offset` — when AVPlayer honors it vs. overrides it
 
 **Date:** 2026-07-05 · **Platform:** iPhone 15 simulator (ipad-sim), AVPlayer, HLS-LL
-**Signal:** `wall_offset = seekable_end_s − position_s` (the app seek's achieved offset behind the available live edge). `live_offset_s` / `true_offset_s` over-read (they include the HOLD-BACK + encode/deliver latency).
+**Signal:** `edge_gap = seekable_end_s − position_s` (the app seek's achieved headroom behind the last **advertised/packaged** segment). ⚠️ **Naming correction (2026-07-07):** earlier drafts called this `wall`/`wall_offset`, which was a misnomer — it is *not* a wall-clock number. The real **wall-clock offset** is `true_offset_s` = `now − the playhead's PROGRAM-DATE-TIME` (`PlayerViewModel.swift:3472`, `= now − playhead_wallclock_ms`). `edge_gap` excludes the HOLD-BACK + encode/deliver latency; `true_offset_s` / `live_offset_s` include them.
 
 > **Followed up 2026-07-07** with a three-platform sweep (real iPhone + sim + Android TV) on `insane_newer` — real iPhone ≈ this sim data, and Android/ExoPlayer applies the offset as a native `targetLiveOffset` (much closer to live). See `.claude/findings/user-live-offset-crossplatform-2026-07-07.md`.
 
@@ -16,11 +16,11 @@ The user (app) live-offset lever — `is.flag.live_offset_s`, a.k.a. **Settings 
 
 ## Method
 
-15 arms swept over the **sweep queue** (only possible after adding the 4 client launch knobs — codec/live_offset/peak_bitrate/starts_first_variant — to `sweep.Experiment`; see branch `feat/sweep-lab`). Plain play, no shaping; `proxy.live_offset=0` except the precedence arm. Each arm: `bootstrap --from backlog` → cold-launch `TestSweepProbe` with `CHAR_SWEEP_LIVE_OFFSET=N` on a Fleet iPhone 15 sim, 60s, then read `wall_offset` (steady-state median). YAMLs: `tests/characterization/matrix/user-live-offset.yaml` (+ `-fine`).
+15 arms swept over the **sweep queue** (only possible after adding the 4 client launch knobs — codec/live_offset/peak_bitrate/starts_first_variant — to `sweep.Experiment`; see branch `feat/sweep-lab`). Plain play, no shaping; `proxy.live_offset=0` except the precedence arm. Each arm: `bootstrap --from backlog` → cold-launch `TestSweepProbe` with `CHAR_SWEEP_LIVE_OFFSET=N` on a Fleet iPhone 15 sim, 60s, then read `edge_gap` (steady-state median). YAMLs: `tests/characterization/matrix/user-live-offset.yaml` (+ `-fine`).
 
 ## Data (steady-state median)
 
-| seg | N | wall | live_off | true_off | buf | recomm | honored? |
+| seg | N | edge_gap | live_off | true_off | buf | recomm | honored? |
 |---|---|---|---|---|---|---|---|
 | s1 | 2 | 1.7 | 7.7 | 9.5 | 8.1 | 6 | ✅ |
 | s1 | 4 | 5.0 | 11 | 11.8 | 11 | 6 | ✅ |
@@ -38,38 +38,38 @@ The user (app) live-offset lever — `is.flag.live_offset_s`, a.k.a. **Settings 
 | s6 | 24 + proxy30 | 21 | 51 | 60.8 | 51 | 30 | ✅ **app wins** (≈24, not 30) |
 | **s1** | **0 †** | 0.2 | 6.2 | **8.4** | 6.2 | 6 | — floor, **on insane_newer** |
 
-† All other rows played `bucks_bunny` (content-pin, see caveats); the s1 N=0 floor was re-run on the **correct** `insane_newer` stream. Config numbers match bucks_bunny exactly (`recomm=6`, `wall~0`) → behaviour is content-independent, so the honored-band/threshold results stand. Only `true_off` shifts: **+~1.6 s on insane_newer** (bucks_bunny s1 N=0 was 6.8), because it includes each content's encode/deliver pipeline latency. So the behind-broadcast *absolute* numbers below under-report the real stream by ~1.6 s.
+† All other rows played `bucks_bunny` (content-pin, see caveats); the s1 N=0 floor was re-run on the **correct** `insane_newer` stream. Config numbers match bucks_bunny exactly (`recomm=6`, `edge_gap~0`) → behaviour is content-independent, so the honored-band/threshold results stand. Only `true_off` shifts: **+~1.6 s on insane_newer** (bucks_bunny s1 N=0 was 6.8), because it includes each content's encode/deliver pipeline latency. So the behind-broadcast *absolute* numbers below under-report the real stream by ~1.6 s.
 
-**Precedence (both levers set, `is.live_offset=24` vs `proxy.live_offset=30`):** the **app seek wins the playhead** — achieved `wall=21` (tracks the app's 24 within a segment; the pure app-24 arm gave 23), **not** the manifest's 30. The manifest offset surfaces only as `recommended_offset_s=30` (advisory) and in the deeper `live_offset=wall+recommended=51`. So the manifest sets the *recommended* position, the app seek sets the *actual* one (the seek runs after manifest bring-up). [n=1, ±1 segment]
+**Precedence (both levers set, `is.live_offset=24` vs `proxy.live_offset=30`):** the **app seek wins the playhead** — achieved `edge_gap=21` (tracks the app's 24 within a segment; the pure app-24 arm gave 23), **not** the manifest's 30. The manifest offset surfaces only as `recommended_offset_s=30` (advisory) and in the deeper `live_offset=edge_gap+recommended=51`. So the manifest sets the *recommended* position, the app seek sets the *actual* one (the seek runs after manifest bring-up). [n=1, ±1 segment]
 
 ## Metric relationships (held across every arm)
 
-- **`live_offset_s = wall + recommended`** exactly (`recommended` = 3×seg HOLD-BACK = 21/9/6). So `live_offset_s` is "behind live *including* the advisory hold-back" — that's the fixed ~21/9/6 it always adds over `wall`.
+- **`live_offset_s = edge_gap + recommended`** exactly (`recommended` = 3×seg HOLD-BACK = 21/9/6). So `live_offset_s` is "behind live *including* the advisory hold-back" — that's the fixed ~21/9/6 it always adds over `edge_gap`.
 - **`true_offset_s ≈ live_offset_s + ~5`** — extra encode/deliver latency (the documented over-read).
 - **`buffer_depth ≈ live_offset_s`** — AVPlayer buffers *forward to the live edge*, so **deeper offset ⇒ proportionally deeper buffer** (~14–20s at the edge → ~50s at N=30). Second-order effect of the setting: more stall resilience + more latency + more memory, roughly linear.
-- **Unforced (N=0) the app rides the live edge (wall~0), not the 21s HOLD-BACK** — the manifest offset is advisory; the user seek (and default behaviour) override it.
+- **Unforced (N=0) the app rides the live edge (edge_gap~0), not the 21s HOLD-BACK** — the manifest offset is advisory; the user seek (and default behaviour) override it.
 
 ## Threshold, quantified
 
-| segment (dur) | min achievable offset (wall) | **closest to broadcast (true_off)** | honored from |
+| segment (dur) | min achievable offset (edge_gap) | **closest to broadcast (true_off)** | honored from |
 |---|---|---|---|
 | s1 (1s) | ~1.7 s | **~9.5 s** | N ≥ 2 (tightest requestable) |
 | s2 (2s) | ~3.5 s | **~15 s** | N ≥ 6 (2 & 4 clamp to ~3.5) |
 | s6 (6s) | ~6–8 s | **~23 s** | N ≥ 12 (N=6 rode the edge) |
 
-The shallow *wall* threshold ≈ **1–2 segment durations**, well below the 3×seg HOLD-BACK.
+The shallow *edge_gap* threshold ≈ **1–2 segment durations**, well below the 3×seg HOLD-BACK.
 
 ## Behind-broadcast latency (the sports-fan view)
 
-`wall_offset` is offset behind the *packaged edge*; the real "how far behind the live event" number is **`true_offset_s`** = wall-clock now − the playhead's `PROGRAM-DATE-TIME` (glass-to-glass latency). It decomposes as:
+`edge_gap` is only offset behind the *packaged edge*; the real "how far behind the live event" number — the **wall-clock offset** — is **`true_offset_s`** = wall-clock now − the playhead's `PROGRAM-DATE-TIME` (glass-to-glass latency). It decomposes as:
 
-> **`true_off ≈ (achieved wall) + 3×seg HOLD-BACK + ~2–4 s deliver latency`**
+> **`true_off ≈ (achieved edge_gap) + 3×seg HOLD-BACK + ~2–4 s deliver latency`**
 > s1: 1.7 + 6 + 2 ≈ **9.5** · s2: 3.5 + 9 + 2 ≈ **15** · s6: 0 + 21 + 2 ≈ **23** · both-levers (app24+proxy30): 21 + 30 + ~10 ≈ **60.8**
 
 Implications:
 - **Segment size dominates liveness** — the 3×seg HOLD-BACK is the biggest term, so s1 gets ~2.5× closer to broadcast than s6 (~9.5 s vs ~23 s), no matter the offset setting.
 - **The user Live-Offset setting only makes you *further* behind** — every +N adds ~N s to `true_off` (s6 N=30 → 56 s).
-- **A deep manifest offset compounds it** — the precedence arm is the deepest (60.8 s) even though the app seek "won" the wall position, because `proxy=30` shifted the reference.
+- **A deep manifest offset compounds it** — the precedence arm is the deepest (60.8 s) even though the app seek "won" the edge_gap position, because `proxy=30` shifted the reference.
 - Absolute numbers are this rig's encode/deliver latency (synthetic live + sim); a production LL path could shave the ~2–4 s term, but the segment-size dominance holds.
 - **Validated liveness floor (correct stream):** `s1 N=0` on `insane_newer` → **`true_off ≈ 8.4 s`** (the true "closest to broadcast" on the intended content; the ~9.5 s in the threshold table is bucks_bunny's s1 N=2 and runs ~1–1.6 s low).
 
@@ -77,8 +77,8 @@ Implications:
 
 - **n=1 per arm.** Trends are monotonic within-run but not rep-confirmed.
 - **`live_offset` enum:** the harness validates it against `{0,2,4,6,12,18,24,30,36,42}` (the *proxy* manifest enum, applied to the *app* lever too), so odd values / <2 can't be requested — finest shallow resolution is 2.
-- **Content-pin quirk (#883) — mostly bucks_bunny:** the driver never set `CHAR_CONTENT`, so nearly all arms played `bucks_bunny` (continue-watching hero), not the pinned `insane_newer`. The requested `master_{1,2,6}s` variant + config loaded correctly regardless (verified via `manifest.master_url`; `recomm`=3×seg identical), so behaviour/thresholds are content-independent. **s1 N=0 was re-run on the correct `insane_newer` stream** (`CHAR_CONTENT` set): identical config (`recomm=6`, `wall~0`), `true_off` +~1.6 s. Net: the *config*-driven results hold on the real stream; the *absolute* behind-broadcast numbers here are bucks_bunny's — add ~1.6 s for insane_newer.
-- **#793 auto-verdict does NOT score the app lever** (it reads `recommended_offset_s`, the manifest lever) — all these runs mark *inconclusive*; `wall_offset` was read manually.
+- **Content-pin quirk (#883) — mostly bucks_bunny:** the driver never set `CHAR_CONTENT`, so nearly all arms played `bucks_bunny` (continue-watching hero), not the pinned `insane_newer`. The requested `master_{1,2,6}s` variant + config loaded correctly regardless (verified via `manifest.master_url`; `recomm`=3×seg identical), so behaviour/thresholds are content-independent. **s1 N=0 was re-run on the correct `insane_newer` stream** (`CHAR_CONTENT` set): identical config (`recomm=6`, `edge_gap~0`), `true_off` +~1.6 s. Net: the *config*-driven results hold on the real stream; the *absolute* behind-broadcast numbers here are bucks_bunny's — add ~1.6 s for insane_newer.
+- **#793 auto-verdict does NOT score the app lever** (it reads `recommended_offset_s`, the manifest lever) — all these runs mark *inconclusive*; `edge_gap` was read manually.
 - **Sim farm wedges after ~4 consecutive probes** — runs were batched with `farm.sh reset` between batches.
 
 ## Related

--- a/content/dashboard-v3/src/pages/Sweep.vue
+++ b/content/dashboard-v3/src/pages/Sweep.vue
@@ -175,6 +175,32 @@ async function toggleScope(dim: string, val: string) {
   loadScope();
 }
 
+// ── Delete / clear (soft-delete via /api/v2/sweep/delete — tombstone) ─────────
+const busy = ref(false);
+async function postDelete(expId: string) {
+  const resp = await fetch('/analytics/api/v2/sweep/delete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ exp_id: expId }),
+  });
+  if (!resp.ok) throw new Error(`delete ${expId}: HTTP ${resp.status}`);
+  experiments.value = experiments.value.filter((e) => e.exp_id !== expId); // optimistic
+}
+async function deleteExperiment(expId: string) {
+  if (!window.confirm(`Delete experiment\n  ${expId}\n?  (soft-delete / tombstone — a seed can be re-added later)`)) return;
+  busy.value = true;
+  try { await postDelete(expId); } catch (e) { error.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; load(); }
+}
+async function clearStatus(s: string) {
+  const ids = byStatus.value[s].map((e) => e.exp_id);
+  if (!ids.length) return;
+  if (!window.confirm(`Delete all ${ids.length} '${STATUS_LABEL[s] || s}' experiment(s)?\nThis tombstones them (seeds can be re-added with 'sweep seed').`)) return;
+  busy.value = true;
+  try { for (const id of ids) await postDelete(id); } catch (e) { error.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; load(); }
+}
+
 const disabledCount = computed(() =>
   Object.values(scope.value).reduce(
     (n, vs) => n + Object.values(vs).filter((en) => en === false).length, 0),
@@ -419,6 +445,14 @@ watch(viewMode, () => { if (viewMode.value === 'history') loadHistory(); });
           <h2>
             {{ STATUS_LABEL[s] }}
             <span class="count">{{ byStatus[s].length }}</span>
+            <button
+              v-if="byStatus[s].length"
+              type="button"
+              class="col-clear"
+              :disabled="busy"
+              :title="`Delete all ${byStatus[s].length} '${STATUS_LABEL[s]}' experiments (tombstone)`"
+              @click="clearStatus(s)"
+            >clear</button>
           </h2>
           <div class="cards">
             <article
@@ -455,6 +489,13 @@ watch(viewMode, () => { if (viewMode.value === 'history') loadHistory(); });
                   @click.stop
                 >{{ s === 'running' ? '▶ watch live' : '↗ viewer' }}</a>
                 <span v-else-if="s === 'running'" class="starting" title="session not bootstrapped yet">⏳ starting…</span>
+                <button
+                  type="button"
+                  class="del"
+                  :disabled="busy"
+                  title="Delete this experiment (soft-delete / tombstone)"
+                  @click.stop="deleteExperiment(e.exp_id)"
+                >🗑</button>
               </div>
             </article>
           </div>
@@ -505,8 +546,14 @@ watch(viewMode, () => { if (viewMode.value === 'history') loadHistory(); });
 .lft-block { margin: 0 0 1rem; }
 .board { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .8rem; align-items: start; }
 .col { background: var(--surface, #f8f9fa); border: 1px solid var(--border, #dadce0); border-radius: 8px; padding: .5rem; }
-.col h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-secondary, #5f6368); margin: .2rem .2rem .6rem; display: flex; justify-content: space-between; }
-.count { background: var(--primary-blue-light, #e8f0fe); color: var(--primary-blue, #1a73e8); border-radius: 10px; padding: 0 .5rem; font-size: .75rem; }
+.col h2 { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: var(--text-secondary, #5f6368); margin: .2rem .2rem .6rem; display: flex; align-items: center; gap: .4rem; }
+.count { margin-left: auto; background: var(--primary-blue-light, #e8f0fe); color: var(--primary-blue, #1a73e8); border-radius: 10px; padding: 0 .5rem; font-size: .75rem; }
+.col-clear { border: 1px solid var(--border, #dadce0); background: transparent; color: var(--text-secondary, #5f6368); border-radius: 6px; font-size: .68rem; padding: 1px 6px; cursor: pointer; text-transform: none; letter-spacing: 0; }
+.col-clear:hover:not(:disabled) { border-color: #d93025; color: #d93025; background: #fce8e6; }
+.col-clear:disabled { opacity: .5; cursor: default; }
+.del { border: 0; background: transparent; cursor: pointer; font-size: .8rem; line-height: 1; padding: 1px 3px; border-radius: 5px; opacity: .5; }
+.del:hover:not(:disabled) { opacity: 1; background: #fce8e6; }
+.del:disabled { opacity: .3; cursor: default; }
 .cards { display: flex; flex-direction: column; gap: .5rem; }
 .card { background: var(--background, #fff); border: 1px solid var(--border-light, #e8eaed); border-left: 3px solid var(--primary-blue, #1a73e8); border-radius: 6px; padding: .5rem .6rem; font-size: .82rem; cursor: pointer; }
 .card:hover { border-color: var(--border, #dadce0); }

--- a/tests/characterization/COVERAGE-LEDGER.md
+++ b/tests/characterization/COVERAGE-LEDGER.md
@@ -1,0 +1,133 @@
+# Player-discovery coverage ledger
+
+The fusion artifact #772 asks for: one table tying the three catalogues together —
+**what we want to know** (the questions in [`matrix/TEST-PLAN.md`](matrix/TEST-PLAN.md)),
+**what we can actually run today** (the `modes/*_test.go` drivers + `matrix/*.yaml` arms),
+and **what we've already found** (`.claude/findings/`). Each row is one player
+behaviour we set out to characterise.
+
+Maintain this by hand when a mode, a matrix arm, or a finding lands. It is the
+coverage side of TEST-PLAN.md's question side — read them together.
+
+## Status legend
+
+| Mark | Meaning |
+|---|---|
+| ✅ **Answered** | A finding answers the question (cited). |
+| 🟡 **Runnable** | A mode/YAML can run it today; no finding written up yet. |
+| 🟠 **Partial** | Related/approximate coverage only — a mode touches it, or a finding is adjacent, but the specific question isn't closed. |
+| 🔴 **Gap** | The hooks exist but nothing runs it and nothing answers it. |
+| ⚫ **Missing hook** | Needs an input/observation hook the harness doesn't have yet. |
+
+⚠ = evidence lives on the **unpushed** `feat/sweep-lab` branch (not in `dev`).
+Runnable column: `mode:` = a Go driver in `modes/`; `yaml:` = an arm in `matrix/`.
+
+---
+
+## Section 1 — Live-edge latency & offset control
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 1.1 | `offset-response-curve` — where does the server offset clamp? | `yaml: live-offset` | ⚠ `user-live-offset-crossplatform`, `…-honored-band-ios` | ✅ | `proxy.live_offset`, `is.segment` |
+| 1.2 | `offset-floor-by-segment` — same offset, opposite outcome by segment | `yaml: live-offset` (+seg) | ⚠ `user-live-offset-crossplatform` (holdback 21/9/6 for s6/s2/s1) | ✅ | `proxy.live_offset`, `is.segment` |
+| 1.3 | `offset-precedence` — client vs server, who wins? | `yaml: precedence` | ⚠ `user-live-offset-crossplatform` (app lever wins the playhead both platforms) | ✅ | `proxy.live_offset` + `is.live_offset` |
+| 1.4 | `offset-source-parity` — do the two mechanisms reach the same latency? | `yaml: precedence` (adjacent) | ⚠ partial (crossplatform shows server-holdback vs client-override differ) | 🟠 | `proxy.live_offset` vs `is.live_offset` |
+
+## Section 2 — Platform & protocol parity
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 2.1 | `platform-offset-parity` — AVPlayer vs ExoPlayer latency across offsets | `yaml: live-offset` (per platform) | ⚠ `user-live-offset-crossplatform` (iOS ≈N+27 vs Android ≈N on s6; converge on s1); supersedes `live-offset-androidtv-untestable` | ✅ | `proxy.live_offset`, `platform` |
+| 2.2 | `protocol-parity` — LL-HLS vs LL-DASH on the same content | — | — | 🔴 | `is.protocol` (hls/dash) |
+| 2.3 | `platform-abr-parity` — same ABR call under load, iOS vs Android? | `mode: pyramid/rampdown` (per platform) | — | 🟠 | shape pattern, `platform` |
+
+## Section 3 — ABR under bandwidth shaping
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 3.1 | `shape-pattern-response` — ABR reaction per bandwidth profile | `yaml: shape-patterns`; `mode: pyramid/rampup/rampdown/transient_shock` | — | 🟡 | `proxy.shape.pattern` |
+| 3.2 | `startup-bitrate-clamp` — does the startup cap change downshift? | `mode: startup_caps` | `avplayer-startup-variant-selection` (adjacent) | 🟠 | `is.peak_bitrate_mbps` |
+| 3.3 | `segment-abr-responsiveness` — segment size vs reaction speed | `yaml: pyramid-seg`, `pyramid-1-s2` vs `-s6` | — | 🟡 | `is.segment`, shape ramp |
+| 3.4 | `rate-step-sensitivity` — fastest bandwidth change the player can track | `mode: steps` | — | 🟡 | `proxy.shape.step_seconds/max_step` |
+| 3.5 | `pyramid-timing` — same pattern, different timing | `yaml: pyramid-*` (12 arms) | — | 🟡 | `proxy.shape.step_seconds/dip_hold_s` |
+| 3.6 | `constant-vs-dynamic-stepping` — uniform vs content-relative vs asymmetric | `yaml: const5-*`, `pyramid-*` | — | 🟡 | `proxy.shape.pattern/step_segments` |
+
+## Section 4 — Manifest manipulation & signalling robustness
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 4.1 | `avgbw-reliance` — does ABR lean on AVERAGE-BANDWIDTH? | `yaml: pyramid-2sim-s2-noavg` | — | 🟡 | `proxy.strip_avg_bandwidth` |
+| 4.2 | `ladder-truncation` — graceful clamp when a rung disappears | — | `over-downshift` (47d16786), `ladder-density-over-downshift` (adjacent: density → hunting) | 🟠 | `proxy.allowed_variants` |
+| 4.3 | `bandwidth-honesty` — trust manifest bitrate or measure it? | — | — | 🔴 | `proxy.overstate_bandwidth` |
+| 4.4 | `codec-signalling` — codec pre-check / fallback | — | — | 🔴 | `is.codec`, `proxy.strip_codecs` |
+| 4.5 | `resolution-signalling` — does ABR use RESOLUTION? | — | — | 🔴 | `proxy.strip_resolution` |
+| 4.6 | `variant-order` — manifest order vs bandwidth sort (HLS-only) | — | — | 🔴 | `proxy.variant_order` |
+
+## Section 5 — Fault recovery
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 5.1 | `fault-by-request-kind` — recovery differs by what's faulted | `mode: fault_recovery` (iOS) | — | 🟡 | `fault.request_kind` (+ new CLI variant/kind flags) |
+| 5.2 | `fault-by-type` — recovery envelope by failure class | `mode: fault_recovery` | — | 🟡 | `fault.type` (403/404/500/timeout/reset/…) |
+| 5.3 | `fault-burst-tolerance` — transient vs sustained | `mode: fault_recovery` (partial) | — | 🟠 | `fault.frequency/consecutive/continuous` |
+| 5.4 | `transfer-timeout-tolerance` — partial-delivery / slow-loris | — | — | 🔴 | `proxy.transfer_timeouts.*` |
+
+## Section 6 — Interaction / cross-cutting
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 6.1 | `offset-under-throttle` — does latency target survive bandwidth pressure? | — | — | 🔴 | `proxy.live_offset` + `proxy.shape` |
+| 6.2 | `truncation-under-throttle` — ladder limits × bandwidth pressure | — | — | 🔴 | `proxy.allowed_variants` + `proxy.shape` |
+| 6.3 | `platform-fault-parity` — recovery parity across stacks | `mode: fault_recovery` (iOS only — Android not wired) | — | 🟠 | `fault.*`, `platform` |
+
+## Section 7 — Per-variant acceptance-band calibration
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 7.1 | `variant-acceptance-band` — coarse staircase, both directions, per platform | `mode: hysteresis_gap` (adjacent) | — | 🟠 | shape staircase, `platform` |
+| 7.2 | `variant-band-bisect` — precise edge per adjacent rung pair | sweep `bisect` kind (engine exists, not run to a table) | — | 🟠 | shape bisect axis |
+| 7.3 | `floor-rung-rebuffer-edge` — lower bound config-class won't reach | `mode: emergency_downshift/abort` (adjacent) | `ipad-262s-stall`, `progressive-stall-wedge` | 🟠 | forced starvation (fault) |
+
+## Section 8 — Startup / join-time characterization
+
+| # | Question | Runnable | Finding | Status | Key hooks |
+|---|---|---|---|---|---|
+| 8.1 | `startup-time-by-bandwidth` — join time & join rung vs starting bandwidth | `mode: startup` | — | 🟡 | `proxy.shape.rate_mbps` |
+| 8.2 | `startup-join-policy` — first-variant vs ABR-pick | `mode: startup` | `avplayer-startup-variant-selection` | ✅ | `is.starts_first_variant` |
+| 8.3 | `startup-cap` — does the peak-bitrate clamp improve join? | `mode: startup_caps` | `avplayer-startup-variant-selection` (+ `reference_avplayer_cold_start_wedge`) | ✅ | `is.peak_bitrate_mbps` |
+| 8.4 | `segment-startup` — segment size vs first-frame latency | `mode: startup` (+seg) | — | 🟠 | `is.segment` |
+
+---
+
+## Roll-up
+
+33 questions across 8 sections:
+
+| Status | Count | Which |
+|---|---|---|
+| ✅ Answered | 6 | 1.1, 1.2, 1.3, 2.1, 8.2, 8.3 *(the 1.x cluster shares one live-offset study)* |
+| 🟡 Runnable, unwritten | 9 | 3.1, 3.3, 3.4, 3.5, 3.6, 4.1, 5.1, 5.2, 8.1 |
+| 🟠 Partial | 10 | 1.4, 2.3, 3.2, 4.2, 5.3, 6.3, 7.1, 7.2, 7.3, 8.4 |
+| 🔴 Gap (hooks exist) | 8 | 2.2, 4.3, 4.4, 4.5, 4.6, 5.4, 6.1, 6.2 |
+| **Total** | **33** | |
+
+### The three things this ledger makes obvious
+
+1. **All five "answered" questions are latency/startup**, and **three of the answers are unpushed** (`feat/sweep-lab`). Backing up that branch is the single highest-leverage move — it's where the confirmed live-offset knowledge lives.
+2. **Section 4 (manifest signalling) is almost entirely 🔴** — `overstate_bandwidth`, `strip_codecs`, `strip_resolution`, `variant_order` all have knobs (and TEST-PLAN specs) but **zero** runnable arms. Cheapest high-value expansion: these are pure `config`-class YAMLs, no new hooks needed.
+3. **10 questions are 🟡 Runnable-but-unwritten** — the harness can answer them *today*; they just need an arm authored and a run. That's the backlog #772's loop is meant to burn down.
+
+### Not in TEST-PLAN at all (⚫ missing-hook behaviours)
+
+Discoverable classes with **no** question row and **no** hook, flagged for scope decisions (from the Part-C gap scan):
+
+- **Seek / trick-play** — no harness support to drive seeks; ABR-after-seek untested.
+- **Concurrent-session contention** — fleet runs parallel arms but "N players degrade each other" is never the swept variable.
+- **DRM / key rotation** — `ContentKeyRequestEvent` is plumbed client-side; license faults untested (confirm if out of scope).
+- **Endurance / soak** — all drivers run 45–180 s; buffer creep / memory drift invisible.
+- **Latency/loss/jitter as an ABR axis** — `proxy.shape.delay_ms/loss_pct/jitter_ms` shipped (#826) but **every** mode still varies bandwidth only.
+- **Content as a variable** — everything pins one clip (`insane_newer_p200_h264`); the `content:` axis is never swept.
+
+---
+
+*Source anchors — questions: [`matrix/TEST-PLAN.md`](matrix/TEST-PLAN.md); runnable: `modes/*_test.go` + `matrix/*.yaml`; findings: `.claude/findings/`; input hooks: `tools/harness-cli/internal/sweep/experiment.go` + `api/openapi/v2/proxy.yaml`; loop engine: issue #772.*

--- a/tests/characterization/matrix/user-live-offset-fine.yaml
+++ b/tests/characterization/matrix/user-live-offset-fine.yaml
@@ -1,0 +1,14 @@
+name: user-live-offset-fine
+class: config
+duration_s: 60
+reps: 1
+defaults:
+  platform: ipad-sim
+  is.protocol: hls
+  content: insane_newer_p200_h264
+arms:
+  - { id: F-s2-02, is.segment: s2, is.live_offset: 2 }
+  - { id: F-s2-04, is.segment: s2, is.live_offset: 4 }
+  - { id: F-s1-02, is.segment: s1, is.live_offset: 2 }
+  - { id: F-s1-04, is.segment: s1, is.live_offset: 4 }
+  - { id: F-s1-06, is.segment: s1, is.live_offset: 6 }


### PR DESCRIPTION
## Summary — clean split of #939 (docs + board, no code conflicts)

The non-conflicting half of #939. All docs + one self-contained frontend change; touches **zero** files that the #946 char-matrix-unify epic (`feat/952-fleet-reservation`) refactors, so it lands independently.

### Research findings (`.claude/findings/`)
- **iOS user live_offset honored-band** — the app live-offset (`is.live_offset`) is honored above a shallow ~1–2 segment threshold, NOT the 3×seg holdback.
- **Cross-platform** (real iPhone + sim + Android TV) — iOS ≈ N+27s behind live on s6 (holdback governs) vs Android ≈ N; gap collapses on s1. Renamed the misleading `wall`→`edge_gap`.
- **Android-TV-untestable** finding marked superseded.
- **Sweep queue ↔ char-matrix fleet integration gaps** — three confound gaps found driving the sweep loop live (cold-start false positive, reps unschedulable, fleet path bypasses the queue). This is the **evidence base for the #946 epic** — see #946 comment.

### Coverage ledger (#772)
`tests/characterization/COVERAGE-LEDGER.md` — 33 TEST-PLAN specs × runnable coverage × findings.

### QE Lab board UX
`Sweep.vue`: per-entry delete + per-column clear (tombstone) buttons via the existing `POST /analytics/api/v2/sweep/delete`.

## Testing
- `origin/dev` base, cherry-picked clean (no conflicts).
- `dashboard-v3` frontend builds (`npm run build` green) — Sweep.vue compiles against current dev.

## Split note
This replaces the docs/board portion of #939. The remaining harness code (#906 client-launch-knob plumbing) is split into a separate PR to be reconciled with the #946 epic; the superseded appium-leak fix is dropped (the epic's device-pool model supersedes it). Relates to #772, #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
