### PR TITLE
fix(dash): read fragment byte-ranges from the manifest, not .byteranges sidecars (#986)

### DIFF
--- a/go-live/internal/api/handlers.go
+++ b/go-live/internal/api/handlers.go
@@ -1225,6 +1225,10 @@ func (h *Handler) OnDemandDashManifest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if rejectPinnedVariant(w, content, variant, duration, llMode) {
+		return
+	}
+
 	mpdRelPath := filepath.Clean(filepath.Join(content, mpdPathForLoad))
 	mpdData, err := dash.LoadMPD(infiniteOutputDir, mpdRelPath)
 	if err != nil {
@@ -1580,6 +1584,10 @@ func (h *Handler) OnDemandMasterPlaylistDuration(w http.ResponseWriter, r *http.
 	prefix := routePrefix(r.URL.Path)
 	mode := "hls-" + duration
 
+	if rejectPinnedDurationLabel(w, content, duration) {
+		return
+	}
+
 	inputPath := filepath.Join(infiniteOutputDir, content, "master.m3u8")
 	if _, err := os.Stat(inputPath); os.IsNotExist(err) {
 		http.Error(w, fmt.Sprintf("Content not found: %s", content), http.StatusNotFound)
@@ -1705,6 +1713,11 @@ func (h *Handler) OnDemandVariantPlaylistDuration(w http.ResponseWriter, r *http
 	duration := vars["duration"]
 	variant := vars["variant"]
 	prefix := routePrefix(r.URL.Path)
+
+	if rejectPinnedDurationLabel(w, content, duration) {
+		return
+	}
+
 	inputPath := filepath.Join(infiniteOutputDir, content, "master.m3u8")
 	worker := ensureHLSWorker(h, content, inputPath, prefix)
 	if worker != nil {

--- a/go-live/internal/api/segment_pin.go
+++ b/go-live/internal/api/segment_pin.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+)
+
+// segmentPinPattern matches a trailing `_1s` / `_2s` / `_6s` on a content name.
+//
+// Such a clip is encoded natively at that one segment length and is served only
+// at it — we do not repackage it into the other lengths. `_xs` (and an
+// unsuffixed name) carries no pin and keeps the normal repackaging behaviour,
+// where a single source is recomposed into 1s/2s/6s and LL.
+//
+// Mirrored in go-upload/internal/util/content.go: these are separate Go modules
+// with no shared package, so the rule is stated in both. The catalogue there
+// must not advertise a length this file will refuse.
+var segmentPinPattern = regexp.MustCompile(`(?i)_(1|2|6)s$`)
+
+// segmentPin returns the segment length a content name is pinned to, or 0 when
+// it carries no pin.
+func segmentPin(content string) int {
+	m := segmentPinPattern.FindStringSubmatch(content)
+	if m == nil {
+		return 0
+	}
+	switch m[1] {
+	case "1":
+		return 1
+	case "2":
+		return 2
+	case "6":
+		return 6
+	}
+	return 0
+}
+
+// rejectPinnedVariant reports whether a request for `duration` on `content`
+// should be refused, writing a 404 naming the pin when so.
+//
+// A pinned clip serves exactly one segment length. Quietly serving its native
+// length under another name would hand a caller data that is not what it asked
+// for — the same silent-wrong-answer failure the DASH byte-range path used to
+// have — so an explicit 404 is the safer contract. LL is exempt: it is
+// partial-segment availability rather than a segment length, and a natively
+// encoded clip carrying partials can still be served low-latency.
+func rejectPinnedVariant(w http.ResponseWriter, content, variant string, duration int, llMode bool) bool {
+	pin := segmentPin(content)
+	if pin == 0 || llMode || variant == "ll" {
+		return false
+	}
+	if duration == pin {
+		return false
+	}
+	msg := fmt.Sprintf(
+		"%s is pinned to %ds segments and is not repackaged; requested %s. Available: %ds and LL.",
+		content, pin, variant, pin,
+	)
+	logf("[GO-LIVE][PIN] refused content=%s pin=%ds requested=%s\n", content, pin, variant)
+	http.Error(w, msg, http.StatusNotFound)
+	return true
+}
+
+// rejectPinnedDurationLabel is the HLS-route form of rejectPinnedVariant, where
+// the duration arrives as the path label "1s" / "2s" / "6s". These routes never
+// carry LL, which has its own unsuffixed route.
+func rejectPinnedDurationLabel(w http.ResponseWriter, content, label string) bool {
+	var duration int
+	switch label {
+	case "1s":
+		duration = 1
+	case "2s":
+		duration = 2
+	case "6s":
+		duration = 6
+	default:
+		return false
+	}
+	return rejectPinnedVariant(w, content, label, duration, false)
+}

--- a/go-live/internal/api/segment_pin_test.go
+++ b/go-live/internal/api/segment_pin_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSegmentPin(t *testing.T) {
+	cases := []struct {
+		name string
+		want int
+	}{
+		// Pinned: natively encoded at one length, never repackaged.
+		{"fpv_p200_h264_1s", 1},
+		{"fpv_p200_h264_2s", 2},
+		{"fpv_p200_h264_6s", 6},
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264_6s", 6},
+
+		// _xs is the repackaging source, not a pin.
+		{"fpv_p200_h264_xs", 0},
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264_xs", 0},
+
+		// Unsuffixed legacy content keeps repackaging.
+		{"bucks_bunny_p200_h264", 0},
+		{"redbull_p200_av1", 0},
+
+		// A double underscore still ends in _6s and is treated as pinned —
+		// the name that prompted the rename, kept here so the behaviour is
+		// pinned down rather than accidental.
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264__6s", 6},
+
+		// Only 1/2/6 are real variants; nothing else is a pin.
+		{"clip_p200_h264_3s", 0},
+		{"clip_p200_h264_10s", 0},
+		{"clip_p200_h264_0s", 0},
+
+		// The marker must be a suffix. A mid-name _6s is part of the title.
+		{"fpv_6s_p200_h264", 0},
+		{"my_2s_clip_p200_h264", 0},
+
+		// Case-insensitive, matching the codec pattern's behaviour.
+		{"clip_p200_h264_6S", 6},
+
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := segmentPin(c.name); got != c.want {
+			t.Errorf("segmentPin(%q) = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRejectPinnedVariant(t *testing.T) {
+	cases := []struct {
+		desc       string
+		content    string
+		variant    string
+		duration   int
+		llMode     bool
+		wantReject bool
+	}{
+		{"pinned clip asked for its own length", "fpv_p200_h264_1s", "1s", 1, false, false},
+		{"pinned clip asked for another length", "fpv_p200_h264_1s", "2s", 2, false, true},
+		{"pinned 6s asked for 1s", "fpv_p200_h264_6s", "1s", 1, false, true},
+
+		// LL is partial-segment availability, not a segment length, so a pin
+		// must not suppress it.
+		{"pinned clip asked for LL", "fpv_p200_h264_1s", "ll", 6, true, false},
+		{"pinned clip LL by variant name", "fpv_p200_h264_6s", "ll", 6, false, false},
+
+		// Unpinned content is never refused.
+		{"xs clip asked for 2s", "fpv_p200_h264_xs", "2s", 2, false, false},
+		{"legacy clip asked for 1s", "bucks_bunny_p200_h264", "1s", 1, false, false},
+	}
+
+	for _, c := range cases {
+		w := httptest.NewRecorder()
+		got := rejectPinnedVariant(w, c.content, c.variant, c.duration, c.llMode)
+		if got != c.wantReject {
+			t.Errorf("%s: rejectPinnedVariant = %v, want %v", c.desc, got, c.wantReject)
+			continue
+		}
+		if c.wantReject {
+			if w.Code != http.StatusNotFound {
+				t.Errorf("%s: status = %d, want 404", c.desc, w.Code)
+			}
+			// The reason must name the clip and its pin, or the 404 is
+			// indistinguishable from "content not found".
+			body := w.Body.String()
+			if !contains(body, c.content) || !contains(body, "pinned") {
+				t.Errorf("%s: body %q does not explain the pin", c.desc, body)
+			}
+		} else if w.Code != http.StatusOK {
+			t.Errorf("%s: wrote status %d when it should not have responded", c.desc, w.Code)
+		}
+	}
+}
+
+func TestRejectPinnedDurationLabel(t *testing.T) {
+	cases := []struct {
+		content    string
+		label      string
+		wantReject bool
+	}{
+		{"fpv_p200_h264_2s", "2s", false},
+		{"fpv_p200_h264_2s", "6s", true},
+		{"fpv_p200_h264_xs", "6s", false},
+		{"bucks_bunny_p200_h264", "1s", false},
+		// An unrecognised label is not this guard's business.
+		{"fpv_p200_h264_2s", "banana", false},
+	}
+	for _, c := range cases {
+		w := httptest.NewRecorder()
+		if got := rejectPinnedDurationLabel(w, c.content, c.label); got != c.wantReject {
+			t.Errorf("rejectPinnedDurationLabel(%q, %q) = %v, want %v", c.content, c.label, got, c.wantReject)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(h, n string) int {
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}

--- a/go-live/pkg/dash/fragmented_mpd.go
+++ b/go-live/pkg/dash/fragmented_mpd.go
@@ -1,0 +1,345 @@
+package dash
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/beevik/etree"
+)
+
+// fragmentedMPDName is the sibling manifest the encoder emits alongside
+// manifest.mpd. It describes the same content at fragment granularity: one
+// <SegmentURL> per fragment carrying @mediaRange, rather than one per segment.
+const fragmentedMPDName = "manifest_fragmented.mpd"
+
+// segmentMPDName is the manifest go-live always loads, whatever granularity it
+// turns out to be written at. Granularity is detected from content — whether
+// its <SegmentURL> entries carry @mediaRange — never from the filename, so one
+// name serves both shapes and the serving path needs no special case.
+const segmentMPDName = "manifest.mpd"
+
+// fragmentRanges maps a segment's @media value (as it appears in manifest.mpd,
+// e.g. "1080p/segment_00001.m4s") to that segment's fragments in playback order.
+type fragmentRanges map[string][]byterangePayloadFragment
+
+var (
+	fragmentedCacheMu sync.RWMutex
+	// fragmentedCache holds one parsed fragmented MPD per content directory. A
+	// nil value is a negative result: we looked and there was nothing usable, so
+	// don't re-read the file on every segment of every request.
+	fragmentedCache = make(map[string]fragmentRanges)
+
+	// noRangeSourceWarned keeps the "no fragment data at all" warning to one line
+	// per content instead of one per segment per manifest generation.
+	noRangeSourceWarned sync.Map
+)
+
+// normalizeFragmentedMPD collapses a fragment-granularity MPD in place to the
+// segment-granularity form the rest of this package expects, returning the
+// fragment byte-ranges it stripped out.
+//
+// This is the DASH equivalent of what the HLS side gets for free. A
+// playlist.m3u8 marks both levels explicitly — EXTINF for segments,
+// EXT-X-PART for fragments — so one file drives every variant. A fragmented
+// MPD marks only the fragment level; segment boundaries are implicit in which
+// @media each <SegmentURL> points at. Grouping by @media recovers them exactly,
+// after which manifest_fragmented.mpd carries everything manifest.mpd does and
+// go-live can generate 1s/2s/6s/LL from the single file.
+//
+// Returns (nil, false) when the document is already segment-granularity, so
+// legacy content flows through untouched.
+func normalizeFragmentedMPD(root *etree.Element) (fragmentRanges, bool) {
+	ranges := make(fragmentRanges)
+	collapsed := false
+
+	for _, rep := range findAllByLocal(root, "Representation") {
+		segList := findFirstByLocal(rep, "SegmentList")
+		if segList == nil {
+			continue
+		}
+		urls := findAllByLocal(segList, "SegmentURL")
+		if len(urls) == 0 || !anyHasMediaRange(urls) {
+			// Already segment-granularity — nothing to collapse.
+			continue
+		}
+
+		timeline := findFirstByLocal(segList, "SegmentTimeline")
+		durations := expandTimelineDurations(timeline)
+		if timeline != nil && len(durations) != len(urls) {
+			// The timeline and the URL list disagree about how many fragments
+			// exist. Collapsing on a guess would silently shift every segment
+			// boundary, so leave this representation alone and let the caller
+			// fall back to the segment-granularity manifest.
+			fmt.Fprintf(os.Stderr,
+				"WARN: representation %q has %d SegmentURL entries but %d timeline entries; not collapsing\n",
+				rep.SelectAttrValue("id", "?"), len(urls), len(durations))
+			return nil, false
+		}
+
+		groups := groupFragmentsByMedia(urls, durations)
+		if len(groups) == 0 {
+			continue
+		}
+		for _, g := range groups {
+			if len(g.fragments) > 0 {
+				ranges[g.media] = append(ranges[g.media], g.fragments...)
+			}
+		}
+		rewriteSegmentList(segList, timeline, groups)
+		collapsed = true
+	}
+
+	if !collapsed {
+		return nil, false
+	}
+	return ranges, true
+}
+
+// mediaGroup is the set of consecutive fragments belonging to one segment file.
+type mediaGroup struct {
+	media         string
+	durationTicks int64
+	fragments     []byterangePayloadFragment
+}
+
+func anyHasMediaRange(urls []*etree.Element) bool {
+	for _, u := range urls {
+		if u.SelectAttrValue("mediaRange", "") != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// expandTimelineDurations flattens <S d=... r=.../> runs into one duration per
+// entry, matching the order of the SegmentURL list.
+func expandTimelineDurations(timeline *etree.Element) []int64 {
+	if timeline == nil {
+		return nil
+	}
+	var out []int64
+	for _, s := range findAllByLocal(timeline, "S") {
+		d := parseInt64(s.SelectAttrValue("d", "0"), 0)
+		for i := int64(0); i <= parseInt64(s.SelectAttrValue("r", "0"), 0); i++ {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// groupFragmentsByMedia walks the fragment list in document order and starts a
+// new group each time @media changes. Document order is playback order, so
+// consecutive runs are exactly the segments.
+func groupFragmentsByMedia(urls []*etree.Element, durations []int64) []mediaGroup {
+	var groups []mediaGroup
+	for i, u := range urls {
+		media := normalizeMediaKey(u.SelectAttrValue("media", ""))
+		if media == "" {
+			continue
+		}
+		if len(groups) == 0 || groups[len(groups)-1].media != media {
+			groups = append(groups, mediaGroup{media: media})
+		}
+		g := &groups[len(groups)-1]
+		if i < len(durations) {
+			g.durationTicks += durations[i]
+		}
+		if mr := u.SelectAttrValue("mediaRange", ""); mr != "" {
+			if offset, length, err := parseMediaRange(mr); err == nil {
+				g.fragments = append(g.fragments, byterangePayloadFragment{
+					Offset: offset,
+					Length: length,
+				})
+			}
+		}
+	}
+	return groups
+}
+
+// rewriteSegmentList replaces the fragment-level SegmentURL and SegmentTimeline
+// children with their segment-level equivalents, producing the same shape the
+// encoder writes into manifest.mpd.
+func rewriteSegmentList(segList, timeline *etree.Element, groups []mediaGroup) {
+	for _, u := range findAllByLocal(segList, "SegmentURL") {
+		if parent := u.Parent(); parent != nil {
+			parent.RemoveChild(u)
+		}
+	}
+	for _, g := range groups {
+		segURL := segList.CreateElement("SegmentURL")
+		segURL.CreateAttr("media", g.media)
+	}
+
+	if timeline == nil {
+		return
+	}
+	for _, s := range findAllByLocal(timeline, "S") {
+		if parent := s.Parent(); parent != nil {
+			parent.RemoveChild(s)
+		}
+	}
+	// Run-length encode equal-duration runs, and stamp @t on the first entry,
+	// exactly as a segment-granularity manifest would.
+	start := int64(0)
+	for i := 0; i < len(groups); {
+		j := i
+		for j+1 < len(groups) && groups[j+1].durationTicks == groups[i].durationTicks {
+			j++
+		}
+		s := timeline.CreateElement("S")
+		if i == 0 {
+			s.CreateAttr("t", strconv.FormatInt(start, 10))
+		}
+		s.CreateAttr("d", strconv.FormatInt(groups[i].durationTicks, 10))
+		if j > i {
+			s.CreateAttr("r", strconv.Itoa(j-i))
+		}
+		for k := i; k <= j; k++ {
+			start += groups[k].durationTicks
+		}
+		i = j + 1
+	}
+}
+
+// loadFragmentedRanges returns the fragment byte-ranges declared in the
+// manifest_fragmented.mpd sitting next to mpdPath, or nil if that file is
+// absent or carries no usable ranges.
+//
+// This is the preferred source of fragment byte-ranges. The per-segment
+// .byteranges JSON sidecars carry the same offsets and lengths, but the encoder
+// is dropping them now that the manifests are self-describing.
+func loadFragmentedRanges(mpdPath string) fragmentRanges {
+	dir := filepath.Dir(mpdPath)
+
+	fragmentedCacheMu.RLock()
+	cached, ok := fragmentedCache[dir]
+	fragmentedCacheMu.RUnlock()
+	if ok {
+		return cached
+	}
+
+	ranges := parseFragmentedMPD(filepath.Join(dir, fragmentedMPDName))
+
+	fragmentedCacheMu.Lock()
+	fragmentedCache[dir] = ranges
+	fragmentedCacheMu.Unlock()
+
+	return ranges
+}
+
+// parseFragmentedMPD reads a fragmented MPD and groups its <SegmentURL>
+// entries by @media, preserving document order within each segment.
+//
+// @mediaRange is an inclusive byte range ("first-last"), so a fragment's length
+// is last-first+1. That matches what the .byteranges sidecars report: the first
+// fragment of a segment starts at 432, not 0, because the leading bytes are the
+// segment's own styp/sidx header and belong to no fragment.
+func parseFragmentedMPD(path string) fragmentRanges {
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(path); err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: %s is unreadable, falling back to .byteranges sidecars: %v\n", path, err)
+		return nil
+	}
+	root := doc.Root()
+	if root == nil {
+		fmt.Fprintf(os.Stderr, "WARN: %s has no root element, falling back to .byteranges sidecars\n", path)
+		return nil
+	}
+
+	ranges := make(fragmentRanges)
+	skipped := 0
+	for _, segURL := range findAllByLocal(root, "SegmentURL") {
+		media := segURL.SelectAttrValue("media", "")
+		mediaRange := segURL.SelectAttrValue("mediaRange", "")
+		if media == "" || mediaRange == "" {
+			// A fragmented MPD should carry a range on every entry. One without
+			// is either a segment-granularity manifest handed to us by mistake
+			// or a malformed entry; either way there's nothing to take from it.
+			skipped++
+			continue
+		}
+		offset, length, err := parseMediaRange(mediaRange)
+		if err != nil {
+			skipped++
+			continue
+		}
+		key := normalizeMediaKey(media)
+		ranges[key] = append(ranges[key], byterangePayloadFragment{
+			Offset: offset,
+			Length: length,
+			// @mediaRange carries no independence flag. Nothing in this package
+			// reads Independent — only the HLS side needs it, and it takes it
+			// from #EXT-X-PART's INDEPENDENT attribute.
+		})
+	}
+
+	if len(ranges) == 0 {
+		fmt.Fprintf(os.Stderr, "WARN: %s declares no fragment ranges, falling back to .byteranges sidecars\n", path)
+		return nil
+	}
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "WARN: %s: skipped %d SegmentURL entries without a usable @mediaRange\n", path, skipped)
+	}
+
+	fragmentCount := 0
+	for _, frags := range ranges {
+		fragmentCount += len(frags)
+	}
+	fmt.Fprintf(os.Stderr, "INFO: loaded %d fragment ranges across %d segments from %s\n",
+		fragmentCount, len(ranges), path)
+
+	return ranges
+}
+
+// parseMediaRange converts an inclusive "first-last" byte range into the
+// offset/length pair the rest of this package works in.
+func parseMediaRange(mediaRange string) (int64, int64, error) {
+	first, last, found := strings.Cut(mediaRange, "-")
+	if !found {
+		return 0, 0, fmt.Errorf("mediaRange %q is not a range", mediaRange)
+	}
+	start, err := strconv.ParseInt(strings.TrimSpace(first), 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("mediaRange %q has an unparseable start: %w", mediaRange, err)
+	}
+	end, err := strconv.ParseInt(strings.TrimSpace(last), 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("mediaRange %q has an unparseable end: %w", mediaRange, err)
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("mediaRange %q ends before it starts", mediaRange)
+	}
+	return start, end - start + 1, nil
+}
+
+// normalizeMediaKey strips the leading slash that @media values sometimes
+// carry, so lookups match however the calling manifest spelled the path. This
+// mirrors how the sidecar path is resolved from @media.
+func normalizeMediaKey(media string) string {
+	return strings.TrimPrefix(media, "/")
+}
+
+// warnNoRangeSource reports, once per content, that neither the fragmented MPD
+// nor the .byteranges sidecars could supply fragment ranges.
+//
+// This case is worth a log line because it is not a failure the caller sees:
+// callers fall back to whole-segment granularity, so DASH partials silently
+// stop existing while the manifests still look well-formed.
+func warnNoRangeSource(mpdPath string) {
+	dir := filepath.Dir(mpdPath)
+	if _, loaded := noRangeSourceWarned.LoadOrStore(dir, true); loaded {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"WARN: no fragment byte-ranges for %s — neither %s nor .byteranges sidecars are usable; "+
+			"DASH partials are unavailable and manifests will fall back to whole-segment granularity\n",
+		dir, fragmentedMPDName)
+}

--- a/go-live/pkg/dash/fragmented_mpd_real_test.go
+++ b/go-live/pkg/dash/fragmented_mpd_real_test.go
@@ -1,0 +1,152 @@
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/beevik/etree"
+)
+
+// realFragmentedMPD locates a real encoder-produced manifest to test against.
+//
+// The unit tests above run on hand-written fixtures, which prove the collapse
+// logic but not that it matches what the encoder ACTUALLY writes — the two
+// drifted once already (the encoder stopped emitting a second
+// manifest_fragmented.mpd and started rewriting manifest.mpd in place, #282),
+// and a fixture would never have noticed.
+//
+// Set DASH_REAL_MPD to point at a package directory, or leave it unset to use
+// the default staging path. Skips when neither is present, so this stays a
+// local-only check and never fails CI on a box without the volume mounted.
+func realFragmentedMPD(t *testing.T) string {
+	t.Helper()
+	dir := os.Getenv("DASH_REAL_MPD")
+	if dir == "" {
+		dir = "/Volumes/4TB/media/encode-staging/insane_fpv_shots_hydrofoil_windsurfing_p200_h264_xs"
+	}
+	path := filepath.Join(dir, "manifest.mpd")
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("no real encoder manifest at %s (set DASH_REAL_MPD to override)", path)
+	}
+	return path
+}
+
+// The acceptance case for #986: real encoder output, fragment-granularity
+// manifest.mpd, and NO .byteranges sidecars anywhere in the package.
+func TestRealEncoderManifestHasNoSidecars(t *testing.T) {
+	path := realFragmentedMPD(t)
+	dir := filepath.Dir(path)
+
+	var sidecars int
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() && filepath.Ext(p) == ".byteranges" {
+			sidecars++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if sidecars != 0 {
+		t.Fatalf("expected a sidecar-free package, found %d .byteranges files", sidecars)
+	}
+	t.Logf("package is sidecar-free: %s", dir)
+}
+
+// Collapsing the real manifest must recover segment granularity AND the
+// fragment ranges, with the segment timeline reconstructed exactly. The encoder
+// splits a segment's duration across its fragments with divmod (remainder to
+// the leading fragments); summing them back must return the original.
+func TestRealEncoderManifestCollapses(t *testing.T) {
+	path := realFragmentedMPD(t)
+
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(path); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	root := doc.Root()
+	if root == nil {
+		t.Fatal("no root element")
+	}
+
+	// Capture the pre-collapse shape so the assertions below are about THIS
+	// file rather than an assumed one.
+	fragURLs := 0
+	for _, rep := range findAllByLocal(root, "Representation") {
+		if sl := findFirstByLocal(rep, "SegmentList"); sl != nil {
+			fragURLs += len(findAllByLocal(sl, "SegmentURL"))
+		}
+	}
+	if fragURLs == 0 {
+		t.Fatal("no SegmentURL entries — not a SegmentList manifest")
+	}
+
+	ranges, collapsed := normalizeFragmentedMPD(root)
+	if !collapsed {
+		t.Fatal("real encoder manifest was not recognised as fragment-granularity")
+	}
+	if len(ranges) == 0 {
+		t.Fatal("collapse recovered no fragment ranges")
+	}
+
+	segURLs := 0
+	for _, rep := range findAllByLocal(root, "Representation") {
+		sl := findFirstByLocal(rep, "SegmentList")
+		if sl == nil {
+			continue
+		}
+		urls := findAllByLocal(sl, "SegmentURL")
+		segURLs += len(urls)
+
+		// Post-collapse, no SegmentURL may carry a range: the document must be
+		// indistinguishable from an unexpanded manifest.mpd.
+		for _, u := range urls {
+			if mr := u.SelectAttrValue("mediaRange", ""); mr != "" {
+				t.Fatalf("collapsed manifest still carries mediaRange %q", mr)
+			}
+		}
+
+		// The rebuilt timeline must describe exactly as many segments as there
+		// are SegmentURL entries, or every downstream boundary shifts.
+		tl := findFirstByLocal(sl, "SegmentTimeline")
+		if tl == nil {
+			continue
+		}
+		if got := len(expandTimelineDurations(tl)); got != len(urls) {
+			t.Fatalf("rebuilt timeline has %d entries for %d segments", got, len(urls))
+		}
+	}
+
+	if segURLs >= fragURLs {
+		t.Fatalf("collapse did not reduce entries: %d segments from %d fragments", segURLs, fragURLs)
+	}
+
+	// Within a segment, fragments must be contiguous and ascending — that is
+	// what makes a regrouped 1s/2s variant a valid byte-range request.
+	checked := 0
+	for media, frags := range ranges {
+		for i, f := range frags {
+			if f.Length <= 0 {
+				t.Fatalf("%s fragment %d has non-positive length %d", media, i, f.Length)
+			}
+			if i > 0 {
+				prev := frags[i-1]
+				if got, want := f.Offset, prev.Offset+prev.Length; got != want {
+					t.Fatalf("%s fragment %d starts at %d, expected %d (contiguous)", media, i, got, want)
+				}
+			}
+		}
+		checked += len(frags)
+	}
+
+	t.Logf("collapsed %d fragments across %d segments in %d media entries",
+		fragURLs, segURLs, len(ranges))
+	if checked != fragURLs {
+		t.Logf("note: %d ranges recovered from %d SegmentURL entries "+
+			"(entries without @mediaRange are expected for un-fragmented segments)", checked, fragURLs)
+	}
+}

--- a/go-live/pkg/dash/fragmented_mpd_test.go
+++ b/go-live/pkg/dash/fragmented_mpd_test.go
@@ -1,0 +1,316 @@
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Ranges lifted from the encoder sample
+// insane_fpv_shots_hydrofoil_windsurfing_p200_h264_xs, 1080p/segment_00001.m4s.
+// The MPD spells them as inclusive @mediaRange; the sidecar spells the same
+// fragments as offset/length. Keeping both here is the point of the parity test.
+//
+// Three fragments for segment 1, one for segment 2, so grouping by @media has
+// something to get wrong.
+const sampleFragmentedMPD = `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT12S">
+  <Period id="0">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" bandwidth="6779837">
+        <SegmentList timescale="30000">
+          <Initialization sourceURL="1080p/init.mp4"/>
+          <SegmentTimeline>
+            <S t="0" d="6006" r="2"/>
+            <S d="18018"/>
+          </SegmentTimeline>
+          <SegmentURL media="1080p/segment_00001.m4s" mediaRange="432-150105"/>
+          <SegmentURL media="1080p/segment_00001.m4s" mediaRange="150106-240493"/>
+          <SegmentURL media="1080p/segment_00001.m4s" mediaRange="240494-434605"/>
+          <SegmentURL media="1080p/segment_00002.m4s" mediaRange="432-67505"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`
+
+// The segment-granularity equivalent of the document above: two segments, the
+// first 3*6006 ticks, the second 18018. This is what the encoder writes into
+// manifest.mpd, and what collapsing the fragmented file must reproduce.
+const sampleSegmentMPD = `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT12S">
+  <Period id="0">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" bandwidth="6779837">
+        <SegmentList timescale="30000">
+          <Initialization sourceURL="1080p/init.mp4"/>
+          <SegmentTimeline>
+            <S t="0" d="18018" r="1"/>
+          </SegmentTimeline>
+          <SegmentURL media="1080p/segment_00001.m4s"/>
+          <SegmentURL media="1080p/segment_00002.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>`
+
+const sampleSidecar = `{
+  "fragments": [
+    {"offset": 432, "length": 149674, "independent": true},
+    {"offset": 150106, "length": 90388, "independent": false},
+    {"offset": 240494, "length": 194112, "independent": false}
+  ]
+}`
+
+// writeContent lays out a content directory and loads the named manifest the
+// way production does, so the tests exercise the real load path.
+func loadContent(t *testing.T, name, manifest, sidecar string) *MPDData {
+	t.Helper()
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+	if sidecar != "" {
+		if err := os.MkdirAll(filepath.Join(dir, "1080p"), 0o755); err != nil {
+			t.Fatalf("creating rung dir: %v", err)
+		}
+		p := filepath.Join(dir, "1080p", "segment_00001.m4s.byteranges")
+		if err := os.WriteFile(p, []byte(sidecar), 0o644); err != nil {
+			t.Fatalf("writing sidecar: %v", err)
+		}
+	}
+
+	data, err := LoadMPD(dir, name)
+	if err != nil {
+		t.Fatalf("LoadMPD(%s): %v", name, err)
+	}
+	return data
+}
+
+func TestParseMediaRangeIsInclusive(t *testing.T) {
+	// 432-150105 is 149674 bytes, not 149673: @mediaRange includes both ends.
+	offset, length, err := parseMediaRange("432-150105")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if offset != 432 {
+		t.Errorf("offset = %d, want 432", offset)
+	}
+	if length != 149674 {
+		t.Errorf("length = %d, want 149674 (inclusive range)", length)
+	}
+}
+
+func TestParseMediaRangeRejectsMalformed(t *testing.T) {
+	for _, in := range []string{"", "432", "abc-def", "150105-432", "-", "432-"} {
+		if _, _, err := parseMediaRange(in); err == nil {
+			t.Errorf("parseMediaRange(%q) succeeded, want error", in)
+		}
+	}
+}
+
+// The claim that makes single-input DASH possible: collapsing the fragmented
+// manifest reproduces the segment-granularity manifest exactly. If this drifts,
+// every segment boundary shifts and nothing downstream notices.
+func TestCollapsedFragmentedMatchesSegmentManifest(t *testing.T) {
+	fragmented := loadContent(t, fragmentedMPDName, sampleFragmentedMPD, "")
+	segmented := loadContent(t, segmentMPDName, sampleSegmentMPD, "")
+
+	if fragmented.SegmentCount != segmented.SegmentCount {
+		t.Errorf("SegmentCount = %d, want %d", fragmented.SegmentCount, segmented.SegmentCount)
+	}
+	if fragmented.SegmentDuration != segmented.SegmentDuration {
+		t.Errorf("SegmentDuration = %v, want %v", fragmented.SegmentDuration, segmented.SegmentDuration)
+	}
+	if fragmented.TotalDuration != segmented.TotalDuration {
+		t.Errorf("TotalDuration = %v, want %v", fragmented.TotalDuration, segmented.TotalDuration)
+	}
+
+	fw, sw := fragmented.Timelines["0"], segmented.Timelines["0"]
+	if fw == nil || sw == nil {
+		t.Fatalf("missing timeline: fragmented=%v segmented=%v", fw != nil, sw != nil)
+	}
+	if len(fw.SegmentDurations) != len(sw.SegmentDurations) {
+		t.Fatalf("timeline length = %d, want %d", len(fw.SegmentDurations), len(sw.SegmentDurations))
+	}
+	for i := range fw.SegmentDurations {
+		if fw.SegmentDurations[i] != sw.SegmentDurations[i] {
+			t.Errorf("segment %d duration = %d, want %d", i, fw.SegmentDurations[i], sw.SegmentDurations[i])
+		}
+	}
+}
+
+// Collapsing must keep the byte-ranges it strips out, or the 1s/2s/LL variants
+// lose their partials.
+func TestCollapseRetainsFragmentRanges(t *testing.T) {
+	data := loadContent(t, fragmentedMPDName, sampleFragmentedMPD, "")
+
+	first, err := loadByterangesForSegment(data, "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("segment 1: %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("segment 1 has %d fragments, want 3", len(first))
+	}
+	// Document order is playback order; offsets must ascend.
+	for i := 1; i < len(first); i++ {
+		if first[i].Offset <= first[i-1].Offset {
+			t.Errorf("fragment %d offset %d does not follow %d", i, first[i].Offset, first[i-1].Offset)
+		}
+	}
+	if first[0].Offset != 432 || first[0].Length != 149674 {
+		t.Errorf("fragment 0 = {%d,%d}, want {432,149674}", first[0].Offset, first[0].Length)
+	}
+
+	// Grouping is by @media, so segment 2 must not absorb segment 1's fragments.
+	second, err := loadByterangesForSegment(data, "1080p/segment_00002.m4s")
+	if err != nil {
+		t.Fatalf("segment 2: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("segment 2 has %d fragments, want 1", len(second))
+	}
+	if second[0].Offset != 432 || second[0].Length != 67074 {
+		t.Errorf("segment 2 fragment = {%d,%d}, want {432,67074}", second[0].Offset, second[0].Length)
+	}
+}
+
+// Ranges recovered from the collapse must equal what the sidecar reported.
+func TestCollapsedRangesMatchSidecar(t *testing.T) {
+	fromMPD, err := loadByterangesForSegment(
+		loadContent(t, fragmentedMPDName, sampleFragmentedMPD, ""), "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("loading from fragmented MPD: %v", err)
+	}
+	fromSidecar, err := loadByterangesForSegment(
+		loadContent(t, segmentMPDName, sampleSegmentMPD, sampleSidecar), "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("loading from sidecar: %v", err)
+	}
+
+	if len(fromMPD) != len(fromSidecar) {
+		t.Fatalf("fragment count differs: MPD %d, sidecar %d", len(fromMPD), len(fromSidecar))
+	}
+	for i := range fromMPD {
+		if fromMPD[i].Offset != fromSidecar[i].Offset || fromMPD[i].Length != fromSidecar[i].Length {
+			t.Errorf("fragment %d differs: MPD {%d,%d}, sidecar {%d,%d}",
+				i, fromMPD[i].Offset, fromMPD[i].Length,
+				fromSidecar[i].Offset, fromSidecar[i].Length)
+		}
+	}
+}
+
+// Legacy content has a segment-granularity manifest and sidecars; it must be
+// left completely alone.
+func TestSegmentManifestIsNotCollapsed(t *testing.T) {
+	data := loadContent(t, segmentMPDName, sampleSegmentMPD, sampleSidecar)
+	if len(data.InlineRanges) != 0 {
+		t.Errorf("segment-granularity manifest produced %d inline ranges, want 0", len(data.InlineRanges))
+	}
+	fragments, err := loadByterangesForSegment(data, "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fragments) != 3 {
+		t.Fatalf("got %d fragments, want the sidecar's 3", len(fragments))
+	}
+	if !fragments[0].Independent {
+		t.Error("sidecar path dropped the independent flag")
+	}
+}
+
+// Inline ranges win over a sidecar. Values differ so a silent fall-through
+// would fail rather than coincidentally pass.
+func TestInlineRangesTakePriorityOverSidecar(t *testing.T) {
+	divergent := `{"fragments": [{"offset": 999999, "length": 1, "independent": true}]}`
+	data := loadContent(t, fragmentedMPDName, sampleFragmentedMPD, divergent)
+
+	fragments, err := loadByterangesForSegment(data, "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fragments) != 3 {
+		t.Fatalf("got %d fragments, want 3 from the manifest", len(fragments))
+	}
+	if fragments[0].Offset == 999999 {
+		t.Error("read the sidecar when the manifest carried ranges")
+	}
+}
+
+func TestErrorsWhenNoRangeSourceExists(t *testing.T) {
+	data := loadContent(t, segmentMPDName, sampleSegmentMPD, "")
+	if _, err := loadByterangesForSegment(data, "1080p/segment_00001.m4s"); err == nil {
+		t.Error("expected an error when no range source exists")
+	}
+}
+
+func TestLeadingSlashInMediaPathStillMatches(t *testing.T) {
+	data := loadContent(t, fragmentedMPDName, sampleFragmentedMPD, "")
+	fragments, err := loadByterangesForSegment(data, "/1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fragments) != 3 {
+		t.Fatalf("got %d fragments, want 3", len(fragments))
+	}
+}
+
+// A timeline that disagrees with the SegmentURL count means we cannot know
+// where segments end; collapsing on a guess would silently move every boundary.
+func TestMismatchedTimelineIsNotCollapsed(t *testing.T) {
+	bad := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"><Period><AdaptationSet><Representation id="0">
+  <SegmentList timescale="30000">
+    <SegmentTimeline><S t="0" d="6006"/></SegmentTimeline>
+    <SegmentURL media="1080p/segment_00001.m4s" mediaRange="432-150105"/>
+    <SegmentURL media="1080p/segment_00001.m4s" mediaRange="150106-240493"/>
+  </SegmentList>
+</Representation></AdaptationSet></Period></MPD>`
+
+	data := loadContent(t, fragmentedMPDName, bad, "")
+	if len(data.InlineRanges) != 0 {
+		t.Errorf("collapsed a manifest whose timeline disagrees with its URL list (%d ranges)", len(data.InlineRanges))
+	}
+}
+
+// Granularity is decided by content, not by filename: the same fragment-level
+// document collapses identically whether it is called manifest.mpd or
+// manifest_fragmented.mpd. That is what lets the serving path keep one name.
+func TestGranularityIsDetectedFromContentNotFilename(t *testing.T) {
+	underStandardName := loadContent(t, segmentMPDName, sampleFragmentedMPD, "")
+	underFragmentedName := loadContent(t, fragmentedMPDName, sampleFragmentedMPD, "")
+
+	if len(underStandardName.InlineRanges) == 0 {
+		t.Fatal("a fragment-granularity document named manifest.mpd was not collapsed")
+	}
+	if underStandardName.SegmentCount != underFragmentedName.SegmentCount {
+		t.Errorf("SegmentCount differs by filename: %d vs %d",
+			underStandardName.SegmentCount, underFragmentedName.SegmentCount)
+	}
+
+	got, err := loadByterangesForSegment(underStandardName, "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d fragments, want 3", len(got))
+	}
+}
+
+// The reverse: a segment-granularity document keeps working under either name,
+// sourcing its ranges from the sidecars.
+func TestSegmentGranularityUnderEitherName(t *testing.T) {
+	data := loadContent(t, fragmentedMPDName, sampleSegmentMPD, sampleSidecar)
+	if len(data.InlineRanges) != 0 {
+		t.Errorf("collapsed a segment-granularity document because of its filename")
+	}
+	got, err := loadByterangesForSegment(data, "1080p/segment_00001.m4s")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d fragments, want the sidecar's 3", len(got))
+	}
+}

--- a/go-live/pkg/dash/mpd.go
+++ b/go-live/pkg/dash/mpd.go
@@ -70,6 +70,12 @@ type MPDData struct {
 	StreamStartTime       float64
 	PeriodCounter         int
 	PeriodCounterInit     bool
+
+	// InlineRanges holds the fragment byte-ranges recovered when the loaded
+	// manifest was itself fragment-granularity. Empty for segment-granularity
+	// manifests, which source ranges from a sibling manifest_fragmented.mpd or
+	// from .byteranges sidecars instead.
+	InlineRanges fragmentRanges
 }
 
 var (
@@ -134,6 +140,17 @@ func LoadMPD(folder, uri string) (*MPDData, error) {
 		return nil, fmt.Errorf("mpd root missing")
 	}
 
+	// A fragment-granularity manifest is collapsed to segment granularity here,
+	// at the boundary, so every reader below sees the same shape it always has.
+	// The byte-ranges stripped out during the collapse are kept on MPDData and
+	// serve the 1s/2s/LL variants — no second file, no chance of the structure
+	// and the ranges disagreeing.
+	inlineRanges, collapsed := normalizeFragmentedMPD(root)
+	if collapsed {
+		fmt.Fprintf(os.Stderr, "INFO: %s is fragment-granularity; collapsed to %d segments carrying inline byte-ranges\n",
+			path, len(inlineRanges))
+	}
+
 	data := &MPDData{
 		Tree:                     doc,
 		Root:                     root,
@@ -147,6 +164,7 @@ func LoadMPD(folder, uri string) (*MPDData, error) {
 		TempSegmentDurationByDur: make(map[int]float64),
 		PartialDurationByDur:     make(map[int]float64),
 		VirtualSegmentsByDur:     make(map[int]map[string][]virtualSegment),
+		InlineRanges:             inlineRanges,
 	}
 
 	if mpdDuration := root.SelectAttrValue("mediaPresentationDuration", ""); mpdDuration != "" {
@@ -486,7 +504,7 @@ func parseSegmentTimeline(segTimeline *etree.Element, timescale int) (*timelineD
 
 // usesVirtualSegments reports whether a variant duration is synthesized by
 // regrouping the base (6s) fmp4 fragments into shorter segments via their
-// .byteranges sidecars, rather than served from the base SegmentList directly.
+// byte-ranges, rather than served from the base SegmentList directly.
 // The 1s and 2s variants are both sub-base regroupings; LL and 6s use the base
 // segments as-is (LL just exposes them with partial-segment availability).
 func usesVirtualSegments(duration int) bool {
@@ -586,7 +604,7 @@ func buildVirtualSegmentsForRep(data *MPDData, rep *etree.Element, repID string,
 		}
 		segmentTicks := baseDurations[minInt(i, len(baseDurations)-1)]
 		segmentDuration := float64(segmentTicks) / float64(timescale)
-		fragments, err := loadByterangesForSegment(data.Path, media)
+		fragments, err := loadByterangesForSegment(data, media)
 		if err != nil || len(fragments) == 0 {
 			virtualSegments = append(virtualSegments, virtualSegment{
 				Media:         media,
@@ -625,11 +643,37 @@ func buildVirtualSegmentsForRep(data *MPDData, rep *etree.Element, repID string,
 	return virtualSegments, nil
 }
 
-func loadByterangesForSegment(mpdPath, mediaPath string) ([]byterangePayloadFragment, error) {
+// loadByterangesForSegment returns the fragment byte-ranges for one segment.
+//
+// Sources, in priority order:
+//  1. ranges carried by the loaded manifest itself, when it was
+//     fragment-granularity (the single-input case, mirroring HLS)
+//  2. a sibling manifest_fragmented.mpd, when the loaded manifest was
+//     segment-granularity but the encoder shipped both files
+//  3. <segment>.byteranges — the legacy JSON sidecar, for older content
+//
+// Callers treat an error here as "this segment has no partials" and fall back to
+// whole-segment granularity, so a content item with none of the three degrades
+// silently. warnNoRangeSource makes that case visible.
+func loadByterangesForSegment(data *MPDData, mediaPath string) ([]byterangePayloadFragment, error) {
+	key := normalizeMediaKey(mediaPath)
+
+	if fragments, ok := data.InlineRanges[key]; ok && len(fragments) > 0 {
+		return fragments, nil
+	}
+
+	mpdPath := data.Path
+	if ranges := loadFragmentedRanges(mpdPath); ranges != nil {
+		if fragments, ok := ranges[key]; ok && len(fragments) > 0 {
+			return fragments, nil
+		}
+	}
+
 	segmentPath := filepath.Join(filepath.Dir(mpdPath), filepath.FromSlash(strings.TrimPrefix(mediaPath, "/")))
 	byterangesPath := segmentPath + ".byteranges"
 	payloadBytes, err := os.ReadFile(byterangesPath)
 	if err != nil {
+		warnNoRangeSource(mpdPath)
 		return nil, err
 	}
 	var payload byterangePayload
@@ -1076,7 +1120,7 @@ func buildExplicitSegmentList(representation *etree.Element, data *MPDData, wind
 		}
 
 		if usePartials && len(virtualSegments) == 0 {
-			fragments, err := loadByterangesForSegment(data.Path, baseMediaPath)
+			fragments, err := loadByterangesForSegment(data, baseMediaPath)
 			if err == nil && len(fragments) > 0 {
 				fragCount := int64(len(fragments))
 				baseDur := durationTicks / fragCount

--- a/go-upload/internal/util/content.go
+++ b/go-upload/internal/util/content.go
@@ -155,7 +155,7 @@ func ListContent(contentDir string) ([]ContentInfo, error) {
 			thumbnailURLLarge = base + "/thumbnail-large.jpg"
 		}
 		segmentDuration := detectSegmentDuration(itemPath)
-		segmentDurations := availableSegmentDurations(itemPath, hasHls, segmentDuration)
+		segmentDurations := availableSegmentDurations(name, itemPath, hasHls, segmentDuration)
 		hasLL := hasHls && contentHasPartials(itemPath)
 		maxResolution, maxHeight := detectMaxResolution(itemPath)
 		variants := parseMasterVariants(itemPath)
@@ -239,13 +239,52 @@ func detectSegmentDuration(contentPath string) *int {
 	return nil
 }
 
+// segmentPinPattern matches a trailing `_1s` / `_2s` / `_6s` on a content name.
+//
+// Such a clip is encoded natively at that one segment length and is served only
+// at it — go-live does not repackage it. `_xs` (and an unsuffixed name) carries
+// no pin and keeps the normal repackaging behaviour.
+//
+// Mirrored in go-live/internal/api/segment_pin.go: these are separate Go
+// modules with no shared package, so the rule is stated in both. The catalogue
+// must not advertise a length the manifest handler will refuse.
+var segmentPinPattern = regexp.MustCompile(`(?i)_(1|2|6)s$`)
+
+// SegmentPin returns the segment length a content name is pinned to, or 0 when
+// it carries no pin.
+func SegmentPin(name string) int {
+	m := segmentPinPattern.FindStringSubmatch(name)
+	if m == nil {
+		return 0
+	}
+	switch m[1] {
+	case "1":
+		return 1
+	case "2":
+		return 2
+	case "6":
+		return 6
+	}
+	return 0
+}
+
 // availableSegmentDurations reports the integer segment lengths go-live can
-// serve this clip at. go-live composes both a 2s and a 6s virtual master from
-// any HLS source master, so any HLS clip is available at both regardless of
-// its native encode. The natively-detected duration is folded in too so a
-// DASH-only clip (no HLS synthesis) still advertises something. LL is not an
-// integer length — it's reported separately via HasLL.
-func availableSegmentDurations(contentPath string, hasHls bool, native *int) []int {
+// serve this clip at.
+//
+// A name pinned with `_1s`/`_2s`/`_6s` reports exactly that one length: the
+// clip is natively encoded at it and is not repackaged. Everything else —
+// `_xs` and unsuffixed content alike — is repackaged, and go-live composes both
+// a 2s and a 6s virtual master from any HLS source master, so any HLS clip is
+// available at both regardless of its native encode. The natively-detected
+// duration is folded in too so a DASH-only clip (no HLS synthesis) still
+// advertises something. LL is not an integer length — it's reported separately
+// via HasLL, and a pin does not suppress it, because LL is partial-segment
+// availability rather than a segment length.
+func availableSegmentDurations(name, contentPath string, hasHls bool, native *int) []int {
+	if pin := SegmentPin(name); pin != 0 {
+		return []int{pin}
+	}
+
 	set := map[int]bool{}
 	if hasHls {
 		set[2] = true
@@ -254,7 +293,10 @@ func availableSegmentDurations(contentPath string, hasHls bool, native *int) []i
 			set[1] = true
 		}
 	}
-	if native != nil {
+	// A native duration of 0 is not a segment length — it means detection
+	// failed (an unparseable playlist or manifest). Advertising it produced
+	// rows like segment_durations [0,1,2,6], which no client can use.
+	if native != nil && *native > 0 {
 		set[*native] = true
 	}
 	if len(set) == 0 {

--- a/go-upload/internal/util/segment_pin_test.go
+++ b/go-upload/internal/util/segment_pin_test.go
@@ -1,0 +1,93 @@
+package util
+
+import "testing"
+
+// The catalogue's view of a pin must agree with go-live's, or /api/content
+// advertises a segment length the manifest handler will 404. Kept as its own
+// table rather than shared code because the two live in separate Go modules —
+// see the note on segmentPinPattern in content.go.
+func TestSegmentPin(t *testing.T) {
+	cases := []struct {
+		name string
+		want int
+	}{
+		{"fpv_p200_h264_1s", 1},
+		{"fpv_p200_h264_2s", 2},
+		{"fpv_p200_h264_6s", 6},
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264_6s", 6},
+
+		{"fpv_p200_h264_xs", 0},
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264_xs", 0},
+		{"bucks_bunny_p200_h264", 0},
+		{"redbull_p200_av1", 0},
+
+		{"insane_fpv_shots_hydrofoil_windsurfing_p200_h264__6s", 6},
+
+		{"clip_p200_h264_3s", 0},
+		{"clip_p200_h264_10s", 0},
+		{"clip_p200_h264_0s", 0},
+
+		{"fpv_6s_p200_h264", 0},
+		{"my_2s_clip_p200_h264", 0},
+
+		{"clip_p200_h264_6S", 6},
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := SegmentPin(c.name); got != c.want {
+			t.Errorf("SegmentPin(%q) = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestAvailableSegmentDurationsPinned(t *testing.T) {
+	// A pinned clip reports exactly its own length, regardless of what the
+	// on-disk probe would otherwise allow.
+	for _, c := range []struct {
+		name string
+		want int
+	}{
+		{"fpv_p200_h264_1s", 1},
+		{"fpv_p200_h264_2s", 2},
+		{"fpv_p200_h264_6s", 6},
+	} {
+		got := availableSegmentDurations(c.name, t.TempDir(), true, nil)
+		if len(got) != 1 || got[0] != c.want {
+			t.Errorf("availableSegmentDurations(%q) = %v, want [%d]", c.name, got, c.want)
+		}
+	}
+}
+
+func TestAvailableSegmentDurationsUnpinnedKeepsRepackaging(t *testing.T) {
+	// _xs and unsuffixed content keep today's behaviour. No partials on disk
+	// here, so 1s is absent but 2s and 6s are still composed.
+	for _, name := range []string{"fpv_p200_h264_xs", "bucks_bunny_p200_h264"} {
+		got := availableSegmentDurations(name, t.TempDir(), true, nil)
+		if len(got) != 2 || got[0] != 2 || got[1] != 6 {
+			t.Errorf("availableSegmentDurations(%q) = %v, want [2 6]", name, got)
+		}
+	}
+}
+
+// A native duration of 0 means detection failed. It used to be advertised
+// verbatim, producing segment_durations [0 1 2 6] on a real clip.
+func TestAvailableSegmentDurationsDropsZeroNative(t *testing.T) {
+	zero := 0
+	got := availableSegmentDurations("bucks_bunny_p200_h264", t.TempDir(), true, &zero)
+	for _, d := range got {
+		if d == 0 {
+			t.Fatalf("advertised a 0s segment length: %v", got)
+		}
+	}
+	if len(got) != 2 || got[0] != 2 || got[1] != 6 {
+		t.Errorf("got %v, want [2 6]", got)
+	}
+}
+
+func TestAvailableSegmentDurationsKeepsRealNative(t *testing.T) {
+	four := 4
+	got := availableSegmentDurations("clip_p200_h264", t.TempDir(), false, &four)
+	if len(got) != 1 || got[0] != 4 {
+		t.Errorf("DASH-only clip: got %v, want [4]", got)
+	}
+}


### PR DESCRIPTION
Addresses #986.

## Why

LL-DASH partial byte-ranges came only from `<segment>.byteranges` JSON sidecars. The encoder has stopped shipping them, and **both** call sites treat a missing sidecar as "no partials" rather than an error:

```go
fragments, err := loadByterangesForSegment(data.Path, media)
if err != nil || len(fragments) == 0 {
    virtualSegments = append(virtualSegments, virtualSegment{
        Media: media, Offset: 0, Length: 0, DurationTicks: segmentTicks,
    })
    continue
}
```

So LL-DASH and the sub-6s variants quietly drop to whole-segment granularity. No error, no log — it looks like it still works. That is the dangerous part.

## What changed in the encoder (this is the part worth checking)

The issue text is **out of date**, and the difference matters:

- It describes a *second* file, `manifest_fragmented.mpd`, sitting next to `manifest.mpd`.
- The encoder no longer does that (Encoder #282). It rewrites **`manifest.mpd` in place** at fragment granularity and ships one file. `write_fragmented_mpd()` in `manifests.py` is explicit: *"go-live opens `manifest.mpd` and detects granularity from content rather than the filename."*
- The marker is the presence of `@mediaRange` on a `<SegmentURL>` — the encoder uses the same signal for its own idempotency guard.

This implementation already keys off content, not filename (`TestGranularityIsDetectedFromContentNotFilename`, `TestSegmentGranularityUnderEitherName`), so it matches. The `manifest_fragmented.mpd` lookup is retained purely as a fallback for the older content on disk that still has both files.

**Timeline math agrees in both directions.** The encoder splits a segment's duration across its fragments with `divmod` (remainder to the leading fragments); this collapse sums fragment durations per `@media` group. Exact inverse, lossless round-trip.

## Approach

`loadByterangesForSegment` now resolves ranges in priority order:

1. **ranges carried by the loaded manifest itself**, when it was fragment-granularity — the single-input case, mirroring how HLS gets `EXT-X-PART` for free
2. a sibling `manifest_fragmented.mpd`, for content from the two-file era
3. `<segment>.byteranges` — the legacy sidecar

The collapse happens once in `LoadMPD`, at the boundary, so every reader below sees the shape it always has. Ranges stripped during the collapse ride on `MPDData.InlineRanges` — no second file, no chance of the structure and the ranges disagreeing.

"No fragment data at all" is now **loud**: `warnNoRangeSource` logs one line per content directory instead of degrading in silence.

Refuses to collapse when the timeline and URL list disagree about how many fragments exist, rather than guessing and shifting every segment boundary.

## Acceptance criteria

- [x] **LL-DASH and 1s/2s variants from `insane_fpv_shots_hydrofoil_windsurfing_p200_h264_xs` with all `.byteranges` deleted.** Verified against the real encode on disk, which is genuinely sidecar-free: `21736 fragments across 728 segments`, no `@mediaRange` surviving the collapse, one timeline entry per segment, fragments contiguous and ascending within each segment.
- [x] **Legacy content with sidecars but no fragmented manifest is unchanged** — `TestSegmentManifestIsNotCollapsed` plus the sidecar-fallback tests.
- [x] **Content with neither logs a distinguishable warning** — `warnNoRangeSource` / `TestErrorsWhenNoRangeSourceExists`.

## Testing

12 unit tests on fixtures, plus a new **real-content** test. The fixtures prove the logic is self-consistent; they cannot prove it matches what the encoder writes, and those two have already drifted once. `fragmented_mpd_real_test.go` runs the collapse over actual encoder output and skips when the media volume is not mounted, so it never fails CI. `DASH_REAL_MPD` points it at another package.

`go build` + `go test` clean in go-live and go-upload.

## Note on scope

Two features here, both about the encoder's delivery-profile tags:

1. **`feat(dash)`** — #986 proper.
2. **`feat(content)`** — pins `_1s`/`_2s`/`_6s` clips to their native segment length, so the catalogue stops advertising lengths that do not exist and go-live 404s a mismatched request instead of serving something else under that name. `_xs` and unsuffixed names keep today's repackaging. This is the natively-segmented counterpart to `_xs`, already verified on test-dev.

Happy to split the second into its own PR if you would rather land them separately.

`gofmt -l` flags 5 files in `go-live/` — identical on clean `dev`, so pre-existing and deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMY8ZznDirDHnJswffsYpH
