### PR TITLE
docs: note that the built-in encoder is superseded by the Encoder project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,13 +171,32 @@ Make targets: `make analytics-rebuild-forwarder` (rebuild + recreate forwarder o
 Defaults: 6s segment, 200ms partial, 1s GOP, AAC-LC 96k stereo 48kHz, two-pass
 software encode, `--ladder apple-uniq-live-xs`.
 
-**This is the fallback encoder, not the primary one.** Content is normally
-produced by the separate **Encoder** project (`~/Projects/Encoder`) and landed in
-`$ENCODE_STAGING_DIR`. The built-in pipeline is kept aligned with the Encoder's
-default ladder of the same name so either tool yields the same shape of content:
-identical rungs (12 per codec — h264 climbs to 4K, hevc/av1 to 2160p), the same
-VBV, and the same `_xs` directory tag. `generate_abr/ladder_audit.py` and
-`analytics/tools/` compare across both.
+**This is the fallback encoder, not the primary one — it is largely superseded.**
+Production content is produced by the separate **Encoder** project
+(`infinite-streaming-encoder`, `~/Projects/Encoder`) and copied onto the
+infinite-streaming server:
+
+```
+Encoder project  →  $ENCODE_STAGING_DIR  →  rsync  →  server  →  /media/dynamic_content/
+```
+
+The Encoder writes finished packages to `$ENCODE_STAGING_DIR` (e.g.
+`/Volumes/4TB/media/encode-staging`); they are rsynced to the server's content
+volume (`CONTENT_DIR`, bind-mounted to `/media` in the container), landing under
+`/media/dynamic_content/<content>/`. Discovery is a plain directory scan gated on
+a manifest being present, so a package joins the catalogue as soon as it is in
+place — no registration step, no restart.
+
+Do not add features to `generate_abr/` that belong in the Encoder project. **Do**
+keep the two aligned: content from either must be the same shape, or a clip
+encoded here cannot be compared against one encoded there — which is the whole
+reason the fallback still exists. `generate_abr/README.md` carries the detail,
+including what the Encoder produces that this script does not (self-describing
+manifests with per-fragment `@mediaRange`, distributed encoding, VMAF audit).
+
+Concretely, "same shape" means identical rungs (12 per codec — h264 climbs to 4K,
+hevc/av1 to 2160p), the same VBV, and the same `_xs` directory tag.
+`generate_abr/ladder_audit.py` and `analytics/tools/` compare across both.
 
 The ladder is a *delivery profile*, not just a bitrate table. Its VBV is what
 makes ONE encode safe for go-live to re-chop into LL/2s/6s:

--- a/generate_abr/README.md
+++ b/generate_abr/README.md
@@ -1,14 +1,87 @@
 # generate_abr
 
-**Status (Jan 2026):** The active encoding pipeline is `create_abr_ladder.sh` with two Python helpers.
+**Status (Aug 2026): largely superseded.** This is the FALLBACK encoder, not the primary one.
+
+Production content is now produced by the separate **Encoder** project
+(`infinite-streaming-encoder`, `~/Projects/Encoder`) and copied onto the
+infinite-streaming server. `create_abr_ladder.sh` is kept working, and kept
+*aligned* with that project, for the cases where standing the Encoder up is not
+worth it — a quick one-off clip, a box without it, or a change to the pipeline
+itself.
+
+Do not add features here that belong in the Encoder project. Do keep the two
+aligned: content produced by either must be the same shape, or a clip encoded
+here cannot be compared against one encoded there — which is the entire reason
+this fallback still exists.
+
+## The normal path
+
+```
+Encoder project  →  $ENCODE_STAGING_DIR  →  rsync  →  server  →  /media/dynamic_content/
+```
+
+The Encoder writes finished packages to the staging directory
+(`$ENCODE_STAGING_DIR`, e.g. `/Volumes/4TB/media/encode-staging`), and they are
+rsynced to the server's content volume. On the server that volume is `CONTENT_DIR`,
+bind-mounted to `/media` inside the container, so a package must land under
+`/media/dynamic_content/<content>/` to be discovered by `/api/content` and served
+by go-live.
+
+Content discovery is a plain directory scan gated on a manifest being present, so
+a package appears in the catalogue as soon as it is in place — no registration
+step, no restart.
+
+## What the Encoder produces that this script does not
+
+- **Self-describing manifests.** `manifest.mpd` is rewritten in place at fragment
+  granularity, one `<SegmentURL @media @mediaRange>` per fragment, so the fragment
+  index lives in the manifest. No `.byteranges` sidecars at serve time (Encoder
+  #282, consumed by #986 on this side). This script still generates sidecars,
+  consumes them to inject `#EXT-X-PART` into the HLS playlists, then prunes them —
+  so its DASH output has no per-fragment ranges.
+- Distributed/chunked encoding, VMAF audit, and the ladder store + UI.
+
+## Alignment with the Encoder
+
+Defaults here match the Encoder's default delivery profile, `apple-uniq-live-xs`:
+
+| | |
+|---|---|
+| Ladder | `--ladder apple-uniq-live-xs`, 12 rungs per codec (h264 to 4K) |
+| VBV | maxrate 100% of target, bufsize 0.25x |
+| Passes | two-pass software encode |
+| Audio | AAC-LC 96k stereo 48kHz |
+| Timing | 6s segment, 200ms partial, 1s GOP |
+| Output tag | `_xs` → `<stem>_p200_<codec>_xs` |
+
+The ladder is a *delivery profile*, not just a bitrate table. Its VBV is what makes
+ONE encode safe for go-live to re-chop into LL/2s/6s:
+
+```
+peak/avg = maxrate%/100 + bufsize/T   =   1.04x (6s) / 1.13x (2s) / 1.25x (1s)
+```
+
+The 1s case lands exactly on Apple's live/linear 1.25x bound and longer variants sit
+below it. Two-pass is not optional at that buffer size: single-pass x265 undershoots
+`-b:v` by ~17%, so the published bitrates are only truthful with it.
+
+Other ladders (`legacy`, `apple`, `apple-uniq`) are retained for comparison runs and
+stay untagged, so pre-existing content keeps its names.
 
 ## Active scripts
-- `create_abr_ladder.sh` (main pipeline)
-- `create_hls_manifests.py` (HLS manifest generation)
-- `convert_to_segmentlist.py` (SegmentTemplate → SegmentList)
+
+- `create_abr_ladder.sh` — main pipeline (ffmpeg + shaka-packager)
+- `create_hls_manifests.py` — HLS manifest generation
+- `convert_to_segmentlist.py` — SegmentTemplate → SegmentList
+- `backfill_thumbnails.sh` — thumbnails for existing content (`make backfill-thumbnails`)
+- `ladder_audit.py` — spacing / peak-accuracy / VMAF checks over a finished package
 
 ## Notes
+
+- Output defaults to `$ENCODE_STAGING_DIR` when set, else the current directory —
+  so encodes do not scatter across whatever directory they were launched from.
 - Legacy test scripts (avsync, LL-HLS tests, etc.) were removed.
-- Output is written under the target content directory in `dynamic_content`.
-- Encoding characterization runs and raw sweep tables are documented in:
-  - `generate_abr/ENCODING_CHARACTERIZATION.md`
+- `ladder_audit.py` enforces a >=1.5x *combined* (video+audio) spacing rule inherited
+  from the legacy ladder. Apple's published ladder does not satisfy it by design, so
+  `tight_spacing` is expected on the apple ladders and is not a regression.
+- Encoding characterization runs and raw sweep tables: `ENCODING_CHARACTERIZATION.md`.


### PR DESCRIPTION
Docs only.

## Why

`generate_abr/README.md` opened with:

> **Status (Jan 2026):** The active encoding pipeline is `create_abr_ladder.sh` with two Python helpers.

That stopped being true a while ago and is now actively misleading. Production content comes from the separate **Encoder** project and is rsynced onto the server; `create_abr_ladder.sh` is the fallback. Someone landing in that directory had no way to know, and CLAUDE.md only said it in passing.

## What it records

**The normal path, explicitly:**

```
Encoder project  →  $ENCODE_STAGING_DIR  →  rsync  →  server  →  /media/dynamic_content/
```

Plus the bit people guess wrong about: discovery is a plain directory scan gated on a manifest being present, so a package joins the catalogue as soon as it lands — no registration step, no restart.

**The rule that keeps the fallback worth having.** Don't add features to `generate_abr/` that belong in the Encoder project, but *do* keep the two aligned — content from either has to be the same shape, or a clip encoded here can't be compared against one encoded there. That is the entire reason the script still exists and it isn't visible from the code.

**What the Encoder produces that this does not** — chiefly self-describing manifests (`manifest.mpd` rewritten in place with per-fragment `@mediaRange`, Encoder #282) versus this script's generate-consume-prune sidecar cycle, which leaves its DASH output with no per-fragment ranges. That asymmetry is what #986/#997 was about.

**Two traps, recorded while fresh:**
- `ladder_audit.py` enforces a >=1.5x *combined* (video+audio) spacing rule inherited from the legacy ladder. Apple's published ladder does not satisfy it by design, so `tight_spacing` on the apple ladders is expected, not a regression. Without this noted, the next person reads it as something they broke.
- Output defaults to `$ENCODE_STAGING_DIR` when set, so encodes don't scatter across whatever directory they were launched from.

## Note

The rsync step is described at the level verified from the repo (`CONTENT_DIR` → `/media` bind mount, packages landing under `/media/dynamic_content/<content>/`). The **exact invocation** is not recorded, since there's no content-sync target in the Makefile — every `rsync` there is a code/dashboard deploy. If you want the real command captured, tell me and I'll add it (or a `make` target, which would be better than a doc line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMY8ZznDirDHnJswffsYpH
