### PR TITLE
feat(proxy): perceptual log-bitrate video_quality_pct (#962)

### DIFF
--- a/api/openapi/v2/proxy.yaml
+++ b/api/openapi/v2/proxy.yaml
@@ -1682,7 +1682,7 @@ components:
         display_resolution:  { type: string,  nullable: true, description: 'Player-reported window/display resolution (separate from the active video resolution).' }
         fetching_resolution: { type: string,  nullable: true, description: 'WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event.' }
         video_bitrate_mbps:  { type: number, format: float, nullable: true }
-        video_quality_pct:   { type: number, format: float, nullable: true, description: 'video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)' }
+        video_quality_pct:   { type: number, format: float, nullable: true, description: 'Log-bitrate (Weber-Fechner) quality of the snapshot video_bitrate_mbps on the active manifest ladder: log(mbps/min)/log(max/min), clamped to a 0.20 floor. Shares the model with video_quality_60s_pct / video_quality_avg_pct (unset for single-rung ladders).' }
         video_quality_60s_pct: { type: number, format: float, nullable: true, description: 'Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.' }
         video_quality_avg_pct: { type: number, format: float, nullable: true, description: 'Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().' }
         avg_network_bitrate_mbps: { type: number, format: float, nullable: true, description: 'Player-computed avgNetworkBitrate.' }

--- a/content/dashboard/api-docs/proxy-v2.yaml
+++ b/content/dashboard/api-docs/proxy-v2.yaml
@@ -1682,7 +1682,7 @@ components:
         display_resolution:  { type: string,  nullable: true, description: 'Player-reported window/display resolution (separate from the active video resolution).' }
         fetching_resolution: { type: string,  nullable: true, description: 'WxH of the variant the player is about to fetch — derived iOS-side from indicatedBitrate vs the variant ladder. Empty before the first access-log event.' }
         video_bitrate_mbps:  { type: number, format: float, nullable: true }
-        video_quality_pct:   { type: number, format: float, nullable: true, description: 'video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)' }
+        video_quality_pct:   { type: number, format: float, nullable: true, description: 'Log-bitrate (Weber-Fechner) quality of the snapshot video_bitrate_mbps on the active manifest ladder: log(mbps/min)/log(max/min), clamped to a 0.20 floor. Shares the model with video_quality_60s_pct / video_quality_avg_pct (unset for single-rung ladders).' }
         video_quality_60s_pct: { type: number, format: float, nullable: true, description: 'Log-bitrate (Weber-Fechner) quality over the last 60s of watched playback. Formula: log(kbps/min) / log(max/min) per event, clamped to a 0.20 floor, time-weighted by durationWatched. Matches dashboard PlayLog computeQualityPct.' }
         video_quality_avg_pct: { type: number, format: float, nullable: true, description: 'Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().' }
         avg_network_bitrate_mbps: { type: number, format: float, nullable: true, description: 'Player-computed avgNetworkBitrate.' }

--- a/go-proxy/cmd/server/main.go
+++ b/go-proxy/cmd/server/main.go
@@ -9878,11 +9878,22 @@ func (a *App) normalizeSessionsForResponse(sessions []SessionData) []SessionData
 		setDefault("loop_count_server", 0)
 		setDefault("player_metrics_loop_count_player", 0)
 		setDefault("player_metrics_loop_count_delta", 0)
-		bestMbps := bestVariantMbps(session)
+		// Perceptual (Weber-Fechner) video quality: the played bitrate's
+		// position on the ladder measured in log space, so doubling the
+		// bitrate near the top barely moves the score while the bottom
+		// rungs spread out. Mirrors the iOS log-bitrate model in
+		// PlayerViewModel.swift (qualityWeightForBitrate), including the
+		// 0.20 baseline floor, so this server snapshot metric and the iOS
+		// avg/60s metrics share one model. NB: the ladder here is the full
+		// advertised manifest; iOS uses its post-cap *selectable* peaks, so
+		// the two agree in shape, not to the decimal. A single-rung ladder
+		// leaves the field unset (the log ratio is undefined).
 		videoMbps := getFloat(session, "player_metrics_video_bitrate_mbps")
-		if bestMbps > 0 && videoMbps > 0 {
-			quality := (videoMbps / bestMbps) * 100
-			session["player_metrics_video_quality_pct"] = math.Round(quality*100) / 100
+		if minMbps, maxMbps, ok := variantMbpsRange(session); ok && videoMbps > 0 {
+			const qualityFloor = 0.20 // matches PlayerViewModel.qualityBaselineFloor
+			weight := math.Log(videoMbps/minMbps) / math.Log(maxMbps/minMbps)
+			weight = math.Max(qualityFloor, math.Min(1.0, weight))
+			session["player_metrics_video_quality_pct"] = math.Round(weight*100*100) / 100
 		} else {
 			delete(session, "player_metrics_video_quality_pct")
 		}
@@ -10365,21 +10376,27 @@ func inferServerVideoRendition(session SessionData, filename string, isManifest,
 	}
 }
 
-func bestVariantMbps(session SessionData) float64 {
-	variants := getManifestVariants(session)
-	if len(variants) == 0 {
-		return 0
-	}
-	maxBandwidth := 0
-	for _, variant := range variants {
+// variantMbpsRange returns the min and max declared BANDWIDTH across the
+// active manifest ladder, in Mbps. ok is false unless there are at least
+// two distinct positive-bandwidth rungs — the log-quality ratio is
+// undefined for a single-rung ladder (log(max/min) would be 0).
+func variantMbpsRange(session SessionData) (minMbps, maxMbps float64, ok bool) {
+	minBandwidth, maxBandwidth := 0, 0
+	for _, variant := range getManifestVariants(session) {
+		if variant.Bandwidth <= 0 {
+			continue
+		}
+		if minBandwidth == 0 || variant.Bandwidth < minBandwidth {
+			minBandwidth = variant.Bandwidth
+		}
 		if variant.Bandwidth > maxBandwidth {
 			maxBandwidth = variant.Bandwidth
 		}
 	}
-	if maxBandwidth <= 0 {
-		return 0
+	if minBandwidth <= 0 || maxBandwidth <= minBandwidth {
+		return 0, 0, false
 	}
-	return float64(maxBandwidth) / 1_000_000
+	return float64(minBandwidth) / 1_000_000, float64(maxBandwidth) / 1_000_000, true
 }
 
 func nowISO() string {

--- a/go-proxy/pkg/v2oapigen/oapigen.gen.go
+++ b/go-proxy/pkg/v2oapigen/oapigen.gen.go
@@ -1640,7 +1640,7 @@ type PlayerMetrics struct {
 	// VideoQualityAvgPct Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
 	VideoQualityAvgPct *float32 `json:"video_quality_avg_pct,omitempty"`
 
-	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
+	// VideoQualityPct Log-bitrate (Weber-Fechner) quality of the snapshot video_bitrate_mbps on the active manifest ladder: log(mbps/min)/log(max/min), clamped to a 0.20 floor. Shares the model with video_quality_60s_pct / video_quality_avg_pct (unset for single-rung ladders).
 	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
 	VideoResolution *string  `json:"video_resolution,omitempty"`
 

--- a/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
+++ b/tools/harness-cli/internal/v2gen/proxy/proxy.gen.go
@@ -1641,7 +1641,7 @@ type PlayerMetrics struct {
 	// VideoQualityAvgPct Same log-bitrate formula as video_quality_60s_pct but over the lifetime of the play. Computed by iOS from AVPlayerItem.accessLog().
 	VideoQualityAvgPct *float32 `json:"video_quality_avg_pct,omitempty"`
 
-	// VideoQualityPct video_bitrate_mbps as a percentage of the top variant in the active manifest (snapshot)
+	// VideoQualityPct Log-bitrate (Weber-Fechner) quality of the snapshot video_bitrate_mbps on the active manifest ladder: log(mbps/min)/log(max/min), clamped to a 0.20 floor. Shares the model with video_quality_60s_pct / video_quality_avg_pct (unset for single-rung ladders).
 	VideoQualityPct *float32 `json:"video_quality_pct,omitempty"`
 	VideoResolution *string  `json:"video_resolution,omitempty"`
 


### PR DESCRIPTION
## What

Replaces the **linear** snapshot quality metric `video_quality_pct` in go-proxy with the **Weber-Fechner log-bitrate** model that iOS already uses for `video_quality_avg_pct` / `video_quality_60s_pct`.

```
weight = clamp( log(mbps/min) / log(max/min), 0.20, 1.0 )
video_quality_pct = weight * 100
```

## Why

- **Perceptual accuracy.** Bitrate→quality is concave, not linear. On a 1–16 Mbps ladder, 4 Mbps now reads **50%** (was 25%), 8 Mbps reads **75%** (was 50%).
- **Consistency.** All four quality metrics now share one model; the `avg_quality_pct` / `min_quality_pct` ClickHouse rollups aggregate this column and inherit it for free.
- **Bug fix.** Linear had no upper clamp — an above-top burst during a cap change reported **>100%** (125% in testing). Now clamped to 100%.

## Verified

- Numeric check across the ladder + edge cases (floor at/below min → 20%, above-max → 100%, single-rung ladder + `video=0` → field unset).
- `go build ./...` clean for both `go-proxy` and `tools/harness-cli` on the `dev` base.
- No existing test asserts the old linear value.

## Changes

| File | Change |
|---|---|
| `go-proxy/cmd/server/main.go` | Log-bitrate formula; `bestVariantMbps` → `variantMbpsRange` (needs ladder min + max) |
| `api/openapi/v2/proxy.yaml` | Field doc-string updated |
| `content/dashboard/api-docs/proxy-v2.yaml` | Scalar mirror synced |
| `go-proxy/pkg/v2oapigen/oapigen.gen.go`, `tools/harness-cli/.../proxy.gen.go` | Regenerated typed clients |

## Accepted trade-offs

- **Historical discontinuity**: archived rows before deploy stay linear; `avg/min_quality_pct` history straddles two formulas across the change date. Cost of replacing in place (no new field).
- **Not decimal-identical to iOS**: server uses the full advertised ladder's `BANDWIDTH` min/max; iOS uses post-cap *selectable* peaks. Same model, slightly different inputs.

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
