### PR TITLE
chore: add GitHub Sponsors button and README coffee badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Renders the "Sponsor" button at the top of the repo page.
+# GitHub only reads this file from the default branch.
+github: [jonathaneoliver]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/license-InfiniteStream-lightgrey)](LICENSE)
 [![GHCR](https://img.shields.io/badge/ghcr.io-infinite--streaming-2496ED?logo=docker&logoColor=white)](https://github.com/jonathaneoliver/infinite-streaming/pkgs/container/infinite-streaming)
 [![Stars](https://img.shields.io/github/stars/jonathaneoliver/infinite-streaming?style=flat&color=yellow)](https://github.com/jonathaneoliver/infinite-streaming/stargazers)
+[![Sponsor](https://img.shields.io/badge/%E2%98%95%20send%20me%20a%20coffee-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/jonathaneoliver)
 
 A Docker-based HLS/DASH test server for video players. Generates LL-HLS and LL-DASH streams (plus 2s and 6s segment variants) from short VOD content on a shared clock, and lets you inject deterministic, streaming-aware failures — HTTP errors, hung responses, corrupted segments, transport drops, bandwidth limits — on a per-session basis so player bugs become reproducible.
 


### PR DESCRIPTION
Same change as #976 (which targets `dev`), cherry-picked onto `main`.

- `.github/FUNDING.yml` — renders GitHub's native **Sponsor** button in the repo header.
- `README.md` — one shields.io badge appended to the existing badge row, after Stars.

This is the PR that actually makes the button appear: GitHub reads `FUNDING.yml` only from the default branch, and renders `main`'s README on the repo landing page. #976 exists so the change isn't lost the next time `dev` merges forward.

Both point at `https://github.com/sponsors/jonathaneoliver`, a live listing (`hasSponsorsListing: true`) — link and badge image both verified 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
