### PR TITLE
docs: add docs/ index + finish the standards index

### DIFF
--- a/.claude/standards/README.md
+++ b/.claude/standards/README.md
@@ -54,9 +54,15 @@ it's a reference catalogue (see below), which is exempt by design.
   filled limit ladder, manifest ladder hazards
 - `codec-strings.md` — avc1/hev1/mp4a profile-level-tier, what
   platforms require what, common stripping bugs
+- `player-fault-response.md` — how AVPlayer and ExoPlayer differ when
+  absorbing a faulted segment; read when an armed fault produces "no
+  error" and you suspect the fault engine
 - `qoe-metrics.md` — CIRR/CIRT/VST/EBVS definitions (Conviva
   provenance, not standards), our label math, the seek-exclusion
   caveat
+- `label-facets.md` — encoding a multi-dimensional condition in the
+  `labels[]` vocabulary; read before adding a label that carries more
+  than one dimension
 - `invariants.md` — operating manual for the aberration-crawl rule
   catalogue (`tests/aberration_crawl/invariants.yaml`): validity
   windows, census-before-assert, documented NON-rules

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# docs/ — operator & reference documentation
+
+Longer-form reference docs that don't belong in `CLAUDE.md` (the orientation
+map and knowledge-routing table) or in `.claude/standards/` (terse
+mid-investigation cheat sheets). Read these when you need depth on a
+subsystem.
+
+## Operator & subsystem reference
+
+| Doc | What it covers |
+|-----|----------------|
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Service topology — go-live / go-upload / go-proxy / nginx, and how a request flows through them |
+| [API.md](API.md) | HTTP API reference across the services (endpoints, params, responses) |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Deploy procedures and environment layout (Docker Compose, test-dev, k3d dev/release) |
+| [FAULT_INJECTION.md](FAULT_INJECTION.md) | Fault-injection reference — failure types and how the proxy applies them. Pairs with [`.claude/standards/fault-injection-wire-contract.md`](../.claude/standards/fault-injection-wire-contract.md), which is the on-the-wire contract |
+| [live-offset-testing.md](live-offset-testing.md) | The two independent distance-from-live-edge levers (manifest/proxy vs app override), which fields each moves, and how to validate a run |
+| [TLS.md](TLS.md) | TLS & certificate setup |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Common failure modes and how to diagnose them |
+
+## Design notes & specs
+
+These record intent rather than current behaviour. **Check the status line at
+the top of each before treating it as a description of what ships** — several
+are partially implemented or design-only.
+
+| Doc | What it covers |
+|-----|----------------|
+| [EVENT_TAXONOMY.md](EVENT_TAXONOMY.md) | Proposed event reclassification replacing the 2-way cause/effect axis the session dashboards use. *Partially implemented.* |
+| [characterization-results-design.md](characterization-results-design.md) | What characterization runs should produce and how the existing pieces relate. *Design captured; no build started.* |
+| [sweep-design.md](sweep-design.md) | Automated fault-injection sweep design (issue #772). *Design approved; build landed — see QE Lab.* |
+
+Also here: `network-log-demo.html` (a standalone Network Log demo page) and
+`screenshots/`.
+
+## Related doc sets elsewhere in the repo
+
+- **`.claude/standards/`** — terse, operationally-relevant cheat sheets read
+  mid-investigation, plus longer reference catalogues dual-consumed by the
+  dashboard chat bot via `read_standard()`. Index:
+  [`.claude/standards/README.md`](../.claude/standards/README.md).
+- **`.claude/findings/`** — confirmed/suspected causes captured across
+  sessions, one file per observed behaviour. Index:
+  [`.claude/findings/README.md`](../.claude/findings/README.md).
+- **`generate_abr/`** — encoding-pipeline docs (ABR ladder, packager
+  comparisons, encoder validation/burn-in). Note the built-in encoder is the
+  fallback, not the primary — start at
+  [`generate_abr/README.md`](../generate_abr/README.md).
+- **`android/InfiniteStreamPlayer/`** — Android client docs:
+  [`README`](../android/InfiniteStreamPlayer/README.md),
+  [`BEHAVIOR`](../android/InfiniteStreamPlayer/BEHAVIOR.md),
+  [`TESTING`](../android/InfiniteStreamPlayer/TESTING.md),
+  [`UI-LAYOUT`](../android/InfiniteStreamPlayer/UI-LAYOUT.md).
+- **`tests/characterization/README.md`** — the player ABR characterization
+  framework, its modes, and the launch-mode picker.
+- **`analytics/README.md`** — analytics sidecar ops, ClickHouse schema, and
+  the WAN-deploy auth runbook.
+- **`PRD.md`** (repo root) — product-behaviour source of truth; read before
+  any UI or product-behaviour change.


### PR DESCRIPTION
## Summary

Salvages the still-useful part of a stale worktree
(`iridescent-gathering-pumpkin`, based 277 commits back on 2026-06-13)
and refreshes it against current `dev` rather than replaying it verbatim.

| File | Change |
|---|---|
| `docs/README.md` | **New** — `docs/` had no index at all |
| `.claude/standards/README.md` | +6 lines — two files that existed on `dev` but appeared in no section |

## `docs/README.md`

Refreshed, not replayed. The stale version indexed 6 files; `dev` has 10
plus `screenshots/`, all now covered.

Split into two tables on purpose. Three of the additions —
`EVENT_TAXONOMY.md`, `characterization-results-design.md`,
`sweep-design.md` — record **intent, not shipped behaviour**, and each
carries a status line saying so (*partially implemented* / *no build
started* / *design approved*). Filing them next to `ARCHITECTURE.md`
would invite exactly the misreading those status lines exist to prevent,
so they sit under **Design notes & specs** with their status inline.

## `.claude/standards/README.md`

The stale branch re-categorised this file into a four-way split. That was
**dropped** — `dev`'s index already has a better, more current scheme
(*Cheat sheets* / *Reference catalogues* / *Test-procedure docs*, with a
rationale about which are exempt from the one-page bar). Replaying June's
version would have been a regression.

What was genuinely missing: `label-facets.md` and
`player-fault-response.md` exist on `dev` but were listed nowhere. Both
added to Cheat sheets. **All 18 standards files are now indexed.**

## Deliberately not included

The stale branch's `CLAUDE.md` "Key Docs" table. #998 landed a
*Knowledge layout* table covering that ground.

## Verification

- Every file in `docs/` is indexed.
- All 18 relative links resolve.
- Every `.claude/standards/*.md` appears in its README.

Docs only — no code, no behaviour change. Post-v2.1.0; does not affect
the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QucjtfYLKJpxztExCnG2cK
