### PR TITLE
chore: add GitHub Sponsors button and README coffee badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Renders the "Sponsor" button at the top of the repo page.
+# GitHub only reads this file from the default branch.
+github: [jonathaneoliver]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/license-InfiniteStream-lightgrey)](LICENSE)
 [![GHCR](https://img.shields.io/badge/ghcr.io-infinite--streaming-2496ED?logo=docker&logoColor=white)](https://github.com/jonathaneoliver/infinite-streaming/pkgs/container/infinite-streaming)
 [![Stars](https://img.shields.io/github/stars/jonathaneoliver/infinite-streaming?style=flat&color=yellow)](https://github.com/jonathaneoliver/infinite-streaming/stargazers)
+[![Sponsor](https://img.shields.io/badge/%E2%98%95%20send%20me%20a%20coffee-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/jonathaneoliver)
 
 A Docker-based HLS/DASH test server for video players. Generates LL-HLS and LL-DASH streams (plus 2s and 6s segment variants) from short VOD content on a shared clock, and lets you inject deterministic, streaming-aware failures — HTTP errors, hung responses, corrupted segments, transport drops, bandwidth limits — on a per-session basis so player bugs become reproducible.
 


### PR DESCRIPTION
Adds a "send me a coffee" affordance to the GitHub project page.

- `.github/FUNDING.yml` — renders GitHub's native **Sponsor** button in the repo header.
- `README.md` — one shields.io badge appended to the existing badge row, after Stars.

Both point at `https://github.com/sponsors/jonathaneoliver`, which is a live listing (`hasSponsorsListing: true`) — the link resolves 200, not a 404 placeholder. The badge image URL was also checked (200 SVG).

**Note:** GitHub only reads `FUNDING.yml` from the default branch, so an identical PR goes to `main` — this one alone won't make the button appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
