### PR TITLE
feat(encode): two-pass software encode + common-res VMAF audit (#965)

### DIFF
--- a/.claude/findings/hevc-single-pass-avg-undershoot-two-pass-fix-2026-07-13.md
+++ b/.claude/findings/hevc-single-pass-avg-undershoot-two-pass-fix-2026-07-13.md
@@ -1,0 +1,71 @@
+# HEVC single-pass average undershoot under tight VBV — fixed by `--two-pass`
+
+- **Observed:** 2026-07-13
+- **Content:** `insane_fpv_shots_hydrofoil_windsurfing.mkv`, apple-uniq ladder, software libx265, 6s segments
+- **Status:** **confirmed** — scoped 1080p-cap A/B + full 4K 12-rung re-run
+  (`insane_fpv_apple_uniq_2pass_hevc_20260713_081239`, 197m). Full 4K: avg_accuracy
+  fails 10→0, undershoot −18%(top)→flat −3..−7%, measured overlap 7→1 pair, meas avg
+  rose +13%(360p)..+27%(4K) toward target, VMAF held.
+
+## Symptom
+
+On the single-pass HEVC encode `insane_fpv_apple_uniq_hevc_20260707_085406`, the measured
+average bitrate ran **12–18% below the advertised AVERAGE-BANDWIDTH**, and the shortfall
+*grew* up the ladder (−4% at 360p → **−17%** at 1080p+). `ladder_audit.py` logged **10
+`avg_accuracy` fails**. Because avg-keyed ABR players select on AVERAGE-BANDWIDTH, this
+produced **7 overlapping rung pairs** (measured peak(N) > measured avg(N+1)) from 540p up —
+the manifest hid the overlap behind an overstated average.
+
+The peaks were NOT the problem: adv peak ≈ meas peak (Δ~0%). The tight `BUFSIZE_MULT=0.25`
+(#868, a 0.25s VBV buffer) flattened peaks correctly — but left single-pass x265 no buffer
+to bank bits for complex scenes, so it played conservative and **undershot the `-b:v`
+target**. The *floor* dropped, not the ceiling. x264 was unaffected (±1% avg accuracy) —
+this is an x265 1-pass ABR conservatism specific to small VBV.
+
+## Fix
+
+Added `--two-pass` CLI option to `generate_abr/create_abr_ladder.sh` (helper
+`encode_two_pass_sw`, wired into the software libx264 + libx265 branches; hardware
+VideoToolbox / AV1 stay single-pass with a warning). Pass 1 profiles complexity to a stats
+file (`-f null`, output discarded); pass 2 distributes bits to hit `-b:v` accurately while
+the SAME `maxrate`/`bufsize` VBV still holds peaks flat.
+
+## Evidence (scoped 1080p-cap A/B, same source/ladder)
+
+| Metric | Single-pass | Two-pass |
+|---|---|---|
+| `avg_accuracy` fails | **10** | **0** |
+| Avg undershoot (worst) | −17% (top, worsening up ladder) | **−5 to −7%, flat** |
+| Measured overlap pairs | 7 (from 540p up) | **2** (only 720↔1044↔1080) |
+| VMAF | baseline | held / +~0.1 |
+
+The 2 residual overlaps both involve **1044p, independently flagged `vmaf_inversion`
+(52.8 < 720p 55.1) + `vmaf_redundant_rung`** — a junk rung to drop, not a VBV issue.
+Residual ~5% undershoot is the 0.25× VBV still constraining slightly; within the ±10% gate.
+
+## Takeaways
+
+- `bufsize` controls peak-above-maxrate; it does NOT make the encoder *spend to target*.
+  For accurate average under a tight VBV, use **two-pass** (decouples avg-accuracy from
+  peak-flatness) — not a looser bufsize (which re-inflates peaks and re-widens overlap).
+- Follow-up: drop the VMAF-inverted/redundant 1044p (and re-check 1440p/2124p on the full
+  4K ladder, which were also inverted single-pass).
+
+Related: [[reference_avplayer_cold_start_wedge]] (ABR selection), `.claude/standards/abr-ladder.md`.
+
+## Update 2026-07-14 — the vmaf_inversion flags were a scoring artifact
+
+`ladder_audit.py` scored each rung at its OWN native resolution (both distorted +
+reference downscaled to the variant's res), so every rung faced a different-difficulty
+target — a higher-res rung is compared to a more-detailed reference and scores lower even
+when its on-screen quality is equal/better. Fixed: `measure_vmaf` now scales to a COMMON
+comparison resolution (`--vmaf-compare-res source`, default = probe the mezzanine → 4K here;
+`native` keeps legacy; `--vmaf-model` added for vmaf_4k). Re-scoring the two-pass 4K ladder
+at common 4K: the ladder is **monotonic (3.4→53.2)** and all **3 inversions vanish**
+(1044<720, 1440<1080, 2124<1440 → NONE). Native scoring had inflated the low rungs (+27 VMAF
+at 360p) which compressed the top and manufactured the inversions.
+
+**Correction:** do NOT drop 1044p/1440p/2124p on VMAF grounds — they are not wasteful.
+Remaining real issues are `tight_spacing` (bitrate math) only. Caveat: absolute common-4K
+scores are low (top ~53) — possibly the 1080p-trained model at 4K; re-run with
+`--vmaf-model vmaf_4k_v0.6.1` to confirm the absolute scale.

--- a/generate_abr/create_abr_ladder.sh
+++ b/generate_abr/create_abr_ladder.sh
@@ -65,6 +65,12 @@ Optional Arguments:
   --time <seconds>       Limit video duration (e.g., --time 30 for 30 seconds)
   --force-software       Force software encoding (default behavior)
   --force-hardware       Force hardware encoding via VideoToolbox (macOS)
+  --two-pass             Two-pass software encode (libx264/libx265). Pass 1
+                         profiles complexity; pass 2 distributes bits to hit the
+                         -b:v target accurately while the tight VBV still holds
+                         peaks flat. Fixes the single-pass x265 average undershoot
+                         under a small bufsize (~17% low on HEVC — see #868).
+                         Roughly doubles encode time. Ignored for hardware/AV1.
   --max-res <resolution> Limit maximum resolution tier encoded
                          Valid: 360p, 540p, 720p, 1080p, 1440p, 2160p
                          Example: --max-res 1080p (skips 1440p, 2160p)
@@ -143,6 +149,9 @@ Examples:
   
   # Force hardware encoding (VideoToolbox, macOS)
   $0 --input video.mp4 --force-hardware
+
+  # Two-pass HEVC for accurate average bitrate (honest AVERAGE-BANDWIDTH)
+  $0 --input video.mp4 --codec hevc --two-pass
   
   # Enable padding with black frames
   $0 --input video.mp4 --padding
@@ -194,6 +203,7 @@ CODEC_SELECTION_EXPLICIT=false
 TIME_LIMIT=""  # Optional duration limit in seconds
 FORCE_SOFTWARE=false  # Force software encoding (disables hardware)
 FORCE_HARDWARE=false  # Force hardware encoding (VideoToolbox)
+TWO_PASS=false        # Two-pass software encode (libx264/libx265) for accurate avg
 HLS_FORMAT="fmp4"  # fmp4, ts, both
 PAD_TO_SEGMENT_BOUNDARY=false  # Padding is disabled by default
 MAX_RESOLUTION_HEIGHT=""  # Optional max resolution limit (e.g., "1080p")
@@ -275,6 +285,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --force-hardware)
             FORCE_HARDWARE=true
+            shift
+            ;;
+        --two-pass)
+            TWO_PASS=true
             shift
             ;;
         --no-padding)
@@ -360,6 +374,12 @@ case "$LADDER" in
         exit 1
         ;;
 esac
+
+# Two-pass only applies to software libx264/libx265. Hardware VideoToolbox and
+# AV1 (libsvtav1) fall back to single pass; warn so the flag isn't assumed active.
+if [[ "$TWO_PASS" == "true" ]] && [[ "$FORCE_HARDWARE" == "true" ]]; then
+    echo "Warning: --two-pass is ignored under --force-hardware (VideoToolbox is single-pass); use software encoding for two-pass."
+fi
 
 # Validate required arguments
 if [[ "$RESUME_MODE" == "false" ]] && [[ -z "$INPUT_FILE" ]]; then
@@ -2115,6 +2135,57 @@ select_resolution_tiers() {
 # Phase 3: Encode Variants
 ################################################################################
 
+# Two-pass software encode for libx264/libx265 (#868). Single-pass x265 under a
+# tight 0.25x VBV bufsize undershoots the -b:v target by ~17% because it has no
+# buffer to bank bits for complex scenes, which sags the achieved average well
+# below the advertised AVERAGE-BANDWIDTH and packs the ladder rungs together.
+# Two-pass fixes this: pass 1 profiles scene complexity into a stats file (muxed
+# output discarded via -f null), pass 2 distributes bits to hit the average
+# accurately while the SAME maxrate/bufsize VBV keeps peaks flat. Relies on bash
+# dynamic scope to read encode_variant's locals (filter, bitrate_kbps,
+# bufsize_kbps, preset, output_file, label). Args: <vcodec> <params_key>
+# <base_params> <vtag>.
+encode_two_pass_sw() {
+    local vcodec="$1"       # libx265 | libx264
+    local params_key="$2"   # x265-params | x264-params
+    local base_params="$3"  # keyint=...:scenecut=0:open-gop=0[:pools=...]
+    local vtag="$4"         # hvc1 | avc1
+    local maxrate_k="$((bitrate_kbps * MAXRATE_PERCENT / 100))k"
+    local passlog="$TEMP_DIR/${codec}_${label}_2pass.log"
+
+    log "  Two-pass: pass 1/2 (complexity analysis, output discarded)"
+    ffmpeg -i "$MEZZANINE" \
+           -vf "$filter" \
+           -c:v "$vcodec" \
+           -b:v "${bitrate_kbps}k" \
+           -maxrate "$maxrate_k" \
+           -bufsize "${bufsize_kbps}k" \
+           -preset "$preset" \
+           -threads 0 \
+           "-${params_key}" "${base_params}:pass=1:stats=${passlog}" \
+           -pix_fmt yuv420p \
+           -an \
+           -f null - \
+           -loglevel warning -stats 2>&1 | tee -a "$LOG_FILE"
+
+    log "  Two-pass: pass 2/2 (final encode to target average)"
+    ffmpeg -i "$MEZZANINE" \
+           -vf "$filter" \
+           -c:v "$vcodec" \
+           -b:v "${bitrate_kbps}k" \
+           -maxrate "$maxrate_k" \
+           -bufsize "${bufsize_kbps}k" \
+           -preset "$preset" \
+           -threads 0 \
+           "-${params_key}" "${base_params}:pass=2:stats=${passlog}" \
+           -tag:v "$vtag" \
+           -pix_fmt yuv420p \
+           -an \
+           -movflags empty_moov+default_base_moof -frag_duration 1000000 \
+           "$output_file" \
+           -loglevel warning -stats 2>&1 | tee -a "$LOG_FILE"
+}
+
 encode_variant() {
     local codec=$1
     local width=$2
@@ -2346,8 +2417,13 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -movflags empty_moov+default_base_moof -frag_duration 1000000 \
                    "$output_file" \
                    -loglevel warning -stats 2>&1 | tee -a "$LOG_FILE"
+        elif [ "$TWO_PASS" = true ]; then
+            # libx265 software, two-pass (accurate average — see encode_two_pass_sw)
+            encode_two_pass_sw libx265 x265-params \
+                "keyint=${KEYINT}:min-keyint=${KEYINT}:scenecut=0:open-gop=0:pools=+:frame-threads=0" \
+                hvc1
         else
-            # libx265 software with bitrate control
+            # libx265 software with bitrate control (single pass)
             ffmpeg -i "$MEZZANINE" \
                    -vf "$filter" \
                    -c:v libx265 \
@@ -2382,8 +2458,13 @@ drawtext=fontfile='${FONT}':text='JEO':fontsize=${fontsize_label}:fontcolor=whit
                    -movflags empty_moov+default_base_moof -frag_duration 1000000 \
                    "$output_file" \
                    -loglevel warning -stats 2>&1 | tee -a "$LOG_FILE"
+        elif [ "$TWO_PASS" = true ]; then
+            # libx264 software, two-pass (accurate average — see encode_two_pass_sw)
+            encode_two_pass_sw libx264 x264-params \
+                "keyint=${KEYINT}:min-keyint=${KEYINT}:scenecut=0:open-gop=0" \
+                avc1
         else
-            # libx264 software with bitrate control
+            # libx264 software with bitrate control (single pass)
             ffmpeg -i "$MEZZANINE" \
                    -vf "$filter" \
                    -c:v libx264 \

--- a/generate_abr/ladder_audit.py
+++ b/generate_abr/ladder_audit.py
@@ -152,24 +152,72 @@ def measure(base, playlist_uri, n=MEASURE_SEGMENTS):
 
 
 # ---- VMAF (ffmpeg libvmaf) -------------------------------------------------
-def measure_vmaf(base, variant_uri, ref, ref_w, ref_h, subsample, full):
-    """Pooled VMAF (mean / harmonic_mean / min) of a variant vs the mezzanine."""
+def probe_resolution(path):
+    """(width, height) of a video file via ffprobe, or None on failure."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe:
+        return None
+    try:
+        r = subprocess.run(
+            [ffprobe, "-v", "error", "-select_streams", "v:0",
+             "-show_entries", "stream=width,height",
+             "-of", "csv=s=x:p=0", path],
+            capture_output=True, text=True, timeout=60)
+        w, h = r.stdout.strip().split("x")
+        return int(w), int(h)
+    except Exception:
+        return None
+
+
+def resolve_compare_res(spec, ref):
+    """Resolve a --vmaf-compare-res spec to (w, h) or None (== per-rung native).
+
+    spec: 'source' -> probe the mezzanine; 'native' -> None (each rung at its
+    own res, legacy behaviour); 'WxH' -> that fixed resolution.
+    """
+    if spec == "native":
+        return None
+    if spec == "source":
+        wh = probe_resolution(ref) if ref else None
+        if not wh:
+            raise SystemExit("--vmaf-compare-res source: could not probe reference resolution")
+        return wh
+    if "x" in spec:
+        w, h = spec.lower().split("x")
+        return int(w), int(h)
+    raise SystemExit(f"--vmaf-compare-res: expected 'source', 'native', or 'WxH' (got {spec!r})")
+
+
+def measure_vmaf(base, variant_uri, ref, cmp_w, cmp_h, subsample, full, model=None):
+    """Pooled VMAF (mean / harmonic_mean / min) of a variant vs the mezzanine.
+
+    Both the distorted variant AND the reference are scaled to the SAME
+    comparison resolution (cmp_w x cmp_h) before scoring. Passing a COMMON
+    comparison resolution for every rung (e.g. the source's native 4K) is what
+    makes VMAF comparable across the ladder: each rung is judged on how faithful
+    it is to the source at one fixed display resolution, so a higher-res rung
+    that preserves more detail legitimately scores higher. Scoring each rung at
+    its OWN native resolution instead (the pre-2026-07 default) compares every
+    rung against a different-difficulty target and produces false `inversion`
+    flags — a higher-res rung faces a harder reference, not a worse encode.
+    """
     ffmpeg = shutil.which("ffmpeg")
     if not ffmpeg:
         return {"error": "ffmpeg not on PATH"}
     src = resolve(base, variant_uri)
     sub = "" if full else f"n_subsample={subsample}:"
+    mdl = f"model=version={model}:" if model else ""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tf:
         log = tf.name
     try:
         # input 0 = distorted variant, input 1 = reference mezzanine. Normalise
-        # BOTH to the ref resolution + yuv420p + SAR 1 + reset PTS so libvmaf
-        # never hits a dimension/format/SAR/timebase mismatch (the upscaled rungs
-        # otherwise died with "-22 Invalid argument / no packets"). libvmaf wants
-        # [distorted][reference].
-        flt = (f"[0:v]scale={ref_w}:{ref_h}:flags=bicubic,format=yuv420p,setsar=1,setpts=PTS-STARTPTS[dist];"
-               f"[1:v]scale={ref_w}:{ref_h}:flags=bicubic,format=yuv420p,setsar=1,setpts=PTS-STARTPTS[ref];"
-               f"[dist][ref]libvmaf={sub}log_fmt=json:log_path={log}")
+        # BOTH to the comparison resolution + yuv420p + SAR 1 + reset PTS so
+        # libvmaf never hits a dimension/format/SAR/timebase mismatch (the
+        # upscaled rungs otherwise died with "-22 Invalid argument / no
+        # packets"). libvmaf wants [distorted][reference].
+        flt = (f"[0:v]scale={cmp_w}:{cmp_h}:flags=bicubic,format=yuv420p,setsar=1,setpts=PTS-STARTPTS[dist];"
+               f"[1:v]scale={cmp_w}:{cmp_h}:flags=bicubic,format=yuv420p,setsar=1,setpts=PTS-STARTPTS[ref];"
+               f"[dist][ref]libvmaf={mdl}{sub}log_fmt=json:log_path={log}")
         cmd = [ffmpeg, "-nostdin", "-hide_banner", "-i", src, "-i", ref,
                "-lavfi", flt, "-f", "null", "-"]
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
@@ -316,6 +364,14 @@ def main():
     ap.add_argument("--no-vmaf", action="store_true", help="skip VMAF even if --vmaf-ref given")
     ap.add_argument("--vmaf-full", action="store_true", help="VMAF every frame (no subsample)")
     ap.add_argument("--vmaf-subsample", type=int, default=VMAF_SUBSAMPLE)
+    ap.add_argument("--vmaf-compare-res", default="source",
+                    help="Common resolution to score every rung at: 'source' (probe "
+                         "the mezzanine, default — makes VMAF comparable across the "
+                         "ladder), 'native' (each rung at its own res, legacy — "
+                         "produces false inversion flags), or explicit 'WxH'.")
+    ap.add_argument("--vmaf-model", default=None,
+                    help="libvmaf model version (e.g. vmaf_4k_v0.6.1 for 4K-scored "
+                         "content). Default: ffmpeg's built-in 1080p model.")
     ap.add_argument("--segments", type=int, default=MEASURE_SEGMENTS)
     ap.add_argument("--json", action="store_true", help="print ladder_audit.json to stdout")
     ap.add_argument("--out", help="write ladder_audit.json here (default <dir>/ladder_audit.json for --dir)")
@@ -338,13 +394,20 @@ def main():
 
     # VMAF (encode-time only — needs the mezzanine; skip on live audits without a ref)
     do_vmaf = bool(args.vmaf_ref) and not args.no_vmaf
+    cmp_res = None
     if do_vmaf:
+        # Resolve a single COMMON comparison resolution for the whole ladder so
+        # VMAF is comparable across rungs (default: the source's native res).
+        # 'native' falls back to per-rung own-resolution scoring (legacy).
+        cmp_res = resolve_compare_res(args.vmaf_compare_res, args.vmaf_ref)
         for v in variants:
             wh = v["resolution"].split("x") if "x" in v["resolution"] else None
             if not wh:
                 continue
-            v["vmaf"] = measure_vmaf(base, v["uri"], args.vmaf_ref, wh[0], wh[1],
-                                     args.vmaf_subsample, args.vmaf_full)
+            cw, ch = cmp_res if cmp_res else (wh[0], wh[1])
+            v["vmaf"] = measure_vmaf(base, v["uri"], args.vmaf_ref, cw, ch,
+                                     args.vmaf_subsample, args.vmaf_full,
+                                     model=args.vmaf_model)
 
     variants.sort(key=lambda v: v["bw"])
     checks = run_checks(variants, (a_peak, a_avg))
@@ -360,6 +423,8 @@ def main():
         "source": base,
         "mode": "on-disk" if args.dir else "live",
         "vmaf": "subsampled" if (do_vmaf and not args.vmaf_full) else ("full" if do_vmaf else "off"),
+        "vmaf_compare_res": (f"{cmp_res[0]}x{cmp_res[1]}" if cmp_res else "native") if do_vmaf else None,
+        "vmaf_model": args.vmaf_model if do_vmaf else None,
         "audio_measured_bps": {"peak": round(a_peak), "avg": round(a_avg)},
         "variants": variants,
         "checks": checks,


### PR DESCRIPTION
Fixes #965.

Two independent fixes surfaced by the `insane_fpv` apple-uniq HEVC ladder investigation.

## 1. `create_abr_ladder.sh --two-pass`

Single-pass libx265 under the tight `BUFSIZE_MULT=0.25` VBV has no headroom to bank bits for complex scenes, so it undershoots `-b:v` by **12–18%** (worsening up the ladder). The achieved average sags below the advertised `AVERAGE-BANDWIDTH`, so avg-keyed ABR players over-select and rungs overlap.

New opt-in `--two-pass` runs a two-pass software encode (libx264/libx265): pass 1 profiles complexity to a stats file (`-f null`, discarded), pass 2 hits the target average while the same `maxrate`/`bufsize` VBV keeps peaks flat. Hardware VideoToolbox / AV1 stay single-pass with a warning. Default single-pass path is byte-for-byte unchanged.

## 2. `ladder_audit.py --vmaf-compare-res`

VMAF was scored at each rung's **own native resolution** (both distorted + reference downscaled to the variant's res), comparing every rung against a different-difficulty target — a higher-res rung faces a more-detailed reference and scores lower even at equal on-screen quality, producing **false `vmaf_inversion` flags**.

Now scores every rung at ONE common comparison resolution. New `--vmaf-compare-res` (default `source` = probe the mezzanine; `native` = legacy; or `WxH`) and `--vmaf-model` (e.g. `vmaf_4k_v0.6.1`); records `vmaf_compare_res` / `vmaf_model` in the audit JSON.

## Validation (full 4K apple-uniq HEVC ladder, 12 rungs)

| | single-pass / native | two-pass / common-res |
|---|---|---|
| `avg_accuracy` fails | 10 | **0** |
| avg undershoot | −4% → −18% | **flat −3 to −7%** |
| measured overlap pairs | 7 | **1** |
| VMAF inversions | 3 | **0** (common-res) |

Conclusion: the inversions were a measurement artifact — 1044p/1440p/2124p are **not** wasteful and should not be dropped on VMAF grounds. Remaining `tight_spacing` findings are separate (bitrate spacing) and out of scope.

## Test plan

- `bash -n create_abr_ladder.sh` clean; `--two-pass` smoke-tested end-to-end (valid `hvc1` fMP4, stats file written) and run on the full 4K ladder.
- `ladder_audit.py` re-scored the two-pass ladder at common 4K with both the default and `vmaf_4k_v0.6.1` models; monotonic, zero inversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
